### PR TITLE
OSDOCS-14937:Storage breakout from Classic to HCP.

### DIFF
--- a/modules/dynamic-provisioning-available-plugins.adoc
+++ b/modules/dynamic-provisioning-available-plugins.adoc
@@ -17,7 +17,7 @@ configured provider's API to create new storage resources:
 |Provisioner plugin name
 |Notes
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |{rh-openstack-first} Cinder
 |`kubernetes.io/cinder`
 |
@@ -25,7 +25,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 |{rh-openstack} Manila Container Storage Interface (CSI)
 |`manila.csi.openstack.org`
 |Once installed, the OpenStack Manila CSI Driver Operator and ManilaDriver automatically create the required storage classes for all available Manila share types needed for dynamic provisioning.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 |Amazon Elastic Block Store (Amazon EBS)
 |`kubernetes.io/aws-ebs`
@@ -33,7 +33,7 @@ endif::openshift-dedicated,openshift-rosa[]
 tag each node with `Key=kubernetes.io/cluster/<cluster_name>,Value=<cluster_id>`
 where `<cluster_name>` and `<cluster_id>` are unique per cluster.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |Azure Disk
 |`kubernetes.io/azure-disk`
 |
@@ -42,9 +42,9 @@ ifndef::openshift-dedicated,openshift-rosa[]
 |`kubernetes.io/azure-file`
 |The `persistent-volume-binder` service account requires permissions to create
 and get secrets to store the Azure storage account and keys.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 |GCE Persistent Disk (gcePD)
 |`kubernetes.io/gce-pd`
 |In multi-zone configurations, it is advisable to run one {product-title}
@@ -54,7 +54,7 @@ no node in the current cluster exists.
 |{ibm-power-server-name} Block
 |`powervs.csi.ibm.com`
 |After installation, the {ibm-power-server-name} Block CSI Driver Operator and {ibm-power-server-name} Block CSI Driver automatically create the required storage classes for dynamic provisioning.
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 //|GlusterFS
 //|`kubernetes.io/glusterfs`
@@ -68,11 +68,11 @@ endif::openshift-rosa[]
 //|`netapp.io/trident`
 //|Storage orchestrator for NetApp ONTAP, SolidFire, and E-Series storage.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |link:https://www.vmware.com/support/vsphere.html[VMware vSphere]
 |`kubernetes.io/vsphere-volume`
 |
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 //|HPE Nimble Storage
 //|`hpe.com/nimble`

--- a/modules/dynamic-provisioning-defining-storage-class.adoc
+++ b/modules/dynamic-provisioning-defining-storage-class.adoc
@@ -10,7 +10,7 @@
 `StorageClass` objects are currently a globally scoped object and must be
 created by `cluster-admin` or `storage-admin` users.
 
-ifndef::microshift,openshift-rosa[]
+ifndef::microshift,openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 The Cluster Storage Operator might install a default storage class depending
@@ -19,13 +19,13 @@ Operator. It cannot be deleted or modified beyond defining annotations
 and labels. If different behavior is desired, you must define a custom
 storage class.
 ====
-endif::microshift,openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::microshift,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 The Cluster Storage Operator installs a default storage class. This storage class is owned and controlled by the Operator. It cannot be deleted or modified beyond defining annotations and labels. If different behavior is desired, you must define a custom storage class.
 ====
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 The following sections describe the basic definition for a
 `StorageClass` object and specific examples for each of the supported plugin types.

--- a/modules/openshift-storage-common-terms.adoc
+++ b/modules/openshift-storage-common-terms.adoc
@@ -15,9 +15,9 @@ Access modes:: Volume access modes describe volume capabilities. You can use acc
 * ReadWriteMany (RWX)
 * ReadWriteOncePod (RWOP)
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Cinder:: The Block Storage service for {rh-openstack-first} which manages the administration, security, and scheduling of all volumes.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 Config map:: A config map provides a way to inject configuration data into pods. You can reference the data stored in a config map in a volume of type `ConfigMap`. Applications running in a pod can use this data.
 
