### PR TITLE
Add "date since CVE was published" policy criteria to RNs and docs

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -90,6 +90,15 @@ AND, OR
 *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
+| Days Since CVE Was Published
+| Results in a violation if it has been more than a specified number of days since the CVE published date, or the date when the CVE was made public by the reporting source. You can use this criterion to build a policy that provides a grace period in which to fix vulnerabilities in images, starting from the CVE published date. If the grace period elapses, you will get violations of the policy.
+| Days Since CVE Was Published
+| Integer
+| ✕
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
 | Days Since CVE Was First Discovered In Image
 | This criterion results in a violation only if it has been more than a specified number of days since {product-title-short} discovered the CVE in a specific image.
 | Days Since CVE Was First Discovered In Image

--- a/release_notes/47-release-notes.adoc
+++ b/release_notes/47-release-notes.adoc
@@ -425,7 +425,11 @@ This release also addresses the following security vulnerabilities:
 
 *Release date*: 15 April 2025
 
-This release of {product-title-short} contains the following bug fix:
+This release of {product-title-short} contains the following change:
+
+* A new policy criteria, "Days since CVE was published," was added. This criteria allows teams to design more sophisticated grace periods to fix CVEs based on the CVE published date.
+
+It contains the following bug fix:
 
 //ROX-28699
 * Fixed an issue where verifying multi-signed images failed due to incorrect error handling.


### PR DESCRIPTION
Version(s): 4.7+
(will need to manually CP to 4.8)

[Issue](https://issues.redhat.com/browse/ROX-28724)

Link to docs preview:

https://94680--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/about-security-policies.html#policy-criteria_about-security-policies (in table - search for "published")

https://94680--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/47-release-notes.html#about-release-4.7.2_release-notes-47

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
