### PR TITLE
[enterprise-4.15] OCPBUGS-56989: Swapped out v4InternalSubnet for internalJoinSubnet

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -188,7 +188,8 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
         "ovnKubernetesConfig":{
           "mtu":<mtu>,
           "genevePort":<port>,
-          "v4InternalSubnet":"<ipv4_subnet>"
+          "ipv4":
+            "InternalJoinSubnet": "<ipv4_subnet>"
     }}}}'
 ----
 +


### PR DESCRIPTION
Cherry pick of #94168 with commit ID ad936445ada73ac392875354f4d29b97958acc31


Version(s):
4.15

Issue:
[OCPBUGS-56989](https://issues.redhat.com/browse/OCPBUGS-56989)

Link to docs preview:
