### PR TITLE
OSSM-9365: Resolve documentations issues for OSSM from OSDDOCs 

### DIFF
--- a/install/ossm-installing-openshift-service-mesh.adoc
+++ b/install/ossm-installing-openshift-service-mesh.adoc
@@ -39,7 +39,10 @@ include::modules/ossm-about-bookinfo-application.adoc[leveloffset=+1]
 include::modules/ossm-deploying-bookinfo-application.adoc[leveloffset=+2]
 include::modules/ossm-about-accessing-bookinfo-application-using-gateway.adoc[leveloffset=+2]
 include::modules/ossm-accessing-bookinfo-application-using-istio-gateway-injection.adoc[leveloffset=+2]
-include::modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc[leveloffset=+2]
-include::modules/ossm-customizing-istio-configuration.adoc[leveloffset=+1]
+include::modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc[leveloffset=+2] 
 
-//adding comment for force change to see if migration link updates in Pantheon. Currently returning a 404 error.
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/networking/configuring-ingress-cluster-traffic[Configuring ingress cluster traffic]
+
+include::modules/ossm-customizing-istio-configuration.adoc[leveloffset=+1]

--- a/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
+++ b/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
@@ -1,9 +1,10 @@
 :_mod-docs-content-type: Procedure
 [id="ossm-accessing-bookinfo-application-using-gateway-api"]
 = Accessing the Bookinfo application by using Gateway API
-:context: ossm-accessing-bookinfo-application-using-gateway-API
 
-The {k8s} Gateway API deploys a gateway by creating a `Gateway` resource. In {ocp-product-title} 4.15 and later versions. If you want your cluster to use the Gateway API CRDs, you must enable the CRDs because they are disabled by default.
+The {k8s} Gateway API deploys a gateway by creating a `Gateway` resource. In {ocp-product-title} 4.15 and later, {SMProductName} implements the Gateway API custom resource definitions (CRDs). However, in {ocp-product-title} 4.18 and earlier, the CRDs are not installed by default. Hence, in {ocp-product-title} 4.15 through 4.18, you must manually install the CRDs. Starting with {ocp-product-title} 4.19, these CRDs are automatically installed and managed, and you can no longer create, update, or delete them.
+
+For details about enabling Gateway API for Ingress in {ocp-product-title} 4.19 and later, see "Configuring ingress cluster traffic" in the {ocp-product-title} documentation.
 
 [NOTE]
 ====
@@ -20,14 +21,14 @@ Red{nbsp}Hat provides support for using the {k8s} Gateway API with {SMProductNam
 
 .Procedure
 
-. Enable the Gateway API CRDs:
+. Enable the Gateway API CRDs for {ocp-product-title} 4.18 and earlier, by running the following command:
 +
 [source,terminal]
 ----
 $ oc get crd gateways.gateway.networking.k8s.io &> /dev/null ||  { oc kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.0.0" | oc apply -f -; }
 ----
 
-. Create and configure a gateway using a `Gateway` resource and `HTTPRoute` resource:
+. Create and configure a gateway by using the `Gateway` and `HTTPRoute` resources by running the following command:
 +
 [source,terminal]
 ----
@@ -39,27 +40,41 @@ $ oc apply -f https://raw.githubusercontent.com/openshift-service-mesh/istio/rel
 To configure a gateway with the `bookinfo` application by using the Gateway API, this example uses a sample gateway configuration file that must be applied in the namespace where the application is installed.
 ====
 
-. Ensure that the Gateway API service is ready, and has an address allocated:
+. Ensure that the Gateway API service is ready, and has an address allocated by running the following command:
 +
 [source,terminal]
 ----
 $ oc wait --for=condition=programmed gtw bookinfo-gateway -n bookinfo
 ----
 
-. Retrieve the host, port and gateway URL:
+. Retrieve the host by running the following command:
 +
 [source,terminal]
 ----
 $ export INGRESS_HOST=$(oc get gtw bookinfo-gateway -n bookinfo -o jsonpath='{.status.addresses[0].value}')
+----
+
+. Retrieve the port by running the following command:
++
+[source,terminal]
+----
 $ export INGRESS_PORT=$(oc get gtw bookinfo-gateway -n bookinfo -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
+----
+
+. Retrieve the gateway URL by running the following command:
++
+[source,terminal]
+----
 $ export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
 ----
 
-. Obtain the gateway host name and the URL of the product page:
+. Obtain the gateway host name and the URL of the product page by running the following command:
 +
 [source,terminal]
 ----
 $ echo "http://${GATEWAY_URL}/productpage"
 ----
 
-. Verify that the `productpage` is accessible from a web browser.
+.Verification
+
+* Verify that the *productpage* is accessible from a web browser.


### PR DESCRIPTION
Change type: Doc update; Resolve documentations issues for OSSM from OSDDOCs 

Doc JIRA: https://issues.redhat.com/browse/OSSM-9365

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) ,[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0) and [service-mesh-docs-3.0.0tp1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0.0tp1)

Note: This PR is related to [OSDOCS-13694](https://issues.redhat.com/browse/OSDOCS-13694) from Network Edge

Doc Preview: https://94730--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#ossm-accessing-bookinfo-application-using-gateway-api

QE Review: @FilipB 
OCP reviewers: @Miciah @shaneutt 
Peer Review: @xenolinux 