### PR TITLE
OCPBUGS-37089_2#style change

### DIFF
--- a/modules/installation-aws-creating-cloudformation-stack-compute.adoc
+++ b/modules/installation-aws-creating-cloudformation-stack-compute.adoc
@@ -11,7 +11,7 @@ You can create a stack of {aws-short} resources for the compute machines by usin
 
 [IMPORTANT]
 ====
-When you use the CloudFormation template for the control plane machines, the template provisions all the three control plane machines with a single stack; however, when you use the CloudFormation template to deploy the compute machines, you must create the number of stacks based on the number that you defined in the `install-config.yaml` file. Each stack is provisioned once for each machine. To provision a new compute machine, you must change the stack name.
+When you use the CloudFormation template for the control plane machines, the template provisions all three control plane machines with a single stack; however, when you use the CloudFormation template to deploy the compute machines, you must create the number of stacks based on the number that you defined in the `install-config.yaml` file. Each stack is provisioned once for each machine. To provision a new compute machine, you must change the stack name.
 ====
 
 .Procedure


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-37089

Link to docs preview:
This update is reflected in these pages:

- [Creating the CloudFormation stack for compute machines](https://94693--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-creating-cloudformation-stack_installing-aws-user-infra) in the assembly 'Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates'
- [Creating the CloudFormation stack for compute machines](https://94693--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-creating-cloudformation-stack_installing-restricted-networks-aws) in the assembly 'Installing a cluster on AWS in a disconnected environment with user-provisioned infrastructure'

QE review:
- [x] QE has approved this change (see the PR https://github.com/openshift/openshift-docs/pull/89952)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The text of the original PR (PR https://github.com/openshift/openshift-docs/pull/89952) included an unnecessary word. This PR correct this. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
