### PR TITLE
OLS-1866: Create snippet about unified perspective in web UI

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -6,12 +6,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-After the {ols-long} Operator is installed, configuring and deploying {ols-long} consists of three tasks. First, you create a credential secret using the credentials for your Large Language Model (LLM) provider. Next, you create the `OLSConfig` custom resource (CR) that the Operator uses to deploy the service. Finally, you verify that the {ols-short} service is operating.
+After the {ols-long} Operator is installed, configuring and deploying {ols-short} consists of three tasks. 
 
 [NOTE]
 ====
 The instructions assume that you are installing {ols-long} using the `kubeadmin` user account. If you are using a regular user account with `cluster-admin` privileges, read the section of the documentation that discusses RBAC.
 ====
+
+First, create a credential secret using the credentials for your Large Language Model (LLM) provider. Next, create the `OLSConfig` custom resource (CR) that the Operator uses to deploy the service. Finally, verify that the {ols-short} service is operating.
+
+include::snippets/ols-unified-perspective-web-console.adoc[]
 
 include::modules/ols-creating-the-credentials-secret-using-web-console.adoc[leveloffset=+1]
 include::modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc[leveloffset=+1]

--- a/modules/ols-verifying-openshift-lightspeed-deployment.adoc
+++ b/modules/ols-verifying-openshift-lightspeed-deployment.adoc
@@ -4,6 +4,8 @@
 
 After the {ols-long} service is deployed, verify that it is operating. 
 
+include::snippets/ols-unified-perspective-web-console.adoc[]
+
 .Prerequisites
 
 * You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
@@ -16,17 +18,16 @@ After the {ols-long} service is deployed, verify that it is operating.
 
 .Procedure
 
-. In the {ocp-product-title} web console, select the *Developer* perspective from the drop-down list at the top of the pane.
-
-. Click the *Project* drop-down lsit.
+. In the {ocp-product-title} web console, click the *Project* drop-down list.
++
+[NOTE]
+====
+For {ocp-product-title} 4.18 and earlier, select the *Developer* perspective from the drop-down list at the top of the pane to access the *Project* drop-down list.
+====
 
 . Enable the toggle switch to show default projects.
 
 . Select *openshift-lightspeed* from the list.
-
-. Click *Topology*.
-+
-When the circle around the Lightspeed icon turns dark blue, the service is ready.
 
 . Verify that the {ols-long} is ready by running the following command: 
 +

--- a/snippets/ols-unified-perspective-web-console.adoc
+++ b/snippets/ols-unified-perspective-web-console.adoc
@@ -1,0 +1,15 @@
+// Snippet included in the following assemblies:
+//
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+Starting with {ocp-product-title} 4.19, the perspectives in the web console are unified. The *Developer* perspective is no longer enabled by default.
+
+All users can interact with all {ocp-product-title} web console features. However, if you are not the cluster owner, you might need to request permission to certain features from the cluster owner.
+
+You can still enable the *Developer* perspective. On the *Getting Started* pane in the web console, you can take a tour of the console, find information on setting up your cluster, view a quick start for enabling the *Developer* perspective, and follow links to explore new features and capabilities.
+====


### PR DESCRIPTION
Please note: This PR essentially takes a snippet that was reviewed and approved in the console docs, and creates the snippet on the OLS standalone docs. 

Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-1866
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

Link to verification procedure:
https://95121--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-verifying-openshift-lightspeed-deployment_ols-configuring-openshift-lightspeed

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
