### PR TITLE
OBSDOCS-1726: Port the "Installing log storage" sections to 5.8 and 6…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -27,8 +27,8 @@ Distros: openshift-logging
 Topics:
 - Name: Configuring log forwarding
   File: configuring-log-forwarding
-- Name: Configuring LokiStack storage
-  File: configuring-lokistack-storage
+- Name: Configuring the log store
+  File: configuring-the-log-store
 - Name: Configuring LokiStack for OTLP
   File: configuring-lokistack-otlp
 - Name: OpenTelemetry data model

--- a/configuring/configuring-the-log-store.adoc
+++ b/configuring/configuring-the-log-store.adoc
@@ -1,0 +1,83 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="configuring-lokistack-storage"]
+= Configuring the log store
+:context: configuring-the-log-store
+
+toc::[]
+
+You can configure a `LokiStack` custom resource (CR) to store application, audit, and infrastructure-related logs.
+
+include::snippets/loki-statement-snip.adoc[leveloffset=+1]
+
+
+// Loki sizing
+include::modules/loki-sizing.adoc[leveloffset=+1]
+
+
+// Loki object storage
+include::modules/logging-loki-storage.adoc[leveloffset=+1]
+
+// create object storage
+include::modules/logging-loki-storage-aws.adoc[leveloffset=+2]
+include::modules/logging-loki-storage-azure.adoc[leveloffset=+2]
+include::modules/logging-loki-storage-gcp.adoc[leveloffset=+2]
+include::modules/logging-loki-storage-minio.adoc[leveloffset=+2]
+include::modules/logging-loki-storage-odf.adoc[leveloffset=+2]
+include::modules/logging-loki-storage-swift.adoc[leveloffset=+2]
+
+//Loki stirage STS
+[id="installing-log-storage-loki-sts"]
+=== Deploying a Loki log store on a cluster that uses short-term credentials
+
+For some storage providers, you can use the Cloud Credential Operator utility (`ccoctl`) during installation to implement short-term credentials. These credentials are created and managed outside the {ocp-product-title} cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/authentication_and_authorization/managing-cloud-provider-credentials#cco-short-term-creds[Manual mode with short-term credentials for components].
+
+[NOTE]
+====
+Short-term credential authentication must be configured during a new installation of {loki-op}, on a cluster that uses this credentials strategy. You cannot configure an existing cluster that uses a different credentials strategy to use this feature.
+====
+
+include::modules/logging-identity-federation.adoc[leveloffset=+3]
+
+include::modules/logging-create-loki-cr-console.adoc[leveloffset=+3,tag=!pre-5.9]
+
+include::modules/loki-create-object-storage-secret-cli.adoc[leveloffset=+3]
+
+include::modules/logging-loki-log-access.adoc[leveloffset=+2,tag=!NetObservMode]
+
+
+include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+2]
+
+//Enhanced reliability and performance
+[id="performance_{context}"]
+== Enhanced reliability and performance
+
+Use the following configurations to ensure reliability and efficiency of Loki in production.
+
+include::modules/loki-pod-placement.adoc[leveloffset=+2]
+
+include::modules/logging-loki-reliability-hardening.adoc[leveloffset=+2]
+
+include::modules/loki-retention.adoc[leveloffset=+2]
+
+
+include::modules/loki-memberlist-ip.adoc[leveloffset=+2]
+
+include::modules/loki-restart-hardening.adoc[leveloffset=+2]
+
+//Advanced deployment and scalability
+[id="advanced_{context}"]
+== Advanced deployment and scalability
+
+To configure high availability, scalability, and error handling, use the following information.
+
+include::modules/loki-zone-aware-replication.adoc[leveloffset=+2]
+include::modules/loki-zone-fail-recovery.adoc[leveloffset=+2]
+include::modules/loki-rate-limit-errors.adoc[leveloffset=+2]
+
+//log based alerts
+[id="log-based-alerts_{context}"]
+== Log-based alerts
+
+include::modules/loki-rbac-rules-permissions.adoc[leveloffset=+2]
+include::modules/enabling-loki-alerts.adoc[leveloffset=+2]

--- a/modules/enabling-loki-alerts.adoc
+++ b/modules/enabling-loki-alerts.adoc
@@ -1,3 +1,7 @@
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="logging-enabling-loki-alerts_{context}"]
 = Creating a log-based alerting rule with Loki

--- a/modules/logging-create-loki-cr-console.adoc
+++ b/modules/logging-create-loki-cr-console.adoc
@@ -1,6 +1,6 @@
-// Module included in the following assemblies:
+// Module is included in the following assemblies:
 //
-// * logging/log_storage/installing-log-storage.adoc
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-create-loki-cr-console_{context}"]

