### PR TITLE
OADP-6290: Created seperate modules from the OADP API assembly [mod-docs work]

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-api.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-api.adoc
@@ -9,246 +9,52 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The document provides information about the following APIs that you can use with OADP:
+You can use the following APIs with {oadp-short}:
 
-* Velero API
-* OADP API
+Velero API::
+Velero API documentation is maintained by Velero and is not maintained by Red{nbsp}Hat. For more information, see link:https://velero.io/docs/main/api-types/[API types] (Velero documentation).
 
-[id="velero-api"]
-== Velero API
+OADP API::
 
-Velero API documentation is maintained by Velero, not by Red Hat. It can be found at link:https://velero.io/docs/main/api-types/[Velero API types].
+The following are the {oadp-short} APIs:
 
-[id="oadp-api-tables"]
-== OADP API
+* `DataProtectionApplicationSpec`
+* `BackupLocation`
+* `SnapshotLocation`
+* `ApplicationConfig`
+* `VeleroConfig`
+* `CustomPlugin`
+* `ResticConfig`
+* `PodConfig`
+* `Features`
+* `DataMover`
++
+For more information, see in link:https://pkg.go.dev/github.com/openshift/oadp-operator[OADP Operator](Go documentation).
 
-The following tables provide the structure of the OADP API:
+include::modules/dataprotectionapplicationspec-type.adoc[leveloffset=+1]
 
-.DataProtectionApplicationSpec
-[options="header"]
-|===
-|Property|Type|Description
+include::modules/backuplocation-type.adoc[leveloffset=+1]
 
-|`backupLocations`
-|[] link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#BackupLocation[`BackupLocation`]
-|Defines the list of configurations to use for `BackupStorageLocations`.
+include::modules/snapshotlocation-type.adoc[leveloffset=+1]
 
-|`snapshotLocations`
-|[] link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#SnapshotLocation[`SnapshotLocation`]
-|Defines the list of configurations to use for `VolumeSnapshotLocations`.
+include::modules/applicationconfig-type.adoc[leveloffset=+1]
 
