### PR TITLE
[RHDEVDOCS-6461] Configuring securityContext in EventListener definition

### DIFF
--- a/modules/op-setting-eventlistener-scc.adoc
+++ b/modules/op-setting-eventlistener-scc.adoc
@@ -1,0 +1,43 @@
+// This module is included in the following assemblies:
+// * secure/securing-webhooks-with-event-listeners.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="op-setting-eventlistener-scc_{context}"]
+= Configuring security context for event listeners
+
+You can configure a custom security context directly in your `EventListener` custom resource (CR) to meet your security requirements. A custom security context can help ensure that containers run with restricted privileges and comply with {OCP} security context constraints (SCCs).
+
+.Procedure
+
+* Create a YAML file that defines your `EventListener` CR:
++
+.Example EventListener custom resource with configured security context
+[source,yaml,subs="attributes+"]
+----
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+#...
+spec:
+  serviceAccountName: tekton-triggers-sa
+  resources:
+    kubernetesResource:
+      spec:
+        template:
+          spec:
+            securityContext:
+              runAsNonRoot: true <1>
+            containers:
+              - resources:
+                  requests:
+                    memory: "64Mi"
+                    cpu: "250m"
+                  limits:
+                    memory: "128Mi"
+                    cpu: "500m"
+                securityContext:
+                  readOnlyRootFilesystem: true <2>
+#...
+----
+<1> Specify the pod-level security context settings. The example setting sets the pod-level security context to prevent the containers from running as the root user.
+<2> Specify the container-level security context settings. The example setting restricts the container root filesystem to read-only to limit potential file system modifications at runtime.

--- a/secure/securing-webhooks-with-event-listeners.adoc
+++ b/secure/securing-webhooks-with-event-listeners.adoc
@@ -21,4 +21,6 @@ In addition, you can mount the created secret into the `Eventlistener` pod to se
 
 include::modules/op-providing-secure-connection.adoc[leveloffset=+1]
 
+include::modules/op-setting-eventlistener-scc.adoc[leveloffset=+1]
+
 include::modules/op-sample-eventlistener-resource.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
pipelines-docs-1.19+

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6461

Link to docs preview:
- [Configuring security context for event listeners](https://94734--ocpdocs-pr.netlify.app/openshift-pipelines/latest/secure/securing-webhooks-with-event-listeners.html#op-setting-eventlistener-scc_securing-webhooks-with-event-listeners)

QE review:
- [x] QE has approved this change.

