### PR TITLE
CNV#62954 - VM runStrategy table

### DIFF
--- a/modules/virt-runstrategies-vms.adoc
+++ b/modules/virt-runstrategies-vms.adoc
@@ -35,8 +35,8 @@ The following table describes a VM's transition between states. The first column
 |Always
 
 |RerunOnFailure
-|-
-|Halted
+|RerunOnFailure
+|RerunOnFailure
 |RerunOnFailure
 
 |Manual


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/CNV-62954

Link to docs preview:
https://94577--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-node-maintenance.html#virt-runstrategies-vms_virt-node-maintenance

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Upstream kubevirt doclink:
https://kubevirt.io/user-guide/compute/run_strategies/
