### PR TITLE
OSDOCS-14978: updates OCP image advisory MicroShift 4.19

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -198,7 +198,7 @@ This section is updated over time to provide notes on enhancements and bug fixes
 
 Issued: 17 June 2025
 
-{product-title} release 4.19.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:11040[RHEA-2024:11040] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHEA-2024:11038[RHEA-2024:11038] advisory.
+{product-title} release 4.19.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:11040[RHEA-2024:11040] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:11038[RHSA-2024:11038] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-14978](https://issues.redhat.com/browse/OSDOCS-14978)

Link to docs preview:
https://94857--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-0-dp_release-notes

QE review:
- N/A no technical changes; customer advisory link only
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
