### PR TITLE
OBSDOCS-1802: Support Multiple CloudWatch Outputs with unique STS Rol…

### DIFF
--- a/configuring/configuring-log-forwarding.adoc
+++ b/configuring/configuring-log-forwarding.adoc
@@ -116,6 +116,41 @@ Administrators can configure the following types of filters:
 include::modules/enabling-multi-line-exception-detection.adoc[leveloffset=+2]
 include::modules/logging-http-forward.adoc[leveloffset=+2]
 include::modules/cluster-logging-collector-log-forward-syslog.adoc[leveloffset=+2]
+
+
+[id="forwarding-logs-to-amazon-cloudwatch-from-sts-enabled-clusters_{context}"]
+== Forwarding logs to Amazon CloudWatch from STS-enabled clusters
+
+Amazon CloudWatch is a service that helps administrators observe and monitor resources and applications on {aws-first}. You can forward logs from {loggingproductname} to CloudWatch securely by leveraging {aws-short}'s Identity and Access Management (IAM) Roles for Service Accounts (IRSA), which uses {aws-short} {sts-first}.
+
+The authentication with CloudWatch works as follows:
+
+. The log collector requests temporary {aws-short} credentials from {sts-first} by presenting its service account token to the OpenID Connect (OIDC) provider in {aws-short}. 
+. {aws-short} validates the token. Afterward, depending on the trust policy, {aws-short} issues short-lived, temporary credentials, including an access key ID, secret access key, and session token, for the log collector to use.
+
+On {sts-short}-enabled clusters such as {product-rosa}, {aws-short} roles are pre-configured with the required trust policies. This allows service accounts to assume the roles. Therefore, you can create a secret for {aws-short} with {sts-short} that uses the IAM role. You can then create or update a `ClusterLogForwarder` custom resource (CR) that uses the secret to forward logs to CloudWatch output. Follow these procedures to create a secret and a `ClusterLogForwarder` CR if roles have been pre-configured:
+
+////
+* xref:../modules/cluster-logging-collector-log-forward-secret-cloudwatch.adoc#cluster-logging-collector-log-forward-secret-cloudwatch_configuring-log-forwarding[Creating a secret for CloudWatch with an existing {aws-short} role]
+
+* xref:../modules/cluster-logging-collector-log-forward-sts-cloudwatch.adoc#cluster-logging-collector-log-forward-sts-cloudwatch_configuring-log-forwarding[Forwarding logs to Amazon CloudWatch from STS enabled clusters]
+////
+* Creating a secret for CloudWatch with an existing {aws-short} role
+
+* Forwarding logs to Amazon CloudWatch from STS-enabled clusters
+
+If you do not have an {aws-short} IAM role pre-configured with trust policies, you must first create the role with the required trust policies. Complete the following procedures to create a secret, `ClusterLogForwarder` CR, and role.
+
+////
+* xref:../modules/creating-an-aws-role.adoc#creating-an-aws-role_configuring-log-forwarding[Creating an AWS IAM role]
+* xref:../modules/cluster-logging-collector-log-forward-secret-cloudwatch.adoc#cluster-logging-collector-log-forward-secret-cloudwatch_configuring-log-forwarding[Creating a secret for AWS CloudWatch with an existing AWS role]
+* xref:../modules/cluster-logging-collector-log-forward-sts-cloudwatch.adoc#cluster-logging-collector-log-forward-sts-cloudwatch[Forwarding logs to Amazon CloudWatch from STS enabled clusters]
+////
+
+include::modules/creating-an-aws-role.adoc[leveloffset=+2]
+include::modules/cluster-logging-collector-log-forward-secret-cloudwatch.adoc[leveloffset=+2]
+include::modules/cluster-logging-collector-log-forward-sts-cloudwatch.adoc[leveloffset=+2]
+
 include::modules/logging-content-filter-drop-records.adoc[leveloffset=+2]
 include::modules/logging-audit-log-filtering.adoc[leveloffset=+2]
 include::modules/input-spec-filter-labels-expressions.adoc[leveloffset=+2]

--- a/modules/cluster-logging-collector-log-forward-secret-cloudwatch.adoc
+++ b/modules/cluster-logging-collector-log-forward-secret-cloudwatch.adoc
@@ -1,11 +1,17 @@
 // Module included in the following assemblies:
 //
