### PR TITLE
OSDOCS#14952: Release notes for OSSO 1.4.1

### DIFF
--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -12,6 +12,31 @@ These release notes track the development of the {secondary-scheduler-operator-f
 
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
 
+[id="secondary-scheduler-operator-release-notes-1.4.1_{context}"]
+== Release notes for {secondary-scheduler-operator-full} 1.4.1
+
+Issued: 9 July 2025
+
+The following advisory is available for the {secondary-scheduler-operator-full} 1.4.1:
+
+* link:https://access.redhat.com/errata/RHBA-2025:10723[RHBA-2025:10723]
+
+[id="secondary-scheduler-1.4.1-new-features_{context}"]
+=== New features and enhancements
+
+* This release of the {secondary-scheduler-operator} updates the Kubernetes version to 1.32.
+
+[id="secondary-scheduler-1.4.1-bug-fixes_{context}"]
+=== Bug fixes
+
+* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+* Previously, some secondary scheduler plugins could not be deployed if they needed to create temporary files. This was due to more restricted permissions that were introduced in a previous release. With this update, secondary schedulers deployed through the Operator can create temporary files again and these secondary scheduler plugins can now be deployed successfully. (link:https://issues.redhat.com/browse/OCPBUGS-58154[*OCPBUGS-58154*])
+
+[id="secondary-scheduler-operator-1.4.1-known-issues_{context}"]
+=== Known issues
+
+* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])
+
 [id="secondary-scheduler-operator-release-notes-1.4.0_{context}"]
 == Release notes for {secondary-scheduler-operator-full} 1.4.0
 
@@ -20,8 +45,6 @@ Issued: 6 May 2025
 The following advisory is available for the {secondary-scheduler-operator-full} 1.4.0:
 
 * link:https://access.redhat.com/errata/RHBA-2025:4332[RHBA-2025:4332]
-
-// TODO: Update errata link once available
 
 [id="secondary-scheduler-1.4.0-new-features_{context}"]
 === New features and enhancements


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-14952

Link to docs preview:
https://94823--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html#secondary-scheduler-operator-release-notes-1.4.1_nodes-secondary-scheduler-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**Advisory link will be updated once the release goes out!**

Technically this release will only be for 4.18 and 4.19, but 1.4.0 and 1.4.1 will be removed from 4.20 in a future PR