### PR TITLE
OLS-1873: Create OLS 1.0.1 release notes

### DIFF
--- a/modules/ols-1-0-1-known-issues.adoc
+++ b/modules/ols-1-0-1-known-issues.adoc
@@ -1,0 +1,13 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-1-known-issues_{context}"]
+= Known issues
+
+The following issues are identified with {ols-official} 1.0.1:
+
+* If the {ocp-product-title} cluster has a cluster-wide proxy and the `no_proxy` environment variable is set, the {ols-long} service tries to connect to the large language model (LLM) provider through the proxy. link:https://issues.redhat.com/browse/OLS-1861[OLS-1861].
++
+Workaround: None.

--- a/modules/ols-1-0-1-release-notes.adoc
+++ b/modules/ols-1-0-1-release-notes.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-1-release-notes_{context}"]
+= {ols-long} version 1.0.1
+
+{ols-official} 1.0.1 is now available on {ocp-product-title} 4.15 and later.
+
+[id="ols-1-0-1-enhancements_{context}"]
+== Enhancements
+
+The following enhancements are made with {ols-official} 1.0.1:
+
+* This release makes {ols-official} 1.0.1 generally available, and is supported on {ocp-product-title} 4.15 and later.
+
+* This release introduces the BYO Knowledge tool as a Technology Preview feature. You can use this tool to add your own custom content as a knowledge source so that a large language model (LLM) can make use of information that is unique to your environment. By using this information, the tool creates a retrieval-augmented generation (RAG) database to enhance the knowledge that is available to the LLM.
++
+--
+:FeatureName: The BYO Knowledge tool
+include::snippets/technology-preview.adoc[]
+--

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -13,5 +13,7 @@ The release notes highlight what is new and what has changed with each {ols-offi
 {ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
 ====
 
+include::modules/ols-1-0-1-release-notes.adoc[leveloffset=+1]
+include::modules/ols-1-0-1-known-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-release-notes.adoc[leveloffset=+1]
 include::modules/ols-1-0-known-issues.adoc[leveloffset=+2]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-1873
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://95462--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-1-0-1-release-notes_ols-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
