### PR TITLE
OBSDOCS-1912: Review the format for external links in monitoring docs

### DIFF
--- a/observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer.adoc
+++ b/observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer.adoc
@@ -24,7 +24,7 @@ include::modules/monitoring-querying-metrics-for-user-defined-projects-with-mon-
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus] (Prometheus documentation)
+* link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus (Prometheus documentation)]
 
 //Reviewing monitoring dashboards as a developer
 include::modules/monitoring-reviewing-monitoring-dashboards-developer.adoc[leveloffset=+1]

--- a/observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc
+++ b/observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc
@@ -24,7 +24,7 @@ include::modules/monitoring-querying-metrics-for-all-projects-with-mon-dashboard
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus] (Prometheus documentation)
+* link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus (Prometheus documentation)]
 
 //Getting detailed information about a metrics target
 include::modules/monitoring-getting-detailed-information-about-a-target.adoc[leveloffset=+1]

--- a/observability/monitoring/configuring-core-platform-monitoring/configuring-alerts-and-notifications.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/configuring-alerts-and-notifications.adoc
@@ -17,7 +17,7 @@ include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+2
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://prometheus.io/docs/alerting/latest/alertmanager/[Alertmanager] (Prometheus documentation)
+* link:https://prometheus.io/docs/alerting/latest/alertmanager/[Alertmanager (Prometheus documentation)]
 * xref:../../../observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc#managing-alerts-as-an-administrator[Managing alerts as an Administrator]
 
 //Configuring secrets for Alertmanager
@@ -47,8 +47,8 @@ Alertmanager does not send notifications by default. It is strongly recommended 
 .Additional resources
 
 * xref:../../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#sending-notifications-to-external-systems_key-concepts[Sending notifications to external systems]
-* link:https://www.pagerduty.com/[PagerDuty] (PagerDuty official site)
-* link:https://www.pagerduty.com/docs/guides/prometheus-integration-guide/[Prometheus Integration Guide] (PagerDuty official site)
+* link:https://www.pagerduty.com/[PagerDuty website]
+* link:https://www.pagerduty.com/docs/guides/prometheus-integration-guide/[Prometheus Integration Guide (PagerDuty documentation)]
 * xref:../../../observability/monitoring/getting-started/maintenance-and-support-for-monitoring.adoc#support-version-matrix-for-monitoring-components_maintenance-and-support-for-monitoring[Support version matrix for monitoring components]
 * xref:../../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#enabling-alert-routing-for-user-defined-projects_preparing-to-configure-the-monitoring-stack-uwm[Enabling alert routing for user-defined projects]
 
@@ -57,13 +57,13 @@ include::modules/monitoring-configuring-alert-routing-default-platform-alerts.ad
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/solutions/6828481[Send test alerts to Alertmanager in OpenShift 4] (Red{nbsp}Hat Customer Portal)
+* link:https://access.redhat.com/solutions/6828481[Send test alerts to Alertmanager in OpenShift 4 (Red{nbsp}Hat Customer Portal)]
 
 include::modules/monitoring-configuring-alert-routing-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/solutions/6828481[Send test alerts to Alertmanager in OpenShift 4] (Red{nbsp}Hat Customer Portal)
+* link:https://access.redhat.com/solutions/6828481[Send test alerts to Alertmanager in OpenShift 4 (Red{nbsp}Hat Customer Portal)]
 
 include::modules/monitoring-configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts.adoc[leveloffset=+2]

