### PR TITLE
OSDOCS-14810:Removed 'at least' wording for control plane and infra nodes in ROSA Classic cluster failure doc.

### DIFF
--- a/modules/rosa-policy-failure-points.adoc
+++ b/modules/rosa-policy-failure-points.adoc
@@ -40,9 +40,9 @@ When accounting for possible node failures, it is also important to understand h
 ifndef::openshift-rosa-hcp[]
 [id="rosa-policy-container-cluster-failure_{context}"]
 == Cluster failure
-Single-AZ ROSA clusters have at least three control plane and two infrastructure nodes in the same availability zone (AZ) in the private subnet.
+Single-AZ ROSA clusters have three control plane nodes and two infrastructure nodes in the same availability zone (AZ) in the private subnet.
 
-Multi-AZ ROSA clusters have at least three control plane nodes and three infrastructure nodes that are preconfigured for high availability, either in a single zone or across multiple zones, depending on the type of cluster you have selected. Control plane and infrastructure nodes have the same resiliency as worker nodes, with the added benefit of being managed completely by Red{nbsp}Hat.
+Multi-AZ ROSA clusters have three control plane nodes and three infrastructure nodes that are preconfigured for high availability, one in each AZ. Control plane and infrastructure nodes have the same resiliency as worker nodes, with the added benefit of being managed completely by Red{nbsp}Hat.
 
 In the event of a complete control plane outage, the OpenShift APIs will not function, and existing worker node pods are unaffected. However, if there is also a pod or node outage at the same time, the control planes must recover before new pods or nodes can be added or scheduled.
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-14810

Link to docs preview:
[Cluster failure](https://95079--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-understand-availability.html#rosa-policy-container-cluster-failure_rosa-policy-understand-availability)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
**QE approval is not required as no update to procedural information.**

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
