### PR TITLE
OSDOCS-14857: Documented the 4.17.33 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2890,9 +2890,35 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.33
+[id="ocp-4-17-33_{context}"]
+=== RHSA-2025:8552 - {product-title} {product-version}.33 bug fix update and security update
+
+Issued: 11 June 2025
+
+{product-title} release {product-version}.33 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:8552[RHSA-2025:8552] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:8553[RHBA-2025:8553] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.33 --pullspecs
+----
+
+[id="ocp-4-17-33-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, the {product-title} web console sent you an alert that compute nodes must be updated within 60 days after you updated control plane nodes. This action request was invalid. With this update, the {product-title} web console no longer sends you this invalid alert. (link:https://issues.redhat.com/browse/OCPBUGS-56375[OCPBUGS-56375])
+
+[id="ocp-4-17-33-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.32
 [id="ocp-4-17-32_{context}"]
-=== RHSA-2025:8280 - {product-title} {product-version}.32 bug fix
+=== RHSA-2025:8280 - {product-title} {product-version}.32 bug fix update and security update
 
 Issued: 04 June 2025
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-14857](https://issues.redhat.com/browse/OSDOCS-14857)

Link to docs preview:
* [4.17.33](https://94369--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-33_release-notes)
