### PR TITLE
OSDOCS-14603-2: ESO documentation assembly and modules

### DIFF
--- a/modules/external-secrets-operator-install-cli.adoc
+++ b/modules/external-secrets-operator-install-cli.adoc
@@ -107,7 +107,8 @@ $ oc get pods -n external-secrets-operator
 .Example output
 [source,terminal]
 ----
-// content to be added
+NAME                                                            READY   STATUS    RESTARTS   AGE
+external-secrets-operator-controller-manager-75c4599766-t6qs6   1/1     Running   0          143m
 ----
 
 . Verify that the status of the `external-secrets` pods is `Running` by running the following command:
@@ -120,5 +121,8 @@ $ oc get pods -n external-secrets
 .Example output
 [source,terminal]
 ----
-// content to be added
+NAME                                                READY   STATUS    RESTARTS   AGE
+external-secrets-75d47cb9c8-6p4n2                   1/1     Running   0          4h5m
+external-secrets-cert-controller-676444b897-qb6ft   1/1     Running   0          4h5m
+external-secrets-webhook-b566658ff-7m4d5            1/1     Running   0          4h5m
 ----

--- a/modules/external-secrets-operator-install-console.adoc
+++ b/modules/external-secrets-operator-install-console.adoc
@@ -29,7 +29,7 @@ You can use the web console to install the {external-secrets-operator}.
 //====
 . On the *Install Operator* page:
 
-.. Update the *Update channel*, if necessary. The channel defaults to *name to be added*, which installs the latest stable release of the {external-secrets-operator-short}.
+.. Update the *Update channel*, if necessary. The channel defaults to *techpreview-v0.1*, which installs the latest stable release of the {external-secrets-operator-short}.
 
 .. Select the version from *Version* drop-down list.
 


### PR DESCRIPTION
Version(s):
4.19 +

Issue:
[OSDOCS-14603](https://issues.redhat.com/browse/OSDOCS-14603)

Link to docs preview:
[External secrets Operator for Red Hat OpenShift overview]()
[External secrets Operator for Red Hat OpenShift release notes]()
[Installing the external secrets Operator for Red Hat OpenShift]()
[Monitoring external secrets Operator for Red Hat OpenShift]()
[Uninstalling the external secrets Operator for Red Hat OpenShift]()

QE review:
- [ ]QE approval is not required.

Additional information:
Refer to the PR https://github.com/openshift/openshift-docs/pull/93201 for all the approvals.