### PR TITLE
OLS-1744: Update supported resource types

### DIFF
--- a/modules/ols-attaching-a-resource-object-to-your-query.adoc
+++ b/modules/ols-attaching-a-resource-object-to-your-query.adoc
@@ -16,17 +16,6 @@ This procedure explains how to attach a resource object to provide additional co
 . Click the plus icon in the {ols-official} user interface to attach a resource object.
 
 . Select the resource object to attach to the question.
-+
-[TIP]
-====
-You can attach the following resources:
-
-* `CronJob`, `DaemonSet`, `Deployment`, `Job`, `Pod`, `ReplicaSet` and `StatefulSet` from *Workloads* in the {ocp-product-title} web console.
-
-* `Alert` from *Observe* in the {ocp-product-title} web console.
-
-* `Services`, `Routes`, `Ingresses`, and `NetworkPolicies` from *Networking* in the {ocp-product-title} web console.
-====
 
 . Enter a question.
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-1744
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://94840--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/operate/ols-using-openshift-lightspeed.html#ols-attaching-a-resource-object-to-your-query_ols-using-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
