### PR TITLE
OBSDOCS-1975 backfill the errata link

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -27,32 +27,31 @@ The following table provides information about which features are available depe
 [id="cluster-observability-operator-release-notes-1-2_{context}"]
 == {coo-full} 1.2
 
-// Back fill advisory when it is created by Konflux
-// The following advisory is available for {coo-full} 1.2:
-//
-// * link:https://access.redhat.com/errata/RHSA-2025:????[RHEA-2025:??? {coo-full} 1.2]
+The following advisory is available for {coo-full} 1.2:
+
+* link:https://access.redhat.com/errata/RHBA-2025:8940[RHBA-2025:8940 {coo-full} 1.2]
 
 [id="cluster-observability-operator-1-2-new-features-enhancements_{context}"]
 === New features and enhancements
 
-* The logging UI plugin now supports the OTEL format, in addition to the previously supported ViaQ scheme. (link:https://issues.redhat.com/browse/COO-816[*COO-816*])
+* The logging UI plugin now supports the OTEL format, in addition to the previously supported ViaQ scheme. (link:https://issues.redhat.com/browse/COO-816[COO-816])
 
-* Accelerators Perses dashboards are deployed by default when you install the monitoring UI plugin. (link:https://issues.redhat.com/browse/COO-942[*COO-942*]) 
+* Accelerators Perses dashboards are deployed by default when you install the monitoring UI plugin. (link:https://issues.redhat.com/browse/COO-942[COO-942])
 
-* Multiple results per graph node are now displayed for Korrel8r. (link:https://issues.redhat.com/browse/COO-785[*COO-785*]) 
+* Multiple results per graph node are now displayed for Korrel8r. (link:https://issues.redhat.com/browse/COO-785[COO-785])
 
-* Direct navigation to individual incident detail is now supported in the incident detection panel, and this enables the incidents overview functionality in {rh-rhacm-first} 2.14. (link:https://issues.redhat.com/browse/COO-977[*COO-977*], link:https://issues.redhat.com/browse/ACM-18751[*ACM-18751*])
+* Direct navigation to individual incident detail is now supported in the incident detection panel, and this enables the incidents overview functionality in {rh-rhacm-first} 2.14. (link:https://issues.redhat.com/browse/COO-977[COO-977], link:https://issues.redhat.com/browse/ACM-18751[ACM-18751])
 
-* Advanced filters have been added to the tracing view. (link:https://issues.redhat.com/browse/COO-979[*COO-979*]) 
+* Advanced filters have been added to the tracing view. (link:https://issues.redhat.com/browse/COO-979[COO-979])
 
-* The status of the distributed tracing UI plugin is now General Availability (GA), supporting Patternfly 4, 5 and 6. (link:https://issues.redhat.com/browse/COO-873[*COO-873*]) 
+* The status of the distributed tracing UI plugin is now General Availability (GA), supporting Patternfly 4, 5 and 6. (link:https://issues.redhat.com/browse/COO-873[COO-873])
 
 [id="cluster-observability-operator-1-2-bug-fixes_{context}"]
 === Bug fixes
 
-* Previously, LokiStack was a prerequisite for installing the logging UI plugin. With this release, you can install the logging UI plugin without LokiStack. (link:https://issues.redhat.com/browse/COO-760[*COO-760*])
+* Previously, LokiStack was a prerequisite for installing the logging UI plugin. With this release, you can install the logging UI plugin without LokiStack. (link:https://issues.redhat.com/browse/COO-760[COO-760])
 
-* Previously, the *Silence Alert* button in the **Incidents** -> **Component** section did not pre-populate the fields and was not usable. This release resolves the issue. (link:https://issues.redhat.com/browse/COO-970[*COO-970*])
+* Previously, the *Silence Alert* button in the **Incidents** -> **Component** section did not pre-populate the fields and was not usable. This release resolves the issue. (link:https://issues.redhat.com/browse/COO-970[COO-970])
 
 
 [id="cluster-observability-operator-1-2-known-issues_{context}"]
@@ -60,7 +59,7 @@ The following table provides information about which features are available depe
 
 These are the known issues in {coo-full} 1.2.0:
 
-* When upgrading from {coo-short} 1.1.1 to {coo-short} 1.2, the Perses dashboard is not correctly reconciled, and this requires the monitoring UI plugin to be reinstalled. (link:https://issues.redhat.com/browse/COO-978[*COO-978*])
+* When upgrading from {coo-short} 1.1.1 to {coo-short} 1.2, the Perses dashboard is not correctly reconciled, and this requires the monitoring UI plugin to be reinstalled. (link:https://issues.redhat.com/browse/COO-978[COO-978])
 
 
 [id="cluster-observability-operator-release-notes-1-1-1_{context}"]
@@ -69,7 +68,7 @@ These are the known issues in {coo-full} 1.2.0:
 // Back fill advisory when it is created by KOnflux
 // The following advisory is available for {coo-full} 1.1.1:
 //
-// * link:https://access.redhat.com/errata/RHSA-2025:????[RHEA-2025:??? {coo-full} 1.1.1]
+// * link:https://access.redhat.com/errata/RHBA-2025:????[RHBA-2025:??? {coo-full} 1.1.1]
 
 
 [id="cluster-observability-operator-1-1-1-bug-fixes_{context}"]
@@ -80,10 +79,10 @@ These are the known issues in {coo-full} 1.2.0:
 [id="cluster-observability-operator-release-notes-1-1_{context}"]
 == {coo-full} 1.1
 
-// Back fill advisory when it is created by KOnflux
-// The following advisory is available for {coo-full} 1.1:
-//
-// * link:https://access.redhat.com/errata/RHSA-2025:????[RHEA-2025:??? {coo-full} 1.1]
+
+The following advisory is available for {coo-full} 1.1:
+
+* link:https://access.redhat.com/errata/RHBA-2025:4360[RHBA-2025:4360 {coo-full} 1.1]
 
 
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-1975](https://issues.redhat.com//browse/OBSDOCS-1975)

Link to docs preview:
https://95332--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-release-notes.html#cluster-observability-operator-release-notes-1-2_cluster-observability-operator-release-notes

QE review:
n/a

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
