### PR TITLE
OSDOCS-14997: Documented 4.15.53 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2778,6 +2778,40 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.53
+[id="ocp-4-15-53_{context}"]
+=== RHSA-2025:9259 - {product-title} 4.15.53 bug fix and security update
+
+Issued: 26 June 2025
+
+{product-title} release 4.15.53, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:9259[RHSA-2025:9259 ] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:9260[RHBA-2025:9260] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.53 --pullspecs
+----
+
+[id="ocp-4-15-53-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, if the Subject Alternative Name (SAN) of the custom certificate that the user added to the `hc.spec.configuration.apiServer.servingCerts.namedCertificates` field conflicted with the hostname set in the `hc.spec.services.servicePublishingStrategy` field for the Kubernetes agent server (KAS), the KAS certificate was not added to the set of certificates to generate a new payload. This caused certificate validation issues for nodes that joined the hosted cluster. With this release, the validation fails earlier so that the user is warned about the issue with the conflicting SANs. (link:https://issues.redhat.com/browse/OCPBUGS-57121[OCPBUGS-57121])
+
+* Previously, disabling feature migration prevented Cluster Network Operator (CNO) from initiating software defined networking (SDN) live migration. With this release, the CNO can trigger SDN live migration when feature migration is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-56649[OCPBUGS-56649])
+
+* Previously, if the default proxy environment variables were set to null on build containers, some applications in the container would not run. With this release, the proxy environment variables are added to the build container only if they are defined and the default values are not null. (link:https://issues.redhat.com/browse/OCPBUGS-56474[OCPBUGS-56474]) 
+
+* Previously, {product-title} 4.15 and later versions managed by OpenShift Lifecycle  Manager (OLM) were required to have the `olm.managed: "true"` label. In some cases, the solution failed to start and entered a `CrashLoopBackOff` state if the label was missing. The logs for this scenario were displayed as `informative`, which made it more challenging to identify the root cause. For this release, the log level is changed to `error` to make the issue clearer and easier to diagnose when the label is missing. (link:https://issues.redhat.com/browse/OCPBUGS-56463[OCPBUGS-56463])
+
+* Previously, the Konnectivity proxy used by the `openshift-apiserver` in the control plane resolved registry names with cloud API suffixes on the control plane and then attempted to access them through the data plane. A hosted cluster that used the no-egress feature in ROSA, as well as a container registry that was accessible through an Amazon Virtual Private Cloud (VPC) endpoint was created but failed to install because `imagestreams` that use the container registry could not resolve.  With this release, the Konnectivity proxy resolves and routes hostnames consistently. (link:https://issues.redhat.com/browse/OCPBUGS-46467[OCPBUGS-46467]) 
+
+[id="ocp-4-15-53-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.15.52
 [id="ocp-4-15-52_{context}"]
 === RHSA-2025:8299 - {product-title} 4.15.52 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-14997](https://issues.redhat.com/browse/OSDOCS-14997)

Link to docs preview:
* [4.15.53](https://95025--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-53_release-notes)
