### PR TITLE
Add updates to 4.18 release notes

### DIFF
--- a/virt/release_notes/virt-4-18-release-notes.adoc
+++ b/virt/release_notes/virt-4-18-release-notes.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"] 
+The release notes summarize new features and enhancements, notable technical changes, and known issues for this release of OpenShift Virtualization. 
+
 [id="virt-doc-feedback"]
 == Providing documentation feedback
 
@@ -129,11 +132,13 @@ These sections include streamlined and improved content.
 == Deprecated and removed features
 //NOTE: Comment out deprecated and removed features (and their IDs) if not used in a release
 
+[role="_abstract"] 
+The deprecated and removed features section lists the features that are no longer supported or planned for removal in this release of OpenShift Virtualization.
+
 [id="virt-4-18-deprecated"]
 === Deprecated features
 // NOTE: When uncommenting deprecated features list, change the Removed features header level below to ===
 
-Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
 
 //CNV-26316: Release note: Align tekton tasks with instancestypes
 * The `copy-template`, `modify-vm-template`, and `create-vm-from-template` tasks are deprecated.


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/CNV-58674

Link to docs preview:
https://94940--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-18-release-notes.html

QE review:
No QE required

Additional information:
 This particular PR should just be for 4.18
