### PR TITLE
OSDOCS-13727.1:Corrected link to point directly to ROSA specific OCM doc

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -19,7 +19,7 @@ toc::[]
 
 ifdef::openshift-rosa[]
 //Remove when ROSA HCP is published.
-* **ROSA Classic cluster ownership transfer is now available for {product-title}.** You can now transfer ownership of ROSA Classic clusters. For more information, see link:https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#transferring-cluster-ownership_downloading-and-updating-pull-secrets[Transferring ownership of a ROSA Classic cluster].
+* **ROSA Classic cluster ownership transfer is now available for {product-title}.** You can now transfer ownership of ROSA Classic clusters. For more information, see link:https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html/managing_clusters/assembly-managing-clusters#initiating-rosa-classic-ownership-transfer-proc_downloading-and-updating-pull-secrets[Initiating ownership transfer of a ROSA Classic cluster].
 endif::openshift-rosa[]
 
 [id="rosa-q1-2025_{context}"]


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-13727

Link to docs preview:
https://94576--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html

QE review:
- QE approval is not required as this is just correcting a link to point to the specific doc.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
