### PR TITLE
OSDOCS-13549 updating AWS AMIs for 4.19

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,97 +23,106 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-01bf6b6fca71a7dc3`
+|`ami-0163621ea085783d8`
 
 |`ap-east-1`
-|`ami-0594c08334dcc4afb`
+|`ami-033db3b659641feea`
 
 |`ap-northeast-1`
-|`ami-0313928874609075d`
+|`ami-0baf16f8c6bd53f63`
 
 |`ap-northeast-2`
-|`ami-09cfc5a33f840ce70`
+|`ami-01a92be7f419359cc`
 
 |`ap-northeast-3`
-|`ami-02fece2c48e16e9f2`
+|`ami-0f16895f6f50e656e`
 
 |`ap-south-1`
-|`ami-063d0eaf658eb4dc5`
+|`ami-0272be2f6528576f3`
 
 |`ap-south-2`
-|`ami-0c4930cae17448786`
+|`ami-0311119df2ebc0bbc`
 
 |`ap-southeast-1`
-|`ami-068f696694b2fc0f1`
+|`ami-0637678b0ad540477`
 
 |`ap-southeast-2`
-|`ami-04aee88a86e139991`
+|`ami-0b67b492c091ac746`
 
 |`ap-southeast-3`
-|`ami-0363d9df44ce25cd3`
+|`ami-0a9e63bf1df36a936`
 
 |`ap-southeast-4`
-|`ami-05b72aa8744449f86`
+|`ami-0f153b95673592039`
+
+|`ap-southeast-5`
+|`ami-025944207bb28ae8f`
+
+|`ap-southeast-7`
+|`ami-0b5e29c2ae4aaa66d`
 
 |`ca-central-1`
-|`ami-0a7c95e80fb37ade8`
+|`ami-03263f0cfdfa8bbdb`
 
 |`ca-west-1`
-|`ami-0818def2f3d7a696d`
+|`ami-0254620c2dc7dcacc`
 
 |`eu-central-1`
-|`ami-02c8714aef084ee90`
+|`ami-0a0a87862b24395d8`
 
 |`eu-central-2`
-|`ami-083d349477a4e9f69`
+|`ami-015c8ca32f5d8300a`
 
 |`eu-north-1`
-|`ami-03f4002a3746bc66b`
+|`ami-0c4404a6ae5921a1b`
 
 |`eu-south-1`
-|`ami-038d816008adca0be`
+|`ami-0e0724943dd915bb2`
 
 |`eu-south-2`
-|`ami-099f491d6ab9706d0`
+|`ami-0e6cac787a21b221d`
 
 |`eu-west-1`
-|`ami-0f0ebf16ff38e816f`
+|`ami-0355d4c968e466965`
 
 |`eu-west-2`
-|`ami-0abb7730ffd4d9944`
+|`ami-0e079f8742280b034`
 
 |`eu-west-3`
-|`ami-032c22188cbfff12c`
+|`ami-06702aad076acda7b`
 
 |`il-central-1`
-|`ami-08171fe42c6af2676`
+|`ami-0094ac2722d41c18c`
 
 |`me-central-1`
-|`ami-0f1c6a3d726f5b7b5`
+|`ami-03680a3dcecfbe79d`
 
 |`me-south-1`
-|`ami-019faf03d74520d13`
+|`ami-04e14a3c4be812ac7`
+
+|`mx-central-1`
+|`ami-0eac1c8d4154a417f`
 
 |`sa-east-1`
-|`ami-01591af00107320c3`
+|`ami-07abd63bb465f89b6`
 
 |`us-east-1`
-|`ami-08f1807771f4e468b`
+|`ami-0e8fd9094e487d1ff`
 
 |`us-east-2`
-|`ami-078e26f293629fe91`
+|`ami-0d4a7b7677c0c883f`
 
 |`us-gov-east-1`
-|`ami-068e56023ec09c2b1`
+|`ami-0b67e7ffd11a17645`
 
 |`us-gov-west-1`
-|`ami-09ba2da65d9d836cf`
+|`ami-041e18a76f42c752c`
 
 |`us-west-1`
-|`ami-01d1d2ed3d63466da`
+|`ami-0167f257577d883cc`
 
 |`us-west-2`
-|`ami-0d769ba340e913a8c`
+|`ami-0b29d41f2ed6b8c94`
 
 |===
 
@@ -126,97 +135,106 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-02d76a4f0c0ee24cd`
+|`ami-009231bfc2490c6f9`
 
 |`ap-east-1`