--- a/observability/monitoring/configuring-core-platform-monitoring/configuring-metrics.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/configuring-metrics.adoc
@@ -22,7 +22,7 @@ include::modules/monitoring-configuring-remote-write-storage.adoc[leveloffset=+1
 .Additional resources
 
 * xref:../../../rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc#spec-remotewrite-writerelabelconfigs[`writeRelabelConfigs`]
-* link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[`relabel_config`] (Prometheus documentation)
+* link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[`relabel_config` (Prometheus documentation)]
 
 include::modules/monitoring-supported-remote-write-authentication-settings.adoc[leveloffset=+2]
 
@@ -34,8 +34,8 @@ include::modules/monitoring-example-remote-write-queue-configuration.adoc[levelo
 .Additional resources
 
 * xref:../../../rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc#spec-remotewrite-2[Prometheus REST API reference for remote write]
-* link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Setting up remote write compatible endpoints] (Prometheus documentation)
-* link:https://prometheus.io/docs/practices/remote_write/#remote-write-tuning[Tuning remote write settings] (Prometheus documentation)
+* link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Remote write compatible endpoints (Prometheus documentation)]
+* link:https://prometheus.io/docs/practices/remote_write/#remote-write-tuning[Remote write tuning (Prometheus documentation)]
 * xref:../../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets-about_nodes-pods-secrets[Understanding secrets]
 
 //Creating cluster ID labels for metrics for core platform monitoring

--- a/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc
@@ -35,7 +35,7 @@ include::modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
 * xref:../../../observability/monitoring/configuring-core-platform-monitoring/preparing-to-configure-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure core platform monitoring stack]
 * xref:../../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes]
 * xref:../../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
-* link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[nodeSelector] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[`nodeSelector` (Kubernetes documentation)]
 
 include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[leveloffset=+2,tags=**;CPM;!UWM]
 
@@ -44,7 +44,7 @@ include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[
 
 * xref:../../../observability/monitoring/configuring-core-platform-monitoring/preparing-to-configure-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure core platform monitoring stack]
 * xref:../../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
-* link:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[Taints and Tolerations] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[Taints and tolerations (Kubernetes documentation)]
 
 // Setting the body size limit for metrics scraping
 include::modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.adoc[leveloffset=+1]
@@ -52,7 +52,7 @@ include::modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.ado
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config[scrape_config configuration] (Prometheus documentation)
+* link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config[`scrape_config` (Prometheus documentation)]
 
 [id="managing-cpu-and-memory-resources-for-monitoring-components_{context}"]
 == Managing CPU and memory resources for monitoring components
@@ -67,7 +67,7 @@ include::modules/monitoring-specifying-limits-and-requests-for-monitoring-compon
 .Additional resources
 
 * xref:../../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#about-specifying-limits-and-requests-for-monitoring-components_key-concepts[About specifying limits and requests]
-* link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits[Kubernetes requests and limits documentation] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits[Requests and limits (Kubernetes documentation)]
 
 // Choosing a metrics collection profile
 include::modules/monitoring-choosing-a-metrics-collection-profile.adoc[leveloffset=+1]
