### PR TITLE
TELCODOCS-2304: Make the operator configuration persistent during clu…

### DIFF
--- a/modules/kmm-configuring-kmmo.adoc
+++ b/modules/kmm-configuring-kmmo.adoc
@@ -6,43 +6,39 @@
 [id="kmm-configuring-kmmo_{context}"]
 = Configuring the Kernel Module Management Operator
 
-In most cases, the default configuration for the Kernel Module Management (KMM) Operator does not need to be modified. However, you can modify the Operator settings to suit your environment using the following procedure.
-
-The Operator configuration is set in the `kmm-operator-manager-config` `ConfigMap` in the Operator namespace.
+In most cases, the default configuration for the Kernel Module Management (KMM) Operator does not need to be modified. However, you can modify the Operator settings to suit your environment.
 
 .Procedure
 
-. To modify the settings, edit the `ConfigMap` data by entering the following command:
+* To modify any setting, create a `ConfigMap` with the name `kmm-operator-manager-config` in the Operator namespace with the relevant data and restart the controller using the following command:
 +
 [source,terminal]
 ----
-$ oc edit configmap -n "$namespace" kmm-operator-manager-config
+$ oc rollout restart -n "$namespace" deployment/kmm-operator-controller
 ----
++
+The value of `$namespace` depends on your installation method.
 +
 .Example output
 +
 [source,yaml]
 ----
-healthProbeBindAddress: :8081
-job:
-  gcDelay: 1h
-leaderElection:
-  enabled: true
-  resourceID: kmm.sigs.x-k8s.io
-webhook:
-  disableHTTP2: true  # CVE-2023-44487
-  port: 9443
-metrics:
-  enableAuthnAuthz: true
-  disableHTTP2: true  # CVE-2023-44487
-  bindAddress: 0.0.0.0:8443
-  secureServing: true
-worker:
-  runAsUser: 0
-  seLinuxType: spc_t
-  setFirmwareClassPath: /var/lib/firmware
+apiVersion: v1
+data:
+  controller_config.yaml: |
+    worker:
+      firmwareHostPath: /example/different/firmware/path
+kind: ConfigMap
+metadata:
+  name: kmm-operator-manager-config
+  namespace: openshift-kmm
 ----
-+
+
+[NOTE]
+====
+If you want to configure `KMM Hub`, create the `ConfigMap` using the name `kmm-operator-hub-manager-config` in the KMM Hub controller's namespace.
+====
+
 .Operator configuration parameters
 [cols="2,8",options="header"]
 |===
@@ -52,19 +48,19 @@ worker:
 | Defines the address on which the Operator monitors for kubelet health probes. The recommended value is `:8081`.
 
 |`job.gcDelay`
-|Defines the duration that successful build pods should be preserved for before they are deleted. There is no recommended value for this setting. For information about the valid values for this setting, see link:https://pkg.go.dev/time#ParseDuration[ParseDuration].
+|Defines the duration for which successful build pods should be preserved before they are deleted. For information about the valid values for this setting, see link:https://pkg.go.dev/time#ParseDuration[ParseDuration]. The default value is `0s`.
 
 |`leaderElection.enabled`
-|Determines whether leader election is used to ensure that only one replica of the KMM Operator is running at any time. For more information, see https://kubernetes.io/docs/concepts/architecture/leases/[Leases]. The recommended value is `true`.
+|Determines whether leader election is used to ensure that only one replica of the KMM Operator is running at any time. For more information, see https://kubernetes.io/docs/concepts/architecture/leases/[Leases]. The default value is `true`.
 
 |`leaderElection.resourceID`
-|Determines the name of the resource that leader election uses for holding the leader lock. The recommended value is `kmm.sigs.x-k8s.io`.
+|Determines the name of the resource that leader election uses for holding the leader lock. The default value for KMM is `kmm.sigs.x-k8s.io`. The default value for KMM-hub is `kmm-hub.sigs.x-k8s.io`.
 
