### PR TITLE
MCO Clarity in Custom Config Application RN

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1188,6 +1188,14 @@ Status displays are paused on all other consoles while the interactive network c
 Previously, the displays could be shown only on a graphical console.
 (link:https://issues.redhat.com/browse/OCPBUGS-19688[OCPBUGS-19688])
 
+[discrete]
+[id="ocp-4-15-mco-mc-ordering"]
+=== MCO gives priority to custom machine config changes
+
+When making changes to your worker nodes through a machine config, the changes are also applied to any node that is in a custom machine config pool. The machine configs are applied in alphanumeric order. As such, previously it was possible that if you changed a parameter for a worker node through a machine config and the same parameter for a custom node through a separate machine config at the same time, the worker machine config could have overridden the custom machine config, based on the name of the machine config. This could have resulted in an incorrect parameter being applied to the nodes in the custom machine config pool.
+
+With this update, machine config changes made to a custom node take precedence over machine config changes made to a worker node, regardless of the machine config names. 
+
 [id="ocp-4-15-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Release note retroactively added to announce the change in documented https://github.com/openshift/openshift-docs/pull/95297. 

Preview:
OCP 4.15 Release Notes -> [Notable technical changes](https://95451--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-notable-technical-changes) -- MCO gives priority to custom machine config changes

The note is being added to the 4.15 release notes; as such change management is needed.  Change mangement:
- [x] Michelle Krejci -- Manager (approval in [Slack](https://redhat-internal.slack.com/archives/C0942KFAHLZ/p1751375326939369))
- [x] Mark Russell -- PM (approval in [Slack](https://redhat-internal.slack.com/archives/C0942KFAHLZ/p1751375326939369))
- [x] Derrick Ornelas -- PX
- [x] Sergio Regidor de la Rosa -- QE (approval in [initial PR](https://github.com/openshift/openshift-docs/pull/95297#issuecomment-3013860870))
- [x] Jerry Zhang -- Eng (approval in [initial PR](https://github.com/openshift/openshift-docs/pull/95297#pullrequestreview-2968010347))
- [x] Kathryn Alexander -- Docs
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->