@@ -30,18 +30,18 @@ The framework allows you to create storage volumes on-demand, eliminating the ne
 Ephemeral storage::
 Pods and containers can require temporary or transient local storage for their operation. The lifetime of this ephemeral storage does not extend beyond the life of the individual pod, and this ephemeral storage cannot be shared across pods.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Fiber channel:: A networking technology that is used to transfer data among data centers, computer servers, switches and storage.
 
 FlexVolume:: FlexVolume is an out-of-tree plugin interface that uses an exec-based model to interface with storage drivers. You must install the FlexVolume driver binaries in a pre-defined volume plugin path on each node and in some cases the control plane nodes.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 fsGroup:: The fsGroup defines a file system group ID of a pod.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 iSCSI:: Internet Small Computer Systems Interface (iSCSI) is an Internet Protocol-based storage networking standard for linking data storage facilities.
 An iSCSI volume allows an existing iSCSI (SCSI over IP) volume to be mounted into your Pod.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 hostPath::
 A hostPath volume in an OpenShift Container Platform cluster mounts a file or directory from the host node’s filesystem into your pod.
@@ -86,9 +86,9 @@ spec:
 +
 Do _not_ use nested mount points because {product-title} does not guarantee the order in which mount points are created. Such usage is prone to race conditions and undefined behavior.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 NFS:: A Network File System (NFS) that allows remote hosts to mount file systems over a network and interact with those file systems as though they are mounted locally. This enables system administrators to consolidate resources onto centralized servers on the network.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 OpenShift Data Foundation::
 A provider of agnostic persistent storage for OpenShift Container Platform supporting file, block, and object storage, either in-house or in hybrid clouds
@@ -115,10 +115,16 @@ Stateful applications:: A stateful application is an application program that sa
 
 Static provisioning:: A cluster administrator creates a number of PVs. PVs contain the details of storage. PVs exist in the Kubernetes API and are available for consumption.
 
-Storage:: {product-title} supports many types of storage, both for on-premise and cloud providers. You can manage container storage for persistent and non-persistent data in an {product-title} cluster.
+Storage:: {product-title} supports many types of storage, both for on-premise and cloud providers. You can manage container storage for persistent and non-persistent data in
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+a {product-title} cluster.
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+an {product-title} cluster.
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 Storage class:: A storage class provides a way for administrators to describe the classes of storage they offer. Different classes might map to quality of service levels, backup policies, arbitrary policies determined by the cluster administrators.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 VMware vSphere’s Virtual Machine Disk (VMDK) volumes:: Virtual Machine Disk (VMDK) is a file format that describes containers for virtual hard disk drives that is used in virtual machines.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -9,30 +9,30 @@
 
 To create CSI-provisioned persistent volumes that mount to these supported storage assets, {product-title} installs the necessary CSI driver Operator, the CSI driver, and the required storage class by default. For more details about the default namespace of the Operator and driver, see the documentation for the specific CSI Driver Operator.
 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 The AWS EFS and GCP Filestore CSI drivers are not installed by default, and must be installed manually. For instructions on installing the AWS EFS CSI driver, see link:https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html/storage/using-container-storage-interface-csi#osd-persistent-storage-aws-efs-csi[Setting up AWS Elastic File Service CSI Driver Operator]. For instructions on installing the GCP Filestore CSI driver, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/storage/using-container-storage-interface-csi#persistent-storage-csi-google-cloud-file-overview[Google Compute Platform Filestore CSI Driver Operator].
 ====
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 The following table describes the CSI drivers that are
 ifndef::openshift-dedicated[]
 installed with {product-title}
 endif::openshift-dedicated[]
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 supported by {product-title}
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 and which CSI features they support, such as volume snapshots and resize.
 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 If your CSI driver is not listed in the following table, you must follow the installation instructions provided by your CSI storage vendor to use their supported CSI features.
 ====
