### PR TITLE
CNV-55964: Right-click VM operation in the tree view

### DIFF
--- a/modules/virt-cloning-vm-web.adoc
+++ b/modules/virt-cloning-vm-web.adoc
@@ -13,6 +13,8 @@ You can clone an existing VM by using the web console.
 . Navigate to *Virtualization* -> *VirtualMachines* in the web console.
 . Select a VM to open the *VirtualMachine details* page.
 . Click *Actions*.
++
+Alternatively, access the same menu in the tree view by right-clicking the VM.
 . Select *Clone*.
 . On the *Clone VirtualMachine* page, enter the name of the new VM.
 . (Optional) Select the *Start cloned VM* checkbox to start the cloned VM.

--- a/modules/virt-controlling-multiple-vms.adoc
+++ b/modules/virt-controlling-multiple-vms.adoc
@@ -14,3 +14,5 @@ You can start, stop, restart, pause, and unpause multiple virtual machines from 
 . Optional: To limit the number of displayed virtual machines, select a relevant project from the *Projects* list.
 . Select a checkbox next to the virtual machines you want to work with. To select all virtual machines, click the checkbox in the *VirtualMachines* table header.
 . Click *Actions* and select the intended action from the menu.
++
+Alternatively, change the state of all VMs in a project by right-clicking the project in the tree view and selecting the intended command from the pop-up menu.

--- a/modules/virt-creating-vm-snapshot-web.adoc
+++ b/modules/virt-creating-vm-snapshot-web.adoc
@@ -22,6 +22,8 @@ You can create a snapshot of a virtual machine (VM) by using the {product-title}
 . Navigate to *Virtualization* -> *VirtualMachines* in the web console.
 . Select a VM to open the *VirtualMachine details* page.
 . Click the *Snapshots* tab and then click *Take Snapshot*.
++
+Alternatively, right-click the VM and select *Create snapshot* from the pop-up menu.
 . Enter the snapshot name.
 . Expand *Disks included in this Snapshot* to see the storage volumes to be included in the snapshot.
 . If your VM has disks that cannot be included in the snapshot and you wish to proceed, select *I am aware of this warning and wish to proceed*.

--- a/modules/virt-delete-vm-web.adoc
+++ b/modules/virt-delete-vm-web.adoc
@@ -23,9 +23,11 @@ If the VM is delete protected, the *Delete* action is disabled in the VM's *Acti
 
     * For a general view, navigate to *Virtualization* → *VirtualMachines*.
 
-. Click the *Actions* menu {kebab} beside a VM and select *Delete*.
+. Click the *Options* menu {kebab} beside a VM and select *Delete*.
 +
 Alternatively, click the VM's name to open the *VirtualMachine details* page and click *Actions* -> *Delete*.
++
+You can also right-click the VM in the tree view and select *Delete* from the pop-up menu.
 
 . Optional: Select *With grace period* or clear *Delete disks*.
 

--- a/modules/virt-migrating-storage-class-ui.adoc
+++ b/modules/virt-migrating-storage-class-ui.adoc
@@ -31,6 +31,8 @@ include::snippets/technology-preview.adoc[]
 . Click the Options menu {kebab} beside the virtual machine and select *Migration* -> *Storage*.
 +
 You can also access this option from the *VirtualMachine details* page by selecting *Actions* -> *Migration* -> *Storage*.
++
+Alternatively, right-click the VM in the tree view and select *Migration* from the pop-up menu.
 . On the *Migration details* page, choose whether to migrate the entire VM storage or selected volumes only. If you click *Selected volumes*, select any disks that you intend to migrate. Click *Next* to proceed.
 . From the list of available options on the *Destination StorageClass* page, select the storage class to migrate to. Click *Next* to proceed.
 . On the *Review* page, review the list of affected disks and the target storage class. To start the migration, click *Migrate VirtualMachine storage*.

--- a/virt/managing_vms/virt-accessing-vm-ssh.adoc
+++ b/virt/managing_vms/virt-accessing-vm-ssh.adoc
@@ -91,6 +91,8 @@ include::modules/virt-using-virtctl-ssh-command.adoc[leveloffset=+2]
 [TIP]
 ====
 You can copy the `virtctl ssh` command in the web console by selecting *Copy SSH command* from the options {kebab} menu beside a VM on the *VirtualMachines* page.
+
+Alternatively, right-click the VM in the tree view and select *Copy SSH command* from the pop-up menu to copy the `virtctl ssh` command.
 ====
 
 include::modules/virt-using-virtctl-port-forward-command.adoc[leveloffset=+1]


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-55964

CNV 4.19+
OCP 4.19+

Preview:
https://94476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-controlling-vm-states#virt-controlling-multiple-vms-web_virt-controlling-vm-states
https://94476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-delete-vms#virt-delete-vm-web_virt-delete-vms
https://94476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vms_advanced/creating_vms_advanced_web/virt-cloning-vms#virt-cloning-vm-snapshot_virt-cloning-vms
https://94476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-snapshots#virt-creating-vm-snapshot-web_virt-backup-restore-snapshots
https://94476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-accessing-vm-ssh#virt-using-virtctl-ssh-command_virt-accessing-vm-ssh
