### PR TITLE
OCPBUGS#57365: Documented IPSec node reboots

### DIFF
--- a/networking/network_security/configuring-ipsec-ovn.adoc
+++ b/networking/network_security/configuring-ipsec-ovn.adoc
@@ -10,6 +10,18 @@ By enabling IPsec, you can encrypt both internal pod-to-pod cluster traffic betw
 
 IPsec is disabled by default. You can enable IPsec either during or after installing the cluster. For information about cluster installation, see xref:../../installing/overview/index.adoc#ocp-installation-overview[{product-title} installation overview].
 
+[NOTE]
+====
+Upgrading your cluster to {product-title} {product-version} when the `libreswan` and `NetworkManager-libreswan` packages have different {product-title} versions causes two consecutive compute node reboot operations. For the first reboot, the Cluster Network Operator (CNO) applies the IPsec configuration to compute nodes. For the second reboot, the Machine Config Operator (MCO) applies the latest machine configs to the cluster.
+
+To combine the CNO and MCO updates into a single node reboot, complete the following tasks:
+
+* Before upgrading your cluster, set the `paused` parameter to `true` in the `MachineConfigPools` custom resource (CR) that groups compute nodes. 
+* After you upgrade your cluster, set the parameter to `false`. 
+
+For more information, see xref:../../updating/updating_a_cluster/control-plane-only-update.adoc#control-plane-only-update[Performing a Control Plane Only update].
+====
+
 The following support limitations exist for IPsec on a {product-title} cluster:
 
 * On {ibm-cloud-name}, IPsec supports only network address translation-traversal (NAT-T). Encapsulating Security Payload (ESP) is not supported on this platform.
@@ -83,4 +95,4 @@ include::modules/nw-ovn-ipsec-disable.adoc[leveloffset=+1]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-butane-install_installing-customizing[Installing Butane]
 * xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes Container Network Interface (CNI) network plugin]
 * xref:../../networking/changing-cluster-network-mtu.adoc#changing-cluster-network-mtu[Changing the MTU for the cluster network]
-* xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1\]] API
+* xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1\] API


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OCPBUGS-57365](https://issues.redhat.com/browse/OCPBUGS-57365)

Link to docs preview:
* [Configuring IPsec encryption](https://94844--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/configuring-ipsec-ovn.html)


- [X] TAM has approved this change (David Coronel).
- [x] SME has approved this change (Peri P).
- [x] QE has approved this change (Zhanqi Zhao).

