### PR TITLE
OSDOCS-13834: Namespace opt in docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -57,6 +57,8 @@ Topics:
   File: using-cohorts
 - Name: Configuring fair sharing
   File: configuring-fairsharing
+- Name: Managing jobs and workloads
+  File: managing-workloads
 ---
 Name: Support
 Dir: support

--- a/configure/managing-workloads.adoc
+++ b/configure/managing-workloads.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="managing-workloads"]
+= Managing jobs and workloads
+:context: managing-workloads
+
+toc::[]
+
+{product-title} does not directly manipulate jobs that are created by users. Instead, Kueue manages `Workload` objects that represent the resource requirements of a job. {product-title} automatically creates a workload for each job, and syncs any decisions and statuses between the two objects.
+
+include::modules/configuring-labelpolicy.adoc[leveloffset=+1]

--- a/install/install-kueue.adoc
+++ b/install/install-kueue.adoc
@@ -9,16 +9,15 @@ toc::[]
 You can install {product-title} by using the {kueue-op} in OperatorHub.
 
 include::modules/install-kueue-operator.adoc[leveloffset=+1]
-include::modules/create-kueue-cr.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_{context}"]
-== Additional resources
-
+.Additional resources
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#installing-the-cert-manager-operator-for-red-hat-openshift[Installing the cert-manager Operator for Red Hat OpenShift]
+
+include::modules/create-kueue-cr.adoc[leveloffset=+1]
+include::modules/label-namespaces.adoc[leveloffset=+1]
 
 [id="next-steps_{context}"]
 == Next steps
-
 * Complete the procedures in xref:../authentication/rbac-permissions.adoc#configure-rbac-batch-admins_rbac-permissions[Configuring permissions for batch administrators] and xref:../authentication/rbac-permissions.adoc#configure-rbac-batch-users_rbac-permissions[Configuring permissions for users].
 * Complete the procedures in the xref:../configure/configuring-quotas.adoc#configuring-quotas[Configuring quotas] documentation.

--- a/modules/configuring-labelpolicy.adoc
+++ b/modules/configuring-labelpolicy.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * configure/managing-workloads.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="configuring-labelpolicy_{context}"]
+= Configuring label policies for jobs
+
+The `spec.config.workloadManagement.labelPolicy` spec in the `Kueue` custom resource (CR) is an optional field that controls how {product-title} decides whether to manage or ignore different jobs. The allowed values are `QueueName`, `None` and empty (`""`).
+
+If the `labelPolicy` setting is omitted or empty (`""`), the default policy is that {product-title} manages jobs that have a `kueue.x-k8s.io/queue-name` label, and ignores jobs that do not have the `kueue.x-k8s.io/queue-name` label. This is the same workflow as if the `labelPolicy` is set to `QueueName`.
+
+If the `labelPolicy` setting is set to `None`, jobs are managed by {product-title} even if they do not have the `kueue.x-k8s.io/queue-name` label.
+
+.Example `workloadManagement` spec configuration
+[source,yaml]
+----
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  config:
+    workloadManagement:
+      labelPolicy: QueueName
+# ...
+----
+
+.Example user-created `Job` object containing the `kueue.x-k8s.io/queue-name` label
+[source,yaml]
+----
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: sample-job-
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+# ...
+----

--- a/modules/label-namespaces.adoc
+++ b/modules/label-namespaces.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * install/install-kueue.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="label-namespaces_{context}"]
+= Labeling namespaces to allow {product-title} to manage jobs
+
+The {product-title} Operator uses an opt-in webhook mechanism to ensure that policies are only enforced for the jobs and namespaces that it is expected to target.
+
+You must label the namespaces where you want {product-title} to manage jobs with the `kueue.openshift.io/managed=true` label.
+
+.Procedure
+
+* Add the `kueue.openshift.io/managed=true` label to a namespace by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace <namespace> kueue.openshift.io/managed=true
+----
+
+When you add this label, you instruct the {product-title} Operator that the namespace is managed by its webhook admission controllers. As a result, any {product-title} resources within that namespace are properly validated and mutated.


### PR DESCRIPTION
Version(s):
- `kueue-docs`
- `kueue-docs-1.0`

Issue:
https://issues.redhat.com/browse/OSDOCS-13834

Link to docs preview:
- https://95464--ocpdocs-pr.netlify.app/openshift-kueue/latest/install/install-kueue.html#label-namespaces_install-kueue
- https://95464--ocpdocs-pr.netlify.app/openshift-kueue/latest/configure/managing-workloads.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
