### PR TITLE
OSDOCS#14286: Release notes for KDO 5.2.0

### DIFF
--- a/nodes/scheduling/descheduler/index.adoc
+++ b/nodes/scheduling/descheduler/index.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 While the xref:../../../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[scheduler] is used to determine the most suitable node to host a new pod, the descheduler can be used to evict a running pod so that the pod can be rescheduled onto a more suitable node.
 
-:operator-name: The {descheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 // About the descheduler
 include::modules/nodes-descheduler-about.adoc[leveloffset=+1]
 

--- a/nodes/scheduling/descheduler/nodes-descheduler-configuring.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-configuring.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 You can run the descheduler in {product-title} by installing the {descheduler-operator} and setting the desired profiles and other customizations.
 
-:operator-name: The {descheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 // Installing the descheduler
 include::modules/nodes-descheduler-installing.adoc[leveloffset=+1]
 

--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -10,7 +10,29 @@ The {descheduler-operator} allows you to evict pods so that they can be reschedu
 
 These release notes track the development of the {descheduler-operator}.
 
-:operator-name: The {descheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#nodes-descheduler-about_nodes-descheduler-about[About the descheduler].
+
+[id="descheduler-operator-release-notes-5.2.0"]
+== Release notes for {descheduler-operator} 5.2.0
+
+Issued: 9 July 2025
+
+The following advisory is available for the {descheduler-operator} 5.2.0:
+
+* link:https://access.redhat.com/errata/RHBA-2025:10724[RHBA-2025:10724]
+
+[id="descheduler-operator-5.2.0-new-features"]
+=== New features and enhancements
+
+* This release of the {descheduler-operator} updates the Kubernetes version to 1.32.
+
+[id="descheduler-operator-5.2.0-bug-fixes"]
+=== Bug fixes
+
+* This release of the {descheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+// No known issues to list
+// [id="descheduler-operator-5.2.0-known-issues"]
+// === Known issues
+//
+// * TODO

--- a/nodes/scheduling/descheduler/nodes-descheduler-uninstalling.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-uninstalling.adoc
@@ -8,8 +8,5 @@ toc::[]
 
 You can remove the {descheduler-operator} from {product-title} by uninstalling the Operator and removing its related resources.
 
-:operator-name: The {descheduler-operator}
-include::snippets/operator-not-available.adoc[]
-
 // Uninstalling the descheduler
 include::modules/nodes-descheduler-uninstalling.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-14286

Link to docs preview:
https://94824--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-release-notes.html#descheduler-operator-release-notes-5.2.0

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**Advisory link will be updated once the release goes out!**
