### PR TITLE
WMCO hiding 4.19.0 docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -867,8 +867,8 @@ Topics:
     File: troubleshooting-s2i
   - Name: Troubleshooting storage issues
     File: troubleshooting-storage-issues
-  - Name: Troubleshooting Windows container workload issues
-    File: troubleshooting-windows-container-workload-issues
+#  - Name: Troubleshooting Windows container workload issues
+#    File: troubleshooting-windows-container-workload-issues
   - Name: Investigating monitoring issues
     File: investigating-monitoring-issues
   - Name: Diagnosing OpenShift CLI (oc) issues
@@ -2817,47 +2817,47 @@ Distros: openshift-origin,openshift-enterprise
 Topics:
 - Name: Red Hat OpenShift support for Windows Containers overview
   File: index
-- Name: Release notes
-  Dir: wmco_rn
-  Topics:
-  - Name: Red Hat OpenShift support for Windows Containers release notes
-    File: windows-containers-release-notes-10-17-x
-  - Name: Past releases
-    File: windows-containers-release-notes-10-17-x-past
-  - Name: Windows Machine Config Operator prerequisites
-    File: windows-containers-release-notes-10-17-x-prereqs
-  - Name: Windows Machine Config Operator known limitations
-    File: windows-containers-release-notes-10-17-x-limitations
-- Name: Getting support
-  File: windows-containers-support
-  Distros: openshift-enterprise
-- Name: Understanding Windows container workloads
-  File: understanding-windows-container-workloads
-- Name: Enabling Windows container workloads
-  File: enabling-windows-container-workloads
-- Name: Creating Windows machine sets
-  Dir: creating_windows_machinesets
-  Topics:
-  - Name: Creating a Windows machine set on AWS
-    File: creating-windows-machineset-aws
-  - Name: Creating a Windows machine set on Azure
-    File: creating-windows-machineset-azure
-  - Name: Creating a Windows machine set on GCP
-    File: creating-windows-machineset-gcp
-  - Name: Creating a Windows machine set on Nutanix
-    File: creating-windows-machineset-nutanix
-  - Name: Creating a Windows machine set on vSphere
-    File: creating-windows-machineset-vsphere
-- Name: Scheduling Windows container workloads
-  File: scheduling-windows-workloads
-- Name: Windows node updates
-  File: windows-node-upgrades
-- Name: Using Bring-Your-Own-Host Windows instances as nodes
-  File: byoh-windows-instance
-- Name: Removing Windows nodes
-  File: removing-windows-nodes
-- Name: Disabling Windows container workloads
-  File: disabling-windows-container-workloads
+#- Name: Release notes
+#  Dir: wmco_rn
+#  Topics:
+#  - Name: Red Hat OpenShift support for Windows Containers release notes
+#    File: windows-containers-release-notes-10-19-x
+#  - Name: Past releases
+#    File: windows-containers-release-notes-10-19-x-past
+#  - Name: Windows Machine Config Operator prerequisites
+#    File: windows-containers-release-notes-10-19-x-prereqs
+#  - Name: Windows Machine Config Operator known limitations
+#    File: windows-containers-release-notes-10-19-x-limitations
+#- Name: Getting support
+#  File: windows-containers-support
+#  Distros: openshift-enterprise
+#- Name: Understanding Windows container workloads
+#  File: understanding-windows-container-workloads
+#- Name: Enabling Windows container workloads
+#  File: enabling-windows-container-workloads
+#- Name: Creating Windows machine sets
+#  Dir: creating_windows_machinesets
+#  Topics:
+#  - Name: Creating a Windows machine set on AWS
+#    File: creating-windows-machineset-aws
+#  - Name: Creating a Windows machine set on Azure
+#    File: creating-windows-machineset-azure
+#  - Name: Creating a Windows machine set on GCP
+#    File: creating-windows-machineset-gcp
+#  - Name: Creating a Windows machine set on Nutanix
+#    File: creating-windows-machineset-nutanix
+#  - Name: Creating a Windows machine set on vSphere
+#    File: creating-windows-machineset-vsphere
+#- Name: Scheduling Windows container workloads
+#  File: scheduling-windows-workloads
+#- Name: Windows node updates
+#  File: windows-node-upgrades
+#- Name: Using Bring-Your-Own-Host Windows instances as nodes
+#  File: byoh-windows-instance
+#- Name: Removing Windows nodes
+#  File: removing-windows-nodes
+#- Name: Disabling Windows container workloads
+#  File: disabling-windows-container-workloads
 ---
 Name: OpenShift sandboxed containers
 Dir: sandboxed_containers

