### PR TITLE
[OSDOCS-13172]: DR docs for HCP on agent

### DIFF
--- a/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.adoc
@@ -76,9 +76,26 @@ If the data plane workload is not important, you can skip this procedure. To bac
 
 * Restoring a hosted cluster by using {oadp-short}
 
-include::modules/hcp-dr-oadp-backup-cp-workload.adoc[leveloffset=+1]
+[id="backing-up-cp-oadp_{context}"]
+== Backing up the control plane workload
 
-include::modules/hcp-dr-oadp-restore.adoc[leveloffset=+1]
+You can back up the control plane workload by creating the `Backup` custom resource (CR). The steps vary depending on whether your platform is {aws-short} or bare metal.
+
+include::modules/hcp-dr-oadp-backup-cp-workload-aws.adoc[leveloffset=+2]
+include::modules/hcp-dr-oadp-backup-cp-workload-bm.adoc[leveloffset=+2]
+
+[id="hcp-restoring-oadp_{context}"]
+== Restoring a hosted cluster by using {oadp-short}
+
+You can restore a hosted cluster into the same management cluster or into a new management cluster.
+
+include::modules/hcp-dr-oadp-restore.adoc[leveloffset=+2]
+include::modules/hcp-dr-oadp-restore-new-mgmt.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#remove-a-cluster-by-using-the-console[Removing a cluster by using the console]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/clusters/cluster_mce_overview#removing-a-cluster-from-management-in-special-cases[Removing remaining resources after removing a cluster]
 
 include::modules/hcp-dr-oadp-observe.adoc[leveloffset=+1]
 

