### PR TITLE
CNV#63543: RN update for x86-64 CPU arm-based nodes

### DIFF
--- a/modules/virt-supported-cluster-version.adoc
+++ b/modules/virt-supported-cluster-version.adoc
@@ -8,7 +8,9 @@
 
 {VirtProductName} {VirtVersion} is supported for use on {product-title} {product-version} clusters. To use the latest z-stream release of {VirtProductName}, you must first upgrade to the latest version of {product-title}.
 
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 {VirtProductName} is currently available on x86-64 CPUs. Arm-based nodes are not yet supported.
 ====
+endif::openshift-rosa,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.18, 4.19

Issue:
https://issues.redhat.com/browse/CNV-63543

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This note has been removed from the OCP, but kept for ROSA. Since this is off of the main branch, there is no release note link, but this module is included in the About section of CNV so you can confirm the note is not present in OCP, but is present in ROSA by the following links:

* OCP: https://94726--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/about-virt.html#virt-supported-cluster-version_about-virt
* ROSA: https://94726--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/about_virt/about-virt.html#virt-supported-cluster-version_about-virt
