### PR TITLE
OSDOCS-14867 deleting a dupe RN.

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -849,7 +849,7 @@ For more information, see xref:../networking/ptp/ptp-cloud-events-consumer-dev-r
 [id="ocp-4-19-sr-iov-arm_{context}"]
 ==== Deploying the SR-IOV Network Operator on a cluster that runs on ARM architecture
 
-You can now deploy the SR-IOV Network Operator on a cluster that runs on ARM architecture. (link:https://issues.redhat.com/browse/OCPBUGS-56271[OCPBUGS-56271]) 
+You can now deploy the SR-IOV Network Operator on a cluster that runs on ARM architecture. (link:https://issues.redhat.com/browse/OCPBUGS-56271[OCPBUGS-56271])
 
 [id="ocp-4-19-route-external-cert-feature-gate_{context}"]
 ==== Re-add a previously deleted secret with `RouteExternalCertificate` feature gate enabled
@@ -1049,12 +1049,6 @@ This release also introduces the following updates to the web console. You can n
 === Pods deploy with readOnlyRootFilesystem set to true
 
 With this release, Cloud Credential Operator pods now deploy with the `readOnlyRootFilesystem` security context setting set to `true`. This enhances security by ensuring that the container root file system is mounted as read-only.
-
-[discrete]
-[id="ocp-4-19-notable-technical-changes-loopback-cert_{context}"]
-=== Extended loopback certificate validity to three years for kube-apiserver
-
-Previously, in-memory loopback certificates in kube-apiserver were issued for one year. This meant that if the kube-apiserver ran without rollouts or restarts, the kube-apiserver would stop functioning after one year. In {product-title} {product-version} the in-memory loopback certificates are extended so the kube-apiserver can run for three years without interruption.
 
 [id="ocp-release-notes-readiness-probes-etcd_{context}"]
 === Readiness probes exclude etcd checks
@@ -1470,11 +1464,11 @@ For more information about the unsupported, community-maintained, version of the
 
 * Previously, if you forgot to include a Redfish system ID, such as `redfish://host/redfish/v1/` instead of `redfish://host/redfish/v1/Self`, in a Baseboard Management Console (BMC) URL, a JSON parsing issue existed in Ironic. With this release, BMO can now handle URLs without a Redfish system ID as a valid address without causing a JSON parsing issue. (link:https://issues.redhat.com/browse/OCPBUGS-56026[OCPBUGS-56026])
 
-* Previously, a race condition existed during provisioning which, in case of a slow DHCP response, could cause different hostnames to be used for machine and node objects. This could prevent CSRs of worker nodes from being automatically approved. With this release, the race condition was fixed and CSRs of worker nodes are now properly approved.  (link:https://issues.redhat.com/browse/OCPBUGS-55315[OCPBUGS-55315]) 
+* Previously, a race condition existed during provisioning which, in case of a slow DHCP response, could cause different hostnames to be used for machine and node objects. This could prevent CSRs of worker nodes from being automatically approved. With this release, the race condition was fixed and CSRs of worker nodes are now properly approved.  (link:https://issues.redhat.com/browse/OCPBUGS-55315[OCPBUGS-55315])
 
-* Previously, certain models of SuperMicro machines, such as `ars-111gl-nhr`, use a different virtual media device string than other SuperMicro machines, which could cause virtual media boot attempts to fail on these servers. With this release, an extra conditional check was added to check for the specific model affected and adjust behavior accordingly, so that SuperMicro models such as ars-111gl-nhr can now boot from virtual media. (link:https://issues.redhat.com/browse/OCPBUGS-56639[OCPBUGS-56639]) 
+* Previously, certain models of SuperMicro machines, such as `ars-111gl-nhr`, use a different virtual media device string than other SuperMicro machines, which could cause virtual media boot attempts to fail on these servers. With this release, an extra conditional check was added to check for the specific model affected and adjust behavior accordingly, so that SuperMicro models such as ars-111gl-nhr can now boot from virtual media. (link:https://issues.redhat.com/browse/OCPBUGS-56639[OCPBUGS-56639])
 
-* Previously, after deleting a `BaremetalHost` that has a related `DataImage`, the `DataImage` was still present. With this release, the `DataImage` is deleted if it exists after the `BaremetalHost` has been deleted. (link:https://issues.redhat.com/browse/OCPBUGS-51294[OCPBUGS-51294]) 
+* Previously, after deleting a `BaremetalHost` that has a related `DataImage`, the `DataImage` was still present. With this release, the `DataImage` is deleted if it exists after the `BaremetalHost` has been deleted. (link:https://issues.redhat.com/browse/OCPBUGS-51294[OCPBUGS-51294])
 
 [discrete]
 [id="ocp-release-note-builds-bug-fixes_{context}"]
@@ -1683,7 +1677,7 @@ With this release, availability sets are no longer modified after creation, allo
 
 * When a Proxy is configured, the installation program adds the `machineNetwork` CIDR to the `noProxy` field. Previously, if the `machineNetwork` CIDR had also been configured by the user in the `noProxy` field, this would result in a duplicate entry, which is not allowed by ignition and could prevent the host from booting properly. With this release, the installation program will not add the `machineNetwork` CIDR to the `noProxy` field if it has already been set. (link:https://issues.redhat.com/browse/OCPBUGS-53183[OCPBUGS-53183])
 
-* Previously, API and ingress VIPs were automatically assigned even when a user-managed load balancer was in use. This behavior was unintended. Now, API and ingress VIPs are no longer automatically assigned. If these values are not explicitly set in the `install-config.yaml` file, the installation fails with an error, prompting the user to provide them. (link:https://issues.redhat.com/browse/OCPBUGS-53140[OCPBUGS-53140]) 
+* Previously, API and ingress VIPs were automatically assigned even when a user-managed load balancer was in use. This behavior was unintended. Now, API and ingress VIPs are no longer automatically assigned. If these values are not explicitly set in the `install-config.yaml` file, the installation fails with an error, prompting the user to provide them. (link:https://issues.redhat.com/browse/OCPBUGS-53140[OCPBUGS-53140])
 
 * Previously, when using the Agent-based Installer, the WWN of Fibre Channel (FC) multipath volumes was not detected during hardware discovery. As a result, when the `wwn` root device hint was specified, all multipath FC volumes were excluded by it. With this release, the WWN is now collected for multipath FC volumes, so when more than one multipath volume is present, users can select between them by using the `wwn` root device hint. (link:https://issues.redhat.com/browse/OCPBUGS-52994[OCPBUGS-52994])
 
@@ -1841,7 +1835,7 @@ With this release, availability sets are no longer modified after creation, allo
 
 * Previously, if you tried to add a node to a disconnected environment using the `oc adm node-image` command, private registry images were inaccessible to the command, causing node addition failure. This error only occurred if the cluster was initially installed with an installer binary downloaded from (link:https://mirror.openshift.com/pub/)[mirror.openshift.com]. With this release, a fix has been implemented that enables successful image pull and node creation in disconnected environments. (link:https://issues.redhat.com/browse/OCPBUGS-53106[OCPBUGS-53106])
 
-* Previously, a bug on `oc adm inspect --all-namespaces` command construction meant that must-gather was not correctly gathering information about leases, `csistoragecapacities`, and the assisted-installer namespace. With this release, the issue is fixed and must-gather will gather the information correctly. (link:https://issues.redhat.com/browse/OCPBUGS-44857[OCPBUGS-44857]) 
+* Previously, a bug on `oc adm inspect --all-namespaces` command construction meant that must-gather was not correctly gathering information about leases, `csistoragecapacities`, and the assisted-installer namespace. With this release, the issue is fixed and must-gather will gather the information correctly. (link:https://issues.redhat.com/browse/OCPBUGS-44857[OCPBUGS-44857])
 
 * Previously, the `oc adm node-image create --pxe generated` command did not create only the Preboot Execution Environment (PXE) artifacts. Instead, the command created the PXE artifacts with other artifacts from a `node-joiner` pod and stored them all in the wrong subdirectory. Additionally, the PXE artifacts were incorrectly prefixed with `agent` instead of `node`. With this release, generated PXE artifacts are stored in the correct directory and receive the correct prefix. (link:https://issues.redhat.com/browse/OCPBUGS-45311[OCPBUGS-45311])
 
@@ -1862,7 +1856,7 @@ With this release, availability sets are no longer modified after creation, allo
 Docker references with both a tag and digest are currently not supported.
 ----
 +
-With this update, oc-mirror plugin v2 supports Helm charts that reference images using both tag and digest. The tool mirrors the image using the digest as the source and applies the tag at the destination. (link:https://issues.redhat.com/browse/OCPBUGS-54891[OCPBUGS-54891]) 
+With this update, oc-mirror plugin v2 supports Helm charts that reference images using both tag and digest. The tool mirrors the image using the digest as the source and applies the tag at the destination. (link:https://issues.redhat.com/browse/OCPBUGS-54891[OCPBUGS-54891])
 
 * Previously, during image cleanup, oc-mirror plugin v2 would stop the deletion process if any error occurred while removing an image. With this release, oc-mirror plugin v2 continues attempting to delete remaining images even after encountering errors. After the process completes, it displays a list of any failed deletions. (link:https://issues.redhat.com/browse/OCPBUGS-54653[OCPBUGS-54653])
 
@@ -2590,7 +2584,7 @@ Previously, the kubelet would not account for probes that ran in the `syncPod` m
 
 * There is a known issue with RHEL 8 worker nodes that  use `cgroupv1` Linux Control Groups (cgroup). The following is an example of the error message displayed for impacted nodes: `UDN are not supported on the node ip-10-0-51-120.us-east-2.compute.internal as it uses cgroup v1.` As a workaround, migrate worker nodes from `cgroupv1` to `cgroupv2`. (link:https://issues.redhat.com/browse/OCPBUGS-49933[OCPBUGS-49933])
 
-* There is a known issue when the grandmaster clock (T-GM) transitions to the `Locked` state too soon. This happens before the Digital Phase-Locked Loop (DPLL) completes its transition to the `Locked-HO-Acquired` state, and after the Global Navigation Satellite Systems (GNSS) time source is restored. (link:https://issues.redhat.com/browse/OCPBUGS-49826[OCPBUGS-49826]) 
+* There is a known issue when the grandmaster clock (T-GM) transitions to the `Locked` state too soon. This happens before the Digital Phase-Locked Loop (DPLL) completes its transition to the `Locked-HO-Acquired` state, and after the Global Navigation Satellite Systems (GNSS) time source is restored. (link:https://issues.redhat.com/browse/OCPBUGS-49826[OCPBUGS-49826])
 
 * When a pod uses the CNI plugin for DHCP address assignment, in conjunction with other CNI plugins, the pod's network interface might be unexpectedly deleted. As a result, when the pod's DHCP lease expires, the DHCP proxy enters a loop when trying to re-create a new lease, leading to the node becoming unresponsive. There is currently no known workaround. (link:https://issues.redhat.com/browse/OCPBUGS-45272[OCPBUGS-45272])
 
@@ -2608,7 +2602,7 @@ $ oc patch networks.operator.openshift.io cluster --type=merge -p \
     "defaultNetwork":{
       "ovnKubernetesConfig":{
         "ipsecConfig":{
-          "mode":"Full" 
+          "mode":"Full"
         }}}}}'
 ----
 +


### PR DESCRIPTION
Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-14867
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Extended loopback certificate validity to three years for kube-apiserver was duped by another writer so I'm deleting mine.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
