### PR TITLE
adding Nutanix example for Agent

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -102,8 +102,16 @@ include::modules/agent-install-sample-config-bond-sriov.adoc[leveloffset=+1]
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/configuring-network-bonding_configuring-and-managing-networking[Configuring network bonding]
 
+[id="agent-sample-install-config_{context}"]
+== Sample install-config.yaml files
+
+The following sections describe example `install-config.yaml` files for different platforms, which you can use as a basis for your installation configurations and modify according to your needs.
+
 //Sample install-config.yaml file for bare metal
-include::modules/installation-bare-metal-agent-installer-config-yaml.adoc[leveloffset=+1]
+include::modules/installation-bare-metal-agent-installer-config-yaml.adoc[leveloffset=+2]
+
+//Sample install-config.yaml file for Nutanix
+include::modules/installation-nutanix-agent-installer-config-yaml.adoc[leveloffset=+2]
 
 //Validation checks before agent ISO creation
 include::modules/validations-before-agent-iso-creation.adoc[leveloffset=+1]

--- a/modules/installation-nutanix-agent-installer-config-yaml.adoc
+++ b/modules/installation-nutanix-agent-installer-config-yaml.adoc
@@ -1,0 +1,88 @@
+// Module included in the following assemblies:
+
+// * installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-nutanix-agent-installer-config-yaml_{context}"]
+= Sample install-config.yaml file for Nutanix
+
+You can customize the `install-config.yaml`` file to specify more details about your {product-title} cluster's platform or modify the values of the required parameters.
+
+[IMPORTANT]
+====
+* Installing Nutanix virtual machines (VMs) on {aws-first} is not supported.
+
+* Before you begin an installation, you must change the boot order of all Nutanix VMs to prioritize the disk first.
+====
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: test.metalkube.org <1>
+controlPlane: <2>
+  name: master
+  replicas: 3 <3>
+compute: <2>
+- name: worker
+  replicas: 0 <4>
+metadata:
+  name: nutanix-cluster <5>
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 <6>
+    hostPrefix: 23 <7>
+  networkType: OVNKubernetes <8>
+  machineNetwork:
+  - cidr: 192.168.111.0/24
+  serviceNetwork: <9>
+  - 172.30.0.0/16
+platform:
+  nutanix:
+    apiVips:
+    - 192.168.111.5
+    ingressVips:
+    - 192.168.111.4
+    prismCentral:
+      endpoint:
+        address: pc1.test.metalkube.org
+        port: 9440
+      password: testPassword
+      username: testUser
+    prismElements:
+    - endpoint:
+        address: pe1.test.metalkube.org
+        port: 9440
+      uuid: 00061f7f-44f7-19dc-72gc-7cc25586ee53
+    subnetUUIDs:
+    - a2e46975-2cde-4a49-9dda-815eb4fcd681
+pullSecret: '{"auths": ...}' <10>
+sshKey: 'ssh-rsa AAAA...' <11>
+----
+<1> The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
+<2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
+<3> The number of control plane machines that you add to the cluster. Because the cluster uses these values as the number of etcd endpoints in the cluster, the value must match the number of control plane machines that you deploy.
+<4> This parameter controls the number of compute machines that the Agent-based Installer waits to discover before triggering the installation process. It is the number of compute machines that must be booted with the generated ISO.
++
+[NOTE]
+====
+If you are installing a three-node cluster, do not deploy any compute machines when you install the {op-system-first} machines.
+====
+<5> The cluster name that you specified in your DNS records.
+<6> A block of IP addresses from which pod IP addresses are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the pod network. If you need to access the pods from an external network, you must configure load balancers and routers to manage the traffic.
++
+[NOTE]
+====
+Class E CIDR range is reserved for a future use. To use the Class E CIDR range, you must ensure your networking environment accepts the IP addresses within the Class E CIDR range.
+====
++
+<7> The subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
+<8> The cluster network plugin to install. The default value `OVNKubernetes` is the only supported value.
+<9> The IP address pool to use for service IP addresses. You can enter only one IP address pool. This block must not overlap with existing physical networks. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
+<10> This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<11> The SSH public key for the `core` user in {op-system-first}.
++
+[NOTE]
+====
+For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
+====


### PR DESCRIPTION
Version(s): 4.19+

This PR adds a sample install-config.yaml file for Agent installs on Nutanix

QE review:
- [ ] QE has approved this change.

Preview: [Sample install-config.yaml file for Nutanix](https://94533--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#installation-nutanix-agent-installer-config-yaml_preparing-to-install-with-agent-based-installer)