### PR TITLE
OSDOCS-15130 [NETOBSERV] Update admin/dev preview language in Overview

### DIFF
--- a/observability/network_observability/network-observability-overview.adoc
+++ b/observability/network_observability/network-observability-overview.adoc
@@ -22,13 +22,11 @@ The Network Observability Operator provides the Flow Collector API custom resour
 [id="no-console-integration"]
 == {product-title} console integration
 
-{product-title} console integration offers overview, topology view, and traffic flow tables in both *Administrator* and *Developer* perspectives.
-
-In the *Administrator* perspective, you can find the Network Observability *Overview*, *Traffic flows*, and *Topology* views by clicking *Observe* -> *Network Traffic*. In the *Developer* perspective, you can view this information by clicking *Observe*. The Network Observability metrics dashboards in *Observe* -> *Dashboards* are only available to administrators. 
+{product-title} console integration offers an overview, a topology view, and traffic flow tables. The Network Observability metrics dashboards in *Observe* -> *Dashboards* are available only to users with administrator access.
 
 [NOTE]
 ====
-To enable multi-tenancy for the developer perspective and for administrators with limited access to namespaces, you must specify permissions by defining roles. For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-multi-tenancy_network_observability[Enabling multi-tenancy in Network Observability].
+To enable multi-tenancy for developer access and for administrators with limited access to namespaces, you must specify permissions by defining roles. For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-multi-tenancy_network_observability[Enabling multi-tenancy in Network Observability].
 ====
 
 [id="network-observability-dashboards"]
@@ -51,4 +49,4 @@ The *Traffic flow* table view provides a view for raw flows, non aggregated filt
 
 [id="network-observability-cli"]
 == Network Observability CLI
-You can quickly debug and troubleshoot networking issues with Network Observability by using the Network Observability CLI (`oc netobserv`). The Network Observability CLI is a flow and packet visualization tool that relies on eBPF agents to stream collected data to an ephemeral collector pod. It requires no persistent storage during the capture. After the run, the output is transferred to your local machine. This enables quick, live insight into packets and flow data without installing the Network Observability Operator.  
+You can quickly debug and troubleshoot networking issues with Network Observability by using the Network Observability CLI (`oc netobserv`). The Network Observability CLI is a flow and packet visualization tool that relies on eBPF agents to stream collected data to an ephemeral collector pod. It requires no persistent storage during the capture. After the run, the output is transferred to your local machine. This enables quick, live insight into packets and flow data without installing the Network Observability Operator.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15130 [NETOBSERV] Update admin/dev preview language in Overview

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the `no-1.9` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the NetObserv content just before its GA.

Cherry-pick to OCP 4.12, 4.14, 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-15130

Link to docs preview:
https://95455--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-overview.html#no-console-integration

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
