### PR TITLE
TELCODOCS-2342: Fixes for hub cluster 4.18 and later

### DIFF
--- a/modules/telco-hub-architecture-overview.adoc
+++ b/modules/telco-hub-architecture-overview.adoc
@@ -19,11 +19,11 @@ You can control the timing and progression of the rollout across the fleet.
 Monitoring::
 +
 --
-The hub cluster provides monitoring and status reporting for the managed clusters through the Observability pillar of the {rh-rhacm-full} Operator.
+The hub cluster provides monitoring and status reporting for the managed clusters through the Observability pillar of the {rh-rhacm} Operator.
 This includes aggregated metrics, alerts, and compliance monitoring through the Governance policy framework.
 --
 
-The telco management hub reference design specifications (RDS) and the associated reference custom resources (CRs) describe the telco engineering and QE validated method for deploying, configuring and managing the lifecycle of telco managed cluster infrastructure.
+The telco management hub reference design specification (RDS) and the associated reference custom resources (CRs) describe the telco engineering and QE validated method for deploying, configuring and managing the lifecycle of telco managed cluster infrastructure.
 The reference configuration includes the installation and configuration of the hub cluster components on top of {product-title}.
 
 

--- a/modules/telco-hub-hub-cluster-openshift-deployment.adoc
+++ b/modules/telco-hub-hub-cluster-openshift-deployment.adoc
@@ -9,7 +9,7 @@ The reference method for installing {product-title} for the hub cluster is throu
 
 Agent-based Installer provides installation capabilities without additional centralized infrastructure.
 The Agent-based Installer creates an ISO image, which you mount to the server to be installed.
-When you boot the server, {product-title} is installed alongside optionally supplied extra manifests, such as {ztp} custom resources.
+When you boot the server, {product-title} is installed alongside optionally supplied extra manifests, such as the {gitops-title} Operator.
 
 [NOTE]
 ====
@@ -31,8 +31,7 @@ You can also add the reference configuration to the Git repository and apply it 
 
 [NOTE]
 ====
-If applying manually the CRs manually, take care to apply the CRs in the order indicated by the ArgoCD wave annotations.
-Any CRs without annotations are in the initial wave.
+If you apply the CRs manually, ensure you apply the CRs in the order of their dependencies. For example, apply namespaces before Operators and apply Operators before configurations.
 ====
 --
 
@@ -46,7 +45,3 @@ Engineering considerations::
 You apply Day 2 Operators and other configuration CRs after the cluster is installed.
 * The reference configuration supports Agent-based Installer installation in a disconnected environment.
 * A limited set of additional manifests can be supplied at installation time.
-* Any `MachineConfiguration` CRs you require should be included as extra manifests during installation.
-
-
-

--- a/modules/telco-hub-managed-cluster-updates-and-upgrades.adoc
+++ b/modules/telco-hub-managed-cluster-updates-and-upgrades.adoc
@@ -25,7 +25,7 @@ IBU uses an OCI image generated from a dedicated seed cluster to install {sno} o
 --
 
 Limits and requirements::
-* You can perform direct upgrades for {sno} clusters using image-based upgrade for {product-title} <4.y> to `<4.y+2>`, and `<4.y.z>` to `<4.y.z+n>`.
+* You can perform direct upgrades for {sno} clusters using image-based upgrade for {product-title} `<4.y>` to `<4.y+2>`, and `<4.y.z>` to `<4.y.z+n>`.
 * Image-based upgrade uses custom images that are specific to the hardware platform that the clusters are running on.
 Different hardware platforms require separate seed images.
 

--- a/modules/telco-hub-resource-utilization.adoc
+++ b/modules/telco-hub-resource-utilization.adoc
@@ -2,16 +2,18 @@
 [id="telco-hub-resource-utilization_{context}"]
 = Hub cluster resource utilization
 
-Resource utilization was measured for hub clusters in the following scenario:
+Resource utilization was measured for deploying hub clusters in the following scenario:
 
 * Under reference load managing 3500 {sno} clusters.
 * 3-node compact cluster for management hub running on dual socket bare-metal servers.
 * Network impairment of 50 ms round-trip latency, 100 Mbps bandwidth limit and 0.02% packet loss.
+* Observability was not enabled.
+* Only local storage was used.
 
 .Resource utilization values
 [options="header"]
 |====
 |Metric |Peak Measurement
-|OpenShift Platform CPU |106 cores (52 cores per node)
-|OpenShift Platform memory |504 G (168 G per node)
+|OpenShift Platform CPU |106 cores (52 cores peak per node)
+|OpenShift Platform memory |504 G (168 G peak per node)
 |====

--- a/scalability_and_performance/telco-hub-rds.adoc
+++ b/scalability_and_performance/telco-hub-rds.adoc
@@ -1,13 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 :telco-hub:
 [id="telco-hub-ref-design-specs"]
-= Telco hub reference design specifications
+= Telco hub reference design specification
 include::_attributes/common-attributes.adoc[]
 :context: telco-hub
 
 toc::[]
 
-The telco hub reference design specifications (RDS) describes the configuration for a hub cluster that deploys and operates fleets of {product-title} clusters in a telco environment.
+The telco hub reference design specification (RDS) describes the configuration for a hub cluster that deploys and operates fleets of {product-title} clusters in a telco environment.
 
 :FeatureName: The telco hub RDS
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
[TELCODOCS-2342](https://issues.redhat.com//browse/TELCODOCS-2342): Fixes for hub cluster 4.18 and later

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2342

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
