### PR TITLE
OSDOCS-13319 - Shared VPC formatting changes.

### DIFF
--- a/modules/rosa-sharing-vpc-dns-and-roles.adoc
+++ b/modules/rosa-sharing-vpc-dns-and-roles.adoc
@@ -72,10 +72,14 @@ $ rosa create operator-roles --oidc-config-id <oidc-config-ID> <1>
 The Installer account role and the shared VPC role must have a one-to-one relationship. If you want to create multiple shared VPC roles, you should create one set of account roles per shared VPC role.
 ====
 
-. After you create the Operator roles, share the full domain name, which is created with `<intended_cluster_domain_prefix>.<reserved_dns_domain>`, your _Ingress Operator Cloud Credentials_ role's ARN, and your _Installer_ role's ARN with the *VPC Owner* to continue configuration.
-+
+ . After creating the Operator roles, share the following information with the *VPC Owner* to proceed with the configuration:
+
+ ** The full domain name, `<intended_cluster_domain_prefix>.<reserved_dns_domain>`
+ ** The ARN for your Ingress Operator Cloud Credentials role.
+ ** The ARN for your Installer role.
+
 The shared information resembles these examples:
-+
+
 * ``my-rosa-cluster.14eo.p1.openshiftapps.com``
 * ``arn:aws:iam::111122223333:role/ManagedOpenShift-Installer-Role``
 * ``arn:aws:iam::111122223333:role/my-rosa-cluster-openshift-ingress-operator-cloud-credentials``

--- a/modules/rosa-sharing-vpc-hosted-zones.adoc
+++ b/modules/rosa-sharing-vpc-hosted-zones.adoc
@@ -39,7 +39,10 @@ image::372_OpenShift_on_AWS_persona_worflows_0923_3.png[]
   ]
 }
 ----
-. Create a private hosted zone in the link:https://us-east-1.console.aws.amazon.com/route53/v2/[Route 53 section of the AWS console]. In the hosted zone configuration, the domain name is `<cluster_domain_prefix>.<reserved_dns_domain>`. The private hosted zone must be associated with the created VPC.
+. Create a private hosted zone in the link:https://us-east-1.console.aws.amazon.com/route53/v2/[Route 53 section of the AWS console]. Configure the hosted zone following these guidelines:
+
+* Express the domain name as `<cluster_domain_prefix>.<reserved_dns_domain>`
+* Associate the private hosted zone with the created VPC.
 . After the hosted zone is created and associated with the VPC, provide the following to the *Cluster Creator* to continue configuration:
 * Hosted zone ID
 * AWS region


### PR DESCRIPTION
Version(s):
enterprise-4.17+

Issue:
[OSDOCS-13319](https://issues.redhat.com/browse/OSDOCS-13319)

Link to docs preview:
[See Step 4 of Step 2](https://95056--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-shared-vpc-config.html#rosa-sharing-vpc-dns-and-roles_rosa-shared-vpc-config)
[See Step 4 of Step 3](https://95056--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-shared-vpc-config.html#rosa-sharing-vpc-hosted-zones_rosa-shared-vpc-config)


QE review not needed.

Additional information:
See https://github.com/openshift/openshift-docs/pull/87731/files for formatting change suggestions.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
