### PR TITLE
CNF#18626: Change bm-sno communication matrix name to none-sno

### DIFF
--- a/modules/network-flow-matrix.adoc
+++ b/modules/network-flow-matrix.adoc
@@ -25,7 +25,7 @@ To view or download the complete raw CSV content for an environment, see the fol
 
 * link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/bm.csv[{product-title} on bare metal]
 
-* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/bm-sno.csv[{sno-caps} on bare metal]
+* link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/none-sno.csv[{sno-caps} on bare metal]
 
 * link:https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/raw/aws.csv[{product-title} on {aws-short}]
 
@@ -79,7 +79,7 @@ In addition to the base network flows, the following matrix describes the ingres
 .{sno-caps} on bare metal
 [%header,format=csv]
 |===
-include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/bm-sno.csv[]
+include::https://raw.githubusercontent.com/openshift-kni/commatrix/release-4.18/docs/stable/unique/none-sno.csv[]
 |===
 
 [id="network-flow-matrix-aws_{context}"]


### PR DESCRIPTION
As the bm-sno cluster telco partners deploys is of platform type "None", we want to change the name of the files containing this type of commatrix data to none, to avoid confusion. Hence we have duplicated the bm-sno commatrix under the name none-sno (see [PR](https://github.com/openshift-kni/commatrix/pull/149)). after changing the pointer to the new communication matrix, the old one will be deleted.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/CNF-18626

Link to docs preview:
[OpenShift Container Platform network flow matrix](https://95468--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#network-flow-matrix_configuring-firewall) -- Second bullet
[Additional network flows for single-node OpenShift on bare metal](https://95468--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#network-flow-matrix-sno_configuring-firewall) -- Table


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
