### PR TITLE
[RHDEVDOCS-6475] Pipelines 1.17.2 Release Notes

### DIFF
--- a/modules/op-release-notes-1-17.adoc
+++ b/modules/op-release-notes-1-17.adoc
@@ -292,3 +292,18 @@ With this update, {pipelines-title} General Availability (GA) 1.17.1 is availabl
      value: '--build-arg EXAMPLE="abc def"'
 # ...
 ----
+
+[id="release-notes-1-17-2_{context}"]
+== Release notes for {pipelines-title} General Availability 1.17.2
+
+With this update, {pipelines-title} General Availability (GA) 1.17.2 is available on {OCP} 4.12, {OCP} 4.14 through to 4.18.
+
+[id="fixed-issues-1-17-2_{context}"]
+=== Fixed issues
+
+* Before this update, the `skopeo-copy` task required you to explicitly set the `source_image_url` and `destination_image_url` parameters. This requirement prevented the use of the `images_url` workspace with a `url.txt` file for batch image copying. With this update, both parameters default to empty values and are excluded from strict validation, allowing the task to fall back to the `url.txt` method as intended.
+
+* Before this update, when you used matrixed tasks in a fan-out and fan-in pattern, the `PipelineRun` execution failed with the following error: `invalid result reference in pipeline task 'printer': unable to validate result referencing pipeline task 'platforms': task spec not found`. This issue occurred when a downstream task attempted to reference aggregated results from a matrixed task by using the following syntax: `$(tasks.<taskName>.results.<resultName>[*])`.
+With this update, {pipelines-shortname} correctly resolves and validates result references from matrixed tasks. This enables dynamic fan-out and fan-in task orchestration using arrays and matrix expressions without triggering validation errors.
+
+* Before this update, there was no upgrade path from {pipelines-shortname} 1.16.x to later versions. With this update, the issue is fixed.


### PR DESCRIPTION
Version(s):
pipelines-docs-1.17

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6475

Link to docs preview:
- https://94997--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-17.html

QE review:
- [x] QE has approved this change.
