### PR TITLE
HCIDOCS-623: Added release notes for BMaaS

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -946,6 +946,13 @@ For more information, see link:https://access.redhat.com/node/7123119[Updating t
 [id="ocp-release-notes-postinstallation-configuration_{context}"]
 === Postinstallation configuration
 
+[id=ocp-release-notes-postinstallation-configuration-using-bmaas_{context}]
+==== Using bare metal as a service (Technology Preview)
+
+In {product-title} {product-version}, you can deploy non-{product-title} nodes by using bare metal as a service (BMaaS). BMaaS nodes can run workloads that might not be suitable for containerization or virtualization. For example, workloads such as applications that require direct hardware access, conduct high-performance computing tasks or are legacy applications and operate independently of the cluster are suitable for deployment by using BMaaS.
+
+For more information, see xref:../installing/installing_bare_metal/bare-metal-using-bare-metal-as-a-service.html#bmo-configuring-userdata_bare-metal-using-bmaas[Using bare metal as a service].
+
 [id="ocp-release-notes-rhcos_{context}"]
 === {op-system-first}
 
@@ -2164,6 +2171,11 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 |Technology Preview
+
+|Using bare metal as a service
+|Not Available
+|Not Available
+|Technology Preview
 |====
 
 [discrete]
@@ -2214,6 +2226,11 @@ In the following tables, features are marked with the following statuses:
 |Managing machines with the Cluster API for {vmw-full}
 |Technology Preview
 |Technology Preview
+|Technology Preview
+
+|Managing machines with the Cluster API for bare metal
+|Not Available
+|Not Available
 |Technology Preview
 
 |Cloud controller manager for {ibm-power-server-name}


### PR DESCRIPTION
Adds release notes for [HCIDOCS-623](https://issues.redhat.com//browse/HCIDOCS-623) BMaaS, which is a Tech Preview. Also added Cluster API on bare metal to the tech preview tables. Jeana has another PR for release notes related to CAPI. 

Version(s): 4.19

Issue: [HCIDOCS-623](https://issues.redhat.com//browse/HCIDOCS-623)

Link to docs preview: https://94784--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-postinstallation-configuration-using-bmaas_release-notes and https://94784--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-technology-preview-tables_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
