### PR TITLE
[RHACS] Added release notes for 4.8

### DIFF
--- a/release_notes/48-release-notes.adoc
+++ b/release_notes/48-release-notes.adoc
@@ -15,7 +15,7 @@ toc::[]
 
 |{product-title-short} version |Released on
 
-|`4.8.0` | 30 June 2025
+|`4.8.0` | 23 June 2025
 
 |====
 
@@ -24,20 +24,28 @@ toc::[]
 
 {product-title-short} 4.8 includes the following new features, improvements, and updates:
 
-Documentation::
-
-
-Network::
-
-
-
 Platform::
-
+* xref:../release_notes/48-release-notes.adoc#central-db-postgresql_15_release-notes-48[Central DB uses PostgreSQL 15]
+* xref:../release_notes/48-release-notes.adoc#quay-registry-keyless-authentication_release-notes-48[Quay registry keyless authentication]
+* xref:../release_notes/48-release-notes.adoc#openshift-infrastructure-compliance-ga_release-notes-48[OpenShift Infrastructure Compliance is now generally available]
+* xref:../release_notes/48-release-notes.adoc#arm-architecture-support-ga_release-notes-48[ARM architecture support is now generally available]
+* xref:../release_notes/48-release-notes.adoc#view-and-customize-platform-components_release-notes-48[View and customize platform components]
+* xref:../release_notes/48-release-notes.adoc#support-for-keyless-signing-verification_release-notes-48[Support for keyless signing verification]
 
 Policy::
+* xref:../release_notes/48-release-notes.adoc#policy-as-code-ga_release-notes-48[Policy as code is now generally available]
 
+Vulnerability Management::
+* xref:../release_notes/48-release-notes.adoc#external-ip-visibility-ga_release-notes-48[External IP visibility is now generally available]
+* xref:../release_notes/48-release-notes.adoc#cve-and-rhsa-separation_release-notes-48[{product-title-short} now reports CVEs and RHSAs as separate entities]
 
-[id="new-features-rn-48_{context}"]
+External integrations::
+* xref:../release_notes/48-release-notes.adoc#define-project-scope-for-google-registries_release-notes-48[Optionally define project scope when integrating with Google Registries]
+
+Network::
+* xref:../release_notes/48-release-notes.adoc#build-time-network-policy-tools-enhancements_release-notes-48[Build-time network policy tool enhancements]
+
+[id="new-features_{context}"]
 == New features
 
 This release adds improvements related to the following components and concepts:
@@ -46,11 +54,8 @@ This release adds improvements related to the following components and concepts:
 [id="central-db-postgresql_15_{context}"]
 === Central DB uses PostgreSQL 15
 
-The Central DB component now uses PostgreSQL 15, and {product-title-short} 4.8
-supports this version for external databases. A new installation with an
-internal database now uses this version by default. When upgrading an existing
-cluster to {product-title-short} 4.8, Central DB will perform an upgrade of the
-data it has collected.
+The Central DB component now uses PostgreSQL 15, and {product-title-short} 4.8 supports this version for external databases.
+A new installation with an internal database now uses this version by default. When upgrading an existing cluster to {product-title-short} 4.8, Central DB performs an upgrade of the data it has collected.
 
 [IMPORTANT]
 ====
@@ -58,32 +63,150 @@ When preparing the upgrade to {product-title-short} 4.8, follow these
 suggestions:
 
 * Back up the database before upgrading to {product-title-short} 4.8.
