### PR TITLE
Redo-OSDOCS-14786 [NETOBSERV] Add section for IPSec

### DIFF
--- a/modules/network-observability-con_filter-network-flows-at-ingestion.adoc
+++ b/modules/network-observability-con_filter-network-flows-at-ingestion.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+
+// * networking/network_observability/configuring-operators.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-filter-network-flows-at-ingestion_{context}"]
+= Filter network flows at ingestion
+
+You can create filters to reduce the number of generated network flows. Filtering network flows can reduce the resource usage of the Network Observability components.
+
+You can configure two kinds of filters:
+
+* eBPF agent filters
+* Flowlogs-pipeline filters
+
+[id="ebpf-agent-filters_{context}"]
+== eBPF agent filters
+
+eBPF agent filters maximize performance because they take effect at the earliest stage of the network flows collection process.
+
+To configure eBPF agent filters with the Network Observability Operator, see "Filtering eBPF flow data using multiple rules".
+
+[id="flowlogs-pipeline-filters_{context}"]
+== Flowlogs-pipeline filters
+
+Flowlogs-pipeline filters provide greater control over traffic selection because they take effect later in the network flows collection process. They are primarily used to improve data storage.
+
+Flowlogs-pipeline filters use a simple query language to filter network flow, as shown in the following example:
+
+[source,terminal]
+----
+(srcnamespace="netobserv" OR (srcnamespace="ingress" AND dstnamespace="netobserv")) AND srckind!="service"
+----
+
+The query language uses the following syntax:
+
+.Query language syntax
+[cols="1,3", options="header"]
+|===
+| Category
+| Operators
+
+| Logical boolean operators (not case-sensitive)
+| `and`, `or`
+
+| Comparison operators
+| `=` (equals), +
+`!=` (not equals), +
+`=~` (matches regexp), +
+`!~` (not matches regexp), +
+`<` / `\<=` (less than or equal to), +
+`>` / `>=` (greater than or equal to)
+
+| Unary operations
+| `with(field)` (field is present), +
+`without(field)` (field is absent)
+
+| Parenthesis-based priority
+|===
+
+You can configure flowlogs-pipeline filters in the `spec.processor.filters` section of the `FlowCollector` resource. For example:
+
+.Example YAML Flowlogs-pipeline filter
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  namespace: netobserv
+  agent:
+  processor:
+    filters:
+      - query: |
+          (SrcK8S_Namespace="netobserv" OR (SrcK8S_Namespace="openshift-ingress" AND DstK8S_Namespace="netobserv"))
+        outputTarget: Loki  <1>
+        sampling: 10  <2>
+----
+<1> Sends matching flows to a specific output, such as Loki, Prometheus, or an external system. When omitted, sends to all configured outputs.
+<2> Optional. Applies a sampling ratio to limit the number of matching flows to be stored or exported. For example, `sampling: 10` means 1/10 of the flows are kept.

--- a/modules/network-observability-con_user-defined-networks.adoc
+++ b/modules/network-observability-con_user-defined-networks.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-user-defined-networks_{context}"]
+= User-defined networks
+
+User-defined networks (UDN) improve the flexibility and segmentation capabilities of the default Layer 3 topology for a Kubernetes pod network by enabling custom Layer 2 and Layer 3 network segments, where all these segments are isolated by default. These segments act as primary or secondary networks for container pods and virtual machines that use the default OVN-Kubernetes CNI plugin.
+
+UDNs enable a wide range of network architectures and topologies, enhancing network flexibility, security, and performance.
+
+When the `UDNMapping` feature is enabled with Network Observability, the *Traffic* flow table has a *UDN labels* column. You can filter on *Source Network Name* and *Destination Network Name*.

--- a/modules/network-observability-ebpf-rule-flow-filter.adoc
+++ b/modules/network-observability-ebpf-rule-flow-filter.adoc
@@ -5,13 +5,15 @@
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-ebpf-flow-rule-filter_{context}"]
 = eBPF flow rule filter
