### PR TITLE
OSDOCS-14620 Release Note for confidential computing expansion

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -468,6 +468,16 @@ On 30 September 2025, the default outbound access connectivity for all new virtu
 
 For more information, see link:https://azure.microsoft.com/en-us/updates?id=default-outbound-access-for-vms-in-azure-will-be-retired-updates-and-more-information[Azure Updates] (Microsoft documentation), link:https://learn.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections#scenarios[Azure's outbound connectivity methods] (Microsoft documentation), and xref:../installing/installing_azure/upi/installing-azure-preparing-upi.adoc#installing-azure-preparing-upi[Preparing to install a cluster on {azure-short}].
 
+[id="ocp-4-19-installation-and-update-gcp-confidential-computing-expansion_{context}"]
+==== Additional Confidential Computing platforms for {gcp-short}
+With this release, you can use additional Confidential Computing platforms when installing a cluster on {gcp-short}. The new supported platforms, which can be enabled in the `install-config.yaml` file prior to installation, are as follows:
+
+* `AMDEncryptedVirtualization`, which enables Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV)
+* `AMDEncryptedVirtualizationNestedPaging`, which enables Confidential Computing with AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP)
+* `IntelTrustedDomainExtensions`, which enables Confidential Computing with Intel Trusted Domain Extensions (Intel TDX)
+
+For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-config-parameters-additional-gcp_installation-config-parameters-gcp[Installation configuration parameters for {gcp-full}].
+
 [id="ocp-4-19-GCP-custom-dns_{context}"]
 ==== Installing a cluster on {gcp-first} with a user-provisioned DNS
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-14620

Link to docs preview:
https://94356--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-installation-and-update-gcp-confidential-computing-expansion_release-notes

QE review:
Content is a subset of https://github.com/openshift/openshift-docs/pull/94278, which was approved

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
