### PR TITLE
OCPBUGS#58128: Tweaked the nw-egress-ips-multi-nic-considerations .ad…

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -164,7 +164,7 @@ ifdef::ovn[]
 [id="nw-egress-ips-multi-nic-considerations_{context}"]
 == Considerations for using an egress IP on additional network interfaces
 
-In {product-title}, egress IPs provide administrators a way to control network traffic. Egress IPs can be used with the `br-ex`, or primary, network interface, which is a Linux bridge interface associated with Open vSwitch, or they can be used with additional network interfaces.
+In {product-title}, egress IPs provide administrators a way to control network traffic. Egress IPs can be used with a `br-ex` Open vSwitch (OVS) bridge interface and any physical interface that has IP connectivity enabled.
 
 You can inspect your network interface type by running the following command:
 
@@ -192,27 +192,13 @@ OVN-Kubernetes provides a mechanism to control and direct outbound network traff
 
 For users who want an egress IP and traffic to be routed over a particular interface that is not the primary network interface, the following conditions must be met:
 
-* {product-title} is installed on a bare metal cluster. This feature is disabled within cloud or hypervisor environments.
+* {product-title} is installed on a bare-metal cluster. This feature is disabled within a cloud or a hypervisor environment.
 
-* Your {product-title} pods are not configured as host-networked.
+* Your {product-title} pods are not configured as _host-networked_.
 
-* If a network interface is removed or if the IP address and subnet mask which allows the egress IP to be hosted on the interface is removed, then the egress IP is reconfigured. Consequently, it could be assigned to another node and interface.
+* If a network interface is removed or if the IP address and subnet mask which allows the egress IP to be hosted on the interface is removed, the egress IP is reconfigured. Consequently, the egress IP could be assigned to another node and interface.
 
-* IP forwarding must be enabled for the network interface. To enable IP forwarding, you can use the `oc edit network.operator` command and edit the object like the following example:
-+
-[source,yaml]
-----
-# ...
-spec:
-  clusterNetwork:
-  - cidr: 10.128.0.0/14
-    hostPrefix: 23
-  defaultNetwork:
-    ovnKubernetesConfig:
-      gatewayConfig:
-        ipForwarding: Global
-# ...
-----
+* If you use an Egress IP address on a secondary network interface card (NIC), you must use the Node Tuning Operator to enable IP forwarding on the secondary NIC.
 endif::ovn[]
 endif::openshift-rosa[]
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-58128](https://issues.redhat.com/browse/OCPBUGS-58128)

Link to docs preview:
* [Considerations for using an egress IP on additional network interfaces](https://95351--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-multi-nic-considerations_configuring-egress-ips-ovn)


- [x] SME has approved this change (Tim Rozet).
- [x] QE has approved this change (Jean Chen).

