### PR TITLE
Nodes release notes cgroup v1 should be Removed not Deprecated

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -1255,7 +1255,7 @@ In the following tables, features are marked with the following statuses:
 |cgroup v1
 |Deprecated
 |Deprecated
-|Deprecated
+|Removed
 |====
 
 [discrete]
@@ -1459,6 +1459,15 @@ Red{nbsp}Hat will provide bug fixes and support for versions of the Operator SDK
 Operator authors with existing Operator projects can use link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/operators/developing-operators#osdk-about[the version of the Operator SDK CLI tool released with {product-title} 4.18] to maintain their projects and create Operator releases that target newer versions of {product-title}. For more information, see link:https://access.redhat.com/node/7123119[Updating the base image for existing Ansible- or Helm-based Operator projects for {product-title} 4.19 and later] (Red{nbsp}Hat Knowledgebase).
 
 For more information about the unsupported, community-maintained, version of the Operator SDK, see link:https://sdk.operatorframework.io[Operator SDK (Operator Framework)].
+
+[id="ocp-4-19-removed-cgroup-v1_{context}"]
+==== cgroup v1 has been removed
+
+cgroup v1, which was deprecated in {product-title} 4.16, is no longer supported and has been removed from {product-title}. If your cluster is using cgroup v1, you must configure cgroup v2 before you can upgrade to  {product-title} {product-version}. All workloads must now be compatible with cgroup v2.
+
+For information on configuring cgroup v2 in your cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/nodes/working-with-clusters#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2[Configuring Linux cgroup] in the {product-title} version 4.18 documentation.
+
+For more information on cgroup v2, see xref:../architecture/index.adoc#architecture-about-cgroup-v2_architecture-overview[About Linux cgroup version 2] and link:https://www.redhat.com/en/blog/rhel-9-changes-context-red-hat-openshift-workloads[Red Hat Enterprise Linux 9 changes in the context of Red Hat OpenShift workloads] (Red{nbsp}Hat blog).
 
 [id="ocp-4-19-bug-fixes_{context}"]
 == Bug fixes


### PR DESCRIPTION
cgroup v1 has been [removed in 4.19](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes#ocp-release-notes-machine-config-operator-cgroup-v1_release-notes). The **Node deprecated and removed tracker** table should have been updated as such.