### PR TITLE
updates link to resolve 404

### DIFF
--- a/networking/ovn_kubernetes_network_provider/ovn-kubernetes-tracing-using-ovntrace.adoc
+++ b/networking/ovn_kubernetes_network_provider/ovn-kubernetes-tracing-using-ovntrace.adoc
@@ -19,4 +19,4 @@ include::modules/nw-ovn-kubernetes-running-ovnkube-trace.adoc[leveloffset=+1]
 == Additional resources
 
 * link:https://access.redhat.com/solutions/5887511[Tracing Openflow with ovnkube-trace utility]
-* link:https://github.com/ovn-org/ovn-kubernetes/blob/master/docs/ovnkube-trace.md[ovnkube-trace]
+* link:https://github.com/ovn-kubernetes/ovn-kubernetes/blob/master/docs/troubleshooting/ovnkube-trace.md[ovnkube-trace]


### PR DESCRIPTION
Just a minor URL update.

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-45128

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed. Link update.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
