### PR TITLE
OSDOCS-14855-2: updates gitops and bootc, MicroShift 4.19 release notes

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -161,7 +161,7 @@ The following release notes are for downstream Red{nbsp}Hat products only; upstr
 //TODO check the latest gitops release version
 [id="microshift-4-19-additional-release-notes-gitops_{context}"]
 === GitOps release notes
-See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.15/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps 1.15: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package, link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
+See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/latest/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package, link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
 
 [id="microshift-4-19-additional-release-notes-ocp_{context}"]
 === {OCP} release notes
@@ -198,6 +198,7 @@ Issued: 17 June 2025
 
 {product-title} release 4.19.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:11040[RHEA-2024:11040] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHEA-2024:11038[RHEA-2024:11038] advisory.
 
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+See the latest images included with {microshift-short} by using the following instructions:
 
-
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-14855](https://issues.redhat.com/browse/OSDOCS-14855)

Link to docs preview:
[GitOps release notes](https://94531--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-additional-release-notes-gitops_release-notes)
[bootc addition to async release notes](https://94531--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-0-dp_release-notes)

QE review:
- [x] QE has approved this change. (See related PRs that are QE'd for this change)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
See https://github.com/openshift/openshift-docs/pull/94340
See https://github.com/openshift/openshift-docs/pull/94477
See https://github.com/openshift/openshift-docs/pull/94340

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
