### PR TITLE
OSDOCS-14920 Day 2 confidential VM expansion for GCP

### DIFF
--- a/modules/machineset-gcp-confidential-vm.adoc
+++ b/modules/machineset-gcp-confidential-vm.adoc
@@ -18,10 +18,7 @@ For more information about Confidential VM features, functions, and compatibilit
 [NOTE]
 ====
 Confidential VMs are currently not supported on 64-bit ARM architectures.
-====
-[IMPORTANT]
-====
-{product-title} {product-version} does not support some Confidential Compute features, such as Confidential VMs with AMD Secure Encrypted Virtualization Secure Nested Paging (SEV-SNP).
+If you use Confidential VM, you must ensure that you select a supported region. For details on supported regions and configurations, see the GCP Compute Engine documentation about link:https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#supported-zones[supported zones].
 ====
 
 .Procedure
@@ -35,12 +32,7 @@ Confidential VMs are currently not supported on 64-bit ARM architectures.
 ifndef::cpmso[]
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
-endif::cpmso[]
-ifdef::cpmso[]
-apiVersion: machine.openshift.io/v1
-kind: ControlPlaneMachineSet
-endif::cpmso[]
-...
+# ...
 spec:
   template:
     spec:
@@ -49,11 +41,35 @@ spec:
           confidentialCompute: Enabled <1>
           onHostMaintenance: Terminate <2>
           machineType: n2d-standard-8 <3>
-...
+endif::cpmso[]
+ifdef::cpmso[]
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+# ...
+    machines_v1beta1_machine_openshift_io:
+      spec:
+        providerSpec:
+          value:
+            confidentialCompute: Enabled <1>
+            onHostMaintenance: Terminate <2>
+            machineType: n2d-standard-8 <3>
+endif::cpmso[]
+# ...
 ----
-<1> Specify whether Confidential VM is enabled. Valid values are `Disabled` or `Enabled`.
+<1> Specify whether Confidential VM is enabled. The following values are valid:
+
+`Enabled`:: Enables Confidential VM with a default selection of Confidential VM technology. The default selection is AMD Secure Encrypted Virtualization (AMD SEV).
+
+`Disabled`:: Disables Confidential VM.
+
+`AMDEncryptedVirtualization`:: Enables Confidential VM using AMD SEV. AMD SEV supports c2d, n2d, and c3d machines.
+
+`AMDEncryptedVirtualizationNestedPaging`:: Enables Confidential VM using AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP). AMD SEV-SNP supports n2d machines.
+
+`IntelTrustedDomainExtensions`:: Enables Confidential VM using Intel Trusted Domain Extensions (Intel TDX). Intel TDX supports n2d machines.
++
 <2> Specify the behavior of the VM during a host maintenance event, such as a hardware or software update. For a machine that uses Confidential VM, this value must be set to `Terminate`, which stops the VM. Confidential VM does not support live VM migration.
-<3> Specify a machine type that supports Confidential VM. Confidential VM supports the N2D and C2D series of machine types.
+<3> Specify a machine type that supports the Confidential VM option that you specified in the `confidentialCompute` field.
 
 .Verification
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-14920

Link to docs preview:
[Configuring Confidential VM by using machine sets (control plane)](https://94552--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.html#machineset-gcp-confidential-vm_cpmso-config-options-gcp)
[Configuring Confidential VM by using machine sets (compute)](https://94552--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-gcp-confidential-vm_creating-machineset-gcp)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
