### PR TITLE
OCPBUGS-56241#Update RHEL 8 to RHEL 9 in the cnf-tests image URL

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
+++ b/modules/cnf-performing-end-to-end-tests-disconnected-mode.adoc
@@ -23,7 +23,7 @@ A `mirror` executable is shipped in the image to provide the input required by `
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
-registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 /usr/bin/mirror -registry <disconnected_registry> | oc image mirror -f -
 ----
 +
@@ -39,9 +39,9 @@ where:
 ----
 podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e IMAGE_REGISTRY="<disconnected_registry>" \
--e CNF_TESTS_IMAGE="cnf-tests-rhel8:v{product-version}" \
+-e CNF_TESTS_IMAGE="cnf-tests-rhel9:v{product-version}" \
 -e LATENCY_TEST_RUNTIME=<time_in_seconds> \
-<disconnected_registry>/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --ginkgo.v --ginkgo.timeout="24h"
+<disconnected_registry>/cnf-tests-rhel9:v{product-version} /usr/bin/test-run.sh --ginkgo.v --ginkgo.timeout="24h"
 ----
 
 [discrete]
@@ -58,7 +58,7 @@ $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e IMAGE_REGISTRY="<custom_image_registry>" \
 -e CNF_TESTS_IMAGE="<custom_cnf-tests_image>" \
 -e LATENCY_TEST_RUNTIME=<time_in_seconds> \
-registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --ginkgo.v --ginkgo.timeout="24h"
+registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} /usr/bin/test-run.sh --ginkgo.v --ginkgo.timeout="24h"
 ----
 +
 where:
@@ -133,7 +133,7 @@ $ echo "{\"auths\": { \"$REGISTRY\": { \"auth\": $TOKEN } }}" > dockerauth.json
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
-registry.redhat.io/openshift4/cnf-tests-rhel8:{product-version} \
+registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true \
 -a=$(pwd)/dockerauth.json -f -
 ----
@@ -173,7 +173,7 @@ You can optionally change the default upstream images that are mirrored for the 
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
-registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/mirror \
+registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} /usr/bin/mirror \
 --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" \
 |  oc image mirror -f -
 ----

--- a/modules/cnf-performing-end-to-end-tests-junit-test-output.adoc
+++ b/modules/cnf-performing-end-to-end-tests-junit-test-output.adoc
@@ -26,7 +26,7 @@ You must create the `junit` folder before running this command.
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -v $(pwd)/junit:/junit \
--e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+-e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 /usr/bin/test-run.sh --ginkgo.junit-report junit/<file-name>.xml --ginkgo.v
 ----
 +

--- a/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-cyclictest.adoc
@@ -25,7 +25,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
-registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 /usr/bin/test-run.sh --ginkgo.focus="cyclictest" --ginkgo.v --ginkgo.timeout="24h"
 ----
 +

--- a/modules/cnf-performing-end-to-end-tests-running-hwlatdetect.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-hwlatdetect.adoc
@@ -25,7 +25,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
-registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 /usr/bin/test-run.sh --ginkgo.focus="hwlatdetect" --ginkgo.v --ginkgo.timeout="24h"
 ----
 +

--- a/modules/cnf-performing-end-to-end-tests-running-in-single-node-cluster.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-in-single-node-cluster.adoc
@@ -28,7 +28,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
--e LATENCY_TEST_RUNTIME=<time_in_seconds> registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+-e LATENCY_TEST_RUNTIME=<time_in_seconds> registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 /usr/bin/test-run.sh --ginkgo.v --ginkgo.timeout="24h"
 ----
 +

--- a/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
@@ -25,7 +25,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
-registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 /usr/bin/test-run.sh --ginkgo.focus="oslat" --ginkgo.v --ginkgo.timeout="24h"
 ----
 +

--- a/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-the-tests.adoc
@@ -33,7 +33,7 @@ In the following command, your local `kubeconfig` is mounted to kubeconfig/kubec
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUNTIME=600\
 -e MAXIMUM_LATENCY=20 \
-registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh \
+registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} /usr/bin/test-run.sh \
 --ginkgo.v --ginkgo.timeout="24h"
 ----
 +

--- a/modules/cnf-performing-end-to-end-tests-test-failure-report.adoc
+++ b/modules/cnf-performing-end-to-end-tests-test-failure-report.adoc
@@ -21,7 +21,7 @@ Use the following procedures to generate a JUnit latency test output and test fa
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -v $(pwd)/reportdest:<report_folder_path> \
--e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+-e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 /usr/bin/test-run.sh --report <report_folder_path> --ginkgo.v
 ----
 +

--- a/modules/cnf-performing-end-to-end-tests-troubleshooting.adoc
+++ b/modules/cnf-performing-end-to-end-tests-troubleshooting.adoc
@@ -21,7 +21,7 @@ To run latency tests, the cluster must be accessible from within the `cnf-tests`
 [source,terminal,subs="attributes+"]
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
-registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
+registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version} \
 oc get nodes
 ----
 +

--- a/scalability_and_performance/cnf-performing-platform-verification-latency-tests.adoc
+++ b/scalability_and_performance/cnf-performing-platform-verification-latency-tests.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 You can use the Cloud-native Network Functions (CNF) tests image to run latency tests on a CNF-enabled {product-title} cluster, where all the components required for running CNF workloads are installed. Run the latency tests to validate node tuning for your workload.
 
-The `cnf-tests` container image is available at `registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version}`.
+The `cnf-tests` container image is available at `registry.redhat.io/openshift4/cnf-tests-rhel9:v{product-version}`.
 
 [id="cnf-latency-tests-prerequisites_{context}"]
 == Prerequisites for running latency tests


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):4.16, 4.17, 4.18, 4.19, 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-56241
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://95329--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performing-platform-verification-latency-tests.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
