### PR TITLE
Update storage-persistent-storage-pv.adoc

### DIFF
--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -34,7 +34,7 @@ You can view the name of a PVC that is bound to a PV by running the following co
 
 [source,terminal]
 ----
-$ oc get pv <pv-name> -o jsonpath='{.spec.claimRef.name}'
+$ oc get pv <pv_name> -o jsonpath='{.spec.claimRef.name}'
 ----
 
 ifndef::microshift[]
@@ -261,7 +261,7 @@ The `LastPhaseTransitionTime` field has a timestamp that updates every time a pe
 
 [source,terminal]
 ----
-$ oc get pv <pv-name> -o json | jq '.status.lastPhaseTransitionTime' <1>
+$ oc get pv <pv_name> -o json | jq '.status.lastPhaseTransitionTime' <1>
 ----
 <1> Specify the name of the PV that you want to see the last phase transition.
 


### PR DESCRIPTION
- The command structure requires correction.

Current Look:

- You can view the name of a PVC that is bound to a PV by running the following command 
~~~
$ oc get pv <pv-name> -o jsonpath='{.spec.claimRef.name}' 
~~~

- Last phase transition time
- The LastPhaseTransitionTime field has a timestamp that updates every time a persistent volume (PV) transitions to a different phase (pv.Status.Phase). To find the time of the last phase transition for a PV, run the following command: 
~~~
$ oc get pv <pv-name> -o json | jq '.status.lastPhaseTransitionTime' (1) 
~~~

- Here pv-name is mentioned with hyphens.
- But as per the standard format, it should be with underscores.

Updated Look:

- You can view the name of a PVC that is bound to a PV by running the following command 
~~~
$ oc get pv <pv_name> -o jsonpath='{.spec.claimRef.name}' 
~~~

- Last phase transition time
- The LastPhaseTransitionTime field has a timestamp that updates every time a persistent volume (PV) transitions to a different phase (pv.Status.Phase). To find the time of the last phase transition for a PV, run the following command: 
~~~
$ oc get pv <pv_name> -o json | jq '.status.lastPhaseTransitionTime' (1) 
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.20, RHOCP 4.19, RHOCP 4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-14803

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://94799--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/understanding-persistent-storage-microshift.html
https://94799--ocpdocs-pr.netlify.app/openshift-dedicated/latest/storage/understanding-persistent-storage.html
https://94799--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html
https://94799--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/storage/understanding-persistent-storage.html
https://94799--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/understanding-persistent-storage.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
