### PR TITLE
TELCODOCS-2356: Correct the Configuring NFD procedure

### DIFF
--- a/modules/rdma-configuring-the-nfd-operator.adoc
+++ b/modules/rdma-configuring-the-nfd-operator.adoc
@@ -38,7 +38,7 @@ The `ClusterServiceVersion` specification for NFD Operator provides default valu
 $ NFD_OPERAND_IMAGE=`echo $(oc get csv -n openshift-nfd -o json | jq -r '.items[0].metadata.annotations["alm-examples"]') | jq -r '.[] | select(.kind == "NodeFeatureDiscovery") | .spec.operand.image'`
 ----
 
-. Optional: Add entries to the default `deviceClasseWhiteList` field, to support more network adapters, such as the NVIDIA BlueField DPUs.
+. Optional: Add entries to the default `deviceClassWhiteList` field, to support more network adapters, such as the NVIDIA BlueField DPUs.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
BUG: Correct the Configuring NFD procedure

Jira: https://issues.redhat.com/browse/TELCODOCS-2356

Version(s):  openshift-4.19, openshift-4.18.z, openshift-4.18 

Issue: https://issues.redhat.com/browse/TELCODOCS-2356

Link to docs preview: https://94724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_accelerators/rdma-remote-direct-memory-access.html#rdma-configuring-the-nfd-operator_rdma-remote-direct-memory-access

QE review: @wabouhamad 
[ ] QE has approved this change.