### PR TITLE
OSDOCS-14855: adds microshift-bootc image access to async relnotes

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -106,7 +106,7 @@ The following release notes are for downstream Red{nbsp}Hat products only; upstr
 
 [id="microshift-4-18-additional-release-notes-gitops_{context}"]
 === GitOps release notes
-See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.15/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps 1.15: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package, link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
+See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/latest/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package, link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
 
 [id="microshift-4-18-additional-release-notes-ocp_{context}"]
 === {OCP} release notes
@@ -170,7 +170,11 @@ Issued: 1 May 2025
 
 {product-title} release 4.18.11 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4249[RHBA-2025:4249] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:4211[RHSA-2025:4211] advisory.
 
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+//addition of this bullet requires notification-only change management; bootc bullet carries forward to all 4.18 async releases
 
 [id="microshift-4-18-11-bugs_{context}"]
 ==== Bug fixes


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-14855](https://issues.redhat.com/browse/OSDOCS-14855)

Link to docs preview:
[microshift-4-18-11-dp_release-notes](https://94340--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-11-dp_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
A change management email will accompany this change to the release notes.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
