### PR TITLE
OSSM-9812 DOCS ServiceMesh-3 , East-West gateway templete URL not working (404)

### DIFF
--- a/modules/ossm-installing-external-control-plane.adoc
+++ b/modules/ossm-installing-external-control-plane.adoc
@@ -79,7 +79,7 @@ EOF
 +
 [source,terminal]
 ----
-$ oc --context "${CTX_CONTROL_PLANE_CLUSTER}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/controlplane-gateway.yaml
+$ oc --context "${CTX_CONTROL_PLANE_CLUSTER}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/deployment-models/resources/controlplane-gateway.yaml
 ----
 
 .. Get the assigned IP address for the ingress gateway by running the following command:

--- a/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
@@ -69,14 +69,14 @@ $ oc --context "${CTX_CLUSTER1}" wait --for condition=Ready istio/default --time
 +
 [source,terminal]
 ----
-$ oc --context "${CTX_CLUSTER1}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/east-west-gateway-net1.yaml
+$ oc --context "${CTX_CLUSTER1}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/deployment-models/resources/east-west-gateway-net1.yaml
 ----
 
 .. Expose the services through the gateway by running the following command:
 +
 [source,terminal]
 ----
-$ oc --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/expose-services.yaml
+$ oc --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/deployment-models/resources/expose-services.yaml
 ----
 
 . Install {istio} on the West cluster:
@@ -113,14 +113,14 @@ $ oc --context "${CTX_CLUSTER2}" wait --for condition=Ready istio/default --time
 +
 [source,terminal]
 ----
-$ oc --context "${CTX_CLUSTER2}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/east-west-gateway-net2.yaml
+$ oc --context "${CTX_CLUSTER2}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/deployment-models/resources/east-west-gateway-net2.yaml
 ----
 
 .. Expose the services through the gateway by running the following command:
 +
 [source,terminal]
 ----
-$ oc --context "${CTX_CLUSTER2}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/expose-services.yaml
+$ oc --context "${CTX_CLUSTER2}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/deployment-models/resources/expose-services.yaml
 ----
 
 . Create the `istio-reader-service-account` service account for the East cluster by running the following command:

--- a/modules/ossm-installing-primary-remote-multi-network-mesh.adoc
+++ b/modules/ossm-installing-primary-remote-multi-network-mesh.adoc
@@ -78,21 +78,21 @@ $ oc --context "${CTX_CLUSTER1}" wait --for condition=Ready istio/default --time
 +
 [source,terminal]
 ----
-$ oc --context "${CTX_CLUSTER1}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/east-west-gateway-net1.yaml
+$ oc --context "${CTX_CLUSTER1}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/deployment-models/resources/east-west-gateway-net1.yaml
 ----
 
 .. Expose the control plane through the gateway so that services in the West cluster can access the control plane by running the following command:
 +
 [source,terminal]
 ----
-$ oc --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/expose-istiod.yaml
+$ oc --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/deployment-models/resources/expose-istiod.yaml
 ----
 
 .. Expose the application services through the gateway by running the following command:
 +
 [source,terminal]
 ----
-$ oc --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/expose-services.yaml
+$ oc --context "${CTX_CLUSTER1}" apply -n istio-system -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/deployment-models/resources/expose-services.yaml
 ----
 
 . Install {istio} on the West cluster:
@@ -162,7 +162,7 @@ $ oc --context "${CTX_CLUSTER2}" wait --for condition=Ready istio/default --time
 +
 [source,terminal]
 ----
-$ oc --context "${CTX_CLUSTER2}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/multicluster/east-west-gateway-net2.yaml
+$ oc --context "${CTX_CLUSTER2}" apply -f https://raw.githubusercontent.com/istio-ecosystem/sail-operator/main/docs/deployment-models/resources/east-west-gateway-net2.yaml
 ----
 +
 [NOTE]


### PR DESCRIPTION
Change type: Doc update; ServiceMesh-3 , East-West gateway templete URL not working (404)

Doc JIRA: https://issues.redhat.com/browse/OSSM-9812

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) ,[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0) and [service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

Doc Previews:

- https://95325--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html#ossm-installing-multi-primary-multi-network-mesh_ossm-multi-cluster-topologies

- https://95325--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html#ossm-installing-primary-remote-multi-network-mesh_ossm-multi-cluster-topologies

- https://95325--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-external-control-plane-topology.html#ossm-installing-external-control-plane_ossm-external-control-plane-topology

QE Review: @fjglira 
Peer Review: 