-|`webhook.disableHTTP2`
-|If `true`, disables HTTP/2 for the webhook server, as a mitigation for link:https://access.redhat.com/security/cve/cve-2023-44487[cve-2023-44487]. The recommended value is `true`.
+|`metrics.bindAddress`
+|Determines the bind address for the metrics server. Set this to "0" to disable the metrics server. The default value is `0.0.0.0:8443`.
 
-|`webhook.port`
-|Defines the port on which the Operator monitors webhook requests. The recommended value is `9443`.
+|`metrics.disableHTTP2`
+|If `true`, disables HTTP/2 for the metrics server as a mitigation for https://access.redhat.com/security/cve/cve-2023-44487[CVE-2023-44487]. The default value is `true`.
 
 |`metrics.enableAuthnAuthz`
 a|Determines if metrics are authenticated using `TokenReviews` and authorized using `SubjectAccessReviews` with the kube-apiserver.
@@ -79,35 +75,23 @@ To scrape metrics, for example, using Prometheus, the client needs a `ClusterRol
 
 * `nonResourceURLs: "/metrics", verbs: get`
 
-The recommended value is `true`.
-
-|`metrics.disableHTTP2`
-|If `true`, disables HTTP/2 for the metrics server as a mitigation for https://access.redhat.com/security/cve/cve-2023-44487[CVE-2023-44487]. The recommended value is `true`.
-
-|`metrics.bindAddress`
-|Determines the bind address for the metrics server. If unspecified, the default is `:8080`. To disable the metrics server, set to `0`. The recommended value is `0.0.0.0:8443`.
+The default value is `true`.
 
 |`metrics.secureServing`
-|Determines whether the metrics are served over HTTPS instead of HTTP. The recommended value is `true`.
+|Determines whether the metrics are served over HTTPS instead of HTTP. The default value is `true`.
+
+|`webhook.disableHTTP2`
+|If `true`, disables HTTP/2 for the webhook server, as a mitigation for link:https://access.redhat.com/security/cve/cve-2023-44487[CVE-2023-44487]. The default value is `true`.
+
+|`webhook.port`
+|Defines the port on which the Operator monitors webhook requests. The default value is `9443`.
 
 |`worker.runAsUser`
-|Determines the value of the `runAsUser` field of the worker container's security context. For more information, see link:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[SecurityContext]. The recommended value is `9443`.
+|Determines the value of the `runAsUser` field of the worker container's security context. For more information, see link:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[SecurityContext]. The default value is `9443`.
 
 |`worker.seLinuxType`
-|Determines the value of the `seLinuxOptions.type` field of the worker container's security context. For more information, see link:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[SecurityContext]. The recommended value is `spc_t`.
+|Determines the value of the `seLinuxOptions.type` field of the worker container's security context. For more information, see link:https://kubernetes.io/docs/tasks/configure-pod-container/security-context/[SecurityContext]. The default value is `spc_t`.
 
-|`worker.setFirmwareClassPath`
-|Sets the kernel's firmware search path into the `/sys/module/firmware_class/parameters/path` file on the node. The recommended value is `/var/lib/firmware` if you need to set that value through the worker app. Otherwise, unset.
+|`worker.firmwareHostPath`
+|If set, the value of this field is written by the worker container into the /sys/module/firmware_class/parameters/path file on the node. For more information see link:https://openshift-kmm.netlify.app/documentation/firmwares/#setting-the-kernels-firmware-search-path[Setting the kernel's firmware search path]. The default value is `/var/lib/firmware`.
 |===
-
-. After modifying the settings, restart the controller with the following command:
-+
-[source,terminal]
-----
-$ oc delete pod -n "<namespace>" -l app.kubernetes.io/component=kmm
-----
-+
-[NOTE]
-====
-The value of <namespace> depends on your original installation method.
-====


### PR DESCRIPTION
Make the operator configuration persistent during cluster/operator upgrades

Version(s):
openshift-4.19, openshift-4.20
KMMO 2.4

Issue:
https://issues.redhat.com/browse/TELCODOCS-2304

Link to docs preview:
https://95124--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-configuring-kmmo_kernel-module-management-operator

Dev: @ybettan
QE: @cdvultur

QE review:

- [ x]  QE has approved this change.