### PR TITLE
Explain central-db rollback from 4.8

### DIFF
--- a/modules/rollback-central-forced.adoc
+++ b/modules/rollback-central-forced.adoc
@@ -17,6 +17,15 @@ Using forced rollback to switch back to a previous version might result in loss 
 
 * Before you can perform a rollback, you must have free disk space available on your persistent storage. {product-title} uses disk space to keep a copy of databases during the upgrade. If the disk space is not enough to store a copy and the upgrade fails, you will not be able to roll back to an earlier version.
 
+* If you rollback from {product-title} 4.8 to an earlier version and use an
+  internal database (i.e. `central-db` component), you need to restore the
+  database from a PostgreSQL 13 backup first. Such a backup is automatically
+  created during the upgrade, and to restore it add `RESTORE_BACKUP=true` and
+  `FORCE_OLD_BINARIES=true` environment variables to `central-db` and `init-db`
+  containers of `central-db` component and wait until it updated. See
+  xref:customize-installation-operator-overlays.adoc#adding-an-environment-variable-to-a-deployment[Injecting an environment variable into the Central deployment]
+  for an example how to do that.
+
 .Procedure
 
 * Run the following commands to perform a forced rollback:

--- a/modules/rollback-central-normal.adoc
+++ b/modules/rollback-central-normal.adoc
@@ -12,6 +12,15 @@ You can roll back to a previous version of Central if upgrading {product-title} 
 
 * Before you can perform a rollback, you must have free disk space available on your persistent storage. {product-title} uses disk space to keep a copy of databases during the upgrade. If the disk space is not enough to store a copy and the upgrade fails, you might not be able to roll back to an earlier version.
 
+* If you rollback from {product-title} 4.8 to an earlier version and use an
+  internal database (i.e. `central-db` component), you need to restore the
+  database from a PostgreSQL 13 backup first. Such a backup is automatically
+  created during the upgrade, and to restore it add `RESTORE_BACKUP=true` and
+  `FORCE_OLD_BINARIES=true` environment variables to `central-db` and `init-db`
+  containers of `central-db` component and wait until it updated. See
+  xref:customize-installation-operator-overlays.adoc#adding-an-environment-variable-to-a-deployment[Injecting an environment variable into the Central deployment]
+  for an example how to do that.
+
 .Procedure
 
 * Run the following command to roll back to a previous version when an upgrade fails (before the Central service starts):


### PR DESCRIPTION
Rolling back from ACS 4.8 is more complicated due to major version upgrade. Describe this in the rollback section.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
