### PR TITLE
OBSDOCS-1997: Add a redirect to logging docs and remove them

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2994,46 +2994,46 @@ Topics:
 #      File: logging-5-8-release-notes
 #    - Name: Logging 5.7
 #      File: logging-5-7-release-notes
-  - Name: Logging 6.2
-    Dir: logging-6.2
-    Topics:
-    - Name: Support
-      File: log62-cluster-logging-support
-    - Name: Release notes
-      File: log6x-release-notes-6.2
-    - Name: About logging 6.2
-      File: log6x-about-6.2
-    - Name: Configuring log forwarding
-      File: log6x-clf-6.2
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.2
-    - Name: Configuring LokiStack storage
-      File: log6x-loki-6.2
-    - Name: Configuring LokiStack for OTLP
-      File: log6x-configuring-lokistack-otlp-6.2
-    - Name: Visualization for logging
-      File: log6x-visual-6.2
-  - Name: Logging 6.1
-    Dir: logging-6.1
-    Topics:
-    - Name: Support
-      File: log61-cluster-logging-support
-    - Name: Release notes
-      File: log6x-release-notes-6.1
-    - Name: About logging 6.1
-      File: log6x-about-6.1
-    - Name: Configuring log forwarding
-      File: log6x-clf-6.1
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.1
-    - Name: Configuring LokiStack storage
-      File: log6x-loki-6.1
-    - Name: Configuring LokiStack for OTLP
-      File: log6x-configuring-lokistack-otlp-6.1
-    - Name: OpenTelemetry data model
-      File: log6x-opentelemetry-data-model-6.1
-    - Name: Visualization for logging
-      File: log6x-visual-6.1
+#  - Name: Logging 6.2
+#    Dir: logging-6.2
+#    Topics:
+#    - Name: Support
+#      File: log62-cluster-logging-support
+#    - Name: Release notes
+#      File: log6x-release-notes-6.2
+#    - Name: About logging 6.2
+#      File: log6x-about-6.2
+#    - Name: Configuring log forwarding
+#      File: log6x-clf-6.2
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.2
+#    - Name: Configuring LokiStack storage
+#      File: log6x-loki-6.2
+#    - Name: Configuring LokiStack for OTLP
+#      File: log6x-configuring-lokistack-otlp-6.2
+#    - Name: Visualization for logging
+#      File: log6x-visual-6.2
+#  - Name: Logging 6.1
+#    Dir: logging-6.1
+#    Topics:
+#    - Name: Support
+#      File: log61-cluster-logging-support
+#    - Name: Release notes
+#      File: log6x-release-notes-6.1
+#    - Name: About logging 6.1
+#      File: log6x-about-6.1
+#    - Name: Configuring log forwarding
+#      File: log6x-clf-6.1
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.1
+#    - Name: Configuring LokiStack storage
+#      File: log6x-loki-6.1
+#    - Name: Configuring LokiStack for OTLP
+#      File: log6x-configuring-lokistack-otlp-6.1
+#    - Name: OpenTelemetry data model
+#      File: log6x-opentelemetry-data-model-6.1
+#    - Name: Visualization for logging
+#      File: log6x-visual-6.1
 #  - Name: Support
 #    File: cluster-logging-support
 #  - Name: Troubleshooting logging
@@ -3046,8 +3046,8 @@ Topics:
 #    - Name: Troubleshooting logging alerts
 #      File: troubleshooting-logging-alerts
 #      File: cluster-logging-log-store-status
-#  - Name: About Logging
-#    File: cluster-logging
+     - Name: About Logging
+       File: about-logging
 #  - Name: Installing Logging
 #    File: cluster-logging-deploying
 #  - Name: Updating Logging

--- a/observability/logging/about-logging.adoc
+++ b/observability/logging/about-logging.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="about-logging"]
+= About Logging
+:context: cluster-logging
+
+toc::[]
+
+As a cluster administrator, you can deploy {logging} on an {product-title} cluster, and use it to collect and aggregate node system audit logs, application container logs, and infrastructure logs.
+
+You can use {logging} to perform the following tasks:
+
+* Forward logs to your chosen log outputs, including on-cluster, Red{nbsp}Hat managed log storage.
+* Visualize your log data in the {product-title} web console.
+
+[NOTE]
+====
+Because {logging} releases on a different cadence from {product-title}, the {logging} documentation is available as a separate documentation set at link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/[Red{nbsp}Hat OpenShift {logging-uc}].
+====


### PR DESCRIPTION
Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1997
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94807--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/about-logging.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not required as there are no technical changes.
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