-|`unsupportedOverrides`
-|map [ link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#UnsupportedImageKey[UnsupportedImageKey] ]  link:https://pkg.go.dev/builtin#string[string]
-|Can be used to override the deployed dependent images for development. Options are `veleroImageFqin`, `awsPluginImageFqin`, `openshiftPluginImageFqin`, `azurePluginImageFqin`, `gcpPluginImageFqin`, `csiPluginImageFqin`, `dataMoverImageFqin`, `resticRestoreImageFqin`, `kubevirtPluginImageFqin`, and `operator-type`.
+include::modules/veleroconfig-type.adoc[leveloffset=+1]
 
-|`podAnnotations`
-|map [ link:https://pkg.go.dev/builtin#string[string] ] link:https://pkg.go.dev/builtin#string[string]
-|Used to add annotations to pods deployed by Operators.
+include::modules/customplugin-type.adoc[leveloffset=+1]
 
-|`podDnsPolicy`
-|link:https://pkg.go.dev/k8s.io/api/core/v1#DNSPolicy[`DNSPolicy`]
-|Defines the configuration of the DNS of a pod.
+include::modules/resticconfig-type.adoc[leveloffset=+1]
 
-|`podDnsConfig`
-|link:https://pkg.go.dev/k8s.io/api/core/v1#PodDNSConfig[`PodDNSConfig`]
-|Defines the DNS parameters of a pod in addition to those generated from `DNSPolicy`.
+include::modules/podconfig-type.adoc[leveloffset=+1]
 
-|`backupImages`
-|*link:https://pkg.go.dev/builtin#bool[bool]
-|Used to specify whether or not you want to deploy a registry for enabling backup and restore of images.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../backup_and_restore/application_backup_and_restore/oadp-api.adoc#oadp-configuring-node-agents_oadp-api[Configuring node agents and node labels]
+* xref:../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#oadp-setting-resource-limits-and-requests_installing-oadp-aws[Setting Velero CPU and memory resource allocations]
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#PodConfig[Complete schema definitions for the type `PodConfig`](Go documentation)
 
-|`configuration`
-|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ApplicationConfig[`ApplicationConfig`]
-|Used to define the data protection application's server configuration.
+include::modules/oadp-configuring-node-agents.adoc[leveloffset=+1]
 
-|`features`
-|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#Features[`Features`]
-|Defines the configuration for the DPA to enable the Technology Preview features.
-|===
+include::modules/features-type.adoc[leveloffset=+1]
 
-link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#DataProtectionApplicationSpec[Complete schema definitions for the OADP API].
-
-.BackupLocation
-[options="header"]
-|===
-|Property|Type|Description
-
-|`velero`
-|*link:https://pkg.go.dev/github.com/vmware-tanzu/velero/pkg/apis/velero/v1#BackupStorageLocationSpec[velero.BackupStorageLocationSpec]
-|Location to store volume snapshots, as described in link:https://pkg.go.dev/github.com/vmware-tanzu/velero/pkg/apis/velero/v1#BackupStorageLocation[Backup Storage Location].
-
-|`bucket`
-| *link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#CloudStorageLocation[CloudStorageLocation]
-| [Technology Preview] Automates creation of a bucket at some cloud storage providers for use as a backup storage location.
-|===
-
-:FeatureName: The `bucket` parameter
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
-link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#BackupLocation[Complete schema definitions for the type `BackupLocation`].
-
-.SnapshotLocation
-[options="header"]
-|===
-|Property|Type|Description
-
-|`velero`
-|*link:https://pkg.go.dev/github.com/vmware-tanzu/velero/pkg/apis/velero/v1#VolumeSnapshotLocationSpec[VolumeSnapshotLocationSpec]
-|Location to store volume snapshots, as described in link:https://pkg.go.dev/github.com/vmware-tanzu/velero/pkg/apis/velero/v1#VolumeSnapshotLocation[Volume Snapshot Location].
-|===
-
-link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#SnapshotLocation[Complete schema definitions for the type `SnapshotLocation`].
-
-.ApplicationConfig
-[options="header"]
-|===
-|Property|Type|Description
-
-|`velero`
-|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#VeleroConfig[VeleroConfig]
-|Defines the configuration for the Velero server.
-
-|`restic`
-|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ResticConfig[ResticConfig]
-|Defines the configuration for the Restic server.
-|===
-
-link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ApplicationConfig[Complete schema definitions for the type `ApplicationConfig`].
-
-.VeleroConfig
-[options="header"]
-|===
-|Property|Type|Description
-
-|`featureFlags`
-|[] link:https://pkg.go.dev/builtin#string[string]
-|Defines the list of features to enable for the Velero instance.
-
-|`defaultPlugins`
-|[] link:https://pkg.go.dev/builtin#string[string]
-|The following types of default Velero plugins can be installed: `aws`,`azure`, `csi`, `gcp`, `kubevirt`, and `openshift`.
-
-|`customPlugins`
-|[]link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#CustomPlugin[CustomPlugin]
-|Used for installation of custom Velero plugins.
-
-Default and custom plugins are described in xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins#oadp-features-plugins[OADP plugins]
-
-|`restoreResourcesVersionPriority`
-|link:https://pkg.go.dev/builtin#string[string]
-|Represents a config map that is created if defined for use in conjunction with the `EnableAPIGroupVersions` feature flag. Defining this field automatically adds `EnableAPIGroupVersions` to the Velero server feature flag.
-
-|`noDefaultBackupLocation`
-|link:https://pkg.go.dev/builtin#bool[bool]
-|To install Velero without a default backup storage location, you must set the `noDefaultBackupLocation` flag in order to confirm installation.
-
-|`podConfig`
-|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#PodConfig[`PodConfig`]
-|Defines the configuration of the `Velero` pod.
-
-|`logLevel`
-|link:https://pkg.go.dev/builtin#string[string]
-|Velero server’s log level (use `debug` for the most granular logging, leave unset for Velero default). Valid options are `trace`, `debug`, `info`, `warning`, `error`, `fatal`, and `panic`.
-|===
-
-link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#VeleroConfig[Complete schema definitions for the type `VeleroConfig`].
-
-.CustomPlugin
-[options="header"]
-|===
-|Property|Type|Description
-
-|`name`
-|link:https://pkg.go.dev/builtin#string[string]
-|Name of custom plugin.
-
-|`image`
-|link:https://pkg.go.dev/builtin#string[string]
-|Image of custom plugin.
-|===
-
-link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#CustomPlugin[Complete schema definitions for the type `CustomPlugin`].
-
-.ResticConfig
-[options="header"]
-|===
-|Property|Type|Description
-
-|`enable`
-|*link:https://pkg.go.dev/builtin#bool[bool]
-|If set to `true`, enables backup and restore using Restic. If set to `false`, snapshots are needed.
-
-|`supplementalGroups`
-|[]link:https://pkg.go.dev/builtin#int64[int64]
-|Defines the Linux groups to be applied to the `Restic` pod.
-
-|`timeout`
-|link:https://pkg.go.dev/builtin#string[string]
-|A user-supplied duration string that defines the Restic timeout. Default value is `1hr` (1 hour). A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as `300ms`, -1.5h` or `2h45m`. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`.
-
-|`podConfig`
-|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#PodConfig[`PodConfig`]
-|Defines the configuration of the `Restic` pod.
-|===
-
-link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ResticConfig[Complete schema definitions for the type `ResticConfig`].
-
-.PodConfig
-[options="header"]
-|===
-|Property|Type|Description
-
-|`nodeSelector`
-|map [ link:https://pkg.go.dev/builtin#string[string] ] link:https://pkg.go.dev/builtin#string[string]
-|Defines the `nodeSelector` to be supplied to a `Velero` `podSpec` or a `Restic` `podSpec`.
-For more details, see xref:../../backup_and_restore/application_backup_and_restore/oadp-api.adoc#oadp-configuring-node-agents_oadp-api[Configuring node agents and node labels].
-
-|`tolerations`
-|[]link:https://pkg.go.dev/k8s.io/api/core/v1#Toleration[Toleration]
-|Defines the list of tolerations to be applied to a Velero deployment or a Restic `daemonset`.
-
-|`resourceAllocations`
-|link:https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements[ResourceRequirements]
-|Set specific resource `limits` and `requests` for a `Velero` pod or a `Restic` pod as described in xref:../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.adoc#oadp-setting-resource-limits-and-requests_installing-oadp-aws[Setting Velero CPU and memory resource allocations].
-
-|`labels`
-|map [ link:https://pkg.go.dev/builtin#string[string] ] link:https://pkg.go.dev/builtin#string[string]
-|Labels to add to pods.
-|===
-
-include::modules/oadp-configuring-node-agents.adoc[leveloffset=+2]
-
-link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#PodConfig[Complete schema definitions for the type `PodConfig`].
-
-.Features
-[options="header"]
-|===
-|Property|Type|Description
-
-|`dataMover`
-|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#DataMover[`DataMover`]
-|Defines the configuration of the Data Mover.
-|===
-
-link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#Features[Complete schema definitions for the type `Features`].
-
-.DataMover
-[options="header"]
-|===
-|Property|Type|Description
-
-|`enable`
-|link:https://pkg.go.dev/builtin#bool[bool]
-|If set to `true`, deploys the volume snapshot mover controller and a modified CSI Data Mover plugin. If set to `false`, these are not deployed.
-
-|`credentialName`
-|link:https://pkg.go.dev/builtin#string[string]
-|User-supplied Restic `Secret` name for Data Mover.
-
-|`timeout`
-|link:https://pkg.go.dev/builtin#string[string]
-|A user-supplied duration string for `VolumeSnapshotBackup` and `VolumeSnapshotRestore` to complete. Default is `10m` (10 minutes). A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as `300ms`, -1.5h` or `2h45m`. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`.
-|===
-
-The OADP API is more fully detailed in link:https://pkg.go.dev/github.com/openshift/oadp-operator[OADP Operator].
-
+include::modules/datamover-type.adoc[leveloffset=+1]

--- a/modules/applicationconfig-type.adoc
+++ b/modules/applicationconfig-type.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-api.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="applicationconfig-type_{context}"]
+= ApplicationConfig type
+
+The following are `ApplicationConfig` {oadp-short} APIs:
+
+.ApplicationConfig
+[options="header"]
+|===
+|Property|Type|Description
+
+|`velero`
+|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#VeleroConfig[VeleroConfig]
+|Defines the configuration for the Velero server.
+
+|`restic`
+|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ResticConfig[ResticConfig]
+|Defines the configuration for the Restic server.
+|===
+
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ApplicationConfig[Complete schema definitions for the type `ApplicationConfig`]

--- a/modules/backuplocation-type.adoc
+++ b/modules/backuplocation-type.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-api.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="backuplocation-type_{context}"]
+= BackupLocation type
+
+The following are `BackupLocation` {oadp-short} APIs:
+
+.BackupLocation
+[options="header"]
+|===
+|Property|Type|Description
+
+|`velero`
+|*link:https://pkg.go.dev/github.com/vmware-tanzu/velero/pkg/apis/velero/v1#BackupStorageLocationSpec[velero.BackupStorageLocationSpec]
+|Location to store volume snapshots, as described in link:https://pkg.go.dev/github.com/vmware-tanzu/velero/pkg/apis/velero/v1#BackupStorageLocation[Backup Storage Location].
+
+|`bucket`
+| *link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#CloudStorageLocation[CloudStorageLocation]
+| Automates creation of a bucket at some cloud storage providers for use as a backup storage location.
+|===
+
+:FeatureName: The `bucket` parameter
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#BackupLocation[Complete schema definitions for the type `BackupLocation`]

--- a/modules/customplugin-type.adoc
+++ b/modules/customplugin-type.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-api.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="customplugin-type_{context}"]
+= CustomPlugin type
+
+The following are `CustomPlugin` {oadp-short} APIs:
+
+.CustomPlugin
+[options="header"]
+|===
+|Property|Type|Description
+
+|`name`
+|link:https://pkg.go.dev/builtin#string[string]
+|Name of custom plugin.
+
+|`image`
+|link:https://pkg.go.dev/builtin#string[string]
+|Image of custom plugin.
+|===
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#CustomPlugin[Complete schema definitions for the type `CustomPlugin`]

--- a/modules/datamover-type.adoc
+++ b/modules/datamover-type.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-api.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="datamover-type_{context}"]
+= DataMover type
+
+The following are `DataMover` {oadp-short} APIs:
+
+.DataMover
+[options="header"]
+|===
+|Property|Type|Description
+
+|`enable`
+|link:https://pkg.go.dev/builtin#bool[bool]
+|If set to `true`, deploys the volume snapshot mover controller and a modified CSI Data Mover plugin. If set to `false`, these are not deployed.
+
+|`credentialName`
+|link:https://pkg.go.dev/builtin#string[string]
+|User-supplied Restic `Secret` name for Data Mover.
+
+|`timeout`
+|link:https://pkg.go.dev/builtin#string[string]
+|A user-supplied duration string for `VolumeSnapshotBackup` and `VolumeSnapshotRestore` to complete. Default is `10m` (10 minutes). A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`.
+|===

--- a/modules/dataprotectionapplicationspec-type.adoc
+++ b/modules/dataprotectionapplicationspec-type.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-api.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="dataprotectionapplicationspec-type_{context}"]
+= DataProtectionApplicationSpec type
+
+The following are `DataProtectionApplicationSpec` {oadp-short} APIs:
+
+.DataProtectionApplicationSpec
+[options="header"]
+|===
+|Property|Type|Description
+
+|`backupLocations`
+|[] link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#BackupLocation[`BackupLocation`]
+|Defines the list of configurations to use for `BackupStorageLocations`.
+
+|`snapshotLocations`
+|[] link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#SnapshotLocation[`SnapshotLocation`]
+|Defines the list of configurations to use for `VolumeSnapshotLocations`.
+
+|`unsupportedOverrides`
+|map [ link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#UnsupportedImageKey[UnsupportedImageKey] ]  link:https://pkg.go.dev/builtin#string[string]
+|Can be used to override the deployed dependent images for development. Options are `veleroImageFqin`, `awsPluginImageFqin`, `openshiftPluginImageFqin`, `azurePluginImageFqin`, `gcpPluginImageFqin`, `csiPluginImageFqin`, `dataMoverImageFqin`, `resticRestoreImageFqin`, `kubevirtPluginImageFqin`, and `operator-type`.
+
+|`podAnnotations`
+|map [ link:https://pkg.go.dev/builtin#string[string] ] link:https://pkg.go.dev/builtin#string[string]
+|Used to add annotations to pods deployed by Operators.
+
+|`podDnsPolicy`
+|link:https://pkg.go.dev/k8s.io/api/core/v1#DNSPolicy[`DNSPolicy`]
+|Defines the configuration of the DNS of a pod.
+
+|`podDnsConfig`
+|link:https://pkg.go.dev/k8s.io/api/core/v1#PodDNSConfig[`PodDNSConfig`]
+|Defines the DNS parameters of a pod in addition to those generated from `DNSPolicy`.
+
+|`backupImages`
+|*link:https://pkg.go.dev/builtin#bool[bool]
+|Used to specify whether or not you want to deploy a registry for enabling backup and restore of images.
+
+|`configuration`
+|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ApplicationConfig[`ApplicationConfig`]
+|Used to define the data protection application's server configuration.
+
+|`features`
+|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#Features[`Features`]
+|Defines the configuration for the DPA to enable the Technology Preview features.
+|===
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#DataProtectionApplicationSpec[Complete schema definitions for the OADP API]

--- a/modules/features-type.adoc
+++ b/modules/features-type.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-api.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="features-type_{context}"]
+= Features type
+
+The following are `Features` {oadp-short} APIs:
+
+.Features
+[options="header"]
+|===
+|Property|Type|Description
+
+|`dataMover`
+|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#DataMover[`DataMover`]
+|Defines the configuration of the Data Mover.
+|===
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#Features[Complete schema definitions for the type `Features`]

--- a/modules/oadp-configuring-node-agents.adoc
+++ b/modules/oadp-configuring-node-agents.adoc
@@ -13,19 +13,25 @@
 [id="oadp-configuring-node-agents_{context}"]
 = Configuring node agents and node labels
 
-The DPA of {oadp-short} uses the `nodeSelector` field to select which nodes can run the node agent. The `nodeSelector` field is the simplest recommended form of node selection constraint.
+The Data Protection Application (DPA) uses the `nodeSelector` field to select which nodes can run the node agent. The `nodeSelector` field is the recommended form of node selection constraint.
 
-Any label specified must match the labels on each node.
 
-The correct way to run the node agent on any node you choose is for you to label the nodes with a custom label:
+.Procedure
 
+. Run the node agent on any node that you choose by adding a custom label:
++
 [source,terminal]
 ----
 $ oc label node/<node_name> node-role.kubernetes.io/nodeAgent=""
 ----
++
+[NOTE]
+====
+Any label specified must match the labels on each node.
+====
 
-Use the same custom label in the `DPA.spec.configuration.nodeAgent.podConfig.nodeSelector`, which you used for labeling nodes. For example:
-
+. Use the same custom label in the `DPA.spec.configuration.nodeAgent.podConfig.nodeSelector` field, which you used for labeling nodes:
++
 [source,terminal]
 ----
 configuration:
@@ -35,9 +41,9 @@ configuration:
       nodeSelector:
         node-role.kubernetes.io/nodeAgent: ""
 ----
-
-The following example is an anti-pattern of `nodeSelector` and does not work unless both labels, `'node-role.kubernetes.io/infra: ""'` and `'node-role.kubernetes.io/worker: ""'`, are on the node:
-
++
+The following example is an anti-pattern of `nodeSelector` and does not work unless both labels, `node-role.kubernetes.io/infra: ""` and `node-role.kubernetes.io/worker: ""`, are on the node:
++
 [source,terminal]
 ----
     configuration:

--- a/modules/podconfig-type.adoc
+++ b/modules/podconfig-type.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-api.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="podconfig-type_{context}"]
+= PodConfig type
+
+The following are `PodConfig` {oadp-short} APIs:
+
+.PodConfig
+[options="header"]
+|===
+|Property|Type|Description
+
+|`nodeSelector`
+|map [ link:https://pkg.go.dev/builtin#string[string] ] link:https://pkg.go.dev/builtin#string[string]
+|Defines the `nodeSelector` to be supplied to a `Velero` `podSpec` or a `Restic` `podSpec`.
+
+|`tolerations`
+|[]link:https://pkg.go.dev/k8s.io/api/core/v1#Toleration[Toleration]
+|Defines the list of tolerations to be applied to a Velero deployment or a Restic `daemonset`.
+
+|`resourceAllocations`
+|link:https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements[ResourceRequirements]
+|Set specific resource `limits` and `requests` for a `Velero` pod or a `Restic` pod as described in the Setting Velero CPU and memory resource allocations section.
+
+|`labels`
+|map [ link:https://pkg.go.dev/builtin#string[string] ] link:https://pkg.go.dev/builtin#string[string]
+|Labels to add to pods.
+|===

--- a/modules/resticconfig-type.adoc
+++ b/modules/resticconfig-type.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-api.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="resticconfig-type_{context}"]
+= ResticConfig type
+
+The following are `ResticConfig` {oadp-short} APIs:
+
+.ResticConfig
+[options="header"]
+|===
+|Property|Type|Description
+
+|`enable`
+|*link:https://pkg.go.dev/builtin#bool[bool]
+|If set to `true`, enables backup and restore using Restic. If set to `false`, snapshots are needed.
+
+|`supplementalGroups`
+|[]link:https://pkg.go.dev/builtin#int64[int64]
+|Defines the Linux groups to be applied to the `Restic` pod.
+
+|`timeout`
+|link:https://pkg.go.dev/builtin#string[string]
+|A user-supplied duration string that defines the Restic timeout. Default value is `1hr` (1 hour). A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`.
+
+|`podConfig`
+|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#PodConfig[`PodConfig`]
+|Defines the configuration of the `Restic` pod.
+|===
+
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ResticConfig[Complete schema definitions for the type `ResticConfig`]

