### PR TITLE
OSDOCS-14341-attributes: Fixed unrendered IBM attributes

### DIFF
--- a/applications/connecting_applications_to_services/getting-started-with-service-binding-ibm-power-ibm-z.adoc
+++ b/applications/connecting_applications_to_services/getting-started-with-service-binding-ibm-power-ibm-z.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="getting-started-with-service-binding-ibm-power-ibm-z"]
-= Getting started with service binding on {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName}
+= Getting started with service binding on IBM Power, IBM Z, and IBM LinuxONE
 include::_attributes/common-attributes.adoc[]
 include::_attributes/servicebinding-document-attributes.adoc[]
 :context: getting-started-with-service-binding-ibm-power-ibm-z

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ibm-cloud.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ibm-cloud.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-oadp-ibm-cloud"]
-= Configuring the {oadp-full} with {ibm-cloud-title}
+= Configuring the OpenShift API for Data Protection with IBM Cloud
 include::_attributes/common-attributes.adoc[]
 :context: installing-oadp-ibm-cloud
 :installing-oadp-ibm-cloud:

--- a/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
@@ -17,7 +17,7 @@ include::modules/oadp-plugins-receiving-eof-message.adoc[leveloffset=+2]
 include::modules/oadp-supported-architecture.adoc[leveloffset=+1]
 
 [id="oadp-support-for-ibm-power-and-ibm-z"]
-== OADP support for {ibm-power-title} and {ibm-z-title}
+== OADP support for IBM Power and IBM Z
 
 OpenShift API for Data Protection (OADP) is platform neutral. The information that follows relates only to {ibm-power-name} and to {ibm-z-name}.
 

--- a/installing/installing_ibm_cloud/install-ibm-cloud-prerequisites.adoc
+++ b/installing/installing_ibm_cloud/install-ibm-cloud-prerequisites.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use installer-provisioned installation to install {product-title} on {ibmcloudBMRegProductName} nodes. This document describes the prerequisites and procedures when installing {product-title} on IBM Cloud nodes.
+You can use installer-provisioned installation to install {product-title} on {ibm-cloud-bm} nodes. This document describes the prerequisites and procedures when installing {product-title} on IBM Cloud nodes.
 
 [IMPORTANT]
 ====
@@ -20,6 +20,6 @@ Installer-provisioned installation of {product-title} requires:
 * One routable network
 * One provisioning network
 
-Before starting an installer-provisioned installation of {product-title} on {ibmcloudBMProductName}, address the following prerequisites and requirements.
+Before starting an installer-provisioned installation of {product-title} on {ibm-cloud-bm}, address the following prerequisites and requirements.
 
 include::modules/install-ibm-cloud-setting-up-ibm-cloud-infrastructure.adoc[leveloffset=+1]

--- a/installing/installing_ibm_powervs/creating-ibm-power-vs-workspace.adoc
+++ b/installing/installing_ibm_powervs/creating-ibm-power-vs-workspace.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="creating-ibm-power-vs-workspace"]
-= Creating an {ibmpowerProductName} Virtual Server workspace
+= Creating an IBM Power Virtual Server workspace
 include::_attributes/common-attributes.adoc[]
 :context: creating-ibm-power-vs-workspace
 

--- a/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-ibm-power-vs-customizations"]
-= Installing a cluster on {ibmpowerProductName} Virtual Server with customizations
+= Installing a cluster on IBM Power Virtual Server with customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-power-vs-customizations
 

--- a/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-ibm-power-vs-private-cluster"]
-= Installing a private cluster on {ibmpowerProductName} Virtual Server
+= Installing a private cluster on IBM Power Virtual Server
 include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-power-vs-private-cluster
 

--- a/installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-ibm-powervs-vpc"]
-= Installing a cluster on {ibmpowerProductName} Virtual Server into an existing VPC
+= Installing a cluster on IBM Power Virtual Server into an existing VPC
 include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-powervs-vpc
 

--- a/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-ibm-power-vs"]
-= Installing a cluster on {ibmpowerProductName} Virtual Server in a restricted network
+= Installing a cluster on IBM Power Virtual Server in a restricted network
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-ibm-power-vs
 

--- a/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="preparing-to-install-on-ibm-power-vs"]
-= Preparing to install on {ibmpowerProductName} Virtual Server
+= Preparing to install on IBM Power Virtual Server
 include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-power-vs
 

--- a/installing/installing_ibm_powervs/uninstalling-cluster-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/uninstalling-cluster-ibm-power-vs.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="uninstalling-cluster-ibm-power-vs"]
-= Uninstalling a cluster on {ibm-power-title} Virtual Server
+= Uninstalling a cluster on IBM Power Virtual Server
 include::_attributes/common-attributes.adoc[]
 :context: uninstalling-cluster-ibm-power-vs
 

