### PR TITLE
[OSDOCS#14932] Add RN for ShiftStack HCP TP

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -126,6 +126,13 @@ For more information, see xref:../extensions/ce/managing-ce.adoc#olmv1-deploying
 
 Because {hcp} releases asynchronously from {product-title}, it has its own release notes. For more information, see xref:../hosted_control_planes/hosted-control-planes-release-notes.adoc#hosted-control-planes-release-notes[{hcp-capital} release notes].
 
+[id="ocp-release-notes-hcp-openstack-tp_{context}"]
+==== Hosted control planes on {rh-openstack-first} 17.1 (Technology Preview)
+
+{hcp} on {rh-openstack} 17.1 are now supported as a Technology Preview.
+
+For more information, see xref:../hosted_control_planes/hcp-deploy/hcp-deploy-openstack.adoc#hosted-clusters-openstack-prerequisites_hcp-deploy-openstack[Deploying hosted control planes on OpenStack].
+
 [id="ocp-release-notes-ibm-power_{context}"]
 === {ibm-power-title}
 
@@ -2426,6 +2433,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 |General Availability
+
+|Hosted control planes on {rh-openstack} 17.1
+|Not Available
+|Not Available
+|Technology Preview
 |====
 
 [discrete]


### PR DESCRIPTION
RN for https://github.com/openshift/openshift-docs/pull/93726

Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-14932](https://issues.redhat.com//browse/OSDOCS-14932)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
- https://94685--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-hcp-openstack-tp_release-notes
- https://94685--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-technology-preview-tables_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
- [x] QE will approve this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: I have confirmation from DPM that I can get merge this prior to QE ack to beat freeze. QE can ack retroactively prior to GA date. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
