### PR TITLE
[enterprise-4.18] OCPBUGS-57952 changed agentSocketPath to agentSocketName

### DIFF
--- a/modules/zero-trust-manager-oidc-config.adoc
+++ b/modules/zero-trust-manager-oidc-config.adoc
@@ -30,7 +30,7 @@ metadata:
   name: cluster
 spec:
   trustDomain: <trust_domain> #<1>
-    agentSocketPath: 'spire-agent.sock' #<2>
+  agentSocketName: 'spire-agent.sock' #<2>
   jwtIssuer: <jwt_issuer_domain> #<3>
 ----
 <1> The trust domain to be used for the SPIFFE identifiers.


### PR DESCRIPTION
Cherry pick from https://github.com/openshift/openshift-docs/pull/95106