@@ -87,7 +87,7 @@ include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[lev
 
 * xref:../../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#using-pod-topology-spread-constraints-for-monitoring_key-concepts[About pod topology spread constraints for monitoring]
 * xref:../../../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints-about[Controlling pod placement by using pod topology spread constraints]
-* link:https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/[Pod Topology Spread Constraints] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/[Pod topology spread constraints (Kubernetes documentation)]
 
 
 

--- a/observability/monitoring/configuring-core-platform-monitoring/storing-and-recording-data.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/storing-and-recording-data.adoc
@@ -17,7 +17,7 @@ include::modules/monitoring-configuring-a-persistent-volume-claim.adoc[leveloffs
 .Additional resources
 
 * xref:../../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
-* link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims[PersistentVolumeClaims] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims[PersistentVolumeClaims (Kubernetes documentation)]
 
 include::modules/monitoring-resizing-a-persistent-volume.adoc[leveloffset=+2,tags=**;CPM;!UWM]
 

--- a/observability/monitoring/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm.adoc
@@ -56,8 +56,8 @@ Review the following limitations of alert routing for user-defined projects:
 
 * xref:../../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#understanding-alert-routing-for-user-defined-projects_key-concepts[Understanding alert routing for user-defined projects]
 * xref:../../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#sending-notifications-to-external-systems_key-concepts[Sending notifications to external systems]
-* link:https://www.pagerduty.com/[PagerDuty] (PagerDuty official site)
-* link:https://www.pagerduty.com/docs/guides/prometheus-integration-guide/[Prometheus Integration Guide] (PagerDuty official site)
+* link:https://www.pagerduty.com/[PagerDuty website]
+* link:https://www.pagerduty.com/docs/guides/prometheus-integration-guide/[Prometheus Integration Guide (PagerDuty documentation)]
 * xref:../../../observability/monitoring/getting-started/maintenance-and-support-for-monitoring.adoc#support-version-matrix-for-monitoring-components_maintenance-and-support-for-monitoring[Support version matrix for monitoring components]
 * xref:../../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#enabling-alert-routing-for-user-defined-projects_preparing-to-configure-the-monitoring-stack-uwm[Enabling alert routing for user-defined projects]
 
@@ -66,13 +66,13 @@ include::modules/monitoring-configuring-alert-routing-for-user-defined-projects.
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/solutions/6828481[Send test alerts to Alertmanager in OpenShift 4] (Red{nbsp}Hat Customer Portal)
+* link:https://access.redhat.com/solutions/6828481[Send test alerts to Alertmanager in OpenShift 4 (Red{nbsp}Hat Customer Portal)]
 
 include::modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/solutions/6828481[Send test alerts to Alertmanager in OpenShift 4] (Red{nbsp}Hat Customer Portal)
+* link:https://access.redhat.com/solutions/6828481[Send test alerts to Alertmanager in OpenShift 4 (Red{nbsp}Hat Customer Portal)]
 
 include::modules/monitoring-configuring-different-alert-receivers-for-default-platform-alerts-and-user-defined-alerts.adoc[leveloffset=+2]

--- a/observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc
@@ -23,7 +23,7 @@ include::modules/monitoring-configuring-remote-write-storage.adoc[leveloffset=+1
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../../rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc#spec-remotewrite-writerelabelconfigs[`writeRelabelConfigs`]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[`relabel_config`] (Prometheus documentation)
+* link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[`relabel_config` (Prometheus documentation)]
 
 include::modules/monitoring-supported-remote-write-authentication-settings.adoc[leveloffset=+2]
 
@@ -36,8 +36,8 @@ include::modules/monitoring-example-remote-write-queue-configuration.adoc[levelo
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../../rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.adoc#spec-remotewrite-2[Prometheus REST API reference for remote write]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Setting up remote write compatible endpoints] (Prometheus documentation)
-* link:https://prometheus.io/docs/practices/remote_write/#remote-write-tuning[Tuning remote write settings] (Prometheus documentation)
+* link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Remote write compatible endpoints (Prometheus documentation)]
+* link:https://prometheus.io/docs/practices/remote_write/#remote-write-tuning[Remote write tuning (Prometheus documentation)]
 * xref:../../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets-about_nodes-pods-secrets[Understanding secrets]
 
 // Creating cluster ID labels for metrics for monitoring of user-defined projects
@@ -67,5 +67,5 @@ ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../../rest_api/monitoring_apis/podmonitor-monitoring-coreos-com-v1.adoc#podmonitor-monitoring-coreos-com-v1[PodMonitor API]
 * xref:../../../rest_api/monitoring_apis/servicemonitor-monitoring-coreos-com-v1.adoc#servicemonitor-monitoring-coreos-com-v1[ServiceMonitor API]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* link:https://access.redhat.com/articles/6675491[Scrape Prometheus metrics using TLS in ServiceMonitor configuration] (Red{nbsp}Hat Customer Portal article)
+* link:https://access.redhat.com/articles/6675491[Scrape Prometheus metrics using TLS in ServiceMonitor configuration (Red{nbsp}Hat Customer Portal)]
 

--- a/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
@@ -35,7 +35,7 @@ ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes]
 * xref:../../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[nodeSelector] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[`nodeSelector` (Kubernetes documentation)]
 
 include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[leveloffset=+2,tags=**;!CPM;UWM]
 
@@ -46,7 +46,7 @@ ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#enabling-monitoring-for-user-defined-projects-uwm_preparing-to-configure-the-monitoring-stack-uwm[Enabling monitoring for user-defined projects]
 * xref:../../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* link:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[Taints and Tolerations] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[Taints and tolerations (Kubernetes documentation)]
 
 [id="managing-cpu-and-memory-resources-for-monitoring-components_{context}"]
 == Managing CPU and memory resources for monitoring components
@@ -60,7 +60,7 @@ include::modules/monitoring-specifying-limits-and-requests-for-monitoring-compon
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#about-specifying-limits-and-requests-for-monitoring-components_key-concepts[About specifying limits and requests for monitoring components]
-* link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits[Kubernetes requests and limits documentation] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits[Requests and limits (Kubernetes documentation)]
 
 [id="controlling-the-impact-of-unbound-attributes-in-user-defined-projects_{context}"]
 == Controlling the impact of unbound metrics attributes in user-defined projects
@@ -110,4 +110,4 @@ include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[lev
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints-about[Controlling pod placement by using pod topology spread constraints]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-* link:https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/[Pod Topology Spread Constraints] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/[Pod topology spread constraints (Kubernetes documentation)]

--- a/observability/monitoring/configuring-user-workload-monitoring/storing-and-recording-data-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/storing-and-recording-data-uwm.adoc
@@ -17,7 +17,7 @@ include::modules/monitoring-configuring-a-persistent-volume-claim.adoc[leveloffs
 .Additional resources
 
 * xref:../../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
-* link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims[PersistentVolumeClaims] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims[PersistentVolumeClaims (Kubernetes documentation)]
 
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/monitoring-resizing-a-persistent-volume.adoc[leveloffset=+2,tags=**;!CPM;UWM]

--- a/observability/monitoring/managing-alerts/managing-alerts-as-a-developer.adoc
+++ b/observability/monitoring/managing-alerts/managing-alerts-as-a-developer.adoc
@@ -28,7 +28,7 @@ include::modules/monitoring-getting-information-about-alerts-silences-and-alerti
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://github.com/openshift/runbooks/tree/master/alerts/cluster-monitoring-operator[{cmo-full} runbooks] ({cmo-full} GitHub repository)
+* link:https://github.com/openshift/runbooks/tree/master/alerts/cluster-monitoring-operator[GitHub {cmo-full} runbooks repository]
 
 [id="managing-silences_{context}"]
 == Managing silences
@@ -77,7 +77,7 @@ include::modules/monitoring-creating-cross-project-alerting-rules-for-user-defin
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../observability/monitoring/about-ocp-monitoring/monitoring-stack-architecture.adoc#monitoring-stack-architecture[Monitoring stack architecture]
-* link:https://prometheus.io/docs/practices/alerting/[Alerting] (Prometheus documentation)
+* link:https://prometheus.io/docs/practices/alerting/[Alerting (Prometheus documentation)]
 
 include::modules/monitoring-accessing-alerting-rules-for-your-project.adoc[leveloffset=+2]
 include::modules/monitoring-removing-alerting-rules-for-user-defined-projects.adoc[leveloffset=+2]
@@ -85,4 +85,4 @@ include::modules/monitoring-removing-alerting-rules-for-user-defined-projects.ad
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager] (Prometheus documentation)
+* link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager (Prometheus documentation)]

--- a/observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc
+++ b/observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc
@@ -28,7 +28,7 @@ include::modules/monitoring-getting-information-about-alerts-silences-and-alerti
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://github.com/openshift/runbooks/tree/master/alerts/cluster-monitoring-operator[{cmo-full} runbooks] ({cmo-full} GitHub repository)
+* link:https://github.com/openshift/runbooks/tree/master/alerts/cluster-monitoring-operator[GitHub {cmo-full} runbooks repository]
 
 [id="managing-silences_{context}"]
 == Managing silences
@@ -83,9 +83,9 @@ include::modules/monitoring-modifying-core-platform-alerting-rules.adoc[leveloff
 .Additional resources
 
 * xref:../../../observability/monitoring/about-ocp-monitoring/monitoring-stack-architecture.adoc#monitoring-stack-architecture[Monitoring stack architecture]
-* link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager] (Prometheus documentation)
-* link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[relabel_config configuration] (Prometheus documentation)
-* link:https://prometheus.io/docs/practices/alerting/[Alerting] (Prometheus documentation)
+* link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager (Prometheus documentation)]
+* link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[`relabel_config` (Prometheus documentation)]
+* link:https://prometheus.io/docs/practices/alerting/[Alerting (Prometheus documentation)]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 [id="managing-alerting-rules-for-user-defined-projects_{context}"]
@@ -106,7 +106,7 @@ include::modules/monitoring-creating-cross-project-alerting-rules-for-user-defin
 .Additional resources
 
 * xref:../../../observability/monitoring/about-ocp-monitoring/monitoring-stack-architecture.adoc#monitoring-stack-architecture[Monitoring stack architecture]
-* link:https://prometheus.io/docs/practices/alerting/[Alerting] (Prometheus documentation)
+* link:https://prometheus.io/docs/practices/alerting/[Alerting (Prometheus documentation)]
 
 include::modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc[leveloffset=+2]
 include::modules/monitoring-removing-alerting-rules-for-user-defined-projects.adoc[leveloffset=+2]
@@ -115,7 +115,7 @@ include::modules/monitoring-disabling-cross-project-alerting-rules-for-user-defi
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager] (Prometheus documentation)
+* link:https://prometheus.io/docs/alerting/alertmanager/[Alertmanager (Prometheus documentation)]
 
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1912
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* [Querying metrics for user-defined projects with the OpenShift Container Platform web console
](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer#querying-metrics-for-user-defined-projects-with-mon-dashboard_accessing-metrics-as-a-developer)
* [Querying metrics for all projects with the OpenShift Container Platform web console](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator#querying-metrics-for-all-projects-with-mon-dashboard_accessing-metrics-as-an-administrator)
* [Configuring alerts and notifications for core platform monitoring](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-core-platform-monitoring/configuring-alerts-and-notifications)
* [Configuring metrics for core platform monitoring](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-core-platform-monitoring/configuring-metrics)
* [Configuring performance and scalability for core platform monitoring](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability)
* [Storing and recording data for core platform monitoring](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-core-platform-monitoring/storing-and-recording-data)
* [Configuring alerts and notifications for user workload monitoring](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm)
* [Configuring metrics for user workload monitoring](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm)
* [Configuring performance and scalability for user workload monitoring](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm)
* [Storing and recording data for user workload monitoring](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-user-workload-monitoring/storing-and-recording-data-uwm)
* [Managing alerts as an Administrator](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/managing-alerts/managing-alerts-as-an-administrator)
* [Managing alerts as a Developer](https://94837--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/managing-alerts/managing-alerts-as-a-developer)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: `n/a`
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* the PR is aimed to change external link format in Additional resouces section due to DITA not supporting text around the link:

  :green_circle:  I am trying to get rid of this structure: `link:path[description](document-source)` because the contribution guide: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#lead-in-link-sentences considers that for the lead-in sentence, not the additional resources section.
I am trying to only repair links in the additional resources and remove the `(document-source)` part because we are adviced to remove text around links in additional resources as it  will not be supported in dita.
- My approach is to follow this part of contribution guide: https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#links-to-external-websites and after some additional reconsideration, i will combine the solutions by adding the bracket with document-source into the link
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
