### PR TITLE
[CNV-52364] IBM Z compatibility section changes

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -102,6 +102,7 @@ The following features are currently not supported on `s390x` architecture:
 * IPv6
 * {ibm-name} Storage scale
 * {hcp-capital} for {VirtProductName}
+* VM pages using HugePages
 
 The following features are not applicable on `s390x` architecture:
 
@@ -110,6 +111,7 @@ The following features are not applicable on `s390x` architecture:
 * USB host passthrough
 * Configuring virtual GPUs
 * Creating and managing Windows VMs
+* Hyper-V
 
 [discrete]
 [id="functionality-differences_{context}"]
@@ -122,6 +124,11 @@ The following features are available for use on s390x architecture but function 
 * When xref:../../virt/managing_vms/advanced_vm_management/virt-configuring-default-cpu-model.adoc#virt-configuring-default-cpu-model_virt-configuring-default-cpu-model[configuring the default CPU model], the `spec.defaultCPUModel` value is `"gen15b"` for an {ibm-z-title} cluster.
 
 * When xref:../../virt/monitoring/virt-exposing-downward-metrics.adoc#virt-configuring-downward-metrics_virt-exposing-downward-metrics[configuring a downward metrics device], if you use a VM preference, the `spec.preference.name` value must be set to `rhel.9.s390x` or another available preference with the format `*.s390x`.
+
+* When xref:../../virt/creating_vm/virt-creating-vms-from-instance-types.adoc#virt-creating-vms-from-instance-types[creating virtual machines from instance types], you are not allowed to set `spec.domain.memory.maxGuest` because memory hot plugging is not supported on {ibm-z-name}.
+
+* Prometheus queries for VM guests could have inconsistent outcome in comparison to `x86`.
+
 
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/CNV-52364
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94343--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html#ibm-z-linuxone-compatibility_preparing-cluster-for-virt
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Google doc with input: https://docs.google.com/document/d/1F_OL7hTnH2G6wXz4L6021-7Y1lbDsESBt58MiUwtcWs/edit?tab=t.0#heading=h.3r2vdsbo6h9q
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
