### PR TITLE
NO-JIRA: Clarifies CSRF protection note for Basic auth challenges

### DIFF
--- a/modules/oauth-token-requests.adoc
+++ b/modules/oauth-token-requests.adoc
@@ -49,11 +49,10 @@ login flow.
 
 [NOTE]
 ====
-To prevent cross-site request forgery (CSRF) attacks against browser
-clients,  only send Basic authentication challenges with if a
-`X-CSRF-Token` header is on the request. Clients that expect
-to receive Basic `WWW-Authenticate` challenges must set this header to a
-non-empty value.
+To prevent cross-site request forgery (CSRF) attacks against browser clients,
+only send Basic authentication challenges if the request includes a
+`X-CSRF-Token` header. Clients that expect to receive Basic `WWW-Authenticate`
+challenges must set this header to a non-empty value.
 
 If the authenticating proxy cannot support `WWW-Authenticate` challenges,
 or if {product-title} is configured to use an identity provider that does


### PR DESCRIPTION
Removes a redundant word for clarity of the security note regarding CSRF token requirements for Basic authentication challenges.

Version(s): 4.20

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
