### PR TITLE
OBSDOCS-2005 API docs from upstream

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2909,6 +2909,10 @@ Topics:
       File: troubleshooting-ui-plugin
 #    - Name: Dashboard UI plugin
 #      File: dashboard-ui-plugin
+  - Name: Monitoring API reference
+    File: api-monitoring-package
+#  - Name: Observability API reference
+#    File: api-observability-package
 - Name: Monitoring
   Dir: monitoring
   Distros: openshift-enterprise,openshift-origin

--- a/observability/cluster_observability_operator/api-monitoring-package.adoc
+++ b/observability/cluster_observability_operator/api-monitoring-package.adoc
@@ -1,0 +1,2509 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="api-monitoring-package"]
+= monitoring.rhobs/v1alpha1
+include::_attributes/common-attributes.adoc[]
+:context: api-monitoring-package
+
+toc::[]
+
+The resource types are xref:#monitoringstack[`MonitoringStack`] and xref:#thanosquerier[ThanosQuerier].
+
+[id="monitoringstack"]
+== MonitoringStack
+
+`MonitoringStack` is the Schema for the monitoringstacks API.
+
+[cols="2,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`apiVersion`
+|string
+|`monitoring.rhobs/v1alpha1`
+|true
+
+|`kind`
+|string
+|`MonitoringStack`
+|true
+
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta[`metadata`]
+|object
+|Refer to the Kubernetes API documentation for the fields of the `metadata` field.
+|true
+
+|xref:#monitoringstackspec[`spec`]
+|object
+|`MonitoringStackSpec` is the specification for the desired `MonitoringStack` object.
+|true
+
+
+|xref:#monitoringstackstatus[`status`]
+|object
+|`MonitoringStackStatus` defines the observed state of the `MonitoringStack` object. It should always be reconstructable from the state of the cluster and/or outside world.
+|false
+|===
+
+[id="monitoringstackspec"]
+== MonitoringStack.spec
+
+`MonitoringStackSpec` is the specification for the desired `MonitoringStack` object.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecalertmanagerconfig[`alertmanagerConfig`]
+|object
+|Define `Alertmanager` config.
+
+_Default_: `map[disabled:false]`
+|false
+
+|`logLevel`
+|enum
+|Set log levels of configured components.
+
+_Enum_: `debug, info, warn, error`
+
+_Default_: `info`
+|false
+
+|xref:#monitoringstackspecnamespaceselector[`namespaceSelector`]
+|object
+a|Namespace selector for `MonitoringStack` resources.
+
+* To monitor everything, set to empty map selector. For example, `namespaceSelector: {}`.
+
+* To monitor resources in the namespace where `MonitoringStack` instance was created, set to null. For example, `namespaceSelector:`.
+|false
+
+|`nodeSelector`
+|`map[string]string`
+|Define node selector for `MonitoringStack` pods.
+|false
+
+|xref:#monitoringstackspecprometheusconfig[`prometheusConfig`]
+|object
+|Define prometheus config.
+
+_Default_: `map[replicas:2]`
+|false
+
+|xref:#monitoringstackspecresourceselector[`resourceSelector`]
+|object
+a|Label selector for `MonitoringStack` resources.
+
+* To monitor everything, set to empty map selector. For example, `resourceSelector: {}`.
+
+* To disable service discovery, set to null. For example, `resourceSelector:`.
+|false
+
+|xref:#monitoringstackspecresources[`resources`]
+|object
+|Define resources requests and limits for `MonitoringStack` pods.
+
+_Default_: `map[limits:map[cpu:500m memory:512Mi] requests:map[cpu:100m memory:256Mi]]`
+|false
+
+|`retention`
+|string
+|Time duration to retain data. The string must match the regular expression `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (milliseconds seconds minutes hours days weeks years).
+
+_Default_: `120h`
+|false
+
+|xref:#monitoringstackspectolerationsindex[`tolerations`]
+|`[]object`
+|Define tolerations for `MonitoringStack` pods.
+|false
+|===
+
+[id="monitoringstackspecalertmanagerconfig"]
+== MonitoringStack.spec.alertmanagerConfig
+
+
+Define `Alertmanager` config.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`disabled`
+|boolean
+|Disables the deployment of `Alertmanager`.
+
+_Default_: false
+|false
+
+|xref:#monitoringstackspecalertmanagerconfigwebtlsconfig[`webTLSConfig`]
+|object
+|Configure TLS options for the `Alertmanager` web server.
+|false
+|===
+
+[id="monitoringstackspecalertmanagerconfigwebtlsconfig"]
+== MonitoringStack.spec.alertmanagerConfig.webTLSConfig
+
+Configure TLS options for the `Alertmanager` web server.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecalertmanagerconfigwebtlsconfigcertificate[`certificate`]
+|object
+|Reference to the TLS public certificate for the web server.
+|true
+
+|xref:#monitoringstackspecalertmanagerconfigwebtlsconfigcertificateauthority[`certificateAuthority`]
+|object
+|Reference to the root Certificate Authority used to verify the web server's certificate.
+|true
+
+|xref:#monitoringstackspecalertmanagerconfigwebtlsconfigcertificateprivatekey[`privateKey`]
+|object
+|Reference to the TLS private key for the web server.
+|true
+|===
+
+[id="monitoringstackspecalertmanagerconfigwebtlsconfigcertificate"]
+== MonitoringStack.spec.alertmanagerConfig.webTLSConfig.certificate
+
+Reference to the TLS public certificate for the web server.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|The name of the secret in the object's namespace to select from.
+|true
+|===
+
+[id="monitoringstackspecalertmanagerconfigwebtlsconfigcertificateauthority"]
+== MonitoringStack.spec.alertmanagerConfig.webTLSConfig.certificateAuthority
+
+Reference to the root Certificate Authority used to verify the web server's certificate.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|The name of the secret in the object's namespace to select from.
+|true
+|===
+
+[id="monitoringstackspecalertmanagerconfigwebtlsconfigcertificateprivatekey"]
+== MonitoringStack.spec.alertmanagerConfig.webTLSConfig.privateKey
+
+Reference to the TLS private key for the web server.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|The name of the secret in the object's namespace to select from.
+|true
+|===
+
+[[monitoringstackspecnamespaceselector]]
+== MonitoringStack.spec.namespaceSelector
+
+Namespace selector for `MonitoringStack` resources.
+
+* To monitor everything, set to empty map selector. For example, `namespaceSelector: {}`.
+
+* To monitor resources in the namespace where the `MonitoringStack` instance was created, set to null. For example, `namespaceSelector:`.
+
+[cols="2,2,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecnamespaceselectormatchexpressionsindex[`matchExpressions`]
+|`[]object`
+|`matchExpressions` is a list of label selector requirements. The requirements are ANDed.
+|false
+
+|`matchLabels`
+|`map[string]string`
+|`matchLabels` is a map of {key,value} pairs. A single {key,value} in the `matchLabels` map is equivalent to an element of `matchExpressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+|false
+|===
+
+[[monitoringstackspecnamespaceselectormatchexpressionsindex]]
+== MonitoringStack.spec.namespaceSelector.matchExpressions[index]
+
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|`key` is the label key that the selector applies to.
+|true
+
+|`operator`
+|string
+|`operator` represents a key's relationship to a set of values. Valid operators are `In`, `NotIn`, `Exists` and `DoesNotExist`.
+|true
+
+|`values`
+|`[]string`
+|`values` is an array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.
+|false
+|===
+
+[[monitoringstackspecprometheusconfig]]
+== MonitoringStack.spec.prometheusConfig
+
+Define Prometheus configuration.
+
+[cols="2,2,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`enableOtlpHttpReceiver`
+|boolean
+|Enable Prometheus to accept OpenTelemetry Metrics via the `otlp`/`http`protocol. Defaults to the value of `false`. The resulting endpoint is `/api/v1/otlp/v1/metrics`.
+|false
+
+|`enableRemoteWriteReceiver`
+|boolean
+|Enable Prometheus to be used as a receiver for the Prometheus remote write protocol. Defaults to the value of `false`.
+|false
+
+|`externalLabels`
+|`map[string]string`
+|Define `ExternalLabels` for Prometheus.
+|false
+
+|xref:#monitoringstackspecprometheusconfigpersistentvolumeclaim[`persistentVolumeClaim`]
+|object
+|Define persistent volume claim for Prometheus.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindex[`remoteWrite`]
+|`[]object`
+|Define remote write for Prometheus.
+|false
+
+|`replicas`
+|integer
+|Number of replicas/pods to deploy for a Prometheus deployment.
+
+_Format_: int32
+
+_Default_: 2
+
+_Minimum_: 0
+|false
+
+|`scrapeInterval`
+|string
+|Default interval between scrapes.
+|false
+
+|xref:#monitoringstackspecprometheusconfigwebtlsconfig[`webTLSConfig`]
+|object
+|Configure TLS options for the Prometheus web server.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigpersistentvolumeclaim]]
+== MonitoringStack.spec.prometheusConfig.persistentVolumeClaim
+
+
+Define persistent volume claim for Prometheus.
+
+[cols="2,2,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`accessModes`
+|`[]string`
+|`accessModes` contains the desired access modes the volume should have. For more information, see link:https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1[Kubernetes Docs].
+|false
+
+|xref:#monitoringstackspecprometheusconfigpersistentvolumeclaimdatasource[`dataSource`]
+|object
+a|`dataSource` field can be used to specify either:
+
+* An existing `VolumeSnapshot` object (`snapshot.storage.k8s.io/VolumeSnapshot`)
+* An existing PVC (PersistentVolumeClaim)
+
+If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source.
+
+When the `AnyVolumeDataSource` feature gate is enabled, `dataSource` contents will be copied to `dataSourceRef`, and `dataSourceRef` contents will be copied to `dataSource` when `dataSourceRef.namespace` is not specified. If the namespace is specified, then `dataSourceRef` will not be copied to `dataSource`.
+|false
+
+|xref:#monitoringstackspecprometheusconfigpersistentvolumeclaimdatasourceref[`dataSourceRef`]
+|object
+a|`dataSourceRef` specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a `PersistentVolumeClaim` object.
+
+When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the `dataSource` field and as such if both fields are non-empty, they must have the same value.
+
+For backwards compatibility, when `namespace` is not specified in `dataSourceRef`, both fields (`dataSource` and `dataSourceRef`) will be set to the same value automatically if one of them is empty and the other is non-empty. When `namespace` is specified in `dataSourceRef`, `dataSource` isn't set to the same value and must be empty.
+
+There are three important differences between `dataSource` and `dataSourceRef`:
+
+* While `dataSource` only allows two specific types of objects, `dataSourceRef` allows any non-core object, as well as `PersistentVolumeClaim` objects.
+* While `dataSource` ignores disallowed values (dropping them), `dataSourceRef` preserves all values, and generates an error if a disallowed value is specified.
+* While `dataSource` only allows local objects, `dataSourceRef` allows objects in any namespaces.
+
+_Beta_: Using this field requires the `AnyVolumeDataSource` feature gate to be enabled.
+
+_Alpha_: Using the namespace field of `dataSourceRef` requires the `CrossNamespaceVolumeDataSource` feature gate to be enabled.
+|false
+
+|xref:#monitoringstackspecprometheusconfigpersistentvolumeclaimresources[`resources`]
+|object
+|`resources` represents the minimum resources the volume should have.
+
+If `RecoverVolumeExpansionFailure` feature is enabled, users are allowed to specify resource requirements that are lower than the previous value but must still be higher than the capacity recorded in the status field of the claim.
+
+For more information, see link:https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources[Kubernetes Docs]
+|false
+
+|xref:#monitoringstackspecprometheusconfigpersistentvolumeclaimselector[`selector`]
+|object
+|`selector` is a label query over volumes to consider for binding.
+|false
+
+|`storageClassName`
+|string
+|`storageClassName` is the name of the `StorageClass` required by the claim. For more information, see link:https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1[Kubernetes Docs]
+|false
+
+|`volumeAttributesClassName`
+|string
+|`volumeAttributesClassName` may be used to set the `VolumeAttributesClass` used by this claim.
+
+If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding `VolumeAttributesClass`. This has a different purpose than `storageClassName`, as it can be changed after the claim is created. An empty string value means that no `VolumeAttributesClass` will be applied to the claim but it is not allowed to reset this field to the empty string once it is set.
+
+If unspecified and the `PersistentVolumeClaim` is unbound, the default `VolumeAttributesClass` will be set by the `persistentvolume` controller if it exists. If the resource referred to by `volumeAttributesClass` does not exist, this `PersistentVolumeClaim` will be set to a `Pending` state, as reflected by the `modifyVolumeStatus` field, until such as a resource exists.
+
+For more information, see link:https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/[Kubernetes Docs]
+
+_Beta_: Using this field requires the `VolumeAttributesClass` feature gate to be enabled (off by default).
+|false
+
+|`volumeMode`
+|string
+|`volumeMode` defines what type of volume is required by the claim. Value of `Filesystem` is implied when not included in claim spec.
+|false
+
+|`volumeName`
+|string
+|`volumeName` is the binding reference to the `PersistentVolume` backing this claim.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigpersistentvolumeclaimdatasource]]
+== MonitoringStack.spec.prometheusConfig.persistentVolumeClaim.dataSource
+
+`dataSource` field can be used to specify either:
+
+* An existing `VolumeSnapshot` object (`snapshot.storage.k8s.io/VolumeSnapshot`)
+* An existing PVC (PersistentVolumeClaim)
+
+If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the `AnyVolumeDataSource` feature gate is enabled, `dataSource` contents will be copied to `dataSourceRef`, and `dataSourceRef` contents will be copied to `dataSource` when `dataSourceRef.namespace` is not specified. If the namespace is specified, then `dataSourceRef` will not be copied to `dataSource`.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`kind`
+|string
+|`kind` is the type of resource being referenced
+|true
+
+|`name`
+|string
+|`name` is the name of resource being referenced
+|true
+
+|`apiGroup`
+|string
+|`apiGroup` is the group for the resource being referenced. If `apiGroup` is not specified, the specified `kind` must be in the core API group. For any other third-party types, `apiGroup` is required.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigpersistentvolumeclaimdatasourceref]]
+== MonitoringStack.spec.prometheusConfig.persistentVolumeClaim.dataSourceRef
+
+`dataSourceRef` specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a `PersistentVolumeClaim` object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner.
+
+This field will replace the functionality of the `dataSource` field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when `namespace` isn't specified in `dataSourceRef`, both fields (`dataSource` and `dataSourceRef`) will be set to the same value automatically if one of them is empty and the other is non-empty. When `namespace` is specified in `dataSourceRef`, `dataSource` isn't set to the same value and must be empty.
+
+There are three important differences between `dataSource` and `dataSourceRef`:
+
+* While `dataSource` only allows two specific types of objects, `dataSourceRef` allows any non-core object, as well as `PersistentVolumeClaim` objects.
+* While `dataSource` ignores disallowed values (dropping them), `dataSourceRef` preserves all values, and generates an error if a disallowed value is specified.
+* While `dataSource` only allows local objects, `dataSourceRef` allows objects in any namespaces.
+
+_Beta_: Using this field requires the `AnyVolumeDataSource` feature gate to be enabled.
+
+_Alpha_: Using the namespace field of `dataSourceRef` requires the `CrossNamespaceVolumeDataSource` feature gate to be enabled.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`kind`
+|string
+|`kind` is the type of resource being referenced
+|true
+
+|`name`
+|string
+|`name` is the name of resource being referenced
+|true
+
+|`apiGroup`
+|string
+|`apiGroup` is the group for the resource being referenced.
+
+If `apiGroup` is not specified, the specified `kind` must be in the core API group. For any other third-party types, `apiGroup` is required.
+|false
+
+|`namespace`
+|string
+|`namespace` is the namespace of resource being referenced.
+
+Note that when a namespace is specified, a `gateway.networking.k8s.io/ReferenceGrant` object is required in the referent namespace to allow that namespace's owner to accept the reference. See the `ReferenceGrant` documentation for details.
+
+_Alpha_: This field requires the `CrossNamespaceVolumeDataSource` feature gate to be enabled.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigpersistentvolumeclaimresources]]
+== MonitoringStack.spec.prometheusConfig.persistentVolumeClaim.resources
+
+`resources` represents the minimum resources the volume should have.
+
+If `RecoverVolumeExpansionFailure` feature is enabled users are allowed to specify resource requirements that are lower than the previous value but must still be higher than the capacity recorded in the status field of the claim.
+
+For more information, see link:https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources[Kubernetes Docs]
+
+[cols="2,2,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`limits`
+|`map[string]int or string`
+|`Limits` describes the maximum amount of compute resources allowed.
+
+For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes Docs]
+|false
+
+|`requests`
+|`map[string]int or string`
+|`Requests` describes the minimum amount of compute resources required.
+
+If `Requests` is omitted for a container, it defaults to `Limits` if that is explicitly specified, otherwise to an implementation-defined value. `Requests` cannot exceed `Limits`.
+
+For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes Docs]
+|false
+|===
+
+[[monitoringstackspecprometheusconfigpersistentvolumeclaimselector]]
+== MonitoringStack.spec.prometheusConfig.persistentVolumeClaim.selector
+
+
+`selector` is a label query over volumes to consider for binding.
+
+[cols="2,2,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigpersistentvolumeclaimselectormatchexpressionsindex[`matchExpressions`]
+|`[]object`
+|`matchExpressions` is a list of label selector requirements. The requirements are ANDed.
+|false
+
+|`matchLabels`
+|`map[string]string`
+|`matchLabels` is a map of {key,value} pairs.
+
+A single {key,value} in the `matchLabels` map is equivalent to an element of `matchExpressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigpersistentvolumeclaimselectormatchexpressionsindex]]
+== MonitoringStack.spec.prometheusConfig.persistentVolumeClaim.selector.matchExpressions[index]
+
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|`key` is the label key that the selector applies to.
+|true
+
+|`operator`
+|string
+|`operator` represents a key's relationship to a set of values. Valid operators are `In`, `NotIn`, `Exists` and `DoesNotExist`.
+|true
+
+|`values`
+|`[]string`
+|`values` is an array of string values.
+
+If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindex]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index]
+
+`RemoteWriteSpec` defines the configuration to write samples from Prometheus to a remote endpoint.
+
+[cols="2,2,5,1"]
+|===
+|Name |Type |Description |Required
+
+|`url`
+|string
+|The URL of the endpoint to send samples to.
+|true
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexauthorization[`authorization`]
+|object
+a|Authorization section for the URL.
+
+* It requires Prometheus >= v2.26.0.
+* Cannot be set at the same time as `sigv4`, `basicAuth`, `oauth2`, or `azureAd`.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexazuread[`azureAd`]
+|object
+a|AzureAD for the URL.
+
+* It requires Prometheus >= v2.45.0.
+* Cannot be set at the same time as `authorization`, `basicAuth`, `oauth2`, or `sigv4`.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexbasicauth[`basicAuth`]
+|object
+a|BasicAuth configuration for the URL.
+
+* Cannot be set at the same time as `sigv4`, `authorization`, `oauth2`, or `azureAd`.
+|false
+
+|`bearerToken`
+|string
+|_Warning: this field should not be used because the token value appears in clear-text. Prefer using `authorization`._
+
+_Deprecated: this will be removed in a future release._
+|false
+
+|`bearerTokenFile`
+|string
+|File from which to read bearer token for the URL.
+
+_Deprecated: this will be removed in a future release. Prefer using `authorization`._
+|false
+
+|`enableHTTP2`
+|boolean
+|Whether to enable HTTP2.
+|false
+
+|`followRedirects`
+|boolean
+|Configure whether HTTP requests follow HTTP 3xx redirects.
+
+It requires Prometheus >= v2.26.0.
+|false
+
+|`headers`
+|`map[string]string`
+|Custom HTTP headers to be sent along with each remote write request. Be aware that headers that are set by Prometheus itself can't be overwritten.
+
+It requires Prometheus >= v2.25.0.
+|false
+
+|`messageVersion`
+|enum
+a|The Remote Write message's version to use when writing to the endpoint.
+
+* `Version1.0` corresponds to the `prometheus.WriteRequest` protobuf message introduced in Remote Write 1.0.
+*`Version2.0` corresponds to the `io.prometheus.write.v2.Request` protobuf message introduced in Remote Write 2.0.
+* When `Version2.0` is selected, Prometheus will automatically be configured to append the metadata of scraped metrics to the WAL.
+* Before setting this field, consult with your remote storage provider what message version it supports.
+* It requires Prometheus >= v2.54.0.
+
+_Enum_: `V1.0`, `V2.0`
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexmetadataconfig[`metadataConfig`]
+|object
+|`MetadataConfig` configures the sending of series metadata to the remote storage.
+|false
+
+|`name`
+|string
+|The name of the remote write queue, it must be unique if specified. The name is used in metrics and logging in order to differentiate queues.
+
+It requires Prometheus >= v2.15.0.
+|false
+
+|`noProxy`
+|string
+|`noProxy` is a comma-separated string that can contain IPs, CIDR notation, or domain names that should be excluded from proxying. IP and domain names can contain port numbers.
+
+It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2[`oauth2`]
+|object
+a|OAuth2 configuration for the URL.
+
+* It requires Prometheus >= v2.27.0.
+* Cannot be set at the same time as `sigv4`, `authorization`, `basicAuth`, or `azureAd`.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexproxyconnectheaderkeyindex[`proxyConnectHeader`]
+|`map[string][]object`
+|`ProxyConnectHeader` optionally specifies headers to send to proxies during CONNECT requests.
+
+It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+|false
+
+|`proxyFromEnvironment`
+|boolean
+|Whether to use the proxy configuration defined by environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`).
+
+It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+|false
+
+|`proxyUrl`
+|string
+|`proxyURL` defines the HTTP proxy server to use.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexqueueconfig[`queueConfig`]
+|object
+|`QueueConfig` allows tuning of the remote write queue parameters.
+|false
+
+|`remoteTimeout`
+|string
+|Timeout for requests to the remote write endpoint.
+|false
+
+|`sendExemplars`
+|boolean
+|Enables sending of exemplars over remote write. Note that exemplar-storage itself must be enabled using the `spec.enableFeatures` option for exemplars to be scraped in the first place.
+
+It requires Prometheus >= v2.27.0.
+|false
+
+|`sendNativeHistograms`
+|boolean
+|Enables sending of native histograms, also known as sparse histograms over remote write.
+
+It requires Prometheus >= v2.40.0.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexsigv4[`sigv4`]
+|object
+a|`Sigv4` allows to configures AWS's Signature Verification 4 for the URL.
+
+* It requires Prometheus >= v2.26.0.
+* Cannot be set at the same time as `authorization`, `basicAuth`, `oauth2`, or `azureAd`.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindextlsconfig[`tlsConfig`]
+|object
+|TLS Config to use for the URL.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexwriterelabelconfigsindex[`writeRelabelConfigs`]
+|`[]object`
+|The list of remote write relabel configurations.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexauthorization]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].authorization
+
+Authorization section for the URL.
+
+* It requires Prometheus >= v2.26.0.
+* Cannot be set at the same time as `sigv4`, `basicAuth`, `oauth2`, or `azureAd`.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexauthorizationcredentials[`credentials`]
+|object
+|Selects a key of a Secret in the namespace that contains the credentials for authentication.
+|false
+
+|`credentialsFile`
+|string
+|File to read a secret from, mutually exclusive with `credentials`.
+|false
+
+|`type`
+|string
+|Defines the authentication type. The value is case-insensitive.
+
+"Basic" is not a supported value.
+
+Default: "Bearer"
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexauthorizationcredentials]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].authorization.credentials
+
+
+Selects a key of a Secret in the namespace that contains the credentials for authentication.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexazuread]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].azureAd
+
+
+AzureAD for the URL.
+
+* It requires Prometheus >= v2.45.0.
+* Cannot be set at the same time as `authorization`, `basicAuth`, `oauth2`, or `sigv4`.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`cloud`
+|enum
+|The Azure Cloud. Options are 'AzurePublic', 'AzureChina', or 'AzureGovernment'.
+
+_Enum_: `AzureChina`, `AzureGovernment`, `AzurePublic`
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexazureadmanagedidentity[`managedIdentity`]
+|object
+|`ManagedIdentity` defines the Azure User-assigned Managed identity. Cannot be set at the same time as `oauth` or `sdk`.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexazureadoauth[`oauth`]
+|object
+a|`OAuth` defines the oauth config that is being used to authenticate.
+
+* Cannot be set at the same time as `managedIdentity` or `sdk`.
+
+* It requires Prometheus >= v2.48.0.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexazureadsdk[`sdk`]
+|object
+a|`SDK` defines the Azure SDK config that is being used to authenticate. See link:https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication[Azure SDK Authentication].
+
+* Cannot be set at the same time as `oauth` or `managedIdentity`.
+
+* It requires Prometheus >= 2.52.0.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexazureadmanagedidentity]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].azureAd.managedIdentity
+
+
+ManagedIdentity defines the Azure User-assigned Managed identity.
+
+* Cannot be set at the same time as `oauth` or `sdk`.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`clientId`
+|string
+|The client id
+|true
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexazureadoauth]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].azureAd.oauth
+
+`OAuth` defines the oauth config that is being used to authenticate.
+
+* Cannot be set at the same time as `managedIdentity` or `sdk`.
+
+* It requires Prometheus >= v2.48.0.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`clientId`
+|string
+|`clientID` is the clientId of the Azure Active Directory application that is being used to authenticate.
+|true
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexazureadoauthclientsecret[`clientSecret`]
+|object
+|`clientSecret` specifies a key of a Secret containing the client secret of the Azure Active Directory application that is being used to authenticate.
+|true
+
+|`tenantId`
+|string
+|`tenantId` is the tenant ID of the Azure Active Directory application that is being used to authenticate.
+|true
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexazureadoauthclientsecret]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].azureAd.oauth.clientSecret
+
+
+`clientSecret` specifies a key of a Secret containing the client secret of the Azure Active Directory application that is being used to authenticate.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexazureadsdk]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].azureAd.sdk
+
+
+`SDK` defines the Azure SDK config that is being used to authenticate.
+
+For more information, see link:https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication[Azure SDK Authentication].
+
+* Cannot be set at the same time as `oauth` or `managedIdentity`.
+
+* It requires Prometheus >= 2.52.0.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`tenantId`
+|string
+|`tenantId` is the tenant ID of the azure active directory application that is being used to authenticate.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexbasicauth]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].basicAuth
+
+BasicAuth configuration for the URL.
+
+* Cannot be set at the same time as `sigv4`, `authorization`, `oauth2`, or `azureAd`.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexbasicauthpassword[`password`]
+|object
+|`password` specifies a key of a Secret containing the password for authentication.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexbasicauthusername[`username`]
+|object
+|`username` specifies a key of a Secret containing the username for authentication.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexbasicauthpassword]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].basicAuth.password
+
+
+`password` specifies a key of a Secret containing the password for authentication.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexbasicauthusername]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].basicAuth.username
+
+`username` specifies a key of a Secret containing the username for authentication.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexmetadataconfig]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].metadataConfig
+
+`MetadataConfig` configures the sending of series metadata to the remote storage.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`send`
+|boolean
+|Defines whether metric metadata is sent to the remote storage or not.
+|false
+
+|`sendInterval`
+|string
+|Defines how frequently metric metadata is sent to the remote storage.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2
+
+OAuth2 configuration for the URL.
+
+* It requires Prometheus >= v2.27.0.
+
+* Cannot be set at the same time as `sigv4`, `authorization`, `basicAuth`, or `azureAd`.
+
+[cols="2,2,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2clientid[`clientId`]
+|object
+|`clientId` specifies a key of a Secret or ConfigMap object containing the OAuth2 client's ID.
+|true
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2clientsecret[`clientSecret`]
+|object
+|`clientSecret` specifies a key of a Secret containing the OAuth2 client's secret.
+|true
+
+|`tokenUrl`
+|string
+|`tokenURL` configures the URL to fetch the token from.
+|true
+
+|`endpointParams`
+|`map[string]string`
+|`endpointParams` configures the HTTP parameters to append to the token URL.
+|false
+
+|`noProxy`
+|string
+|`noProxy` is a comma-separated string that can contain IPs, CIDR notation, or domain names that should be excluded from proxying. IP and domain names can contain port numbers.
+
+It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2proxyconnectheaderkeyindex[`proxyConnectHeader`]
+|`map[string][]object`
+|ProxyConnectHeader optionally specifies headers to send to proxies during `CONNECT` requests.
+
+It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+|false
+
+|`proxyFromEnvironment`
+|boolean
+|Whether to use the proxy configuration defined by environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`).
+
+It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+|false
+
+|`proxyUrl`
+|string
+|`proxyURL` defines the HTTP proxy server to use.
+|false
+
+|`scopes`
+|`[]string`
+|`scopes` defines the OAuth2 scopes used for the token request.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfig[`tlsConfig`]
+|object
+|TLS configuration to use when connecting to the OAuth2 server.
+
+It requires Prometheus >= v2.43.0.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2clientid]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.clientId
+
+
+`clientId` specifies a key of a Secret or ConfigMap containing the OAuth2 client's ID.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2clientidconfigmap[`configMap`]
+|object
+|ConfigMap containing data to use for the targets.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2clientidsecret[`secret`]
+|object
+|Secret containing data to use for the targets.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2clientidconfigmap]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.clientId.configMap
+
+
+ConfigMap containing data to use for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key to select.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the ConfigMap or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2clientidsecret]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.clientId.secret
+
+
+Secret containing data to use for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2clientsecret]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.clientSecret
+
+
+`clientSecret` specifies a key of a Secret containing the OAuth2 client's secret.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2proxyconnectheaderkeyindex]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.proxyConnectHeader[key][index]
+
+
+SecretKeySelector selects a key of a Secret.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfig]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.tlsConfig
+
+TLS configuration to use when connecting to the OAuth2 server.
+
+* It requires Prometheus >= v2.43.0.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigca[`ca`]
+|object
+|Certificate authority used when verifying server certificates.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigcert[`cert`]
+|object
+|Client certificate to present when doing client-authentication.
+|false
+
+|`insecureSkipVerify`
+|boolean
+|Disable target certificate validation.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigkeysecret[`keySecret`]
+|object
+|Secret containing the client key file for the targets.
+|false
+
+|`maxVersion`
+|enum
+|Maximum acceptable TLS version.
+
+It requires Prometheus >= v2.41.0.
+
+_Enum_: `TLS10`, `TLS11`, `TLS12`, `TLS13`
+|false
+
+|`minVersion`
+|enum
+|Minimum acceptable TLS version.
+
+It requires Prometheus >= v2.35.0.
+
+_Enum_: `TLS10`, `TLS11`, `TLS12`, `TLS13`
+|false
+
+|`serverName`
+|string
+|Used to verify the hostname for the targets.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigca]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.tlsConfig.ca
+
+
+Certificate authority used when verifying server certificates.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigcaconfigmap[`configMap`]
+|object
+|ConfigMap containing data to use for the targets.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigcasecret[`secret`]
+|object
+|Secret containing data to use for the targets.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigcaconfigmap]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.tlsConfig.ca.configMap
+
+
+ConfigMap containing data to use for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key to select.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the ConfigMap or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigcasecret]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.tlsConfig.ca.secret
+
+
+Secret containing data to use for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigcert]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.tlsConfig.cert
+
+
+Client certificate to present when doing client-authentication.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigcertconfigmap[`configMap`]
+|object
+|ConfigMap containing data to use for the targets.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigcertsecret[`secret`]
+|object
+|Secret containing data to use for the targets.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigcertconfigmap]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.tlsConfig.cert.configMap
+
+
+ConfigMap containing data to use for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key to select.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the ConfigMap or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigcertsecret]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.tlsConfig.cert.secret
+
+Secret containing data to use for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexoauth2tlsconfigkeysecret]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].oauth2.tlsConfig.keySecret
+
+
+Secret containing the client key file for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexproxyconnectheaderkeyindex]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].proxyConnectHeader[key][index]
+
+SecretKeySelector selects a key of a Secret.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexqueueconfig]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].queueConfig
+
+
+QueueConfig allows tuning of the remote write queue parameters.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`batchSendDeadline`
+|string
+|`BatchSendDeadline` is the maximum time a sample will wait in buffer.
+|false
+
+|`capacity`
+|integer
+|`Capacity` is the number of samples to buffer per shard before we start dropping them.
+|false
+
+|`maxBackoff`
+|string
+|`MaxBackoff` is the maximum retry delay.
+|false
+
+|`maxRetries`
+|integer
+|`MaxRetries` is the maximum number of times to retry a batch on recoverable errors.
+|false
+
+|`maxSamplesPerSend`
+|integer
+|`MaxSamplesPerSend` is the maximum number of samples per send.
+|false
+
+|`maxShards`
+|integer
+|`MaxShards` is the maximum number of shards, that is, the amount of concurrency.
+|false
+
+|`minBackoff`
+|string
+|`MinBackoff` is the initial retry delay. Gets doubled for every retry.
+|false
+
+|`minShards`
+|integer
+|`MinShards` is the minimum number of shards, that is, the amount of concurrency.
+|false
+
+|`retryOnRateLimit`
+|boolean
+|Retry upon receiving a 429 status code from the remote-write storage.
+
+This is an *experimental feature*, it may change in any upcoming release in a breaking way.
+|false
+
+|`sampleAgeLimit`
+|string
+|`SampleAgeLimit` drops samples older than the limit.
+
+It requires Prometheus >= v2.50.0.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexsigv4]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].sigv4
+
+
+Sigv4 allows to configures AWS's Signature Verification 4 for the URL.
+
+* It requires Prometheus >= v2.26.0.
+
+* Cannot be set at the same time as `authorization`, `basicAuth`, `oauth2`, or `azureAd`.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexsigv4accesskey[`accessKey`]
+|object
+|`AccessKey` is the AWS API key. If not specified, the environment variable `AWS_ACCESS_KEY_ID` is used.
+|false
+
+|`profile`
+|string
+|`Profile` is the named AWS profile used to authenticate.
+|false
+
+|`region`
+|string
+|`Region` is the AWS region. If blank, the region from the default credentials chain used.
+|false
+
+|`roleArn`
+|string
+|`RoleArn` is the named AWS profile used to authenticate.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindexsigv4secretkey[`secretKey`]
+|object
+|`SecretKey` is the AWS API secret. If not specified, the environment variable `AWS_SECRET_ACCESS_KEY` is used.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexsigv4accesskey]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].sigv4.accessKey
+
+
+`AccessKey` is the AWS API key. If not specified, the environment variable `AWS_ACCESS_KEY_ID` is used.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexsigv4secretkey]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].sigv4.secretKey
+
+
+`SecretKey` is the AWS API secret. If not specified, the environment variable `AWS_SECRET_ACCESS_KEY` is used.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindextlsconfig]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].tlsConfig
+
+
+TLS Config to use for the URL.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindextlsconfigca[`ca`]
+|object
+|Certificate authority used when verifying server certificates.
+|false
+
+|`caFile`
+|string
+|Path to the CA cert in the Prometheus container to use for the targets.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindextlsconfigcert[`cert`]
+|object
+|Client certificate to present when doing client-authentication.
+|false
+
+|`certFile`
+|string
+|Path to the client cert file in the Prometheus container for the targets.
+|false
+
+|`insecureSkipVerify`
+|boolean
+|Disable target certificate validation.
+|false
+
+|`keyFile`
+|string
+|Path to the client key file in the Prometheus container for the targets.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindextlsconfigkeysecret[`keySecret`]
+|object
+|Secret containing the client key file for the targets.
+|false
+
+|`maxVersion`
+|enum
+|Maximum acceptable TLS version.
+
+It requires Prometheus >= v2.41.0.
+
+_Enum_: `TLS10`, `TLS11`, `TLS12`, `TLS13`
+|false
+
+|`minVersion`
+|enum
+|Minimum acceptable TLS version.
+
+It requires Prometheus >= v2.35.0.
+
+_Enum_: `TLS10`, `TLS11`, `TLS12`, `TLS13`
+|false
+
+|`serverName`
+|string
+|Used to verify the hostname for the targets.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindextlsconfigca]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].tlsConfig.ca
+
+
+Certificate authority used when verifying server certificates.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindextlsconfigcaconfigmap[`configMap`]
+|object
+|ConfigMap containing data to use for the targets.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindextlsconfigcasecret[`secret`]
+|object
+|Secret containing data to use for the targets.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindextlsconfigcaconfigmap]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].tlsConfig.ca.configMap
+
+ConfigMap containing data to use for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key to select.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the ConfigMap or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindextlsconfigcasecret]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].tlsConfig.ca.secret
+
+
+Secret containing data to use for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindextlsconfigcert]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].tlsConfig.cert
+
+
+Client certificate to present when doing client-authentication.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindextlsconfigcertconfigmap[`configMap`]
+|object
+|ConfigMap containing data to use for the targets.
+|false
+
+|xref:#monitoringstackspecprometheusconfigremotewriteindextlsconfigcertsecret[`secret`]
+|object
+|Secret containing data to use for the targets.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindextlsconfigcertconfigmap]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].tlsConfig.cert.configMap
+
+
+ConfigMap containing data to use for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key to select.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the ConfigMap or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindextlsconfigcertsecret]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].tlsConfig.cert.secret
+
+
+Secret containing data to use for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindextlsconfigkeysecret]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].tlsConfig.keySecret
+
+
+Secret containing the client key file for the targets.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong.
+
+For more information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Kubernetes Docs]
+|false
+
+|`optional`
+|boolean
+|Specify whether the Secret or its key must be defined
+|false
+|===
+
+[[monitoringstackspecprometheusconfigremotewriteindexwriterelabelconfigsindex]]
+== MonitoringStack.spec.prometheusConfig.remoteWrite[index].writeRelabelConfigs[index]
+
+
+RelabelConfig allows dynamic rewriting of the label set for targets, alerts, scraped samples and remote write samples.
+
+For more information, see link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config[Prometheus Docs]
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`action`
+|enum
+a|Action to perform based on the regex matching.
+
+* `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+* `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+_Enum_: `replace`, `Replace`, `keep`, `Keep`, `drop`, `Drop`, `hashmod`, `HashMod`, `labelmap`, `LabelMap`, `labeldrop`, `LabelDrop`, `labelkeep`, `LabelKeep`, `lowercase`, `Lowercase`, `uppercase`, `Uppercase`, `keepequal`, `KeepEqual`, `dropequal`, `DropEqual`
+
+_Default_: `replace`
+|false
+
+|`modulus`
+|integer
+|Modulus to take of the hash of the source label values.
+
+Only applicable when the action is `HashMod`.
+
+_Format_: int64
+|false
+
+|`regex`
+|string
+|Regular expression against which the extracted value is matched.
+|false
+
+|`replacement`
+|string
+|Replacement value against which a Replace action is performed if the regular expression matches.
+
+Regex capture groups are available.
+|false
+
+|`separator`
+|string
+|`Separator` is the string between concatenated `SourceLabels`.
+|false
+
+|`sourceLabels`
+|`[]string`
+|The source labels select values from existing labels. Their content is concatenated using the configured Separator and matched against the configured regular expression.
+|false
+
+|`targetLabel`
+|string
+|Label to which the resulting string is written in a replacement.
+
+It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`, `KeepEqual` and `DropEqual` actions.
+
+Regex capture groups are available.
+|false
+|===
+
+[[monitoringstackspecprometheusconfigwebtlsconfig]]
+== MonitoringStack.spec.prometheusConfig.webTLSConfig
+
+
+Configure TLS options for the Prometheus web server.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecprometheusconfigwebtlsconfigcertificate[`certificate`]
+|object
+|Reference to the TLS public certificate for the web server.
+|true
+
+|xref:#monitoringstackspecprometheusconfigwebtlsconfigcertificateauthority[`certificateAuthority`]
+|object
+|Reference to the root Certificate Authority used to verify the web server's certificate.
+|true
+
+|xref:#monitoringstackspecprometheusconfigwebtlsconfigprivatekey[`privateKey`]
+|object
+|Reference to the TLS private key for the web server.
+|true
+|===
+
+[[monitoringstackspecprometheusconfigwebtlsconfigcertificate]]
+== MonitoringStack.spec.prometheusConfig.webTLSConfig.certificate
+
+Reference to the TLS public certificate for the web server.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|The name of the secret in the object's namespace to select from.
+|true
+|===
+
+[[monitoringstackspecprometheusconfigwebtlsconfigcertificateauthority]]
+== MonitoringStack.spec.prometheusConfig.webTLSConfig.certificateAuthority
+
+
+Reference to the root Certificate Authority used to verify the web server's certificate.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|The name of the secret in the object's namespace to select from.
+|true
+|===
+
+[[monitoringstackspecprometheusconfigwebtlsconfigprivatekey]]
+== MonitoringStack.spec.prometheusConfig.webTLSConfig.privateKey
+
+
+Reference to the TLS private key for the web server.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|The name of the secret in the object's namespace to select from.
+|true
+|===
+
+[[monitoringstackspecresourceselector]]
+== MonitoringStack.spec.resourceSelector
+
+
+Label selector for `MonitoringStack` resources.
+
+* To monitor everything, set to empty map selector. For example, `resourceSelector: {}`.
+
+* To disable service discovery, set to null. For example, `resourceSelector:`.
+
+[cols="2,2,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecresourceselectormatchexpressionsindex[`matchExpressions`]
+|`[]object`
+|`matchExpressions` is a list of label selector requirements. The requirements are ANDed.
+|false
+
+|`matchLabels`
+|`map[string]string`
+|`matchLabels` is a map of {key,value} pairs. A single {key,value} in the `matchLabels` map is equivalent to an element of `matchExpressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+|false
+|===
+
+[[monitoringstackspecresourceselectormatchexpressionsindex]]
+== MonitoringStack.spec.resourceSelector.matchExpressions[index]
+
+
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|`key` is the label key that the selector applies to.
+|true
+
+|`operator`
+|string
+|`operator` represents a key's relationship to a set of values. Valid operators are `In`, `NotIn`, `Exists` and `DoesNotExist`.
+|true
+
+|`values`
+|`[]string`
+|`values` is an array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.
+|false
+|===
+
+[[monitoringstackspecresources]]
+== MonitoringStack.spec.resources
+
+
+Define resources requests and limits for `MonitoringStack` pods.
+
+[cols="2,2,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackspecresourcesclaimsindex[`claims`]
+|`[]object`
+|`Claims` lists the names of resources, defined in `spec.resourceClaims`, that are used by this container.
+
+This is an alpha field and requires enabling the `DynamicResourceAllocation` feature gate.
+
+This field is immutable. It can only be set for containers.
+|false
+
+|`limits`
+|`map[string]int or string`
+|`Limits` describes the maximum amount of compute resources allowed.
+
+For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes Docs]
+|false
+
+|`requests`
+|`map[string]int or string`
+|`Requests` describes the minimum amount of compute resources required. If `Requests` is omitted for a container, it defaults to `Limits` if that is explicitly specified, otherwise to an implementation-defined value. `Requests` cannot exceed `Limits`.
+
+For more information, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes Docs]
+|false
+|===
+
+[[monitoringstackspecresourcesclaimsindex]]
+== MonitoringStack.spec.resources.claims[index]
+
+
+`ResourceClaim` references one entry in `PodSpec.ResourceClaims`.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`name`
+|string
+|`Name` must match the name of one entry in `pod.spec.resourceClaims` of the Pod where this field is used. It makes that resource available inside a container.
+|true
+
+|`request`
+|string
+|`Request` is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.
+|false
+|===
+
+[[monitoringstackspectolerationsindex]]
+== MonitoringStack.spec.tolerations[index]
+
+
+The pod this `Toleration` is attached to tolerates any taint that matches the triple `<key,value,effect>` using the matching operator `<operator>`.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`effect`
+|string
+|`Effect` indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are `NoSchedule`, `PreferNoSchedule` and `NoExecute`.
+|false
+
+|`key`
+|string
+|`Key` is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be `Exists`; this combination means to match all values and all keys.
+|false
+
+|`operator`
+|string
+|`Operator` represents a key's relationship to the value. Valid operators are `Exists` and `Equal`. Defaults to `Equal`. `Exists` is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+|false
+
+|`tolerationSeconds`
+|integer
+|`TolerationSeconds` represents the period of time the toleration (which must be of effect `NoExecute`, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+
+_Format_: int64
+|false
+
+|`value`
+|string
+|`Value` is the taint value the toleration matches to. If the operator is `Exists`, the value should be empty, otherwise just a regular string.
+|false
+|===
+
+[[monitoringstackstatus]]
+== MonitoringStack.status
+
+
+`MonitoringStackStatus` defines the observed state of the `MonitoringStack` instance.
+It should always be reconstructable from the state of the cluster and/or outside world.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#monitoringstackstatusconditionsindex[`conditions`]
+|`[]object`
+|`Conditions` provide status information about the `MonitoringStack` instance.
+|true
+|===
+
+[[monitoringstackstatusconditionsindex]]
+== MonitoringStack.status.conditions[index]
+
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`lastTransitionTime`
+|string
+|`lastTransitionTime` is the last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+
+_Format_: date-time
+|true
+
+|`message`
+|string
+|`message` is a human readable message indicating details about the transition. This may be an empty string.
+|true
+
+|`reason`
+|string
+|`reason` contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+|true
+
+|`status`
+|enum
+|status of the condition
+
+_Enum_: `True`, `False`, `Unknown`, `Degraded`
+|true
+
+|`type`
+|string
+|`type` of condition in CamelCase or in `foo.example.com/CamelCase`. The regex it matches is `(dns1123SubdomainFmt/)?(qualifiedNameFmt)`
+|true
+
+|`observedGeneration`
+|integer
+|`observedGeneration` represents the `.metadata.generation` that the condition was set based upon. For instance, if `.metadata.generation` is currently 12, but the `.status.conditions[x].observedGeneration` is 9, the condition is out of date with respect to the current state of the instance.
+
+_Format_: int64
+
+_Minimum_: 0
+|false
+|===
+
+[[thanosquerier]]
+== ThanosQuerier
+
+ThanosQuerier outlines the Thanos querier components, managed by this stack
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`apiVersion`
+|string
+|`monitoring.rhobs/v1alpha1`
+|true
+
+|`kind`
+|string
+|`ThanosQuerier`
+|true
+
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#objectmeta-v1-meta[`metadata`]
+|object
+|Refer to the Kubernetes API documentation for the fields of the `metadata` field.
+|true
+
+|xref:#thanosquerierspec[`spec`]
+|object
+|`ThanosQuerierSpec` defines a single Thanos Querier instance. This means a label selector by which `MonitoringStack` instances to query are selected, and an optional namespace selector and a list of replica labels by which to deduplicate.
+|false
+
+|`status`
+|object
+|`ThanosQuerierStatus` defines the observed state of ThanosQuerier. It should always be reconstructable from the state of the cluster and/or outside world.
+|false
+|===
+
+[[thanosquerierspec]]
+== ThanosQuerier.spec
+
+`ThanosQuerierSpec` defines a single Thanos Querier instance. This means a label selector by which `MonitoringStack` instances to query are selected, and an optional namespace selector and a list of replica labels by which to deduplicate.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#thanosquerierspecselector[`selector`]
+|object
+|Selector to select monitoring stacks to unify.
+|true
+
+|xref:#thanosquerierspecnamespaceselector[`namespaceSelector`]
+|object
+|Selector to select which namespaces the `MonitoringStack` objects are discovered from.
+|false
+
+|`replicaLabels`
+|`[]string`
+|
+|false
+
+|xref:#thanosquerierspecwebtlsconfig[`webTLSConfig`]
+|object
+|Configure TLS options for the Thanos web server.
+|false
+|===
+
+[[thanosquerierspecselector]]
+== ThanosQuerier.spec.selector
+
+Selector to select monitoring stacks to unify.
+
+[cols="2,2,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#thanosquerierspecselectormatchexpressionsindex[`matchExpressions`]
+|`[]object`
+|`matchExpressions` is a list of label selector requirements. The requirements are ANDed.
+|false
+
+|`matchLabels`
+|`map[string]string`
+|`matchLabels` is a map of {key,value} pairs. A single {key,value} in the `matchLabels` map is equivalent to an element of `matchExpressions`, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+|false
+|===
+
+[[thanosquerierspecselectormatchexpressionsindex]]
+== ThanosQuerier.spec.selector.matchExpressions[index]
+
+
+A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|`key` is the label key that the selector applies to.
+|true
+
+|`operator`
+|string
+|`operator` represents a key's relationship to a set of values. Valid operators are `In`, `NotIn`, `Exists` and `DoesNotExist`.
+|true
+
+|`values`
+|`[]string`
+|`values` is an array of string values. If the operator is `In` or `NotIn`, the values array must be non-empty. If the operator is `Exists` or `DoesNotExist`, the values array must be empty. This array is replaced during a strategic merge patch.
+|false
+|===
+
+[[thanosquerierspecnamespaceselector]]
+== ThanosQuerier.spec.namespaceSelector
+
+
+Selector to select which namespaces the `MonitoringStack` objects are discovered from.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`any`
+|boolean
+|Boolean describing whether all namespaces are selected in contrast to a list restricting them.
+|false
+
+|`matchNames`
+|`[]string`
+|List of namespace names.
+|false
+|===
+
+[[thanosquerierspecwebtlsconfig]]
+== ThanosQuerier.spec.webTLSConfig
+
+
+Configure TLS options for the Thanos web server.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#thanosquerierspecwebtlsconfigcertificate[`certificate`]
+|object
+|Reference to the TLS public certificate for the web server.
+|true
+
+|xref:#thanosquerierspecwebtlsconfigcertificateauthority[`certificateAuthority`]
+|object
+|Reference to the root Certificate Authority used to verify the web server's certificate.
+|true
+
+|xref:#thanosquerierspecwebtlsconfigprivatekey[`privateKey`]
+|object
+|Reference to the TLS private key for the web server.
+|true
+|===
+
+[[thanosquerierspecwebtlsconfigcertificate]]
+== ThanosQuerier.spec.webTLSConfig.certificate
+
+
+Reference to the TLS public certificate for the web server.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|The name of the secret in the object's namespace to select from.
+|true
+|===
+
+[[thanosquerierspecwebtlsconfigcertificateauthority]]
+== ThanosQuerier.spec.webTLSConfig.certificateAuthority
+
+
+Reference to the root Certificate Authority used to verify the web server's certificate.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|The name of the secret in the object's namespace to select from.
+|true
+|===
+
+[[thanosquerierspecwebtlsconfigprivatekey]]
+== ThanosQuerier.spec.webTLSConfig.privateKey
+
+
+Reference to the TLS private key for the web server.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`key`
+|string
+|The key of the secret to select from. Must be a valid secret key.
+|true
+
+|`name`
+|string
+|The name of the secret in the object's namespace to select from.
+|true
+|===

--- a/observability/cluster_observability_operator/api-observability-package.adoc
+++ b/observability/cluster_observability_operator/api-observability-package.adoc
@@ -1,0 +1,637 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="api-observability-package"]
+= observability.openshift.io/v1alpha1
+include::_attributes/common-attributes.adoc[]
+:context: api-observability-package
+
+toc::[]
+
+The resource types are xref:#clusterobservability[`ClusterObservability`] and xref:#uiplugin[`UIPlugin`].
+
+[[clusterobservability]]
+== ClusterObservability
+
+ClusterObservability defines the desired state of the observability stack.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`apiVersion`
+|string
+|`observability.openshift.io/v1alpha1`
+|true
+
+|`kind`
+|string
+|`ClusterObservability`
+|true
+
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta[`metadata`]
+|object
+|Refer to the Kubernetes API documentation for the fields of the `metadata` field.
+|true
+
+|xref:#clusterobservabilityspec[`spec`]
+|object
+|`Spec` defines the desired state of the cluster observability.
+|false
+
+|`status`
+|object
+|Status of the signal manager.
+|false
+|===
+
+[[clusterobservabilityspec]]
+== ClusterObservability.spec
+
+
+`Spec` defines the desired state of the cluster observability.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#clusterobservabilityspeccapabilities[`capabilities`]
+|object
+|`Capabilities` defines the observability capabilities. Each capability has to be enabled explicitly.
+|false
+
+|xref:#clusterobservabilityspecstorage[`storage`]
+|object
+|`Storage` defines the storage for the capabilities that require a storage.
+|false
+|===
+
+[[clusterobservabilityspeccapabilities]]
+== ClusterObservability.spec.capabilities
+
+
+`Capabilities` defines the observability capabilities. Each capability has to be enabled explicitly.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#clusterobservabilityspeccapabilitiesopentelemetry[`opentelemetry`]
+|object
+|`OpenTelemetry` defines the OpenTelemetry capabilities.
+|false
+
+|xref:#clusterobservabilityspeccapabilitiestracing[`tracing`]
+|object
+|`Tracing` defines the tracing capabilities.
+|false
+|===
+
+[[clusterobservabilityspeccapabilitiesopentelemetry]]
+== ClusterObservability.spec.capabilities.opentelemetry
+
+
+`OpenTelemetry` defines the OpenTelemetry capabilities.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`enabled`
+|boolean
+|`Enabled` indicates whether the capability is enabled and it operator should deploy an instance. By default, it is set to false.
+
+_Default_: false
+|false
+
+|xref:#clusterobservabilityspeccapabilitiesopentelemetryexporter[`exporter`]
+|object
+|`Exporter` defines the OpenTelemetry exporter configuration. When defined the collector will export telemetry data to the specified endpoint.
+|false
+
+|xref:#clusterobservabilityspeccapabilitiesopentelemetryoperators[`operators`]
+|object
+|`Operators` defines the operators installation for the capability.
+|false
+|===
+
+[[clusterobservabilityspeccapabilitiesopentelemetryexporter]]
+== ClusterObservability.spec.capabilities.opentelemetry.exporter
+
+`Exporter` defines the OpenTelemetry exporter configuration. When defined the collector will export telemetry data to the specified endpoint.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`endpoint`
+|string
+|`Endpoint` is the OTLP endpoint.
+|false
+|===
+
+[[clusterobservabilityspeccapabilitiesopentelemetryoperators]]
+== ClusterObservability.spec.capabilities.opentelemetry.operators
+
+
+`Operators` defines the operators installation for the capability.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`install`
+|boolean
+|`Install` indicates whether the operator(s) used by the capability should be installed via OLM. When the capability is enabled, the install is set to true, otherwise it is set to false.
+|false
+|===
+
+[[clusterobservabilityspeccapabilitiestracing]]
+== ClusterObservability.spec.capabilities.tracing
+
+
+`Tracing` defines the tracing capabilities.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`enabled`
+|boolean
+|`Enabled` indicates whether the capability is enabled and it operator should deploy an instance. By default, it is set to false.
+
+_Default_: false
+|false
+
+|xref:#clusterobservabilityspeccapabilitiestracingoperators[`operators`]
+|object
+|`Operators` defines the operators installation for the capability.
+|false
+|===
+
+[[clusterobservabilityspeccapabilitiestracingoperators]]
+== ClusterObservability.spec.capabilities.tracing.operators
+
+
+`Operators` defines the operators installation for the capability.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`install`
+|boolean
+|`Install` indicates whether the operator(s) used by the capability should be installed via OLM. When the capability is enabled, the install is set to true, otherwise it is set to false.
+|false
+|===
+
+[[clusterobservabilityspecstorage]]
+== ClusterObservability.spec.storage
+
+
+`Storage` defines the storage for the capabilities that require a storage.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#clusterobservabilityspecstoragesecret[`secret`]
+|object
+|`SecretSpec` defines the secret for the storage.
+|false
+|===
+
+[[clusterobservabilityspecstoragesecret]]
+== ClusterObservability.spec.storage.secret
+
+
+`SecretSpec` defines the secret for the storage.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`name`
+|string
+|`Name` is the name of the secret for the storage.
+|false
+|===
+
+[[uiplugin]]
+== UIPlugin
+
+
+UIPlugin defines an observability console plugin.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`apiVersion`
+|string
+|`observability.openshift.io/v1alpha1`
+|true
+
+|`kind`
+|string
+|`UIPlugin`
+|true
+
+|link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta[`metadata`]
+|object
+|Refer to the Kubernetes API documentation for the fields of the `metadata` field.
+|true
+
+|xref:#uipluginspec[`spec`]
+|object
+|`UIPluginSpec` is the specification for desired state of UIPlugin.
+|false
+
+|xref:#uipluginstatus[`status`]
+|object
+|`UIPluginStatus` defines the observed state of UIPlugin. It should always be reconstructable from the state of the cluster and/or outside world.
+|false
+|===
+
+[[uipluginspec]]
+== UIPlugin.spec
+
+`UIPluginSpec` is the specification for desired state of UIPlugin.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`type`
+|enum
+|Type defines the UI plugin.
+
+_Enum_: `Dashboards`, `TroubleshootingPanel`, `DistributedTracing`, `Logging`, `Monitoring`
+|true
+
+|xref:#uipluginspecdeployment[`deployment`]
+|object
+|`Deployment` allows customizing aspects of the generated deployment hosting the UI Plugin.
+|false
+
+|xref:#uipluginspecdistributedtracing[`distributedTracing`]
+|object
+|`DistributedTracing` contains configuration for the distributed tracing console plugin.
+|false
+
+|xref:#uipluginspeclogging[`logging`]
+|object
+|`Logging` contains configuration for the logging console plugin.
+
+It only applies to UIPlugin Type: `Logging`.
+|false
+
+|xref:#uipluginspecmonitoring[`monitoring`]
+|object
+|`Monitoring` contains configuration for the monitoring console plugin.
+|false
+
+|xref:#uipluginspectroubleshootingpanel[`troubleshootingPanel`]
+|object
+|`TroubleshootingPanel` contains configuration for the troubleshooting console plugin.
+|false
+|===
+
+[[uipluginspecdeployment]]
+== UIPlugin.spec.deployment
+
+
+`Deployment` allows customizing aspects of the generated deployment hosting the UI Plugin.
+
+[cols="2,2,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`nodeSelector`
+|`map[string]string`
+|Define a label-selector for nodes which the Pods should be scheduled on.
+
+When no selector is specified it will default to a value only selecting Linux nodes (`"kubernetes.io/os=linux"`).
+|false
+
+|xref:#uipluginspecdeploymenttolerationsindex[`tolerations`]
+|`[]object`
+|Define the tolerations used for the deployment.
+|false
+|===
+
+[[uipluginspecdeploymenttolerationsindex]]
+== UIPlugin.spec.deployment.tolerations[index]
+
+
+The pod this `Toleration` is attached to tolerates any taint that matches the triple `<key,value,effect>` using the matching operator `<operator>`.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`effect`
+|string
+|`Effect` indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are `NoSchedule`, `PreferNoSchedule` and `NoExecute`.
+|false
+
+|`key`
+|string
+|`Key` is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be `Exists`; this combination means to match all values and all keys.
+|false
+
+|`operator`
+|string
+|`Operator` represents a key's relationship to the value. Valid operators are `Exists` and `Equal`. Defaults to `Equal`. `Exists` is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+|false
+
+|`tolerationSeconds`
+|integer
+|`TolerationSeconds` represents the period of time the toleration (which must be of effect `NoExecute`, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+
+_Format_: int64
+|false
+
+|`value`
+|string
+|`Value` is the taint value the toleration matches to. If the operator is `Exists`, the value should be empty, otherwise just a regular string.
+|false
+|===
+
+[[uipluginspecdistributedtracing]]
+== UIPlugin.spec.distributedTracing
+
+
+`DistributedTracing` contains configuration for the distributed tracing console plugin.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`timeout`
+|string
+|`Timeout` is the maximum duration before a query timeout.
+
+The value is expected to be a sequence of digits followed by a unit suffix, which can be 's' (seconds) or 'm' (minutes).
+|false
+|===
+
+[[uipluginspeclogging]]
+== UIPlugin.spec.logging
+
+
+`Logging` contains configuration for the logging console plugin.
+
+* It only applies to UIPlugin Type: `Logging`.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`logsLimit`
+|integer
+|`LogsLimit` is the max number of entries returned for a query.
+
+_Format_: int32
+
+_Minimum_: 0
+|false
+
+|xref:#uipluginspeclogginglokistack[`lokiStack`]
+|object
+|`LokiStack` points to the `LokiStack` instance of which logs should be displayed. It always references a `LokiStack` in the "openshift-logging" namespace.
+|false
+
+|`schema`
+|enum
+|`Schema` is the schema to use for logs querying and display.
+
+Defaults to "viaq" if not specified.
+
+_Enum_: `viaq`, `otel`, `select`
+
+_Default_: `viaq`
+|false
+
+|`timeout`
+|string
+|`Timeout` is the maximum duration before a query timeout.
+
+The value is expected to be a sequence of digits followed by an optional unit suffix, which can be 's' (seconds) or 'm' (minutes). If the unit is omitted, it defaults to seconds.
+|false
+|===
+
+[[uipluginspeclogginglokistack]]
+== UIPlugin.spec.logging.lokiStack
+
+
+`LokiStack` points to the LokiStack instance of which logs should be displayed. It always references a LokiStack in the "openshift-logging" namespace.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`name`
+|string
+|Name of the `LokiStack` resource.
+|false
+
+|`namespace`
+|string
+|
+|false
+|===
+
+[[uipluginspecmonitoring]]
+== UIPlugin.spec.monitoring
+
+
+`Monitoring` contains configuration for the monitoring console plugin.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#uipluginspecmonitoringacm[`acm`]
+|object
+|`ACM` points to the alertmanager and thanosQuerier instance services of which it should create a proxy to.
+|false
+
+|xref:#uipluginspecmonitoringincidents[`incidents`]
+|object
+|`Incidents` feature flag enablement
+|false
+
+|xref:#uipluginspecmonitoringperses[`perses`]
+|object
+|`Perses` points to the perses instance service of which it should create a proxy to.
+|false
+|===
+
+[[uipluginspecmonitoringacm]]
+== UIPlugin.spec.monitoring.acm
+
+
+`ACM` points to the alertmanager and thanosQuerier instance services of which it should create a proxy to.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#uipluginspecmonitoringacmalertmanager[`alertmanager`]
+|object
+|`Alertmanager` points to the alertmanager instance of which it should create a proxy to.
+|true
+
+|`enabled`
+|boolean
+|Indicates if ACM-related feature(s) should be enabled
+|true
+
+|xref:#uipluginspecmonitoringacmthanosquerier[`thanosQuerier`]
+|object
+|`ThanosQuerier` points to the thanos-querier service of which it should create a proxy to.
+|true
+|===
+
+[[uipluginspecmonitoringacmalertmanager]]
+== UIPlugin.spec.monitoring.acm.alertmanager
+
+`Alertmanager` points to the alertmanager instance of which it should create a proxy to.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`url`
+|string
+|Url of the Alertmanager to proxy to.
+|true
+|===
+
+[[uipluginspecmonitoringacmthanosquerier]]
+== UIPlugin.spec.monitoring.acm.thanosQuerier
+
+
+`ThanosQuerier` points to the thanos-querier service of which it should create a proxy to.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`url`
+|string
+|Url of the ThanosQuerier to proxy to.
+|true
+|===
+
+[[uipluginspecmonitoringincidents]]
+== UIPlugin.spec.monitoring.incidents
+
+
+`Incidents` feature flag enablement
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`enabled`
+|boolean
+|Indicates if incidents-related feature(s) should be enabled.
+|true
+|===
+
+[[uipluginspecmonitoringperses]]
+== UIPlugin.spec.monitoring.perses
+
+
+`Perses` points to the perses instance service of which it should create a proxy to.
+
+[cols="1,1,3,1"]
+|===
+|Name |Type |Description |Required
+
+|`enabled`
+|boolean
+|Indicates if perses-related feature(s) should be enabled
+|true
+|===
+
+[[uipluginspectroubleshootingpanel]]
+== UIPlugin.spec.troubleshootingPanel
+
+
+`TroubleshootingPanel` contains configuration for the troubleshooting console plugin.
+
+[cols="1,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`timeout`
+|string
+|`Timeout` is the maximum duration before a query timeout.
+
+The value is expected to be a sequence of digits followed by a unit suffix, which can be 's' (seconds) or 'm' (minutes).
+|false
+|===
+
+[[uipluginstatus]]
+== UIPlugin.status
+
+
+`UIPluginStatus` defines the observed state of UIPlugin. It should always be reconstructable from the state of the cluster and/or outside world.
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|xref:#uipluginstatusconditionsindex[`conditions`]
+|`[]object`
+|`Conditions` provide status information about the plugin.
+|true
+|===
+
+[[uipluginstatusconditionsindex]]
+== UIPlugin.status.conditions[index]
+
+
+[cols="2,1,4,1"]
+|===
+|Name |Type |Description |Required
+
+|`lastTransitionTime`
+|string
+|`lastTransitionTime` is the last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+
+_Format_: date-time
+|true
+
+|`message`
+|string
+|`message` is a human readable message indicating details about the transition. This may be an empty string.
+|true
+
+|`reason`
+|string
+|`reason` contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+|true
+
+|`status`
+|enum
+|status of the condition
+
+_Enum_: `True`, `False`, `Unknown`, `Degraded`
+|true
+
+|`type`
+|string
+|`type` of condition in CamelCase or in `foo.example.com/CamelCase`. The regex it matches is `(dns1123SubdomainFmt/)?(qualifiedNameFmt)`
+|true
+
+|`observedGeneration`
+|integer
+|`observedGeneration` represents the `.metadata.generation` that the condition was set based upon. For instance, if `.metadata.generation` is currently 12, but the `.status.conditions[x].observedGeneration` is 9, the condition is out of date with respect to the current state of the instance.
+
+_Format_: int64
+
+_Minimum_: 0
+|false
+|===


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-2005](https://issues.redhat.com//browse/OBSDOCS-2005)

Link to docs preview:
https://95112--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/api-monitoring-package.html

QE review:
SME approved 

Additional information:

Semi-automated migration of upstream API docs in markdown, so minimal changes to keep it maintainable going forward - so "regex", "CamelCase" and other Vale exceptions are left in.

https://github.com/rhobs/observability-operator/blob/main/docs/api.md
