### PR TITLE
OSDOCS-14842: Added fixes for OSDOCS-14842

### DIFF
--- a/modules/capi-yaml-machine-set-bare-metal.adoc
+++ b/modules/capi-yaml-machine-set-bare-metal.adoc
@@ -11,7 +11,7 @@ The compute machine set also references the cluster resource and machine templat
 
 [source,yaml]
 ----
-apiVersion: cluster.x-k8s.io/v1
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineSet
 metadata:
   name: <machine_set_name> # <1>
@@ -32,13 +32,13 @@ spec:
         test: example
         cluster.x-k8s.io/cluster-name: <cluster_name>
         cluster.x-k8s.io/set-name: <machine_set_name>
-        node-role.kubernetes.io/<role>: ""
+        node-role.kubernetes.io/worker: ""
     spec:
       bootstrap:
-         dataSecretName: worker-user-data
+         dataSecretName: worker-user-data-managed
       clusterName: <cluster_name>
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: Metal3MachineTemplate # <3>
         name: <template_name> # <4>
 ----

--- a/modules/capi-yaml-machine-template-bare-metal.adoc
+++ b/modules/capi-yaml-machine-template-bare-metal.adoc
@@ -11,19 +11,27 @@ The compute machine set references this template when creating machines.
 
 [source,yaml]
 ----
-apiVersion: infrastructure.cluster.x-k8s.io/v1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: Metal3MachineTemplate # <1>
 metadata:
-  name: <template_name> # <2>
+  name: <template_name>  # <2>
   namespace: openshift-cluster-api
 spec:
   template:
     spec: # <3>
       customDeploy: install_coreos
-      userData: worker-user-data
+      userData: 
+        name: worker-user-data-managed # <4>
 ----
 <1> Specify the machine template kind.
 This value must match the value for your platform.
 <2> Specify a name for the machine template.
-<3> Specify the details for your environment.
-The values here are examples.
+<3> Specify the details for your environment. The values here are examples.
+<4> The `userData` parameter refers to the Ignition configuration, which the Machine API Operator generates during installation. You must apply the `openshift-cluster-api` namespace to ensure the cluster can access the secret by running the following command:
++
+[source,terminal]
+----
+$ oc get secret worker-user-data-managed \
+  -n openshift-machine-api -o yaml | \
+  sed 's/namespace: .*/namespace: openshift-cluster-api/' | oc apply -f -
+----


### PR DESCRIPTION
Added fixes for [OSDOCS-14842](https://issues.redhat.com//browse/OSDOCS-14842) and PR https://github.com/openshift/openshift-docs/pull/94279.

Fixes: [OSDOCS-14842](https://issues.redhat.com//browse/OSDOCS-14842)

See https://issues.redhat.com/browse/OSDOCS-14842 for additional details.

Preview URL:https://94725--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-bare-metal.html

For release(s): 4.19
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