-endif::openshift-rosa[]
-ifdef::openshift-rosa,openshift-aro[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,,openshift-rosa-hcp,openshift-aro[]
 In addition to the drivers listed in the following table, ROSA functions with CSI drivers from third-party storage vendors. Red Hat does not oversee third-party provisioners or the connected CSI drivers and the vendors fully control source code, deployment, operation, and Kubernetes compatibility. These volume provisioners are considered customer-managed and the respective vendors are responsible for providing support. See the link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-responsibilities_rosa-policy-responsibility-matrix[Shared responsibilities for {product-title}] matrix for more information. 
-endif::openshift-rosa,openshift-aro[]
+endif::openshift-rosa,,openshift-rosa-hcp,openshift-aro[]
 
 .Supported CSI drivers and features in {product-title}
 [cols=",^v,^v,^v,^v,^v,^v width="100%",options="header"]
@@ -40,16 +40,16 @@ endif::openshift-rosa,openshift-aro[]
 |CSI driver |CSI volume snapshots  |CSI volume group snapshots ^[1]^ |CSI cloning  |CSI resize |Inline ephemeral volumes
 |AWS EBS | ✅ |  |  | ✅| 
 |AWS EFS |  |  |  |  | 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 |Google Compute Platform (GCP) persistent disk (PD)|  ✅|  |✅^[2]^ | ✅|
 |GCP Filestore | ✅ |  | | ✅|  
-endif::openshift-rosa[]
-ifndef::openshift-dedicated,openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |{ibm-power-server-name} Block |   |  |   | ✅ |  
 |{ibm-cloud-name} Block | ✅^[3]^ |  |   | ✅^[3]^|  
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |LVM Storage | ✅ |  | ✅ | ✅ |  
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |Microsoft Azure Disk | ✅ |  | ✅ | ✅|  
 |Microsoft Azure Stack Hub | ✅ |  | ✅ | ✅|  
 |Microsoft Azure File | ✅^[4]^  |  | ✅^[4]^ | ✅| ✅
@@ -59,9 +59,9 @@ ifndef::openshift-dedicated,openshift-rosa[]
 |Shared Resource |   |  |   |   | ✅
 |CIFS/SMB |   |  | ✅  |   |   
 |VMware vSphere | ✅^[5]^ |  |   | ✅^[6]^|  
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |===
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 --
 1. 
 
@@ -95,4 +95,4 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 * Online expansion is supported from vSphere version 7.0 Update 2 and later.
 --
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/storage-ephemeral-vols-overview.adoc
+++ b/modules/storage-ephemeral-vols-overview.adoc
@@ -26,11 +26,11 @@ Generic ephemeral volumes have the following features:
 ====
 Generic ephemeral volumes do not support offline snapshots and resize.
 
-ifndef::openshift-dedicated,openshift-rosa,microshift[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp,microshift[]
 Due to this limitation, the following Container Storage Interface (CSI) drivers do not support the following features for generic ephemeral volumes:
 
 * Azure Disk CSI driver does not support resize.
 
 * Cinder CSI driver does not support snapshot.
-endif::openshift-dedicated,openshift-rosa,microshift[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp,microshift[]
 ====

--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -29,31 +29,31 @@ The following table displays which volume plugins support block volumes.
 |Volume Plugin  |Manually provisioned  |Dynamically provisioned |Fully supported
 |Amazon Elastic Block Store (Amazon EBS) | ✅ | ✅ | ✅
 |Amazon Elastic File Storage (Amazon EFS) | | |
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |Azure Disk | ✅ | ✅ | ✅
 |Azure File | | |
 |Cinder | ✅ | ✅ | ✅
 |Fibre Channel | ✅ | | ✅
-endif::openshift-dedicated,openshift-rosa[]
-ifndef::openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 |GCP | ✅ | ✅ | ✅
-endif::openshift-rosa[]
-ifndef::openshift-dedicated,openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |HostPath | | |
 |IBM Cloud Block Storage volume | ✅ | ✅ | ✅
 |iSCSI | ✅ | | ✅
 |Local volume | ✅ || ✅
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |LVM Storage | ✅ | ✅ | ✅
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |NFS | | |
 |{rh-storage-first} | ✅ | ✅ | ✅
 |CIFS/SMB  |  ✅ |  ✅ |  ✅
 |VMware vSphere  | ✅ | ✅ | ✅
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 |===
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 :FeatureName: Using any of the block volumes that can be provisioned manually, but are not provided as fully supported,
 include::snippets/technology-preview.adoc[leveloffset=+1]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -41,20 +41,20 @@ ifndef::microshift[]
 [id="types-of-persistent-volumes_{context}"]
 == Types of PVs
 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 {product-title} supports the following persistent volume plugins:
-endif::openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 {product-title} (ROSA) supports the following persistent volume storage options:
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 // - GlusterFS
 // - Ceph RBD
 // - OpenStack Cinder
 - AWS Elastic Block Store (EBS)
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa[]
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa,openshift-rosa-hcp[]
 - AWS Elastic File Store (EFS)
-endif::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa[]
+endif::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-aro[]
 - Azure Disk
 - Azure File
@@ -63,10 +63,10 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 - Cinder
 - Fibre Channel
 endif::openshift-enterprise,openshift-webscale,openshift-origin[]
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 - GCP Persistent Disk
 - GCP Filestore
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 - {ibm-power-server-title} Block
 - {ibm-cloud-name} VPC Block
@@ -86,9 +86,9 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 endif::openshift-enterprise,openshift-webscale,openshift-origin[]
 endif::microshift[]
 
-ifdef::openshift-rosa[]
-ROSA functions with Kubernetes Container Storage Interface (CSI) compatible volume provisioners from other storage vendors. See link:https://docs.openshift.com/rosa/storage/container_storage_interface/persistent-storage-csi.html[Configuring CSI volumes] for more information about CSI drivers in ROSA. 
-endif::openshift-rosa[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+ROSA functions with Kubernetes Container Storage Interface (CSI) compatible volume provisioners from other storage vendors. See link:https://docs.openshift.com/rosa/storage/container_storage_interface/persistent-storage-csi.html[Configuring CSI volumes] for more information about CSI drivers in ROSA.
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 [id="pv-capacity_{context}"]
 == Capacity
@@ -114,11 +114,11 @@ ifndef::microshift[]
 ====
 Volume access modes describe volume capabilities. They are not enforced constraints. The storage provider is responsible for runtime errors resulting from invalid use of the resource. Errors in the provider show up at runtime as mount errors.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 For example, NFS offers `ReadWriteOnce` access mode. If you want to use the volume's ROX capability, mark the claims as `ReadOnlyMany`.
 
 iSCSI and Fibre Channel volumes do not currently have any fencing mechanisms. You must ensure the volumes are only used by one node at a time. In certain situations, such as draining a node, the volumes can be used simultaneously by two nodes. Before draining the node, delete the pods that use the volumes.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 ====
 endif::microshift[]
 
@@ -164,10 +164,10 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |Cinder  | ✅ | ✅ | |  
 |Fibre Channel  | ✅ | ✅ |✅ |  ✅ ^[3]^
 endif::[]
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 |GCP Persistent Disk  | ✅ |✅ |   |   
 |GCP Filestore | ✅ | ✅ |✅ | ✅
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 //|GlusterFS  | ✅ |✅ | ✅ | ✅
 |HostPath  | ✅ |✅ |   |   
@@ -192,10 +192,10 @@ endif::[]
 
 3. Only raw block volumes support the ReadWriteMany (RWX) access mode for Fibre Channel and iSCSI. For more information, see "Block volume support".
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 4. If the underlying vSphere environment supports the vSAN file service, then the vSphere Container Storage Interface (CSI) Driver Operator installed by
 {product-title} supports provisioning of ReadWriteMany (RWX) volumes. If you do not have vSAN file service configured, and you request RWX, the volume fails to get created and an error is logged. For more information, see "Using Container Storage Interface" -> "VMware vSphere CSI Driver Operator".
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // GCE Persistent Disks, or Openstack Cinder PVs.
 --
 endif::microshift[]
@@ -302,15 +302,15 @@ The following PV types support mount options:
 // - GlusterFS
 // - Ceph RBD
 - AWS Elastic Block Store (EBS)
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 - Azure Disk
 - Azure File
 - Cinder
-endif::openshift-dedicated,openshift-rosa[]
-ifndef::openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 - GCE Persistent Disk
-endif::openshift-rosa[]
-ifndef::openshift-dedicated,openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 - iSCSI
 - Local volume
 - NFS
@@ -322,7 +322,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 ====
 Fibre Channel and HostPath PVs do not support mount options.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 endif::microshift[]
 
 ifdef::microshift[]

--- a/modules/storage-persistent-storage-pvc.adoc
+++ b/modules/storage-persistent-storage-pvc.adoc
@@ -43,7 +43,7 @@ provisioners to service one or more storage classes. The cluster
 administrator can create a PV on demand that matches the specifications
 in the PVC.
 
-ifndef::microshift,openshift-rosa[]
+ifndef::microshift,openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 The Cluster Storage Operator might install a default storage class depending
@@ -52,13 +52,13 @@ Operator. It cannot be deleted or modified beyond defining annotations
 and labels. If different behavior is desired, you must define a custom
 storage class.
 ====
-endif::microshift,openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::microshift,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 The Cluster Storage Operator installs a default storage class. This storage class is owned and controlled by the Operator. It cannot be deleted or modified beyond defining annotations and labels. If different behavior is desired, you must define a custom storage class.
 ====
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 The cluster administrator can also set a default storage class for all PVCs.
 When a default storage class is configured, the PVC must explicitly ask for

--- a/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
@@ -6,12 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 This procedure is specific to the link:https://github.com/openshift/aws-efs-csi-driver-operator[AWS EFS CSI Driver Operator] (a Red Hat Operator), which is only applicable for {product-title} 4.10 and later versions.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 == Overview
 
@@ -38,14 +38,14 @@ include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 include::modules/persistent-storage-efs-csi-driver-operator-setup.adoc[leveloffset=+1]
 
 // Obtaining a role ARN (OCP)
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/persistent-storage-csi-efs-sts.adoc[leveloffset=+2]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Obtaining a role ARN (OSD and ROSA)
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/sd-persistent-storage-csi-efs-sts.adoc[leveloffset=+2]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Next steps
 xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-olm-operator-install_persistent-storage-csi-aws-efs[Install the AWS EFS CSI Driver Operator].

--- a/storage/container_storage_interface/persistent-storage-csi-ebs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ebs.adoc
@@ -18,12 +18,12 @@ To create CSI-provisioned PVs that mount to AWS EBS storage assets, {product-tit
 
 * The _AWS EBS CSI driver_ enables you to create and mount AWS EBS PVs.
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [NOTE]
 ====
 If you installed the AWS EBS CSI Operator and driver on an {product-title} 4.5 cluster, you must uninstall the 4.5 Operator and driver before you update to {product-title} {product-version}.
 ====
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 

--- a/storage/dynamic-provisioning.adoc
+++ b/storage/dynamic-provisioning.adoc
@@ -16,25 +16,25 @@ include::modules/dynamic-provisioning-storage-class-definition.adoc[leveloffset=
 
 include::modules/dynamic-provisioning-annotations.adoc[leveloffset=+2]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/dynamic-provisioning-cinder-definition.adoc[leveloffset=+2]
 
 include::modules/dynamic-provisioning-manila-csi-definition.adoc[leveloffset=+2]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/dynamic-provisioning-aws-definition.adoc[leveloffset=+2]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/dynamic-provisioning-azure-disk-definition.adoc[leveloffset=+2]
 
 include::modules/dynamic-provisioning-azure-file-definition.adoc[leveloffset=+2]
 
 include::modules/dynamic-provisioning-azure-file-considerations.adoc[leveloffset=+3]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 include::modules/dynamic-provisioning-gce-definition.adoc[leveloffset=+2]
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 // include::modules/dynamic-provisioning-gluster-definition.adoc[leveloffset=+2]
 
 // include::modules/dynamic-provisioning-ceph-rbd-definition.adoc[leveloffset=+2]

--- a/storage/index.adoc
+++ b/storage/index.adoc
@@ -6,13 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 {product-title} supports multiple types of storage, both for on-premise and cloud providers. You can manage container storage for persistent and non-persistent data in an {product-title} cluster.
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-rosa[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 {product-title} supports Amazon Elastic Block Store (Amazon EBS) and Amazon Elastic File System (Amazon EFS) storage. You can manage container storage for persistent and non-persistent data in an {product-title} cluster.
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/openshift-storage-common-terms.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14937

Link to docs preview:
https://94710--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/storage/

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
