### PR TITLE
OSDOCS-14861 [NETOBSERV] Update netobserv-reader to netobserv-loki-reader

### DIFF
--- a/modules/network-observability-multitenancy.adoc
+++ b/modules/network-observability-multitenancy.adoc
@@ -5,7 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-multi-tenancy_{context}"]
 = Enabling multi-tenancy in Network Observability
-Multi-tenancy in the Network Observability Operator allows and restricts individual user access, or group access, to the flows stored in Loki and or Prometheus. Access is enabled for project administrators. Project administrators who have limited access to some namespaces can access flows for only those namespaces. 
+Multi-tenancy in the Network Observability Operator allows and restricts individual user access, or group access, to the flows stored in Loki and or Prometheus. Access is enabled for project administrators. Project administrators who have limited access to some namespaces can access flows for only those namespaces.
 
 For Developers, multi-tenancy is available for both Loki and Prometheus but requires different access rights.
 
@@ -15,11 +15,11 @@ For Developers, multi-tenancy is available for both Loki and Prometheus but requ
 
 .Procedure
 
-*  For per-tenant access, you must have the `netobserv-reader` cluster role and the `netobserv-metrics-reader` namespace role to use the developer perspective. Run the following commands for this level of access:
+*  For per-tenant access, you must have the `netobserv-loki-reader` cluster role and the `netobserv-metrics-reader` namespace role to use the developer perspective. Run the following commands for this level of access:
 +
 [source,terminal]
 ----
-$ oc adm policy add-cluster-role-to-user netobserv-reader <user_group_or_name>
+$ oc adm policy add-cluster-role-to-user netobserv-loki-reader <user_group_or_name>
 ----
 +
 [source,terminal]
@@ -27,11 +27,11 @@ $ oc adm policy add-cluster-role-to-user netobserv-reader <user_group_or_name>
 $ oc adm policy add-role-to-user netobserv-metrics-reader <user_group_or_name> -n <namespace>
 ----
 
-* For cluster-wide access, non-cluster-administrators must have the `netobserv-reader`, `cluster-monitoring-view`, and `netobserv-metrics-reader` cluster roles. In this scenario, you can use either the admin perspective or the developer perspective. Run the following commands for this level of access:
+* For cluster-wide access, non-cluster-administrators must have the `netobserv-loki-reader`, `cluster-monitoring-view`, and `netobserv-metrics-reader` cluster roles. In this scenario, you can use either the admin perspective or the developer perspective. Run the following commands for this level of access:
 +
 [source,terminal]
 ----
-$ oc adm policy add-cluster-role-to-user netobserv-reader <user_group_or_name>
+$ oc adm policy add-cluster-role-to-user netobserv-loki-reader <user_group_or_name>
 ----
 +
 [source,terminal]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14861 [NETOBSERV] Update netobserv-reader to netobserv-loki-reader

Version(s):
Merge to only the `no-1.9` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the NetObserv content just before its GA.

Cherry-pick to OCP 4.12, 4.14, 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-14861

Link to docs preview:
https://94341--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-multi-tenancy_network_observability 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
