### PR TITLE
HCIDOCS-745: Indent bullets on postinstallation configuration.

### DIFF
--- a/post_installation_configuration/index.adoc
+++ b/post_installation_configuration/index.adoc
@@ -18,9 +18,9 @@ After installing {product-title}, a cluster administrator can configure and cust
 * Alerts and notifications
 
 [id="post-install-tasks"]
-== Post-installation configuration tasks
+== Postinstallation configuration tasks
 
-You can perform the post-installation configuration tasks to configure your environment to meet your need.
+You can perform the postinstallation configuration tasks to configure your environment to meet your needs.
 
 The following lists details these configurations:
 
@@ -49,10 +49,10 @@ The following lists details these configurations:
 ** Configure the maximum number of pods per node.
 ** Enable Device Manager.
 
-* xref:../post_installation_configuration/preparing-for-users.adoc#post-install-preparing-for-users[Configure users]: OAuth access tokens allow users to authenticate themselves to the API. You can configure OAuth to perform the following tasks:
+* xref:../post_installation_configuration/preparing-for-users.adoc#post-install-preparing-for-users[Configure users]: Users can authenticate themselves to the API by using OAuth access tokens. You can configure OAuth to perform the following tasks:
 
-* Specify an identity provider
-* Use role-based access control to define and supply permissions to users
-* Install an Operator from OperatorHub
+** Specify an identity provider.
+** Use role-based access control to define and grant permissions to users.
+** Install an Operator from OperatorHub.
 
 * xref:../post_installation_configuration/configuring-alert-notifications.adoc#configuring-alert-notifications[Configuring alert notifications]: By default, firing alerts are displayed on the Alerting UI of the web console. You can also configure {product-title} to send alert notifications to external systems.


### PR DESCRIPTION
Indented bullets properly. Incorporated vale comments. Edits only. No QE needed.

Fixes: [HCIDOCS-745](https://issues.redhat.com//browse/HCIDOCS-745)

See https://issues.redhat.com/browse/HCIDOCS-745 for additional details.

Preview URL: https://95004--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/index.html

For release(s): 4.16-4.19
QE Review: 

- [ ] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
