### PR TITLE
ROX-29352: Remove Technology Preview labels from policy as code

### DIFF
--- a/installing/installing_ocp/install-central-ocp.adoc
+++ b/installing/installing_ocp/install-central-ocp.adoc
@@ -111,3 +111,4 @@ include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
 include::modules/using-the-interactive-installer.adoc[leveloffset=+2]
 
 include::modules/install-central-roxctl.adoc[leveloffset=+2]
+

--- a/installing/installing_other/install-central-other.adoc
+++ b/installing/installing_other/install-central-other.adoc
@@ -80,3 +80,4 @@ include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
 include::modules/using-the-interactive-installer.adoc[leveloffset=+2]
 
 include::modules/install-central-roxctl.adoc[leveloffset=+2]
+

--- a/modules/install-central-roxctl.adoc
+++ b/modules/install-central-roxctl.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/install_ocp/install-central-ocp.adoc
 // * installing/install_other/install-central-other.adoc
+// * backup_and_restore/restore-acs.htm
 :_mod-docs-content-type: PROCEDURE
 [id="install-central-roxctl_{context}"]
 = Running the Central installation scripts
@@ -14,6 +15,10 @@ ifeval::["{context}" == "install-central-other"]
 :kube:
 endif::[]
 
+ifeval::["{context}" == "restore-acs"]
+:openshift:
+endif::[]
+
 After you run the interactive installer, you can run the `setup.sh` script to install Central.
 
 .Procedure
@@ -23,27 +28,6 @@ After you run the interactive installer, you can run the `setup.sh` script to in
 ----
 $ ./central-bundle/central/scripts/setup.sh
 ----
-. To enable the policy as code feature (Technology Preview), manually apply the `config.stackrox.io` CRD that is located in the .zip file at `helm/chart/crds/config.stackrox.io_securitypolicies.yaml`.
-+
---
-:FeatureName: Policy as code
-include::snippets/technology-preview.adoc[]
-
-To apply the CRD, run the following command:
-
-ifdef::openshift[]
-[source,terminal]
-----
-$ oc create -f helm/chart/crds/config.stackrox.io_securitypolicies.yaml
-----
-endif::openshift[]
-ifdef::kube[]
-[source,terminal]
-----
-$ kubectl create -f helm/chart/crds/config.stackrox.io_securitypolicies.yaml
-----
-endif::kube[]
---
 . Create the necessary resources:
 +
 ifdef::openshift[]

--- a/modules/policy-as-code-about.adoc
+++ b/modules/policy-as-code-about.adoc
@@ -9,9 +9,6 @@
 
 You can create and manage policies as code by saving policies as Kubernetes custom resources (CRs) and applying them to clusters by using a Kubernetes-native continuous delivery (CD) tool such as Argo CD.
 
-:FeatureName: Policy as code
-include::snippets/technology-preview.adoc[]
-
 Policy as code is useful for Kubernetes security architects who want to author policies in YAML or JSON instead of using the {product-title-short} portal. GitOps administrators who already manage Kubernetes configurations by using a GitOps workflow can also find it useful.
 
 {product-title-short} provides the ability to use default policies or create custom policies for your system. With the policy as code feature, you can create custom policies locally by downloading them and modifying them, or by creating them from empty files. To author policies locally, you create CRs that represent the desired state of the policies. You then use a continuous delivery tool such as Argo CD to track, manage, and apply policies to your clusters that are running {product-title-short}. After you create or update CRs and use the CI/CD tool to apply them, the policies stored in the {product-title-short} database are created or updated.

--- a/modules/upgrade-central-cluster-crds.adoc
+++ b/modules/upgrade-central-cluster-crds.adoc
@@ -2,7 +2,7 @@
 //
 // * upgrade/upgrade-roxctl.adoc
 :_mod-docs-content-type: PROCEDURE
-[id="upgrade-central-cluster-crds{context}"]
+[id="upgrade-central-cluster-crds_{context}"]
 = Upgrading the SecurityPolicy custom resource definition
 
 [role="_abstract"]

--- a/modules/upgrade-crd-helm.adoc
+++ b/modules/upgrade-crd-helm.adoc
@@ -2,7 +2,7 @@
 //
 // * upgrading/upgrade-helm.adoc
 :_mod-docs-content-type: PROCEDURE
-[id="upgrade-crd-helm{context}"]
+[id="upgrade-crd-helm_{context}"]
 = Preparing the custom resource definition for upgrade
 
 [role="_abstract"]


### PR DESCRIPTION
Version(s):
4.8

[Issue](https://issues.redhat.com/browse/ROX-29352)

Links to docs previews:

- https://95038--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/custom-security-policies.html#policy-as-code-about_custom-security-policies - remove TP designation
- https://95038--ocpdocs-pr.netlify.app/openshift-acs/latest/backup_and_restore/restore-acs.html#install-central-roxctl_restore-acs - remove TP designation and fix conditional text that wasn't properly displaying
- https://95038--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp.html#install-central-roxctl_install-central-ocp - remove TP designation
- https://95038--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-central-other.html#install-central-roxctl_install-central-other - remove TP designation
- removed manual step that is not needed in 4.8 per Kyle (see [slack](https://redhat-internal.slack.com/archives/C07GLPJPB35/p1750698385651869?thread_ts=1750682557.686479&cid=C07GLPJPB35))
- fixed a couple of files' metadata to not break cross references


QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
