### PR TITLE
OCPBUGS-57952 changed agentSocketPath to agentSocketName

### DIFF
--- a/modules/zero-trust-manager-oidc-config.adoc
+++ b/modules/zero-trust-manager-oidc-config.adoc
@@ -30,7 +30,7 @@ metadata:
   name: cluster
 spec:
   trustDomain: <trust_domain> #<1>
-  agentSocketPath: 'spire-agent.sock' #<2>
+  agentSocketName: 'spire-agent.sock' #<2>
   jwtIssuer: <jwt_issuer_domain> #<3>
 ----
 <1> The trust domain to be used for the SPIFFE identifiers.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OCPBUGS-57952

Link to docs preview:
https://95106--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.html


QE review:
- [x] QE has approved this change.


Additional information:

