### PR TITLE
OSDOCS-14867 4.19 release note for extended loopback certificate

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -645,6 +645,12 @@ The *Getting Started* pane in the web console provides resources such as, a tour
 
 With this release, Cloud Credential Operator pods now deploy with the `readOnlyRootFilesystem` security context setting set to `true`. This enhances security by ensuring that the container root file system is mounted as read-only.
 
+[discrete]
+[id="ocp-4-19-notable-technical-changes-loopback-cert_{context}"]
+=== Extended loopback certificate validity to three years for kube-apiserver
+
+Previously, in-memory loopback certificates in kube-apiserver were issued for one year. This meant that if the kube-apiserver ran without rollouts or restarts, the kube-apiserver would stop functioning after one year. In {product-title} {product-version} the in-memory loopback certificates are extended so the kube-apiserver can run for three years without interruption.
+
 [id="ocp-4-19-deprecated-removed-features_{context}"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-14867](https://issues.redhat.com/browse/OSDOCS-14867)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94360--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-notable-technical-changes_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