-
-* If you are not upgrading by using the Operator, check the disk space
-  available for the database by viewing the
-  `rox_central_postgres_available_size_bytes` metric. For the purposes of the
-  upgrade, the value should be double the amount of the already-consumed disk
-  space, as shown in the `rox_central_postgres_total_size_bytes` metric. If the
-  value is not correct, extend the database PVC.
-
-* Do not interrupt the upgrade procedure. If the upgrade is interrupted, a
-  manual intervention might be required to proceed.
-
+* If you are not upgrading by using the Operator, check the disk space available for the database by viewing the `rox_central_postgres_available_size_bytes` metric.
+For the purposes of the upgrade, the value should be double the amount of the already-consumed disk space, as shown in the `rox_central_postgres_total_size_bytes` metric.
+If the value is not correct, extend the database PVC.
+* Do not interrupt the upgrade procedure. If you interrupt the upgrade, you might need to intervene manually to continue.
 Depending on the amount of data, the upgrade can take extra time to finish.
 ====
 
-[id="notable-technical-changes-rn-48_{context}"]
+For more information, see link:https://access.redhat.com/articles/7045053[{product-title-short} Support Matrix].
+
+//ROX-29279
+[id="quay-registry-keyless-authentication_{context}"]
+=== Quay registry keyless authentication
+
+You can now use keyless authentication to access the Quay registry when {product-title-short} has delegated scanning enabled for the Secured cluster.
+For keyless authentication, {product-title-short} uses a Quay access token that is stored in a secret managed by the External Secrets Operator (ESO).
+The ESO on the Secured cluster manages the rotation of the credential in secret, and {product-title-short} APIs can use this credential to authenticate to the Quay Image registry during image scans and check-ins in a particular namespace.
+
+For more information, see xref:../integration/integrate-with-image-registries.adoc#quay-keyless-eso_integrate-with-image-registries[Enabling Quay registry keyless authentication by using an external secret].
+
+//ROX-28348
+[id="openshift-infrastructure-compliance-ga_{context}"]
+=== {ocp} Infrastructure Compliance is now generally available
+
+With this release, {ocp} Infrastructure Compliance is now generally available. Use it to:
+
+* Easily assess compliance across your entire {ocp} Cluster Fleet.
+* Ensure your {ocp} infrastructure consistently adheres to your organizational security policies.
+
+Additionally, this release also includes enhancement in Compliance Reporting. {product-title-short} now generates compliance reports even when some clusters encounter failures during a scheduled scan. It prevents data gaps and provides continuous visibility, ensuring that you always receive a report reflecting the compliance status of all successfully scanned clusters.
+
+//ROX-27659
+[id="arm-architecture-support-ga_{context}"]
+=== ARM architecture support is now generally available
+With this release, {product-title-short} now supports ARM architecture in Secured clusters. This update enables you to use ARM's efficient power consumption and high performance-per-watt benefits, making it ideal for resource-intensive tasks and cost-effective scaling while enhancing flexibility and performance.
+
+For more details, see link:https://access.redhat.com/articles/7045053[{product-title-short} Support Matrix]
+
+//ROX-27876
+[id="build-time-network-policy-tools-enhancements_{context}"]
+=== Build-time network policy tool enhancements
+
+This release introduces two key enhancements to the Build-time network policy tools `roxctl netpol`:
+
+* **Expanded network policy visualization** - The `roxctl netpol connectivity map` command now supports visualizing Admin Network Policies (ANP) and Baseline Admin Network Policies (BANP). It gives you a more comprehensive view of your network's security posture.
+* **Enhanced connectivity explainability** - A new `roxctl` explainability feature helps you pinpoint the exact resources, including network policies, ANP, and BANP, that allow or deny connectivity between any two workloads. You can use the report to verify expected connectivity outcomes and guide you in modifying resources to achieve your desired network configuration.
+
+For more information, see xref:../operating/build-time-network-policy-tools.adoc#build-time-network-policy-tools[Build-time network policy tools].
+
+//ROX-26858
+[id="view-and-customize-platform-components_{context}"]
+=== View and customize platform components
+
+{product-title-short} now allows you to view and modify the definition of platform components using the system menu in the user interface or through the API. Red Hat recommends updating the platform components definition if you install {ocp} Operators into non-default namespaces or if you want {product-title-short} to consider any third-party software as a "Platform component". You can focus on actionable data in the **User Workloads** tabs by customizing this definition.
+
+//ROX-27858
+[id="policy-as-code-ga_{context}"]
+=== Policy as code is now generally available
+
+Policy as code, which enables you to manage {product-title-short} policies as Kubernetes custom resources, is now generally available. This feature supports GitOps workflows with tools like {ocp} GitOps (Argo CD).
+
+Key enhancements include:
+
+* Clusters and notifiers are addressed by name instead of by UUID.
+* The system provides additional error handling.
+
+For more information, see xref:../operating/manage_security_policies/custom-security-policies.adoc#policy-as-code-about_custom-security-policies[Managing policies as code].
+
+//ROX-23580
+[id="support-for-keyless-signing-verification_{context}"]
+=== Support for keyless signing verification
+
+{product-title-short} 4.8 includes enhanced Sigstore integration with support for validating images signed using short-lived credentials. This enhancement uses an integration with Rekor transparency log, which records the public key or certificate used to sign the image. {product-title-short} retrieves this record to validate the signature.
+
+Additionally, Fulcio integrates with OIDC Identity Providers to exchange a user's identity token for a short-lived credential to sign images, which facilitates a keyless signing workflow.
+
+//ROX-29006
+[id="define-project-scope-for-google-registries_{context}"]
+=== Optionally define project scope when integrating with Google Registries
+
+{product-title-short} now allows you to include multiple {ocp} projects or Kubernetes namespaces in a single Google Artifact Registry integration. For more details, see xref:../integration/integrate-with-image-registries.adoc#integrate-with-image-registries[Integrating with image registries].
+
+//ROX-27696
+[id="external-ip-visibility-ga_{context}"]
+=== External IP visibility is now generally available
+
+The external IP visibility feature is now generally available. This enhancement provides crucial insight into your cluster's external communications. You can now visualize the exact external IP addresses your deployments communicate with. This improves your ability to understand external connections, identify potential threats, and validate network policies.
+
+By default, this feature is disabled. However, when enabled, you see external IPs in the Network Graph. Additionally, Unauthorized Network Flow violations automatically include detailed external IP information, which streamlines your investigation process.
+
+//ROX-26476
+[id="cve-and-rhsa-separation_{context}"]
+=== {product-title-short} now reports CVEs and RHSAs as separate entities
+
+Starting with {product-title-short} 4.8, the system now reports both the CVE ID (Common Vulnerabilities and Exposures) and the RHSA (Red Hat Security Advisory) when available. RHSAs might include one or more security fixes, and might also contain bug or enhancement updates. In previous versions up to {product-title-short} 4.7, {product-title-short} replaced the CVE ID with the corresponding RHSA ID once Red Hat released a fix for the associated vulnerability.
+
+
+[id="notable-technical-changes_{context}"]
 == Notable technical changes
 
 This release contains the following changes:
 
