### PR TITLE
OSSM-9730 2.6.8 (At Stage): [DOC] Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -190,7 +190,7 @@ endif::[]
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.7
+:SMProductVersion: 2.6.8
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-5-11.adoc
+++ b/modules/ossm-release-2-5-11.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/servicemesh-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-5-11_{context}"]
+= {SMProductName} version 2.5.11
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.8 and is supported on {product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+[id="ossm-release-2-5-11-components_{context}"]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.18.7
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali Server
+|1.73.21
+|===

--- a/modules/ossm-release-2-6-7.adoc
+++ b/modules/ossm-release-2-6-7.adoc
@@ -10,8 +10,6 @@ This release of {SMProductName} updates the {SMProductName} Operator version to 
 
 This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
 
-include::snippets/ossm-current-version-support-snippet.adoc[]
-
 You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} is specified by using the `ServiceMeshControlPlane` resource. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
 [id="ossm-release-2-6-7-components_{context}"]

--- a/modules/ossm-release-2-6-8.adoc
+++ b/modules/ossm-release-2-6-8.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/servicemesh-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-6-8_{context}"]
+= {SMProductName} version 2.6.8
+
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.8, and includes the following `ServiceMeshControlPlane` resource version updates: 2.6.8 and 2.5.11.
+
+This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
+You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
+
+[id="ossm-release-2-6-8-components_{context}"]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.7
+
+|Kiali Server
+|1.73.21
+|===

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -8,6 +8,10 @@ toc::[]
 
 // The following include statements pull in the module files that comprise 2.x release notes.
 
+include::modules/ossm-release-2-6-8.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-5-11.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-7.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-5-10.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.8 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-9730

Fix Version: 4.14+

Doc Preview: https://95077--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-release-2-6-8_ossm-release-notes

QE Review: @unsortedhashsets 
Peer Review: @lahinson 