### PR TITLE
OSDOCS-13499: Removed unused sections from 4.19.0 RN doc

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -1422,9 +1422,9 @@ Starting with this release, use the `useOverlay` API hook to launch modals
 
 [id="ocp-4-19-rhel-worker-nodes-removed_{context}"]
 ==== Package-based {op-system-base} compute machines
-With this release, support for the installation of packaged-based {op-system-base} worker nodes is removed.
+With this release, support for the installation of packaged-based {op-system-base} compute nodes is removed.
 
-{op-system} image layering replaces this feature and supports installing additional packages on the base operating system of your worker nodes.
+{op-system} image layering replaces this feature and supports installing additional packages on the base operating system of your compute nodes.
 
 For information on how to identify and remove {op-system-base} nodes in your cluster, see xref:../updating/preparing_for_updates/updating-cluster-prepare-past-4-18.adoc#updating-cluster-prepare-past-4-18[Preparing to update from {product-title} 4.18 to a newer version]. For more information on image layering, see xref:../machine_configuration/mco-coreos-layering.adoc#mco-coreos-layering[{op-system} image layering].
 
@@ -1517,7 +1517,7 @@ For more information about the unsupported, community-maintained, version of the
 
 * Previously, if you forgot to include a Redfish system ID, such as `redfish://host/redfish/v1/` instead of `redfish://host/redfish/v1/Self`, in a Baseboard Management Console (BMC) URL, a JSON parsing issue existed in Ironic. With this release, BMO can now handle URLs without a Redfish system ID as a valid address without causing a JSON parsing issue. (link:https://issues.redhat.com/browse/OCPBUGS-56026[OCPBUGS-56026])
 
-* Previously, a race condition existed during provisioning which, in case of a slow DHCP response, could cause different hostnames to be used for machine and node objects. This could prevent CSRs of worker nodes from being automatically approved. With this release, the race condition was fixed and CSRs of worker nodes are now properly approved.  (link:https://issues.redhat.com/browse/OCPBUGS-55315[OCPBUGS-55315])
+* Previously, a race condition existed during provisioning which, in case of a slow DHCP response, could cause different hostnames to be used for machine and node objects. This could prevent CSRs of compute nodes from being automatically approved. With this release, the race condition was fixed and CSRs of compute nodes are now properly approved. (link:https://issues.redhat.com/browse/OCPBUGS-55315[OCPBUGS-55315])
 
 * Previously, certain models of SuperMicro machines, such as `ars-111gl-nhr`, use a different virtual media device string than other SuperMicro machines, which could cause virtual media boot attempts to fail on these servers. With this release, an extra conditional check was added to check for the specific model affected and adjust behavior accordingly, so that SuperMicro models such as ars-111gl-nhr can now boot from virtual media. (link:https://issues.redhat.com/browse/OCPBUGS-56639[OCPBUGS-56639])
 
@@ -1797,7 +1797,7 @@ With this release, availability sets are no longer modified after creation, allo
 
 * Previously, the `ContainerRuntimeConfig` incorrectly set the `--root` path for the `runc` runtime. This caused containers to run with an incorrect root path and led to issues with the container operations. With this release, the `--root` path for container runtime is correct and matches the specified runtime, providing consistent operation. (link:https://issues.redhat.com/browse/OCPBUGS-47629[OCPBUGS-47629])
 
-* Previously, users were not warned if their cluster contained {op-system-base-full} worker nodes, which are no longer supported in {product-title} 4.19 and later. With this release, the Machine Config Operator detects {op-system-base} nodes and notifies users that are not compatible with {product-title} 4.19. (link:https://issues.redhat.com/browse/OCPBUGS-54611[OCPBUGS-54611])
+* Previously, users were not warned if their cluster contained {op-system-base-full} compute nodes, which are no longer supported in {product-title} 4.19 and later. With this release, the Machine Config Operator detects {op-system-base} nodes and notifies users that are not compatible with {product-title} 4.19. (link:https://issues.redhat.com/browse/OCPBUGS-54611[OCPBUGS-54611])
 
 * Previously, when the Machine Config Operator (MCO) rebooted a node too quickly after staging an update, the update failed. With this release, the MCO waits for the staging operation to finish before rebooting the system, allowing the update to complete. (link:https://issues.redhat.com/browse/OCPBUGS-51150[OCPBUGS-51150])
 
@@ -2087,7 +2087,7 @@ With this release, PPC no longer fails to create the performance profile because
 
 * Previously, when creating a hosted cluster with specified labels, the AWS EBS driver, Driver Operator, snapshot controller, and snapshot webhook pods do not get theses specified labels propagated to them. With this release, the specified labels are propagated. (link:https://issues.redhat.com/browse/OCPBUGS-45073[OCPBUGS-45073])
 
-* Previously, the Manila Container Storage Interface (CSI) driver had services running on unintended hosts. This occurred because the Manila CSI driver uses a single binary for both the controller and node (worker) services.  With this release, the CSI driver controller pods run only controller services, and CSI driver node pods run only node services. (https://issues.redhat.com/browse/OCPBUGS-54447[OCPBUGS-54447])
+* Previously, the Manila Container Storage Interface (CSI) driver had services running on unintended hosts. This occurred because the Manila CSI driver uses a single binary for both the controller and node (worker) services. With this release, the CSI driver controller pods run only controller services, and CSI driver node pods run only node services. (https://issues.redhat.com/browse/OCPBUGS-54447[OCPBUGS-54447])
 
 * Previously, the Container Storage Interface (CSI) Operator was issuing warnings in the log about missing items that would become fatal in the future. With this release, the warnings are no longer issued. (link:https://issues.redhat.com/browse/OCPBUGS-44374[OCPBUGS-44374])
 
@@ -2770,7 +2770,7 @@ In the following tables, features are marked with the following statuses:
 
 * Previously, the kubelet would not account for probes that ran in the `syncPod` method, which periodically checks the state of a pod and does a readiness probe outside of the normal probe period. With this release, a bug is fixed for when the kubelet incorrectly calculates `readinessProbe` periods. However, pod authors might see that the readiness latency of pods configured with readiness probes might increase. This behavior is more accurate to the configured probe. For more information, see (link:https://issues.redhat.com/browse/OCPBUGS-50522[OCPBUGS-50522])
 
-* There is a known issue with RHEL 8 worker nodes that  use `cgroupv1` Linux Control Groups (cgroup). The following is an example of the error message displayed for impacted nodes: `UDN are not supported on the node ip-10-0-51-120.us-east-2.compute.internal as it uses cgroup v1.` As a workaround, migrate worker nodes from `cgroupv1` to `cgroupv2`. (link:https://issues.redhat.com/browse/OCPBUGS-49933[OCPBUGS-49933])
+* There is a known issue with RHEL 8 compute nodes that  use `cgroupv1` Linux Control Groups (cgroup). The following is an example of the error message displayed for impacted nodes: `UDN are not supported on the node ip-10-0-51-120.us-east-2.compute.internal as it uses cgroup v1.` As a workaround, migrate compute nodes from `cgroupv1` to `cgroupv2`. (link:https://issues.redhat.com/browse/OCPBUGS-49933[OCPBUGS-49933])
 
 * There is a known issue when the grandmaster clock (T-GM) transitions to the `Locked` state too soon. This happens before the Digital Phase-Locked Loop (DPLL) completes its transition to the `Locked-HO-Acquired` state, and after the Global Navigation Satellite Systems (GNSS) time source is restored. (link:https://issues.redhat.com/browse/OCPBUGS-49826[OCPBUGS-49826])
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13499](https://issues.redhat.com/browse/OSDOCS-13499)

Link to docs preview:
* [4.19](https://94798--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html)
