### PR TITLE
WMCO 10.16.2 RN added link to errata

### DIFF
--- a/modules/windows-containers-release-notes-10-16-2.adoc
+++ b/modules/windows-containers-release-notes-10-16-2.adoc
@@ -6,7 +6,7 @@
 [id="windows-containers-release-notes-10-16-2_{context}"]
 = Release notes for Red{nbsp}Hat Windows Machine Config Operator 10.16.2
 
-This release of the Windows Machine Config Operator (WMCO) provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.16.2 were released in link:https://access.redhat.com/errata/RHSA-TBD[RHSA-TBD].
+This release of the Windows Machine Config Operator (WMCO) provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 10.16.2 were released in link:https://access.redhat.com/errata/RHSA-2025:9136[RHSA-2025:9136].
 
 [id="wmco-10-16-2-new-features"]
 == New features and improvements


### PR DESCRIPTION
Adding link to errata

Preview: [Release notes for Red Hat Windows Machine Config Operator 10.16.2](https://94859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes-10-16-x.html#windows-containers-release-notes-10-16-2_windows-containers-release-notes)