### PR TITLE
OCPBUGS-54613: Added acessing to kubeconfig using oc CLI module

### DIFF
--- a/cli_reference/openshift_cli/configuring-cli.adoc
+++ b/cli_reference/openshift_cli/configuring-cli.adoc
@@ -16,3 +16,6 @@ include::modules/cli-configuring-completion.adoc[leveloffset=+2]
 
 // Enabling tab completion for Zsh
 include::modules/cli-configuring-completion-zsh.adoc[leveloffset=+2]
+
+// Configuring a kubeconfig file by using the oc CLI
+include::modules/cli-configuring-kubeconfig-using-cli.adoc[leveloffset=+1]

--- a/modules/cli-configuring-kubeconfig-using-cli.adoc
+++ b/modules/cli-configuring-kubeconfig-using-cli.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/openshift_cli/configuring-cli.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cli-accessing-kubeconfig-using-cli_{context}"]
+= Accessing kubeconfig by using the oc CLI
+
+You can use the `oc` CLI to log in to your OpenShift cluster and retrieve a kubeconfig file for accessing the cluster from the command line.
+
+.Prerequisites
+
+* You have access to the {product-title} web console or API server endpoint.
+
+.Procedure
+
+. Log in to your OpenShift cluster by running the following command:
++
+[source,terminal]
+----
+$ oc login <api-server-url> -u <username> -p <password> <1><2><3>
+----
++
+<1> Specify the full API server URL. For example: `https://api.my-cluster.example.com:6443`.
+<2> Specify a valid username. For example: `kubeadmin`.
+<3> Provide the password for the specified user. For example, the `kubeadmin` password generated during cluster installation.
+
+. Save the cluster configuration to a local file by running the following command:
++
+[source,terminal]
+----
+$ oc config view --raw > kubeconfig
+----
+
+. Set the `KUBECONFIG` environment variable to point to the exported file by running the following command:
++
+[source,terminal]
+----
+$ export KUBECONFIG=./kubeconfig
+----
+
+. Use `oc` to interact with your OpenShift cluster by running the following command:
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
+[NOTE]
+====
+If you plan to reuse the exported `kubeconfig` file across sessions or machines, store it securely and avoid committing it to source control.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-54613
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://95219--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/configuring-cli.html#cli-accessing-cli
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
