### PR TITLE
[enterprise-4.16] OCPBUGS-49379 autoAssign=true present in ipaddresspool CR assigns the first available host IP from a network

### DIFF
--- a/modules/nw-metallb-addresspool-cr.adoc
+++ b/modules/nw-metallb-addresspool-cr.adoc
@@ -40,8 +40,13 @@ Specify each range in CIDR notation or as starting and ending IP addresses separ
 |`spec.autoAssign`
 |`boolean`
 |Optional: Specifies whether MetalLB automatically assigns IP addresses from this pool.
-Specify `false` if you want explicitly request an IP address from this pool with the `metallb.universe.tf/address-pool` annotation.
+Specify `false` if you want to explicitly request an IP address from this pool with the `metallb.universe.tf/address-pool` annotation.
 The default value is `true`.
+
+[NOTE]
+====
+For IP address pool configurations, ensure the addresses field specifies only IPs that are available and not in use by other network devices, especially gateway addresses, to prevent conflicts when `autoAssign` is enabled.
+====
 
 |`spec.avoidBuggyIPs`
 |`boolean`


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/94990