### PR TITLE
OADP-6292: incorrect version of Velero shown in OADP cloud providers

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -68,7 +68,7 @@ endif::[]
 :cli-manager: CLI Manager Operator
 // Backup and restore
 :velero-domain: velero.io
-:velero-version: 1.14
+:velero-version: 1.16
 :launch: image:app-launcher.png[title="Application Launcher"]
 :mtc-first: Migration Toolkit for Containers (MTC)
 :mtc-short: MTC
@@ -392,9 +392,9 @@ endif::openshift-origin[]
 // Formerly on-cluster image layering
 :image-mode-os-caps: Image mode for OpenShift
 :image-mode-os-lower: image mode for OpenShift
-// Formerly on-cluster layering 
+// Formerly on-cluster layering
 :image-mode-os-on-caps: On-cluster image mode
 :image-mode-os-on-lower: on-cluster image mode
-// Formerly out-of-cluster layering 
+// Formerly out-of-cluster layering
 :image-mode-os-out-caps: Out-of-cluster image mode
 :image-mode-os-out-lower: out-of-cluster image mode


### PR DESCRIPTION
### JIRA

* [OADP-6292](https://issues.redhat.com/browse/OADP-6292)

### Version(s):

* OCP 4.19
* OCP 4.20

### Link to docs preview:

Updated the attribute to Velero 1.16. We show to `y` not to `z` because of a link to the Velero documentation:

* [AWS](https://95002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws)
* [GCP](https://95002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp)
* [MCG](https://95002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
