### PR TITLE
OSDOCS-14928: MCO 4.18 updated boot images context: marketplace images

### DIFF
--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -58,3 +58,7 @@ include::modules/mco-update-boot-images-configuring.adoc[leveloffset=+1]
 * xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
 
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Modifying a compute machine set]

--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -23,6 +23,8 @@ $ oc -n openshift-config patch cm admin-acks --patch '{"data":{"ack-4.18-boot-im
 ----
 
 * If you do not want the updated boot image feature enabled, explicitly disable the feature by using the following procedure.
+
+It is important to note that if you use boot images from the AWS Marketplace or the GCP Marketplace, enabling the updated boot image feature overwrites those images with a standard {op-system-first} image. You should explicitly disable this feature and not patch the `admin-acks` config map. If you accidentally enable the updated boot image feature, you can disable it by using the following procedure. Then, replace the marketplace boot images by modifying the compute machine sets, as described  in _Modifying a compute machine set_.
 ====
 
 If you disable this feature after some nodes have been created with the new boot image version, any existing nodes retain their current boot image. Turning off this feature does not rollback the nodes or machine sets to the originally-installed boot image. The machine sets retain the boot image version that was present when the feature was enabled and is not updated again when the cluster is upgraded to a new {product-title} version in the future.

--- a/nodes/nodes/nodes-nodes-managing.adoc
+++ b/nodes/nodes/nodes-nodes-managing.adoc
@@ -24,6 +24,10 @@ include::modules/nodes-nodes-managing-about.adoc[leveloffset=+1]
 include::modules/mco-update-boot-images.adoc[leveloffset=+1]
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../machine_management/modifying-machineset.adoc#modifying-machineset[Modifying a compute machine set]
+
 include::modules/nodes-nodes-working-master-schedulable.adoc[leveloffset=+1]
 include::modules/nodes-nodes-working-setting-booleans.adoc[leveloffset=+1]
 include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14928

A rather [lengthy conversation in Slack](https://redhat-internal.slack.com/archives/C68TNFWA2/p1749651650860599) led to the need to expand on a [note that occurs in the 4.18 docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/machine_configuration/mco-update-boot-images#mco-update-boot-images-disable_machine-configs-configure) only. 

I don't think QE is needed as it is not a technical change, but a suggestion to follow one of the two documented paths. Peer review, let me know if you think otherwise.

Previews:
Machine configuration -> Updated boot images -> [Disabling updated boot images](https://94706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-disable_machine-configs-configure) -- Added last paragraph to note, Additional resources
Nodes Working with nodes -> Managing nodes -> Updating boot images -> [Disabling updated boot images](https://94706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#mco-update-boot-images-disable_nodes-nodes-managing) -- Added last paragraph to note, Additional resources