### PR TITLE
OCPBUGS#49997: Enhanced the info for the k8s.v1.cni.cncf.io/policy-fo…

### DIFF
--- a/modules/configuration-ovnk-multi-network-policy.adoc
+++ b/modules/configuration-ovnk-multi-network-policy.adoc
@@ -26,7 +26,7 @@ a|
 
 |====
 
-For example, the following multi-network policy is valid only if the `subnets` field is defined in the secondary network CNI configuration for the secondary network named `blue2`:
+You can use the `k8s.v1.cni.cncf.io/policy-for` annotation on a `MultiNetworkPolicy` object to point to a `NetworkAttachmentDefinition` (NAD) custom resource (CR). The NAD CR defines the network to which the policy applies. The following example multi-network policy is valid only if the `subnets` field is defined in the secondary network CNI configuration for the secondary network named `blue2`:
 
 .Example multi-network policy that uses a pod selector
 [source,yaml]
@@ -36,7 +36,7 @@ kind: MultiNetworkPolicy
 metadata:
   name: allow-same-namespace
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: blue2
+    k8s.v1.cni.cncf.io/policy-for: blue2 <1>
 spec:
   podSelector:
   ingress:

--- a/modules/nw-multi-network-policy-differences.adoc
+++ b/modules/nw-multi-network-policy-differences.adoc
@@ -18,19 +18,21 @@ kind: MultiNetworkPolicy
 
 * You must use the `multi-networkpolicy` resource name when using the CLI to interact with multi-network policies. For example, you can view a multi-network policy object with the `oc get multi-networkpolicy <name>` command where `<name>` is the name of a multi-network policy.
 
-* You must specify an annotation with the name of the network attachment definition that defines the secondary network:
+* You can use the `k8s.v1.cni.cncf.io/policy-for` annotation on a `MultiNetworkPolicy` object to point to a `NetworkAttachmentDefinition` (NAD) custom resource (CR). The NAD CR defines the network to which the policy applies.
 +
+.Example multi-network policy that includes the `k8s.v1.cni.cncf.io/policy-for` annotation
 [source,yaml]
 ----
 apiVersion: k8s.cni.cncf.io/v1beta1
 kind: MultiNetworkPolicy
 metadata:
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: <network_name>
+    k8s.v1.cni.cncf.io/policy-for:<namespace_name>/<network_name>
 ----
 +
 --
 where:
 
+`<namespace_name>`:: Specifies the namespace name.
 `<network_name>`:: Specifies the name of a network attachment definition.
 --

--- a/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
+++ b/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
@@ -54,7 +54,7 @@ metadata:
   namespace: default
 ifdef::multi[]
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: <network_name>
+    k8s.v1.cni.cncf.io/policy-for:<namespace_name>/<network_name>
 endif::multi[]
 spec:
   podSelector:

--- a/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
+++ b/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
@@ -57,7 +57,7 @@ metadata:
   namespace: default
 ifdef::multi[]
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: <network_name>
+    k8s.v1.cni.cncf.io/policy-for:<namespace_name>/<network_name>
 endif::multi[]
 spec:
   podSelector:

--- a/modules/nw-networkpolicy-allow-external-clients.adoc
+++ b/modules/nw-networkpolicy-allow-external-clients.adoc
@@ -61,7 +61,7 @@ metadata:
   namespace: default
 ifdef::multi[]
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: <network_name>
+    k8s.v1.cni.cncf.io/policy-for:<namespace_name>/<network_name>
 endif::multi[]
 spec:
   policyTypes:

--- a/modules/nw-networkpolicy-create-cli.adoc
+++ b/modules/nw-networkpolicy-create-cli.adoc
@@ -104,7 +104,7 @@ metadata:
   name: allow-same-namespace
 ifdef::multi[]
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: <network_name>
+    k8s.v1.cni.cncf.io/policy-for:<namespace_name>/<network_name>
 endif::multi[]
 spec:
   podSelector:
@@ -139,7 +139,7 @@ metadata:
   name: allow-traffic-pod
 ifdef::multi[]
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: <network_name>
+    k8s.v1.cni.cncf.io/policy-for:<namespace_name>/<network_name>
 endif::multi[]
 spec:
   podSelector:
@@ -186,7 +186,7 @@ metadata:
   name: api-allow
 ifdef::multi[]
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: <network_name>
+    k8s.v1.cni.cncf.io/policy-for:<namespace_name>/<network_name>
 endif::multi[]
 spec:
   podSelector:

--- a/modules/nw-networkpolicy-deny-all-allowed.adoc
+++ b/modules/nw-networkpolicy-deny-all-allowed.adoc
@@ -46,7 +46,7 @@ metadata:
   name: deny-by-default
   namespace: my-project <1>
   annotations:
-    k8s.v1.cni.cncf.io/policy-for: <namespace_name>/<network_name> <2>
+    k8s.v1.cni.cncf.io/policy-for:<namespace_name>/<network_name> <2>
 spec:
   podSelector: {} <3>
   policyTypes: <4>
@@ -66,7 +66,7 @@ endif::multi[]
 ----
 ifdef::multi[]
 <1> Specifies the namespace in which to deploy the policy. For example, the `my-project` namespace.
-<2> Specifies the name of a network attachment definition.
+<2> Specifies the name of namespace project followed by the network attachment definition name.
 <3> If this field is empty, the configuration matches all the pods. Therefore, the policy applies to all pods in the `my-project` namespace.
 <4> Specifies a list of rule types that the `NetworkPolicy` relates to.
 <5> Specifies `Ingress` only `policyTypes`.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-49997](https://issues.redhat.com/browse/OCPBUGS-49997)

Link to docs preview:
* [Compatibility with multi-network policy](https://95148--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.html#compatibility-with-multi-network-policy_configuring-additional-network-ovnk)
* [Differences between multi-network policy and network policy](https://95148--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.html#nw-multi-network-policy-differences_configuring-multi-network-policy)

- [x] SME has approved this change (Miguel Barroso).
- [x] QE has approved this change (Weibin Liang).
