### PR TITLE
CNV#61769: re-adding TP note to s390x known issues

### DIFF
--- a/virt/release_notes/virt-4-19-release-notes.adoc
+++ b/virt/release_notes/virt-4-19-release-notes.adoc
@@ -283,6 +283,12 @@ include::snippets/technology-preview.adoc[]
 [id="virt-4-19-ki-ibm-z_{context}"]
 === {ibm-z-title} and {ibm-linuxone-title}
 
+ifdef::openshift-enterprise[]
+:FeatureName: Using {VirtProductName} in a cluster deployed on s390x architecture
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
+endif::[]
+
 // cnv-61740 - s390x VM fails to boot with SATA CD-ROM
 * If you create a VM from a template and select *Boot from CD*, the VM fails to boot and the error `unsupported configuration: SATA is not supported with this QEMU binary` is logged. This occurs because the CD-ROM is automatically mounted as a SATA device, which is not supported on s390x architecture. (link:https://issues.redhat.com/browse/CNV-61740[CNV-61740])
 ** As a workaround, navigate to the VM's *Configuration* ->  *Storage* tab, select the CD-ROM, and change the interface type from *SATA* to *SCSI*.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19 RN
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: related to [CNV-61769](https://issues.redhat.com//browse/CNV-61769)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94782--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-19-release-notes.html#virt-4-19-known-issues_virt-4-19-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change. n/a
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: I removed this TP notice in a recent PR because I was expecting the feature to go GA. It is staying TP, so I need to re-add it. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