--- a/installing/installing_aws/ipi/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-network-customizations.adoc
@@ -109,11 +109,13 @@ include::modules/nw-aws-nlb-new-cluster.adoc[leveloffset=+1]
 
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-
+////
+Hiding until WMCO 10.19.0 GAs
 [NOTE]
 ====
-For more information about using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information about using Linux and Windows nodes in the same cluster, see ../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
+////
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/ipi/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/ipi/installing-azure-network-customizations.adoc
@@ -46,11 +46,13 @@ include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-
+////
+Hiding until WMCO 10.19.0 GAs
 [NOTE]
 ====
-For more information about using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information about using Linux and Windows nodes in the same cluster, see ../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
+////
 
 [role="_additional-resources"]
 .Additional resources

--- a/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.adoc
@@ -50,12 +50,13 @@ include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-
+////
+Hiding until WMCO 10.19.0 GAs
 [NOTE]
 ====
-For more information about using Linux and Windows nodes in the same cluster, see xref:../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
+For more information about using Linux and Windows nodes in the same cluster, see ../../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads].
 ====
-
+////
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/overview/installing-preparing.adoc
+++ b/installing/overview/installing-preparing.adoc
@@ -116,7 +116,11 @@ For a production cluster, you must configure the following integrations:
 == Preparing your cluster for workloads
 
 Depending on your workload needs, you might need to take extra steps before you begin deploying applications. For example, after you prepare infrastructure to support your application xref:../../cicd/builds/build-strategies.adoc#build-strategies[build strategy], you might need to make provisions for xref:../../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-low-latency-perf-profile[low-latency] workloads or to xref:../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets[protect sensitive workloads]. You can also configure xref:../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#enabling-monitoring-for-user-defined-projects-uwm_preparing-to-configure-the-monitoring-stack-uwm[monitoring] for application workloads.
-If you plan to run xref:../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Windows workloads], you must enable xref:../../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[hybrid networking with OVN-Kubernetes] during the installation process; hybrid networking cannot be enabled after your cluster is installed.
+
+////
+Hiding until WMCO 10.19.0 GAs
+If you plan to run ../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Windows workloads], you must enable xref:../../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[hybrid networking with OVN-Kubernetes] during the installation process; hybrid networking cannot be enabled after your cluster is installed.
+////
 
 [id="supported-installation-methods-for-different-platforms"]
 == Supported installation methods for different platforms

--- a/modules/configuring-hybrid-ovnkubernetes.adoc
+++ b/modules/configuring-hybrid-ovnkubernetes.adoc
@@ -15,11 +15,139 @@ endif::[]
 
 You can configure your cluster to use hybrid networking with the OVN-Kubernetes network plugin. This allows a hybrid cluster that supports different node networking configurations.
 
+////
+Hiding until WMCO 10.19.0 GAs.  Swap the two sections after WMCO GA.
 [NOTE]
 ====
 This configuration is necessary to run both Linux and Windows nodes in the same cluster.
 ====
+////
 
