### PR TITLE
CNV#63765: adding TP notice to bulk storage class migration doc

### DIFF
--- a/modules/virt-migrating-bulk-vms-different-storage-class-web.adoc
+++ b/modules/virt-migrating-bulk-vms-different-storage-class-web.adoc
@@ -8,6 +8,12 @@
 
 By using the {product-title} web console, you can migrate single-cluster VMs in bulk from one storage class to another storage class.
 
+ifdef::openshift-enterprise[]
+:FeatureName: Bulk storage class migration
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
+endif::[]
+
 .Prerequisites
 
 * The VMs you select for each bulk migration must be in the same namespace.

--- a/virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.adoc
+++ b/virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.adoc
@@ -8,4 +8,10 @@ toc::[]
 
 You can migrate virtual machines (VMs) within a single cluster from one storage class to a different storage class. By using the {product-title} web console, you can perform the migration for the VMs in bulk.
 
+ifdef::openshift-enterprise[]
+:FeatureName: Bulk storage class migration
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
+endif::[]
+
 include::modules/virt-migrating-bulk-vms-different-storage-class-web.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-63765](https://issues.redhat.com//browse/CNV-63765)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94830--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: n/a
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This feature is remaining tech preview, so we need to add the tech preview snippets. Original doc PR: https://github.com/openshift/openshift-docs/pull/93632

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
