### PR TITLE
WMCO 4.17 RN add release date

### DIFF
--- a/modules/windows-containers-release-notes-10-17-1.adoc
+++ b/modules/windows-containers-release-notes-10-17-1.adoc
@@ -6,6 +6,8 @@
 [id="windows-containers-release-notes-10-17-1_{context}"]
 = Release notes for Red Hat Windows Machine Config Operator 10.17.1
 
+Issued: 9 June 2025
+
 This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.17.1 were released in link:https://access.redhat.com/errata/RHSA-2025:8704[RHSA-2025:8704].
 
 [id="wmco-10-17-1-new-features"]


### PR DESCRIPTION
Adding the release date to the WMCO 4.17 release notes. 

Preview: [Release notes for Red Hat Windows Machine Config Operator 10.17.1](https://94540--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-17-x.html#windows-containers-release-notes-10-17-1_windows-containers-release-notes) 