### PR TITLE
OLS-1841: Change cluster interaction topic title to match other topic…

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -24,7 +24,7 @@ include::modules/ols-about-lightspeed-and-role-based-access-control.adoc[levelof
 include::modules/ols-granting-access-to-individual-users.adoc[leveloffset=+2]
 include::modules/ols-granting-access-to-user-group.adoc[leveloffset=+2]
 include::modules/ols-filtering-and-redacting-information.adoc[leveloffset=+1]
-include::modules/ols-cluster-interaction-overview.adoc[leveloffset=+1]
+include::modules/ols-about-cluster-interaction.adoc[leveloffset=+1]
 include::modules/ols-enabling-cluster-interaction.adoc[leveloffset=+2]
 include::modules/ols-about-the-byo-knowledge-tool.adoc[leveloffset=+1]
 include::modules/ols-providing-custom-knowledge-to-the-llm.adoc[leveloffset=+2]

--- a/modules/ols-about-cluster-interaction.adoc
+++ b/modules/ols-about-cluster-interaction.adoc
@@ -2,8 +2,8 @@
 // * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="cluster-interaction-overview_{context}"]
-= Cluster interaction overview
+[id="about-cluster-interaction_{context}"]
+= About cluster interaction
 
 A large language model (LLM) is used with the {ols-long} service to generate responses to questions. Use the cluster interaction feature to enhance the knowledge available to the LLM with information about an {ocp-product-title} cluster. Providing cluster information, such as the namespaces or pods that the cluster contains, enables the LLM to generate highly customized responses for your environment.
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be merged to the lightspeed-docs-main branch and CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-1841
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://94558--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#about-cluster-interaction_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
