### PR TITLE
[enterprise-4.16] OCPBUGS-46045 Symmetric routing with MetalLB improvements + missing rule

### DIFF
--- a/modules/nw-egress-service-cr.adoc
+++ b/modules/nw-egress-service-cr.adoc
@@ -26,7 +26,7 @@ spec:
 <2> Specify the namespace for the egress service. The namespace for the `EgressService` must match the namespace of the load-balancer service that you want to modify. The egress service is namespace-scoped.
 <3> Specify the source IP address of egress traffic for pods behind a service. Valid values are `LoadBalancerIP` or `Network`. Use the `LoadBalancerIP` value to assign the `LoadBalancer` service ingress IP address as the source IP address for egress traffic. Specify `Network` to assign the network interface IP address as the source IP address for egress traffic.
 <4> Optional: If you use the `LoadBalancerIP` value for the `sourceIPBy` specification, a single node handles the `LoadBalancer` service traffic. Use the `nodeSelector` field to limit which node can be assigned this task. When a node is selected to handle the service traffic, OVN-Kubernetes labels the node in the following format: `egress-service.k8s.ovn.org/<svc-namespace>-<svc-name>: ""`. When the `nodeSelector` field is not specified, any node can manage the `LoadBalancer` service traffic.
-<5> Optional: Specify the routing table for egress traffic. If you do not include the `network` specification, the egress service uses the default host network.
+<5> Optional: Specify the routing table ID for egress traffic. Ensure that the value matches the `route-table-id` ID defined in the `NodeNetworkConfigurationPolicy` resource. If you do not include the `network` specification, the egress service uses the default host network.
 
 .Example egress service specification
 [source,yaml]

--- a/modules/nw-egress-service-ovn.adoc
+++ b/modules/nw-egress-service-ovn.adoc
@@ -105,7 +105,7 @@ metadata:
 spec:
   ipAddressPools:
   - example-pool
-  nodeSelector:
+  nodeSelectors:
   - matchLabels:
       egress-service.k8s.ovn.org/example-namespace-example-service: "" <1>
 ----

--- a/modules/nw-metallb-configure-return-traffic-proc.adoc
+++ b/modules/nw-metallb-configure-return-traffic-proc.adoc
@@ -73,6 +73,9 @@ spec:
       - ip-to: 10.132.0.0/14
         priority: 998
         route-table: 254
+      - ip-to: 169.254.169.0/29
+        priority: 998
+        route-table: 254
 ----
 <1> The name of the policy.
 <2> This example applies the policy to all nodes with the label `vrf:true`.
@@ -82,7 +85,7 @@ spec:
 <6> The name of the route table ID for the VRF.
 <7> The IPv4 address of the interface associated with the VRF. 
 <8> Defines the configuration for network routes. The `next-hop-address` field defines the IP address of the next hop for the route. The `next-hop-interface` field defines the outgoing interface for the route. In this example, the VRF routing table is `2`, which references the ID that you define in the `EgressService` CR.
-<9> Defines additional route rules. The `ip-to` fields must match the `Cluster Network` CIDR and `Service Network` CIDR. You can view the values for these CIDR address specifications by running the following command: `oc describe network.config/cluster`.
+<9> Defines additional route rules. The `ip-to` fields must match the `Cluster Network` CIDR, `Service Network` CIDR, and `Internal Masquerade` subnet CIDR. You can view the values for these CIDR address specifications by running the following command: `oc describe network.operator/cluster`.
 <10> The main routing table that the Linux kernel uses when calculating routes has the ID `254`.
 
 .. Apply the policy by running the following command:
@@ -193,7 +196,7 @@ spec:
 <2> Specify the namespace for the egress service. The namespace for the `EgressService` must match the namespace of the load-balancer service that you want to modify. The egress service is namespace-scoped.
 <3> This example assigns the `LoadBalancer` service ingress IP address as the source IP address for egress traffic.
 <4> If you specify `LoadBalancer` for the `sourceIPBy` specification, a single node handles the `LoadBalancer` service traffic. In this example, only a node with the label `vrf: "true"` can handle the service traffic. If you do not specify a node, OVN-Kubernetes selects a worker node to handle the service traffic. When a node is selected, OVN-Kubernetes labels the node in the following format: `egress-service.k8s.ovn.org/<svc_namespace>-<svc_name>: ""`.
-<5> Specify the routing table for egress traffic.
+<5> Specify the routing table ID for egress traffic. Ensure that the value matches the `route-table-id` ID defined in the `NodeNetworkConfigurationPolicy` resource, for example, `route-table-id: 2`. 
 
 .. Apply the configuration for the egress service by running the following command:
 +
@@ -213,4 +216,3 @@ $ curl <external_ip_address>:<port_number> <1>
 <1> Update the external IP address and port number to suit your application endpoint.
 
 . Optional: If you assigned the `LoadBalancer` service ingress IP address as the source IP address for egress traffic, verify this configuration by using tools such as `tcpdump` to analyze packets received at the external client.
-


### PR DESCRIPTION
[OCPBUGS-44843]: Symmetric routing with MetalLB improvements + missing rule
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-46045
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://94592--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-return-traffic.html
https://94592--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
“Cherry Picked from https://github.com/openshift/openshift-docs/pull/87631/commits/8d18d43c8dde220757a6e80a9f9a838fccf4a734 xref: [https://github.com/openshift/openshift-docs/pull/87631/]. Already merged missed merge to 4.16. Manual CP.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