-// * observability/logging/cluster-logging-external.adoc
+// * configuring/configuring-log-forwarding.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-collector-log-forward-secret-cloudwatch_{context}"]
 = Creating a secret for AWS CloudWatch with an existing AWS role
-If you have an existing role for AWS, you can create a secret for AWS with STS using the `oc create secret --from-literal` command.
+
+Create a secret for {aws-first} {sts-first} from the configured {aws-short} IAM role by using the `oc create secret --from-literal` command.
+
+.Prerequisites
+
+* You have created an {aws-short} IAM role.
+* You have administrator access to {product-title}.
 
 .Procedure
 
@@ -13,7 +19,7 @@ If you have an existing role for AWS, you can create a secret for AWS with STS u
 +
 [source,terminal]
 ----
-$ oc create secret generic cw-sts-secret -n openshift-logging --from-literal=role_arn=arn:aws:iam::123456789012:role/my-role_with-permissions
+$ oc create secret generic sts-secret -n openshift-logging --from-literal=role_arn=arn:aws:iam::123456789012:role/openshift-logger
 ----
 +
 .Example Secret
@@ -23,7 +29,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   namespace: openshift-logging
-  name: my-secret-name
+  name: sts-secret
 stringData:
-  role_arn: arn:aws:iam::123456789012:role/my-role_with-permissions
+  role_arn: arn:aws:iam::123456789012:role/openshift-logger
 ----

--- a/modules/cluster-logging-collector-log-forward-sts-cloudwatch.adoc
+++ b/modules/cluster-logging-collector-log-forward-sts-cloudwatch.adoc
@@ -1,111 +1,65 @@
 // Module included in the following assemblies:
 //
-// * observability/logging/log_collection_forwarding/configuring-log-forwarding.adoc
+// * configuring/configuring-log-forwarding.adoc
+
+//https://github.com/openshift/cluster-logging-operator/blob/master/docs/features/logforwarding/outputs/cloudwatch-sts-forwarding.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-collector-log-forward-sts-cloudwatch_{context}"]
-= Forwarding logs to Amazon CloudWatch from STS enabled clusters
+= Forwarding logs to Amazon CloudWatch from STS-enabled clusters
 
-For clusters with AWS Security Token Service (STS) enabled, you can create an AWS service account manually or create a credentials request by using the Cloud Credential Operator (CCO) utility `ccoctl`.
+You can forward logs from {logging-title} deployed on clusters with {aws-first} {sts-first}-enabled to Amazon CloudWatch. Amazon CloudWatch is a service that helps administrators observe and monitor resources and applications on {aws-short}.
 
 .Prerequisites
 
-* {logging-title-uc}: 5.5 and later
+* {clo} has been installed.
+* You have configured a credential secret.
+* You have administrator access to {product-title}.
 
 .Procedure
 
-. Create a `CredentialsRequest` custom resource YAML by using the template below:
-+
-.CloudWatch credentials request template
-[source,yaml]
-----
-apiVersion: cloudcredential.openshift.io/v1
-kind: CredentialsRequest
-metadata:
-  name: <your_role_name>-credrequest
-  namespace: openshift-cloud-credential-operator
-spec:
-  providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1
-    kind: AWSProviderSpec
-    statementEntries:
-      - action:
-          - logs:PutLogEvents
-          - logs:CreateLogGroup
-          - logs:PutRetentionPolicy
-          - logs:CreateLogStream
-          - logs:DescribeLogGroups
-          - logs:DescribeLogStreams
-        effect: Allow
-        resource: arn:aws:logs:*:*:*
-  secretRef:
-    name: <your_role_name>
-    namespace: openshift-logging
-  serviceAccountNames:
-    - logcollector
-----
-+
-. Use the `ccoctl` command to create a role for AWS using your `CredentialsRequest` CR. With the `CredentialsRequest` object, this `ccoctl` command creates an IAM role with a trust policy that is tied to the specified OIDC identity provider, and a permissions policy that grants permissions to perform operations on CloudWatch resources. This command also creates a YAML configuration file in `/<path_to_ccoctl_output_dir>/manifests/openshift-logging-<your_role_name>-credentials.yaml`. This secret file contains the `role_arn` key/value used during authentication with the AWS IAM identity provider.
-+
-[source,terminal]
-----
-$ ccoctl aws create-iam-roles \
---name=<name> \
---region=<aws_region> \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
---identity-provider-arn=arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com <1>
-----
-<1> <name> is the name used to tag your cloud resources and should match the name used during your STS cluster install
-+
-. Apply the secret created:
-[source,terminal]
-+
-----
-$ oc apply -f output/manifests/openshift-logging-<your_role_name>-credentials.yaml
-----
-+
-. Create or edit a `ClusterLogForwarder` custom resource:
+* Create or update a `ClusterLogForwarder` custom resource (CR):
 +
 [source,yaml]
 ----