+ifndef::post-install[]
+.Prerequisites
+
+// Made changes to hide Windows-related material until WMCO 4.19.0 releases. The full procedure is below, commented out.
+
+* You defined `OVNKubernetes` for the `networking.networkType` parameter in the `install-config.yaml` file. See the installation documentation for configuring {product-title} network customizations on your chosen cloud provider for more information.
+
+.Procedure
+
+. Change to the directory that contains the installation program and create the manifests:
++
+[source,terminal]
+----
+$ ./openshift-install create manifests --dir <installation_directory>
+----
++
+--
+where:
+
+`<installation_directory>`:: Specifies the name of the directory that contains the `install-config.yaml` file for your cluster.
+--
+
+. Create a stub manifest file for the advanced network configuration that is named `cluster-network-03-config.yml` in the `<installation_directory>/manifests/` directory:
++
+[source,terminal]
+----
+$ cat <<EOF > <installation_directory>/manifests/cluster-network-03-config.yml
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+EOF
+----
++
+--
+where:
+
+`<installation_directory>`:: Specifies the directory name that contains the
+`manifests/` directory for your cluster.
+--
+
+. Open the `cluster-network-03-config.yml` file in an editor and configure OVN-Kubernetes with hybrid networking, as in the following example:
++
+--
+.Specify a hybrid networking configuration
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      hybridOverlayConfig:
+        hybridClusterNetwork: <1>
+        - cidr: 10.132.0.0/14
+          hostPrefix: 23
+----
+<1> Specify the CIDR configuration used for nodes on the additional overlay network. The `hybridClusterNetwork` CIDR must not overlap with the `clusterNetwork` CIDR.
+--
+
+. Save the `cluster-network-03-config.yml` file and quit the text editor.
+. Optional: Back up the `manifests/cluster-network-03-config.yml` file. The
+installation program deletes the `manifests/` directory when creating the
+cluster.
+endif::post-install[]
+ifdef::post-install[]
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in to the cluster as a user with `cluster-admin` privileges.
+* Ensure that the cluster uses the OVN-Kubernetes network plugin.
+
+.Procedure
+
+
+. To configure the OVN-Kubernetes hybrid network overlay, enter the following command:
++
+[source,terminal]
+----
+$ oc patch networks.operator.openshift.io cluster --type=merge \
+  -p '{
+    "spec":{
+      "defaultNetwork":{
+        "ovnKubernetesConfig":{
+          "hybridOverlayConfig":{
+            "hybridClusterNetwork":[
+              {
+                "cidr": "<cidr>",
+                "hostPrefix": <prefix>
+              }
+            ]
+          }
+        }
+      }
+    }
+  }'
+----
++
+--
+where:
+
+`cidr`:: Specify the CIDR configuration used for nodes on the additional overlay network. This CIDR must not overlap with the cluster network CIDR.
+`hostPrefix`:: Specifies the subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
+--
++
+.Example output
+[source,text]
+----
+network.operator.openshift.io/cluster patched
+----
+
+. To confirm that the configuration is active, enter the following command. It can take several minutes for the update to apply.
++
+[source,terminal]
+----
+$ oc get network.operator.openshift.io -o jsonpath="{.items[0].spec.defaultNetwork.ovnKubernetesConfig}"
+----
+
+endif::post-install[]
+
+////
+Hiding until WMCO 10.19.0 GAs. Swap the two sections after WMCO GA.
 ifndef::post-install[]
 .Prerequisites
 
@@ -102,6 +230,7 @@ ifdef::post-install[]
 
 .Procedure
 
+
 . To configure the OVN-Kubernetes hybrid network overlay, enter the following command:
 +
 [source,terminal]
@@ -152,6 +281,7 @@ network.operator.openshift.io/cluster patched
 $ oc get network.operator.openshift.io -o jsonpath="{.items[0].spec.defaultNetwork.ovnKubernetesConfig}"
 ----
 endif::post-install[]
+////
 
 ifdef::post-install[]
 :!post-install:

--- a/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
@@ -14,7 +14,10 @@ include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 [id="configuring-hybrid-networking-additional-resources"]
 == Additional resources
 
-* xref:../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads]
-* xref:../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Enabling Windows container workloads]
+////
+Hiding until WMCO 10.19.0 GAs
+* ../../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads[Understanding Windows container workloads]
+* ../../windows_containers/enabling-windows-container-workloads.adoc#enabling-windows-container-workloads[Enabling Windows container workloads]
+////
 * xref:../../installing/installing_aws/ipi/installing-aws-network-customizations.adoc#installing-aws-network-customizations[Installing a cluster on AWS with network customizations]
 * xref:../../installing/installing_azure/ipi/installing-azure-network-customizations.adoc#installing-azure-network-customizations[Installing a cluster on Azure with network customizations]

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -172,10 +172,13 @@ a|* xref:../networking/networking_operators/cluster-network-operator.adoc#nw-clu
 | xref:../operators/understanding/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[Manage Operators]
 | xref:../operators/user/olm-creating-apps-from-installed-operators.adoc#olm-creating-apps-from-installed-operators[Creating applications from installed Operators]
 
-| xref:../windows_containers/index.adoc#index[{productwinc} overview]
-| xref:../windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads_understanding-windows-container-workloads[Understanding Windows container workloads]
-
 |===
