### PR TITLE
OCPBUGS-49379 autoAssign=true present in ipaddresspool CR assigns the first available host IP from a network

### DIFF
--- a/modules/nw-metallb-addresspool-cr.adoc
+++ b/modules/nw-metallb-addresspool-cr.adoc
@@ -40,8 +40,13 @@ Specify each range in CIDR notation or as starting and ending IP addresses separ
 |`spec.autoAssign`
 |`boolean`
 |Optional: Specifies whether MetalLB automatically assigns IP addresses from this pool.
-Specify `false` if you want explicitly request an IP address from this pool with the `metallb.io/address-pool` annotation.
+Specify `false` if you want to explicitly request an IP address from this pool with the `metallb.io/address-pool` annotation.
 The default value is `true`.
+
+[NOTE]
+====
+For IP address pool configurations, ensure the addresses field specifies only IPs that are available and not in use by other network devices, especially gateway addresses, to prevent conflicts when `autoAssign` is enabled.
+====
 
 |`spec.avoidBuggyIPs`
 |`boolean`


### PR DESCRIPTION
[OCPBUGS-49379]: autoAssign=true present in ipaddresspool CR assigns the first available host IP from a network

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-49379
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://94990--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-address-pools.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
