### PR TITLE
TELCODOCS-2311: Using in-tree modules

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -59,6 +59,9 @@ include::modules/kmm-example-module-cr.adoc[leveloffset=+2]
 .Additional resources
 * xref:../security/certificates/updating-ca-bundle.adoc#ca-bundle-replacing_updating-ca-bundle[Replacing the CA Bundle certificate]
 
+// Added for TELCODOCS-2311
+include::modules/kmm-using-intree-modules.adoc[leveloffset=+1]
+
 // Added for TELCODOCS-1827
 include::modules/kmm-symbolic-links-for-in-tree-dependencies.adoc[leveloffset=+1]
 

--- a/modules/kmm-using-intree-modules.adoc
+++ b/modules/kmm-using-intree-modules.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="kmm-using-intree-modules_{context}"]
+
+= Using in-tree modules with the device plugin
+
+In some cases, you might need to configure the KMM Module to avoid loading an out-of-tree kernel module and instead use the in-tree module, running only the device plugin. In such cases, you can omit the `moduleLoader` parameter from the `Module` custom resource (CR), and leave only the `devicePlugin` section, as shown in the following example.
+
+.Example `Module` CR
+[source,yaml]
+----
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: my-kmod
+spec:
+  selector:
+    node-role.kubernetes.io/worker: ""
+  devicePlugin:
+    container:
+      image: some.registry/org/my-device-plugin:latest
+----


### PR DESCRIPTION
Issue:
Allow option to not load out-of-tree kernel module with KMM Module

Version(s): openshift-4.19, openshift-4.20, KMMO 2.4

Jira: https://issues.redhat.com/browse/TELCODOCS-2311

Link to docs preview: https://95060--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-using-intree-modules_kernel-module-management-operator

Dev: @ybettan
QE: @cdvultur

QE review:

[x]  QE has approved this change.

