### PR TITLE
OSDOCS-14434: Updated ROSA and ROSA Classic variables

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -58,3 +58,11 @@
 //ROSA CLI variables
 :zero-egress: zero egress
 //unclear whether this is going to be zero egress or egress lockdown
+// ROSA specific
+:rosa-first: Red{nbsp}Hat OpenShift Service on AWS (ROSA) with {hcp} (HCP)
+:rosa-short: ROSA with HCP
+:rosa-classic-first: {product-title} (ROSA) (classic architecture)
+:rosa-classic: Red{nbsp}Hat OpenShift Service on AWS (classic architecture)
+:rosa-classic-short: ROSA (classic)
+:classic: {rosa-classic}
+:classic-short: {rosa-classic-short}

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -196,7 +196,7 @@ openshift-aro:
       name: '4'
       dir: aro/4
 openshift-rosa:
-  name: Red Hat OpenShift Service on AWS
+  name: Red Hat OpenShift Service on AWS (classic architecture)
   author: OpenShift Documentation Project <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -13,6 +13,16 @@ toc::[]
 
 [id="rosa-new-changes-and-updates_{context}"]
 == New changes and updates
+//
+// This release note should remain hidden until the renaming project is completed to avoid confusion
+//
+// [id="rosa-q3-2025_{context}"]
+// === Q3 2025
+
+// * **Updated ROSA product titles**. Previously, the product names for {rosa-classic} and {rosa-first} in the documentation were inconsistent, potentially causing confusion for users. This release updates the product names as follows:
+// +
+// ** "Red Hat OpenShift on AWS (ROSA)" is now **{rosa-classic}** and abbreviated as {rosa-classic-short}
+// ** "Red Hat OpenShift on AWS (ROSA) with hosted control planes" is now **{rosa-first}** and abbreviated as **{rosa-short}**
 
 [id="rosa-q2-2025_{context}"]
 === Q2 2025


### PR DESCRIPTION
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
**[OSDOCS-14434](https://issues.redhat.com/browse/OSDOCS-14434)**

QE review:
- [ ] QE has approved this change.

Additional information:
Updated the product names to `ROSA (classic)` and `ROSA` as well as adds some new variables for these changes. There should be no apparent changes to the published docs.

Approved names tracked here: https://docs.google.com/spreadsheets/d/1DLS_lS3VKidgZIvcLmLp9BoiqptkvqHWfe1D5FD2kfk/edit?usp=sharing