### PR TITLE
OSDOCS-14901: Added network-type-migration-  annotation step to nw-ov…

### DIFF
--- a/modules/initiating-limited-live-migration.adoc
+++ b/modules/initiating-limited-live-migration.adoc
@@ -59,3 +59,10 @@ $ oc get network.config cluster -o=jsonpath='{.status.conditions}' | jq .
 ----
 +
 You can check limited live migration metrics for troubleshooting issues. For more information, see "Checking limited live migration metrics".
+
+. After a successful migration operation, remove the `network.openshift.io/network-type-migration-` annotation from the `network.config` custom resource by entering the following command:
++
+[source,terminal]
+----
+$ oc annotate network.config cluster network.openshift.io/network-type-migration-
+----

--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -206,7 +206,7 @@ The MTU for the Geneve overlay network. This value is normally configured automa
 The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by OpenShift SDN. The default value for the VXLAN port is `4789`.
 `ipv4_subnet`::
 An IPv4 address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. The default value is `100.64.0.0/16`.
-`routingViaHost::
+`routingViaHost`::
 A value of `true` sets local gateway mode and a value of `false` sets shared gateway mode. The default value is `false`. In local gateway mode, traffic is routed through the host network stack. In shared gateway mode, traffic is not routed through the host network stack.
 `ipForwarding:`:: Set IP forwarding to `Global` alongside the local gateway mode if you need the host network of the node to act as a router for traffic not related to OVN-Kubernetes.
 --
@@ -460,7 +460,7 @@ $ oc get co
 The status of every cluster Operator must be the following: `AVAILABLE="True"`, `PROGRESSING="False"`, `DEGRADED="False"`. If a cluster Operator is not available or degraded, check the logs for the cluster Operator for more information.
 
 . Complete the following steps only if the migration succeeds and your cluster is in a good state:
-
++
 .. To remove the migration configuration from the CNO configuration object, enter the following command:
 +
 [source,terminal]
@@ -468,7 +468,7 @@ The status of every cluster Operator must be the following: `AVAILABLE="True"`, 
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
   --patch '{ "spec": { "migration": null } }'
 ----
-
++
 .. To remove custom configuration for the OpenShift SDN network provider, enter the following command:
 +
 [source,terminal]
@@ -476,12 +476,19 @@ $ oc patch Network.operator.openshift.io cluster --type='merge' \
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
   --patch '{ "spec": { "defaultNetwork": { "openshiftSDNConfig": null } } }'
 ----
-
++
 .. To remove the OpenShift SDN network provider namespace, enter the following command:
 +
 [source,terminal]
 ----
 $ oc delete namespace openshift-sdn
+----
++
+.. After a successful migration operation, remove the `network.openshift.io/network-type-migration-` annotation from the `network.config` custom resource by entering the following command:
++
+[source,terminal]
+----
+$ oc annotate network.config cluster network.openshift.io/network-type-migration-
 ----
 
 .Next steps


### PR DESCRIPTION
Version(s):
4.12 to 4.16

Issue:
[OSDOCS-14901](https://issues.redhat.com/browse/OSDOCS-14901)

Link to docs preview:
* [Initiating the limited live migration process](https://95003--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#initiating-limited-live-migration_migrate-from-openshift-sdn)
* [Migrating to the OVN-Kubernetes network plugin by using the offline migration method](https://95003--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn)

- [x] SME has approved this change (Sanjay Tripathi).
- [x] QE has approved this change (Zhanqi Zhao).