--- a/installing/installing_ibm_z/installation-config-parameters-ibm-z.adoc
+++ b/installing/installing_ibm_z/installation-config-parameters-ibm-z.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="installation-config-parameters-ibm-z"]
-= Installation configuration parameters for {ibm-z-title} and {ibm-linuxone-title}
+= Installation configuration parameters for IBM Z and IBM LinuxONE
 include::_attributes/common-attributes.adoc[]
 :context: installation-config-parameters-ibm-z
 :platform: IBM Z

--- a/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-ibm-z-kvm"]
-= Installing a cluster with {op-system-base} KVM on {ibmzProductName} and {ibm-linuxone-title}
+= Installing a cluster with {op-system-base} KVM on IBM Z and IBM LinuxONE
 include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-z-kvm
 

--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-ibm-z"]
-= Installing a cluster with z/VM on {ibmzProductName} and {ibm-linuxone-title}
+= Installing a cluster with z/VM on IBM Z and IBM LinuxONE
 include::_attributes/common-attributes.adoc[]
 :context: installing-ibm-z
 

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-ibm-z-kvm"]
-= Installing a cluster with {op-system-base} KVM on {ibmzProductName} and {ibm-linuxone-title} in a restricted network
+= Installing a cluster with {op-system-base} KVM on IBM Z and IBM LinuxONE in a restricted network
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-ibm-z-kvm
 

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-restricted-networks-ibm-z"]
-= Installing a cluster with z/VM on {ibmzProductName} and {ibm-linuxone-title} in a restricted network
+= Installing a cluster with z/VM on IBM Z and IBM LinuxONE in a restricted network
 include::_attributes/common-attributes.adoc[]
 :context: installing-restricted-networks-ibm-z
 

--- a/installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc
+++ b/installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="preparing-to-install-on-ibm-z"]
-= Preparing to install on {ibm-z-title} and {ibm-linuxone-title}
+= Preparing to install on IBM Z and IBM LinuxONE
 include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-z
 

--- a/installing/installing_rhv/preparing-to-install-on-rhv.adoc
+++ b/installing/installing_rhv/preparing-to-install-on-rhv.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="preparing-to-install-on-rhv"]
-= Preparing to install on {rh-virtualization-first}
+= Preparing to install on Red Hat Virtualization (RHV)
 include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-rhv
 

--- a/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-ibm-power-vs.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="creating-machineset-ibm-power-vs"]
-= Creating a compute machine set on {ibmpowerProductName} Virtual Server
+= Creating a compute machine set on IBM Power Virtual Server
 include::_attributes/common-attributes.adoc[]
 :context: creating-machineset-ibm-power-vs
 

--- a/modules/distr-tracing-tempo-object-storage-setup-ibm-storage.adoc
+++ b/modules/distr-tracing-tempo-object-storage-setup-ibm-storage.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="distr-tracing-tempo-object-storage-setup-ibm-storage_{context}"]
-= Setting up {ibm-cloud-title} Object Storage
+= Setting up IBM Cloud Object Storage
 
 You can set up {ibm-cloud-title} Object Storage by using the {oc-first}.
 

--- a/modules/install-ibm-cloud-configuring-the-install-config-file.adoc
+++ b/modules/install-ibm-cloud-configuring-the-install-config-file.adoc
@@ -6,7 +6,7 @@
 [id="configuring-the-install-config-file_{context}"]
 = Configuring the install-config.yaml file
 
-The `install-config.yaml` file requires some additional details. Most of the information is teaching the installer and the resulting cluster enough about the available {ibmcloudBMRegProductName} hardware so that it is able to fully manage it. The material difference between installing on bare metal and installing on {ibmcloudBMProductName} is that you must explicitly set the privilege level for IPMI in the BMC section of the `install-config.yaml` file.
+The `install-config.yaml` file requires some additional details. Most of the information is teaching the installer and the resulting cluster enough about the available {ibm-cloud-bm} hardware so that it is able to fully manage it. The material difference between installing on bare metal and installing on {ibm-cloud-bm} is that you must explicitly set the privilege level for IPMI in the BMC section of the `install-config.yaml` file.
 
 .Procedure
 
@@ -59,7 +59,7 @@ pullSecret: '<pull_secret>'
 sshKey: '<ssh_pub_key>'
 ----
 +