-You can use rule-based filtering to control the volume of packets cached in the eBPF flow table. For example, a filter can specify that only packets coming from port 100 should be recorded. Then only the packets that match the filter are cached and the rest are not cached. 
+You can use rule-based filtering to control the volume of packets cached in the eBPF flow table. For example, a filter can specify that only packets coming from port 100 should be captured. Then only the packets that match the filter are captured and the rest are dropped.
+
+You can apply multiple filter rules.
 
 [id="ingress-and-egress-traffic-filtering_{context}"]
 == Ingress and egress traffic filtering
-CIDR notation efficiently represents IP address ranges by combining the base IP address with a prefix length. For both ingress and egress traffic, the source IP address is first used to match filter rules configured with CIDR notation. If there is a match, then the filtering proceeds. If there is no match, then the destination IP is used to match filter rules configured with CIDR notation. 
+Classless Inter-Domain Routing (CIDR) notation efficiently represents IP address ranges by combining the base IP address with a prefix length. For both ingress and egress traffic, the source IP address is first used to match filter rules configured with CIDR notation. If there is a match, then the filtering proceeds. If there is no match, then the destination IP is used to match filter rules configured with CIDR notation.
 
-After matching either the source IP or the destination IP CIDR, you can pinpoint specific endpoints using the `peerIP` to differentiate the destination IP address of the packet. Based on the provisioned action, the flow data is either cached in the eBPF flow table or not cached. 
+After matching either the source IP or the destination IP CIDR, you can pinpoint specific endpoints using the `peerIP` to differentiate the destination IP address of the packet. Based on the provisioned action, the flow data is either cached in the eBPF flow table or not cached.
 
 [id="dashboard-and-metrics-integrations_{context}"]
 == Dashboard and metrics integrations

--- a/modules/network-observability-filtering-ebpf-rule.adoc
+++ b/modules/network-observability-filtering-ebpf-rule.adoc
@@ -8,7 +8,7 @@ You can configure the `FlowCollector` custom resource to filter eBPF flows using
 
 [IMPORTANT]
 ====
-* You cannot use duplicate CIDRs in filter rules.
+* You cannot use duplicate Classless Inter-Domain Routing (CIDRs) in filter rules.
 * When an IP address matches multiple filter rules, the rule with the most specific CIDR prefix (longest prefix) takes precedence.
 ====
 

--- a/modules/network-observability-filtering-ebpf-rule.adoc
+++ b/modules/network-observability-filtering-ebpf-rule.adoc
@@ -1,22 +1,28 @@
 // Module included in the following assemblies:
-//
 // network_observability/observing-network-traffic.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-filtering-ebpf-rule_{context}"]
-= Filtering eBPF flow data using a global rule
-You can configure the `FlowCollector` to filter eBPF flows using a global rule to control the flow of packets cached in the eBPF flow table.
+= Filtering eBPF flow data using multiple rules
+You can configure the `FlowCollector` custom resource to filter eBPF flows using multiple rules to control the flow of packets cached in the eBPF flow table.
+
+[IMPORTANT]
+====
+* You cannot use duplicate CIDRs in filter rules.
+* When an IP address matches multiple filter rules, the rule with the most specific CIDR prefix (longest prefix) takes precedence.
+====
 
 .Procedure
 . In the web console, navigate to *Operators* -> *Installed Operators*.
 . Under the *Provided APIs* heading for *Network Observability*, select *Flow Collector*.
 . Select *cluster*, then select the *YAML* tab.
 . Configure the `FlowCollector` custom resource, similar to the following sample configurations:
-+
 
-[%collapsible]
-.Filter Kubernetes service traffic to a specific Pod IP endpoint
-====
+
+.Example YAML to sample all North-South traffic, and 1:50 East-West traffic
+
+By default, all other flows are rejected.
+
 [source, yaml]
 ----
 apiVersion: flows.netobserv.io/v1beta2
@@ -30,22 +36,29 @@ spec:
     type: eBPF
     ebpf:
       flowFilter:
