### PR TITLE
Update logging-loki-storage-azure.adoc

### DIFF
--- a/modules/logging-loki-storage-azure.adoc
+++ b/modules/logging-loki-storage-azure.adoc
@@ -36,7 +36,7 @@ You can create the Loki object storage secret manually by running the following 
 [source,terminal,subs="+quotes"]
 ----
 $ oc -n openshift-logging create secret generic logging-loki-azure \
---from-literal=environment="<azure_environment>" \
---from-literal=account_name="<storage_account_name>" \
---from-literal=container="<container_name>"
+  --from-literal=environment="<azure_environment>" \
+  --from-literal=account_name="<storage_account_name>" \
+  --from-literal=container="<container_name>"
 ----


### PR DESCRIPTION
- Incorrect command structure in the Azure Object Store documentation.
- Here is the documentation link: 
https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/logging/log-storage-3#logging-loki-storage-azure_installing-log-storage Here is the current documentation look:

You can create the Loki object storage secret manually by running the following command:
~~~
$ oc -n openshift-logging create secret generic logging-loki-azure \
--from-literal=environment="<azure_environment>" \
--from-literal=account_name="<storage_account_name>" \
--from-literal=container="<container_name>" 
~~~

- In the above command, the "- -" signs are incorrectly placed below the "$" symbol. 
- However, it should be aligned parallel to the "oc" command, where the command begins. 

Here is the updated look for all these commands:

~~~
$ oc -n openshift-logging create secret generic logging-loki-azure \
  --from-literal=environment="<azure_environment>" \
  --from-literal=account_name="<storage_account_name>" \
  --from-literal=container="<container_name>" 
~~~

- The commands will work as it is, but the structure is incorrect. 
- It should be a standard format all over the documentation.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.15, RHOCP 4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-2048

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://95411--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/log_storage/installing-log-storage.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
