### PR TITLE
OLS-1756: Subscription services for OLS

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -14,6 +14,12 @@
 :rhel: Red Hat Enterprise Linux
 :rhelai: Red Hat Enterprise Linux AI
 :rhoai: Red Hat OpenShift AI
+:ove-first: Red Hat OpenShift Virtualization Engine
+:ove: OpenShift Virtualization Engine
+:oke-first: Red Hat OpenShift Kubernetes Engine
+:oke: OpenShift Kubernetes Engine
+:opp-first: Red Hat OpenShift Platform Plus
+:opp: OpenShift Platform Plus
 // OC CLI
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 //OpenShift

--- a/install/ols-installing-openshift-lightspeed.adoc
+++ b/install/ols-installing-openshift-lightspeed.adoc
@@ -9,4 +9,5 @@ toc::[]
 The installation process for {ols-official} consists of two main tasks: installing the {ols-short} Operator and configuring the large language model (LLM) provider.
 
 include::modules/ols-large-language-model-configuration-overview.adoc[leveloffset=+1]
+include::modules/ols-about-subscription-requirements.adoc[leveloffset=+1]
 include::modules/ols-installing-operator.adoc[leveloffset=+1]

--- a/modules/ols-about-subscription-requirements.adoc
+++ b/modules/ols-about-subscription-requirements.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/install/ols-installing-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-subscription-requirements_{context}"]
+= About subscription requirements
+
+{ols-official} requires an active and valid subscription to one of the following products:
+
+* {oke-first}, only supported for virtual machines
+* {ove-first}
+* {ocp-product-title}
+* {opp-first}


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-1756
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://94827--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/install/ols-installing-openshift-lightspeed.html#about-subscription-requirements_ols-installing-openshift-lightspeed

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
