### PR TITLE
TELCODOCS-2358: Fixing SW version in Hub RDS

### DIFF
--- a/modules/telco-hub-software-stack.adoc
+++ b/modules/telco-hub-software-stack.adoc
@@ -33,7 +33,7 @@ The telco hub {product-version} solution has been validated using the following 
 |4.19
 
 |{mce-short} PolicyGenerator plugin
-|2.12
+|2.13
 
 |{cgu-operator-first}
 |4.19


### PR DESCRIPTION
[TELCODOCS-2358](https://issues.redhat.com//browse/TELCODOCS-2358): Fixing SW version in Hub RDS

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2358

Link to docs preview:


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