-apiVersion: logging.openshift.io/v1
+apiVersion: observability.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  name: <log_forwarder_name> <1>
-  namespace: <log_forwarder_namespace> <2>
+  name: <log_forwarder_name>
+  namespace: openshift-logging
 spec:
-  serviceAccountName: clf-collector <3>
+  serviceAccount:
+    name: <service_account_name> #<1>
   outputs:
-   - name: cw <4>
-     type: cloudwatch <5>
+   - name: cw-output #<2>
+     type: cloudwatch #<3>
      cloudwatch:
-       groupBy: logType <6>
-       groupPrefix: <group prefix> <7>
-       region: us-east-2 <8>
-     secret:
-        name: <your_secret_name> <9>
+       groupName: 'cw-projected{.log_type||"missing"}' #<4>
+       region: us-east-2 #<5>
+       authentication:
+         type: iamRole #<6>
+         iamRole:
+           roleARN: #<7>
+             key: role_arn 
+             secretName: sts-secret
+           token: #<8>
+             from: serviceAccount  
   pipelines:
-    - name: to-cloudwatch <10>
-      inputRefs: <11>
+    - name: to-cloudwatch
+      inputRefs: #<9>
         - infrastructure
         - audit
         - application
-      outputRefs:
-        - cw <12>
+      outputRefs: #<10>
+        - cw-output
 ----
-<1> In legacy implementations, the CR name must be `instance`. In multi log forwarder implementations, you can use any name.
-<2> In legacy implementations, the CR namespace must be `openshift-logging`. In multi log forwarder implementations, you can use any namespace.
-<3> Specify the `clf-collector` service account. The service account is only required in multi log forwarder implementations if the log forwarder is not deployed in the `openshift-logging` namespace.
-<4> Specify a name for the output.
-<5> Specify the `cloudwatch` type.
-<6> Optional: Specify how to group the logs:
-+
-* `logType` creates log groups for each log type.
-* `namespaceName` creates a log group for each application name space. Infrastructure and audit logs are unaffected, remaining grouped by `logType`.
-* `namespaceUUID` creates a new log groups for each application namespace UUID. It also creates separate log groups for infrastructure and audit logs.
-<7> Optional: Specify a string to replace the default `infrastructureName` prefix in the names of the log groups.
-<8> Specify the AWS region.
-<9> Specify the name of the secret that contains your AWS credentials.
-<10> Optional: Specify a name for the pipeline.
-<11> Specify which log types to forward by using the pipeline: `application,` `infrastructure`, or `audit`.
-<12> Specify the name of the output to use when forwarding logs with this pipeline.
+<1> Specify the service account.
+<2> Specify a name for the output.
+<3> Specify the `cloudwatch` type.
+<4> Specify the group name for the log stream.
+<5> Specify the AWS region.
+<6> Specify `iamRole` as the authentication type for STS.
+<7> Specify the name of the secret and the key where the `role_arn` resource is stored.
+<8> Specify the service account token to use for authentication. To use the projected service account token, use `from: serviceAccount`.
+<9> Specify which log types to forward by using the pipeline: `application,` `infrastructure`, or `audit`.
+<10> Specify the names of the output to use when forwarding logs with this pipeline.

