### PR TITLE
OCPBUGS#56526 updating install encryption proc to use XTS only

### DIFF
--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -44,7 +44,7 @@ This feature:
 * Is supported on {op-system-first} systems only
 * Sets up disk encryption during the manifest installation phase, encrypting all data written to disk, from first boot forward
 * Requires no user intervention for providing passphrases
-* Uses AES-256-XTS encryption, or AES-256-CBC if FIPS mode is enabled
+* Uses AES-256-XTS encryption
 
 [id="installation-special-config-encryption-threshold_{context}"]
 === Configuring an encryption threshold
@@ -289,6 +289,19 @@ $ butane $HOME/clusterconfig/worker-storage.bu -o <installation_directory>/opens
 +
 Repeat this step for each node type that requires disk encryption or mirroring.
 
+. If you enable encryption, edit the manifest that was produced by the previous step and replace the cipher `aes-cbc-essiv:sha256` with `aes-xts-plain64`.
+The following excerpt shows a sample encryption configuration after this change:
++
+[source,yaml]
+----
+# ...
+        luks:
+# ...
+          options:
+            - --cipher
+            - aes-xts-plain64
+----
+
 . Save the Butane configuration file in case you need to update the manifests in the future.
 
 . Continue with the remainder of the {product-title} installation.
@@ -357,7 +370,6 @@ In such situations, it is possible to access nodes using `ssh core@<node>.<clust
 <1> The encryption format.
 When the TPM v2 or Tang encryption modes are enabled, the {op-system} boot disks are encrypted using the LUKS2 format.
 <2> The encryption algorithm used to encrypt the LUKS2 volume.
-The `aes-cbc-essiv:sha256` cipher is used if FIPS mode is enabled.
 <3> The device that contains the encrypted LUKS2 volume.
 If mirroring is enabled, the value will represent a software mirror device, for example `/dev/md126`.
 +


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OCPBUGS-56526

Link to docs preview:
[About disk encryption](https://94347--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-encrypt-disk_installing-customizing)
[Configuring disk encryption and mirroring](https://94347--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-storage-procedure_installing-customizing)


QE review:
- [x] QE has approved this change.
