### PR TITLE
OCPBUGS-52463# Add note on viewing additional ccoctl options + optional param for specifying VNET RG

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -224,7 +224,8 @@ $ ccoctl azure create-all \
   --subscription-id=<azure_subscription_id> \// <4>
   --credentials-requests-dir=<path_to_credentials_requests_directory> \// <5>
   --dnszone-resource-group-name=<azure_dns_zone_resource_group_name> \// <6>
-  --tenant-id=<azure_tenant_id> <7>
+  --tenant-id=<azure_tenant_id> \// <7> 
+  --network-resource-group-name <azure_resource_group> <8>
 ----
 <1> Specify the user-defined name for all created Azure resources used for tracking.
 <2> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
@@ -233,6 +234,7 @@ $ ccoctl azure create-all \
 <5> Specify the directory containing the files for the component `CredentialsRequest` objects.
 <6> Specify the name of the resource group containing the cluster's base domain Azure DNS zone.
 <7> Specify the Azure tenant ID to use.
+<8> Optional: Specify the virtual network resource group if it is different from the cluster resource group.
 +
 [NOTE]
 ====

--- a/modules/enabling-entra-workload-id-existing-cluster.adoc
+++ b/modules/enabling-entra-workload-id-existing-cluster.adoc
@@ -171,6 +171,11 @@ $ AZURE_INSTALL_RG=`oc get infrastructure cluster -o jsonpath --template '{ .sta
 
 . Use the `ccoctl` utility to create managed identities for all `CredentialsRequest` objects by running the following command:
 +
+[NOTE]
+====
+The following command does not show all available options. For a complete list of options, including those that might be necessary for your specific use case, run `$ ccoctl azure create-managed-identities --help`.
+====
++
 [source,terminal]
 ----
 $ ccoctl azure create-managed-identities \
@@ -181,9 +186,11 @@ $ ccoctl azure create-managed-identities \
   --credentials-requests-dir <path_to_directory_for_credentials_requests> \
   --issuer-url "${OIDC_ISSUER_URL}" \
   --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name> \// <1>
-  --installation-resource-group-name "${AZURE_INSTALL_RG}"
+  --installation-resource-group-name "${AZURE_INSTALL_RG}" \
+  --network-resource-group-name <azure_resource_group> <2>
 ----
 <1> Specify the name of the resource group that contains the DNS zone.
+<2> Optional: Specify the virtual network resource group if it is different from the cluster resource group.
 
 . Apply the {azure-short} pod identity webhook configuration for {entra-short} by running the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-52463?jql=assignee%20%3D%20currentUser()%20AND%20resolution%20%3D%20Unresolved%20ORDER%20BY%20priority%20DESC%2C%20cf%5B12316142%5D%20ASC%2C%20updated%20DESC

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
* Day 0 https://95218--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-customizations.html#cco-ccoctl-creating-at-once_installing-azure-customizations
* Day 2 https://95218--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration.html#enabling-entra-workload-id-existing-cluster_changing-cloud-credentials-configuration

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

Added note to step 13 in day 2 procedure. Documented optional param for specifying VNET RG in both day 0/2 procedures.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
