### PR TITLE
ROX-29040: Revisions to declarative config

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -186,6 +186,8 @@ Topics:
   File: configure-audit-logging
 - Name: Configuring API tokens
   File: configure-api-token
+- Name: Using RHACS with GitOps
+  File: using-rhacs-with-gitops
 - Name: Using declarative configuration
   File: declarative-configuration-using
 - Name: Inviting users to your RHACS instance
@@ -300,7 +302,7 @@ Distros: openshift-acs
 Topics:
 - Name: Integrating with image registries
   File: integrate-with-image-registries
-- Name: Integrating RHACS into your DevOps system
+- Name: Integrating with CI systems
   File: integrate-with-ci-systems
 - Name: Integrating with PagerDuty
   File: integrate-with-pagerduty

--- a/configuration/using-rhacs-with-gitops.adoc
+++ b/configuration/using-rhacs-with-gitops.adoc
@@ -1,0 +1,25 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="using-rhacs-with-gitops"]
+= Using RHACS with GitOps
+include::modules/common-attributes.adoc[]
+:context: using-rhacs-with-gitops
+
+toc::[]
+
+You can configure key {product-title-short} attributes by using GitOps workflows by storing the values as code and applying them to {product-title-short} declaratively.
+
+{product-title-short} provides the following two different mechanisms to control two different sets of attributes:
+
+* _Declarative configuration_ is a lightweight mechanism that uses config maps and secrets to configure mostly authentication and authorization resources.
+* _Policy as code_ leverages a {product-title-short}-provided custom resource (CR), along with its controller, to manage {product-title-short} policies.
+
+include::modules/config-using-declarative-config.adoc[leveloffset=+1]
+
+include::modules/config-using-policy-as-code.adoc[leveloffset=+1]
+
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../configuration/declarative-configuration-using.adoc#declarative-configuration-using[Using declarative configuration]
+* xref:../operating/manage_security_policies/custom-security-policies.adoc#policy-as-code-about_custom-security-policies[Managing policies as code]

--- a/integration/integrate-with-ci-systems.adoc
+++ b/integration/integrate-with-ci-systems.adoc
@@ -1,26 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="integrate-with-ci-systems"]
-= Integrating {product-title-short} into your DevOps system
+= Integrating with CI systems
 include::modules/common-attributes.adoc[]
 :context: integrate-with-ci-systems
 
 toc::[]
 
 [role="_abstract"]
-You can integrate {product-title} ({product-title-short}) into your DevOps system by using DevOps tools to configure specific {product-title-short} parameters and to create and manage custom security policies. You can also configure {product-title-short} to work with the continuous integration (CI) tools in your system to apply security policies to your images before or during deployment.
-
-include::modules/configuration-using-devops.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../configuration/declarative-configuration-using.adoc#declarative-configuration-using[Using declarative configuration]
-
-* xref:../operating/manage_security_policies/custom-security-policies.adoc#policy-as-code-about_custom-security-policies[Managing policies as code]
-
-
-[id="integrate-ci-systems"]
-== Integrating with CI systems
 
 {product-title} ({product-title-short}) integrates with a variety of continuous integration (CI) products. Before you deploy images, you can use {product-title-short} to apply build-time and deploy-time security rules to your images.
 

--- a/modules/config-using-declarative-config.adoc
+++ b/modules/config-using-declarative-config.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * configuration/using-rhacs-with-gitops.adoc
+:_mod-docs-content-type: CONCEPT
+[id="config-using-declarative-config_{context}"]
+= Configuration by using declarative configuration
+
+You can  configure the following resources by using the {product-title-short} declarative configuration method:
+
+* Authentication providers
+* Roles
+* Permission sets
+* Notifiers
+* Access scopes
+
+To configure these resources, you create YAML files that contain configuration information. These files are used to create a ConfigMap or Secret that is added to {product-title-short} by using a mount point during installation of the {product-title-short} Central resource.

--- a/modules/config-using-policy-as-code.adoc
+++ b/modules/config-using-policy-as-code.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+//
+// * configuration/using-rhacs-with-gitops.adoc
+:_mod-docs-content-type: CONCEPT
+[id="config-using-policy-as-code_{context}"]
+= Configuration by using policy as code
+
+You can create and manage policies as code by authoring policies as Kubernetes custom resources (CRs), and then applying them to the {product-title-short} Central namespace by using a GitOps tool such as OpenShift GitOps, which is built on ArgoCD.


### PR DESCRIPTION
Version(s): 4.8+

[Issue](https://issues.redhat.com/browse/ROX-29040)

Links to docs previews:

https://95383--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/using-rhacs-with-gitops.html - new section
https://95383--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-ci-systems.html - reverted previous change

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

* Backs out #95122 
* Adds info as given by Boaz in [Comment Doc](https://docs.google.com/document/d/1FZz6gqC_RvnJ5eA-r_1JRoF89PMbFl71HGbclM1_K6U/edit?usp=sharing)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
