### PR TITLE
TELCODOCS-2284: Updates for 4.19 hub cluster with GA support

### DIFF
--- a/modules/telco-hub-gitops-operator-and-ztp-plugins.adoc
+++ b/modules/telco-hub-gitops-operator-and-ztp-plugins.adoc
@@ -19,8 +19,6 @@ To maintain multiple per-version policies simultaneously, use Git to manage the 
 
 
 Limits and requirements::
-* 300 single node `SiteConfig` CRs can be synchronized for each ArgoCD application.
-You can use multiple applications to achieve the maximum number of clusters supported by a single hub cluster.
 * To ensure consistent and complete cleanup of managed clusters and their associated resources during cluster or node deletion, you must configure ArgoCD to use background deletion mode.
 
 Engineering considerations::

--- a/modules/telco-hub-scaling-targets.adoc
+++ b/modules/telco-hub-scaling-targets.adoc
@@ -19,6 +19,9 @@ The reference configuration is also validated for deployment and management of a
 The specific limits depend on the mix of cluster topologies, enabled {rh-rhacm} features, and so on.
 In a mixed topology scenario, the reference hub configuration is validated with a combination of 1200 {sno} clusters, 400 compact clusters (3 nodes combined control plane and compute nodes), and 230 standard clusters (3 control plane and 2 worker nodes).
 
+A hub cluster conforming to this reference specification can support synchronization of 1000 single-node `ClusterInstance` CRs for each ArgoCD application.
+You can use multiple applications to achieve the maximum number of clusters supported by a single hub cluster.
+
 [NOTE]
 ====
 Specific dimensioning requirements are highly dependent on the cluster topology and workload.

--- a/modules/telco-hub-software-stack.adoc
+++ b/modules/telco-hub-software-stack.adoc
@@ -15,10 +15,10 @@ The telco hub {product-version} solution has been validated using the following 
 |Component |Software version
 
 |{product-title}
-|4.18
+|4.19
 
 |Local Storage Operator
-|4.18
+|4.19
 
 |{odf-first}
 |4.18
@@ -27,16 +27,16 @@ The telco hub {product-version} solution has been validated using the following 
 |2.13
 
 |{gitops-title}
-|1.15
+|1.16
 
 |{ztp-first} plugins
-|4.18
+|4.19
 
 |{mce-short} PolicyGenerator plugin
 |2.12
 
 |{cgu-operator-first}
-|4.18
+|4.19
 
 |Cluster Logging Operator
 |6.2

--- a/scalability_and_performance/telco-hub-rds.adoc
+++ b/scalability_and_performance/telco-hub-rds.adoc
@@ -9,9 +9,6 @@ toc::[]
 
 The telco hub reference design specifications (RDS) describes the configuration for a hub cluster that deploys and operates fleets of {product-title} clusters in a telco environment.
 
-:FeatureName: The telco hub RDS
-include::snippets/technology-preview.adoc[]
-
 include::modules/telco-ran-core-ref-design-spec.adoc[leveloffset=+1]
 
 include::modules/telco-deviations-from-the-ref-design.adoc[leveloffset=+1]
@@ -222,7 +219,7 @@ include::modules/telco-hub-oadp-operator.adoc[leveloffset=+2]
 [id="telco-yaml-reference_{context}"]
 == Hub cluster reference configuration CRs
 
-The following is the complete YAML reference of all the custom resources (CRs) for the telco management hub reference configuration in 4.18.
+The following is the complete YAML reference of all the custom resources (CRs) for the telco management hub reference configuration in 4.19.
 
 [id="telco-hub-rhacm-ref-crs_{context}"]
 === {rh-rhacm} reference YAML


### PR DESCRIPTION
[TELCODOCS-2284](https://issues.redhat.com//browse/TELCODOCS-2284): Updates for 4.19 hub cluster with GA support

This bumps the software versions. 
Adds content based on the upstream [MR](https://gitlab.cee.redhat.com/reference-configurations/reference-design-specifications/-/merge_requests/91).
Bumps instances of 4.18 to 4.19.
Removes TP note

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2284

Link to docs preview:
- https://94468--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html#telco-hub-software-stack_telco-hub
- https://94468--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html#telco-hub-scaling-targets_telco-hub
- https://94468--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html#telco-hub-gitops-operator-and-ztp-plugins_telco-hub
- https://94468--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html#telco-yaml-reference_telco-hub

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

