### PR TITLE
OSDOCS-15031 Creating AWS specialized regions assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -216,12 +216,8 @@ Topics:
       File: installing-aws-vpc
     - Name: Installing a private cluster
       File: installing-aws-private
-    - Name: Installing a cluster into a government region
-      File: installing-aws-government-region
-    - Name: Installing a cluster into a Secret or Top Secret Region
-      File: installing-aws-secret-region
-    - Name: Installing a cluster into a China region
-      File: installing-aws-china
+    - Name: Installing a cluster in a specialized region
+      File: installing-aws-specialized-region
     - Name: Installing a cluster with compute nodes on Local Zones
       File: installing-aws-localzone
     - Name: Installing a cluster with compute nodes on Wavelength Zones

--- a/installing/installing_aws/ipi/installing-aws-specialized-region.adoc
+++ b/installing/installing_aws/ipi/installing-aws-specialized-region.adoc
@@ -1,0 +1,163 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="installing-aws-specialized-region"]
+= Installing a cluster on AWS into a specialized region
+include::_attributes/common-attributes.adoc[]
+:context: installing-aws-specialized-region
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster on
+{aws-first} into specialized regions, including secret and top secret regions,
+government regions, and China regions. To configure the region, modify parameters in the `install-config.yaml` file before you install the cluster.
+
+The following specialized regions are supported:
+
+.Specialized regions
+|====
+|Region type|Supported regions
+
+|China
+a|
+* `cn-north-1` (Beijing)
+* `cn-northwest-1` (Ningxia)
+
+|Secret and Top Secret
+a|
+* `us-isob-east-1` (SC2S)
+* `us-iso-east-1` (C2S)
+
+|Government
+a|
+* `us-gov-east-1`
+* `us-gov-west-1`
+
+|====
+
+[WARNING]
+====
+In {product-title} {product-version}, the installation program uses Cluster API instead of Terraform to provision cluster infrastructure during installations on AWS. Installing a cluster on AWS into a secret or top-secret region by using the Cluster API implementation has not been tested as of the release of {product-title} {product-version}. This document will be updated when installation into a secret region has been tested.
+
+There is a known issue with Network Load Balancers' support for security groups in secret or top secret regions that causes installations in these regions to fail. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-33311[OCPBUGS-33311].
+
+The maximum supported MTU in the AWS SC2S and C2S regions is not the same as
+the public regions. For more information about configuring MTU during installation,
+see the _Cluster Network Operator configuration object_ section in _Installing
+a cluster on AWS with network customizations_
+====
+
+[id="prerequisites_{context}"]
+== Prerequisites
+
+* If you install a cluster into a China region, you have an Internet Content Provider (ICP) license.
+* You reviewed details about the xref:../../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
+* If you use a firewall, you xref:../../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+
+[IMPORTANT]
+====
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use long-term credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
+====
+
+include::modules/installation-aws-about-government-region.adoc[leveloffset=+1]
+include::modules/installation-aws-marketplace-government.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../installing/installing_aws/installation-config-parameters-aws.adoc#installation-config-parameters-aws[Installation configuration parameters for AWS]
+
+include::modules/installation-aws-regions-with-no-ami.adoc[leveloffset=+1]
+
+include::modules/private-clusters-default.adoc[leveloffset=+1]
+include::modules/private-clusters-about-aws.adoc[leveloffset=+2]
+
+include::modules/installation-custom-aws-vpc.adoc[leveloffset=+1]
+include::modules/installation-aws-security-groups.adoc[leveloffset=+2]
+
+include::modules/installation-aws-upload-custom-rhcos-ami.adoc[leveloffset=+1]
+
+include::modules/installation-initializing-manual.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../installing/installing_aws/installation-config-parameters-aws.adoc#installation-config-parameters-aws[Installation configuration parameters for AWS]
+
+include::modules/installation-aws-config-yaml-customizations.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../installing/installing_aws/installation-config-parameters-aws.adoc#installation-config-parameters-aws[Installation configuration parameters for AWS]
+
+include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
+
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
+
+[id="installing-aws-manual-modes_{context}"]
+== Alternatives to storing administrator-level secrets in the kube-system project
+
+By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
+
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#manually-create-iam_installing-aws-specialized-region[Manually creating long-term credentials].
+
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-with-short-term-creds_installing-aws-specialized-region[Configuring an AWS cluster to use short-term credentials].
+
+//Manually creating long-term credentials
+include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an AWS cluster to use short-term credentials
+[id="installing-aws-with-short-term-creds_{context}"]
+=== Configuring an AWS cluster to use short-term credentials
+
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required AWS resources
+[id="sts-mode-create-aws-resources-ccoctl_{context}"]
+==== Creating AWS resources with the Cloud Credential Operator utility
+
+You have the following options when creating AWS resources:
+
+* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#cco-ccoctl-creating-at-once_installing-aws-specialized-region[Creating AWS resources with a single command].
+
+* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#cco-ccoctl-creating-individually_installing-aws-specialized-region[Creating AWS resources individually].
+
+//Task part 2a: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+
+//Task part 2b: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
+
+[id="next-steps_{context}"]
+== Next steps
+
+* xref:../../../installing/validation_and_troubleshooting/validating-an-installation.adoc#validating-an-installation[Validating an installation].
+* xref:../../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
+* If necessary, you can xref:../../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../../post_installation_configuration/changing-cloud-credentials-configuration.adoc#manually-removing-cloud-creds_changing-cloud-credentials-configuration[remove cloud provider credentials].

