### PR TITLE
ROX-29040: Add info about devops and rhacs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -298,7 +298,7 @@ Distros: openshift-acs
 Topics:
 - Name: Integrating with image registries
   File: integrate-with-image-registries
-- Name: Integrating with CI systems
+- Name: Integrating RHACS into your DevOps system
   File: integrate-with-ci-systems
 - Name: Integrating with PagerDuty
   File: integrate-with-pagerduty

--- a/integration/integrate-with-ci-systems.adoc
+++ b/integration/integrate-with-ci-systems.adoc
@@ -1,16 +1,30 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="integrate-with-ci-systems"]
-= Integrating with CI systems
+= Integrating {product-title-short} into your DevOps system
 include::modules/common-attributes.adoc[]
 :context: integrate-with-ci-systems
 
 toc::[]
 
 [role="_abstract"]
+You can integrate {product-title} ({product-title-short}) into your DevOps system by using DevOps tools to configure specific {product-title-short} parameters and to create and manage custom security policies. You can also configure {product-title-short} to work with the continuous integration (CI) tools in your system to apply security policies to your images before or during deployment.
+
+include::modules/configuration-using-devops.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../configuration/declarative-configuration-using.adoc#declarative-configuration-using[Using declarative configuration]
+
+* xref:../operating/manage_security_policies/custom-security-policies.adoc#policy-as-code-about_custom-security-policies[Managing policies as code]
+
+
+[id="integrate-ci-systems"]
+== Integrating with CI systems
+
 {product-title} ({product-title-short}) integrates with a variety of continuous integration (CI) products. Before you deploy images, you can use {product-title-short} to apply build-time and deploy-time security rules to your images.
 
-After images are built and pushed to a registry, {product-title-short} integrates into CI pipelines.
-Pushing the image first allows developers to continue testing their artifacts while dealing with any policy violations alongside any other CI test failures, linter violations, or other problems.
+After images are built and pushed to a registry, {product-title-short} integrates into CI pipelines. Pushing the image first allows developers to continue testing their artifacts while dealing with any policy violations alongside any other CI test failures, linter violations, or other problems.
 
 If possible, configure the version control system to block pull or merge requests from being merged if the build stage, which includes {product-title-short} checks, fails.
 

--- a/modules/configuration-using-devops.adoc
+++ b/modules/configuration-using-devops.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * integration/integrate-with-ci-systems.adoc
+:_mod-docs-content-type: CONCEPT
+[id="configuration-using-devops_{context}"]
+= Configuration using DevOps
+
+You can use {product-title-short} with your DevOps system to configure authentication and authorization resources, including the following examples:
+
+* Authentication providers
+* Roles
+* Permission sets
+* Notifiers
+* Access scopes
+
+To use DevOps to configure these parameters, you create YAML files that contain configuration information. These files are used to create a config map that is added to {product-title-short} by using a mount point during installation of the {product-title-short} Central resource.
+
+Additionally, you can use your DevOps system to configure and manage security policies by using the "policy as code" feature. You can author policies in YAML or JSON and save them as Kubernetes custom resources (CRs). Then, you use your DevOps system to track, manage, and apply policies to your clusters that are running {product-title-short}. A Kubernetes controller in {product-title-short} uses the API to receive information about new, updated, or deleted policies and reconciles the policy changes.


### PR DESCRIPTION
Version(s):
4.8+

[Issue](https://issues.redhat.com/browse/ROX-29040)

Link to docs preview:

* https://95122--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-ci-systems - Changed page name and added intro paragraph
* https://95122--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-ci-systems#configuration-using-devops_integrate-with-ci-systems - added section about declarative config/policy as code and links to where they are documented

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