--- a/modules/hcp-dr-oadp-backup-cp-workload-aws.adoc
+++ b/modules/hcp-dr-oadp-backup-cp-workload-aws.adoc
@@ -1,0 +1,164 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-disaster-recovery-oadp.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="hcp-dr-oadp-backup-cp-workload-aws_{context}"]
+= Backing up the control plane workload on {aws-short}
+
+You can back up the control plane workload by creating the `Backup` custom resource (CR).
+
+To monitor and observe the backup process, see "Observing the backup and restore process".
+
+.Procedure
+
+. Pause the reconciliation of the `HostedCluster` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  patch hostedcluster -n <hosted_cluster_namespace> <hosted_cluster_name> \
+  --type json -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "true"}]'
+----
+
+. Get the infrastructure ID of your hosted cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get hostedcluster -n local-cluster <hosted_cluster_name> -o=jsonpath="{.spec.infraID}"
+----
++
+Note the infrastructure ID to use in the next step.
+
+. Pause the reconciliation of the `cluster.cluster.x-k8s.io` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  patch cluster.cluster.x-k8s.io \
+  -n local-cluster-<hosted_cluster_name> <hosted_cluster_infra_id> \
+  --type json -p '[{"op": "add", "path": "/spec/paused", "value": true}]'
+----
+
+. Pause the reconciliation of the `NodePool` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  patch nodepool -n <hosted_cluster_namespace> <node_pool_name> \
+  --type json -p '[{"op": "add", "path": "/spec/pausedUntil", "value": "true"}]'
+----
+
+. Pause the reconciliation of the `AgentCluster` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  annotate agentcluster -n <hosted_control_plane_namespace>  \
+  cluster.x-k8s.io/paused=true --all'
+----
+
+. Pause the reconciliation of the `AgentMachine` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  annotate agentmachine -n <hosted_control_plane_namespace>  \
+  cluster.x-k8s.io/paused=true --all'
+----
+
+. Annotate the `HostedCluster` resource to prevent the deletion of the hosted control plane namespace by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  annotate hostedcluster -n <hosted_cluster_namespace> <hosted_cluster_name> \
+  hypershift.openshift.io/skip-delete-hosted-controlplane-namespace=true
+----
+
+. Create a YAML file that defines the `Backup` CR:
++
+.Example `backup-control-plane.yaml` file
+[%collapsible]
+====
+[source,yaml]
+----
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: <backup_resource_name> <1>
+  namespace: openshift-adp
+  labels:
+    velero.io/storage-location: default
+spec:
+  hooks: {}
+  includedNamespaces: <2>
+  - <hosted_cluster_namespace> <3>
+  - <hosted_control_plane_namespace> <4>
+  includedResources:
+  - sa
+  - role
+  - rolebinding
+  - pod
+  - pvc
+  - pv
+  - bmh
+  - configmap
+  - infraenv <5>
+  - priorityclasses
+  - pdb
+  - agents
+  - hostedcluster
+  - nodepool
+  - secrets
+  - services
+  - deployments
+  - hostedcontrolplane
+  - cluster
+  - agentcluster
+  - agentmachinetemplate
+  - agentmachine
+  - machinedeployment
+  - machineset
+  - machine
+  excludedResources: []
+  storageLocation: default
+  ttl: 2h0m0s
+  snapshotMoveData: true <6>
+  datamover: "velero" <6>
+  defaultVolumesToFsBackup: true <7>
+----
+====
+<1> Replace `backup_resource_name` with the name of your `Backup` resource.
+<2> Selects specific namespaces to back up objects from them. You must include your hosted cluster namespace and the hosted control plane namespace.
+<3> Replace `<hosted_cluster_namespace>` with the name of the hosted cluster namespace, for example, `clusters`.
+<4> Replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, for example, `clusters-hosted`.
+<5> You must create the `infraenv` resource in a separate namespace. Do not delete the `infraenv` resource during the backup process.
+<6> Enables the CSI volume snapshots and uploads the control plane workload automatically to the cloud storage.
+<7> Sets the `fs-backup` backing up method for persistent volumes (PVs) as default. This setting is useful when you use a combination of Container Storage Interface (CSI) volume snapshots and the `fs-backup` method.
++
+[NOTE]
+====
+If you want to use CSI volume snapshots, you must add the `backup.velero.io/backup-volumes-excludes=<pv_name>` annotation to your PVs.
+====
+
+. Apply the `Backup` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f backup-control-plane.yaml
+----
+
+.Verification
+
+* Verify if the value of the `status.phase` is `Completed` by running the following command:
++
+[source,terminal]
+----
+$ oc get backups.velero.io <backup_resource_name> -n openshift-adp \
+  -o jsonpath='{.status.phase}'
+----
+
+.Next steps
+
+* Restoring a hosted cluster by using OADP

--- a/modules/hcp-dr-oadp-backup-cp-workload-bm.adoc
+++ b/modules/hcp-dr-oadp-backup-cp-workload-bm.adoc
@@ -2,9 +2,9 @@
 //
 // * hosted_control_planes/hcp-disaster-recovery-oadp.adoc
 
-:_mod-docs-content-type: REFERENCE
-[id="hcp-dr-oadp-backup-cp-workload_{context}"]
-= Backing up the control plane workload
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-dr-oadp-backup-cp-workload-bm_{context}"]
+= Backing up the control plane workload on a bare-metal platform
 
 You can back up the control plane workload by creating the `Backup` custom resource (CR).
 
@@ -25,19 +25,20 @@ $ oc --kubeconfig <management_cluster_kubeconfig_file> \
 +
 [source,terminal]
 ----
-$ oc get hostedcluster -n local-cluster <hosted_cluster_name> -o=jsonpath="{.spec.infraID}"
+$ oc --kubeconfig <management_cluster_kubeconfig_file> \
+  get hostedcluster -n <hosted_cluster_namespace> \
+  <hosted_cluster_name> -o=jsonpath="{.spec.infraID}"
 ----
-+
-Note the infrastructure ID to use in the next step.
+
+. Note the infrastructure ID to use in the next step.
 
 . Pause the reconciliation of the `cluster.cluster.x-k8s.io` resource by running the following command:
 +
 [source,terminal]
 ----
 $ oc --kubeconfig <management_cluster_kubeconfig_file> \
