### PR TITLE
OBSDOCS-2041 COO 1.2.1 release notes

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -24,6 +24,21 @@ The following table provides information about which features are available depe
 | 1.1+          | 4.18+              | ✔                     | ✔         | ✔                     | ✔          | ✔
 |===
 
+[id="cluster-observability-operator-release-notes-1-2-1_{context}"]
+== {coo-full} 1.2.1
+
+[id="cluster-observability-operator-1-2-1-bug-fixes_{context}"]
+=== Bug fixes
+
+* Before this update, an old version label matcher was retained during the Operator version 1.2 upgrade. This caused Perses dashboards to become unavailable. With this release, the version label is removed and Perses dashboards are correctly reconciled.
+
+[id="cluster-observability-operator-1-2-1-known-issues_{context}"]
+=== Known issues
+
+These are the known issues in {coo-full} 1.2.1:
+
+* Upgrading from version 1.2.0 to 1.2.1 corrupts the monitoring plugin's `UIPlugin` resource, when you have also deployed distributed tracing, the troubleshooting panel, and Advance Cluster Management (ACM), together with the monitoring UI plugin. You can resolve this issue by recreating the UI plugin. (link:https://issues.redhat.com/browse/COO-1051[COO-1051])
+
 [id="cluster-observability-operator-release-notes-1-2_{context}"]
 == {coo-full} 1.2
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-2041](https://issues.redhat.com//browse/OBSDOCS-2041)

Link to docs preview:
https://95426--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
