### PR TITLE
OSDOCS-13484: Adds 4.19 machine management feature introductions

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -515,10 +515,10 @@ With this release, you can enable a user-provisioned domain name server (DNS) in
 For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-enabling-user-managed-DNS_installing-gcp-customizations[Enabling user-managed DNS].
 
 [id="ocp-4-19-installation-and-update-vsphere-multidisk_{context}"]
-==== Installing a cluster on {vmw-first} with multiple disks
+==== Installing a cluster on {vmw-first} with multiple disks (Technology Preview)
 With this release, you can install a cluster on {vmw-first} with multiple storage disks as a Technology Preview feature. You can assign these additional disks to special functions within the cluster, such as etcd storage.
 
-For more information, see xref:../installing/installing_vsphere/installation-config-parameters-vsphere.html#installation-configuration-parameters-optional-vsphere_installation-config-parameters-vsphere[Optional vSphere configuration parameters].
+For more information, see xref:../installing/installing_vsphere/installation-config-parameters-vsphere.adoc#installation-configuration-parameters-optional-vsphere_installation-config-parameters-vsphere[Optional vSphere configuration parameters].
 
 [id="ocp-4-19-installation-and-update-azure-boot-diagnostics_{context}"]
 ==== Enabling boot diagnostics collection during installation on {azure-first}
@@ -618,6 +618,19 @@ With this release, you can customize the prefix of machine names for machines cr
 This feature is enabled by modifying the `spec.machineNamePrefix` parameter of the `ControlPlaneMachineSet` custom resource.
 
 For more information, see xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-config-prefix_cpmso-configuration[Adding a custom prefix to control plane machine names].
+
+[id="ocp-4-19-aws-capacity-reservations_{context}"]
+==== Configuring Capacity Reservations on {aws-full} clusters
+
+With this release, you can deploy machines that use Capacity Reservations, including On-Demand Capacity Reservations and Capacity Blocks for ML, on {aws-full} clusters.
+
+You can configure these features with xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-capacity-reservation_creating-machineset-aws[compute] and xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc#machineset-capacity-reservation_cpmso-config-options-aws[control plane] machine sets.
+
+[id="ocp-4-19-vmw-multi-disk_{context}"]
+==== Support for multiple {vmw-full} data disks (Technology Preview)
+
+With this release, you can add up to 29 disks to the virtual machine (VM) controller for your {vmw-short} cluster as a Technology Preview feature.
+This capability is available for xref:../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#machineset-vsphere-data-disks_creating-machineset-vsphere[compute] and xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc#machineset-vsphere-data-disks_cpmso-config-options-vsphere[control plane] machine sets.
 
 [id="ocp-release-notes-monitoring_{context}"]
 === Monitoring


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13484](https://issues.redhat.com/browse/OSDOCS-13484)

Link to docs preview:
https://94590--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-machine-management_release-notes

QE review:
- [x] QE has approved this change. (on earlier version of #94462)

Additional information:
Splits mergeable content out of #94462 (which is blocked by #93633 and #94127)