-  patch cluster.cluster.x-k8s.io \
-  -n local-cluster-<hosted_cluster_name> <hosted_cluster_infra_id> \
-  --type json -p '[{"op": "add", "path": "/spec/paused", "value": true}]'
+  annotate cluster -n <hosted_control_plane_namespace> \
+  <hosted_cluster_infra_id> cluster.x-k8s.io/paused=true
 ----
 
 . Pause the reconciliation of the `NodePool` resource by running the following command:
@@ -55,7 +56,7 @@ $ oc --kubeconfig <management_cluster_kubeconfig_file> \
 ----
 $ oc --kubeconfig <management_cluster_kubeconfig_file> \
   annotate agentcluster -n <hosted_control_plane_namespace>  \
-  cluster.x-k8s.io/paused=true --all'
+  cluster.x-k8s.io/paused=true --all
 ----
 
 . Pause the reconciliation of the `AgentMachine` resource by running the following command:
@@ -64,10 +65,10 @@ $ oc --kubeconfig <management_cluster_kubeconfig_file> \
 ----
 $ oc --kubeconfig <management_cluster_kubeconfig_file> \
   annotate agentmachine -n <hosted_control_plane_namespace>  \
-  cluster.x-k8s.io/paused=true --all'
+  cluster.x-k8s.io/paused=true --all
 ----
 
-. Annotate the `HostedCluster` resource to prevent the deletion of the hosted control plane namespace by running the following command:
+. If you are backing up and restoring to the same management cluster, annotate the `HostedCluster` resource to prevent the deletion of the hosted control plane namespace by running the following command:
 +
 [source,terminal]
 ----
@@ -86,15 +87,16 @@ $ oc --kubeconfig <management_cluster_kubeconfig_file> \
 apiVersion: velero.io/v1
 kind: Backup
 metadata:
-  name: <backup_resource_name> <1>
+  name: <backup_resource_name> # <1>
   namespace: openshift-adp
   labels:
     velero.io/storage-location: default
 spec:
   hooks: {}
-  includedNamespaces: <2>
-  - <hosted_cluster_namespace> <3>
-  - <hosted_control_plane_namespace> <4>
+  includedNamespaces: # <2>
+  - <hosted_cluster_namespace> # <3>
+  - <hosted_control_plane_namespace> # <4>
+  - <agent_namespace> # <5>
   includedResources:
   - sa
   - role
@@ -104,7 +106,7 @@ spec:
   - pv
   - bmh
   - configmap
-  - infraenv <5>
+  - infraenv
   - priorityclasses
   - pdb
   - agents
@@ -124,16 +126,16 @@ spec:
   excludedResources: []
   storageLocation: default
   ttl: 2h0m0s
-  snapshotMoveData: true <6>
-  datamover: "velero" <6>
-  defaultVolumesToFsBackup: true <7>
+  snapshotMoveData: true # <6>
+  datamover: "velero" # <6>
+  defaultVolumesToFsBackup: true # <7>
 ----
 ====
 <1> Replace `backup_resource_name` with the name of your `Backup` resource.
 <2> Selects specific namespaces to back up objects from them. You must include your hosted cluster namespace and the hosted control plane namespace.
 <3> Replace `<hosted_cluster_namespace>` with the name of the hosted cluster namespace, for example, `clusters`.
 <4> Replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, for example, `clusters-hosted`.
-<5> You must create the `infraenv` resource in a separate namespace. Do not delete the `infraenv` resource during the backup process.
+<5> Replace `<agent_namespace>` with the namespace where your `Agent`, `BMH`, and `InfraEnv` CRs are located, for example, `agents`.
 <6> Enables the CSI volume snapshots and uploads the control plane workload automatically to the cloud storage.
 <7> Sets the `fs-backup` backing up method for persistent volumes (PVs) as default. This setting is useful when you use a combination of Container Storage Interface (CSI) volume snapshots and the `fs-backup` method.
 +
