### PR TITLE
CNV-58547_2: Release Notes: UI - Bulk Storage Class Migration within a single cluster

### DIFF
--- a/virt/release_notes/virt-4-19-release-notes.adoc
+++ b/virt/release_notes/virt-4-19-release-notes.adoc
@@ -96,6 +96,9 @@ As a cluster administrator, you can prevent users from enabling VM delete protec
 //CNV-55497 Doc: PVC source support for DataImportCron
 * You can now use a PVC as the source of a custom `DataImportCron` in the `dataImportCronTemplates` section of the `HyperConverged` custom resource (CR). See xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates] for more information.
 
+//CNV-58547 UI - Bulk Storage Class Migration within a single cluster
+* By using the {product-title} web console, you can now xref:../../virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.adoc#virt-migrating-bulk-vms-different-storage-class-web_virt-migrating-vms-in-single-cluster-to-different-storage-class[migrate VMs in bulk from one storage class to another storage class].
+
 
 [id="virt-4-19-web_{context}"]
 === Web console


### PR DESCRIPTION
Version(s): 4.19

Issue: [CNV-58547](https://issues.redhat.com//browse/CNV-58547)

Link to docs preview: in [Storage ](https://94479--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-19-release-notes.html#virt-4-19-storage_virt-4-19-release-notes) section

QE review:
- [x] QE has approved this change.

Additional information: This PR covers the bulk migration release note for both [CNV-58547](https://issues.redhat.com//browse/CNV-58547) (UI - Bulk Storage Class Migration within a single cluster) and [CNV-57712](https://issues.redhat.com/browse/CNV-57712) (Release note: NEW bulk storage class migration of VMs ). 
