### PR TITLE
OSDOCS#14993: Adding monitoring cert-manager metrics section

### DIFF
--- a/modules/cert-manager-enable-metrics.adoc
+++ b/modules/cert-manager-enable-metrics.adoc
@@ -4,88 +4,89 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cert-manager-enable-metrics_{context}"]
-= Enabling monitoring by using a service monitor for the {cert-manager-operator}
+= Configuring metrics collection for {cert-manager-operator} operands by using a ServiceMonitor
 
-You can enable monitoring and metrics collection for the {cert-manager-operator} by using a service monitor to perform the custom metrics scraping.
+The {cert-manager-operator} operands exposes metrics by default on port `9402` at the `/metrics` service endpoint. You can configure metrics collection for the cert-manager operands by creating a `ServiceMonitor` custom resource (CR) that enables Prometheus Operator to collect custom metrics. For more information, see "Configuring user workload monitoring".
 
 .Prerequisites
 
-* You have access to the cluster with `cluster-admin` privileges.
-* The {cert-manager-operator} is installed.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {cert-manager-operator}.
+* You have enabled the user workload monitoring.
 
 .Procedure
 
-. Add the label to enable cluster monitoring by running the following command:
+. Create the `ServiceMonitor` CR:
+
+.. Create the YAML file that defines the `ServiceMonitor` CR:
 +
-[source,terminal]
-----
-$ oc label namespace cert-manager openshift.io/cluster-monitoring=true
-----
-
-. Create a service monitor:
-
-.. Create a YAML file that defines the `Role`, `RoleBinding`, and `ServiceMonitor` objects:
-+
-.Example `monitoring.yaml` file
-
+.Example `servicemonitor-cert-manager.yaml` file
 [source,yaml]
 ----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: prometheus-k8s
-  namespace: cert-manager
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - services
-  - endpoints
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: prometheus-k8s
-  namespace: cert-manager
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: prometheus-k8s
-subjects:
-- kind: ServiceAccount
-  name: prometheus-k8s
-  namespace: openshift-monitoring
----
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
     app: cert-manager
-    app.kubernetes.io/component: controller
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/name: cert-manager
   name: cert-manager
   namespace: cert-manager
 spec:
   endpoints:
-  - interval: 30s
-    port: tcp-prometheus-servicemonitor
-    scheme: http
+    - honorLabels: false
+      interval: 60s
+      path: /metrics
+      scrapeTimeout: 30s
+      targetPort: 9402
   selector:
-    matchLabels:
-      app.kubernetes.io/component: controller
-      app.kubernetes.io/instance: cert-manager
-      app.kubernetes.io/name: cert-manager
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - cainjector
+          - cert-manager
+          - webhook
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+          - cert-manager
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+          - cainjector
+          - controller
+          - webhook
 ----
 
-.. Create the `Role`, `RoleBinding`, and `ServiceMonitor` objects by running the following command:
+.. Create the `ServiceMonitor` CR by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f monitoring.yaml
+$ oc apply -f servicemonitor-cert-manager.yaml
 ----
++
+After the `ServiceMonitor` CR is created, the user workload Prometheus instance begins metrics collection from the {cert-manager-operator} operands. The collected metrics are labeled with `job="cert-manager"`,`job="cert-manager-cainjector"`, and `job="cert-manager-webhook"`.
+
+.Verification
+
+. In the {product-title} web console, navigate to *Observe* → *Targets*.
+
+. In the *Label* filter field, enter the following labels to filter the metrics targets for each operand:
++
+[source,terminal]
+----
+$ service=cert-manager
+----
++
+[source,terminal]
+----
+$ service=cert-manager-webhook
+----
++
+[source,terminal]
+----
+$ service=cert-manager-cainjector
+----
+
+. Confirm that the *Status* column shows `Up` for the `cert-manager`, `cert-manager-webhook`, and `cert-manager-cainjector` entries.