@@ -161,4 +163,4 @@ $ oc get backups.velero.io <backup_resource_name> -n openshift-adp \
 
 .Next steps
 
-* Restoring a hosted cluster by using OADP
+* Restore a hosted cluster by using OADP.

--- a/modules/hcp-dr-oadp-restore-new-mgmt.adoc
+++ b/modules/hcp-dr-oadp-restore-new-mgmt.adoc
@@ -1,0 +1,302 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-disaster-recovery-oadp.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-dr-oadp-restore-new-mgmt_{context}"]
+= Restoring a hosted cluster into a new management cluster by using {oadp-short}
+
+You can restore the hosted cluster into a new management cluster by creating the `Restore` custom resource (CR).
+
+* If you are using an in-place update, the `InfraEnv` resource does not need spare nodes. Instead, you need to re-provision the worker nodes from the new management cluster.
+* If you are using a replace update, you need some spare nodes for the `InfraEnv` resource to deploy the worker nodes.
+
+.Prerequisites
+
+* You configured the new management cluster to use {oadp-first}. The new management cluster must have the same Data Protection Application (DPA) as the management cluster that you backed up from so that the `Restore` CR can access the backup storage.
+* You configured the networking settings of the new management cluster to resolve the DNS of the hosted cluster.
+
+** The DNS of the host must resolve to the IP of both the new management cluster and the hosted cluster.
+** The hosted cluster must resolve to the IP of the new management cluster. 
+
+To monitor and observe the backup process, see "Observing the backup and restore process".
+
+[IMPORTANT]
+====
+Complete the following steps on the new management cluster that you are restoring the hosted cluster to, not on the management cluster that you created the backup from.
+====
+
+.Procedure
+
+. Create a YAML file that defines the `Restore` CR:
++
+.Example `restore-hosted-cluster.yaml` file
+[source,yaml]
+----
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: <restore_resource_name> # <1>
+  namespace: openshift-adp
+spec:
+  includedNamespaces: # <2>
+  - <hosted_cluster_namespace> # <3>
+  - <hosted_control_plane_namespace> # <4>
+  - <agent_namespace> # <5>
+  backupName: <backup_resource_name> # <6>
+  cleanupBeforeRestore: CleanupRestored
+  veleroManagedClustersBackupName: <managed_cluster_name> # <7>
+  veleroCredentialsBackupName: <credentials_backup_name>
+  veleroResourcesBackupName: <resources_backup_name>
+  restorePVs: true # <8>
+  preserveNodePorts: true
+  existingResourcePolicy: update # <9>
+  excludedResources:
+  - pod
+  - nodes
+  - events
+  - events.events.k8s.io
+  - backups.velero.io
+  - restores.velero.io
+  - resticrepositories.velero.io
+  - pv
+  - pvc
+----
+<1> Replace `<restore_resource_name>` with the name of your `Restore` resource.
+<2> Selects specific namespaces to back up objects from them. You must include your hosted cluster namespace and the hosted control plane namespace.
+<3> Replace `<hosted_cluster_namespace>` with the name of the hosted cluster namespace, for example, `clusters`.
+<4> Replace `<hosted_control_plane_namespace>` with the name of the hosted control plane namespace, for example, `clusters-hosted`.
+<5> Replace `<agent_namespace>` with the namespace where your `Agent`, `BMH`, and `InfraEnv` CRs are located, for example, `agents`.
+<6> Replace `<backup_resource_name>` with the name of your `Backup` resource.
+<7> You can omit this field if you are not using {rh-rhacm-title}.
+<8> Initiates the recovery of persistent volumes (PVs) and its pods.
+<9> Ensures that the existing objects are overwritten with the backed up content.
+
+. Apply the `Restore` CR by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> apply -f restore-hosted-cluster.yaml
+----
+
+. Verify that the value of the `status.phase` is `Completed` by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> \
+  get restore.velero.io <restore_resource_name> \
+  -n openshift-adp -o jsonpath='{.status.phase}'
+----
+
+. Verify that all CRs are restored by running the following commands:
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> get infraenv -n <agent_namespace>
+----
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> get agent -n <agent_namespace>
+----
++
+[source,terminal]
+----
+$  oc --kubeconfig <restore_management_kubeconfig> get bmh -n <agent_namespace>
+----
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> get hostedcluster -n <hosted_cluster_namespace>
+----
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> get nodepool -n <hosted_cluster_namespace>
+----
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> get agentmachine -n <hosted_controlplane_namespace>
+----
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> get agentcluster -n <hosted_controlplane_namespace>
+----
+
+. If you plan to use the new management cluster as your main management cluster going forward, complete the following steps. Otherwise, if you plan to use the management cluster that you backed up from as your main management cluster, complete steps 5 - 8 in "Restoring a hosted cluster into the same management cluster by using {oadp-short}".
+
+.. Remove the Cluster API deployment from the management cluster that you backed up from by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <backup_management_kubeconfig> delete deploy cluster-api \
+  -n <hosted_control_plane_namespace>
+----
++
+Because only one Cluster API can access a cluster at a time, this step ensures that the Cluster API for the new management cluster functions correctly.
+
+.. After the restore process is complete, start the reconciliation of the `HostedCluster` and `NodePool` resources that you paused during backing up of the control plane workload:
+
+... Start the reconciliation of the `HostedCluster` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> \
+  patch hostedcluster -n <hosted_cluster_namespace> <hosted_cluster_name> \
+  --type json \
+  -p '[{"op": "replace", "path": "/spec/pausedUntil", "value": "false"}]'
+----
+
+... Start the reconciliation of the `NodePool` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> \
+  patch nodepool -n <hosted_cluster_namespace> <node_pool_name> \
+  --type json \
+  -p '[{"op": "replace", "path": "/spec/pausedUntil", "value": "false"}]'
+----
+
+... Verify that the hosted cluster is reporting that the hosted control plane is available by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> get hostedcluster
+----
+
+... Verify that the hosted cluster is reporting that the cluster operators are available by running the following command:
++
+[source,terminal]
+----
+$ oc get co --kubeconfig <hosted_cluster_kubeconfig>
+----
+
+.. Start the reconciliation of the Agent provider resources that you paused during backing up of the control plane workload:
+
+... Start the reconciliation of the `AgentCluster` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> \
+  annotate agentcluster -n <hosted_control_plane_namespace>  \
+  cluster.x-k8s.io/paused- --overwrite=true --all
+----
+
+... Start the reconciliation of the `AgentMachine` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> \
+  annotate agentmachine -n <hosted_control_plane_namespace>  \
+  cluster.x-k8s.io/paused- --overwrite=true --all
+----
+
+... Start the reconciliation of the `Cluster` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> \
+  annotate cluster -n <hosted_control_plane_namespace> \
+  cluster.x-k8s.io/paused- --overwrite=true --all
+----
+
+.. Verify that the node pool is working as expected by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <restore_management_kubeconfig> \
+  get nodepool -n <hosted_cluster_namespace> 
+----
++
+.Example output
+[source,terminal]
+----
+NAME       CLUSTER    DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
+hosted-0   hosted-0   3               3               False         False        4.17.11   False             False
+----
+
+.. Optional: To ensure that no conflicts exist and that the new management cluster has continued functionality, remove the `HostedCluster` resources from the backup management cluster by completing the following steps:
+
+... In the management cluster that you backed up from, in the `ClusterDeployment` resource, set the `spec.preserveOnDelete` parameter to `true` by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <backup_management_kubeconfig> patch \
+  -n <hosted_control_plane_namespace> \
+  ClusterDeployment/<hosted_cluster_name> -p \
+  '{"spec":{"preserveOnDelete":'true'}}' \
+  --type=merge
+----
++
+This step ensures that the hosts are not deprovisioned.
+
+... Delete the machines by running the following commands:
++
+[source,terminal]
+----
+$ oc --kubeconfig <backup_management_kubeconfig> patch \
+  <machine_name> -n <hosted_control_plane_namespace> -p \
+  '[{"op":"remove","path":"/metadata/finalizers"}]' \
+  --type=merge
+----
++
+[source,terminal]
+----
+$ oc --kubeconfig <backup_management_kubeconfig> \
+  delete machine <machine_name> \
+  -n <hosted_control_plane_namespace>
+----
+
+... Delete the `AgentCluster` and `Cluster` resources by running the following commands:
++
+[source,terminal]
+----
+$ oc --kubeconfig <backup_management_kubeconfig> \
+  delete agentcluster <hosted_cluster_name> \
+  -n <hosted_control_plane_namespace>
+----
++
+[source,terminal]
+----
+$ oc --kubeconfig <backup_management_kubeconfig> \
+  patch cluster <cluster_name> \
+  -n <hosted_control_plane_namespace> \
+  -p '[{"op":"remove","path":"/metadata/finalizers"}]' \
+  --type=json
+----
++
+[source,terminal]
+----
+$ oc --kubeconfig <backup_management_kubeconfig> \
+  delete cluster <cluster_name> \
+  -n <hosted_control_plane_namespace> 
+----
+
+... If you use {rh-rhacm-title}, delete the managed cluster by running the following commands:
++
+[source,terminal]
+----
+$ oc --kubeconfig <backup_management_kubeconfig> \
+  patch managedcluster <hosted_cluster_name> \
+  -n <hosted_cluster_namespace> \
+  -p '[{"op":"remove","path":"/metadata/finalizers"}]' \
+  --type=json
+----
++
+[source,terminal]
+----
+$ oc --kubeconfig <backup_management_kubeconfig> \
+  delete managedcluster <hosted_cluster_name> \
+  -n <hosted_cluster_namespace>
+----
+
+... Delete the `HostedCluster` resource by running the following command:
++
+[source,terminal]
+----
+$ oc --kubeconfig <backup_management_kubeconfig> \
+  delete hostedcluster \
+  -n <hosted_cluster_namespace> <hosted_cluster_name>
+----