-        action: Accept  <1>
-        cidr: 172.210.150.1/24 <2>
-        protocol: SCTP
-        direction: Ingress
-        destPortRange: 80-100
-        peerIP: 10.10.10.10
-        enable: true    <3>
+        enable: true <1>
+        rules:
+         - action: Accept <2>
+           cidr: 0.0.0.0/0 <3>
+           sampling: 1 <4>
+         - action: Accept
+           cidr: 10.128.0.0/14
+           peerCIDR: 10.128.0.0/14 <5>
+         - action: Accept
+           cidr: 172.30.0.0/16
+           peerCIDR: 10.128.0.0/14
+           sampling: 50
 ----
-<1> The required `action` parameter describes the action that is taken for the flow filter rule. Possible values are `Accept` or `Reject`. 
-<2> The required `cidr` parameter provides the IP address and CIDR mask for the flow filter rule and supports IPv4 and IPv6 address formats. If you want to match against any IP address, you can use `0.0.0.0/0` for IPv4 or `::/0` for IPv6.
-<3> You must set `spec.agent.ebpf.flowFilter.enable` to `true` to enable this feature.
-====
-+
-[%collapsible]
-.See flows to any addresses outside the cluster 
-====
+<1> To enable eBPF flow filtering, set `spec.agent.ebpf.flowFilter.enable` to `true`.
+<2> To define the action for the flow filter rule, set the required `action` parameter. Valid values are `Accept` or `Reject`.
+<3> To define the IP address and CIDR mask for the flow filter rule, set the required `cidr` parameter. This parameter supports both IPv4 and IPv6 address formats. To match any IP address, use `0.0.0.0/0` for IPv4 or ``::/0` for IPv6.
+<4> To define the sampling rate for matched flows and override the global sampling setting `spec.agent.ebpf.sampling`, set the `sampling` parameter.
+<5> To filter flows by Peer IP CIDR, set the `peerCIDR` parameter.
+
+.Example YAML to filter flows with packet drops
+
+By default, all other flows are rejected.
+
 [source, yaml]
 ----
 apiVersion: flows.netobserv.io/v1beta2
@@ -57,18 +70,19 @@ spec:
   deploymentModel: Direct
   agent:
     type: eBPF
-    ebpf:        
+    ebpf:
+      privileged: true <1>
+      features:
+        - PacketDrop <2>
       flowFilter:
-        action: Accept  <1>
-        cidr: 0.0.0.0/0 <2>
-        protocol: TCP
-        direction: Egress
-        sourcePort: 100
-        peerIP: 192.168.127.12 <3>
-        enable: true    <4>
-----       
-<1> You can `Accept` flows based on the criteria in the `flowFilter` specification.
-<2> The `cidr` value of `0.0.0.0/0` matches against any IP address.
-<3> See flows after `peerIP` is configured with `192.168.127.12`. 
-<4> You must set `spec.agent.ebpf.flowFilter.enable` to `true` to enable the feature.
-====
+        enable: true <3>
+        rules:
+        - action: Accept <4>
+          cidr: 172.30.0.0/16
+          pktDrops: true <5>
+----
+<1> To enable packet drops, set `spec.agent.ebpf.privileged` to `true`.
+<2> To report packet drops for each network flow, add the `PacketDrop` value to the `spec.agent.ebpf.features` list.
+<3> To enable eBPF flow filtering, set `spec.agent.ebpf.flowFilter.enable` to `true`.
+<4> To define the action for the flow filter rule, set the required `action` parameter. Valid values are `Accept` or `Reject`.
+<5> To filter flows containing drops, set `pktDrops` to `true`.

--- a/modules/network-observability-flowcollector-api-specifications.adoc
+++ b/modules/network-observability-flowcollector-api-specifications.adoc
@@ -444,7 +444,6 @@ To filter two ports, use a "port1,port2" in string format. For example, `ports: 
 | `rules` defines a list of filtering rules on the eBPF Agents.
 When filtering is enabled, by default, flows that don't match any rule are rejected.
 To change the default, you can define a rule that accepts everything: `{ action: "Accept", cidr: "0.0.0.0/0" }`, and then refine with rejecting rules.