+
+//// 
+Hiding until WMCO 10.19.0 releases, replace as the last row of the above table after WMCO GAs
+| xref:../windows_containers/index.adoc#index[{productwinc} overview]
+| windows_containers/understanding-windows-container-workloads.adoc#understanding-windows-container-workloads_understanding-windows-container-workloads[Understanding Windows container workloads]
+////
 
 [discrete]
 ==== Changing cluster components

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,7 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.adoc#windows-containers-release-notes-10-17-x[release notes].
+
+Documentation for {productwinc} is planned to be available for {product-title} {product-version} in the near future.
+
+////
+Hiding until WMCO 10.19.0 GAs
+{productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/wmco_rn/windows-containers-release-notes-10-19-x.adoc#windows-containers-release-notes-10-19-x[release notes].
 
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
 
@@ -33,7 +38,4 @@ You can xref:../windows_containers/disabling-windows-container-workloads.adoc#di
 
 * Uninstalling the Windows Machine Config Operator
 * Deleting the Windows Machine Config Operator namespace
-
-////
-Documentation for {productwinc} will be available for {product-title} {product-version} in the near future.
 ////


### PR DESCRIPTION
The WMCO version 4.19.0 will not be ready for OCP 4.19.0 GA release. This PR hides the WMCO docs, except for the index.adoc assembly, but with wording explaining the absence of the rest of the doc set. Also, hiding other Windows references and links into the WMCO docs. 

Windows -- Windows book is after Nodes. Hiding all but Red Hat OpenShift support for Windows Containers overview (index.html). Added text to index that the WMCO docs not available.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/windows_container_support_for_openshift/windows-container-overview)
[Updated docs](https://94522--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/)

Installing preparing -> Preparing your cluster for workloads -> Preparing your cluster for workloads -> If you plan to run Windows workloads paragraph hidden
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/installation_overview/installing-preparing#installing-preparing-cluster-for-workloads)
[Updated docs](https://94522--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/installing-preparing#installing-preparing-cluster-for-workloads)

--------
For the [configuring-hybrid-ovnkubernetes.adoc](https://github.com/openshift/openshift-docs/pull/88987/files#diff-7ad795770aa1997333ecebb522fcf6b4786241523796c479a832d542b98f4bcf) module, I need to hide some Windows-related details in the two procedures. However, commenting-out information within steps in the procedure caused issues. I copied the two procedures and manually removed the details. The original steps are commented-out below. **NO NEED TO READ THE NEW STEPS** in the following 4 previews. Just want to make sure everything looks OK. 

The files is used in the following assemblies:

Installing a cluster on AWS with network customizations -> Configuring hybrid networking with OVN-Kubernetes - Note after first paragraph and note at end hidden. The `hybridOverlayVXLANPort: 9898` and call-out text hidden.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/installing_on_aws/installer-provisioned-infrastructure#configuring-hybrid-ovnkubernetes_installing-aws-network-customizations)
[Updated docs](https://94522--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-network-customizations#configuring-hybrid-ovnkubernetes_installing-aws-network-customizations)

Installing a cluster on Azure with network customizations -> Configuring hybrid networking with OVN-Kubernetes -> Note after first paragraph and note at end hidden. The `hybridOverlayVXLANPort: 9898` and call-out text hidden.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/installing_on_azure/installer-provisioned-infrastructure#configuring-hybrid-ovnkubernetes_installing-azure-network-customizations)
[Updated docs](https://94522--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-network-customizations#configuring-hybrid-ovnkubernetes_installing-azure-network-customizations)

Installing a cluster on Azure Stack Hub with network customizations -> Configuring hybrid networking with OVN-Kubernetes -> Note after first paragraph and note at end hidden. The `hybridOverlayVXLANPort: 9898` and call-out text hidden.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/installing_on_azure_stack_hub/installer-provisioned-infrastructure#configuring-hybrid-ovnkubernetes_installing-azure-stack-hub-network-customizations)
[Updated docs](https://94522--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations#configuring-hybrid-ovnkubernetes_installing-azure-stack-hub-network-customizations)

Networking -> OVN-Kubernetes network plugin ->  Configuring hybrid networking - Note after first paragraph hidden. The `hybridOverlayVXLANPort: 9898` and call-out text hidden.
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking/ovn-kubernetes-network-plugin#configuring-hybrid-networking)
[Updated docs](https://94522--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking#configuring-hybrid-ovnkubernetes_configuring-hybrid-networking)

Networking -> OVN -> Configuring hybrid networking -> Additional resources -> Removed two bullets
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking/ovn-kubernetes-network-plugin#configuring-hybrid-networking)
[Updated docs](https://94522--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking#configuring-hybrid-networking-additional-resources)

--------
**REVIEW AS USUAL**

Troubleshooting Windows container workload issues -- Assembly hidden
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/support/troubleshooting#troubleshooting-windows-container-workload-issues)
[Updated docs](https://94522--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-storage-issues)

About -> Learn more about OpenShift Container Platform -- Last row of "Managing cluster components" table hidden
[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/about/learn_more_about_openshift#managing-changing-cluster-components)
[Updated docs](https://94522--ocpdocs-pr.netlify.app/openshift-enterprise/latest/welcome/learn_more_about_openshift#managing-changing-cluster-components)
