### PR TITLE
OSDOCS-13484: Adds 4.19 Cluster API feature introduction

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -602,6 +602,14 @@ For more information about the MCO certificates, see xref:../security/certificat
 [id="ocp-release-notes-machine-management_{context}"]
 === Machine management
 
+[id="ocp-4-19-capi-mapi-migration_{context}"]
+==== Migrating resources between the Cluster API and the Machine API (Technology Preview)
+
+With this release, you can migrate some resources between the Cluster API and the Machine API on supported platforms as a Technology Preview feature.
+For more information, see xref:../machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc#capi-mapi-migration-overview_cluster-api-getting-started[Migrating Machine API resources to Cluster API resources].
+
+To support this capability, the {product-title} Cluster API documentation now includes additional configuration details for xref:../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-bare-metal.html#cluster-api-supported-features-bare-metal_cluster-api-config-options-bare-metal[bare metal] and xref:../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.html#cluster-api-supported-features-aws_cluster-api-config-options-aws[{aws-full}] clusters.
+
 [id="ocp-4-19-cpms-prefix_{context}"]
 ==== Custom prefixes for control plane machine names
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13484](https://issues.redhat.com//browse/OSDOCS-13484)

Link to docs preview:
https://94462--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-machine-management_release-notes

QE review:
- [x] QE has approved this change.

Additional information:
xrefs blocked by
#93633 
#94127 

Split non-CAPI related features off into #94590 so that they can merge.

Peer review: please check this content with the knowledge that anchors in the linked pages aren't yet merged. I would like to get any editorial feedback in so it's otherwise ready to go :nerd_face: 