### PR TITLE
OSDOCS#14859: Update the z-stream RN for 4.18.17

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3017,6 +3017,34 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.17
+[id="ocp-4-18-17_{context}"]
+=== RHSA-2025:8560 - {product-title} {product-version}.17 bug fix and security update
+
+Issued: 10 June 2025
+
+{product-title} release {product-version}.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:8560[RHSA-2025:8560] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:8561[RHBA-2025:8561] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.17 --pullspecs
+----
+
+[id="ocp-4-18-17-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, a {sno} deployment on {product-title} 4.11 failed on a {rh-openstack-first} provider because of an unsupported installation on the platform. With this release, {sno} deployments support installations on {rh-openstack}, which enhances installation flexibility. (link:https://issues.redhat.com/browse/OCPBUGS-56864[OCPBUGS-56864])
+
+* Previously, the `disk2mirror` process did not display logs during the cache registry population, which caused an incomplete process. With this release, the working and cache directories are verified before adding the  extracted mirror archives. This update improves visibility during the `disk2mirror` process and reduces user uncertainty about an incomplete process. (link:https://issues.redhat.com/browse/OCPBUGS-56659[OCPBUGS-56659])
+
+[id="ocp-4-18-17-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.16
 [id="ocp-4-18-16_{context}"]
 === RHSA-2025:8284 - {product-title} {product-version}.16 bug fix update


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-14859](https://issues.redhat.com//browse/OSDOCS-14859)

Link to docs preview:
[4.18.17](https://94492--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-17_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream release notes

Additional information:
The errata URLs will return 404 until the go-live date of 6/10/25.