--- a/modules/logging-creating-new-group-cluster-admin-user-role.adoc
+++ b/modules/logging-creating-new-group-cluster-admin-user-role.adoc
@@ -1,7 +1,6 @@
-// Module included in the following assemblies:
-
-//  * cluster-logging-loki.adoc
-//  * network_observability/installing-operators.adoc
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-creating-new-group-cluster-admin-user-role_{context}"]

--- a/modules/logging-identity-federation.adoc
+++ b/modules/logging-identity-federation.adoc
@@ -1,5 +1,6 @@
-// Module included in the following assemblies:
-// * logging/log_storage/installing-log-storage.adoc
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-identity-federation_{context}"]

--- a/modules/logging-loki-log-access.adoc
+++ b/modules/logging-loki-log-access.adoc
@@ -1,13 +1,12 @@
-// Module included in the following assemblies:
+// Module is included in the following assemblies:
 //
-// * observability/network_observability/installing-operators.adoc
-// * logging/cluster-logging-loki.adoc
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="logging-loki-log-access_{context}"]
 = Fine grained access for Loki logs
 
-In {logging} 5.8 and later, the {clo} does not grant all users access to logs by default. As an administrator, you must configure your users' access unless the Operator was upgraded and prior configurations are in place. Depending on your configuration and need, you can configure fine grain access to logs using the following:
+The {clo} does not grant all users access to logs by default. As an administrator, you must configure your users' access unless the Operator was upgraded and prior configurations are in place. Depending on your configuration and need, you can configure fine grain access to logs using the following:
 
 * Cluster wide policies
 * Namespace scoped policies

--- a/modules/logging-loki-reliability-hardening.adoc
+++ b/modules/logging-loki-reliability-hardening.adoc
@@ -1,6 +1,6 @@
-// Module included in the following assemblies:
+// Module is included in the following assemblies:
 //
-// * logging/cluster-logging-loki.adoc
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="logging-loki-reliability-hardening_{context}"]

--- a/modules/logging-loki-storage-aws.adoc
+++ b/modules/logging-loki-storage-aws.adoc
@@ -1,6 +1,6 @@
 // Module is included in the following assemblies:
 //
-// * observability/logging/log_storage/installing-log-storage.adoc
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-aws_{context}"]

--- a/modules/logging-loki-storage-azure.adoc
+++ b/modules/logging-loki-storage-azure.adoc
@@ -1,6 +1,6 @@
 // Module is included in the following assemblies:
 //
-// * observability/logging/log_storage/installing-log-storage.adoc
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-azure_{context}"]

--- a/modules/logging-loki-storage-gcp.adoc
+++ b/modules/logging-loki-storage-gcp.adoc
@@ -1,6 +1,6 @@
 // Module is included in the following assemblies:
 //
-// * observability/logging/log_storage/installing-log-storage.adoc
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-gcp_{context}"]

--- a/modules/logging-loki-storage-minio.adoc
+++ b/modules/logging-loki-storage-minio.adoc
@@ -1,6 +1,6 @@
 // Module is included in the following assemblies:
 //
-// * observability/logging/log_storage/installing-log-storage.adoc
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-minio_{context}"]

--- a/modules/logging-loki-storage-odf.adoc
+++ b/modules/logging-loki-storage-odf.adoc
@@ -1,5 +1,6 @@
 // Module is included in the following assemblies:
-// logging/cluster-logging-loki.adoc
+//
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-odf_{context}"]

--- a/modules/logging-loki-storage-swift.adoc
+++ b/modules/logging-loki-storage-swift.adoc
@@ -1,6 +1,6 @@
 // Module is included in the following assemblies:
 //
-// * observability/logging/log_storage/installing-log-storage.adoc
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-swift_{context}"]

--- a/modules/logging-loki-storage.adoc
+++ b/modules/logging-loki-storage.adoc
@@ -1,6 +1,6 @@
 // Module is included in the following assemblies:
 //
-// * observability/logging/log_storage/installing-log-storage.adoc
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="logging-loki-storage_{context}"]

--- a/modules/loki-create-object-storage-secret-cli.adoc
+++ b/modules/loki-create-object-storage-secret-cli.adoc
@@ -1,6 +1,6 @@
-// Module included in the following assemblies:
+// Module is included in the following assemblies:
 //
-// * list assemblies
+// * configuring/configuring-the-log-store.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="loki-create-object-storage-secret-cli_{context}"]

--- a/modules/loki-memberlist-ip.adoc
+++ b/modules/loki-memberlist-ip.adoc
@@ -1,3 +1,7 @@
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="loki-memberlist-ip_{context}"]
 = Configuring Loki to tolerate memberlist creation failure

--- a/modules/loki-pod-placement.adoc
+++ b/modules/loki-pod-placement.adoc
@@ -1,3 +1,7 @@
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="loki-pod-placement_{context}"]
 = Loki pod placement

