### PR TITLE
Node cgroup v1 remove rn link

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -878,6 +878,8 @@ If you enabled the `RouteExternalCertificate` feature gate for your cluster, you
 
 cgroup v1, which was deprecated in {product-title} 4.16, is no longer supported and has been removed from {product-title}. If your cluster is using cgroup v1, you must configure cgroup v2 before you can upgrade to  {product-title} {product-version}. All workloads must now be compatible with cgroup v2.
 
+For information on configuring cgroup v2 in your cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/nodes/working-with-clusters#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2[Configuring Linux cgroup] in the {product-title} version 4.18 documentation.
+
 For more information on cgroup v2, see xref:../architecture/index.adoc#architecture-about-cgroup-v2_architecture-overview[About Linux cgroup version 2] and link:https://www.redhat.com/en/blog/rhel-9-changes-context-red-hat-openshift-workloads[Red Hat Enterprise Linux 9 changes in the context of Red Hat OpenShift workloads] (Red{nbsp}Hat blog).
 
 [id="ocp-release-notes-openshift-cli_{context}"]


### PR DESCRIPTION
To address the concern stated by the Product Operations (formerly Product Experience Engineering) team in [Docs for [OCPSTRAT-1341](https://issues.redhat.com//browse/OCPSTRAT-1341) Remove Cgroup v1 from OCP in 4.19](https://issues.redhat.com/browse/OSDOCS-10355?focusedId=27397096&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27397096), I added to the 4.19 release notes a hard-coded link to the Configuring Linux cgroup v2 module in the OCP 4.18 docs. 

No QE. 