--- a/modules/creating-an-aws-role.adoc
+++ b/modules/creating-an-aws-role.adoc
@@ -1,0 +1,117 @@
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-06-24
+:_mod-docs-content-type: PROCEDURE
+
+[id="creating-an-aws-role_{context}"]
+= Creating an {aws-short} IAM role
+
+Create an {aws-first} IAM role that your service account can assume to securely access AWS resources.
+
+The following procedure demonstrates creating an {aws-short} IAM role by using the {aws-short} CLI. You can alternatively use the Cloud Credential Operator (CCO) utility `ccoctl`. Using the `ccoctl` utility creates many fields in the IAM role policy that are not required by the `ClusterLogForwarder` custom resource (CR). These extra fields are ignored by the CR. However, the `ccoctl` utility provides a convenient way for configuring IAM roles. For more information see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/authentication_and_authorization/managing-cloud-provider-credentials#cco-short-term-creds[Manual mode with short-term credentials for components].
+
+.Prerequisites
+
+* You have access to an {product-title} cluster with {sts-first} enabled and configured for {aws-short}.
+* You have administrator access to the {aws-short} account.
+* {aws-short} CLI installed. 
+
+.Procedure
+
+. Create an IAM policy that grants permissions to write logs to CloudWatch.
+
+.. Create a file, for example `cw-iam-role-policy.json`, with the following content:
++
+[source,json]
+----
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:PutLogEvents",
+                "logs:CreateLogGroup",
+                "logs:PutRetentionPolicy",
+                "logs:CreateLogStream",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams"
+            ],
+            "Resource": "arn:aws:logs:*:*:*"
+        }
+    ]
+}
+----
+
+.. Create the IAM policy based on the previous policy definition by running the following command:
++
+[source,terminal]
+----
+aws iam create-policy \
+    --policy-name cluster-logging-allow \
+    --policy-document file://cw-iam-role-policy.json
+----
++
+Note the `Arn` value of the created policy.
+
+. Create a trust policy to allow the logging service account to assume an IAM role:
+
+.. Create a file, for example `cw-trust-policy.json`, with the following content:  
++
+[source,json]
+----
+{
+"Version": "2012-10-17",
+"Statement": [
+    {
+        "Effect": "Allow",
+        "Principal": {
+            "Federated": "arn:aws:iam::123456789012:oidc-provider/<OPENSHIFT_OIDC_PROVIDER_URL>" //<1>
+        },
+        "Action": "sts:AssumeRoleWithWebIdentity",
+        "Condition": {
+            "StringEquals": {
+                "<OPENSHIFT_OIDC_PROVIDER_URL>:sub": "system:serviceaccount:openshift-logging:logcollector" //<2>
+            }
+        }
+    }
+]
+}
+----
+<1> Replace `<OPENSHIFT_OIDC_PROVIDER_URL>` with the URL of your {product-title} OIDC URL.
+<2> The namespace and service account must match the namespace and service account that the log forwarder uses.
+
+. Create an IAM role based on the previously defined trust policy by running the following command:
++
+[source,terminal]
+----
+$ aws iam create-role --role-name openshift-logger --assume-role-policy-document file://cw-trust-policy.json
+----
++
+Note the `Arn` value of the created role.
+
+. Attach the policy to the role by running the following command:
++
+[source,terminal]
+----
+$ aws iam put-role-policy \ 
+      --role-name openshift-logger --policy-name cluster-logging-allow \
+      --policy-document file://cw-role-policy.json
+----
+
+.Verification
+* Verify the role and the permissions policy by running the following command:
++
+[source,terminal]
+----
+$ aws iam get-role --role-name openshift-logger
+----
++
+.Example output
+[source,options="nowrap"]
+----
+ROLE	arn:aws:iam::123456789012:role/openshift-logger
+ASSUMEROLEPOLICYDOCUMENT	2012-10-17
+STATEMENT	sts:AssumeRoleWithWebIdentity	Allow
+STRINGEQUALS	system:serviceaccount:openshift-logging:openshift-logger
+PRINCIPAL	arn:aws:iam::123456789012:oidc-provider/<OPENSHIFT_OIDC_PROVIDER_URL>
+----


### PR DESCRIPTION
…e Authentication

Version(s): 6.0+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1802
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94634--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-log-forwarding.html#forwarding-logs-to-amazon-cloudwatch-from-sts-enabled-clusters_configuring-log-forwarding
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
