### PR TITLE
Update persistent-storage-csi-vol-detach-non-graceful-shutdown-proced…

### DIFF
--- a/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
+++ b/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
@@ -21,9 +21,9 @@ To allow volumes to detach automatically from a node after a non-graceful node s
 +
 [source,terminal]
 ----
-oc get node <node name> <1>
+$ oc get node <node_name> <1>
 ----
-<1> <node name> = name of the non-gracefully shutdown node
+<1> <node_name> = name of the node that shut down non-gracefully
 +
 [IMPORTANT]
 ====
@@ -40,9 +40,9 @@ statefulsets to be evicted, and replacement pods to be created on a different no
 +
 [source,terminal]
 ----
-oc adm taint node <node name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute <1>
+$ oc adm taint node <node_name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute <1>
 ----
-<1> <node name> = name of the non-gracefully shutdown node
+<1> <node_name> = name of the node that shut down non-gracefully
 +
 After the taint is applied, the volumes detach from the shutdown node allowing their disks to be attached to a different node.
 +
@@ -65,5 +65,6 @@ spec:
 +
 [source, terminal]
 ----
-oc adm taint node <node name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute- <1>
+$ oc adm taint node <node_name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute- <1>
 ----
+<1> <node_name> = name of the node that shut down non-gracefully


### PR DESCRIPTION
- Incorrect structure in the OpenShift documentation
- Here is the documentation link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/storage/ephemeral-storage-csi-vol-detach-non-graceful-shutdown#persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure_ephemeral-storage-csi-vol-detach-non-graceful-shutdown

- $ sign is missing from every command.
- <node name> is mentioned without an underscore.

Following changes are required:

1. Need to add $ sign at the start of each command.
2. Need to mention underscore between <node name>
3. Need to add <node_name> value for 1

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.20, RHOCP 4.19, RHOCP 4.18, RHOCP 4.17, RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13 

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-2047

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

https://95410--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent-storage-csi-vol-detach-non-graceful-shutdown.html

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
