### PR TITLE
CNV-56275: Confirm VM stop restart pause actions

### DIFF
--- a/modules/virt-controlling-multiple-vms.adoc
+++ b/modules/virt-controlling-multiple-vms.adoc
@@ -21,8 +21,9 @@ You can start, stop, restart, pause, and unpause multiple virtual machines (VMs)
 * To change the state of all VMs in the selected project:
 
 .. Right-click the name of the project in the tree view and select the intended action from the menu.
-
+.. If action confirmation is enabled, confirm the action in the confirmation dialog.
 * To change the state of specific VMs:
 
 .. Select a checkbox next to the VMs you want to work with. To select all VMs, click the checkbox in the *VirtualMachines* table header.
 .. Click *Actions* and select the intended action from the menu.
+.. If action confirmation is enabled, confirm the action in the confirmation dialog.

--- a/modules/virt-enable-vm-action-confirmation-web.adoc
+++ b/modules/virt-enable-vm-action-confirmation-web.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * virt/managing-vms/virt-controlling-vm-states.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-enable-vm-action-confirmation-web_{context}"]
+
+= Enabling confirmations of virtual machine actions
+
+The *Stop*, *Restart*, and *Pause* actions can display confirmation dialogs if confirmation is enabled. By default, confirmation is disabled.
+
+.Procedure
+
+. In the *Virtualization* section of the {product-title} web console, navigate to *Overview* -> *Settings* -> *Cluster* -> *General settings*.
+. Toggle the *VirtualMachine actions confirmation* setting to On.

--- a/modules/virt-pausing-vm-web.adoc
+++ b/modules/virt-pausing-vm-web.adoc
@@ -19,15 +19,15 @@ You can pause a virtual machine (VM) from the web console.
 * To stay on this page, where you can perform actions on multiple VMs:
 
 .. Click the Options menu {kebab} located at the far right end of the row and click *Pause VirtualMachine*.
+.. If action confirmation is enabled, click *Pause* in the confirmation dialog.
 
 * To pause the VM from the tree view:
-
 .. Click the *>* icon next to the project name to open the list of VMs.
-
 .. Right-click the name of the VM and select *Pause*.
-
+.. If action confirmation is enabled, click *Pause* in the confirmation dialog.
 * To view comprehensive information about the selected VM before you pause it:
 
 .. Access the *VirtualMachine details* page by clicking the name of the VM.
 
 .. Click *Actions* -> *Pause*.
+.. If action confirmation is enabled, click *Pause* in the confirmation dialog.

--- a/modules/virt-restarting-vm-web.adoc
+++ b/modules/virt-restarting-vm-web.adoc
@@ -24,12 +24,14 @@ To avoid errors, do not restart a VM while it has a status of *Importing*.
 * To stay on this page, where you can perform actions on multiple VMs:
 
 .. Click the Options menu {kebab} located at the far right end of the row and click *Restart*.
+.. If action confirmation is enabled, click *Restart* in the confirmation dialog.
 
 * To restart the VM from the tree view:
 
 .. Click the *>* icon next to the project name to open the list of VMs.
 
 .. Right-click the name of the VM and select *Restart*.
+.. If action confirmation is enabled, click *Restart* in the confirmation dialog.
 
 * To view comprehensive information about the selected VM before
 you restart it:
@@ -38,3 +40,4 @@ you restart it:
 machine.
 
 .. Click *Actions* -> *Restart*.
+.. If action confirmation is enabled, click *Restart* in the confirmation dialog.

--- a/modules/virt-stopping-vm-web.adoc
+++ b/modules/virt-stopping-vm-web.adoc
@@ -19,15 +19,16 @@ You can stop a virtual machine (VM) from the web console.
 * To stay on this page, where you can perform actions on multiple VMs:
 
 .. Click the Options menu {kebab} located at the far right end of the row and click *Stop VirtualMachine*.
-
+.. If action confirmation is enabled, click *Stop* in the confirmation dialog.
 * To stop the VM from the tree view:
 
 .. Click the *>* icon next to the project name to open the list of VMs.
 
 .. Right-click the name of the VM and select *Stop*.
-
+.. If action confirmation is enabled, click *Stop* in the confirmation dialog.
 * To view comprehensive information about the selected VM before you stop it:
 
 .. Access the *VirtualMachine details* page by clicking the name of the VM.
 
 .. Click *Actions* → *Stop*.
+.. If action confirmation is enabled, click *Stop* in the confirmation dialog.

--- a/virt/managing_vms/virt-controlling-vm-states.adoc
+++ b/virt/managing_vms/virt-controlling-vm-states.adoc
@@ -6,9 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+You can use xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[`virtctl`] to manage virtual machine states and perform other actions from the CLI. For example, you can use `virtctl` to force stop a VM or expose a port.
+
 You can stop, start, restart, pause, and unpause virtual machines from the web console.
 
-You can use xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[`virtctl`] to manage virtual machine states and perform other actions from the CLI. For example, you can use `virtctl` to force stop a VM or expose a port.
+include::modules/virt-enable-vm-action-confirmation-web.adoc[leveloffset=+1]
 
 include::modules/virt-starting-vm-web.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-56275

CNV 4.19+
OCP 4.19+

Preview:
https://94664--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-controlling-vm-states.html#virt-enable-vm-action-confirmation-web_virt-controlling-vm-states
https://94664--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-controlling-vm-states.html#virt-stopping-vm-web_virt-controlling-vm-states
https://94664--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-controlling-vm-states.html#virt-restarting-vm-web_virt-controlling-vm-states
https://94664--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-controlling-vm-states.html#virt-pausing-vm-web_virt-controlling-vm-states