### PR TITLE
[SRVKE-1687] Unify KafkaChannel and KafkaBroker secret format

### DIFF
--- a/modules/serverless-kafka-broker-sasl-default-config.adoc
+++ b/modules/serverless-kafka-broker-sasl-default-config.adoc
@@ -31,17 +31,12 @@ $ oc create secret -n knative-eventing generic <secret_name> \
   --from-literal=password="SecretPassword" \
   --from-literal=user="my-sasl-user"
 ----
-** Use the key names `ca.crt`, `password`, and `sasl.mechanism`. Do not change them.
-** If you want to use SASL with public CA certificates, you must use the `tls.enabled=true` flag, rather than the `ca.crt` argument, when creating the secret. For example:
+** Use the key names `protocol`, `sasl.mechanism`, `ca.crt`, `password`, and `user`. Do not change them.
 +
-[source,terminal]
-----
-$ oc create secret -n <namespace> generic <kafka_auth_secret> \
-  --from-literal=tls.enabled=true \
-  --from-literal=password="SecretPassword" \
-  --from-literal=saslType="SCRAM-SHA-512" \
-  --from-literal=user="my-sasl-user"
-----
+[NOTE]
+====
+The `ca.crt` key is optional if the Kafka cluster uses a certificate signed by a public CA whose certificate is already in the system truststore.
+====
 
 . Edit the `KnativeKafka` CR and add a reference to your secret in the `broker` spec:
 +

--- a/modules/serverless-kafka-sasl-channels.adoc
+++ b/modules/serverless-kafka-sasl-channels.adoc
@@ -25,22 +25,18 @@ _Simple Authentication and Security Layer_ (SASL) is used by Apache Kafka for au
 [source,terminal]
 ----
 $ oc create secret -n <namespace> generic <kafka_auth_secret> \
+  --from-literal=protocol="SASL_SSL"
+  --from-literal=sasl.mechanism="SCRAM-SHA-512" \
   --from-file=ca.crt=caroot.pem \
   --from-literal=password="SecretPassword" \
-  --from-literal=saslType="SCRAM-SHA-512" \
   --from-literal=user="my-sasl-user"
 ----
-** Use the key names `ca.crt`, `password`, and `sasl.mechanism`. Do not change them.
-** If you want to use SASL with public CA certificates, you must use the `tls.enabled=true` flag, rather than the `ca.crt` argument, when creating the secret. For example:
+** Use the key names `protocol`, `sasl.mechanism`, `ca.crt`, `password`, and `user`. Do not change them.
 +
-[source,terminal]
-----
-$ oc create secret -n <namespace> generic <kafka_auth_secret> \
-  --from-literal=tls.enabled=true \
-  --from-literal=password="SecretPassword" \
-  --from-literal=saslType="SCRAM-SHA-512" \
-  --from-literal=user="my-sasl-user"
-----
+[NOTE]
+====
+The `ca.crt` key is optional if the Kafka cluster uses a certificate signed by a public CA whose certificate is already in the system truststore.
+====
 
 . Start editing the `KnativeKafka` custom resource:
 +


### PR DESCRIPTION
Version(s):
serverless-docs-1.35+

Issue:
- https://issues.redhat.com/browse/SRVKE-1687

Link to docs preview:
- [Knative channels](https://95471--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/channels/serverless-kafka-admin-security-channels.html#serverless-kafka-sasl-channels_serverless-kafka-admin-security-channels)
- [Kafka brokers](https://95471--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/brokers/kafka-broker.html#serverless-kafka-broker-tls-default-config_kafka-broker)

QE review:
- [x] QE has approved this change.
