### PR TITLE
CNV-64163: Fixed namespace value in localnet UDN doc

### DIFF
--- a/modules/virt-attaching-vm-to-secondary-udn.adoc
+++ b/modules/virt-attaching-vm-to-secondary-udn.adoc
@@ -21,7 +21,7 @@ apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: example-vm
-  namespace: my-namespace # <1>
+  namespace: red # <1>
 spec:
   template:
     spec:

--- a/modules/virt-creating-secondary-localnet-udn.adoc
+++ b/modules/virt-creating-secondary-localnet-udn.adoc
@@ -29,13 +29,13 @@ spec:
   desiredState:
     ovn:
       bridge-mappings:
-      - localnet: tenantblue # <3>
+      - localnet: localnet1 # <3>
         bridge: br-ex # <4>
         state: present # <5>
 ----
 <1> The name of the configuration object.
 <2> Specifies the nodes to which the node network configuration policy is applied. The recommended node selector value is `node-role.kubernetes.io/worker: ''`.
-<3> The name of the additional network from which traffic is forwarded to the OVS bridge. This attribute must match the value of the `spec.network.localnet.physicalNetworkName` field of the `ClusterUserDefinedNetwork` object that defines the OVN-Kubernetes additional network. This example uses the name `tenantblue`.
+<3> The name of the additional network from which traffic is forwarded to the OVS bridge. This attribute must match the value of the `spec.network.localnet.physicalNetworkName` field of the `ClusterUserDefinedNetwork` object that defines the OVN-Kubernetes additional network. This example uses the name `localnet1`.
 <4> The name of the OVS bridge on the node. This value is required if the `state` attribute is `present` or not specified.
 <5> The state of the mapping. Must be either `present` to add the mapping or `absent` to remove the mapping. The default value is `present`.
 +
@@ -74,7 +74,7 @@ spec:
     topology: Localnet # <5>
     localnet:
         role: Secondary # <6>
-        physicalNetworkName: tenantblue # <7>
+        physicalNetworkName: localnet1 # <7>
         ipam:
           mode: Disabled # <8>
 # ...

--- a/modules/virt-creating-secondary-udn-namespace.adoc
+++ b/modules/virt-creating-secondary-udn-namespace.adoc
@@ -22,7 +22,7 @@ You can create a namespace to be used with an existing secondary cluster-scoped 
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cudn_namespace
+  name: red
 # ...
 ----
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-64163](https://issues.redhat.com//browse/CNV-64163)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://95180--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-secondary-udn.html#virt-creating-secondary-udn-namespace_virt-connecting-vm-to-secondary-udn

https://95180--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-secondary-udn.html#virt-attaching-vm-to-secondary-udn_virt-connecting-vm-to-secondary-udn
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
