### PR TITLE
OSDOCS-13532: Add small explainer about the need for ECR

### DIFF
--- a/rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
+++ b/rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
@@ -9,6 +9,8 @@ Creating a {product-title} (ROSA) cluster with egress lockdown provides a way to
 
 All public and private clusters with egress lockdown get their Red{nbsp}Hat container images from an Amazon Elastic Container Registry (ECR) located in the local region of the cluster instead of gathering these images from various endpoints and registries on the internet. ECR provides storage for OpenShift release images as well as Red{nbsp}Hat Operators. All requests for ECR are kept within your AWS network by serving them over a VPC endpoint within your cluster.
 
+ROSA clusters with egress lockdown use AWS ECR to provision ROSA with HCP clusters without the need for public internet. Because necessary cluster lifecycle processes occur over AWS private networking, AWS ECR serves as a critical service for core cluster platform images. For more information on AWS ECR, see link:https://aws.amazon.com/ecr/[Amazon Elastic Container Registry].
+
 You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster.
 
 See xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading {product-title} clusters] to upgrade clusters using egress lockdown. 


### PR DESCRIPTION
[OSDOCS-13532](https://issues.redhat.com//browse/OSDOCS-13532): Add small explainer about the need for ECR

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13532

Link to docs preview:
https://94399--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-egress-lockdown-install.html

QE review:
No QE needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
