### PR TITLE
OSDOCS-11720#updating commands

### DIFF
--- a/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
+++ b/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
@@ -36,7 +36,7 @@ stored the installation files in.
 If the command exits without a `FATAL` warning, your production control plane
 has initialized.
 
-. Delete the bootstrap resources:
+. To remove the bootstrap instance group from the backend services' backends, run the following commands:
 +
 [source,terminal]
 ----
@@ -45,8 +45,23 @@ $ gcloud compute backend-services remove-backend ${INFRA_ID}-api-internal --regi
 +
 [source,terminal]
 ----
-$ gsutil rm gs://${INFRA_ID}-bootstrap-ignition/bootstrap.ign
+$ ingress_backendservice=$(gcloud compute backend-services list --filter="backends.group~${INFRA_ID}" --format='value(name)' | grep -v "${INFRA_ID}")
 ----
++
+.. If `ingress_backendservice` is not empty, run the following `describe` command for the bootstrap group:
++
+[source,terminal]
+----
+$ gcloud compute backend-services describe ${ingress_backendservice} --region=${REGION}
+----
+.. If the `describe` command displays that the bootstrap group is one of its backends, run the following `remove-backend` command to remove the bootstrap group from the backends:
++
+[source,terminal]
+----
+$ gcloud compute backend-services remove-backend ${ingress_backendservice} --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-ig --instance-group-zone=${ZONE_0}
+----
++
+. To remove the bucket and the deployment, run the following commands:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.17+

Issue:
https://issues.redhat.com/browse/OSDOCS-11720

Link to docs preview:
This module update is reflected in these three assemblies:

- [Wait for bootstrap completion and remove bootstrap resources in GCP](https://95450--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-gcp-user-infra-wait-for-bootstrap_installing-gcp-user-infra) (Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates)
- [Wait for bootstrap completion and remove bootstrap resources in GCP](https://95450--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-gcp-user-infra-wait-for-bootstrap_installing-gcp-user-infra-vpc) (Installing a cluster into a shared VPC on GCP using Deployment Manager templates)
- [Wait for bootstrap completion and remove bootstrap resources in GCP](https://95450--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp.html#installation-gcp-user-infra-wait-for-bootstrap_installing-restricted-networks-gcp) (Installing a cluster on GCP in a disconnected environment with user-provisioned infrastructure

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
