### PR TITLE
TELCODOCS-2365: minor formatting fix

### DIFF
--- a/hardware_enablement/kmm-release-notes.adoc
+++ b/hardware_enablement/kmm-release-notes.adoc
@@ -63,7 +63,7 @@ https://catalog.redhat.com/search?searchType=software[Red Hat Catalog].
 ** `status.nodeInfo`
 ** `status.conditions[]` (`NodeReady` only) and still filtering heartbeats  
 
-== Notable technical changes
+=== Notable technical changes
 // TELCODOCS-2343
 * In this release, the preflight validation resource in the cluster has been modified. You can use the  preflight validation to verify kernel modules to be installed on the nodes after cluster upgrades and possible kernel upgrades. Preflight validation also reports on the status and progress of each module in the cluster that it attempts or has attempted to validate. For more information, see xref:../updating/preparing_for_updates/kmm-preflight-validation.adoc#kmm-validation-kickoff_kmm-preflight-validation[Preflight validation for Kernel Module Management (KMM) Modules].
 


### PR DESCRIPTION
Fix heading in KMM 2.4 Release Notes 

Version(s):
openshift-4.19, openshift-4.20
KMM 2.4

Issue:
https://issues.redhat.com/browse/TELCODOCS-2365

Link to docs preview:
https://95452--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-release-notes.html

Additional information:
Note to Peer Reviewer: This is a very minor formatting fix with NO TECHNICAL CHANGES.
Change the heading level:
`== Notable technical changes`
to `=== Notable technical changes`
