### PR TITLE
OSDOCS-13633#removing duplicate prereqs AWS

### DIFF
--- a/modules/installation-aws-user-infra-bootstrap.adoc
+++ b/modules/installation-aws-user-infra-bootstrap.adoc
@@ -12,14 +12,6 @@ you can start the bootstrap sequence that initializes the {product-title} contro
 
 .Prerequisites
 
-* You configured an AWS account.
-* You added your AWS keys and region to your local AWS profile by running `aws configure`.
-* You generated the Ignition config files for your cluster.
-* You created and configured a VPC and associated subnets in AWS.
-* You created and configured DNS, load balancers, and listeners in AWS.
-* You created the security groups and roles required for your cluster in AWS.
-* You created the bootstrap machine.
-* You created the control plane machines.
 * You created the worker nodes.
 
 .Procedure

--- a/modules/installation-creating-aws-bootstrap.adoc
+++ b/modules/installation-creating-aws-bootstrap.adoc
@@ -22,10 +22,6 @@ have to contact Red Hat support with your installation logs.
 
 .Prerequisites
 
-* You configured an AWS account.
-* You added your AWS keys and region to your local AWS profile by running `aws configure`.
-* You generated the Ignition config files for your cluster.
-* You created and configured a VPC and associated subnets in AWS.
 * You created and configured DNS, load balancers, and listeners in AWS.
 * You created the security groups and roles required for your cluster in AWS.
 

--- a/modules/installation-creating-aws-control-plane.adoc
+++ b/modules/installation-creating-aws-control-plane.adoc
@@ -26,12 +26,6 @@ have to contact Red Hat support with your installation logs.
 
 .Prerequisites
 
-* You configured an AWS account.
-* You added your AWS keys and region to your local AWS profile by running `aws configure`.
-* You generated the Ignition config files for your cluster.
-* You created and configured a VPC and associated subnets in AWS.
-* You created and configured DNS, load balancers, and listeners in AWS.
-* You created the security groups and roles required for your cluster in AWS.
 * You created the bootstrap machine.
 
 .Procedure

--- a/modules/installation-creating-aws-dns.adoc
+++ b/modules/installation-creating-aws-dns.adoc
@@ -23,9 +23,6 @@ have to contact Red Hat support with your installation logs.
 
 .Prerequisites
 
-* You configured an AWS account.
-* You added your AWS keys and region to your local AWS profile by running `aws configure`.
-* You generated the Ignition config files for your cluster.
 * You created and configured a VPC and associated subnets in AWS.
 
 .Procedure

--- a/modules/installation-creating-aws-security.adoc
+++ b/modules/installation-creating-aws-security.adoc
@@ -19,13 +19,6 @@ the infrastructure. If your cluster does not initialize correctly, you might
 have to contact Red Hat support with your installation logs.
 ====
 
-.Prerequisites
-
-* You configured an AWS account.
-* You added your AWS keys and region to your local AWS profile by running `aws configure`.
-* You generated the Ignition config files for your cluster.
-* You created and configured a VPC and associated subnets in AWS.
-
 .Procedure
 
 . Create a JSON file that contains the parameter values that the template

--- a/modules/installation-creating-aws-vpc.adoc
+++ b/modules/installation-creating-aws-vpc.adoc
@@ -23,9 +23,7 @@ have to contact Red Hat support with your installation logs.
 
 .Prerequisites
 
-* You configured an AWS account.
 * You added your AWS keys and region to your local AWS profile by running `aws configure`.
-* You generated the Ignition config files for your cluster.
 
 .Procedure
 

--- a/modules/installation-creating-aws-worker.adoc
+++ b/modules/installation-creating-aws-worker.adoc
@@ -42,13 +42,6 @@ have to contact Red Hat support with your installation logs.
 
 .Prerequisites
 
-* You configured an AWS account.
-* You added your AWS keys and region to your local AWS profile by running `aws configure`.
-* You generated the Ignition config files for your cluster.
-* You created and configured a VPC and associated subnets in AWS.
-* You created and configured DNS, load balancers, and listeners in AWS.
-* You created the security groups and roles required for your cluster in AWS.
-* You created the bootstrap machine.
 * You created the control plane machines.
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-13633

Link to docs preview:
One set of changes are displayed in two assemblies: 
 1. **Installing a cluster using CloudFormation templates**
- [Creating a VPC in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-vpc_installing-aws-user-infra)
- [Creating networking and load balancing components in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-dns_installing-aws-user-infra)
- [Creating security group and roles in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-security_installing-aws-user-infra)
- [Creating the bootstrap node in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-bootstrap_installing-aws-user-infra)
- [Creating the control plane machines in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-control-plane_installing-aws-user-infra)
- [Creating the worker nodes in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-creating-aws-worker_installing-aws-user-infra)
- [Initializing the bootstrap sequence on AWS with user-provisioned infrastructure](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-user-infra-bootstrap_installing-aws-user-infra)

 2. **Installing a cluster in a disconnected environment with user-provisioned infrastructure**
- [Creating a VPC in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-creating-aws-vpc_installing-restricted-networks-aws)
- [Creating networking and load balancing components in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-creating-aws-dns_installing-restricted-networks-aws)
- [Creating security group and roles in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-creating-aws-security_installing-restricted-networks-aws)
- [Creating the bootstrap node in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-creating-aws-bootstrap_installing-restricted-networks-aws)
- [Creating the control plane machines in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-creating-aws-control-plane_installing-restricted-networks-aws)
- [Creating the worker nodes in AWS](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-creating-aws-worker_installing-restricted-networks-aws)
- [Initializing the bootstrap sequence on AWS with user-provisioned infrastructure](https://94809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-restricted-networks-aws.html#installation-aws-user-infra-bootstrap_installing-restricted-networks-aws)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Rationale for changes outlined in [AWS proposal to remove duplicate prerequisites](https://docs.google.com/document/d/1zsr11il_UYVC8gf2dvP3xkoLw2DRI8yn84MGvGJM4IQ/edit?tab=t.0)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
