### PR TITLE
OSDOCS-14925: Documented the slb mode release note

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -775,6 +775,11 @@ For more information, see xref:../updating/preparing_for_updates/updating-cluste
 ==== Updates to Gateway API custom resource definitions (CRDs)
 {product-title} {product-version} updates {SMProductName} to version 3.0.2, and Gateway API to version 1.2.1. See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/release_notes/ossm-release-notes[{SMProductShortName} 3.0.0 release notes] and the link:https://github.com/kubernetes-sigs/gateway-api/blob/main/CHANGELOG/1.2-CHANGELOG.md#v121[Gateway API 1.2.1 changelog] for more information.
 
+[id="ocp-4-19-networking-balance-slb-mode_{context}"]
+==== Enable OVS balance-slb mode for your cluster (General Availability)
+
+You can enable the Open vSwitch (OVS) `balance-slb` mode on infrastructure where your cluster runs so that two or more physical interfaces can share their network traffic. For more information, see xref:../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#enabling-OVS-balance-slb-mode_ipi-install-installation-workflow[Enabling OVS balance-slb mode for your cluster].
+
 [id="ocp-4-19-networking-ptp-dual-oc_{context}"]
 ==== Dual-port NICs for improved redundancy in PTP ordinary clocks (Technology Preview)
 With this release, you can use a dual-port network interface controller (NIC) to improve redundancy for Precision Time Protocol (PTP) ordinary clocks.
@@ -797,7 +802,7 @@ With this release, {product-title} introduces the Data Processing Unit (DPU) Ope
 Administrators can now use the `ClusterUserDefinedNetwork` custom resource to deploy secondary networks on a `Localnet` topology. This feature allows pods and virtual machines connected to the localnet network to egress to the physical network. For more information, see xref:../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-cudn-localnet[Creating a ClusterUserDefinedNetwork CR for a Localnet topology].
 
 [id="ocp-4-19-port-isolation-linux-bridge_{context}"]
-==== Enable port isolation for a Linux bridge NAD
+==== Enable port isolation for a Linux bridge NAD (Generally Available)
 
 You can enable port isolation for a Linux bridge network attachment definition (NAD) so that virtual machines (VMs) or pods that run on the same virtual LAN (VLAN) can operate in isolation from one another. For more information, see xref:../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-linux-bridge-nad-port-isolation_virt-connecting-vm-to-linux-bridge[Enabling port isolation for a Linux bridge NAD].
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-14925](https://issues.redhat.com/browse/OSDOCS-14925)

Preview: https://94606--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-networking_release-notes

Approvals on the feature PR. Note taken verbatim from feature opening. https://github.com/openshift/openshift-docs/pull/92313