### PR TITLE
[RHACS] Minor updates and touchup for 4.8 release notes

### DIFF
--- a/release_notes/48-release-notes.adoc
+++ b/release_notes/48-release-notes.adoc
@@ -27,22 +27,24 @@ toc::[]
 Platform::
 * xref:../release_notes/48-release-notes.adoc#central-db-postgresql_15_release-notes-48[Central DB uses PostgreSQL 15]
 * xref:../release_notes/48-release-notes.adoc#quay-registry-keyless-authentication_release-notes-48[Quay registry keyless authentication]
-* xref:../release_notes/48-release-notes.adoc#openshift-infrastructure-compliance-ga_release-notes-48[OpenShift Infrastructure Compliance is now generally available]
 * xref:../release_notes/48-release-notes.adoc#arm-architecture-support-ga_release-notes-48[ARM architecture support is now generally available]
 * xref:../release_notes/48-release-notes.adoc#view-and-customize-platform-components_release-notes-48[View and customize platform components]
 * xref:../release_notes/48-release-notes.adoc#support-for-keyless-signing-verification_release-notes-48[Support for keyless signing verification]
+
+Compliance::
+* xref:../release_notes/48-release-notes.adoc#openshift-infrastructure-compliance-ga_release-notes-48[OpenShift Infrastructure Compliance is now generally available]
 
 Policy::
 * xref:../release_notes/48-release-notes.adoc#policy-as-code-ga_release-notes-48[Policy as code is now generally available]
 
 Vulnerability Management::
-* xref:../release_notes/48-release-notes.adoc#external-ip-visibility-ga_release-notes-48[External IP visibility is now generally available]
 * xref:../release_notes/48-release-notes.adoc#cve-and-rhsa-separation_release-notes-48[{product-title-short} now reports CVEs and RHSAs as separate entities]
 
 External integrations::
 * xref:../release_notes/48-release-notes.adoc#define-project-scope-for-google-registries_release-notes-48[Optionally define project scope when integrating with Google Registries]
 
 Network::
+* xref:../release_notes/48-release-notes.adoc#external-ip-visibility-ga_release-notes-48[External IP visibility is now generally available]
 * xref:../release_notes/48-release-notes.adoc#build-time-network-policy-tools-enhancements_release-notes-48[Build-time network policy tool enhancements]
 
 [id="new-features_{context}"]
@@ -151,6 +153,8 @@ Additionally, Fulcio integrates with OIDC Identity Providers to exchange a user'
 The external IP visibility feature is now generally available. This enhancement provides crucial insight into your cluster's external communications. You can now visualize the exact external IP addresses your deployments communicate with. This improves your ability to understand external connections, identify potential threats, and validate network policies.
 
 By default, this feature is disabled. However, when enabled, you see external IPs in the Network Graph. Additionally, Unauthorized Network Flow violations automatically include detailed external IP information, which streamlines your investigation process.
+
+For more information, see xref:../operating/visualizing-external-entities.adoc#visualizing-external-entities[Visualizing external entities].
 
 //ROX-26476
 [id="cve-and-rhsa-separation_{context}"]


### PR DESCRIPTION
Minor updates based on the following Slack convo:
```
In the section for: “External IP visibility is now generally available” 
it would be good if you add ‘For more details….’ and a link to the docs
 where it describes the feature and how to enable it
And it should be under “Network” section and now under “Vuln. Management” 

[OpenShift Infrastructure Compliance is now generally available] maybe 
deserves it’s own section called “Compliance” in the summary
```