### PR TITLE
HCIDOCS-304: Added a concept module introducing the Cluster API

### DIFF
--- a/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+++ b/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
@@ -8,6 +8,16 @@ toc::[]
 
 After successfully deploying a bare-metal cluster, consider the following postinstallation procedures.
 
+
+//About the cluster API
+include::modules/bare-metal-about-the-cluster-api.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_management/cluster_api_machine_management/cluster-api-about.adoc#luster-api-about[About the Cluster API]
+* xref:../../machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc#cluster-api-getting-started[Getting started with the Cluster API]
+
 // Configuring NTP for disconnected clusters
 include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+1]
 

--- a/machine_management/cluster_api_machine_management/cluster-api-about.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-about.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: Managing machines with the Cluster API
 include::snippets/technology-preview.adoc[]
 
-The link:https://cluster-api.sigs.k8s.io/[Cluster API] is an upstream project that is integrated into {product-title} as a Technology Preview for {aws-first}, {gcp-first}, {azure-first}, {rh-openstack-first}, and {vmw-first}.
+The link:https://cluster-api.sigs.k8s.io/[Cluster API] is an upstream project that is integrated into {product-title} as a Technology Preview for {aws-first}, {gcp-first}, {azure-first}, {rh-openstack-first}, {vmw-first}, and bare metal.
 
 //Cluster API overview
 include::modules/capi-overview.adoc[leveloffset=+1]

--- a/machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc
@@ -25,6 +25,7 @@ include::modules/capi-creating-machine-template.adoc[leveloffset=+2]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-azure.adoc#capi-yaml-machine-template-azure_cluster-api-config-options-azure[Sample YAML for a Cluster API machine template resource on {azure-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc#capi-yaml-machine-template-rhosp_cluster-api-config-options-rhosp[Sample YAML for a Cluster API machine template resource on {rh-openstack}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-machine-template-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API machine template resource on {vmw-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-bare-metal.adoc#capi-yaml-machine-template-bare-metal_cluster-api-config-options-bare-metal[Sample YAML for a Cluster API machine template resource on bare metal]
 
 //Creating a Cluster API compute machine set
 include::modules/capi-creating-machine-set.adoc[leveloffset=+2]
@@ -35,3 +36,4 @@ include::modules/capi-creating-machine-set.adoc[leveloffset=+2]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-azure.adoc#capi-yaml-machine-set-azure_cluster-api-config-options-azure[Sample YAML for a Cluster API compute machine set resource on {azure-full}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-rhosp.adoc#capi-yaml-machine-set-rhosp_cluster-api-config-options-rhosp[Sample YAML for a Cluster API compute machine set resource on {rh-openstack}]
 * xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-vsphere.adoc#capi-yaml-machine-set-vsphere_cluster-api-config-options-vsphere[Sample YAML for a Cluster API compute machine set resource on {vmw-full}]
+* xref:../../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-bare-metal.adoc#capi-yaml-machine-set-bare-metal_cluster-api-config-options-bare-metal[Sample YAML for a Cluster API compute machine set resource on bare metal]

--- a/modules/bare-metal-about-the-cluster-api.adoc
+++ b/modules/bare-metal-about-the-cluster-api.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="bare-metal-about-the-cluster-api_{context}"]
+= About the Cluster API
+
+{product-title} 4.19 and later releases can manage machines by using the Cluster API. 
+
+:FeatureName: Managing machines with the Cluster API
+include::snippets/technology-preview.adoc[]
+
+You can use the Cluster API to perform compute node provisioning management actions after the cluster installation finishes. The Cluster API allows dynamic management of compute node machine sets and machines. However, there is no support for control plane machines.

--- a/modules/capi-creating-machine-template.adoc
+++ b/modules/capi-creating-machine-template.adoc
@@ -76,7 +76,7 @@ $ oc create -f <machine_template_resource_file>.yaml
 +
 [source,terminal]
 ----
-$ oc get <machine_template_kind>
+$ oc get <machine_template_kind> -n openshift-cluster-api
 ----
 +
 where `<machine_template_kind>` is the value that corresponds to your platform.

--- a/modules/capi-limitations.adoc
+++ b/modules/capi-limitations.adoc
@@ -15,7 +15,7 @@ Using the Cluster API to manage machines is a Technology Preview feature and has
 Enabling this feature set cannot be undone and prevents minor version updates.
 ====
 
-* Only {aws-first}, {gcp-first}, {azure-first}, {rh-openstack-first}, and {vmw-first} clusters can use the Cluster API.
+* Only {aws-first}, {gcp-first}, {azure-first}, {rh-openstack-first}, {vmw-first}, and bare-metal clusters can use the Cluster API.
 
 * You must manually create some of the primary resources that the Cluster API requires.
 For more information, see "Getting started with the Cluster API".


### PR DESCRIPTION
This PR adds a concept module in bare metal post-installation configuration introducing the Cluster API as a Tech Preview, and provides links to the Cluster API modules Jeana updated as part of https://github.com/openshift/openshift-docs/pull/94279. I also updated the About and Limitations sections to include bare metal, and updated the additional resources links to point to the module Jeana created. 

Version(s): 4.19

Issue: [HCIDOCS-304](https://issues.redhat.com//browse/HCIDOCS-304)

Link to docs preview: https://94569--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html and https://94569--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-about.html and https://94569--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster-api-getting-started.html

QE review:
- [x] QE has approved this change.
