### PR TITLE
OCPBUGS#44329-15: Added a release note for the removal of the  Networ…

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1497,6 +1497,11 @@ To view information about the integrated {product-registry}, run `oc get imagest
 
 {product-title} {product-version} has removed support for the `OPENSHIFT_DEFAULT_REGISTRY` variable. This variable was primarily used to enable backwards compatibility of the internal image registry for earlier setups. The `REGISTRY_OPENSHIFT_SERVER_ADDR` variable can be used in its place.
 
+[id="ocp-4-15-removed-networkpolicystatus"]
+==== Removal of the status field from the NetworkPolicy API
+
+{product-title} {product-version} has removed support for the `status` field from the `NetworkPolicy` object. If you need to check the status information of network policies, you can use the observeability function of your container network interface (CNI) plug-in or monitor logs and events from CNI controller pods.
+
 //.APIs removed from Kubernetes 1.27
 //[cols="2,2,2",options="header",]
 //|===


### PR DESCRIPTION
[CM](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r5741682856885294593) sent on the fourth of July.

Version(s):
4.15

Issue:
[OCPBUGS-44329](https://issues.redhat.com/browse/OCPBUGS-44329)

Link to docs preview:
* [Removal of the NetworkPolicyStatus property](https://95158--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-removed-networkpolicystatus)

- [x] SME has approved this change (David Hernandez Fernandez: approval on the Jira because of GitHub access issues).
- [x] QE has approved this change (Arnab Ghosh).
* [NetworkPolicy API doc](https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html-single/network_apis/index#networkpolicy-networking-k8s-io-v1)
