### PR TITLE
OSDOCS#13677: Update RHDE page for MicroShift 4.20

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -15,7 +15,7 @@
 :op-system-version-major: 9
 :microshift-first: Red{nbsp}Hat build of MicroShift (MicroShift)
 :microshift-short: MicroShift
-:microshift-version: 4.19
+:microshift-version: 4.20
 :rhde: Red{nbsp}Hat Device Edge
 :ansible: Red{nbsp}Hat Ansible Automation Platform
 :ansible-version: 2.5

--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -36,7 +36,7 @@ The latest release notes for each product that is part of {product-title} are av
 [id="device-edge-compatibility_{context}"]
 == {product-title} product release compatibility matrix
 
-{op-system-base} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.14 to 4.16 or an update from 4.18 to 4.19 requires a {op-system-base} update. Supported configurations of {product-title} use verified releases for each together as listed in the following table:
+{op-system-base} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.18 to 4.20 requires a {op-system-base} update. Supported configurations of {product-title} use verified releases for each together as listed in the following table:
 
 [%header,cols="3",cols="1,1,2"]
 |===
@@ -45,12 +45,16 @@ The latest release notes for each product that is part of {product-title} are av
 ^|*Supported {microshift-short} Version{nbsp}&#8594;{nbsp}Version Updates*
 
 ^|9.6
+^|4.20
+^|4.20.0{nbsp}&#8594;{nbsp}4.20.z
+
+^|9.6
 ^|4.19
-^|4.19.0{nbsp}&#8594;{nbsp}4.19.z
+^|4.19.0{nbsp}&#8594;{nbsp}4.19.z; 4.19{nbsp}&#8594;{nbsp}4.20
 
 ^|9.4
 ^|4.18
-^|4.18.0{nbsp}&#8594;{nbsp}4.18.z, 4.18{nbsp}&#8594;{nbsp}4.19 on {op-system-base} 9.6
+^|4.18.0{nbsp}&#8594;{nbsp}4.18.z, 4.18{nbsp}&#8594;{nbsp}4.20 on {op-system-base} 9.6
 
 ^|9.4
 ^|4.17


### PR DESCRIPTION
Version(s):
RHDE 4

Issue:
[OSDOCS-13677](https://95064--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)

Link to docs preview:
[RHDE overview](https://95064--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html) (updated 6/23)

QE review:
- [ ] QE has approved this change.
QE not required.

Additional information:
@kalexand-rh  OK to merge, but NOT to sync and publish until 4.20 is released.
