### PR TITLE
[RHACS] Added docs for customizing platform components

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -162,6 +162,8 @@ Topics:
   File: reissue-internal-certificates
 - Name: Adding security notices
   File: add-security-notices
+- Name: Customizing platform components
+  File: customizing-platform-components
 - Name: Enabling offline mode
   File: enable-offline-mode
 - Name: Enabling alert data retention

--- a/configuration/customizing-platform-components.adoc
+++ b/configuration/customizing-platform-components.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="customizing-platform-components_{context}"]
+= Customizing platform components
+include::modules/common-attributes.adoc[]
+:context: customizing-platform-components
+
+toc::[]
+
+[role="_abstract"]
+{rh-rhacs-first} includes enhanced capabilities to classify violations and vulnerabilities into User Workload or Platform categories. Thus helping you focus on actionable data by segmenting issues based on who is responsible for addressing them.
+
+User workloads refer to the applications and images you deploy and manage directly. Platform components include the underlying infrastructure, Operators, and third-party services. By categorizing security findings, {product-title-short} helps you maintain oversight while prioritizing fixes for issues they directly control.
+
+{product-title-short} automatically identifies platform components based on predefined namespaces. Additionally, you can also customize which namespaces {product-title-short} identify as platform components. You can address platform issues by upgrading the offending component, such as {ocp} or third-party software, rather than requiring direct user remediation. Thus, by customizing platform components, you can focus on actionable security findings within your user workloads
+
+include::modules/understanding-platform-components.adoc[leveloffset=+1]
+
+include::modules/modifying-platform-component-definitions.adoc[leveloffset=+1]

--- a/modules/modifying-platform-component-definitions.adoc
+++ b/modules/modifying-platform-component-definitions.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * configuration/customizing-platform-components.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="modifying-platform-component-definitions_{context}"]
+= Modifying platform component definitions
+
+You can define platform components by using namespaces to segment platform security findings from user workloads.
+
+.Prerequisites
+* You must have the `Administration` role with `read` permission to view the platform component configuration options.
+* You must have the `Administration` role with `write` permission to modify the platform component configuration.
+
+.Procedure
+
+. In the RHACS portal, go to **Platform Configuration** > **System Configuration**.
+. On the *System Configuration* view header, click **Edit**.
+. Under the **Platform components configuration** section, click on the **Red{nbsp}Hat layered products** tab. Components found in Red{nbsp}Hat layered and partner product namespaces are included in the platform definition by default.
+.. To modify the Red{nbsp}Hat layered products definition, enter one or more namespaces using regular expressions, separated by a pipe `|` symbol. For more information on the syntax structure, see the link:https://github.com/google/re2/wiki/syntax[RE2 syntax reference].
+. Click on the **Custom components** tab.
+.. To add a custom platform component, click **Add custom platform component**. You can add more than one.
+.. In the new **Custom component** entry, enter a descriptive **Name**.
+.. Enter the **Namespace rules (Regex)** for this custom component. Enter one or more namespaces using regular expressions, separated by a pipe `|` symbol. For more information on the syntax structure, see the link:https://github.com/google/re2/wiki/syntax[RE2 syntax reference].
+. Click **Save**.

--- a/modules/understanding-platform-components.adoc
+++ b/modules/understanding-platform-components.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * configuration/customizing-platform-components.adoc
+:_mod-docs-content-type: CONCEPT
+[id="understanding-platform-components_{context}"]
+= Understanding platform components
+
+{product-title-short} automatically identify platform components by built-in definitions. However, with {product-title-short} 4.8 and newer, you can view and customize these definitions, providing more granular control over how {product-title-short} categorizes security findings.
+
+When viewing violations and vulnerabilities in RHACS, they are categorized as either **User workloads** or **Platform**. This distinction helps you understand the scope and responsibility for addressing security findings.
+
+**User workloads** include violations and vulnerabilities that affect the applications and images you deploy and manage in your system.
+
+**Platform** includes violations and vulnerabilities related to the platform itself, such as those in workloads and images deployed by {ocp} and layered services. Platform components are currently defined using entire namespaces, and RHACS uses regular expression patterns to specify such namespaces.
+
+You can view the platform components definition in the {product-title-short} portal by going to **Platform Configuration** > **System Configuration**.
+
+The **Platform components configuration** section lists platform components in the following categories:
+
+* **Core system components**: These components are part of the core {ocp} and Kubernetes namespaces. {product-title-short} includes them in the platform definition by default. You cannot customize these definitions. These definitions might change when you upgrade the system.
+* **Red{nbsp}Hat layered products**: Components found in Red{nbsp}Hat layered and partner product namespaces are included in the platform definition by default. You must update the definition if you install Red{nbsp}Hat products, including {product-title-short}, into a non-default namespace.
+* **Custom components**: You can extend the platform definition by defining namespaces for additional applications and products. You can use it to classify other namespaces as **Platform**, such as third-party applications, to exclude them from the focused **User workloads** views.


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-29348

Added documentation for Platform components

Cherrypick in `rhacs-docs-4.8`

Preview: https://95029--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/customizing-platform-components.html