### PR TITLE
TELCODOCS-2344: cp binary in kmod image

### DIFF
--- a/modules/kmm-creating-kmod-image.adoc
+++ b/modules/kmm-creating-kmod-image.adoc
@@ -13,3 +13,5 @@ Keep the following in mind when working with the `.ko` files:
 
 * In most cases, `<prefix>` should be equal to `/opt`. This is the `Module` CRD's default value.
 * `kernel-version` must not be empty and must be equal to the kernel version the kernel modules were built for.
+
+In addition to the `.ko` files, the kmod image also requires the `cp` binary to be present because the `.ko` files are copied from this image to the image-loader worker pod created by the Operator. This is a minimal requirement and no other binary tool is required in the image. 


### PR DESCRIPTION
Document the minimum requirements for the kmod image

Version(s):
openshift-4.19, openshift-4.20
KMMO 2.4

Issue:
https://issues.redhat.com/browse/TELCODOCS-2344

Link to docs preview:
https://95119--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management#kmm-creating-kmod-image_kernel-module-management-operator


Dev: @ybettan
QE: @cdvultur

QE review:

- [x ]  QE has approved this change.

