### PR TITLE
WMCO remove managedIdentity from Azure machine set YAML example

### DIFF
--- a/modules/windows-machineset-azure.adoc
+++ b/modules/windows-machineset-azure.adoc
@@ -48,7 +48,6 @@ spec:
             version: latest
           kind: AzureMachineProviderSpec
           location: <location> <6>
-          managedIdentity: <infrastructure_id>-identity <1>
           networkResourceGroup: <infrastructure_id>-rg <1>
           osDisk:
             diskSizeGB: 128


### PR DESCRIPTION
Removing the `managedIdentity` parameter from the WMCO Azure machine set example, documenting https://github.com/openshift/windows-machine-config-operator/pull/2781

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Windows Container Support for OpenShift -> Creating Windows machine sets -> Creating a Windows machine set on Azure -> [Sample YAML for a Windows MachineSet object on Azure](https://95189--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html#windows-machineset-azure_creating-windows-machineset-azure)  -- Removed `managedIdentity: <infrastructure_id>-identity` from the YAML. It was positioned between `location <6>` and `networkResourceGroup <1>`. See [current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/windows_container_support_for_openshift/creating-windows-machine-sets#windows-machineset-azure_creating-windows-machineset-azure). 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
