### PR TITLE
OSDOCS#14999: Update the z-stream release notes for 4.19.1

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2807,6 +2807,56 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.19.1
+[id="ocp-4-19-1_{context}"]
+=== RHSA-2025:9278 - {product-title} {product-version}.1 image release, bug fix, and security update advisory
+
+Issued: 24 June 2025
+
+{product-title} release {product-version}.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:9278[RHSA-2025:9278] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:9279[RHSA-2025:9279] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.1 --pullspecs
+----
+
+[id="ocp-4-19-1-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when you added vCenter cloud credentials for the post installation of the {ai-full}, a bug was triggered because of an invalid `ConfigMap` object for the cloud provider configuration. As a result, a `missing vcenterplaceholder` error was displayed. With this release, the `ConfigMap` data is correct, and the error is not displayed. (link:https://issues.redhat.com/browse/OCPBUGS-57384[OCPBUGS-57384])
+
+* Previously, a network issue during an API call in a cluster caused a timeout in {olmv0-first}. As a consequence, Operator installations often failed because of timeout issues. With this release, the catalog cache refresh interval is updated to resolve timeout issues. As a result, the likelihood of Operator installation timeouts is reduced. (link:https://issues.redhat.com/browse/OCPBUGS-57352[OCPBUGS-57352])
+
+* Previously, Operator group reconciliation in {olmv0-first} triggered unnecessary `ClusterRole` updates because of the changing order of aggregation rule selectors. As a result, unnecessary API server writes occurred. With this release, a bug fix ensures the deterministic order of a `ClusterRoleSelectors` array in the aggregation rule, reducing unnecessary API server writes and improving cluster stability. (link:https://issues.redhat.com/browse/OCPBUGS-57279[OCPBUGS-57279])
+
+* Previously, ignoring the `AdditionalTrustBundlePolicy` setting in the assisted-service's installation configuration led to Federal Information Processing Standard (FIPS) and other installation configuration overrides. With this release, the installation configuration includes an `AdditionalTrustBundlePolicy` field, which you can set to ensure that FIPS and other installation configuration overrides function as intended. (link:https://issues.redhat.com/browse/OCPBUGS-57208[OCPBUGS-57208])
+
+* Previously, the authentication process for the `/metrics` endpoint was missing a token review check and caused unauthorized requests. As a result, the {product-title} console was prone to `TargetDown` alerts. With this release, the token review for unauthorized requests occurs with the user token provided in the request context. As a result, unauthorized requests to the {product-title} console do not cause `TargetDown` alerts. (link:https://issues.redhat.com/browse/OCPBUGS-57180[OCPBUGS-57180])
+
+* Previously, the *Started* column was hidden when screen size was reduced. As a consequence, the `VirtualizedTable` component malfunctioned because of a missing sort function, and the table sorting functionality was affected on the `PipelineRun` list pages. With this release, the table component handles missing sort functions correctly for reduced screen sizes. (link:https://issues.redhat.com/browse/OCPBUGS-57110[OCPBUGS-57110]) 
+
+* Previously, if you configured a masthead logo for a theme but used the default settings for the rest of the theme, the logo shown on the user interface was inconsistent. With this release, the masthead logo displays a default option for both light and dark themes, improving the interface consistency. (link:https://issues.redhat.com/browse/OCPBUGS-57054[OCPBUGS-57054])
+
+* Previously, the cluster installation failed because of an invalid security group configuration for a Network Load Balancer (NLB). This failure prevented the traffic from both primary subnets for bootstrapping. With this release, the security group allows traffic from both primary subnets for bootstrapping, and the cluster installation does not fail because of security group restrictions on additional primary subnets. (link:https://issues.redhat.com/browse/OCPBUGS-57039[OCPBUGS-57039])
+
+* Previously, users without project access saw an incomplete roles list on the *Roles* page because of improper API group access. With this release, users without project access cannot see an incomplete roles list on the *Roles* page. (link:https://issues.redhat.com/browse/OCPBUGS-56987[OCPBUGS-56987])
+
+* Previously, the `node-image create` command modified directory permissions and caused user directories to lose original permissions during the operation. With this release, the `node-image create` command preserves file permissions during the file-copying process by using the `rsync` tool, and ensures that user directories maintain original permissions during the operation. (link:https://issues.redhat.com/browse/OCPBUGS-56905[OCPBUGS-56905])
+
+* Previously, the `delete` keyword in image names was allowed in the `ImageSetConfiguration` file, which is not supported. As a consequence, users encountered errors while mirroring images. With this release, the error for image names ending with `delete` in the `ImageSetConfiguration` file has been removed. As a result, users can now successfully mirror images with names ending in `delete`. (link:https://issues.redhat.com/browse/OCPBUGS-56798[OCPBUGS-56798])
+
+* Previously, the user interface in the *Observe Alerting* field displayed incorrect alert severity icons for information alerts. With this release, the alert severity icons match in the *Observe Alerting* field. As a result, alert icons match consistently, reducing potential confusion for users. (link:https://issues.redhat.com/browse/OCPBUGS-56470[OCPBUGS-56470])
+
+* Previously, if you used an unauthorized access configuration file in the `oc-mirror` command, an `Unauthorized` error was displayed when you synchronized your image sets. With this release, the Docker configuration is updated to use a custom authorization file for authentication. You can successfully synchronize your image sets without encountering the `Unauthorized` error. (link:https://issues.redhat.com/browse/OCPBUGS-55701[OCPBUGS-55701])
+
+[id="ocp-4-19-1-updating_{context}"]
+==== Updating
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //Update with relevant advisory information
 [id="ocp-4-19-0-ga_{context}"]
 === RHSA-2024:11038 - {product-title} {product-version}.0 image release, bug fix, and security update advisory
@@ -2826,6 +2876,4 @@ $ oc adm release info 4.19.0 --pullspecs
 
 [id="ocp-4-19-0-updating_{context}"]
 ==== Updating
-To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
-
-//replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-14999](https://issues.redhat.com//browse/OSDOCS-14999)

Link to docs preview:
[4.19.1](https://95133--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-1_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream release notes.

Additional information:
The errata URLs will return 404 until the go-live date of 6/24/25.