--- a/modules/loki-rate-limit-errors.adoc
+++ b/modules/loki-rate-limit-errors.adoc
@@ -1,3 +1,7 @@
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="loki-rate-limit-errors_{context}"]
 = Troubleshooting Loki rate limit errors

--- a/modules/loki-rbac-rules-permissions.adoc
+++ b/modules/loki-rbac-rules-permissions.adoc
@@ -1,3 +1,7 @@
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
+
 :_mod-docs-content-type: REFERENCE
 [id="loki-rbac-rules-permissions_{context}"]
 = Authorizing LokiStack rules RBAC permissions

--- a/modules/loki-restart-hardening.adoc
+++ b/modules/loki-restart-hardening.adoc
@@ -1,3 +1,7 @@
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="loki-restart-hardening_{context}"]
 = LokiStack behavior during cluster restarts

--- a/modules/loki-retention.adoc
+++ b/modules/loki-retention.adoc
@@ -1,0 +1,118 @@
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="loki-retention_{context}"]
+= Enabling stream-based retention with Loki
+
+You can configure retention policies based on log streams. Rules for these may be set globally, per-tenant, or both. If you configure both, tenant rules apply before global rules.
+
+include::snippets/logging-retention-period-snip.adoc[]
+
+[NOTE]
+====
+Schema v13 is recommended.
+====
+
+.Procedure
+
+. Create a `LokiStack` CR:
++
+** Enable stream-based retention globally as shown in the following example:
++
+.Example global stream-based retention for AWS
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  limits:
+   global: <1>
+      retention: <2>
+        days: 20
+        streams:
+        - days: 4
+          priority: 1
+          selector: '{kubernetes_namespace_name=~"test.+"}' <3>
+        - days: 1
+          priority: 1
+          selector: '{log_type="infrastructure"}'
+  managementState: Managed
+  replicationFactor: 1
+  size: 1x.small
+  storage:
+    schemas:
+    - effectiveDate: "2020-10-11"
+      version: v13
+    secret:
+      name: logging-loki-s3
+      type: aws
+  storageClassName: gp3-csi
+  tenants:
+    mode: openshift-logging
+----
+<1> Sets retention policy for all log streams. *Note: This field does not impact the retention period for stored logs in object storage.*
+<2> Retention is enabled in the cluster when this block is added to the CR.
+<3> Contains the link:https://grafana.com/docs/loki/latest/logql/query_examples/#query-examples[LogQL query] used to define the log stream.spec:
+  limits:
+
+** Enable stream-based retention per-tenant basis as shown in the following example:
++
+.Example per-tenant stream-based retention for AWS
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+  limits:
+    global:
+      retention:
+        days: 20
+    tenants: <1>
+      application:
+        retention:
+          days: 1
+          streams:
+            - days: 4
+              selector: '{kubernetes_namespace_name=~"test.+"}' <2>
+      infrastructure:
+        retention:
+          days: 5
+          streams:
+            - days: 1
+              selector: '{kubernetes_namespace_name=~"openshift-cluster.+"}'
+  managementState: Managed
+  replicationFactor: 1
+  size: 1x.small
+  storage:
+    schemas:
+    - effectiveDate: "2020-10-11"
+      version: v13
+    secret:
+      name: logging-loki-s3
+      type: aws
+  storageClassName: gp3-csi
+  tenants:
+    mode: openshift-logging
+----
+<1> Sets retention policy by tenant. Valid tenant types are `application`, `audit`, and `infrastructure`.
+<2> Contains the link:https://grafana.com/docs/loki/latest/logql/query_examples/#query-examples[LogQL query] used to define the log stream.
+
+. Apply the `LokiStack` CR:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
++
+[NOTE]
+====
+This is not for managing the retention for stored logs. Global retention periods for stored logs to a supported maximum of 30 days is configured with your object storage.
+====

--- a/modules/loki-sizing.adoc
+++ b/modules/loki-sizing.adoc
@@ -1,3 +1,7 @@
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-storage.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="loki-sizing_{context}"]
 = Loki deployment sizing

--- a/modules/loki-zone-aware-replication.adoc
+++ b/modules/loki-zone-aware-replication.adoc
@@ -1,3 +1,7 @@
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="loki-zone-aware-replication_{context}"]
 = Zone aware data replication

--- a/modules/loki-zone-fail-recovery.adoc
+++ b/modules/loki-zone-fail-recovery.adoc
@@ -1,3 +1,7 @@
+// Module is included in the following assemblies:
+//
+// * configuring/configuring-the-log-store.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="loki-zone-fail-recovery_{context}"]
 = Recovering Loki pods from failed zones


### PR DESCRIPTION
Version(s): 6.1
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1726
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://95028--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-the-log-store.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/94423
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
