### PR TITLE
OSDOCS-15118 RODOO 1.2.2 release notes in OCP 4.18

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -14,26 +14,38 @@ These release notes track the development of the {run-once-operator} for {produc
 
 For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
 
-[id="run-once-duration-override-operator-release-notes-1-2-1"]
+[id="run-once-duration-override-operator-release-notes-1-2-2_{context}"]
+== {run-once-operator} 1.2.2
+
+Issued: 2 July 2025
+
+The following advisory is available for the {run-once-operator} 1.2.2: (link:https://access.redhat.com/errata/RHBA-2025:10199[RHBA-2025:10199])
+
+[id="run-once-duration-override-operator-1-2-2-bug-fixes_{context}"]
+=== Bug fixes
+
+* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+[id="run-once-duration-override-operator-release-notes-1-2-1_{context}"]
 == {run-once-operator} 1.2.1
 
 Issued: 30 April 2025
 
 The following advisory is available for the {run-once-operator} 1.2.1: (link:https://access.redhat.com/errata/RHBA-2025:4333[RHBA-2025:4333])
 
-[id="run-once-duration-override-operator-1-2-1-bug-fixes"]
+[id="run-once-duration-override-operator-1-2-1-bug-fixes_{context}"]
 === Bug fixes
 
 * This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
 
-[id="run-once-duration-override-operator-release-notes-1-2-0"]
+[id="run-once-duration-override-operator-release-notes-1-2-0_{context}"]
 == {run-once-operator} 1.2.0
 
 Issued: 16 October 2024
 
 The following advisory is available for the {run-once-operator} 1.2.0: (link:https://access.redhat.com/errata/RHSA-2024:7548[RHSA-2024:7548])
 
-[id="run-once-duration-override-operator-1-2-0-bug-fixes"]
+[id="run-once-duration-override-operator-1-2-0-bug-fixes_{context}"]
 === Bug fixes
 
 * This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).


### PR DESCRIPTION
Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-15118](https://issues.redhat.com/browse/OSDOCS-15118)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://95487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html#run-once-duration-override-operator-release-notes-1-2-2
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: 
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
