### PR TITLE
OSDOCS-14920-RN Updating confidential VMs GCP RN to include day 2

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -481,13 +481,13 @@ For more information, see link:https://azure.microsoft.com/en-us/updates?id=defa
 
 [id="ocp-4-19-installation-and-update-gcp-confidential-computing-expansion_{context}"]
 ==== Additional Confidential Computing platforms for {gcp-short}
-With this release, you can use additional Confidential Computing platforms when installing a cluster on {gcp-short}. The new supported platforms, which can be enabled in the `install-config.yaml` file prior to installation, are as follows:
+With this release, you can use additional Confidential Computing platforms on {gcp-short}. The new supported platforms, which can be enabled in the `install-config.yaml` file prior to installation, or configured after installation using machine sets and control plane machine sets, are as follows:
 
 * `AMDEncryptedVirtualization`, which enables Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV)
 * `AMDEncryptedVirtualizationNestedPaging`, which enables Confidential Computing with AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP)
 * `IntelTrustedDomainExtensions`, which enables Confidential Computing with Intel Trusted Domain Extensions (Intel TDX)
 
-For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-config-parameters-additional-gcp_installation-config-parameters-gcp[Installation configuration parameters for {gcp-full}].
+For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-config-parameters-additional-gcp_installation-config-parameters-gcp[Installation configuration parameters for {gcp-full}], xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc#machineset-gcp-confidential-vm_cpmso-config-options-gcp[Configuring Confidential VM by using machine sets (control plane)], and xref:../machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-gcp-confidential-vm_creating-machineset-gcp[Configuring Confidential VM by using machine sets (compute)].
 
 [id="ocp-4-19-GCP-custom-dns_{context}"]
 ==== Installing a cluster on {gcp-first} with a user-provisioned DNS
@@ -540,11 +540,11 @@ Image mode for OpenShift, formerly called on-cluster layering, is now Generally 
 
 * The `global-pull-secret-copy` is automatically added to the `openshift-machine-config-operator` namespace.
 
-* You can now revert an on-cluster custom layered image back to the base image by removing a label from the `MachineOSConfig` object 
+* You can now revert an on-cluster custom layered image back to the base image by removing a label from the `MachineOSConfig` object
 
-* You can now automatically delete an on-cluster custom layered image by deleting the associated `MachineOSBuild` object. 
+* You can now automatically delete an on-cluster custom layered image by deleting the associated `MachineOSBuild` object.
 
-* The `must-gather` for the Machine Config Operator now includes data on the `MachineOSConfig` and `MachineOSBuild` objects. 
+* The `must-gather` for the Machine Config Operator now includes data on the `MachineOSConfig` and `MachineOSBuild` objects.
 
 * On-cluster layering is now supported in disconnected environments.
 
@@ -553,9 +553,9 @@ Image mode for OpenShift, formerly called on-cluster layering, is now Generally 
 [id="ocp-release-notes-machine-config-operator-boot-image_{context}"]
 ==== Boot image management is now default for {gcp-first} and {aws-first}
 
-The boot image management feature, previously called updated boot images, is now the default behavior in {gcp-first} and {aws-first} clusters. As such, after updating to {product-title} {product-version}, the boot images in your cluster are automatically updated to version {product-version}. With subsequent updates, the Machine Config Operator (MCO) again updates the boot images in your cluster. A boot images is associated with a machine set and is used when scaling new nodes. Any new nodes you create after updating are based on the new version. Current nodes are not affected by this feature. 
+The boot image management feature, previously called updated boot images, is now the default behavior in {gcp-first} and {aws-first} clusters. As such, after updating to {product-title} {product-version}, the boot images in your cluster are automatically updated to version {product-version}. With subsequent updates, the Machine Config Operator (MCO) again updates the boot images in your cluster. A boot images is associated with a machine set and is used when scaling new nodes. Any new nodes you create after updating are based on the new version. Current nodes are not affected by this feature.
 
-Before upgrading to {product-version}, you must opt-out of this default behavior or acknowledge this change before proceeding. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-disable_machine-configs-configure[Disabling boot image management].  
+Before upgrading to {product-version}, you must opt-out of this default behavior or acknowledge this change before proceeding. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-disable_machine-configs-configure[Disabling boot image management].
 
 [NOTE]
 ====
@@ -569,7 +569,7 @@ The MCS signing key is stored in the `machine-config-server-ca` secret in the `o
 
 The MCS CA and MCS cert are valid for 10 years and are automatically rotated by the MCO at approximately 8 years. Upon update to {product-title} {product-version}, the CA signing key is not present. As a result, the CA bundle is immediately considered expired when the MCO certificate controller comes up. This expiration causes an immediate certificate rotation, even if the cluster is not 10 years old. After that point, the next rotation takes place at the standard 8 year period.
 
-For more information about the MCO certificates, see xref:../security/certificate_types_descriptions/machine-config-operator-certificates.adoc#cert-types-machine-config-operator-certificates[Machine Config Operator certificates]. 
+For more information about the MCO certificates, see xref:../security/certificate_types_descriptions/machine-config-operator-certificates.adoc#cert-types-machine-config-operator-certificates[Machine Config Operator certificates].
 
 [id="ocp-release-notes-management-console_{context}"]
 === Management console
@@ -677,7 +677,7 @@ For more information, see xref:../networking/ptp/ptp-cloud-events-consumer-dev-r
 [id="ocp-release-notes-machine-config-operator-cgroup-v1_{context}"]
 ==== cgroup v1 has been removed
 
-cgroup v1, which was deprecated in {product-title} 4.16, is no longer supported and has been removed from {product-title}. If your cluster is using cgroup v1, you must configure cgroup v2 before you can upgrade to  {product-title} {product-version}. All workloads must now be compatible with cgroup v2. 
+cgroup v1, which was deprecated in {product-title} 4.16, is no longer supported and has been removed from {product-title}. If your cluster is using cgroup v1, you must configure cgroup v2 before you can upgrade to  {product-title} {product-version}. All workloads must now be compatible with cgroup v2.
 
 For more information on cgroup v2, see xref:../architecture/index.adoc#architecture-about-cgroup-v2_architecture-overview[About Linux cgroup version 2] and link:https://www.redhat.com/en/blog/rhel-9-changes-context-red-hat-openshift-workloads[Red Hat Enterprise Linux 9 changes in the context of Red Hat OpenShift workloads] (Red{nbsp}Hat blog).
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-14920

Link to docs preview:
https://94556--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-installation-and-update-gcp-confidential-computing-expansion_release-notes

QE review:
- [x] QE has approved this change.

Amending the existing install RN to include mention of day 2, because the content is identical.