### PR TITLE
OCPBUGS-57620: Added warning to Configuring host network interfaces a…

### DIFF
--- a/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -10,6 +10,11 @@ Before installation, you can set the `networkConfig` configuration setting in th
 
 The most common use case for this functionality is to specify a static IP address on the bare-metal network, but you can also configure other networks such as a storage network. This functionality supports other NMState features such as VLAN, VXLAN, bridges, bonds, routes, MTU, and DNS resolver settings.
 
+[WARNING]
+====
+Do not set the unsupported `rotate` option in the DNS resolver settings for your cluster. The option disrupts the DNS resolution function of the internal API.
+====
+
 .Prerequisites
 
 * Configure a `PTR` DNS record with a valid hostname for each node with a static IP address.
@@ -28,7 +33,7 @@ If you use a provisioning network, configure it by using the `dnsmasq` tool in I
 ====
 Errors in the YAML syntax might result in a failure to apply the network configuration. Additionally, maintaining the validated YAML syntax is useful when applying changes by using Kubernetes NMState after deployment or when expanding the cluster.
 ====
-
++
 .. Create an NMState YAML file:
 +
 [source,yaml]
@@ -54,7 +59,7 @@ routes:
 ----
 +
 <1> Replace `<nic1_name>`, `<ip_address>`, `<dns_ip_address>`, `<next_hop_ip_address>` and `<next_hop_nic1_name>` with appropriate values.
-
++
 .. Test the configuration file by running the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-57620](https://issues.redhat.com/browse/OCPBUGS-57620)

Link to docs preview:
* [Configuring host network interfaces](https://94995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow)

- [x] SME has approved this change.
- [x] QE has approved this change.