-<1> The `bmc.address` provides a `privilegelevel` configuration setting with the value set to `OPERATOR`. This is required for {ibmcloudBMProductName} infrastructure.
+<1> The `bmc.address` provides a `privilegelevel` configuration setting with the value set to `OPERATOR`. This is required for {ibm-cloud-bm} infrastructure.
 <2> Add the MAC address of the private `provisioning` network NIC for the corresponding node.
 +
 [NOTE]

--- a/modules/install-ibm-cloud-configuring-the-public-subnet.adoc
+++ b/modules/install-ibm-cloud-configuring-the-public-subnet.adoc
@@ -6,7 +6,7 @@
 [id="configuring-the-public-subnet_{context}"]
 = Configuring the public subnet
 
-All of the {product-title} cluster nodes must be on the public subnet. {ibmcloudBMRegProductName} does not provide a DHCP server on the subnet. Set it up separately on the provisioner node.
+All of the {product-title} cluster nodes must be on the public subnet. {ibm-cloud-bm} does not provide a DHCP server on the subnet. Set it up separately on the provisioner node.
 
 You must reset the BASH variables defined when preparing the provisioner node. Rebooting the provisioner node after preparing it will delete the BASH variables previously set.
 

--- a/modules/install-ibm-cloud-preparing-the-provisioner-node.adoc
+++ b/modules/install-ibm-cloud-preparing-the-provisioner-node.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="preparing-the-provisioner-node-for-openshift-install-on-ibm-cloud_{context}"]
-= Preparing the provisioner node on {ibmcloudBMProductName} infrastructure
+= Preparing the provisioner node on IBM Cloud Bare Metal (Classic) infrastructure
 
 Perform the following steps to prepare the provisioner node.
 

--- a/modules/install-ibm-cloud-setting-up-ibm-cloud-infrastructure.adoc
+++ b/modules/install-ibm-cloud-setting-up-ibm-cloud-infrastructure.adoc
@@ -5,7 +5,7 @@
 [id="setting-up-ibm-cloud-infrastructure_{context}"]
 = Setting up IBM Cloud Bare Metal (Classic) infrastructure
 
-To deploy an {product-title} cluster on {ibmcloudBMRegProductName} infrastructure, you must first provision the IBM Cloud nodes.
+To deploy an {product-title} cluster on {ibm-cloud-bm} infrastructure, you must first provision the IBM Cloud nodes.
 
 [IMPORTANT]
 ====
@@ -29,7 +29,7 @@ Create all nodes with a single public VLAN and a single private VLAN.
 
 IBM Cloud public VLAN subnets use a `/28` prefix by default, which provides 16 IP addresses. That is sufficient for a cluster consisting of three control plane nodes, four worker nodes, and two IP addresses for the API VIP and Ingress VIP on the `baremetal` network. For larger clusters, you might need a smaller prefix.
 
-IBM Cloud private VLAN subnets use a `/26` prefix by default, which provides 64 IP addresses. {ibmcloudBMProductName} uses private network IP addresses to access the Baseboard Management Controller (BMC) of each node. {product-title} creates an additional subnet for the `provisioning` network. Network traffic for the `provisioning` network subnet routes through the private VLAN. For larger clusters, you might need a smaller prefix.
+IBM Cloud private VLAN subnets use a `/26` prefix by default, which provides 64 IP addresses. {ibm-cloud-bm} uses private network IP addresses to access the Baseboard Management Controller (BMC) of each node. {product-title} creates an additional subnet for the `provisioning` network. Network traffic for the `provisioning` network subnet routes through the private VLAN. For larger clusters, you might need a smaller prefix.
 
 .IP addresses per prefix
 [options="header"]
@@ -138,11 +138,11 @@ Define a consistent clock date and time format in each cluster node's BIOS setti
 [discrete]
 == Configure a DHCP server
 
-{ibmcloudBMProductName} does not run DHCP on the public or private VLANs. After provisioning IBM Cloud nodes, you must set up a DHCP server for the public VLAN, which corresponds to {product-title}'s `baremetal` network.
+{ibm-cloud-bm} does not run DHCP on the public or private VLANs. After provisioning IBM Cloud nodes, you must set up a DHCP server for the public VLAN, which corresponds to {product-title}'s `baremetal` network.
 
 [NOTE]
 ====
-The IP addresses allocated to each node do not need to match the IP addresses allocated by the {ibmcloudBMProductName} provisioning system.
+The IP addresses allocated to each node do not need to match the IP addresses allocated by the {ibm-cloud-bm} provisioning system.
 ====
 
 See the "Configuring the public subnet" section for details.

