### PR TITLE
OSDOCS#15030-main: Create the release notes template for 4.20 on main

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ocp-4-20-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/common-attributes.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch that they are relevant for.
+
+Release note changes should be added or edited in their own PR.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
Version(s):
main

Issue:
[OSDOCS-15030](https://issues.redhat.com//browse/OSDOCS-15030)

Link to docs preview:
[4.20 RN doc](https://95323--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-release-notes)

Additional information:
This PR creates the RN stub in `main` for 4.20.
