### PR TITLE
4-19-rn-fixes: Removed empty sections and dropped cgroup v1 references

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -882,18 +882,6 @@ You can now deploy the SR-IOV Network Operator on a cluster that runs on ARM arc
 
 If you enabled the `RouteExternalCertificate` feature gate for your cluster, you can now re-add a previously deleted secret. (link:https://issues.redhat.com/browse/OCPBUGS-33958[OCPBUGS-33958])
 
-[id="ocp-release-notes-nodes_{context}"]
-=== Nodes
-
-[id="ocp-release-notes-machine-config-operator-cgroup-v1_{context}"]
-==== cgroup v1 has been removed
-
-cgroup v1, which was deprecated in {product-title} 4.16, is no longer supported and has been removed from {product-title}. If your cluster is using cgroup v1, you must configure cgroup v2 before you can upgrade to  {product-title} {product-version}. All workloads must now be compatible with cgroup v2.
-
-For information on configuring cgroup v2 in your cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/nodes/working-with-clusters#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2[Configuring Linux cgroup] in the {product-title} version 4.18 documentation.
-
-For more information on cgroup v2, see xref:../architecture/index.adoc#architecture-about-cgroup-v2_architecture-overview[About Linux cgroup version 2] and link:https://www.redhat.com/en/blog/rhel-9-changes-context-red-hat-openshift-workloads[Red Hat Enterprise Linux 9 changes in the context of Red Hat OpenShift workloads] (Red{nbsp}Hat blog).
-
 [id="ocp-release-notes-openshift-cli_{context}"]
 === OpenShift CLI (oc)
 
@@ -1255,7 +1243,7 @@ In the following tables, features are marked with the following statuses:
 |cgroup v1
 |Deprecated
 |Deprecated
-|Deprecated
+|Removed
 |====
 
 [discrete]
@@ -1319,16 +1307,6 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 |Deprecated
-|====
-
-[discrete]
-[id="ocp-hardware-an-driver-dep-rem_{context}"]
-=== Specialized hardware and driver enablement deprecated and removed features
-
-.Specialized hardware and driver enablement deprecated and removed tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.17 |4.18 |4.19
 |====
 
 [discrete]
@@ -1419,6 +1397,15 @@ Starting with this release, use the `useOverlay` API hook to launch modals
 
 [id="ocp-4-19-removed-features_{context}"]
 === Removed features
+
+[id="ocp-4-19-cgroup-v1-removed_{context}"]
+==== cgroup v1 has been removed
+
+cgroup v1, which was deprecated in {product-title} 4.16, is no longer supported and has been removed from {product-title}. If your cluster is using cgroup v1, you must configure cgroup v2 before you can upgrade to  {product-title} {product-version}. All workloads must now be compatible with cgroup v2.
+
+For information on configuring cgroup v2 in your cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/nodes/working-with-clusters#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2[Configuring Linux cgroup] in the {product-title} version 4.18 documentation.
+
+For more information on cgroup v2, see xref:../architecture/index.adoc#architecture-about-cgroup-v2_architecture-overview[About Linux cgroup version 2] and link:https://www.redhat.com/en/blog/rhel-9-changes-context-red-hat-openshift-workloads[Red Hat Enterprise Linux 9 changes in the context of Red Hat OpenShift workloads] (Red{nbsp}Hat blog).
 
 [id="ocp-4-19-rhel-worker-nodes-removed_{context}"]
 ==== Package-based {op-system-base} compute machines
@@ -2640,16 +2627,6 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
-[id="ocp-release-notes-special-hardware-tech-preview_{context}"]
-=== Specialized hardware and driver enablement Technology Preview features
-
-.Specialized hardware and driver enablement Technology Preview tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.17 |4.18 |4.19
-|====
-
-[discrete]
 [id="ocp-release-notes-storage-tech-preview_{context}"]
 === Storage Technology Preview features
 
@@ -2769,8 +2746,6 @@ In the following tables, features are marked with the following statuses:
 * When installing a cluster on {azure-short}, if you set any of the `compute.platform.azure.identity.type`, `controlplane.platform.azure.identity.type`, or `platform.azure.defaultMachinePlatform.identity.type` field values to `None`, your cluster is unable to pull images from the Azure Container Registry. You can avoid this issue by either providing a user-assigned identity, or by leaving the identity field blank. In both cases, the installation program generates a user-assigned identity. (link:https://issues.redhat.com/browse/OCPBUGS-56008[OCPBUGS-56008])
 
 * Previously, the kubelet would not account for probes that ran in the `syncPod` method, which periodically checks the state of a pod and does a readiness probe outside of the normal probe period. With this release, a bug is fixed for when the kubelet incorrectly calculates `readinessProbe` periods. However, pod authors might see that the readiness latency of pods configured with readiness probes might increase. This behavior is more accurate to the configured probe. For more information, see (link:https://issues.redhat.com/browse/OCPBUGS-50522[OCPBUGS-50522])
-
-* There is a known issue with RHEL 8 worker nodes that  use `cgroupv1` Linux Control Groups (cgroup). The following is an example of the error message displayed for impacted nodes: `UDN are not supported on the node ip-10-0-51-120.us-east-2.compute.internal as it uses cgroup v1.` As a workaround, migrate worker nodes from `cgroupv1` to `cgroupv2`. (link:https://issues.redhat.com/browse/OCPBUGS-49933[OCPBUGS-49933])
 
 * There is a known issue when the grandmaster clock (T-GM) transitions to the `Locked` state too soon. This happens before the Digital Phase-Locked Loop (DPLL) completes its transition to the `Locked-HO-Acquired` state, and after the Global Navigation Satellite Systems (GNSS) time source is restored. (link:https://issues.redhat.com/browse/OCPBUGS-49826[OCPBUGS-49826])
 


### PR DESCRIPTION
[This Slack thread](https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1750190665791639) identified a few issues. No CM needed as GA was yesterday so the scope for noticeable errors for our customers should be small and customers are getting accustomed to the released document.

Version(s):
4.19

Issue:
N/A

Link to docs preview:
* [4.19 RN Doc](https://94954--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-removed-features_release-notes)
