### PR TITLE
Adds doc text for registry bugs

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -1062,7 +1062,9 @@ For more information about the unsupported, community-maintained, version of the
 
 [discrete]
 [id="ocp-release-note-image-registry-bug-fixes_{context}"]
-==== Image Registry
+==== Registry
+
+* Previously, image importing from blocked registries would fail if those registries were configured with `NeverContactSource`, even when mirror registries were set up. With this update, image importing is no longer blocked when a registry has mirrors configured. This ensures that image imports succeed even if the original source was set to `NeverContactSource` in the `ImageDigestMirrorSet` or `ImageTagMirrorSet` resources. (link:https://issues.redhat.com/browse/OCPBUGS-44432[*OCPBUGS-44432*])
 
 [discrete]
 [id="ocp-release-note-installer-bug-fixes_{context}"]


### PR DESCRIPTION
Bug doc text for 4.19 RNs - Registry component. 

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OCPBUGS-44432

Link to docs preview:
https://94385--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