-|`ami-07e78c2c0f5f81a49`
+|`ami-0a23fad8fb25f5bb7`
 
 |`ap-northeast-1`
-|`ami-0e3a6e27f6940ab63`
+|`ami-0754a269f165f227c`
 
 |`ap-northeast-2`
-|`ami-0116db61662393b23`
+|`ami-0d81f596571ce27d8`
 
 |`ap-northeast-3`
-|`ami-07dd3d8930d1c27eb`
+|`ami-01eb2f8b176229523`
 
 |`ap-south-1`
-|`ami-07121d273482babf9`
+|`ami-0be3b34441044e437`
 
 |`ap-south-2`
-|`ami-084f561e41c26ab95`
+|`ami-02a86359661950bb0`
 
 |`ap-southeast-1`
-|`ami-02301ea2b50fc247f`
+|`ami-0c70d35c9b5b190be`
 
 |`ap-southeast-2`
-|`ami-0690a605a9bb33d00`
+|`ami-0310f2acbeca636ed`
 
 |`ap-southeast-3`
-|`ami-08d243c0580c87c80`
+|`ami-04db4055063382442`
 
 |`ap-southeast-4`
-|`ami-013dad9ce63ec3dc0`
+|`ami-0e2e40cc31633d7d6`
+
+|`ap-southeast-5`
+|`ami-0cf0c9ee9f324f763`
+
+|`ap-southeast-7`
+|`ami-04cdafcdc85bf9040`
 
 |`ca-central-1`
-|`ami-0238dbad4895283b7`
+|`ami-0aee20271a9396925`
 
 |`ca-west-1`
-|`ami-0faded0cfdf14248a`
+|`ami-03ca778cd4265aad9`
 
 |`eu-central-1`
-|`ami-085a88c5d03df3675`
+|`ami-0281dddee0884d9f0`
 
 |`eu-central-2`
-|`ami-08d6da8ffaa81e2b4`
+|`ami-00fc4e5e3926530af`
 
 |`eu-north-1`
-|`ami-0077ccc8e7962b7ee`
+|`ami-0696b5b31d326ccc6`
 
 |`eu-south-1`
-|`ami-02c649a544c9395f2`
+|`ami-04090792b7bdb9e0f`
 
 |`eu-south-2`
-|`ami-0a955bda5a7189ebd`
+|`ami-0d45a2586055d5daa`
 
 |`eu-west-1`
-|`ami-040969e306c9a3efa`
+|`ami-02f08479c3613ed0e`
 
 |`eu-west-2`
-|`ami-06b30fcc40988cc96`
+|`ami-0ef2fc25f02a2d475`
 
 |`eu-west-3`
-|`ami-00dc4e0a7798ae0c5`
+|`ami-0ba5d0a0e5d796da8`
 
 |`il-central-1`
-|`ami-0c1adf273a43b58e2`
+|`ami-0e5b8f3b8e71961e7`
 
 |`me-central-1`
-|`ami-00817b16f81e58b86`
+|`ami-0d13d6a91da2ba547`
 
 |`me-south-1`
-|`ami-0f72a9bb1975ba0f9`
+|`ami-0183dab9f96845e3f`
+
+|`mx-central-1`
+|`ami-072535d81a5de8e76`
 
 |`sa-east-1`
-|`ami-083cf54e8ffc2d716`
+|`ami-0977fa46dff272ba9`
 
 |`us-east-1`
-|`ami-0eebf083d985a0bcf`
+|`ami-083de3282c55be3f7`
 
 |`us-east-2`
-|`ami-0b04071739ccf4af2`
+|`ami-02f30107e3441227b`
 
 |`us-gov-east-1`
-|`ami-092fec5203140ddd8`
+|`ami-0abaadf7322cfc258`
 
 |`us-gov-west-1`
-|`ami-078ee5edd87052e70`
+|`ami-0ca27128d77d732aa`
 
 |`us-west-1`
-|`ami-0344d1d886514e258`
+|`ami-05a9426ae7c35740c`
 
 |`us-west-2`
-|`ami-07ef3531e7692a7ae`
+|`ami-0cd6ec50e0480b3a3`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-13549

Link to docs preview:

QE review:
- [x] QE has approved this change.
