### PR TITLE
OCPBUGS-33123: update matchLabels values to strings

### DIFF
--- a/modules/nw-ingress-sharding-namespace-labels.adoc
+++ b/modules/nw-ingress-sharding-namespace-labels.adoc
@@ -44,7 +44,7 @@ spec:
         node-role.kubernetes.io/worker: ""
   namespaceSelector:
     matchLabels:
-      type: sharded
+      type: "sharded"
 ----
 <1> Specify a domain to be used by the Ingress Controller. This domain must be different from the default Ingress Controller domain.
 

--- a/modules/nw-ingress-sharding-route-labels.adoc
+++ b/modules/nw-ingress-sharding-route-labels.adoc
@@ -35,7 +35,7 @@ spec:
         node-role.kubernetes.io/worker: ""
   routeSelector:
     matchLabels:
-      type: sharded
+      type: "sharded"
 ----
 <1> Specify a domain to be used by the Ingress Controller. This domain must be different from the default Ingress Controller domain.
 

--- a/modules/nw-traditional-sharding.adoc
+++ b/modules/nw-traditional-sharding.adoc
@@ -26,7 +26,7 @@ spec:
       - ops
 ----
 
-An example of a configured Ingress Controller `dev-router` that has the label selector `spec.namespaceSelector.matchLabels.name` with the key value set to `dev`:
+An example of a configured Ingress Controller `dev-router` that has the label selector `spec.namespaceSelector.matchLabels.name` with the key value set to `"dev"`:
 
 .Example YAML definition for `dev-router`
 [source,yaml]
@@ -39,7 +39,7 @@ metadata:
 spec:
   namespaceSelector:
     matchLabels:
-      name: dev
+      name: "dev"
 ----
 
 If all application routes are in separate namespaces, such as each labeled with `name:finance`, `name:ops`, and `name:dev`, the configuration effectively distributes your routes between the two Ingress Controllers. {product-title} routes for console, authentication, and other purposes should not be handled.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-33123
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- traditional sharding example: https://95249--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#nw-traditional-sharding_configuring-ingress-cluster-traffic-ingress-controller
- sharding with route labels: https://95249--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#nw-ingress-sharding-route-labels_configuring-ingress-cluster-traffic-ingress-controller
- sharding with namespace labels: https://95249--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#nw-ingress-sharding-namespace-labels_configuring-ingress-cluster-traffic-ingress-controller 

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
