### PR TITLE
OSDOCS-14865 4.19 ServiceAccountTokenNodeBinding release note

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -63,6 +63,11 @@ Direct authentication is available as a Technology Preview feature.
 
 For more information, see xref:../authentication/external-auth.adoc#external-auth[Enabling direct authentication with an external OIDC identity provider].
 
+[id="ocp-4-19-auth-ServiceAccountTokenNodeBinding_{context}"]
+==== Enable ServiceAccountTokenNodeBinding Kubernetes feature by default
+
+In {product-title} {product-version}, the `ServiceAccountTokenNodeBinding` feature is now enabled by default, aligning with upstream Kubernetes behavior. This feature allows service account tokens to be bound directly to node objects in addition to the existing binding options. Benefits of this change include enhanced security through automatic token invalidation when bound nodes are deleted and better protection against token replay attacks across different nodes.
+
 [id="ocp-release-notes-backup-restore_{context}"]
 === Backup and restore
 
@@ -469,8 +474,8 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-release-notes-insights-operator-runtime-extractor_{context}"]
 ==== Insights Runtime Extractor is generally available
 
-In {product-title} 4.18, the Insights Operator introduced the _Insights Runtime Extractor_ workload data collection feature as a Technology Preview feature to help Red{nbsp}Hat better understand the workload of your containers. 
-Now, in version 4.19, the feature is generally available. 
+In {product-title} 4.18, the Insights Operator introduced the _Insights Runtime Extractor_ workload data collection feature as a Technology Preview feature to help Red{nbsp}Hat better understand the workload of your containers.
+Now, in version 4.19, the feature is generally available.
 The Insights Runtime Extractor feature gathers runtime workload data and sends it to Red{nbsp}Hat.
 [id="ocp-release-notes-installation-and-update_{context}"]
 === Installation and update


### PR DESCRIPTION
Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-14865](https://issues.redhat.com/browse/OSDOCS-14865)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94352--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-auth-ServiceAccountTokenNodeBinding_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
