### PR TITLE
MCO Clarity in Custom Config Application

### DIFF
--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -9,8 +9,6 @@
 
 The Machine Config Operator (MCO) manages updates to systemd, CRI-O and Kubelet, the kernel, Network Manager and other system features. It also offers a `MachineConfig` CRD that can write configuration files onto the host (see link:https://github.com/openshift/machine-config-operator#machine-config-operator[machine-config-operator]). Understanding what MCO does and how it interacts with other components is critical to making advanced, system-level changes to an {product-title} cluster. Here are some things you should know about MCO, machine configs, and how they are used:
 
-* Machine configs are processed alphabetically, in lexicographically increasing order, of their name. The render controller uses the first machine config in the list as the base and appends the rest to the base machine config.
-
 * A machine config can make a specific change to a file or service on the operating system of each system representing a pool of {product-title} nodes.
 
 * MCO applies changes to operating systems in pools of machines. All {product-title} clusters start with worker and control plane node pools. By adding more role labels, you can configure custom pools of nodes. For example, you can set up a custom pool of worker nodes that includes particular hardware features needed by an application. However, examples in this section focus on changes to the default pool types.
@@ -19,6 +17,12 @@ The Machine Config Operator (MCO) manages updates to systemd, CRI-O and Kubelet,
 ====
 A node can have multiple labels applied that indicate its type, such as `master` or `worker`, however it can be a member of only a *single* machine config pool.
 ====
+
+* Machine configs are processed alphabetically, in lexicographically increasing order, by their name. The render controller uses the first machine config in the list as the base and appends the rest to the base machine config into a rendered machine config, which is then applied to the appropriate nodes.
+
+* When you create a machine config for the worker nodes, the changes are also applied to the nodes in all custom pools.
++
+However, as of {product-title} 4.15, any machine configs that target custom pools always override worker machine configs if the worker machine configs contain definitions for the same fields.
 
 * After a machine config change, the MCO updates the affected nodes alphabetically by zone, based on the `topology.kubernetes.io/zone` label. If a zone has more than one node, the oldest nodes are updated first. For nodes that do not use zones, such as in bare metal deployments, the nodes are upgraded by age, with the oldest nodes updated first. The MCO updates the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool at a time.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15124

Preview
Machine configuration -> Machine configuration overview -> [Machine config overview](https://95297--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#machine-config-overview_machine-config-overview) -- Moved bullet down to position 3, from 1, so that it is after the bullet that describes custom pools. New bullet 4.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
