### PR TITLE
OSDOCS#3995:Move security information to ROSA HCP topic map

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -472,6 +472,254 @@ Distros: openshift-rosa-hcp
 Topics:
 - Name: Adding additional constraints for IP-based AWS role assumption
   File: rosa-adding-additional-constraints-for-ip-based-aws-role-assumption
+- Name: Security and compliance overview
+  File: index
+- Name: Container security
+  Dir: container_security
+  Topics:
+  - Name: Understanding container security
+    File: security-understanding
+  - Name: Understanding host and VM security
+    File: security-hosts-vms
+  - Name: Hardening Red Hat Enterprise Linux CoreOS
+    File: security-hardening
+    Distros: openshift-enterprise,openshift-aro
+  - Name: Container image signatures
+    File: security-container-signature
+  - Name: Hardening Fedora CoreOS
+    File: security-hardening
+    Distros: openshift-origin
+  - Name: Understanding compliance
+    File: security-compliance
+  - Name: Securing container content
+    File: security-container-content
+  - Name: Using container registries securely
+    File: security-registries
+  - Name: Securing the build process
+    File: security-build
+  - Name: Deploying containers
+    File: security-deploy
+  - Name: Securing the container platform
+    File: security-platform
+  - Name: Securing networks
+    File: security-network
+  - Name: Securing attached storage
+    File: security-storage
+  - Name: Monitoring cluster events and logs
+    File: security-monitoring
+- Name: Configuring certificates
+  Dir: certificates
+  Distros: openshift-enterprise,openshift-origin
+  Topics:
+  - Name: Replacing the default ingress certificate
+    File: replacing-default-ingress-certificate
+  - Name: Adding API server certificates
+    File: api-server
+  - Name: Securing service traffic using service serving certificates
+    File: service-serving-certificate
+  - Name: Updating the CA bundle
+    File: updating-ca-bundle
+- Name: Certificate types and descriptions
+  Dir: certificate_types_descriptions
+  Distros: openshift-enterprise,openshift-origin
+  Topics:
+  - Name: User-provided certificates for the API server
+    File: user-provided-certificates-for-api-server
+  - Name: Proxy certificates
+    File: proxy-certificates
+  - Name: Service CA certificates
+    File: service-ca-certificates
+  - Name: Node certificates
+    File: node-certificates
+  - Name: Bootstrap certificates
+    File: bootstrap-certificates
+  - Name: etcd certificates
+    File: etcd-certificates
+  - Name: OLM certificates
+    File: olm-certificates
+  - Name: Aggregated API client certificates
+    File: aggregated-api-client-certificates
+  - Name: Machine Config Operator certificates
+    File: machine-config-operator-certificates
+  - Name: User-provided certificates for default ingress
+    File: user-provided-certificates-for-default-ingress
+  - Name: Ingress certificates
+    File: ingress-certificates
+  - Name: Monitoring and cluster logging Operator component certificates
+    File: monitoring-and-cluster-logging-operator-component-certificates
+  - Name: Control plane certificates
+    File: control-plane-certificates
+- Name: Compliance Operator
+  Dir: compliance_operator
+  Topics:
+  - Name: Compliance Operator overview
+    File: co-overview
+  - Name: Compliance Operator release notes
+    File: compliance-operator-release-notes
+  - Name: Compliance Operator support
+    File: co-support
+  - Name: Compliance Operator concepts
+    Dir: co-concepts
+    Topics:
+    - Name: Understanding the Compliance Operator
+      File: compliance-operator-understanding
+    - Name: Understanding the Custom Resource Definitions
+      File: compliance-operator-crd
+  - Name: Compliance Operator management
+    Dir: co-management
+    Topics:
+    - Name: Installing the Compliance Operator
+      File: compliance-operator-installation
+    - Name: Updating the Compliance Operator
+      File: compliance-operator-updating
+    - Name: Managing the Compliance Operator
+      File: compliance-operator-manage
+    - Name: Uninstalling the Compliance Operator
+      File: compliance-operator-uninstallation
+  - Name: Compliance Operator scan management
+    Dir: co-scans
+    Topics:
+    - Name: Supported compliance profiles
+      File: compliance-operator-supported-profiles
+    - Name: Compliance Operator scans
+      File: compliance-scans
+    - Name: Tailoring the Compliance Operator
+      File: compliance-operator-tailor
+    - Name: Retrieving Compliance Operator raw results
+      File: compliance-operator-raw-results
+    - Name: Managing Compliance Operator remediation
+      File: compliance-operator-remediation
+    - Name: Performing advanced Compliance Operator tasks
+      File: compliance-operator-advanced
+    - Name: Troubleshooting Compliance Operator scans
+      File: compliance-operator-troubleshooting
+    - Name: Using the oc-compliance plugin
+      File: oc-compliance-plug-in-using
+- Name: File Integrity Operator
+  Dir: file_integrity_operator
+  Topics:
+  - Name: File Integrity Operator Overview
+    File: fio-overview
+  - Name: File Integrity Operator release notes
+    File: file-integrity-operator-release-notes
+  - Name: File Integrity Operator support
+    File: fio-support
+  - Name: Installing the File Integrity Operator
+    File: file-integrity-operator-installation
+  - Name: Updating the File Integrity Operator
+    File: file-integrity-operator-updating
+  - Name: Understanding the File Integrity Operator
+    File: file-integrity-operator-understanding
+  - Name: Configuring the File Integrity Operator
+    File: file-integrity-operator-configuring
+  - Name: Performing advanced File Integrity Operator tasks
+    File: file-integrity-operator-advanced-usage
+  - Name: Troubleshooting the File Integrity Operator
+    File: file-integrity-operator-troubleshooting
+  - Name: Uninstalling the File Integrity Operator
+    File: fio-uninstalling
+- Name: Security Profiles Operator
+  Dir: security_profiles_operator
+  Topics:
+  - Name: Security Profiles Operator overview
+    File: spo-overview
+  - Name: Security Profiles Operator release notes
+    File: spo-release-notes
+  - Name: Security Profiles Operator support
+    File: spo-support
+  - Name: Understanding the Security Profiles Operator
+    File: spo-understanding
+  - Name: Enabling the Security Profiles Operator
+    File: spo-enabling
+  - Name: Managing seccomp profiles
+    File: spo-seccomp
+  - Name: Managing SELinux profiles
+    File: spo-selinux
+  - Name: Advanced Security Profiles Operator tasks
+    File: spo-advanced
+  - Name: Troubleshooting the Security Profiles Operator
+    File: spo-troubleshooting
+  - Name: Uninstalling the Security Profiles Operator
+    File: spo-uninstalling
+- Name: NBDE Tang Server Operator
+  Dir: nbde_tang_server_operator
+  Distros: openshift-enterprise
+  Topics:
+  - Name: NBDE Tang Server Operator overview
+    File: nbde-tang-server-operator-overview
+  - Name: NBDE Tang Server Operator release notes
+    File: nbde-tang-server-operator-release-notes
+  - Name: Understanding the NBDE Tang Server Operator
+    File: nbde-tang-server-operator-understanding
+  - Name: Installing the NBDE Tang Server Operator
+    File: nbde-tang-server-operator-installing
+  - Name: Configuring and managing Tang servers using the NBDE Tang Server Operator
+    File: nbde-tang-server-operator-configuring-managing
+  - Name: Identifying URL of a Tang server deployed with the NBDE Tang Server Operator
+    File: nbde-tang-server-operator-identifying-url
+- Name: cert-manager Operator for Red Hat OpenShift
+  Dir: cert_manager_operator
+  Distros: openshift-enterprise
+  Topics:
+  - Name: cert-manager Operator for Red Hat OpenShift overview
+    File: index
+  - Name: cert-manager Operator for Red Hat OpenShift release notes
+    File: cert-manager-operator-release-notes
+  - Name: Installing the cert-manager Operator for Red Hat OpenShift
+    File: cert-manager-operator-install
+  - Name: Configuring the egress proxy
+    File: cert-manager-operator-proxy
+  - Name: Customizing cert-manager by using the cert-manager Operator API fields
+    File: cert-manager-customizing-api-fields
+  - Name: Authenticating the cert-manager Operator for Red Hat OpenShift
+    File: cert-manager-authenticate
+  - Name: Configuring an ACME issuer
+    File: cert-manager-operator-issuer-acme
+  - Name: Configuring certificates with an issuer
+    File: cert-manager-creating-certificate
+  - Name: Securing routes with the cert-manager Operator for Red Hat OpenShift
+    File: cert-manager-securing-routes
+  - Name: Integrating the cert-manager Operator with Istio-CSR
+    File: cert-manager-operator-integrating-istio
+  - Name: Monitoring the cert-manager Operator for Red Hat OpenShift
+    File: cert-manager-monitoring
+  - Name: Configuring log levels for cert-manager and the cert-manager Operator for Red Hat OpenShift
+    File: cert-manager-log-levels
+  - Name: Uninstalling the cert-manager Operator for Red Hat OpenShift
+    File: cert-manager-operator-uninstall
+- Name: Viewing audit logs
+  File: audit-log-view
+- Name: Configuring the audit log policy
+  File: audit-log-policy-config
+- Name: Configuring TLS security profiles
+  File: tls-security-profiles
+- Name: Configuring seccomp profiles
+  File: seccomp-profiles
+- Name: Allowing JavaScript-based access to the API server from additional hosts
+  File: allowing-javascript-access-api-server
+  Distros: openshift-enterprise,openshift-origin
+- Name: Scanning pods for vulnerabilities
+  File: pod-vulnerability-scan
+  Distros: openshift-enterprise,openshift-origin
+- Name: Network-Bound Disk Encryption (NBDE)
+  Dir: network_bound_disk_encryption
+  Topics:
+  - Name: About disk encryption technology
+    File: nbde-about-disk-encryption-technology
+  - Name: Tang server installation considerations
+    File: nbde-tang-server-installation-considerations
+  - Name: Tang server encryption key management
+    File: nbde-managing-encryption-keys
+  - Name: Disaster recovery considerations
+    File: nbde-disaster-recovery-considerations
+    Distros: openshift-enterprise,openshift-origin
+- Name: zero trust workload identity manager for Red Hat OpenShift
+  Dir: zero_trust_workload_identity_manager
+  Distros: openshift-enterprise
+  Topics:
+  - Name: zero trust workload identity manager for Red Hat OpenShift overview
+    File: zero-trust-manager-overview
+---
 ---
 Name: Authentication and authorization
 Dir: authentication


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-3995](https://issues.redhat.com//browse/OSDOCS-3995)

Link to docs preview:
Security and compliance

Additional information: This PR moves the Security and compliance topics from the OCP topic map to the ROSA HCP topic map.

QE review:
- [ ] QE has approved this change.