-Unsupported *.
 
 | `sampling`
 | `integer`
@@ -470,7 +469,6 @@ Description::
 `rules` defines a list of filtering rules on the eBPF Agents.
 When filtering is enabled, by default, flows that don't match any rule are rejected.
 To change the default, you can define a rule that accepts everything: `{ action: "Accept", cidr: "0.0.0.0/0" }`, and then refine with rejecting rules.
-Unsupported *.
 --
 
 Type::
@@ -483,7 +481,7 @@ Type::
 Description::
 +
 --
-`EBPFFlowFilterRule` defines the desired eBPF agent configuration regarding flow filtering rule.
+`EBPFFlowFilterRules` defines the desired eBPF agent configuration regarding flow filtering rules.
 --
 
 Type::
@@ -1480,15 +1478,15 @@ Type::
 
 | `input`
 | `string`
-| 
+|
 
 | `multiplier`
 | `integer`
-| 
+|
 
 | `output`
 | `string`
-| 
+|
 
 |===
 == .spec.exporters[].openTelemetry.logs

--- a/modules/network-observability-multitenancy.adoc
+++ b/modules/network-observability-multitenancy.adoc
@@ -5,7 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-multi-tenancy_{context}"]
 = Enabling multi-tenancy in Network Observability
-Multi-tenancy in the Network Observability Operator allows and restricts individual user access, or group access, to the flows stored in Loki and or Prometheus. Access is enabled for project administrators. Project administrators who have limited access to some namespaces can access flows for only those namespaces. 
+Multi-tenancy in the Network Observability Operator allows and restricts individual user access, or group access, to the flows stored in Loki and or Prometheus. Access is enabled for project administrators. Project administrators who have limited access to some namespaces can access flows for only those namespaces.
 
 For Developers, multi-tenancy is available for both Loki and Prometheus but requires different access rights.
 
@@ -15,11 +15,11 @@ For Developers, multi-tenancy is available for both Loki and Prometheus but requ
 
 .Procedure
 
-*  For per-tenant access, you must have the `netobserv-reader` cluster role and the `netobserv-metrics-reader` namespace role to use the developer perspective. Run the following commands for this level of access:
+*  For per-tenant access, you must have the `netobserv-loki-reader` cluster role and the `netobserv-metrics-reader` namespace role to use the developer perspective. Run the following commands for this level of access:
 +
 [source,terminal]
 ----
-$ oc adm policy add-cluster-role-to-user netobserv-reader <user_group_or_name>
+$ oc adm policy add-cluster-role-to-user netobserv-loki-reader <user_group_or_name>
 ----
 +
 [source,terminal]
@@ -27,11 +27,11 @@ $ oc adm policy add-cluster-role-to-user netobserv-reader <user_group_or_name>
 $ oc adm policy add-role-to-user netobserv-metrics-reader <user_group_or_name> -n <namespace>
 ----
 
-* For cluster-wide access, non-cluster-administrators must have the `netobserv-reader`, `cluster-monitoring-view`, and `netobserv-metrics-reader` cluster roles. In this scenario, you can use either the admin perspective or the developer perspective. Run the following commands for this level of access:
+* For cluster-wide access, non-cluster-administrators must have the `netobserv-loki-reader`, `cluster-monitoring-view`, and `netobserv-metrics-reader` cluster roles. In this scenario, you can use either the admin perspective or the developer perspective. Run the following commands for this level of access:
 +
 [source,terminal]
 ----
-$ oc adm policy add-cluster-role-to-user netobserv-reader <user_group_or_name>
+$ oc adm policy add-cluster-role-to-user netobserv-loki-reader <user_group_or_name>
 ----
 +
 [source,terminal]