--- a/installing/installing_aws/preparing-to-install-on-aws.adoc
+++ b/installing/installing_aws/preparing-to-install-on-aws.adoc
@@ -25,7 +25,7 @@ You can install a cluster on AWS infrastructure that is provisioned by the {prod
 
 * **xref:../../installing/installing_aws/ipi/installing-aws-private.adoc#installing-aws-private[Installing a private cluster on an existing VPC]**: You can install a private cluster on an existing AWS VPC. You can use this method to deploy {product-title} on an internal network that is not visible to the internet.
 
-* **xref:../../installing/installing_aws/ipi/installing-aws-government-region.adoc#installing-aws-government-region[Installing a cluster on AWS into a government or secret region]**: {product-title} can be deployed into AWS regions that are specifically designed for US government agencies at the federal, state, and local level, as well as contractors, educational institutions, and other US customers that must run sensitive workloads in the cloud.
+* **xref:../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-specialized-region[Installing a cluster on AWS into a government or secret region]**: {product-title} can be deployed into AWS regions that are specifically designed for US government agencies at the federal, state, and local level, as well as contractors, educational institutions, and other US customers that must run sensitive workloads in the cloud.
 
 [id="choosing-an-method-to-install-ocp-on-aws-user-provisioned"]
 == Installing a cluster on user-provisioned infrastructure

--- a/installing/overview/installing-preparing.adoc
+++ b/installing/overview/installing-preparing.adoc
@@ -81,7 +81,7 @@ If you want to prevent your cluster on a public cloud from exposing endpoints ex
 If you need to install your cluster that has limited access to the internet, such as a disconnected or restricted network cluster, you can xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[mirror the installation packages] and install the cluster from them. Follow detailed instructions for user-provisioned infrastructure installations into restricted networks for xref:../../installing/installing_aws/upi/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[AWS], xref:../../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[GCP], xref:../../installing/installing_ibm_z/upi/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[{ibm-z-name} or {ibm-linuxone-name}], xref:../../installing/installing_ibm_z/upi/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[{ibm-z-name} or {ibm-linuxone-name} with {op-system-base} KVM], xref:../../installing/installing_ibm_z/upi/installing-restricted-networks-ibm-z-lpar.adoc#installing-restricted-networks-ibm-z-lpar[{ibm-z-name} or {ibm-linuxone-name} in an LPAR], xref:../../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[{ibm-power-name}], xref:../../installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[vSphere], or xref:../../installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[bare metal]. You can also install a cluster into a restricted network using installer-provisioned infrastructure by following detailed instructions for xref:../../installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[AWS], xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[GCP], xref:../../installing/installing_ibm_cloud/installing-ibm-cloud-restricted.adoc#installing-ibm-cloud-restricted[{ibm-cloud-name}], xref:../../installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc#installing-restricted-networks-nutanix-installer-provisioned[Nutanix], xref:../../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[{rh-openstack}], and xref:../../installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[vSphere].
 
 
-If you need to deploy your cluster to an xref:../../installing/installing_aws/ipi/installing-aws-government-region.adoc#installing-aws-government-region[AWS GovCloud region], xref:../../installing/installing_aws/ipi/installing-aws-china.adoc#installing-aws-china-region[AWS China region], or xref:../../installing/installing_azure/ipi/installing-azure-government-region.adoc#installing-azure-government-region[Azure government region], you can configure those custom regions during an installer-provisioned infrastructure installation.
+If you need to deploy your cluster to an xref:../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-specialized-region[AWS GovCloud region], xref:../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-specialized-region[AWS China region], or xref:../../installing/installing_azure/ipi/installing-azure-government-region.adoc#installing-azure-government-region[Azure government region], you can configure those custom regions during an installer-provisioned infrastructure installation.
 
 ifndef::openshift-origin[]
 You can also configure the cluster machines to use the {op-system-base} cryptographic libraries that have been submitted to NIST for xref:../../installing/overview/installing-fips.adoc#installing-fips[FIPS 140-2/140-3 Validation] during installation.
@@ -245,7 +245,7 @@ ifndef::openshift-origin[]
 |xref:../../installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc#installing-ibm-powervs-vpc[&#10003;]
 
 |Government regions
-|xref:../../installing/installing_aws/ipi/installing-aws-government-region.adoc#installing-aws-government-region[&#10003;]
+|xref:../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-specialized-region[&#10003;]
 |
 |xref:../../installing/installing_azure/ipi/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
 |
@@ -263,7 +263,7 @@ ifndef::openshift-origin[]
 |
 
 |Secret regions
-|xref:../../installing/installing_aws/ipi/installing-aws-secret-region.adoc#installing-aws-secret-region[&#10003;]
+|xref:../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-specialized-region[&#10003;]
 |
 |
 |
@@ -281,7 +281,7 @@ ifndef::openshift-origin[]
 |
 
 |China regions
-|xref:../../installing/installing_aws/ipi/installing-aws-china.adoc#installing-aws-china-region[&#10003;]
+|xref:../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-specialized-region[&#10003;]
 |
 |
 |
@@ -385,7 +385,7 @@ ifdef::openshift-origin[]
 |
 
 |Government regions
-|xref:../../installing/installing_aws/ipi/installing-aws-government-region.adoc#installing-aws-government-region[&#10003;]
+|xref:../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-specialized-region[&#10003;]
 |xref:../../installing/installing_azure/ipi/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
 |
 |
@@ -398,7 +398,7 @@ ifdef::openshift-origin[]
 |
 
 |Secret regions
-|xref:../../installing/installing_aws/ipi/installing-aws-secret-region.adoc#installing-aws-secret-region[&#10003;]
+|xref:../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-specialized-region[&#10003;]
 |
 |
 |
@@ -411,7 +411,7 @@ ifdef::openshift-origin[]
 |
 
 |China regions
-|xref:../../installing/installing_aws/ipi/installing-aws-china.adoc#installing-aws-china-region[&#10003;]
+|xref:../../installing/installing_aws/ipi/installing-aws-specialized-region.adoc#installing-aws-specialized-region[&#10003;]
 |
 |
 |

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -77,6 +77,9 @@ endif::[]
 ifeval::["{context}" == "installing-aws-secret-region"]
 :aws-sts:
 endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:aws-sts:
+endif::[]
 ifeval::["{context}" == "installing-aws-china-region"]
 :aws-sts:
 endif::[]
@@ -284,6 +287,9 @@ ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisione
 endif::[]
 ifeval::["{context}" == "installing-aws-vpc"]
 :!aws-sts:
+endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:aws-sts:
 endif::[]
 ifeval::["{context}" == "installing-aws-private"]
 :!aws-sts:

--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -37,6 +37,9 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
 :aws-sts:
 endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:aws-sts:
+endif::[]
 ifeval::["{context}" == "installing-aws-vpc"]
 :aws-sts:
 endif::[]
@@ -326,6 +329,9 @@ ifeval::["{context}" == "installing-aws-private"]
 :!aws-sts:
 endif::[]
 ifeval::["{context}" == "installing-aws-government-region"]
+:!aws-sts:
+endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
 :!aws-sts:
 endif::[]
 ifeval::["{context}" == "installing-aws-secret-region"]

--- a/modules/installation-aws-marketplace-government.adoc
+++ b/modules/installation-aws-marketplace-government.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-specialized-regions.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installation-aws-marketplace-government_{context}"]
+= Installation requirements for government regions
+If you are deploying an {product-title} cluster using an AWS Marketplace image in a government region, you must first subscribe through {aws-short}. Subscribing to the offer provides you with the AMI ID that the installation program uses to deploy compute nodes.
+
+:platform-abbreviation: an AWS
+:platform-abbreviation-short: AWS
+[NOTE]
+====
+include::snippets/installation-marketplace-note.adoc[]
+====
+
+.Prerequisites
+
+* You have an {aws-short} account to purchase the offer. This account does not have to be the same account that is used to install the cluster.
+
+.Procedure
+
+. Complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace].
+
+. Record the AMI ID for your specific AWS Region. As part of the installation process, you must update the `install-config.yaml` file with this value before deploying the cluster.

--- a/modules/installation-aws-regions-with-no-ami.adoc
+++ b/modules/installation-aws-regions-with-no-ami.adoc
@@ -1,26 +1,22 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
-// * installing/installing_aws/installing-aws-secret-region.adoc
+// * installing/installing_aws/installing-aws-specialized-region.adoc
 
-ifeval::["{context}" == "installing-aws-china-region"]
-:aws-china:
-endif::[]
-ifeval::["{context}" == "installing-aws-secret-region"]
-:aws-secret:
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:specialized:
 endif::[]
 
 [id="installation-aws-regions-with-no-ami_{context}"]
-ifndef::aws-china,aws-secret[]
+ifndef::specialized[]
 = AWS regions without a published {op-system} AMI
-endif::aws-china,aws-secret[]
+endif::specialized[]
 
-ifdef::aws-china,aws-secret[]
-= Installation requirements
-endif::aws-china,aws-secret[]
+ifdef::specialized[]
+= Installation requirements for China, Secret, and Top Secret regions
+endif::specialized[]
 
-ifndef::aws-china,aws-secret[]
+ifndef::specialized[]
 You can deploy an {product-title} cluster to Amazon Web Services (AWS) regions
 without native support for a {op-system-first} Amazon Machine Image (AMI) or the
 AWS software development kit (SDK). If a
@@ -39,13 +35,12 @@ A region without native support for an {op-system} AMI is not available to
 select from the terminal during cluster creation because it is not published.
 However, you can install to this region by configuring the custom AMI in the
 `install-config.yaml` file.
-endif::aws-china,aws-secret[]
+endif::specialized[]
 
-ifdef::aws-china,aws-secret[]
-ifdef::aws-china[Red Hat does not publish a {op-system-first} Amazon Machine Image (AMI) for the AWS China regions.]
-ifdef::aws-secret[Red Hat does not publish a {op-system-first} Amzaon Machine Image for the AWS Secret and Top Secret Regions.]
+ifdef::specialized[]
+Red Hat does not publish a {op-system-first} Amazon Machine Image (AMI) for the AWS China, Secret, or Top Secret regions.
 
-Before you can install the cluster, you must:
+Before you can install a cluster into one of these regions, you must:
 
 * Upload a custom {op-system} AMI.
 * Manually create the installation configuration file (`install-config.yaml`).
@@ -53,18 +48,13 @@ Before you can install the cluster, you must:
 
 You cannot use the {product-title} installation program to create the installation configuration file. The installer does not list an AWS region without native support for an {op-system} AMI.
 
-ifdef::aws-secret[]
 [IMPORTANT]
 ====
-You must also define a custom CA certificate in the `additionalTrustBundle` field of the `install-config.yaml` file because the AWS API requires a custom CA trust bundle. To allow the installation program to access the AWS API, the CA certificates must also be defined on the machine that runs the installation program. You must add the CA bundle to the trust store on the machine, use the `AWS_CA_BUNDLE` environment variable, or define the CA bundle in the link:https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-ca_bundle.html[`ca_bundle`] field of the AWS config file.
+If you install a cluster into a Secret or Top Secret region, you must also define a custom CA certificate in the `additionalTrustBundle` field of the `install-config.yaml` file because the AWS API requires a custom CA trust bundle. To allow the installation program to access the AWS API, the CA certificates must also be defined on the machine that runs the installation program. You must add the CA bundle to the trust store on the machine, use the `AWS_CA_BUNDLE` environment variable, or define the CA bundle in the link:https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-ca_bundle.html[`ca_bundle`] field of the AWS config file.
 ====
-endif::aws-secret[]
 
-endif::aws-china,aws-secret[]
+endif::specialized[]
 
-ifeval::["{context}" == "installing-aws-china-region"]
-:!aws-china:
-endif::[]
-ifeval::["{context}" == "installing-aws-secret-region"]
-:!aws-secret:
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:!specialized:
 endif::[]

--- a/modules/installation-aws-upload-custom-rhcos-ami.adoc
+++ b/modules/installation-aws-upload-custom-rhcos-ami.adoc
@@ -1,14 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/installing-aws-secret-region.adoc
-// * installing/installing_aws/installing-aws-china.adoc
-
-ifeval::["{context}" == "installing-aws-china-region"]
-:aws-china:
-endif::[]
-ifeval::["{context}" == "installing-aws-government-region"]
-:aws-gov:
-endif::[]
+// * installing/installing_aws/installing-aws-specialized-region.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-aws-upload-custom-rhcos-ami_{context}"]
@@ -38,8 +30,7 @@ link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Instal
 ----
 $ export AWS_PROFILE=<aws_profile> <1>
 ----
-ifdef::aws-gov[<1> The AWS profile name that holds your AWS credentials, like `govcloud`.]
-ifdef::aws-china[<1> The AWS profile name that holds your AWS credentials, like `beijingadmin`.]
+<1> The AWS profile name that holds your AWS credentials, like `govcloud` or `beijingadmin`.
 
 . Export the region to associate with your custom AMI as an environment
 variable:
@@ -48,8 +39,7 @@ variable:
 ----
 $ export AWS_DEFAULT_REGION=<aws_region> <1>
 ----
-ifdef::aws-gov[<1> The AWS region, like `us-gov-east-1`.]
-ifdef::aws-china[<1> The AWS region, like `cn-north-1`.]
+<1> The AWS region, like `us-gov-east-1` or `cn-north-1`.
 
 . Export the version of {op-system} you uploaded to Amazon S3 as an environment
 variable:
@@ -155,10 +145,3 @@ endif::openshift-origin[]
 To learn more about these APIs, see the AWS documentation for
 link:https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-import-snapshot.html[importing snapshots]
 and link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/creating-an-ami-ebs.html#creating-launching-ami-from-snapshot[creating EBS-backed AMIs].
-
-ifeval::["{context}" == "installing-aws-china-region"]
-:!aws-china:
-endif::[]
-ifeval::["{context}" == "installing-aws-government-region"]
-:!aws-gov:
-endif::[]

--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -66,6 +66,9 @@ endif::[]
 ifeval::["{context}" == "installing-aws-customizations"]
 :aws:
 endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:aws:
+endif::[]
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :aws:
 endif::[]
@@ -241,6 +244,9 @@ ifeval::["{context}" == "installing-aws-private"]
 :!aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-vpc"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
 :!aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-user-infra"]

--- a/modules/installation-custom-aws-vpc.adoc
+++ b/modules/installation-custom-aws-vpc.adoc
@@ -15,6 +15,10 @@ endif::[]
 ifeval::["{context}" == "installing-aws-secret-region"]
 :aws-secret:
 endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:aws-secret:
+:aws-china:
+endif::[]
 ifeval::["{context}" == "installing-aws-outposts-remote-workers"]
 :aws-outposts:
 endif::[]
@@ -126,6 +130,7 @@ ifndef::aws-china,aws-secret[]
 endif::aws-china,aws-secret[]
 
 ifdef::aws-china[]
+China::
 * `ec2.<aws_region>.amazonaws.com.cn`
 * `elasticloadbalancing.<aws_region>.amazonaws.com`
 * `s3.<aws_region>.amazonaws.com`
@@ -161,6 +166,7 @@ ifndef::aws-china,aws-secret[]
 endif::aws-china,aws-secret[]
 
 ifdef::aws-china[]
+China::
 * `ec2.<aws_region>.amazonaws.com.cn`
 * `elasticloadbalancing.<aws_region>.amazonaws.com`
 * `s3.<aws_region>.amazonaws.com`
@@ -301,4 +307,8 @@ ifeval::["{context}" == "installing-aws-secret-region"]
 endif::[]
 ifeval::["{context}" == "installing-aws-outposts-remote-workers"]
 :!aws-outposts:
+endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:!aws-secret:
+:!aws-china:
 endif::[]

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -6,6 +6,7 @@
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-private.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc
+// * installing/installing_aws/installing-aws-specialized-region.adoc
 // * installing/installing-aws-localzone.adoc
 // * installing/installing-aws-wavelength-zone.adoc
 // * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -58,6 +59,10 @@ ifeval::["{context}" == "installing-aws-china-region"]
 :aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-government-region"]
+:custom-config:
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
 :custom-config:
 :aws:
 endif::[]
@@ -541,6 +546,10 @@ ifeval::["{context}" == "installing-aws-government-region"]
 :!aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-secret-region"]
+:!custom-config:
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
 :!custom-config:
 :!aws:
 endif::[]

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -69,6 +69,10 @@ ifeval::["{context}" == "installing-aws-secret-region"]
 :aws:
 :cco-multi-mode:
 endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:aws:
+:cco-multi-mode:
+endif::[]
 ifeval::["{context}" == "installing-aws-china-region"]
 :aws:
 :cco-multi-mode:
@@ -360,6 +364,10 @@ ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisione
 :!cco-multi-mode:
 endif::[]
 ifeval::["{context}" == "installing-aws-vpc"]
+:!aws:
+:!cco-multi-mode:
+endif::[]
+ifeval::["{context}" == "installing-aws-specialized-region"]
 :!aws:
 :!cco-multi-mode:
 endif::[]

--- a/modules/private-clusters-default.adoc
+++ b/modules/private-clusters-default.adoc
@@ -1,9 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/installing-aws-china.adoc
-// * installing/installing_aws/installing-aws-government-region.adoc
 // * installing/installing_aws/installing-aws-private.adoc
-// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_gcp/installing-gcp-private.adoc
 // * installing/installing_azure/installing-azure-government-region.adoc
 // * installing/installing_azure/installing-azure-private.adoc
@@ -12,16 +9,8 @@
 [id="private-clusters-default_{context}"]
 = Private clusters
 
-ifeval::["{context}" == "installing-aws-government-region"]
-:aws-gov:
-endif::[]
-
-ifeval::["{context}" == "installing-aws-china-region"]
-:aws-china:
-endif::[]
-
-ifeval::["{context}" == "installing-aws-secret-region"]
-:aws-secret:
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:aws-specialized:
 endif::[]
 
 ifeval::["{context}" == "installing-ibm-cloud-private"]
@@ -34,21 +23,13 @@ endif::[]
 
 You can deploy a private {product-title} cluster that does not expose external endpoints. Private clusters are accessible from only an internal network and are not visible to the internet.
 
-ifdef::aws-gov[]
+ifdef::aws-specialized[]
 [NOTE]
 ====
-Public zones are not supported in Route 53 in an AWS GovCloud Region. Therefore, clusters
-must be private if they are deployed to an AWS GovCloud Region.
+Public zones are not supported in Route 53 in {aws-short} Government, Secret, and Top Secret regions. Therefore, clusters must be private if they are deployed to one of these regions.
 ====
-endif::aws-gov[]
+endif::aws-specialized[]
 
-ifdef::aws-secret[]
-[NOTE]
-====
-Public zones are not supported in Route 53 in an AWS Top Secret Region. Therefore, clusters
-must be private if they are deployed to an AWS Top Secret Region.
-====
-endif::aws-secret[]
 By default, {product-title} is provisioned to use publicly-accessible DNS and endpoints. A private cluster sets the DNS, Ingress Controller, and API server to private when you deploy your cluster. This means that the cluster resources are only accessible from your internal network and are not visible to the internet.
 
 include::snippets/snip-private-clusters-public-ingress.adoc[]
@@ -69,32 +50,17 @@ endif::ibm-cloud-private,ibm-power-vs-private[]
 ** The hosts on the network that you provision.
 ** The internet to obtain installation media.
 
-ifndef::aws-china[]
-You can use any machine that meets these access requirements and follows your company's guidelines. For example, this machine can be a bastion host on your cloud network or a machine that has access to the network through a VPN.
-endif::aws-china[]
-
-ifdef::aws-china[]
+ifdef::aws-specialized[]
 You can use any machine that meets these access requirements and follows your company's guidelines. For example, this machine can be a bastion host on your cloud network.
-endif::aws-china[]
 
-ifdef::aws-china[]
 [NOTE]
 ====
 AWS China does not support a VPN connection between the VPC and your network. For more information about the Amazon VPC service in the Beijing and Ningxia regions, see link:https://docs.amazonaws.cn/en_us/aws/latest/userguide/vpc.html[Amazon Virtual Private Cloud] in the AWS China documentation.
-
 ====
-endif::aws-china[]
+endif::aws-specialized[]
 
-ifeval::["{context}" == "installing-aws-government-region"]
-:!aws-gov:
-endif::[]
-
-ifeval::["{context}" == "installing-aws-china-region"]
-:!aws-china:
-endif::[]
-
-ifeval::["{context}" == "installing-aws-secret-region"]
-:!aws-secret:
+ifeval::["{context}" == "installing-aws-specialized-region"]
+:!aws-specialized:
 endif::[]
 
 ifeval::["{context}" == "installing-ibm-cloud-private"]


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-15031

Link to docs preview:
https://95131--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-specialized-region

QE review:
- [x] QE has approved this change.


This PR is combining the AWS China, Secret/Top Secret, and Government install assemblies into one "specialized regions" assembly. The main goal is to reduce the number of assemblies and total amount of doc, as most of the content in these three assemblies is identical.