### PR TITLE
OSDOCS-14586:Added new OSD on GCP cluster deployment troubleshooting section

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -197,6 +197,8 @@ Topics:
   Topics:
 #  - Name: Troubleshooting installations
 #    File: troubleshooting-installations
+  - Name: Troubleshooting an OSD cluster on GCP deployment
+    File: troubleshooting-osd-gcp-cluster-deployment
   - Name: Verifying node health
     File: verifying-node-health
 #  cannot create resource "namespaces", cannot patch resource "nodes"

--- a/modules/osd-on-gcp-troubleshoot-cluster-install.adoc
+++ b/modules/osd-on-gcp-troubleshoot-cluster-install.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * support/troubleshooting/troubleshooting-osd-gcp-cluster-deployment.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="osd-on-gcp-troubleshoot-cluster-install_{context}"]
+= Troubleshooting {product-title} on {gcp-short} installation error codes
+
+The following table lists {product-title} on {gcp-first} installation error codes and what you can do to resolve these errors.
+
+.{product-title} on {gcp-short} installation error codes
+[options="header",cols="3"]
+|===
+| Error code | Description | Resolution
+
+| OCM3022
+| Invalid {gcp-short} project ID.
+| Verify the project ID in the Google cloud console and retry cluster creation.
+
+| OCM3023
+| {gcp-short} instance type not found.
+| Verify the instance type and retry cluster creation.
+
+For more information about {product-title} on {gcp-short} instance types, see _Google Cloud instance types_ in the _Additional resources_ section.
+
+| OCM3024
+| {gcp-short} precondition failed.
+| Verify the organization policy constraints and retry cluster creation.
+
+For more information about organization policy constraints, see link:https://cloud.google.com/resource-manager/docs/organization-policy/org-policy-constraints[Organization policy constraints].
+
+| OCM3025
+| {gcp-short} SSD quota limit exceeded.
+| Check your available persistent disk SSD quota either in the Google Cloud console or in the `gcloud` CLI. There must be at least 896 GB of SSD available. Increase the SSD quota limit and retry cluster creation.
+
+For more information about managing persistent disk SSD quota, see link:https://cloud.google.com/compute/resource-usage[Allocation quotas].
+
+| OCM3026
+| {gcp-short} compute quota limit exceeded.
+| Increase your CPU compute quota and retry cluster installation.
+
+For more information about the CPU compute quota, see link:https://cloud.google.com/compute/quotas-limits[Compute Engine quota and limits overview].
+
+| OCM3027
+| {gcp-short} service account quota limit exceeded.
+| Ensure your quota allows for additional unused service accounts. Check your current usage for quotas in your {gcp-short} account and try again.
+
+For more information about managing your quotas, see link:https://cloud.google.com/docs/quotas/view-manage#managing_your_quota_console[Manage your quotas using the console].
+
+|===

--- a/support/troubleshooting/troubleshooting-osd-gcp-cluster-deployment.adoc
+++ b/support/troubleshooting/troubleshooting-osd-gcp-cluster-deployment.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="troubleshooting-osd-gcp-cluster-deployment"]
+= Troubleshooting an {product-title} on GCP cluster deployment
+include::_attributes/common-attributes.adoc[]
+:context: troubleshooting-osd-gcp-cluster-deployment
+
+toc::[]
+
+{product-title} on {gcp-first} cluster deployment errors can occur for several reasons, including insufficient quota limits and settings, incorrectly inputted data, incompatible configurations, and so on.
+
+Learn how to resolve common {product-title} on {gcp-short} cluster installation errors in the following sections.
+
+include::modules/osd-on-gcp-troubleshoot-cluster-install.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about {product-title} on {gcp-short} instance types, see xref:../../osd_architecture/osd_policy/osd-service-definition.adoc#gcp-compute-types_osd-service-definition[Google Cloud instance types].
+
+


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-14586](https://issues.redhat.com/browse/OSDOCS-14586)

Link to docs preview:
[Troubleshooting an OpenShift Dedicated cluster on GCP deployment](https://94443--ocpdocs-pr.netlify.app/openshift-dedicated/latest/support/troubleshooting/troubleshooting-osd-gcp-cluster-deployment.html)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- QE approval is not required to merge this PR as there are no procedures to be verified.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
