### PR TITLE
[enterprise-4.14] OSDOCS-14901: Added network-type-migration-  annotation step to nw-ov…

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -438,7 +438,7 @@ $ oc get co
 The status of every cluster Operator must be the following: `AVAILABLE="True"`, `PROGRESSING="False"`, `DEGRADED="False"`. If a cluster Operator is not available or degraded, check the logs for the cluster Operator for more information.
 
 . Complete the following steps only if the migration succeeds and your cluster is in a good state:
-
++
 .. To remove the migration configuration from the CNO configuration object, enter the following command:
 +
 [source,terminal]
@@ -446,7 +446,7 @@ The status of every cluster Operator must be the following: `AVAILABLE="True"`, 
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
   --patch '{ "spec": { "migration": null } }'
 ----
-
++
 .. To remove custom configuration for the OpenShift SDN network provider, enter the following command:
 +
 [source,terminal]
@@ -454,12 +454,19 @@ $ oc patch Network.operator.openshift.io cluster --type='merge' \
 $ oc patch Network.operator.openshift.io cluster --type='merge' \
   --patch '{ "spec": { "defaultNetwork": { "openshiftSDNConfig": null } } }'
 ----
-
++
 .. To remove the OpenShift SDN network provider namespace, enter the following command:
 +
 [source,terminal]
 ----
 $ oc delete namespace openshift-sdn
+----
++
+.. After a successful migration operation, remove the `network.openshift.io/network-type-migration-` annotation from the `network.config` custom resource by entering the following command:
++
+[source,terminal]
+----
+$ oc annotate network.config cluster network.openshift.io/network-type-migration-
 ----
 
 .Next steps


### PR DESCRIPTION
[Commit on GitLab](https://gitlab.cee.redhat.com/red-hat-enterprise-openshift-documentation/doc-4.14/-/commit/cb4b8e5b9210c144103bc14e0478864f71530d82).

Cherry pick of #95003 with commit ID 3636d7ca54d26c63f933e7326f16b96f69028832

Version(s):
4.14

Issue:
[OSDOCS-14901](https://issues.redhat.com/browse/OSDOCS-14901)
