### PR TITLE
[OSDOCS-14690]: Release note about heterogeneous node pools for HCP on IBM Power

### DIFF
--- a/hosted_control_planes/hosted-control-planes-release-notes.adoc
+++ b/hosted_control_planes/hosted-control-planes-release-notes.adoc
@@ -33,6 +33,11 @@ Configuring proxy support for {hcp} has a few differences from configuring proxy
 
 In {hcp} for {product-title} 4.18 or later, the default container runtime for worker nodes is changed from runC to crun.
 
+[id="hcp-4-18-ibm-power-heterogeneous_{context}"]
+==== Heterogeneous node pools on agent hosted clusters
+
+In {hcp} on {ibm-power-name}, you can create heterogeneous node pools on agent hosted clusters. Heterogeneous node pools support different configurations so that you can create pools that are optimized for various workloads. For more information, see xref:../hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc#hcp-ibm-power-heterogeneous-nodepools_hcp-deploy-ibm-power[Creating heterogeneous node pools on agent hosted clusters].
+
 [id="bug-fixes-hcp-rn-4-18_{context}"]
 === Bug fixes
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-14690
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hosted-control-planes-release-notes.html#hcp-4-18-ibm-power-heterogeneous_hosted-control-planes-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The xref in this PR will work after the following PR is merged: https://github.com/openshift/openshift-docs/pull/92359

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