--- a/modules/snapshotlocation-type.adoc
+++ b/modules/snapshotlocation-type.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-api.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="snapshotlocation-type_{context}"]
+= SnapshotLocation type
+
+The following are `SnapshotLocation` {oadp-short} APIs:
+
+.SnapshotLocation
+[options="header"]
+|===
+|Property|Type|Description
+
+|`velero`
+|*link:https://pkg.go.dev/github.com/vmware-tanzu/velero/pkg/apis/velero/v1#VolumeSnapshotLocationSpec[VolumeSnapshotLocationSpec]
+|Location to store volume snapshots, as described in link:https://pkg.go.dev/github.com/vmware-tanzu/velero/pkg/apis/velero/v1#VolumeSnapshotLocation[Volume Snapshot Location].
+|===
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#SnapshotLocation[Complete schema definitions for the type `SnapshotLocation`]

--- a/modules/veleroconfig-type.adoc
+++ b/modules/veleroconfig-type.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-api.adoc
+:_mod-docs-content-type: REFERENCE
+
+[id="veleroconfig-type_{context}"]
+= VeleroConfig type
+
+The following are `VeleroConfig` {oadp-short} APIs:
+
+.VeleroConfig
+[options="header"]
+|===
+|Property|Type|Description
+
+|`featureFlags`
+|[] link:https://pkg.go.dev/builtin#string[string]
+|Defines the list of features to enable for the Velero instance.
+
+|`defaultPlugins`
+|[] link:https://pkg.go.dev/builtin#string[string]
+|The following types of default Velero plugins can be installed: `aws`,`azure`, `csi`, `gcp`, `kubevirt`, and `openshift`.
+
+|`customPlugins`
+|[]link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#CustomPlugin[CustomPlugin]
+|Used for installation of custom Velero plugins.
+
+Default and custom plugins are described in xref:../../backup_and_restore/application_backup_and_restore/oadp-features-plugins#oadp-features-plugins[OADP plugins]
+
+|`restoreResourcesVersionPriority`
+|link:https://pkg.go.dev/builtin#string[string]
+|Represents a config map that is created if defined for use in conjunction with the `EnableAPIGroupVersions` feature flag. Defining this field automatically adds `EnableAPIGroupVersions` to the Velero server feature flag.
+
+|`noDefaultBackupLocation`
+|link:https://pkg.go.dev/builtin#bool[bool]
+|To install Velero without a default backup storage location, you must set the `noDefaultBackupLocation` flag in order to confirm installation.
+
+|`podConfig`
+|*link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#PodConfig[`PodConfig`]
+|Defines the configuration of the `Velero` pod.
+
+|`logLevel`
+|link:https://pkg.go.dev/builtin#string[string]
+|Velero server’s log level (use `debug` for the most granular logging, leave unset for Velero default). Valid options are `trace`, `debug`, `info`, `warning`, `error`, `fatal`, and `panic`.
+|===
+
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#VeleroConfig[Complete schema definitions for the type `VeleroConfig`]


### PR DESCRIPTION
Version(s):
OCP 4.20

Issue:
[OADP-6290](https://issues.redhat.com/browse/OADP-6290)

Link to docs preview: https://94973--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-api.html


QE review:
- [ ] QE has approved this change.

Note - 
- Modularization work for the oadp-api assembly. Instead of having multiple tables in the assembly, I've moved the content to new modules. Otherwise, there are no technical changes.
- As discussed with Kathryn, skipping the QE review because this PR focuses on changing structure and there are no technical changes.

