### PR TITLE
OCPBUGS50970 Configuring maxParallelImagePulls value using KubeletConfig in RHOCP 4

### DIFF
--- a/modules/nodes-nodes-parallel-container-pulls-about.adoc
+++ b/modules/nodes-nodes-parallel-container-pulls-about.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/nodes-nodes-managing.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nodes-nodes-parallel-container-pulls-about_{context}"]
+= About configuring parallel container image pulls
+
+To help control bandwidth issues, you can configure the number of workload images that can be pulled at the same time. 
+
+By default, the cluster pulls images in parallel, which allows multiple workloads to pull images at the same time. Pulling multiple images in parallel can improve workload start-up time because workloads can pull needed images without waiting for each other. However, pulling too many images at the same time can use excessive network bandwidth and cause latency issues throughout your cluster.
+
+The default setting allows unlimited simultaneous image pulls. But, you can configure the maximum number of images that can be pulled in parallel. You can also force serial image pulling, which means that only one image can be pulled at a time.
+
+To control the number of images that can be pulled simultaneously, use a kubelet configuration to set the `maxParallelImagePulls` to specify a limit. Additional image pulls above this limit are held until one of the current pulls is complete.
+
+To force serial image pulls, use a kubelet configuration to set `serializeImagePulls` field to `true`. 

--- a/modules/nodes-nodes-parallel-container-pulls-configure.adoc
+++ b/modules/nodes-nodes-parallel-container-pulls-configure.adoc
@@ -1,0 +1,126 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/nodes-nodes-managing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-nodes-parallel-container-pulls-configure_{context}"]
+= Configuring parallel container image pulls
+
+You can control the number of images that can be pulled by your workload simultaneously by using a kubelet configuration.
+
+You can set a maximum number of images that can be pulled or force workloads to pull images one at a time.
+
+.Prerequisites
+
+* You have a running {product-title} cluster.
+
+* You are logged in to the cluster as a user with administrative privileges.
+
+.Procedure
+
+. Apply a custom label to the machine config pool where you want to configure parallel pulls by running a command similar to the following.
++
+[source,terminal]
+----
+$ oc label machineconfigpool <mcp_name> parallel-pulls=set
+----
+
+. Create a custom resource (CR) to configure parallel image pulling.
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: parallel-image-pulls
+# ...
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      parallel-pulls: set
+  kubeletConfig:
+    serializeImagePulls: false <1>
+    maxParallelImagePulls: 3 <2>
+# ...
+----
+<1> Set to `false` to enable parallel image pulls. Set to `true` to force serial image pulling. The default is `false`.
+<2> Specify the maximum number of images that can be pulled in parallel. Enter a number or set to `nil` to specify no limit. This field cannot be set if `SerializeImagePulls` is `true`. The default is `nil`.
+
+. Create the new machine config by running a command similar to the following:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
+
+.Verification
+
+. Check the machine configs to see that a new one was added by running the following command:
++
+[source,terminal]
+----
+$ oc get MachineConfig
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                                                GENERATEDBYCONTROLLER                        IGNITIONVERSION   AGE
+00-master                                           70025364a114fc3067b2e82ce47fdb0149630e4b     3.5.0             133m
+00-worker                                           70025364a114fc3067b2e82ce47fdb0149630e4b     3.5.0             133m
+# ...
+99-parallel-generated-kubelet                       70025364a114fc3067b2e82ce47fdb0149630e4b     3.5.0             15s <1>
+# ...
+rendered-parallel-c634a80f644740974ceb40c054c79e50  70025364a114fc3067b2e82ce47fdb0149630e4b     3.5.0             10s <2>
+----
+<1> The new machine config. In this example, the machine config is for the `parallel` custom machine config pool. 
+<2> The new rendered machine config. In this example, the machine config is for the `parallel` custom machine config pool. 
+
+. Check to see that the nodes in the `parallel` machine config pool are being updated by running the following command:
++
+[source,terminal]
+----
+$ oc get machineconfigpool
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME       CONFIG                                               UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+parallel   rendered-parallel-3904f0e69130d125b3b5ef0e981b1ce1   False     True       False      1              0                   0                     0                      65m
+master     rendered-master-7536834c197384f3734c348c1d957c18     True      False      False      3              3                   3                     0                      140m
+worker     rendered-worker-c634a80f644740974ceb40c054c79e50     True      False      False      2              2                   2                     0                      140m
+----
+
+. When the nodes are updated, verify that the parallel pull maximum was configured:
+
+.. Open an `oc debug` session to a node by running a command similar to the following:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+.. Set `/host` as the root directory within the debug shell by running the following command:
++
+[source,terminal]
+----
+sh-5.1# chroot /host
+----
+
+.. Examine the `kubelet.conf` file by running the following command:
++
+[source,terminal]
+----
+sh-5.1# cat /etc/kubernetes/kubelet.conf | grep -i maxParallelImagePulls
+----
++
+.Example output
++
+[source,terminal]
+----
+maxParallelImagePulls: 3
+----
+

--- a/nodes/nodes/nodes-nodes-managing.adoc
+++ b/nodes/nodes/nodes-nodes-managing.adoc
@@ -24,14 +24,23 @@ configuration of nodes. By creating an instance of a `KubeletConfig` object, a m
 include::modules/nodes-nodes-managing-about.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-working-master-schedulable.adoc[leveloffset=+1]
+
 include::modules/nodes-nodes-working-setting-booleans.adoc[leveloffset=+1]
+
 include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+1]
+
 ifdef::openshift-webscale[]
 include::modules/nodes-nodes-rtkernel-arguments.adoc[leveloffset=+1]
 endif::openshift-webscale[]
 
 include::modules/nodes-nodes-swap-memory.adoc[leveloffset=+1]
+
+include::modules/nodes-nodes-parallel-container-pulls-about.adoc[leveloffset=+1]
+
+include::modules/nodes-nodes-parallel-container-pulls-configure.adoc[leveloffset=+2]
+
 include::modules/nodes-control-plane-osp-migrating.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-50970

Link to docs preview:
Nodes -> Working with nodes -> Managing nodes -> [Configuring parallel container image pulls](https://95384--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing#nodes-nodes-max-image-pulls_nodes-nodes-managing) -- New module

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
