### PR TITLE
[ROX-29729] Remove CVE map from 4.7 scanner sources

### DIFF
--- a/modules/con-vuln-sources.adoc
+++ b/modules/con-vuln-sources.adoc
@@ -37,7 +37,6 @@ link:https://security.access.redhat.com/data/csaf/v2/vex/[Red{nbsp}Hat VEX]:: Us
 {product-title-short} might list a different number of vulnerabilities when you are scanning with a {product-title-short} version that uses OVAL, such as {product-title-short} version 4.5, and a version that uses VEX, such as version 4.6. For example, {product-title-short} no longer displays vulnerabilities with a status of "under investigation," while these vulnerabilities were included with previous versions that used OVAL data.
 +
 For more information about Red Hat security data, including information about the use of OVAL, Common Security Advisory Framework Version 2.0 (CSAF), and VEX, see link:https://www.redhat.com/en/blog/future-red-hat-security-data[The future of Red Hat security data].
-https://access.redhat.com/security/data/metrics/cvemap.xml[Red{nbsp}Hat CVE Map]:: This is used in addition with VEX data for images which appear in the link:https://catalog.redhat.com/software/containers/explore[Red{nbsp}Hat Container Catalog].
 link:https://osv.dev/[OSV]:: This is used for language-related vulnerabilities, such as Go, Java, JavaScript, Python, and Ruby. This source might provide
 vulnerability IDs other than CVE IDs for vulnerabilities, such as a GitHub Security Advisory (GHSA) ID.
 +


### PR DESCRIPTION
Version(s):
4.7 (4.8 is in a separate PR)

[Issue](https://issues.redhat.com/browse/ROX-29729)

Links to docs previews:

https://94834--ocpdocs-pr.netlify.app/openshift-acs/latest/architecture/acs-architecture.html
https://94834--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/acscs-architecture.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
