### PR TITLE
OSDOCS-14732-2: Updates GitOps version MicroShift 4.15-4.16

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -11,6 +11,8 @@
 :product-registry: OpenShift image registry
 :product-version: 4.16
 :rhel-major: rhel-9
+//gitops version for 4.14-4.16
+:gitops-ver: 1.16
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
 :op-system-base: RHEL
 :op-system-ostree-first: Red Hat Enterprise Linux for Edge (RHEL for Edge)

--- a/modules/microshift-install-rpms-gitops.adoc
+++ b/modules/microshift-install-rpms-gitops.adoc
@@ -6,25 +6,25 @@
 [id="microshift-installing-rpms-for-gitops_{context}"]
 = Installing the GitOps Argo CD manifests from an RPM package
 
-You can use a lightweight version of OpenShift GitOps with {microshift-short} to help manage your applications. Install the necessary Argo CD manifests using an RPM package. This RPM package included the necessary manifests that runs core Argo CD.
+You can use a lightweight version of OpenShift GitOps with {microshift-short} to help manage your applications by installing the `microshift-gitops` RPM package. The `microshift-gitops` RPM package includes the manifests required to run core Argo CD.
 
 [IMPORTANT]
 ====
-This process installs the basic GitOps functionalities. The Argo CD CLI is not available on {microshift-short}.
+The Argo CD CLI is not available on {microshift-short}. This process installs basic GitOps functions.
 ====
 
 .Prerequisites
 
-* You installed {microshift-short} version 4.14 or higher
-* Additional RAM storage of 250MB recommended
+* You installed {microshift-short} version 4.14 or newer.
+* You configured 250MB of additional RAM.
 
 .Procedure
 
 . Enable the GitOps repository with the subscription manager by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ sudo subscription-manager repos --enable=gitops-1.12-for-rhel-9-$(uname -m)-rpms
+$ sudo subscription-manager repos --enable=gitops-{gitops-ver}-for-rhel-9-$(uname -m)-rpms
 ----
 
 . Install the GitOps package by running the following command:
@@ -34,7 +34,7 @@ $ sudo subscription-manager repos --enable=gitops-1.12-for-rhel-9-$(uname -m)-rp
 $ sudo dnf install -y microshift-gitops
 ----
 
-. To deploy Argo CD pods, restart the {microshift-short} service by running the following command:
+. To deploy Argo CD pods, restart {microshift-short} by running the following command:
 +
 [source,terminal]
 ----
@@ -43,7 +43,7 @@ $ sudo systemctl restart microshift
 
 .Verification
 
-* You can verify that your pods are running properly by running the following command:
+* Verify that your pods are running by entering the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.15-4.16 only

Issue:
[OSDOCS-14732](https://issues.redhat.com/browse/OSDOCS-14732)

Link to docs preview:
[microshift-installing-rpms-for-gitops](https://94528--ocpdocs-pr.netlify.app/microshift/latest/microshift_install/microshift-install-rpm#microshift-installing-rpms-for-gitops_microshift-install-rpm)

QE review:
- [x] QE has approved this change.

Additional information:
See also https://github.com/openshift/openshift-docs/pull/94477

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
