### PR TITLE
OSDOCS-14869: Change feature title in external auth provider for ROSA docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -268,7 +268,7 @@ Topics:
 # Note the following title should use the same term as the {zero-egress} parameter does
 - Name: Creating a ROSA with HCP cluster with egress lockdown
   File: rosa-hcp-egress-lockdown-install
-- Name: Creating ROSA with HCP clusters with external authentication
+- Name: Creating a ROSA with HCP cluster that uses direct authentication with an external OIDC identity provider
   File: rosa-hcp-sts-creating-a-cluster-ext-auth
 - Name: Creating ROSA with HCP clusters without a CNI plugin
   File: rosa-hcp-cluster-no-cni

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -197,7 +197,7 @@ Topics:
 # Note the following title should use the same term as the {zero-egress} parameter does
 - Name: Creating a ROSA with HCP cluster with egress lockdown
   File: rosa-hcp-egress-lockdown-install
-- Name: Creating ROSA with HCP clusters with external authentication
+- Name: Creating a ROSA with HCP cluster that uses direct authentication with an external OIDC identity provider
   File: rosa-hcp-sts-creating-a-cluster-ext-auth
 ---
 Name: Web console

--- a/modules/rosa-hcp-sts-accessing-a-break-glass-cred-cli.adoc
+++ b/modules/rosa-hcp-sts-accessing-a-break-glass-cred-cli.adoc
@@ -11,7 +11,7 @@ Use the new `kubeconfig` from the break glass credential to gain temporary admin
 
 .Prerequisites
 
-* You have access to a {hcp-title} cluster with external authentication enabled. For more information, see _Creating a {hcp-title} cluster that uses external authentication providers_.
+* You have access to a {hcp-title} cluster with external authentication enabled. For more information, see _Creating a {hcp-title} cluster that uses direct authentication with an external OIDC identity provider_.
 * You have installed the `oc` and the `kubectl` CLIs.
 * You have configured the new `kubeconfig`. For more information, see _Creating a break glass credential for a {hcp-title} cluster_.
 

--- a/modules/rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli_{context}"]
-= Creating a {hcp-title} cluster that uses external authentication providers
+= Creating a {hcp-title} cluster that uses direct authentication with an external OIDC identity provider
 :source-highlighter: pygments
 :pygments-style: emacs
 :icons: font

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-hcp-sts-creating-a-cluster-ext-auth"]
-= Creating ROSA with HCP clusters with external authentication
+= Creating a {hcp-title} cluster that uses direct authentication with an external OIDC identity provider
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-sts-creating-a-cluster-ext-auth
 
@@ -63,7 +63,7 @@ include::modules/rosa-hcp-sts-creating-a-break-glass-cred-cli.adoc[leveloffset=+
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about creating a {hcp-title} cluster with external authentication enabled, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc#rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli_rosa-hcp-sts-creating-a-cluster-ext-auth[Creating a ROSA with HCP cluster that uses external authentication providers].
+* For more information about creating a {hcp-title} cluster with external authentication enabled, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc#rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli_rosa-hcp-sts-creating-a-cluster-ext-auth[Creating a {hcp-title} cluster that uses direct authentication with an external OIDC identity provider].
 //* For more information about CLI configurations, see xref:#../cli_reference/openshift_cli/managing-cli-profiles.adoc#managing-cli-profiles[Managing CLI profiles].
 
 include::modules/rosa-hcp-sts-accessing-a-break-glass-cred-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-14869](https://issues.redhat.com//browse/OSDOCS-14869): Change feature title in external auth provider for ROSA docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14869

Link to docs preview:
https://94402--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-egress-lockdown-install.html

QE review:
No QE needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