--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -50,7 +50,7 @@ See link:https://access.redhat.com/articles/rhel-limits[Red Hat Enterprise Linux
 The {product-title} installer creates the Ignition files, which are necessary for all the {op-system-first} virtual machines. The automated installation of {product-title} is performed by the bootstrap machine. It starts the installation of {product-title} on each node, starts the Kubernetes cluster, and then finishes. During this bootstrap, the virtual machine must have an established network connection either through a Dynamic Host Configuration Protocol (DHCP) server or static IP address.
 
 [id="ibm-z-network-connectivity_{context}"]
-== {ibmzProductName} network connectivity requirements
+== IBM Z network connectivity requirements
 
 To install on {ibmzProductName} under {op-system-base} KVM, you need:
 
@@ -69,7 +69,7 @@ You can install {product-title} version {product-version} on the following IBM h
 * {linuxoneProductName} 4 (all models), {linuxoneProductName} III (all models), {linuxoneProductName} Emperor II, {linuxoneProductName} Rockhopper II
 
 [id="minimum-ibm-z-system-requirements_{context}"]
-== Minimum {ibmzProductName} system environment
+== Minimum IBM Z system environment
 
 [discrete]
 === Hardware requirements
@@ -140,7 +140,7 @@ Each cluster virtual machine must meet the following minimum requirements:
 --
 
 [id="preferred-ibm-z-system-requirements_{context}"]
-== Preferred {ibmzProductName} system environment
+== Preferred IBM Z system environment
 
 [discrete]
 === Hardware requirements

--- a/modules/minimum-ibm-z-system-requirements.adoc
+++ b/modules/minimum-ibm-z-system-requirements.adoc
@@ -40,7 +40,7 @@ On your z/VM instance, set up:
 * One guest virtual machine for the temporary {product-title} bootstrap machine
 
 [discrete]
-== {ibmzProductName} network connectivity requirements
+== IBM Z network connectivity requirements
 
 To install on {ibmzProductName} under z/VM, you require a single z/VM virtual NIC in layer 2 mode. You also need:
 

--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -101,7 +101,7 @@
 5. Cluster is scaled in iterations.
 --
 
-== {ibmzProductName} platform
+== IBM Z platform
 
 [options="header",cols="6*"]
 |===

--- a/modules/preferred-ibm-z-system-requirements.adoc
+++ b/modules/preferred-ibm-z-system-requirements.adoc
@@ -27,7 +27,7 @@ On your z/VM instances, set up:
 * To ensure the availability of integral components in an overcommitted environment, increase the priority of the control plane by using the CP command `SET SHARE`. Do the same for infrastructure nodes, if they exist. See link:https://www.ibm.com/docs/en/zvm/latest?topic=commands-set-share[SET SHARE] in IBM Documentation.
 
 [discrete]
-== {ibmzProductName} network connectivity requirements
+== IBM Z network connectivity requirements
 
 To install on {ibmzProductName} under z/VM, you require a single z/VM virtual NIC in layer 2 mode. You also need:
 

