### PR TITLE
MIG-1744: Release Notes MTC 1.8.8

### DIFF
--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,11 +15,20 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-8.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-7.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-6.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-5.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-4.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-3.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-2.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-1.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-8.adoc
+++ b/modules/migration-mtc-release-notes-1-8-8.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes-1-7.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-8_{context}"]
+= {mtc-full} 1.8.8 release notes
+
+[id="resolved-issues-1-8-8_{context}"]
+== Resolved issues
+
+{mtc-first} 1.8.8 has the following major resolved issues:
+
+.The detection of storage live migration status failed
+
+There was an error in detecting the status of storage live migration. This update resolves the issue.
+link:https://issues.redhat.com/browse/MIG-1746[(MIG-1746)]


### PR DESCRIPTION
### JIRA

* [MIG-1744](https://issues.redhat.com/browse/MIG-1744)

### Version(s):

* OCP 4.14
* OCP 4.15
* OCP 4.16
* OCP 4.17
* OCP 4.18
* OCP 4.19
* OCP 4.20

### Link to docs preview:

* [MTC 1.8.8 release notes](https://94717--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes#migration-mtc-release-notes-1-8-7_mtc-release-notes)

### QE review:
- [ ] QE has approved this change.