--- a/modules/cert-manager-enable-user-workload-monitor.adoc
+++ b/modules/cert-manager-enable-user-workload-monitor.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cert-manager-enable-user-workload-monitor_{context}"]
+= Enabling user workload monitoring
+
+You can enable monitoring for user-defined projects by configuring user workload monitoring in the cluster. For more information, see "Setting up metrics collection for user-defined projects".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Create the `cluster-monitoring-config.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+----
+
+. Apply the `ConfigMap` by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f cluster-monitoring-config.yaml
+----
+
+.Verification
+
+. Verify that the monitoring components for user workloads are running in the `openshift-user-workload-monitoring` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring get pod
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                   READY   STATUS    RESTARTS   AGE
+prometheus-operator-6cb6bd9588-dtzxq   2/2     Running   0          50s
+prometheus-user-workload-0             6/6     Running   0          48s
+prometheus-user-workload-1             6/6     Running   0          48s
+thanos-ruler-user-workload-0           4/4     Running   0          42s
+thanos-ruler-user-workload-1           4/4     Running   0          42s
+----
++
+The status of the pods such as `prometheus-operator`, `prometheus-user-workload`, and `thanos-ruler-user-workload` must be `Running`.

--- a/modules/cert-manager-query-metrics.adoc
+++ b/modules/cert-manager-query-metrics.adoc
@@ -4,33 +4,33 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cert-manager-query-metrics_{context}"]
-= Querying metrics for the {cert-manager-operator}
+= Querying metrics for the {cert-manager-operator} operands
 
-After you have enabled monitoring for the {cert-manager-operator}, you can query its metrics by using the {product-title} web console.
+As a cluster administrator, or as a user with view access to all namespaces, you can query {cert-manager-operator} operands metrics by using the {product-title} web console or the command-line interface (CLI). For more information, see "Accessing metrics".
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the {cert-manager-operator}.
-* You have enabled monitoring and metrics collection for the {cert-manager-operator}.
+* You have enabled monitoring and metrics collection by creating `ServiceMonitor` object.
 
 .Procedure
 
-. From the {product-title} web console, navigate to *Observe* -> *Metrics*.
+. In the {product-title} web console, navigate to *Observe* → *Metrics*.
 
-. Add a query by using one of the following formats:
-
-** Specify the endpoints:
+. In the query field, enter the following PromQL expressions to query the {cert-manager-operator} operands metric for each operand:
 +
 [source,promql]
 ----
-{instance="<endpoint>"} <1>
+{job="cert-manager"}
 ----
-<1> Replace `<endpoint>` with the value of the endpoint for the `cert-manager` service. You can find the endpoint value by running the following command: `oc describe service cert-manager -n cert-manager`.
-
-** Specify the `tcp-prometheus-servicemonitor` port:
 +
 [source,promql]
 ----
-{endpoint="tcp-prometheus-servicemonitor"}
+{job="cert-manager-webhook"}
+----
++
+[source,promql]
+----
+{job="cert-manager-cainjector"}
 ----

--- a/security/cert_manager_operator/cert-manager-monitoring.adoc
+++ b/security/cert_manager_operator/cert-manager-monitoring.adoc
@@ -6,15 +6,27 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can expose controller metrics for the {cert-manager-operator} in the format provided by the Prometheus Operator.
+By default, the {cert-manager-operator} exposes metrics for the three core components: controller, cainjector, and webhook. You can configure OpenShift Monitoring to collect these metrics by using the Prometheus Operator format.
 
-// Enabling metrics for the {cert-manager-operator}
+// Enabling user workload monitoring for the cert-manager operand
+include::modules/cert-manager-enable-user-workload-monitor.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc#setting-up-metrics-collection-for-user-defined-projects_configuring-metrics-uwm[Setting up metrics collection for user-defined projects]
+
+// Metrics scraping for cert-manager operands by using a ServiceMonitor
 include::modules/cert-manager-enable-metrics.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc#setting-up-metrics-collection-for-user-defined-projects_configuring-metrics-uwm[Setting up metrics collection for user-defined projects]
+* xref:../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#configurable-monitoring-components_preparing-to-configure-the-monitoring-stack-uwm[Configuring user workload monitoring]
 
-// Querying metrics for the {cert-manager-operator}
+// Querying metrics for the cert-manager operands
 include::modules/cert-manager-query-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc#accessing-metrics[Accessing metrics]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-14993](https://issues.redhat.com/browse/OSDOCS-14993)

Link to docs preview:
[Enabling user workload monitoring](https://95058--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-monitoring.html#cert-manager-enable-user-workload-monitor_cert-manager-monitoring)
[Configuring metrics scraping for cert-manager operand by using a ServiceMonitor](https://95058--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-monitoring.html#cert-manager-configure-metrics-scraping_cert-manager-monitoring)
[Querying metrics for the cert-manager operand](https://95058--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-monitoring.html#cert-manager-query-metrics-operand_cert-manager-monitoring)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
