### PR TITLE
OSDOCS-14862 NETOBSERV 1.9 Features, Bugs, Known Issues

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -2,7 +2,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-operator-release-notes"]
 = Network Observability Operator release notes
-:context: network-observability-operator-release-notes-v0
+:context: network-observability-operator-release-notes-v1-9
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
@@ -12,6 +12,104 @@ The Network Observability Operator enables administrators to observe and analyze
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
 For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#dependency-network-observability[About Network Observability Operator].
+
+[id="network-observability-operator-release-notes-1-9_{context}"]
+== Network Observability Operator 1.9
+The following advisory is available for the Network Observability Operator 1.9:
+
+* link:https://access.redhat.com/errata/RHSA-2025:10020 [Network Observability Operator 1.9]
+
+[id="new-features-enhancements-1-9"]
+=== New features and enhancements
+
+[id="user-defined-networks-with-network-observability_{context}"]
+==== User-defined networks with Network Observability
+With this release, xref:../../networking/multiple_networks/understanding-multiple-networks.adoc#understanding-multiple-networks[user-defined networks (UDN)] feature is generally available with Network Observability. When the `UDNMapping` feature is enabled in Network Observability, the *Traffic* flow table has a `UDN labels` column. You can filter logs on *Source Network Name* and *Destination Network Name* information.
+
+[id="filter-flowlogs-at-ingestion_{context}"]
+==== Filter flowlogs at ingestion
+With this release, you can create filters to reduce the number of generated network flows and the resource usage of Network Observability components.
+
+You can configure the following filters:
+
+* eBPF Agent filters
+* Flowlogs-pipeline filters
+
+[id="ipsec-support_{context}"]
+==== IPsec support
+This update brings the following enhancements to Network Observability when IPsec is enabled on {product-title}:
+
+* A new column named *IPsec Status* is displayed in the Network Observability *Traffic* flows view to show whether a flow was successfully IPsec-encrypted or if there was an error during encryption/decryption.
+
+* A new dashboard showing the percentage of encrypted traffic is generated.
+
+[id="network-observability-cli-1-9_{context}"]
+==== Network Observability CLI
+The following filtering options are now available for packets, flows, and metrics capture:
+
+* Track IPsec using `--enable_ipsec`
+* Value that determines the ratio of packets being sampled using `--sampling`
+* Filter flows using a custom query using `--query`
+* A comma separated list of interfaces to monitor using `--interfaces`
+* A comma separated list of interfaces to exclude using `--exclude_interfaces`
+* A comma separated list of metric names to generate using `--include_list`
+
+For more information, see xref:../../observability/network_observability/netobserv_cli/netobserv-cli-reference.adoc#network-observability-netobserv-cli-reference_netobserv-cli-reference[Network Observability CLI reference].
+
+[id="notable-technical-changes-1-9_{context}"]
+=== Notable technical changes
+* The `NetworkEvents` feature in Network Observability 1.9 has been updated to work with the newer Linux kernel of {product-title} 4.19. This update breaks compatibility with older kernels. As a result, the `NetworkEvents` feature can only be used with {product-title} 4.19. If you are using this feature with Network Observability 1.8 and {product-title} 4.18, consider avoiding a Network Observability upgrade or upgrading Network Observability to 1.9 and {product-title} to 4.19.
+
+* The `netobserv-reader` `clusterrole` has been renamed to `netobserv-loki-reader`.
+
+* Improved CPU performance of the eBPF agents.
+
+[id="network-observability-technology-preview-1-9_{context}"]
+=== Technology Preview features
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+[id="ebpf-manager-operator-with-network-observability_{context}"]
+==== eBPF Manager Operator with Network Observability
+
+:FeatureName: eBPF Manager Operator with Network Observability
+include::snippets/technology-preview.adoc[]
+
+The eBPF Manager Operator reduces the attack surface and ensures compliance, security, and conflict prevention by managing all eBPF programs. Network observability can use the eBPF Manager Operator to load hooks. This eliminates the need to provide the eBPF Agent with privileged mode or additional Linux capabilities like `CAP_BPF` and `CAP_PERFMON`. The eBPF Manager Operator with network observability is only supported on 64-bit AMD architecture.
+
+[id="network-observability-operator-CVE-1-9_{context}"]
+=== CVE
+
+* link:https://access.redhat.com/security/cve/CVE-2025-26791[*CVE-2025-26791*]
+
+[id="network-observability-operator-1-9-bug-fixes_{context}"]
+=== Bug fixes
+* Previously, when filtering by source or destination IP from the console plugin, using a Classless Inter-Domain Routing (CIDR) notation such as `10.128.0.0/24` did not work, returning results that should be filtered out. With this update, it is now possible to use a CIDR notation, with the results being filtered as expected. (link:https://issues.redhat.com/browse/NETOBSERV-2276[*NETOBSERV-2276*])
+
+* Previously, network flows might have incorrectly identified the network interfaces in use, especially with a risk of mixing up `eth0` and `ens5`. This issue only occurred when the eBPF agents were configured as `Privileged`. With this update, it has been fixed partially, and almost all network interfaces are correctly identified. Refer to the known issues below for more details. (link:https://issues.redhat.com/browse/NETOBSERV-2257[*NETOBSERV-2257*])
+
+* Previously, when the Operator checked for available Kubernetes APIs in order to adapt its behavior, if there was a stale API, this resulted in an error that prevented the Operator from starting normally. With this update, the Operator ignores error on unrelated APIs, logs errors on related APIs, and continues to run normally. (link:https://issues.redhat.com/browse/NETOBSERV-2240[*NETOBSERV-2240*])
+
+* Previously, users could not sort flows by *Bytes* or *Packets* in the *Traffic* flows view of the Console plugin. With this update, users can sort flows by *Bytes* and *Packets*.(link:https://issues.redhat.com/browse/NETOBSERV-2239[*NETOBSERV-2239*])
+
+* Previously, when configuring the `FlowCollector` resource with an IPFIX exporter, MAC addresses in the IPFIX flows were truncated to their 2 first bytes. With this update, MAC addresses are fully represented in the IPFIX flows. (link:https://issues.redhat.com/browse/NETOBSERV-2208[*NETOBSERV-2208*])
+
+* Previously, some of the warnings sent from the Operator validation webhook could lack clarity, such as when not mentioning exactly which feature causes the warning, or what needed to be done. With this update, some of these messages have been reviewed and amended to make them more actionable. (link:https://issues.redhat.com/browse/NETOBSERV-2178[*NETOBSERV-2178*])
+
+* Previously, it was not obvious to figure out there was an issue when referencing a `LokiStack` from the `FlowCollector` resource, such as in case of typing error. With this update, the `FlowCollector` status clearly states that the referenced `LokiStack` is not found in that case. (link:https://issues.redhat.com/browse/NETOBSERV-2174[*NETOBSERV-2174*])
+
+* Previously, in the console plugin *Traffic flows* view, in case of text overflow, text ellipses sometimes hid much of the text to be displayed. With this update, it displays as much text as possible. (link:https://issues.redhat.com/browse/NETOBSERV-2119[*NETOBSERV-2119*])
+
+* Previously, the console plugin for Network Observability 1.8.1 and earlier did not work with the {product-title} 4.19 web console, making the *Network Traffic* page inaccessible. With this update, the console plugin is compatible and the *Network Traffic* page is accessible in Network Observability 1.9.0. (link:https://issues.redhat.com/browse/NETOBSERV-2046[*NETOBSERV-2046*])
+
+* Previously, when using conversation tracking (`logTypes: Conversations` or `logTypes: All` in the `FlowCollector` resource), the *Traffic* rates metrics visible in the dashboards were flawed, wrongly showing an out-of-control increase in traffic. Now, the metrics show more accurate traffic rates. However, note that in `Conversations` and `EndedConversations` modes, these metrics are still not 100% accurate as they don't include long-standing connections. This information has been added to the documentation. The default mode `logTypes: Flows`, is recommended to avoid this kind of inaccuracy. (link:https://issues.redhat.com/browse/NETOBSERV-1955[*NETOBSERV-1955*])
+
+[id="network-observability-operator-1-9-known-issues_{context}"]
+=== Known issues
+* The user-defined network (UDN) feature displays a configuration issue and a warning when used with {product-title} 4.18, even though it is supported. This warning can be ignored.  (link:https://issues.redhat.com/browse/NETOBSERV-2305[*NETOBSERV-2305*])
+
+* In some rare cases, the eBPF agent is unable to appropriately correlate flows with the involved interfaces when running in privileged modes with several network namespaces. A large part of these issues have been identified and resolved in this release, but some inconsistencies remain, especially with the `ens5` interface. (link:https://issues.redhat.com/browse/NETOBSERV-2287[*NETOBSERV-2287*])
 
 [id="network-observability-operator-release-notes-1-8-1_{context}"]
 == Network Observability Operator 1.8.1

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -14,35 +14,35 @@ include::modules/network-observability-working-with-overview.adoc[leveloffset=+2
 include::modules/network-observability-configuring-options-overview.adoc[leveloffset=+2]
 include::modules/network-observability-pktdrop-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-packet-drops"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-packet-drops_nw-observe-network-traffic[Working with packet drops]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 
 include::modules/network-observability-dns-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-dns-overview"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-dns-tracking_nw-observe-network-traffic[Working with DNS tracking]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 
 include::modules/network-observability-RTT-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-rtt-overview"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-RTT_nw-observe-network-traffic[Working with RTT tracing]
 
 include::modules/network-observability-ebpf-rule-flow-filter.adoc[leveloffset=+2]
 include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+3]
 
-[role="_additional-resources"]
+[role="_additional-resources-flow-filter-parameters"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-filtering-ebpf-rule_nw-observe-network-traffic[Filtering eBPF flow data with rules]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 * xref:../../observability/network_observability/network-observability-operator-monitoring.adoc#network-observability-health-dashboard-overview_network_observability[Health dashboards]
 
 include::modules/network-observability-con_user-defined-networks.adoc[leveloffset=+2]
-[role="_additional-resources"]
+[role="_additional-resources-udn"]
 .Additional resources
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#about-user-defined-networks[About user-defined networks]
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
@@ -50,7 +50,7 @@ include::modules/network-observability-con_user-defined-networks.adoc[leveloffse
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-working-with-udn_nw-observe-network-traffic[Working with user-defined networks]
 
 include::modules/network-observability-networking-events-overview.adoc[leveloffset=+2]
-[role="_additional-resources"]
+[role="_additional-resources-networking-events-overview"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-viewing-network-events_nw-observe-network-traffic[Viewing network events]
 
@@ -60,7 +60,7 @@ include::modules/network-observability-working-with-trafficflow.adoc[leveloffset
 include::modules/network-observability-configuring-options-trafficflow.adoc[leveloffset=+2]
 include::modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-ipsec"]
 .Additional resources
 * xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
 
@@ -84,14 +84,14 @@ include::modules/network-observability-packet-translation-overview.adoc[leveloff
 include::modules/network-observability-packet-translation.adoc[leveloffset=+2]
 include::modules/network-observability-proc_working-with-udn.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-working-with-udn"]
 .Additional resources
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr-ui_about-user-defined-networks[Creating a UserDefinedNetwork by using the web console]
 
 include::modules/network-observability-viewing-network-events.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-viewing-network-events"]
 .Additional resources
 * xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli_nodes-cluster-enabling[Enabling feature sets using the CLI]
 * xref:../../networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc#nw-ovn-kubernetes-observability_ovn-kubernetes-sources-of-troubleshooting-information[Checking OVN-Kubernetes network traffic with OVS sampling using the CLI]
@@ -106,7 +106,7 @@ include::modules/network-observability-quickfilter.adoc[leveloffset=+1]
 
 Alternatively, you can access the traffic flow data in the *Network Traffic* tab of the *Namespaces*, *Services*, *Routes*, *Nodes*, and *Workloads* pages which provide the filtered data of the corresponding aggregations.
 
-[role="_additional-resources"]
+[role="_additional-resources-quickfilter"]
 .Additional resources
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14862 NETOBSERV 1.9 Features, Bugs, Known Issues

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the `no-1.9` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the NetObserv content just before its GA.

Issue:
https://issues.redhat.com/browse/OSDOCS-14862

Link to docs preview:
* 1.9 Release notes: https://94440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-release-notes-1-9_network-observability-operator-release-notes-v1-9
* 1.9 New features and enhancements: https://94440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#new-features-and-enhancements
*  1.9 Notable technical changes https://94440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#notable-technical-changes-1-9_network-observability-operator-release-notes-v1-9
* 1.9 Technology preview features: https://94440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-technology-preview-1-9_network-observability-operator-release-notes-v1-9
* 1.9 CVEs: https://94440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-CVE-1-9_network-observability-operator-release-notes-v1-9
* 1.9 Bug fixes: https://94440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-1-9-bug-fixes_network-observability-operator-release-notes-v1-9
* 1.9 Known issues: https://94440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-1-9-known-issues_network-observability-operator-release-notes-v1-9

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
06/24/2025:

See https://github.com/openshift/openshift-docs/pull/95159. All content from previously merged PRs vanished from the `no-1.9` branch, and are appearing in any open PR against `no-1.9`. Hopefully merging 95159 and a rebase will resolve things.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