--- a/modules/network-observability-netobserv-cli-reference.adoc
+++ b/modules/network-observability-netobserv-cli-reference.adoc
@@ -86,7 +86,7 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--query|                     filter flows using a custom query          | –
+|--query|                     filter flows by using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
@@ -134,7 +134,7 @@ $ oc netobserv packets [<option>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--query|                     filter flows using a custom query          | –
+|--query|                     filter flows by using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
@@ -184,7 +184,7 @@ $ oc netobserv metrics [<option>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--query|                     filter flows using a custom query          | –
+|--query|                     filter flows by using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –

--- a/modules/network-observability-netobserv-cli-reference.adoc
+++ b/modules/network-observability-netobserv-cli-reference.adoc
@@ -7,8 +7,8 @@
 You can use the Network Observability CLI (`oc netobserv`) to pass command-line arguments to capture flows data, packets data, and metrics for further analysis and enable features supported by the Network Observability Operator.
 
 [id="cli-syntax_{context}"]
-== Syntax 
-The basic syntax for `oc netobserv` commands: 
+== Syntax
+The basic syntax for `oc netobserv` commands:
 
 .`oc netobserv` syntax
 [source,terminal]
@@ -57,12 +57,14 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 | Option | Description | Default
 |--enable_all|                enable all eBPF features                   | false
 |--enable_dns|                enable DNS tracking                        | false
+|--enable_ipsec|              enable IPsec tracking                      | false
 |--enable_network_events|     enable network events monitoring           | false
 |--enable_pkt_translation|    enable packet translation                  | false
 |--enable_pkt_drop|           enable packet drop                         | false
 |--enable_rtt|                enable RTT tracking                        | false
 |--enable_udn_mapping|        enable User Defined Network mapping | false
 |--get-subnets|               get subnets information                   | false
+|--sampling|                  value that determines the ratio of packets being sampled | 1
 |--background|                run in background                          | false
 |--copy|                      copy the output files locally              | prompt
 |--log-level|                 components logs                            | info
@@ -84,12 +86,13 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--regexes|                   filter flows using regular expression      | –
+|--query|                     filter flows using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
 |--tcp_flags|                 filter TCP flags                           | –
-|--interfaces|                interfaces to monitor                      | –
+|--interfaces|                list of interfaces to monitor, comma separated     | –
+|--exclude_interfaces|        list of interfaces to exclude, comma separated     | lo
 |===
 
 .Example running flows capture on TCP protocol and port 49051 with PacketDrop and RTT features enabled:
@@ -131,7 +134,7 @@ $ oc netobserv packets [<option>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--regexes|                   filter flows using regular expression      | –
+|--query|                     filter flows using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
@@ -157,12 +160,14 @@ $ oc netobserv metrics [<option>]
 | Option | Description | Default
 |--enable_all|                enable all eBPF features                   | false
 |--enable_dns|                enable DNS tracking                        | false
+|--enable_ipsec|              enable IPsec tracking                      | false
 |--enable_network_events|     enable network events monitoring           | false
 |--enable_pkt_translation|    enable packet translation                  | false
 |--enable_pkt_drop|           enable packet drop                         | false
 |--enable_rtt|                enable RTT tracking                        | false
 |--enable_udn_mapping|        enable User Defined Network mapping | false
 |--get-subnets|               get subnets information                   | false
+|--sampling|                  value that defines the ratio of packets being sampled | 1
 |--action|                    filter action                              | Accept
 |--cidr|                      filter CIDR                                | 0.0.0.0/0
 |--direction|                 filter direction                           | –
@@ -179,16 +184,50 @@ $ oc netobserv metrics [<option>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--regexes|                   filter flows using regular expression      | –
+|--query|                     filter flows using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
 |--tcp_flags|                 filter TCP flags                           | –
-|--interfaces|                interfaces to monitor                      | –
+|--include_list|              list of metric names to generate, comma separated           | namespace_flows_total,node_ingress_bytes_total,node_egress_bytes_total,workload_ingress_bytes_total
+|--interfaces|                list of interfaces to monitor, comma separated     | –
+|--exclude_interfaces|        list of interfaces to exclude, comma separated     | lo
 |===
 
 .Example running metrics capture for TCP drops
 [source,terminal]
 ----
-$ oc netobserv metrics --enable_pkt_drop --protocol=TCP 
+$ oc netobserv metrics --enable_pkt_drop --protocol=TCP
+----
+
+.Example running metrics capture for list of metric names to generate
+[source,terminal]
+----
+$ oc netobserv metrics --include_list=node,workload
+----
+
+[source,terminal]
+----
+$ oc netobserv metrics --include_list=node_egress_bytes_total,workload_egress_packets_total
+----
+
+[source,terminal]
+----
+$ oc netobserv metrics --enable_all --include_list=node,namespace,workload
+----
+
+.Example output for list of metric names
+[source, terminal]
+----
+opt: include_list, value: node,workload
+Matching metrics:
+ - node_egress_bytes_total
+ - node_ingress_bytes_total
+ - workload_egress_bytes_total
+ - workload_ingress_bytes_total
+ - workload_egress_packets_total
+ - workload_ingress_packets_total
+ - workload_flows_total
+ - workload_drop_packets_total
+ - workload_drop_bytes_total
 ----

--- a/modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc
+++ b/modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc
@@ -3,8 +3,8 @@
 // network_observability/observing-network-traffic.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="network-observability-working-with-ipsec_{context}"]
-= Working with IPsec
+[id="network-observability-configuring-ipsec-with-flow-collector-resource_{context}"]
+= Configuring IPsec with the FlowCollector custom resource
 
 In {product-title}, IPsec is disabled by default. You can enable IPsec by following the instructions in "Configuring IPsec encryption".
 

--- a/modules/network-observability-proc_working-with-udn.adoc
+++ b/modules/network-observability-proc_working-with-udn.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-working-with-udn_{context}"]
+= Working with user-defined networks
+
+You can enable user-defined networks (UDN) in Network Observability resources.
+The following example shows the configuration for the `FlowCollector` resource.
+
+.Prerequisite
+* You have configured UDN in {openshift-networking}. For more information, see "Creating a UserDefinedNetwork by using the CLI" or "Creating a UserDefinedNetwork by using the web console."
+
+.Procedure
+. Edit the Network Observability `FlowCollector` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit flowcollector
+----
+
+. Configure the `ebpf` section of the `FlowCollector` resource:
++
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  agent:
+    ebpf:
+      sampling: 1  <1>
+      privileged: true
+      features:
+      - UDNMapping
+----
+<1> Recommended so all flows are observed.
+
+.Verification
+
+* Refresh the *Network Traffic* page to view updated UDN information in the *Traffic Flow* and *Topology* views:
+
+** In *Network Traffic* > *Traffic flows*, you can view UDNs under the `SrcK8S_NetworkName` and `DstK8S_NetworkName` fields.
+** In the *Topology* view, you can set *Network* as *Scope* or *Group*.

--- a/modules/network-observability-viewing-network-events.adoc
+++ b/modules/network-observability-viewing-network-events.adoc
@@ -15,10 +15,10 @@ You can edit the `FlowCollector` to view information about network traffic event
 * `BaselineNetworkPolicy`
 * `EgressFirewall`
 * `UserDefinedNetwork` isolation
-* Multicast ACLs 
+* Multicast ACLs
 
 .Prerequisites
-* You must have `OVNObservability` enabled by setting the `TechPreviewNoUpgrade` feature set in the `FeatureGate` custom resource (CR) named `cluster`. For more information, see "Enabling feature sets using the CLI" and "Checking OVN-Kubernetes network traffic with OVS sampling using the CLI". 
+* You must have `OVNObservability` enabled by setting the `TechPreviewNoUpgrade` feature set in the `FeatureGate` custom resource (CR) named `cluster`. For more information, see "Enabling feature sets using the CLI" and "Checking OVN-Kubernetes network traffic with OVS sampling using the CLI".
 * You have created at least one of the following network APIs: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinedNetwork` isolation, multicast, or `EgressFirewall`.
 
 .Procedure
@@ -44,15 +44,15 @@ spec:
       features:
        - "NetworkEvents"
 ----
-<1> Optional: The `sampling` parameter is set to a value of 1 so that all network events are captured. If sampling `1` is too resource heavy, set sampling to something more appropriate for your needs. 
+<1> Optional: The `sampling` parameter is set to a value of 1 so that all network events are captured. If sampling `1` is too resource heavy, set sampling to something more appropriate for your needs.
 <2> The `privileged` parameter is set to `true` because the `OVN observability` library needs to access local Open vSwitch (OVS) socket and OpenShift Virtual Network (OVN) databases.
 
 .Verification
-. Navigate to the *Network Traffic* view and select the *Traffic flows* table. 
-. You should see the new column, *Network Events*, where you can view information about impacts of one of the following network APIs you have enabled: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinedNetwork` isolation, multicast, or egress firewalls. 
+. Navigate to the *Network Traffic* view and select the *Traffic flows* table.
+. You should see the new column, *Network Events*, where you can view information about impacts of one of the following network APIs you have enabled: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinedNetwork` isolation, multicast, or egress firewalls.
 
 An example of the kind of events you could see in this column is as follows:
-+
+
 .Example of Network Events output
 [source,text]
 ----

--- a/modules/proc_network-observability-working-with-ipsec.adoc
+++ b/modules/proc_network-observability-working-with-ipsec.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-working-with-ipsec_{context}"]
+= Working with IPsec
+
+In {product-title}, IPsec is disabled by default. You can enable IPsec by following the instructions in "Configuring IPsec encryption".
+
+.Prerequisite
+
+* You have enabled IPsec encryption on {product-title}.
+
+.Procedure
+. In the web console, navigate to *Operators* -> *Installed Operators*.
+. Under the *Provided APIs* heading for the *NetObserv Operator*, select *Flow Collector*.
+. Select *cluster* then select the *YAML* tab.
+. Configure the `FlowCollector` custom resource for IPsec:
++
+.Example configuration of `FlowCollector` for IPsec
+[source, yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  namespace: netobserv
+  agent:
+    type: eBPF
+    ebpf:
+      features:
+      - "IPSec"
+----
+
+.Verification
+
+When IPsec is enabled:
+
+* A new column named *IPsec Status* is displayed in the network observability *Traffic flows* view to show whether a flow was successfully IPsec-encrypted or if there was an error during encryption/decryption.
+
+* A new dashboard showing the percent of encrypted traffic is generated.
+

--- a/observability/network_observability/configuring-operator.adoc
+++ b/observability/network_observability/configuring-operator.adoc
@@ -24,6 +24,12 @@ include::modules/network-observability-enriched-flows.adoc[leveloffset=+1]
 * xref:../../observability/network_observability/json-flows-format-reference.adoc#network-observability-flows-format_json_reference[Network flows format reference].
 
 include::modules/network-observability-configuring-FLP-sampling.adoc[leveloffset=+1]
+include::modules/network-observability-con_filter-network-flows-at-ingestion.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../network_observability/observing-network-traffic.adoc#network-observability-filtering-ebpf-rule_nw-observe-network-traffic[Filtering eBPF flow data using multiple rules]
+
 include::modules/network-observability-configuring-quickfilters-flowcollector.adoc[leveloffset=+1]
 include::modules/network-observability-resource-recommendations.adoc[leveloffset=+1]
 include::modules/network-observability-resources-table.adoc[leveloffset=+2]

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -41,6 +41,14 @@ include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 * xref:../../observability/network_observability/network-observability-operator-monitoring.adoc#network-observability-health-dashboard-overview_network_observability[Health dashboards]
 
+include::modules/network-observability-con_user-defined-networks.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#about-user-defined-networks[About user-defined networks]
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr-ui_about-user-defined-networks[Creating a UserDefinedNetwork by using the web console]
+* xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-working-with-udn_nw-observe-network-traffic[Working with user-defined networks]
+
 include::modules/network-observability-networking-events-overview.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
@@ -50,6 +58,13 @@ include::modules/network-observability-networking-events-overview.adoc[leveloffs
 include::modules/network-observability-trafficflow.adoc[leveloffset=+1]
 include::modules/network-observability-working-with-trafficflow.adoc[leveloffset=+2]
 include::modules/network-observability-configuring-options-trafficflow.adoc[leveloffset=+2]
+include::modules/proc_network-observability-working-with-ipsec.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+*xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
+
+//Traffic flows continued
 include::modules/network-observability-working-with-conversations.adoc[leveloffset=+2]
 include::modules/network-observability-packet-drops.adoc[leveloffset=+2]
 include::modules/network-observability-dns-tracking.adoc[leveloffset=+2]
@@ -59,6 +74,13 @@ include::modules/network-observability-working-with-zones.adoc[leveloffset=+2]
 include::modules/network-observability-filtering-ebpf-rule.adoc[leveloffset=+2]
 include::modules/network-observability-packet-translation-overview.adoc[leveloffset=+2]
 include::modules/network-observability-packet-translation.adoc[leveloffset=+2]
+include::modules/network-observability-proc_working-with-udn.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr-ui_about-user-defined-networks[Creating a UserDefinedNetwork by using the web console]
+
 include::modules/network-observability-viewing-network-events.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -78,5 +100,5 @@ Alternatively, you can access the traffic flow data in the *Network Traffic* tab
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters] 
+* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -58,11 +58,11 @@ include::modules/network-observability-networking-events-overview.adoc[leveloffs
 include::modules/network-observability-trafficflow.adoc[leveloffset=+1]
 include::modules/network-observability-working-with-trafficflow.adoc[leveloffset=+2]
 include::modules/network-observability-configuring-options-trafficflow.adoc[leveloffset=+2]
-include::modules/proc_network-observability-working-with-ipsec.adoc[leveloffset=+2]
+include::modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-*xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
+* xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
 
 //Traffic flows continued
 include::modules/network-observability-working-with-conversations.adoc[leveloffset=+2]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-14786 [NETOBSERV] Add section for IPsec

Version(s):
Merge to only the `no-1.9` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the NetObserv content just before its GA.

Cherry-pick to OCP 4.12, 4.14, 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-14786

Link to docs preview:

* IPsec: https://95159--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic.html#network-observability-working-with-ipsec_nw-observe-network-traffic 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Redo/copy of https://github.com/openshift/openshift-docs/pull/93858 which I somehow messed up. So this is a copy of the Dev/QE approved PR, and making this copy revealed that the content in the following already merged PRs is no longer present in the `no-1.9` branch: 

* Update netobserv-reader to netobserv-loki-reader: https://github.com/openshift/openshift-docs/pull/94341
* Update callout <2>:  https://github.com/openshift/openshift-docs/pull/94334
* UDN: https://github.com/openshift/openshift-docs/pull/94271
* NetObserv 1.9 CLI documentation updates: https://github.com/openshift/openshift-docs/pull/93795
* Flowlogs flp flitering: https://github.com/openshift/openshift-docs/pull/93270
* Context about mulit-flow filtering capability, updated yaml: https://github.com/openshift/openshift-docs/pull/92375

The only new content is `proc_working-with-ipsec.adoc`, and this addition to `observing-network-traffic.adoc` for IPsec:

```
include::modules/proc_network-observability-working-with-ipsec.adoc[leveloffset=+2]

[role="_additional-resources"]
.Additional resources
*xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]

//Traffic flows continued
```
 The remaining files have been reviewed and merged as part of the PRs listed above. However, removing those files results in build failures as that content has vanished from the `no-1.9` branch for reasons no one has been able to identify. 

The previously reviewed and merged content is now part of this PR, and hopefully this will fix the `no-1.9` branch and return it to its updated state with all NetObserv 1.9 content. And hopefully that will resolve existing open PRs against `no-1.9` that now have these same previously merged PRs.

**Copied from 93858:**
API reference updates are being handled by https://github.com/openshift/openshift-docs/pull/94756 

First time doing NETOBSERV release, and did not realize API/CLI changes were automatically generated, and those updates to prod docs are generally handed separately and not in individual PRs where CLI/API changes may occur. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
