### PR TITLE
OCPBUGS#57625: Added warning note to br-ex doc for reserved SDN int n…

### DIFF
--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -48,6 +48,26 @@ If you require an environment with a single network interface controller (NIC) a
 After you install {op-system-first} and the system reboots, the Machine Config Operator injects Ignition configuration files into each node in your cluster, so that each node received the `br-ex` bridge network configuration. To prevent configuration conflicts, the `configure-ovs.sh` shell script receives a signal to not configure the `br-ex` bridge.
 endif::postinstall-bare-metal[]
 
+[WARNING]
+====
+The following list of interface names are reserved and you cannot use the names with NMstate configurations:
+
+* `br-ext`
+* `br-int`
+* `br-local`
+* `br-nexthop`
+* `br0`
+* `ext-vxlan`
+* `ext`
+* `genev_sys_*`
+* `int`
+* `k8s-*`
+* `ovn-k8s-*`
+* `patch-br-*`
+* `tun0`
+* `vxlan_sys_*`
+====
+
 .Prerequisites
 ifndef::postinstall-bare-metal[]
 * Optional: You have installed the link:https://nmstate.io/[`nmstate`] API so that you can validate the NMState configuration.


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OCPBUGS-57625](https://issues.redhat.com/browse/OCPBUGS-57625)

Link to docs preview:
[DAY 0](https://94959--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#creating-manifest-file-customized-br-ex-bridge_ipi-install-installation-workflow)
[DAY 2](https://94959--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#creating-manifest-file-customized-br-ex-bridge_bare-metal-postinstallation-configuration)

- [x] SME has approved this change.
- [x] QE has approved this change.
