### PR TITLE
WMCO release notes add additional reference

### DIFF
--- a/windows_containers/wmco_rn/windows-containers-release-notes-10-16-x.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-10-16-x.adoc
@@ -16,9 +16,6 @@ Y-stream releases of the WMCO are in step with {product-title}, with only z-stre
 
 include::modules/windows-containers-release-notes-10-16-2.adoc[leveloffset=+1]
 
-////
-Activate the link when https://github.com/openshift/openshift-docs/pull/93939 merges
 [role="_additional-resources"]
 .Additional resources
-* ../../windows_containers/enabling-windows-container-workloads.adoc#images-configuration-registry-mirror-configuring_enabling-windows-container-workloads[Configuring image registry repository mirroring]
-////
+* xref:../../windows_containers/enabling-windows-container-workloads.adoc#images-configuration-registry-mirror-configuring_enabling-windows-container-workloads[Configuring image registry repository mirroring]


### PR DESCRIPTION
A bug fix in WMCO 4.16.2 required "additional guidelines and requirements around using mirror registries have been added to the OpenShift Container Platform documentation." A [separate PR added those guidelines and requirements](https://github.com/openshift/openshift-docs/pull/92629). This PR adds a link from the WMCO 10.18.1 release notes to the new material.

Preview:
[Added Additional reference](https://94847--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-16-x.html)