### PR TITLE
Fixed the ROSA with HCP product title

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -60,5 +60,4 @@
 :rosa-short: ROSA with HCP
 :egress-zero: egress zero
 :egress-zero-title: {rosa-short} clusters with {egress-zero}
-:classic: {rosa-classic}
 :classic-short: {rosa-classic-short}

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -199,7 +199,7 @@ openshift-aro:
       name: '4'
       dir: aro/4
 openshift-rosa:
-  name: Red Hat OpenShift Service on AWS (classic architecture)
+  name: Red Hat OpenShift Service on AWS (classic architecture) (ROSA (classic))
   author: OpenShift Documentation Project <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation
@@ -212,7 +212,7 @@ openshift-rosa:
       name: ''
       dir: rosa-preview/
 openshift-rosa-hcp:
-  name: Red Hat OpenShift Service on AWS
+  name: Red Hat OpenShift Service on AWS (ROSA) with hosted control plane (HCP)
   author: OpenShift Documentation Project <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation


### PR DESCRIPTION
Version:
`enterprise-4.19+`

Previews:
The following examples demonstrate the new attributes sheets:
- [OCM](https://95488--ocpdocs-pr.netlify.app/openshift-dedicated/latest/ocm/ocm-overview.html) (dedicated)
- [OCM](https://95488--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/ocm/ocm-overview.html) (ROSA with HCP)
- [OCM](https://95488--ocpdocs-pr.netlify.app/openshift-rosa/latest/ocm/ocm-overview.html) (ROSA (classic architecture))

Additional notes:
This PR divides the attribute sheets into three for Service Delivery.