--- a/post_installation_configuration/ibmz-post-install.adoc
+++ b/post_installation_configuration/ibmz-post-install.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="post-install-configure-additional-devices-ibmz"]
-= Configuring additional devices in an {ibmzProductName} or {linuxoneProductName} environment
+= Configuring additional devices in an IBM Z or IBM LinuxONE environment
 include::_attributes/common-attributes.adoc[]
 :context: post-install-configure-additional-devices-ibmz
 

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -70,14 +70,14 @@ With this release, {product-title} {product-version} introduces a {op-system-bas
 * Some device drivers have been deprecated, see the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/considerations_in_adopting_rhel_9/assembly_hardware-enablement_considerations-in-adopting-rhel-9#unmaintained-hardware-support[{op-system-base} documentation] for more information.
 
 [id="ocp-4-13-ipi-powervs_{context}"]
-==== {ibmpowerProductName} Virtual Server using installer-provisioned infrastructure (Technology Preview)
+==== IBM Power Virtual Server using installer-provisioned infrastructure (Technology Preview)
 
 Installer-provisioned Infrastructure (IPI) provides a full-stack installation and setup of {product-title}.
 
 For more information, see xref:../installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc#preparing-to-install-on-ibm-power-vs[Preparing to install on {ibmpowerProductName} Virtual Server].
 
 [id="ocp-4-13-secure-execution-z-linux-one_{context}"]
-==== IBM Secure Execution on {ibmzProductName} and {linuxoneProductName}
+==== IBM Secure Execution on IBM Z and IBM LinuxONE
 
 This feature was introduced as a Technology Preview in
 {product-title} 4.12 and is now generally available in
@@ -362,7 +362,7 @@ For more information, see xref:../openshift_images/image-streams-manage.adoc#ima
 With {product-title} {product-version}, running `oc describe` on an image now returns os/arch and digests of each manifest.
 
 [id="ocp-4-13-ibm-z_{context}"]
-=== {ibmzProductName} and {linuxoneProductName}
+=== IBM Z and IBM LinuxONE
 
 With this release, {ibmzProductName} and {linuxoneProductName} are now compatible with {product-title} {product-version}. The installation can be performed with z/VM or {op-system-base-full} Kernel-based Virtual Machine (KVM). For installation instructions, see the following documentation:
 
@@ -377,7 +377,7 @@ Compute nodes must run {op-system-first}
 ====
 
 [discrete]
-==== {ibmzProductName} and {linuxoneProductName} notable enhancements
+==== IBM Z and IBM LinuxONE notable enhancements
 
 The {ibmzProductName} and {linuxoneProductName} release on {product-title} {product-version} adds improvements and new capabilities to {product-title} components and concepts.
 
@@ -402,7 +402,7 @@ For installation instructions, see the following documentation:
 * xref:../installing/installing_ibm_z/installing-ibm-z-kvm.html#installing-rhcos-using-ibm-secure-execution_installing-ibm-z-kvm[Installing {op-system} using IBM Secure Execution]
 
 [id="ocp-4-13-ibm-power_{context}"]
-=== {ibmpowerProductName}
+=== IBM Power
 
 With this release, {ibmpowerProductName} is now compatible with {product-title} {product-version}. For installation instructions, see the following documentation:
 
@@ -415,7 +415,7 @@ Compute nodes must run {op-system-first}
 ====
 
 [discrete]
-==== {ibmpowerProductName} notable enhancements
+==== IBM Power notable enhancements
 
 The {ibmpowerProductName} release on {product-title} {product-version} adds improvements and new capabilities to {product-title} components and concepts.
 
@@ -433,7 +433,7 @@ This release introduces support for the following features on {ibmpowerProductNa
 ////
 
 [discrete]
-=== {ibmpowerProductName},{ibmzProductName}, and {linuxoneProductName} support matrix
+=== IBM Power ,IBM Z , and IBM LinuxONE support matrix
 
 .{product-title} features
 [cols="3,1,1",options="header"]
@@ -959,7 +959,7 @@ This feature is supported with Technology Preview status.
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#absent-default-storage-class[Absent default storage class].
 
 [id="ocp-4-13-powervs-csi-driver-operator_{context}"]
-==== {ibmpowerProductName} Virtual Server Block CSI Driver Operator (Technology Preview)
+==== IBM Power Virtual Server Block CSI Driver Operator (Technology Preview)
 
 {product-title} is capable of provisioning persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for {ibmpowerProductName} Virtual Server Block Storage.
 

--- a/scalability_and_performance/ibm-z-recommended-host-practices.adoc
+++ b/scalability_and_performance/ibm-z-recommended-host-practices.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ibm-z-recommended-host-practices"]
-= Recommended host practices for {ibmzProductName} & {linuxoneProductName} environments
+= Recommended host practices for IBM Z and IBM LinuxONE environments
 include::_attributes/common-attributes.adoc[]
 :context: ibm-z-recommended-host-practices
 

--- a/storage/container_storage_interface/persistent-storage-csi-ibm-powervs-block.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ibm-powervs-block.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="persistent-storage-csi-ibm-powervs-block"]
-= {ibmpowerProductName} Virtual Server Block CSI Driver Operator
+= IBM Power Virtual Server Block CSI Driver Operator
 include::_attributes/common-attributes.adoc[]
 :context: persistent-storage-csi-ibm-powervs-block
 


### PR DESCRIPTION
I've tried various ways to get the IBM attributes to render in headings but no matter where I relocate the attributes include or the [guidance](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#assembly-file-metadata) from our doc, these changes do not work. Best to try hard-coding to avoid the unrendered attributes on docs.redhat.com.

I'm trialing the changes on the 4.13 branch as the ultimate test is publication on docs.redhat.com.

Version(s):
4.13

Issue:
[OSDOCS-14341](https://issues.redhat.com/browse/OSDOCS-14341)

Preview:
* [Installing IBM Cloud Bare Metal (Classic)](https://94841--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/install-ibm-cloud-installation-workflow) - see other books that surround this book.
* [Configuring additional devices in an IBM Z or IBM LinuxONE environment ](https://94841--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/ibmz-post-install)
* [Recommended host practices for IBM Z & IBM® LinuxONE environments ](https://94841--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/ibm-z-recommended-host-practices)

