### PR TITLE
Zero Egress: Clarifies the which channel is mirrored.

### DIFF
--- a/rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
+++ b/rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
@@ -17,8 +17,7 @@ See xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading {prod
 
 [NOTE]
 ====
-
-Clusters created in restricted network environments may be unable to use certain ROSA features including Red Hat Insights and Telemetry. These clusters may also experience potential failures for workloads that require public access to registries such as `quay.io`. When using clusters installed with egress lockdown, you can also install Red Hat-owned Operators from OperatorHub. For a complete list of Red Hat-owned Operators, see the link:https://catalog.redhat.com/search?searchType=software&target_platforms=Red%20Hat%20OpenShift&deployed_as=Operator&p=1&partnerName=Red%20Hat%2C%20Inc.%7CRed%20Hat[Red{nbsp}Hat Ecosystem Catalog].
+Clusters created in restricted network environments may be unable to use certain ROSA features including Red Hat Insights and Telemetry. These clusters may also experience potential failures for workloads that require public access to registries such as `quay.io`. When using clusters installed with egress lockdown, you can also install Red Hat-owned Operators from OperatorHub. For a complete list of Red Hat-owned Operators, see the link:https://catalog.redhat.com/search?searchType=software&target_platforms=Red%20Hat%20OpenShift&deployed_as=Operator&p=1&partnerName=Red%20Hat%2C%20Inc.%7CRed%20Hat[Red{nbsp}Hat Ecosystem Catalog]. Only the default Operator channel is mirrored for any Operator that is installed in egress lockdown.
 ====
 
 [discrete]


### PR DESCRIPTION
Link to docs preview:
- https://94595--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-egress-lockdown-install.html
    ![image](https://github.com/user-attachments/assets/bd1f2adc-2df2-469c-90d1-fa2e1de850df)

Additional information:
Added additional clarification about which Operator channel is mirrored within egress lockdown