### PR TITLE
OSDOCS-14913: Update 4.15 EOL dates to match OCP maintenance end date

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -14,19 +14,12 @@ endif::[]
 [options="header"]
 |===
 |Version    |General availability   |End of life
-ifdef::rosa-with-hcp[]
 |4.18       |Feb 26, 2025           |Jun 21, 2026
 |4.17       |Oct 14, 2024           |Feb 14, 2026
 |4.16       |Jul 2, 2024            |Nov 2, 2025
-|4.15       |Feb 27, 2024           |Jun 30, 2025
-|4.14       |Dec 4, 2023            |Jun 1, 2025
-endif::rosa-with-hcp[]
-ifndef::rosa-with-hcp[]
-|4.18       |Feb 26, 2025           |Jun 21, 2026
-|4.17       |Oct 14, 2024           |Feb 14, 2026
-|4.16       |Jul 2, 2024            |Nov 2, 2025
-|4.15       |Feb 27, 2024           |Jun 30, 2025
+|4.15       |Feb 27, 2024           |Aug 27, 2025
 |4.14       |Oct 31, 2023           |Jun 1, 2025
+ifndef::rosa-with-hcp[]
 |4.13       |May 17, 2023           |Sep 17, 2024
 |4.12       |Jan 17, 2023           |Jul 17, 2024
 |4.11       |Aug 10, 2022           |Dec 10, 2023


### PR DESCRIPTION
[OSDOCS-14913](https://issues.redhat.com//browse/OSDOCS-14913): Update 4.15 EOL dates to match OCP maintenance end date

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14913

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
