### PR TITLE
MTC documentation needs to update the deprecated command

### DIFF
--- a/modules/migration-migrating-applications-api.adoc
+++ b/modules/migration-migrating-applications-api.adoc
@@ -45,7 +45,7 @@ EOF
 +
 [source,terminal]
 ----
-$ oc sa get-token migration-controller -n openshift-migration | base64 -w 0
+$ oc create token migration-controller -n openshift-migration | base64 -w 0
 ----
 
 . Create a `MigCluster` CR manifest for each remote cluster:


### PR DESCRIPTION
Previously the document had deprecated command `oc sa get-token migration-controller -n openshift-migration | base64 -w ` which resulted in  following:
`oc sa get-token` command has been deprecated and one should use `oc create token` command instead.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[MIG-1681](https://issues.redhat.com/browse/MIG-1681)


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16 + 

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
MTC documentation needs to update the deprecated command

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
