### PR TITLE
OSDOCS-14111: Updating OCM guide

### DIFF
--- a/modules/ocm-accesscontrol-tab.adoc
+++ b/modules/ocm-accesscontrol-tab.adoc
@@ -8,13 +8,63 @@
 
 The **Access control** tab allows the cluster owner to set up an identity provider, grant elevated permissions, and grant roles to other users.
 
+[id="ocm-accesscontrol-tab-identity-providers_{context}"]
+== Identity providers
+
+You can create your cluster's identity provider in this section. See the _Additional resources_ for more information.
+
+[id="ocm-accesscontrol-tab-cluster-roles-access_{context}"]
+== Cluster roles and acess
+
+You can create a `dedicated-admins` role for {product-short-name} clusters or `cluster-admins` role for {product-title} clusters.
+
+.Procedure
+. Click the **Add user** button.
+. Enter the ID of the user you want to grant cluster admin access.
+. Select the appropriate group for your user. Either `dedicated-admins` for {product-short-name} clusters, or `cluster-admins` for 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+clusters.
+
+[id="ocm-accesscontrol-tab-ocm-roles-access_{context}"]
+== OCM roles and access
 .Prerequisites
 
 * You must be the cluster owner or have the correct permissions to grant roles on the cluster.
 
 .Procedure
 
-. Select the **Grant role** button.
+. Click the **Grant role** button.
 . Enter the Red Hat account login for the user that you wish to grant a role on the cluster.
-. Select the **Grant role** button on the dialog box.
-. The dialog box closes, and the selected user shows the "Cluster Editor" access.
+. Select the role from following options:
+** **Cluster editor** allows users or groups to manage or configure the cluster. 
+** **Cluster viewer** allows users or groups to view cluster details only.
+ifdef::openshift-rosa[]
+** **Cluster autoscaler editor** allows users or groups to manage and configure the cluster autoscaler settings.
+endif::openshift-rosa[]
+** **Identity provider editor** allows users or groups to manage and configure the identity providers.
+** **Machine pool editor** allows users or groups to manage and configure the machine pools. 
+. Click the **Grant role** button on the dialog box.
+
+ifdef::openshift-rosa[]
+[id="ocm-accesscontrol-tab-transfer-ownership_{context}"]
+== Transfer ownership
+
+You can transfer your cluster to another user.
+
+[NOTE]
+====
+Once you transfer cluster ownership, you lose access to the cluster.
+====
+
+.Procedure
+
+. Select **Initiate transfer**.
+. Enter the user name, account ID, and organization ID of the user that you are transferring the cluster to.
+. Select **Initiate transfer**.
+
+endif::openshift-rosa[]

--- a/modules/ocm-accessing.adoc
+++ b/modules/ocm-accessing.adoc
@@ -11,7 +11,7 @@ You can access {cluster-manager} with your configured OpenShift account.
 .Prerequisites
 
 * You have an account that is part of an OpenShift organization.
-* If you are creating a cluster, your organization has specified quota.
+* If you are creating a cluster, your organization has a specified quota.
 
 .Procedure
 

--- a/modules/ocm-overview-tab.adoc
+++ b/modules/ocm-overview-tab.adoc
@@ -10,12 +10,17 @@ The **Overview** tab provides information about how the cluster was configured:
 
 * **Cluster ID** is the unique identification for the created cluster. This ID can be used when issuing commands to the cluster from the command line.
 * **Domain prefix** is the prefix that is used throughout the cluster. The default value is the cluster's name.
-* **Type** shows the OpenShift version that the cluster is using.
+* **Type** shows the type of cluster, for example {rosa-classic-short}, {rosa-short}, or Dedicated.
 ifndef::openshift-rosa[]
 * **Control plane type** is the architecture type of the cluster. The field only displays if the cluster uses a hosted control plane architecture.
 endif::openshift-rosa[]
 * **Region** is the server region.
+ifdef::openshift-rosa[]
 * **Availability** shows which type of availability zone that the cluster uses, either single or multizone.
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+* **Availability** shows multizone for {rosa-short} clusters.
+endif::openshift-rosa-hcp[]
 * **Version** is the OpenShift version that is installed on the cluster. If there is an update available, you can update from this field.
 * **Created at** shows the date and time that the cluster was created.
 * **Owner** identifies who created the cluster and has owner rights.
@@ -30,7 +35,7 @@ endif::openshift-rosa[]
 * **Total memory** shows the total available memory for this cluster.
 * **Infrastructure AWS account** displays the AWS account that is responsible for cluster creation and maintenance.
 ifdef::openshift-rosa-hcp[]
-* **Billing marketplace account** displays the AWS account that is used for billing purposes.
+* **Billing marketplace account** displays the AWS account that is used for billing purposes. Click on the pencil icon to edit this field.
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa[]
 * **Additional encryption** field shows any applicable additional encryption options.

--- a/modules/ocm-settings-tab.adoc
+++ b/modules/ocm-settings-tab.adoc
@@ -9,7 +9,7 @@
 The **Settings** tab provides a few options for the cluster owner:
 
 ifdef::openshift-rosa[]