--- a/modules/hcp-dr-oadp-restore.adoc
+++ b/modules/hcp-dr-oadp-restore.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-dr-oadp-restore_{context}"]
-= Restoring a hosted cluster by using {oadp-short}
+= Restoring a hosted cluster into the same management cluster by using {oadp-short}
 
 You can restore the hosted cluster by creating the `Restore` custom resource (CR).
 
@@ -136,13 +136,3 @@ $ oc --kubeconfig <management_cluster_kubeconfig_file> \
   hypershift.openshift.io/skip-delete-hosted-controlplane-namespace- \
   --overwrite=true --all
 ----
-
-. Scale the `NodePool` resource to the desired number of replicas by running the following command:
-+
-[source,terminal]
-----
-$ oc --kubeconfig <management_cluster_kubeconfig_file> \
-  scale nodepool -n <hosted_cluster_namespace> <node_pool_name> \
-  --replicas <replica_count> <1>
-----
-<1> Replace `<replica_count>` by an integer value, for example, `3`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-13172
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
- Backing up the control plane workload on a bare-metal platform: https://95105--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.html#hcp-dr-oadp-backup-cp-workload_hcp-disaster-recovery-oadp
- Restoring a hosted cluster into a new management cluster by using OADP: https://95105--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.html#hcp-dr-oadp-restore-new-mgmt_hcp-disaster-recovery-oadp
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

NOTE FOR PEER REVIEWERS: 

This PR adds two additional procedures to the DR with OADP docs: 
- A procedure about backing up the control plane workload for a hosted cluster on bare metal
- A procedure about restoring a hosted cluster to a new management cluster

It also removes one step from "Restoring a hosted cluster into the same management cluster by using OADP"
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