+//ROX-26577
+* Starting with {product-title-short} 4.8, Scanner V4 is the default scanner for reporting vulnerabilities in User Workloads, Platforms, and Nodes for all new installations of {product-title-short} Central and Secured Clusters.
 
-[id="documentation-updates-rn-48_{context}"]
-== Documentation updates
+* {product-title-short} 4.8 preserves the current scanner configuration for existing deployments that you upgrade. If you are using the StackRox Scanner, it remains in use after the upgrade. For switching to Scanner V4, see xref:../operating/examine-images-for-vulnerabilities.adoc#enabling_scanner_v4_examine-images-for-vulnerabilities[Enabling Scanner V4].
 
+* Scanner V4 runs in Central and you do not have to deploy it to secured clusters unless you have specific requirements, for example:
+** Accessing image registries that are not reachable from Central.
+** Using the {ocp} image registry.
+** Running on {product-title-short} Cloud Service with firewall restrictions that limit registry access to internal traffic.
+** Using registry mirroring.
++
+For more details, see xref:../operating/examine-images-for-vulnerabilities.adoc#accessing-delegated-image-scanning_examine-images-for-vulnerabilities[Accessing delegated image scanning].
 
+* In `roxctl` CLI, certificate validation failures are now marked as errors.
 
-[id="deprecated-and-removed-features-rn-48_{context}"]
+* {product-title-short} 4.8 includes the updated `roxctl` help command output making it more readable. The output is now more consistent with other command-line tools.
+
+* Red Hat has moved the `SecurityPolicy`` Custom Resource Definition (CRD) to the template directory within the Helm chart. This change simplifies CRD maintenance if you are using Helm, as it now automatically upgrades.
++
+[IMPORTANT]
+====
+If you are using Helm to manage your {product-title-short} installation, you must apply the following changes to the `SecurityPolicy` CRD before upgrading to avoid upgrade failures:
+[source,terminal]
+----
+$ kubectl annotate crd/securitypolicies.config.stackrox.io meta.helm.sh/release-name=stackrox-central-services <1>
+$ kubectl annotate crd/securitypolicies.config.stackrox.io meta.helm.sh/release-namespace=stackrox <2>
+$ kubectl label crd/securitypolicies.config.stackrox.io app.kubernetes.io/managed-by=Helm
+----
+<1> If you used a different name during your initial installation, update the `release-name` annotation to match that name. The default value is `stackrox-central-services`.
+<2> If you used a different namespace during your initial installation, update the `release-namespace` annotation to match that namespace. The default value is `stackrox`.
+====
+
+* Sensor now ignores entries that contain invalid UTF-8 characters when reading Docker configuration pull secrets from Kubernetes.
+
+* The S3 integration type no longer supports Google Cloud Storage (GCS) buckets. Red Hat announced this change in RHACS 4.5.0. If you use GCS buckets for backups, you must now use the dedicated GCS integration.
+
+* Scoping Google image integrations by project is now optional.
+
+* The default output of the `roxctl image scan` command now includes three new fields when you use the `--output` option: **CVSS**, **Advisory**, and **Advisory Link**. The exact names of these fields depend on the specific output format you select.
+** **CVSS** represents the CVSS score of the vulnerability.
+** **Advisory** and **Advisory Link** represent the advisory related to the vulnerability, if {product-title-short} tracks it. For example, a CVE's associated Red Hat Security Advisory (RHSA), if the CVE relates to a Red Hat product.
+
+[id="deprecated-and-removed-features_{context}"]
 == Deprecated and removed features
 
 Some features available in earlier releases have been deprecated or removed.
@@ -108,67 +231,77 @@ In the table, features are marked with the following statuses:
 |API token authentication for {cloud-redhat-com}^[1]^
 |DEP
 |DEP
-|
+|DEP
+
+|Compliance dashboard
+|NA
+|NA
+|DEP
 
 |`definitions.stackrox.io`
 |DEP
 |DEP
-|
+|DEP
 
 |Google Container Registry integration^[2]^
 |DEP
 |DEP
-|
+|DEP
 
 |Kernel support packages and driver download functionality ^[3]^
 |DEP
 |DEP
-|
+|DEP
 
 |Reporting of Istio vulnerabilities
 |DEP
 |DEP
-|
+|DEP
 
 |StackRox Scanner
 |DEP
 |DEP
-|
+|DEP
+
+|S3 backup on GCS buckets
+|DEP
+|DEP
+|REM
 
 |`/v1/clustercves/suppress` APIs^[5,6]^
 |DEP
 |DEP
-|
+|DEP
 
 |`/v1/clustercves/unsuppress` APIs^[5,6]^
 |DEP
 |DEP
-|
+|DEP
 
 |`/v1/nodecves/suppress` APIs^[5,6]^
 |DEP
 |DEP
-|
+|DEP
 
 |`/v1/nodecves/unsuppress` APIs^[5,6]^
 |DEP
 |DEP
-|
+|DEP
 
 |`/v1/summary/counts` endpoint
 |DEP
 |DEP
-|
+|DEP
 
 |Vulnerability Management (1.0) menu item^[7]^
 |DEP
 |DEP
-|
+|DEP
 
 |Vulnerability Report Creator permission
 |DEP
 |DEP
-|
+|DEP
 
 |===
 
@@ -182,8 +315,8 @@ For more information, see link:https://cloud.google.com/artifact-registry/docs/t
 
 3. Kernel support packages and driver download functionality are deprecated.
 
-4. The `rhacs-collector-slim*` image is deprecated and has been removed in {product-title-short} 4.7.0. `rhacs-collector*` image used to contain kernel modules and eBPF probes, but {product-title-short} no longer needs those items.
-The `rhacs-collector*` and the `rhacs-collector-slim*` images are now functionally the same.
+4. The `{product-title-short}-collector-slim*` image is deprecated and has been removed in {product-title-short} 4.7.0. `{product-title-short}-collector*` image used to contain kernel modules and eBPF probes, but {product-title-short} no longer needs those items.
+The `{product-title-short}-collector*` and the `{product-title-short}-collector-slim*` images are now functionally the same.
 
 5. A feature flag controls this API object, and you can enable or disable this API object by using the `ROX_VULN_MGMT_LEGACY_SNOOZE` environment variable.
 
@@ -196,10 +329,36 @@ For example, `0.300s`, `-5400s`, or `9900s`. The previously valid time units of 
 
 --
 
-[id="bug-fixes-rn-48_{context}"]
+[id="bug-fixes_{context}"]
 == Bug fixes in version 4.8.0
 
-*Release date*: 30 June 2025
+*Release date*: 23 June 2025
 
+* Previously, if messages contained non-UTF-8 characters, the Secured Cluster sensor would remain uninitialized and offline.
+It prevented proper monitoring of affected clusters. With this release, the Sensor now handles non-UTF-8 characters in user-provided data.
+As a result, the Secured Cluster sensor no longer fails to initialize due to these characters and correctly monitors all clusters.
+
+* Previously, warning messages in sensor pod logs incorrectly indicated that images were *Not Pullable* because the system attempted to determine pullability even when the image ID was empty.
+As a consequence, images were skipped from workload CVE scans.
+RHACS 4.8 correctly scans the images for vulnerabilities.
+
+* Fixed an issue where signing images multiple times with different keys led to failed image signature verification.
+
+* Previously, sometimes RHACS did not correctly initialize the Scanner V4 integration with default indexer and matcher endpoints, which caused scanner pods to fail and prevented images from being scanned.
+With this update, RHACS correctly initializes the Scanner V4 integration, scans the images, and creates vulnerability reports as expected.
+
+* Previously, creating a security policy with a cluster scope using the cluster's name would cause the UI to crash upon viewing the policy.
+It was due to the system's inability to resolve the cluster name to its corresponding ID correctly.
+This update enables proper resolution of cluster names to IDs in security policies.
+As a result, you can now view policies with cluster scope in the UI without encountering errors.
+
+* Previously, the Scanner V4 failed to identify some critical CVEs in Java workloads because an `unidentified jar` error caused the scanner to skip valid JAR files during the scanning process.
+As a consequence, RHACS did not detect these vulnerabilities in the scan results.
+This update eliminates the `unidentified jar" error, enabling the scanner to process JAR files properly.
+As a result, the Scanner V4 now accurately identifies critical CVEs in Java workloads, providing comprehensive vulnerability scanning.
+
+* Previously, the **Cancel** button on the delegated scanning page provided no visual feedback if you made no changes, leading to confusion about its functionality.
+This lack of feedback occurred because the button only reset the form for unpersisted changes.
+This update introduces an **Edit** button to initiate editing, making the **Save** and **Cancel** buttons visible and enabled only when you make changes.
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-29255

Added release notes for RHACS 4.8

Cherrypick in `rhacs-docs-4.8`.

Preview: https://95013--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/48-release-notes.html