### PR TITLE
OCPBUGS-58150 added zero trust attributes back into the common attrib…

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -376,3 +376,8 @@ endif::openshift-origin[]
 :hcp: hosted control planes
 :mce: multicluster engine for Kubernetes Operator
 :mce-short: multicluster engine Operator
+//zero trust workload identity manager
+:zero-trust-full: Zero Trust Workload Identity Manager
+:spiffe-full: Secure Production Identity Framework for Everyone (SPIFFE)
+:svid-full: SPIFFE Verifiable Identity Document (SVID)
+:spire-full: SPIFFE Runtime Environment


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-58150

Link to docs preview:


QE review:
- [ ] QE has approved this change.


Additional information:
QE review not needed
