### PR TITLE
TELCODOCS#2164: Added pin information

### DIFF
--- a/modules/nw-ptp-dual-wpc-hardware-config-reference.adoc
+++ b/modules/nw-ptp-dual-wpc-hardware-config-reference.adoc
@@ -36,3 +36,25 @@ The value that you configure depends on your specific measurements and SMA1 cabl
 |`spec.profile.ptp4lConf`
 |Set the value of `boundary_clock_jbod` to 1 to enable support for multiple NICs.
 |====
+
+Each value in the `spec.profile.plugins.e810.pins` list follows the `<function>` `<channel_number>` format.
+
+Where:
+
+`<function>`: Specifies the pin role. The following values are associated with the pin role:
+
+* `0`: Disabled
+* `1`: Receive (Rx) – for 1PPS IN
+* `2`: Transmit (Tx) – for 1PPS OUT
+
+`<channel_number>`: A number associated with the physical connector. The following channel numbers are associated with the physical connectors:
+
+* `1`: `SMA1` or `U.FL1`
+* `2`: `SMA2` or `U.FL2`
+
+Examples:
+
+* `2 1`: Enables `1PPS OUT` (Tx) on `SMA1`.
+* `1 1`: Enables `1PPS IN` (Rx) on `SMA1`.
+
+The PTP Operator passes these values to the Intel E810 hardware plugin and writes them to the sysfs pin configuration interface on each NIC.

--- a/modules/nw-ptp-e810-hardware-configuration-reference.adoc
+++ b/modules/nw-ptp-e810-hardware-configuration-reference.adoc
@@ -24,10 +24,35 @@ The `SMA1` connector is bidirectional.
 The `SMA2` connector is bidirectional.
 |====
 
+You can set the pin configuration on the Intel E810 NIC by using the `spec.profile.plugins.e810.pins` parameters as shown in the following example:
+[source,yaml]
+----
+pins:
+      <interface_name>:
+        <connector_name>: <function> <channel_number>
+----
+
+Where:
+
+`<function>`: Specifies the role of the pin. The following values are associated with the pin role:
+
+* `0`: Disabled
+* `1`: Rx (Receive timestamping)
+* `2`: Tx (Transmit timestamping)
+
+`<channel number>`: A number associated with the physical connector. The following channel numbers are associated with the physical connectors:
+
+* `1`: `SMA1` or `U.FL1`
+* `2`: `SMA2` or `U.FL2`
+
+Examples:
+
+* `0 1`: Disables the pin mapped to `SMA1` or `U.FL1`.
+* `1 2`: Assigns the Rx function to `SMA2` or `U.FL2`.
+
 [NOTE]
 ====
-`SMA1` and `U.FL1` connectors share channel one.
-`SMA2` and `U.FL2` connectors share channel two.
+`SMA1` and `U.FL1` connectors share channel one. `SMA2` and `U.FL2` connectors share channel two.
 ====
 
 Set `spec.profile.plugins.e810.ublxCmds` parameters to configure the GNSS clock in the `PtpConfig` custom resource (CR).


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2164](https://issues.redhat.com/browse/TELCODOCS-2164)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Dual E810 NIC configuration reference](https://95044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/configuring-ptp.html#nw-ptp-dual-e810-hardware-config-reference_configuring-ptp)
- [Intel E810 NIC hardware configuration reference](https://95044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ptp/configuring-ptp.html#nw-ptp-e810-hardware-pins-reference_configuring-ptp)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->