### PR TITLE
TELCODOCS-2306: KMM 2.4 Release Notes

### DIFF
--- a/hardware_enablement/kmm-release-notes.adoc
+++ b/hardware_enablement/kmm-release-notes.adoc
@@ -29,3 +29,249 @@ toc::[]
 
 // TELCODOCS-2197
 * You can now schedule KMM pods by defining taints and tolerations. For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-using-tolerations-for-kernel-module-scheduling_kernel-module-management-operator[Using tolerations for kernel module scheduling].
+
+[id="kmm-2-4-RN"]
+== Release notes for Kernel Module Management Operator 2.4
+=== New features
+// TELCODOCS-2343
+* A new feature in this release is the addition of a preflight validation resource in the cluster that you can use to verify kernel modules to be installed on the nodes after cluster upgrades and possible kernel upgrades. Preflight validation also reports on the status and progress of each module in the cluster that it attempts or has attempted to validate. For more information, see xref:../updating/preparing_for_updates/kmm-preflight-validation.adoc#kmm-validation-kickoff_kmm-preflight-validation[Preflight validation for Kernel Module Management (KMM) Modules].
+
+// TELCODOCS-2344
+* In this release, a new requirement when creating a kmod image is that both the `.ko` kernel module files and the `cp` binary must be included, which is required for copying files during the image loading process.
+For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-creating-kmod-image_kernel-module-management-operator[Creating a kmod image].
+
+// TELCODOCS-2311
+* In this release, you now have the option to configure KMM Module to not load an out-of-tree kernel driver and use the in-tree driver instead and run only the device plugin. For more information see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-using-intree-modules_kernel-module-management-operator[Using in-tree modules].
+
+// TELCODOCS-2304
+* In this release, KMM configurations are now persistent following cluster and KMM Operator upgrades and redeployments of KMM. 
++
+In earlier releases, a cluster or KMM upgrade, or any other intentional or unintentional action, such as upgrading a non-default configuration like the firmware path that redeploys KMM, could create the need to reconfigure KMM. In this release, KMM configurations now remain persistent regardless of any of these actions.
++
+For more information see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-configuring-kmmo_kernel-module-management-operator[Configuring the Kernel Module Management Operator].
+
+=== Bug fixes
+// MGMT-16797
+* Creating or deleting the image / Creating an MCM module does not load the module on the spoke. 
+
+** *Cause*: On a Hub/Spoke setup, when creating or deleting the image in registry, or when creating a `ManagedClusterModule` (MCM), the module on the spoke cluster is not loaded.
+
+** *Consequence*: The module on the spoke is not created.
+
+** *Fix*: Remove the cache package and image translation from the Hub/Spoke setup.
+
+** *Result:* The module on the spoke is created for the second time the MCM object is created.
+
+// MGMT-19859
+* KMM cannot pull images from the private registry while doing in-cluster builds.
+
+** *Cause*: The Kernel Module Management (KMM) Operator cannot pull images from private registry while doing in-cluster builds.
+
+** *Consequence*: Images in private registries that are used in the build process can not be pulled.
+
+** *Fix*: The `imageRepoSecret` configuration is now also used in the build process. The `imageRepoSecret` specified has to include ALL registries being used.
+
+** *Result:* Private registries can now be used when doing in-cluster builds.
+
+// MGMT-19897
+* KMM worker pod is orphaned when deleting a module with a container image that can not be pulled. 
+
+** *Cause*: A Kernel Module Management (KMM) Operator worker pod is orphaned when deleting a module with a container image that can not be pulled.
+
+** *Consequence*: Failing worker pods are left on the cluster and at no point being collected for garbage.
+
+** *Fix*: KMM will now garbage collect orphaned failing pods upon the modules deletion.
+
+** *Result:* The module is successfully deleted, and all associated orphaned failing pods are also deleted.
+
+// MGMT-19898
+* The KMM Operator tries to create a MIC even when the node selector does not match.
+
+** *Cause*: The Kernel Module Management (KMM) Operator tries to create a 'ModuleImagesConfig' (MIC) resource even when the node selector does not match with any actual nodes and fails.
+
+** *Consequence*: The KMM Operator is getting and error when reconciling a module that does not target any node.
+
+** *Fix*: The 'Images' field in the MIC resource is now optional.
+
+** *Result:* The KMM Operator can successfully create the MIC resource even when there are no images in it.
+
+// MGMT-20247
+* KMM does not reload the kernel module in case the node reboot sequence is too quick.
+
+** *Cause*: The Kernel Module Management (KMM) Operator does not reload the kernel module in case the node reboot sequence is too quick. The reboot is determined based on the timestamp of the status condition being later than the timestamp in the Node Machine Configuration (NMC) status.
+
+** *Consequence*: When the reboot happens quickly, in less time than the grace period, the node state will not change. After the node reboots, KMM will not load the kernel module again.
+
+** *Fix*: Instead of relying on the condition state, NMC can rely on the `Status.NodeInfo.BootID` field. This field is set by kubelet based on the /proc/sys/kernel/random/boot_id file of the server node, so it is updated after each reboot.
+
+** *Result:* The more accurate timestamps enable the Kernel Module Management (KMM) Operator to reload the kernel module after the node reboot sequence.
+
+// MGMT-20248
+* Filtering out node heartbeats events for the NMC controller.
+
+** *Cause*: The Node Machine Configuration (NMC) controller gets spammed with events from node heartbeats. The node heartbeats are there to let the Kubernetes API server know that the node is still connected and functional.
+
+** *Consequence*: The spamming causes a constant reconciliation even when no Module, and therefore no NMC, are applied to the cluster.
+
+** *Fix*: The NMC controller will now filter the node's heartbeat from its reconciliation loop.
+
+** *Result:* The NMC controller only gets real events and filters out node heartbeats.
+
+// MGMT-20286
+* NMC status contains toleration values, even though there are no tolerations in the NMC.spec or in the Module. 
+
+** *Cause*: The Node Machine Configuration (NMC) status contains toleration values, even though there are no tolerations in the NMC.spec or in the Module.
+
+** *Consequence*: Tolerations other than Kernel Module Management-specific tolerations can appear in the status.
+
+** *Fix*: The NMC status now gets its toleration from a dedicated annotation rather than from the worker pod.
+
+** *Result:* The NMC status only contains the Module's tolerations.
+
+// MGMT-20725
+* The KMM Operator version 2.4 fails to start properly and cannot list the resource `\modulebuildsignconfigs\`. 
+
+** *Cause*: On the Kernel Module Management (KMM) Operator, when the Operator is installed using Red Hat Konflux it does not start properly as the log files contain errors.
+
+** *Consequence*: The KMM Operator does not work as expected.
+
+** *Fix*: The Cluster Service Version (CSV) file was updated to list the resources `\modulebuildsignconfigs\` and `moduleimagesconfig`.
+
+** *Result:* The KMM Operator works as expected.
+
+// MGMT-20752
+* Konflux build does not include version and git commit in the operator logs.
+
+** *Cause*: On the Kernel Module Management (KMM) Operator, when the Operator was built using Communications Platform as a Service (CPaas), the build included the Operator version and git commit in the log  files. However, with Red Hat Konflux these details are not included in the log files.
+
+** *Consequence*: Important information is missing from the log files.
+
+** *Fix*: Some adjustments were made in Konflux.
+
+** *Result:* The KMM Operator build now includes the Operator version and git commit in the log files.
+
+// MGMT-20754
+* The KMM Operator does not load the module after node with taint is rebooted.
+
+** *Cause*: The Kernel Module Management (KMM) Operator does not reload the kernel module in case the node reboot sequence is too quick. The reboot is determined based on the timestamp of the status condition being later than the timestamp in the Node Machine Configuration (NMC) status.
+
+** *Consequence*: When the reboot happens quickly, in less time than the grace period, the node state will not change. After the node reboots, KMM will not load the kernel module again.
+
+** *Fix*: Instead of relying on the condition state, NMC can rely on the `Status.NodeInfo.BootID` field. This field is set by kubelet based on the /proc/sys/kernel/random/boot_id file of the server node, so it is updated after each reboot.
+
+** *Result:* The more accurate timestamps enable the Kernel Module Management (KMM) Operator to reload the kernel module after the node reboot sequence.
+
+// MGMT-20775
+* Redeploying a module that uses in-cluster builds fails with the `ImagePullBackOff` policy.
+
+** *Cause*: On the Kernel Module Management (KMM) Operator, the `pullPolicy` for the puller pod and the worker pod is different.
+
+** *Consequence*: An image can be considered as existing while it fact it is not.
+
+** *Fix*: Make the pull policy of the pull pod the same as the pull policy defined in the KMM Module, as this is what is used by the worker pod.
+
+** *Result:* The MIC will represent the state of the image in the same way the worker pod will be able to access it.
+
+// MGMT-20785
+* The MIC controller creates two pull-pods when it should create just one.
+
+** *Cause*: On the Kernel Module Management (KMM) Operator, the `ModuleImagesConfig` (MIC) controller may create multiple pull-pods for the same image.
+
+** *Consequence*: Resources are wasted and confusion is caused.
+
+** *Fix*: The `CreateOrPatch` MIC API receives a slice of `ImageSpecs`, as the input is created by going over the the target nodes and adding their images to the slice, so any duplicate `ImageSpecs`, are now filtered out.
+
+** *Result:* The KMM Operator works as expected.
+
+// MGMT-20827
+* The `job.dcDelay` example in the documentation should specify `0s` instead of 0.
+
+** *Cause*: The Kernel Module Management (KMM) Operator default `job.gcDelay` duration field is 0s but the documentation says it is `0`.
+
+** *Consequence*: This can lead a customer in the wrong direction setting a custom value of 60 instead of 60s or 1m that will resolve in an error due to the wrong input type.
+
+** *Fix*: The `job.gcDelay` in the documentation is updated to have a default value of 0s.
+
+** *Result:* Users are less likely to get confused.
+
+// MGMT-20835
+* The KMM Operator Hub environment does not work because of missing MIC and MBSC CRDs.
+
+** *Cause*: The Kernel Module Management (KMM) Operator Hub environment only generates Custom Resource Definitions (CRD) files based on the 'api-hub/' directory. As a result, this does not contain some CRDs required for the KMM Operator Hub environment, such as, 'ModuleImagesConfig' (MIC) resource and Managed Kubernetes Service (MBSC).
+
+** *Consequence*: The KMM Operator Hub environment can not work because it tries to start controllers reconciling CRDs that do not exist in the cluster.
+
+** *Fix*: The fix generates all CRD files into the 'config/crd-hub/bases' directory, but only applies the resources to the cluster that it actually needs.
+
+** *Result:* The KMM Operator Hub environment works as expected.
+
+// MGMT-20852
+* The KMM Operator Hub environment cannot build when finalisers can not be set on a resource.
+
+** *Cause*: The Kernel Module Management (KMM) Operator displays an error with the 'ManagedClusterModule' controller failing to build. This is due to the missing 'ModuleImagesConfig' (MIC) resource finalizers and Role-based Action Control (RBAC) permissions for the KMM Operator Hub environment.
+
+** *Consequence*: The KMM Operator Hub environment cannot build images.
+
+** *Fix*: The RBAC permissions are updated to allow updating finalizers on the MIC resource, and then the appropriate rules created.
+
+** *Result:* The KMM Operator Hub environment builds images without errors with the 'ManagedClusterModule' controller.
+
+// MGMT-20861
+* The 'PreflightValidation' custom resource, with a `kernelVersion: tesdt` causes the KMM Operator to panic.
+
+** *Cause*: Creating a `PreflightValidation` custom resource (CR), with a 'kernelVersion' flag that is set to 'tesdt', causes the Kernel Module Management (KMM) Operator to generate a panic runtime error.
+
+** *Consequence*: Entering invalid kernel versions causes the KMM Operator to panic.
+
+** *Fix*: A webhook - a method for one application to automatically send real-time data to another application when a specific event occurs - has been added to the `PreflightValidation` CR.
+
+** *Result:* The `PreflightValidationOCP` CR with invalid kernel versions can no longer be applied to the cluster, therefore, preventing the operator from generating a panic runtime error.
+
+// MGMT-20866
+* The `PreFflightValidation` custom resource, with a `kernelVersion` flag that is different that the one of the cluster, does not work.
+
+** *Cause*: Creating a `PreflightValidation` custom resource (CR), with a 'kernelVersion' flag that is different from the one of the cluster, does not work.
+
+** *Consequence*: The Kernel Module Management (KMM) Operator is unable to find the Driver Toolkit (DTK) input image for the new kernel version.
+
+** *Fix*: Users should use the `PreflightValidationOCP` CR and explicitly set the 'dtkImage' field in the CR.
+
+** *Result:* Using the fields `kernelVersion` and `dtkImage` the feature can build installed modules for target {product-title} versions.
+
+// MGMT-20888
+* The KMM Operator version 2.4 documentation is updated with `PreflightValidationOCP` information.
+
+** *Cause*: Previously, when creating an `PreflightValidationOCP` CR, you were required to supply the release-image. This has now changed and you need to set the `kernelVersion` the `dtkImage` fields.
+
+** *Consequence*: The documentation was outdated and required an update.
+
+** *Fix*: The documentation is updated with the new support details.
+
+** *Result:* The KMM preflight feature is documented as expected.
+
+// MGMT-20892
+* Using imageRepoSecret in conjunction with DTK as imagestream gets authorization required error.
+
+** *Cause*: On the Kernel Module Management (KMM) Operator, when you set the `imageRepoSecret` in the KMM module, and the build's resulting container image is defined to be stored in the cluster's internal registry, the build will fail to push the final image and generate an `authorization required` error.
+
+** *Consequence*: The KMM Operator does not work as expected.
+
+** *Fix*: When the `imageRepoSecret` is user-defined, it is used as both a pull and push secret by the build process. In order to support using the cluster's internal regsitry, the auth token for that registry needs to be added to the `imageRepoSecret`. The token can be obtained from the "build" service account of the KMM module's namespace.
+
+** *Result:* The KMM Operator works as expected.
+
+// test
+
+=== Known issues
+// MGMT-20453 changed security settings in jira
+* The `ModuleUnloaded` event does not appear when a module is Unloaded.
+
+** *Cause*: When a module is Loaded (using the create a 'ModuleLoad' event) or Unloaded (using the create a 'ModuleUnloaded' event) the events may not appear. This happens when you load and unload the kernel module in a quick succession.
+
+** *Consequence*: The 'ModuleLoad' and 'ModuleUnloaded' events may not appear in {product-title}.
+
+** *Fix*: Alerting the user of this potential behavior and for awareness when working with modules.
+
+** *Result:* Not yet available. 
+
+

--- a/modules/telco-ran-agent-based-installer-abi.adoc
+++ b/modules/telco-ran-agent-based-installer-abi.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="telco-ran-agent-based-installer-abi_{context}"]
-= Agent-based Installer
+= Agent-based installer
 
 New in this release::
 * No reference design updates in this release

--- a/modules/telco-ran-bios-tuning.adoc
+++ b/modules/telco-ran-bios-tuning.adoc
@@ -11,9 +11,8 @@ New in this release::
 
 Description::
 Tune host firmware settings for optimal performance during initial cluster deployment.
-For more information, see "Recommended {sno} cluster configuration for vDU application workloads".
-Apply tuning settings in the host firmware during initial deployment.
-See "Managing host firmware settings with {ztp}" for more information.
+For more information, see link:https://docs.openshift.com/container-platform/4.19/edge_computing/ztp-reference-cluster-configuration-for-vdu.html#ztp-reference-cluster-config[Recommended {sno} cluster configuration for vDU application workloads].
+Apply tuning settings in the host firmware during initial deployment. For more information, see link:https://docs.openshift.com/container-platform/4.19/edge_computing/ztp-deploying-far-edge-sites.html#ztp-configuring-host-firmware-with-gitops-ztp_ztp-deploying-far-edge-sites[Managing host firmware settings with {ztp}].
 The managed cluster host firmware settings are available on the hub cluster as individual `BareMetalHost` custom resources (CRs) that are created when you deploy the managed cluster with the `ClusterInstance` CR and {ztp}.
 +
 [NOTE]

--- a/modules/telco-ran-cluster-tuning.adoc
+++ b/modules/telco-ran-cluster-tuning.adoc
@@ -10,14 +10,10 @@ New in this release::
 * No reference design updates in this release
 
 Description::
-See "Cluster capabilities" for a full list of components that can be disabled by using the cluster capabilities feature.
+For a full list of components that you can disable using the cluster capabilities feature, see link:https://docs.openshift.com/container-platform/4.19/installing/overview/cluster-capabilities.html#cluster-capabilities[Cluster capabilities].
 
 Limits and requirements::
 * Cluster capabilities are not available for installer-provisioned installation methods.
-
-Engineering considerations::
-
-include::snippets/nodes-cgroup-vi-removed.adoc[]
 
 The following table lists the required platform tuning configurations:
 
@@ -58,3 +54,7 @@ Using a single `CatalogSource` fits within the platform CPU budget.
 |If the cluster was deployed with the console disabled, the `Console` CR (`ConsoleOperatorDisable.yaml`) is not needed.
 If the cluster was deployed with the console enabled, you must apply the `Console` CR.
 |====
+
+Engineering considerations::
+* As of {product-title} 4.19, cgroup v1 is no longer supported and has been removed. 
+All workloads must now be compatible with cgroup v2. For more information, see link:https://www.redhat.com/en/blog/rhel-9-changes-context-red-hat-openshift-workloads[Red Hat Enterprise Linux 9 changes in the context of Red Hat OpenShift workloads].

--- a/modules/telco-ran-crs-cluster-tuning.adoc
+++ b/modules/telco-ran-crs-cluster-tuning.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_ran_du_ref_design_specs/telco-ran-du-rds.adoc
+// *scalability_and_performance/telco-ran-du-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="cluster-tuning-crs_{context}"]
@@ -15,7 +15,7 @@ Console disable,`ConsoleOperatorDisable.yaml`,Disables the Console Operator.,No
 Disconnected registry,`09-openshift-marketplace-ns.yaml`,Defines a dedicated namespace for managing the OpenShift Operator Marketplace.,No
 Disconnected registry,`DefaultCatsrc.yaml`,Configures the catalog source for the disconnected registry.,No
 Disconnected registry,`DisableOLMPprof.yaml`,Disables performance profiling for OLM.,No
-Disconnected registry,`DisconnectedICSP.yaml`,Configures disconnected registry image content source policy.,No
+Disconnected registry,`DisconnectedIDMS.yaml`,Configures disconnected registry image content source policy.,No
 Disconnected registry,`OperatorHub.yaml`,"Optional, for multi-node clusters only. Configures the OperatorHub in OpenShift, disabling all default Operator sources. Not required for single-node OpenShift installs with marketplace capability disabled.",No
 Monitoring configuration,`ReduceMonitoringFootprint.yaml`,"Reduces the monitoring footprint by disabling Alertmanager and Telemeter, and sets Prometheus retention to 24 hours",No
 Network diagnostics disable,`DisableSnoNetworkDiag.yaml`,Configures the cluster network settings to disable built-in network troubleshooting and diagnostic features.,No

--- a/modules/telco-ran-crs-day-2-operators.adoc
+++ b/modules/telco-ran-crs-day-2-operators.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_ran_du_ref_design_specs/telco-ran-du-rds.adoc
+// *scalability_and_performance/telco-ran-du-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="day-2-operators-crs_{context}"]
@@ -43,6 +43,7 @@ PTP Operator,`PtpConfigDualCardGmWpc.yaml`,Configures PTP grandmaster clock sett
 PTP Operator,`PtpConfigThreeCardGmWpc.yaml`,Configures PTP grandmaster clock settings for hosts that have 3 NICs. Dependent on cluster role.,No
 PTP Operator,`PtpConfigGmWpc.yaml`,Configures PTP grandmaster clock settings for hosts that have a single NIC. Dependent on cluster role.,No
 PTP Operator,`PtpConfigSlave.yaml`,Configures PTP settings for a PTP ordinary clock. Dependent on cluster role.,No
+PTP Operator,`PtpConfigDualFollower.yaml`,Configures PTP settings for a PTP ordinary clock with 2 interfaces in an active/standby configuration. Dependent on cluster role.,No
 PTP Operator,`PtpOperatorConfig.yaml`,"Configures the PTP Operator settings, specifying node selection criteria for running PTP daemons in the openshift-ptp namespace.",No
 PTP Operator,`PtpSubscription.yaml`,Manages installation and updates of the PTP Operator in the openshift-ptp namespace.,No
 PTP Operator,`PtpSubscriptionNS.yaml`,Configures the namespace for the PTP Operator.,No
@@ -56,7 +57,7 @@ SR-IOV FEC Operator,`SriovFecClusterConfig.yaml`,"Configures SR-IOV FPGA Etherne
 SR-IOV Operator,`SriovNetwork.yaml`,"Defines an SR-IOV network configuration, with placeholders for various network settings.",No
 SR-IOV Operator,`SriovNetworkNodePolicy.yaml`,"Configures SR-IOV network settings for specific nodes, including device type, RDMA support, physical function names, and the number of virtual functions.",No
 SR-IOV Operator,`SriovOperatorConfig.yaml`,"Configures SR-IOV Network Operator settings, including node selection, injector, and webhook options.",No
-SR-IOV Operator,`SriovOperatorConfigForSNO.yaml`,"Configures the SR-IOV Network Operator settings for single-node OpenShift, including node selection, injector, webhook options, and disabling node drain, in the openshift-sriov-network-operator namespace.",No
+SR-IOV Operator,`SriovOperatorConfigForSNO.yaml`,"Configures the SR-IOV Network Operator settings for Single Node OpenShift (SNO), including node selection, injector, webhook options, and disabling node drain, in the openshift-sriov-network-operator namespace.",No
 SR-IOV Operator,`SriovSubscription.yaml`,Manages the installation and updates of the SR-IOV Network Operator.,No
 SR-IOV Operator,`SriovSubscriptionNS.yaml`,Creates the namespace for the SR-IOV Network Operator with specific annotations for workload management and deployment waves.,No
 SR-IOV Operator,`SriovSubscriptionOperGroup.yaml`,"Defines the target namespace for the SR-IOV Network Operators, enabling their management and deployment within this namespace.",No

--- a/modules/telco-ran-crs-machine-configuration.adoc
+++ b/modules/telco-ran-crs-machine-configuration.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * scalability_and_performance/telco_ran_du_ref_design_specs/telco-ran-du-rds.adoc
+// *scalability_and_performance/telco-ran-du-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="machine-configuration-crs_{context}"]
@@ -14,15 +14,16 @@ Container runtime (crun),`enable-crun-master.yaml`,Configures the container runt
 Container runtime (crun),`enable-crun-worker.yaml`,Configures the container runtime (crun) for worker nodes.,No
 CRI-O wipe disable,`99-crio-disable-wipe-master.yaml`,Disables automatic CRI-O cache wipe following a reboot for on control plane nodes.,No
 CRI-O wipe disable,`99-crio-disable-wipe-worker.yaml`,Disables automatic CRI-O cache wipe following a reboot for on worker nodes.,No
-Kdump enable,`06-kdump-master.yaml`,Configures kdump crash reporting on master nodes.,No
+Kdump enable,`06-kdump-master.yaml`,Configures kdump crash reporting on control plane nodes.,No
 Kdump enable,`06-kdump-worker.yaml`,Configures kdump crash reporting on worker nodes.,No
 Kubelet configuration and container mount hiding,`01-container-mount-ns-and-kubelet-conf-master.yaml`,Configures a mount namespace for sharing container-specific mounts between kubelet and CRI-O on control plane nodes.,No
 Kubelet configuration and container mount hiding,`01-container-mount-ns-and-kubelet-conf-worker.yaml`,Configures a mount namespace for sharing container-specific mounts between kubelet and CRI-O on worker nodes.,No
-One-shot time sync,`99-sync-time-once-master.yaml`,Synchronizes time once on master nodes.,No
+One-shot time sync,`99-sync-time-once-master.yaml`,Synchronizes time once on control plane nodes.,No
 One-shot time sync,`99-sync-time-once-worker.yaml`,Synchronizes time once on worker nodes.,No
-SCTP,`03-sctp-machine-config-master.yaml`,Loads the SCTP kernel module on master nodes.,Yes
+SCTP,`03-sctp-machine-config-master.yaml`,Loads the SCTP kernel module on control plane nodes.,Yes
 SCTP,`03-sctp-machine-config-worker.yaml`,Loads the SCTP kernel module on worker nodes.,Yes
 Set RCU normal,`08-set-rcu-normal-master.yaml`,Disables rcu_expedited by setting rcu_normal after the control plane node has booted.,No
 Set RCU normal,`08-set-rcu-normal-worker.yaml`,Disables rcu_expedited by setting rcu_normal after the worker node has booted.,No
-SRIOV-related kernel arguments,`07-sriov-related-kernel-args-master.yaml`,Enables SR-IOV support on master nodes.,No
+SRIOV-related kernel arguments,`07-sriov-related-kernel-args-master.yaml`,Enables SR-IOV support on control plane nodes.,No
+SRIOV-related kernel arguments,`07-sriov-related-kernel-args-worker.yaml`,Enables SR-IOV support on worker nodes.,No
 |====

--- a/modules/telco-ran-du-application-workloads.adoc
+++ b/modules/telco-ran-du-application-workloads.adoc
@@ -3,6 +3,7 @@
 // * scalability_and_performance/telco_ran_du_ref_design_specs/telco-ran-du-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
+
 [id="telco-ran-du-application-workloads_{context}"]
 = Telco RAN DU application workloads
 

--- a/modules/telco-ran-du-reference-design-components.adoc
+++ b/modules/telco-ran-du-reference-design-components.adoc
@@ -3,6 +3,7 @@
 // * scalability_and_performance/telco_ran_du_ref_design_specs/telco-ran-du-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
+
 [id="telco-ran-du-reference-design-components_{context}"]
 = Telco RAN DU reference design components
 

--- a/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
+++ b/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
@@ -12,13 +12,33 @@ Specific limits, requirements and engineering considerations for individual comp
 
 [NOTE]
 ====
-For details of the RAN DU KPI test results, see the link:https://access.redhat.com/articles/7107302[Telco RAN DU reference design specification KPI test results for OpenShift {product-version}].
+For details of the telco RAN DU RDS KPI test results, see the link:https://access.redhat.com/articles/7107302[telco RAN DU {product-version} reference design specification KPI test results].
 This information is only available to customers and partners.
 ====
 
+Cluster topology::
++
+--
+The recommended topology for RAN DU workloads is {sno}.
+DU workloads may be run on other cluster topologies such as 3-node compact cluster, high availability (3 control plane + n worker nodes), or SNO+1 as needed.
+Multiple SNO clusters, or a highly-available 3-node compact cluster, are recommended over the SNO+1 topology.
+
+Remote worker node (RWN) cluster topologies are not recommended or included under this reference design specification.
+For workloads with high service level agreement requirements such as RAN DU the following drawbacks exclude RWN from consideration:
+
+* No support for Image Based Upgrades and the benefits offered by that feature, such as faster upgrades and rollback capability.
+* Updates to Day 2 operators affect all RWNs simultaneously without the ability to perform a rolling update.
+* Loss of the control plane (disaster scenario) would have a significantly higher impact on overall service availability due to the greater number of sites served by that control plane.
+* Loss of network connectivity between the RWN and the control plane for a period exceeding the monitoring grace period and toleration timeouts might result in pod eviction and lead to a service outage.
+* No support for container image pre-caching.
+* Additional complexities in workload affinities.
+
+--
+
 Workloads::
-* DU workloads are described in "Telco RAN DU application workloads".
-* DU worker nodes are Intel 3rd Generation Xeon (IceLake) 2.20 GHz or better with host firmware tuned for maximum performance.
+. DU workloads are described in xref:../scalability_and_performance/telco-ran-du-rds.adoc#telco-ran-du-application-workloads_telco-ran-du[Telco RAN DU application workloads].
+. DU worker nodes are Intel 3rd Generation Xeon (IceLake) 2.20 GHz or newer with host firmware tuned for maximum performance.
+
 
 Resources::
 The maximum number of running pods in the system, inclusive of application workload and {product-title} pods, is 120.
@@ -64,7 +84,7 @@ For example:
 $ query=avg_over_time(pod:container_cpu_usage:sum{namespace="openshift-kube-apiserver"}[30m])
 ----
 ====
-. Application logs are not collected by the platform log collector
+. Application logs are not collected by the platform log collector.
 . Aggregate traffic on the primary CNI is less than 8 Mbps
 
 Hub cluster management characteristics::
@@ -72,7 +92,7 @@ Hub cluster management characteristics::
 --
 {rh-rhacm}  is the recommended cluster management solution and is configured to these limits:
 
-. Use a maximum of 5 {rh-rhacm} configuration policies with a compliant evaluation interval of not less than 10 minutes.
+. Use a maximum of 10 {rh-rhacm} configuration policies, comprising 5 Red{nbsp}Hat provided policies and up to 5 custom configuration policies with a compliant evaluation interval of not less than 10 minutes.
 . Use a minimal number (up to 10) of managed cluster templates in cluster policies.
 Use hub-side templating.
 . Disable {rh-rhacm} addons with the exception of the `policyController` and configure observability with the default configuration.

--- a/modules/telco-ran-gitops-operator-and-ztp-plugins.adoc
+++ b/modules/telco-ran-gitops-operator-and-ztp-plugins.adoc
@@ -8,7 +8,7 @@
 = GitOps Operator and {ztp}
 
 New in this release::
-* No reference design updates in this release
+* https://issues.redhat.com/browse/CNF-9183[GA support for ACM PolicyGenerator with gitops/ZTP (as recommended reference)]
 
 Description::
 +
@@ -20,16 +20,18 @@ In earlier releases, a {ztp} plugin supported the generation of installation CRs
 This plugin is now deprecated.
 A separate {ztp} plugin is available to enable automatic wrapping of configuration CRs into policies based on the `PolicyGenerator` or `PolicyGenTemplate` CR.
 
-You can deploy and manage multiple versions of {product-title} on managed clusters by using the baseline reference configuration CRs.
+You can deploy and manage multiple versions of {product-title} on managed clusters using the baseline reference configuration CRs.
 You can use custom CRs alongside the baseline CRs.
 To maintain multiple per-version policies simultaneously, use Git to manage the versions of the source and policy CRs by using `PolicyGenerator` or `PolicyGenTemplate` CRs.
+{rh-rhacm} `PolicyGenerator` is the recommended generator plugin starting from {product-title} 4.19 release.
 --
 
 Limits and requirements::
-* 300 `ClusterInstance` CRs per ArgoCD application.
+// Scale results ACM-17868
+* 800 `ClusterInstance` CRs per ArgoCD application.
 Multiple applications can be used to achieve the maximum number of clusters supported by a single hub cluster
 * Content in the `source-crs/` directory in Git overrides content provided in the ZTP plugin container, as Git takes precedence in the search path.
-* The `source-crs/` directory is specifically expected to be located in the same directory as the `kustomization.yaml` file, which includes `PolicyGenerator` or `PolicyGenTemplate` CRs as a generator.
+* The `source-crs/` directory must be located in the same directory as the `kustomization.yaml` file, which includes `PolicyGenerator` CRs as a generator.
 Alternative locations for the `source-crs/` directory are not supported in this context.
 
 Engineering considerations::

--- a/modules/telco-ran-lca-operator.adoc
+++ b/modules/telco-ran-lca-operator.adoc
@@ -10,9 +10,10 @@ New in this release::
 * No reference design updates in this release
 
 Description::
-The Lifecycle Agent provides local lifecycle management services for {sno} clusters.
+The Lifecycle Agent provides local lifecycle management services for image-based upgrade of {sno} clusters.
+Image-based upgrade is the recommended upgrade method for {sno} clusters.
 
 Limits and requirements::
 * The Lifecycle Agent is not applicable in multi-node clusters or {sno} clusters with an additional worker.
 * The Lifecycle Agent requires a persistent volume that you create when installing the cluster.
-For descriptions of partition requirements, see "Configuring a shared container directory between ostree stateroots when using {ztp}".
+Partition requirements are described in link:https://docs.openshift.com/container-platform/4.19/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-shared-container-partition.html#ztp-image-based-upgrade-shared-container-partition_shared-container-partition[Configuring a shared container directory between ostree stateroots when using {ztp}].

--- a/modules/telco-ran-machine-configuration.adoc
+++ b/modules/telco-ran-machine-configuration.adoc
@@ -10,8 +10,9 @@ New in this release::
 * No reference design updates in this release
 
 Limits and requirements::
-The CRI-O wipe disable `MachineConfig` CR assumes that images on disk are static other than during scheduled maintenance in defined maintenance windows.
+* The CRI-O wipe disable `MachineConfig` CR assumes that images on disk are static other than during scheduled maintenance in defined maintenance windows.
 To ensure the images are static, do not set the pod `imagePullPolicy` field to `Always`.
+* The configuration CRs in this table are required components unless otherwise noted.
 
 .Machine configuration options
 [cols="1,2", width="90%", options="header"]

--- a/modules/telco-ran-node-tuning-operator.adoc
+++ b/modules/telco-ran-node-tuning-operator.adoc
@@ -10,23 +10,23 @@ New in this release::
 * No reference design updates in this release
 
 Description::
-The RAN DU use model includes cluster performance tuning via `PerformanceProfile` CRs for low-latency performance.
-The `PerformanceProfile` CRs are reconciled by the Node Tuning Operator.
+The RAN DU use model includes cluster performance tuning using `PerformanceProfile` CRs for low-latency performance.
 The RAN DU use case requires the cluster to be tuned for low-latency performance.
-For more details about node tuning with the `PerformanceProfile` CR, see "Tuning nodes for low latency with the performance profile".
+The Node Tuning Operator reconciles the `PerformanceProfile` CRs.
+For more details about node tuning with the `PerformanceProfile` CR, see link:https://docs.openshift.com/container-platform/4.19/scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.html#perf-profile[Tuning nodes for low latency with the performance profile].
 
 Limits and requirements::
 The Node Tuning Operator uses the `PerformanceProfile` CR to configure the cluster.
-You need to configure the following settings in the telco RAN DU profile `PerformanceProfile` CR:
+You must configure the following settings in the telco RAN DU profile `PerformanceProfile` CR:
 +
 --
 * Set a reserved `cpuset` of 4 or more, equating to 4 hyper-threads (2 cores) for either of the following CPUs:
-** Intel 3rd Generation Xeon (IceLake) 2.20 GHz or better CPUs with host firmware tuned for maximum performance
-** AMD EPYC Zen 4 CPUs (Genoa, Bergamo, or newer)
+** Intel 3rd Generation Xeon (IceLake) 2.20 GHz, or newer, CPUs with host firmware tuned for maximum performance
+** AMD EPYC Zen 4 CPUs (Genoa, Bergamo)
 +
 [NOTE]
 ====
-AMD EPYC Zen 4 CPUs (Genoa, Bergamo, or newer) are fully supported.
+AMD EPYC Zen 4 CPUs (Genoa, Bergamo) are fully supported.
 Power consumption evaluations are ongoing.
 It is recommended to evaluate features, such as per-pod power management, to determine any potential impact on performance.
 ====
@@ -37,7 +37,8 @@ Unreserved cores are available as allocatable CPU for scheduling workloads.
 * Ensure that reserved and isolated CPUs include all the threads for all cores in the CPU.
 * Include Core 0 for each NUMA node in the reserved CPU set.
 * Set the huge page size to 1G.
-* Only pin {product-title} pods which are by default configured as part of the management workload partition to reserved cores.
+* Only pin {product-title} pods that are by default configured as part of the management workload partition to reserved cores.
+* When recommended by the hardware vendor, set the maximum CPU frequency for reserved and isolated CPUs using the `hardwareTuning` section.
 --
 
 Engineering considerations::
@@ -49,4 +50,6 @@ Variation in this parameter is expected and allowed.
 The variation must still meet the specified limits.
 * Hardware without IRQ affinity support affects isolated CPUs.
 To ensure that pods with guaranteed whole CPU QoS have full use of allocated CPUs, all hardware in the server must support IRQ affinity.
-* When workload partitioning is enabled by setting `cpuPartitioningMode` to `AllNodes` during deployment, you must allocate enough CPUs to support the operating system, interrupts, and {product-title} pods in the `PerformanceProfile` CR.
+* If you enable workload partitioning by setting `cpuPartitioningMode` to `AllNodes` during deployment, you must use the `PerformanceProfile` CR to allocate enough CPUs to support the operating system, interrupts, and {product-title} pods.
+* The reference performance profile includes additional kernel arguments settings for `vfio_pci`.
+These arguments are included for support of devices such as the FEC accelerator. You can omit them if they are not required for your workload.

--- a/modules/telco-ran-ptp-operator.adoc
+++ b/modules/telco-ran-ptp-operator.adoc
@@ -7,10 +7,12 @@
 = PTP Operator
 
 New in this release::
-* No reference design updates in this release
+* https://issues.redhat.com/browse/CNF-12504[Enable 2 Port Ordinary Clock Use Case for IA]
+* https://issues.redhat.com/browse/CNF-13189[CNF-13189: Remove the internal API and sidecar support]
+* https://issues.redhat.com/browse/CNF-16651[CNF-16651: 3 Card WPC T-G]
 
 Description::
-Configure PTP in cluster nodes with `PTPConfig` CRs for the RAN DU use case with features like Grandmaster clock (T-GM) support via GPS, ordinary clock (OC), boundary clocks (T-BC), dual boundary clocks, high availability (HA), and optional fast event notification over HTTP.
+Configure PTP in cluster nodes with `PTPConfig` CRs for the RAN DU use case with features like Grandmaster clock (T-GM) support using GPS, ordinary clock (OC), boundary clocks (T-BC), dual boundary clocks, high availability (HA), and optional fast event notification over HTTP.
 PTP ensures precise timing and reliability in the RAN environment.
 
 Limits and requirements::
@@ -21,6 +23,4 @@ Engineering considerations::
 * RAN DU RDS configurations are provided for ordinary clocks, boundary clocks, grandmaster clocks, and highly available dual NIC boundary clocks.
 * PTP fast event notifications use `ConfigMap` CRs to persist subscriber details.
 * Hierarchical event subscription as described in the O-RAN specification is not supported for PTP events.
-* Use the PTP fast events REST API v2.
-The PTP fast events REST API v1 is deprecated.
-The REST API v2 is O-RAN Release 3 compliant.
+* The PTP fast events REST API v1 is end of life.

--- a/modules/telco-ran-red-hat-advanced-cluster-management-rhacm.adoc
+++ b/modules/telco-ran-red-hat-advanced-cluster-management-rhacm.adoc
@@ -21,7 +21,7 @@ You manage cluster configuration and upgrades declaratively by applying `Policy`
 * Configuration, upgrades, and cluster status through the {rh-rhacm} policy controller.
 * During managed cluster installation, {rh-rhacm} can apply labels to individual nodes as configured through the `ClusterInstance` CR.
 
-The recommended method for {sno} cluster installation is the image-based installer method available in MCE using the `ClusterInstance` CR for cluster definition.
+The recommended method for {sno} cluster installation is the image-based installation approach, available in MCE, using the `ClusterInstance` CR for cluster definition.
 
 The recommended method for {sno} cluster upgrade is the image-based upgrade method.
 --

--- a/modules/telco-ran-siteconfig-operator.adoc
+++ b/modules/telco-ran-siteconfig-operator.adoc
@@ -7,7 +7,7 @@
 = SiteConfig Operator
 
 New in this release::
-* No RDS updates in this release
+* No reference design updates in this release
 
 Description::
 +
@@ -31,7 +31,7 @@ The Assisted Installer streamlines the installation process while minimizing tim
 
 * **Image-based Installer** expedites the deployment of {sno} clusters by utilizing preconfigured and validated {product-title} seed images.
 Seed images are preinstalled on target hosts, enabling rapid reconfiguration and deployment.
-The Image-based Installer is particularly well-suited for remote or disconnected environments, because it simplifies the cluster creation process and significantly reduces deployment time.
+The Image-based Installer is particularly well-suited for remote or disconnected environments because it simplifies the cluster creation process and significantly reduces deployment time.
 --
 
 Limits and requirements::

--- a/modules/telco-ran-sr-iov-operator.adoc
+++ b/modules/telco-ran-sr-iov-operator.adoc
@@ -7,7 +7,7 @@
 = SR-IOV Operator
 
 New in this release::
-* No reference design updates in this release
+* https://issues.redhat.com/browse/CNF-12813[Support moving failed policy in resource injector to failed for SR-IOV operator]
 
 Description::
 The SR-IOV Operator provisions and configures the SR-IOV CNI and device plugins.
@@ -15,7 +15,7 @@ Both `netdevice` (kernel VFs) and `vfio` (DPDK) devices are supported and applic
 
 Limits and requirements::
 * Use devices that are supported for {product-title}.
-See "Supported devices".
+See link:https://docs.openshift.com/container-platform/4.19/networking/hardware_networks/about-sriov.html#nw-sriov-supported-platforms_about-sriov[Supported devices].
 * SR-IOV and IOMMU enablement in host firmware settings: The SR-IOV Network Operator automatically enables IOMMU on the kernel command line.
 * SR-IOV VFs do not receive link state updates from the PF.
 If link down detection is required you must configure this at the protocol level.
@@ -23,18 +23,18 @@ If link down detection is required you must configure this at the protocol level
 Engineering considerations::
 * SR-IOV interfaces with the `vfio` driver type are typically used to enable additional secondary networks for applications that require high throughput or low latency.
 * Customer variation on the configuration and number of `SriovNetwork` and `SriovNetworkNodePolicy` custom resources (CRs) is expected.
-* IOMMU kernel command-line settings are applied with a `MachineConfig` CR at install time.
+* IOMMU kernel command line settings are applied with a `MachineConfig` CR at install time.
 This ensures that the `SriovOperator` CR does not cause a reboot of the node when adding them.
 * SR-IOV support for draining nodes in parallel is not applicable in a {sno} cluster.
 * You must include the `SriovOperatorConfig` CR in your deployment; the CR is not created automatically.
 This CR is included in the reference configuration policies which are applied during initial deployment.
 * In scenarios where you pin or restrict workloads to specific nodes, the SR-IOV parallel node drain feature will not result in the rescheduling of pods.
 In these scenarios, the SR-IOV Operator disables the parallel node drain functionality.
-* NICs which do not support firmware updates under secure boot or kernel lockdown must be pre-configured with sufficient virtual functions (VFs) to support the number of VFs needed by the application workload.
-For Mellanox NICs, the Mellanox vendor plugin must be disabled in the SR-IOV Network Operator.
-For more information, see "Configuring an SR-IOV network device".
+* You must pre-configure NICs which do not support firmware updates under secure boot or kernel lockdown with sufficient virtual functions (VFs) to support the number of VFs needed by the application workload.
+For Mellanox NICs, you must disable the Mellanox vendor plugin in the SR-IOV Network Operator.
+For more information, see link:https://docs.openshift.com/container-platform/4.19/networking/hardware_networks/configuring-sriov-device.html#nw-sriov-nic-mlx-secure-boot_configuring-sriov-device[Configuring an SR-IOV network device].
 * To change the MTU value of a virtual function after the pod has started, do not configure the MTU field in the `SriovNetworkNodePolicy` CR.
-Instead, configure the Network Manager or use a custom systemd script to set the MTU of the physical function to an appropriate value.
+Instead, configure the Network Manager or use a custom `systemd` script to set the MTU of the physical function to an appropriate value.
 For example:
 +
 [source,terminal]

--- a/modules/telco-ran-sriov-fec-operator.adoc
+++ b/modules/telco-ran-sriov-fec-operator.adoc
@@ -3,6 +3,7 @@
 // * scalability_and_performance/telco_ran_du_ref_design_specs/telco-ran-du-rds.adoc
 
 :_mod-docs-content-type: REFERENCE
+
 [id="telco-ran-sriov-fec-operator_{context}"]
 = SRIOV-FEC Operator
 

--- a/modules/telco-ran-topology-aware-lifecycle-manager-talm.adoc
+++ b/modules/telco-ran-topology-aware-lifecycle-manager-talm.adoc
@@ -11,7 +11,7 @@ New in this release::
 * No reference design updates in this release
 
 Description::
-{cgu-operator-full} is an Operator that runs only on the hub cluster for managing how changes like cluster upgrades, Operator upgrades, and cluster configuration are rolled out to the network.
+{cgu-operator} is an Operator that runs only on the hub cluster for managing how changes like cluster upgrades, Operator upgrades, and cluster configuration are rolled out to the network.
 {cgu-operator} supports the following features:
 
 * Progressive rollout of policy updates to fleets of clusters in user configurable batches.

--- a/modules/telco-ref-design-overview.adoc
+++ b/modules/telco-ref-design-overview.adoc
@@ -18,6 +18,13 @@ Following the RDS minimizes high severity escalations and improves application s
 5G use cases are evolving and your workloads are continually changing.
 Red Hat is committed to iterating over the telco core and RAN DU RDS to support evolving requirements based on customer and partner feedback.
 
+[NOTE]
+====
+Support for an ARM based platform is currently a Developer Preview feature for {product-title} 4.19.
+All information is subject to change on release.
+For more details, see the following Red Hat knowledge base article : https://access.redhat.com/articles/7118870[How to use ARM platform hardware in OpenShift 4.19 Telco RDS (Developer Preview)]
+====
+
 The reference configuration includes the configuration of the far edge clusters and hub cluster components.
 
 The reference configurations in this document are deployed using a centrally managed hub cluster infrastructure as shown in the following image.

--- a/modules/ztp-telco-hub-cluster-software-versions.adoc
+++ b/modules/ztp-telco-hub-cluster-software-versions.adoc
@@ -15,18 +15,18 @@ The Red Hat telco RAN {product-version} solution has been validated using the fo
 |Software version
 
 |Hub cluster version
-|4.18
+|4.19
 
 |{rh-rhacm-first}
-|2.12^1^
+|2.13^1^
 
 |{gitops-title}
-|1.14
+|1.16
 
 |{ztp} site generate plugins
-|4.18
+|4.19
 
 |{cgu-operator-first}
-|4.18
+|4.19
 |====
-[1] This table will be updated when the aligned {rh-rhacm} version 2.13 is released.
+[1] This table will be updated when the aligned {rh-rhacm} version 2.14 is released.

--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -15,27 +15,27 @@ The Red Hat telco RAN DU {product-version} solution has been validated using the
 |Software version
 
 |Managed cluster version
-|4.18
+|4.19
 
 |Cluster Logging Operator
-|6.1^1^
+|6.2^1^
 
 |Local Storage Operator
-|4.18
+|4.19
 
 |OpenShift API for Data Protection (OADP)
-|1.4
+|1.5
 
 |PTP Operator
-|4.18
+|4.19
 
 |SR-IOV Operator
-|4.18
+|4.19
 
 |SRIOV-FEC Operator
-|2.10
+|2.11
 
 |Lifecycle Agent
-|4.18
+|4.19
 |====
-[1] This table will be updated when the aligned Cluster Logging Operator version 6.2 is released.
+[1] This table will be updated when the aligned Cluster Logging Operator version 6.3 is released.

--- a/scalability_and_performance/telco-ran-du-rds.adoc
+++ b/scalability_and_performance/telco-ran-du-rds.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 :telco-ran:
 [id="telco-ran-du-ref-design-specs"]
-= Telco RAN DU reference design specifications
+= Telco RAN DU reference design specification for {product-title} {product-version}
 include::_attributes/common-attributes.adoc[]
 :context: telco-ran-du
 
@@ -9,6 +9,10 @@ toc::[]
 
 The telco RAN DU reference design specifications (RDS) describes the configuration for clusters running on commodity hardware to host 5G workloads in the Radio Access Network (RAN).
 It captures the recommended, tested, and supported configurations to get reliable and repeatable performance for a cluster running the telco RAN DU profile.
+
+Use the use model and system level information to plan telco RAN DU workloads, cluster resources, and minimum hardware specifications for managed {sno} clusters.
+
+Specific limits, requirements, and engineering considerations for individual components are described in individual sections.
 
 include::modules/telco-ref-design-overview.adoc[leveloffset=+1]
 
@@ -137,6 +141,8 @@ include::modules/telco-ran-agent-based-installer-abi.adoc[leveloffset=+2]
 .Additional resources
 
 * xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing an {product-title} cluster with the Agent-based Installer]
+
+// include::modules/telco-ran-additional-components.adoc[leveloffset=+2]
 
 [id="telco-ran-du-reference-configuration-crs"]
 == Telco RAN DU reference configuration CRs


### PR DESCRIPTION
KMM 2.4 release notes

Version(s):
 openshift-4.19 
KMM 2.4

Issue:
https://issues.redhat.com/browse/TELCODOCS-2306

Link to docs preview:
https://95220--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-release-notes.html

Dev: @ybettan 
QE: @cdvultur 
QE review:
- [ ] QE has approved this change.

Additional information:
Note to Reviewers: You have already reviewed jiras for the sections **Bug fixes** and **Known issues**. Please review the **New features** section. 