-* **Monitoring**, which is enabled by default, allows for reporting done on user-defined actions. See link:https://docs.openshift.com/rosa/observability/monitoring/monitoring-overview.html#understanding-the-monitoring-stack_monitoring-overview.html[Understanding the monitoring stack].
+* **Monitoring**, which is enabled by default, allows for reporting done on user-defined actions.
 endif::openshift-rosa[]
 * **Update strategy** allows you to determine if the cluster automatically updates on a certain day of the week at a specified time or if all updates are scheduled manually.
 ifdef::openshift-rosa[]

--- a/ocm/ocm-overview.adoc
+++ b/ocm/ocm-overview.adoc
@@ -7,7 +7,14 @@ toc::[]
 
 {cluster-manager-first} is a managed service where you can install, modify, operate, and upgrade your Red Hat OpenShift clusters. This service allows you to work with all of your organization’s clusters from a single dashboard.
 
-{cluster-manager} guides you to install {OCP}, Red Hat OpenShift Service on AWS (ROSA), and {product-short-name} clusters. It is also responsible for managing both {OCP} clusters after self-installation as well as your ROSA and {product-short-name} clusters.
+{cluster-manager} guides you to install {OCP}, {product-title}, and {product-short-name} clusters. It is also responsible for managing both {OCP} clusters after self-installation as well as your 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+and {product-short-name} clusters.
 
 You can use {cluster-manager} to do the following actions:
 
@@ -34,7 +41,10 @@ include::modules/ocm-accessing.adoc[leveloffset=+1]
 On the top right of the cluster page, there are some actions that a user can perform on the entire cluster:
 
 * **Open console** launches a web console so that the cluster owner can issue commands to the cluster.
-* **Actions** drop-down menu allows the cluster owner to rename the display name of the cluster, change the amount of load balancers and persistent storage on the cluster, if applicable, manually set the node count, and delete the cluster.
+* **Actions** drop-down menu allows the cluster owner to rename the display name of the cluster, edit the machine pools, and delete the cluster. 
+ifdef::openshift-rosa[]
+You may also transfer the cluster's ownership to another user.
+endif::openshift-rosa[]
 * **Refresh** icon forces a refresh of the cluster.
 
 [id="ocm-cluster-tabs"]
@@ -52,14 +62,6 @@ Selecting an active, installed cluster shows tabs associated with that cluster. 
 * Settings
 
 include::modules/ocm-overview-tab.adoc[leveloffset=+2]
-
-ifndef::openshift-rosa-hcp[]
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using Insights to identify issues with your cluster]
-endif::openshift-rosa-hcp[]
-
 include::modules/ocm-accesscontrol-tab.adoc[leveloffset=+2]
 include::modules/ocm-addons-tab.adoc[leveloffset=+2]
 include::modules/ocm-cluster-history-tab.adoc[leveloffset=+2]
@@ -74,11 +76,15 @@ include::modules/ocm-settings-tab.adoc[leveloffset=+2]
 [id="ocm-additional-resources"]
 == Additional resources
 
-* For the complete documentation for {cluster-manager}, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2022/html-single/managing_clusters/index[{cluster-manager} documentation].
+* link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2022/html-single/managing_clusters/index[{cluster-manager} documentation]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-* For steps to add cluster notification contacts, see xref:../rosa_cluster_admin/rosa-cluster-notifications.adoc#add-notification-contact_rosa-cluster-notifications[Adding cluster notification contacts]
+* xref:../rosa_cluster_admin/rosa-cluster-notifications.adoc#add-notification-contact_rosa-cluster-notifications[Adding cluster notification contacts]
+* xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[Configuring identity providers]
 endif::[]
+ifndef::openshift-rosa-hcp[]
+* xref:../observability/monitoring/about-ocp-monitoring/monitoring-stack-architecture.adoc#understanding-the-monitoring-stack_monitoring-stack-architecture[Understanding the monitoring stack]
+* xref:../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using Insights to identify issues with your cluster]
+endif::openshift-rosa-hcp[]
 ifdef::openshift-dedicated[]
-* For steps to add cluster notification contacts, see xref:../osd_cluster_admin/osd-cluster-notifications.adoc#add-notification-contact_osd-cluster-notifications[Adding cluster notification contacts]
+* xref:../osd_cluster_admin/osd-cluster-notifications.adoc#add-notification-contact_osd-cluster-notifications[Adding cluster notification contacts]
 endif::[]
-


### PR DESCRIPTION
Version(s):
`enterprise-4.19+`

Issue:
**[OSDOCS-14111](https://issues.redhat.com/browse/OSDOCS-14111)**

Link to docs preview:
- [Red Hat OpenShift Cluster Manager](https://95396--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/ocm/ocm-overview.html) (ROSA with HCP)
- [Red Hat OpenShift Cluster Manager](https://95396--ocpdocs-pr.netlify.app/openshift-rosa/latest/ocm/ocm-overview.html) (ROSA (classic))

Additional information:
Updated the docs to align with the QE review tracked here: https://docs.google.com/document/d/1Ayhd-xr0qGJfO93uRIN0iPzclMm8JH9Gjc1p4Saok8Q/edit?usp=sharing