### PR TITLE
OCPBUGS55748 Nodes become  temporarily after updating only the trusted CA bundle

### DIFF
--- a/modules/customize-certificates-replace-default-router.adoc
+++ b/modules/customize-certificates-replace-default-router.adoc
@@ -40,7 +40,9 @@ $ oc patch proxy/cluster \
 +
 [NOTE]
 ====
-If you update only the trusted CA for your cluster, the MCO updates the `/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt` file and the Machine Config Controller (MCC) applies the trusted CA update to each node so that a node reboot is not required. Changing any other parameter in the `openshift-config-user-ca-bundle.crt` file, such as `noproxy`, results in the MCO rebooting each node in your cluster.
+If you update only the trusted CA for your cluster, the MCO updates the `/etc/pki/ca-trust/source/anchors/openshift-config-user-ca-bundle.crt` file and the Machine Config Controller (MCC) applies the trusted CA update to each node so that a node reboot is not required. However, with these changes, the Machine Config Daemon (MCD) restarts critical services on each node, such as kubelet and CRI-O. These service restarts cause each node to briefly enter the `NotReady` state until the service is fully restarted.
+
+If you change any other parameter in the `openshift-config-user-ca-bundle.crt` file, such as `noproxy`, the MCO reboots each node in your cluster.
 ====
 
 . Create a secret that contains the wildcard certificate chain and key:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-55748

Link to docs preview:
[Replacing the default ingress certificate](https://95125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/replacing-default-ingress-certificate.html#replacing-default-ingress_replacing-default-ingress) -> Updated note in Step 2.

Version(s):
4.14+

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[<!--- Optional: Include additional context or expand the description here.--->
](https://github.com/openshift/openshift-docs/pull/90698)
