### PR TITLE
OSDOCS#14994: updates for mounting secrets section in SSCSI

### DIFF
--- a/modules/secrets-store-aws.adoc
+++ b/modules/secrets-store-aws.adoc
@@ -15,22 +15,22 @@ endif::[]
 [id="secrets-store-aws_{context}"]
 = Mounting secrets from {secrets-store-provider}
 
-You can use the {secrets-store-operator} to mount secrets from {secrets-store-provider} to a Container Storage Interface (CSI) volume in {product-title}. To mount secrets from {secrets-store-provider}, your cluster must be installed on AWS and use AWS Security Token Service (STS).
+You can use the {secrets-store-operator} to mount secrets from {secrets-store-provider} external secrets store to a Container Storage Interface (CSI) volume in {product-title}.
 
 .Prerequisites
 
-* Your cluster is installed on AWS and uses AWS Security Token Service (STS).
-* You installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
-* You configured {secrets-store-provider} to store the required secrets.
-* You extracted and prepared the `ccoctl` binary.
-* You installed the `jq` CLI tool.
+* You have installed the cluster on Amazon Web Services (AWS) and the cluster uses AWS Security Token Service (STS).
+* You have installed the {secrets-store-operator}. For more information, see "Installing the {secrets-store-driver}".
+* You have configured {secrets-store-provider} to store the required secrets.
+* You have extracted and prepared the `ccoctl` binary tool.
+* You have installed the `jq` CLI tool.
 * You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
 
 . Install the {secrets-store-provider} provider:
 
-.. Create a YAML file with the following configuration for the provider resources:
+.. Create a YAML file with the following provider resource configuration:
 +
 [IMPORTANT]
 ====
@@ -145,19 +145,19 @@ $ oc adm policy add-scc-to-user privileged -z csi-secrets-store-provider-aws -n 
 +
 [source,terminal]
 ----
-$ oc apply -f aws-provider.yaml
+$ oc apply -f <aws-provider>.yaml
 ----
 
-. Grant permission to allow the service account to read the AWS secret object:
+. Grant the service account permission to read the AWS secret object:
 
 .. Create a directory to contain the credentials request by running the following command:
 +
 [source,terminal]
 ----
-$ mkdir credentialsrequest-dir-aws
+$ mkdir <credentialsrequest-dir-aws>
 ----
 
-.. Create a YAML file with the following configuration for the credentials request:
+.. Create a YAML file with the following credentials request configuration:
 +
 .Example `credentialsrequest.yaml` file
 [source,yaml]
@@ -165,7 +165,7 @@ $ mkdir credentialsrequest-dir-aws
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: aws-provider-test
+  name: <aws-provider-test>
   namespace: openshift-cloud-credential-operator
 spec:
   providerSpec:
@@ -188,13 +188,13 @@ ifdef::aws-systems-manager-parameter-store[]
       resource: "arn:*:ssm:*:*:parameter/testParameter*"
 endif::aws-systems-manager-parameter-store[]
   secretRef:
-    name: aws-creds
-    namespace: my-namespace
+    name: <aws-creds>
+    namespace: <my-namespace>
   serviceAccountNames:
-  - aws-provider
+  - <aws-provider>
 ----
 
-.. Retrieve the OIDC provider by running the following command:
+.. Retrieve the OpenID Connect (OIDC) provider by running the following command:
 +
 [source,terminal]
 ----
@@ -213,26 +213,26 @@ Copy the OIDC provider name `<oidc_provider_name>` from the output to use in the
 [source,terminal]
 ----
 $ ccoctl aws create-iam-roles \
-    --name my-role --region=<aws_region> \
-    --credentials-requests-dir=credentialsrequest-dir-aws \
-    --identity-provider-arn arn:aws:iam::<aws_account>:oidc-provider/<oidc_provider_name> --output-dir=credrequests-ccoctl-output
+    --name <my-role> --region=<aws_region> \
+    --credentials-requests-dir=<credentialsrequest-dir-aws> \
+    --identity-provider-arn arn:aws:iam::<aws_account_id>:oidc-provider/<oidc_provider_name> --output-dir=<credrequests-ccoctl-output>
 ----
 +
 .Example output
 [source,terminal]
 ----
-2023/05/15 18:10:34 Role arn:aws:iam::<aws_account_id>:role/my-role-my-namespace-aws-creds created
-2023/05/15 18:10:34 Saved credentials configuration to: credrequests-ccoctl-output/manifests/my-namespace-aws-creds-credentials.yaml
-2023/05/15 18:10:35 Updated Role policy for Role my-role-my-namespace-aws-creds
+2023/05/15 18:10:34 Role arn:aws:iam::<aws_account_id>:role/<my-role>-<my-namespace>-<aws-creds> created
+2023/05/15 18:10:34 Saved credentials configuration to: <credrequests-ccoctl-output>/manifests/<my-namespace>-aws-creds-credentials.yaml
+2023/05/15 18:10:35 Updated Role policy for Role <my-role>-<my-namespace>-<aws-creds>
 ----
 +
 Copy the `<aws_role_arn>` from the output to use in the next step. For example, `arn:aws:iam::<aws_account_id>:role/my-role-my-namespace-aws-creds`.
 
-.. Bind the service account with the role ARN by running the following command:
+.. Bind the service account with the role Amazon Resource Name (ARN) by running the following command:
 +
 [source,terminal]
 ----
-$ oc annotate -n my-namespace sa/aws-provider eks.amazonaws.com/role-arn="<aws_role_arn>"
+$ oc annotate -n <my-namespace> sa/<aws-provider> eks.amazonaws.com/role-arn="<aws_role_arn>"
 ----
 
 . Create a secret provider class to define your secrets store provider:
@@ -245,20 +245,20 @@ $ oc annotate -n my-namespace sa/aws-provider eks.amazonaws.com/role-arn="<aws_r
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: my-aws-provider                   <1>
-  namespace: my-namespace                 <2>
+  name: <my-aws-provider> # <1>
+  namespace: <my-namespace> # <2>
 spec:
-  provider: aws                           <3>
-  parameters:                             <4>
+  provider: aws # <3>
+  parameters: # <4>
 ifdef::aws-secrets-manager[]
     objects: |
-      - objectName: "testSecret"
-        objectType: "secretsmanager"
+      - objectName: "<testSecret>"
+        objectType: "<secretsmanager>"
 endif::aws-secrets-manager[]
 ifdef::aws-systems-manager-parameter-store[]
     objects: |
-      - objectName: "testParameter"
-        objectType: "ssmparameter"
+      - objectName: "<testParameter>"
+        objectType: "<ssmparameter>"
 endif::aws-systems-manager-parameter-store[]
 ----
 <1> Specify the name for the secret provider class.
@@ -283,8 +283,8 @@ $ oc create -f secret-provider-class-aws.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: my-aws-deployment                              <1>
-  namespace: my-namespace                              <2>
+  name: <my-aws-deployment> # <1>
+  namespace: <my-namespace> # <2>
 spec:
   replicas: 1
   selector:
@@ -312,7 +312,7 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: "my-aws-provider" <3>
+              secretProviderClass: "<my-aws-provider>" # <3>
 ----
 <1> Specify the name for the deployment.
 <2> Specify the namespace for the deployment. This must be the same namespace as the secret provider class.
@@ -333,7 +333,7 @@ $ oc create -f deployment.yaml
 +
 [source,terminal]
 ----
-$ oc exec my-aws-deployment-<hash> -n my-namespace -- ls /mnt/secrets-store/
+$ oc exec <my-aws-deployment>-<hash> -n <my-namespace> -- ls /mnt/secrets-store/
 ----
 +
 .Example output
@@ -351,7 +351,7 @@ endif::aws-systems-manager-parameter-store[]
 +
 [source,terminal]
 ----
-$ oc exec my-aws-deployment-<hash> -n my-namespace -- cat /mnt/secrets-store/testSecret
+$ oc exec <my-aws-deployment>-<hash> -n <my-namespace> -- cat /mnt/secrets-store/<testSecret>
 ----
 +
 .Example output

--- a/modules/secrets-store-azure.adoc
+++ b/modules/secrets-store-azure.adoc
@@ -6,21 +6,21 @@
 [id="secrets-store-azure_{context}"]
 = Mounting secrets from Azure Key Vault
 
-You can use the {secrets-store-operator} to mount secrets from Azure Key Vault to a Container Storage Interface (CSI) volume in {product-title}. To mount secrets from Azure Key Vault, your cluster must be installed on Microsoft Azure.
+You can use the {secrets-store-operator} to mount secrets from Azure Key Vault external secrets store to a Container Storage Interface (CSI) volume in {product-title}.
 
 .Prerequisites
 
-* Your cluster is installed on Azure.
-* You installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
-* You configured Azure Key Vault to store the required secrets.
-* You installed the Azure CLI (`az`).
+* Your have installed the cluster on Microsoft Azure.
+* You have installed the {secrets-store-operator}. For more information, see "Installing the {secrets-store-driver}".
+* You have configured Azure Key Vault to store the required secrets.
+* You have installed the Azure CLI (`az`) tool.
 * You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
 
 . Install the Azure Key Vault provider:
 
-.. Create a YAML file with the following configuration for the provider resources:
+.. Create a YAML file with the following provider resources configuration:
 +
 [IMPORTANT]
 ====
@@ -177,14 +177,14 @@ $ SERVICE_PRINCIPAL_CLIENT_ID="$(az ad sp list --display-name https://$KEYVAULT_
 +
 [source,terminal]
 ----
-$ oc create secret generic secrets-store-creds -n my-namespace --from-literal clientid=${SERVICE_PRINCIPAL_CLIENT_ID} --from-literal clientsecret=${SERVICE_PRINCIPAL_CLIENT_SECRET}
+$ oc create secret generic <secrets-store-creds> -n <my-namespace> --from-literal clientid=${SERVICE_PRINCIPAL_CLIENT_ID} --from-literal clientsecret=${SERVICE_PRINCIPAL_CLIENT_SECRET}
 ----
 
 .. Apply the `secrets-store.csi.k8s.io/used=true` label to allow the provider to find this `nodePublishSecretRef` secret:
 +
 [source,terminal]
 ----
-$ oc -n my-namespace label secret secrets-store-creds secrets-store.csi.k8s.io/used=true
+$ oc -n <my-namespace> label secret <secrets-store-creds> secrets-store.csi.k8s.io/used=true
 ----
 
 . Create a secret provider class to define your secrets store provider:
@@ -197,21 +197,21 @@ $ oc -n my-namespace label secret secrets-store-creds secrets-store.csi.k8s.io/u
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: my-azure-provider                 <1>
-  namespace: my-namespace                 <2>
+  name: <my-azure-provider> # <1>
+  namespace: <my-namespace> # <2>
 spec:
-  provider: azure                         <3>
-  parameters:                             <4>
+  provider: azure # <3>
+  parameters: # <4>
     usePodIdentity: "false"
     useVMManagedIdentity: "false"
     userAssignedIdentityID: ""
-    keyvaultName: "kvname"
+    keyvaultName: "<kvname>"
     objects: |
       array:
         - |
-          objectName: secret1
+          objectName: <secret1>
           objectType: secret
-    tenantId: "tid"
+    tenantId: "<tid>"
 ----
 <1> Specify the name for the secret provider class.
 <2> Specify the namespace for the secret provider class.
@@ -235,8 +235,8 @@ $ oc create -f secret-provider-class-azure.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: my-azure-deployment                            <1>
-  namespace: my-namespace                              <2>
+  name: <my-azure-deployment> # <1>
+  namespace: <my-namespace> # <2>
 spec:
   replicas: 1
   selector:
@@ -263,9 +263,9 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: "my-azure-provider" <3>
+              secretProviderClass: "<my-azure-provider>" # <3>
             nodePublishSecretRef:
-              name: secrets-store-creds                <4>
+              name: <secrets-store-creds> # <4>
 ----
 <1> Specify the name for the deployment.
 <2> Specify the namespace for the deployment. This must be the same namespace as the secret provider class.
@@ -287,7 +287,7 @@ $ oc create -f deployment.yaml
 +
 [source,terminal]
 ----
-$ oc exec my-azure-deployment-<hash> -n my-namespace -- ls /mnt/secrets-store/
+$ oc exec <my-azure-deployment>-<hash> -n <my-namespace> -- ls /mnt/secrets-store/
 ----
 +
 .Example output
@@ -300,7 +300,7 @@ secret1
 +
 [source,terminal]
 ----
-$ oc exec my-azure-deployment-<hash> -n my-namespace -- cat /mnt/secrets-store/secret1
+$ oc exec <my-azure-deployment>-<hash> -n <my-namespace> -- cat /mnt/secrets-store/<secret1>
 ----
 +
 .Example output

--- a/modules/secrets-store-google.adoc
+++ b/modules/secrets-store-google.adoc
@@ -6,20 +6,20 @@
 [id="secrets-store-google_{context}"]
 = Mounting secrets from Google Secret Manager
 
-You can use the {secrets-store-operator} to mount secrets from Google Secret Manager to a Container Storage Interface (CSI) volume in {product-title}. To mount secrets from Google Secret Manager, your cluster must be installed on {gcp-first}.
+You can use the {secrets-store-operator} to mount secrets from Google Secret Manager external secrets store to a Container Storage Interface (CSI) volume in {product-title}. To mount secrets from Google Secret Manager, your cluster must be installed on {gcp-first}.
 
 .Prerequisites
 
-* You installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
-* You configured Google Secret Manager to store the required secrets.
-* You created a service account key named `key.json` from your Google Cloud service account.
+* You have installed the {secrets-store-operator}. For more information, see "Installing the {secrets-store-driver}".
+* You have configured Google Secret Manager to store the required secrets.
+* You have created a service account key named `key.json` from your Google Cloud service account.
 * You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
 
 . Install the Google Secret Manager provider:
 
-.. Create a YAML file with the following configuration for the provider resources:
+.. Create a YAML file with the following provider resources configuration:
 +
 .Example `gcp-provider.yaml` file
 [source,yaml]
@@ -148,37 +148,37 @@ $ oc adm policy add-scc-to-user privileged -z csi-secrets-store-provider-gcp -n 
 +
 [source,terminal]
 ----
-$ oc apply -f gcp-provider.yaml
+$ oc apply -f <gcp-provider.yaml>
 ----
 
-. Grant permission to read the Google Secret Manager secret:
+. Grant the permission to read the Google Secret Manager secret:
 
 .. Create a new project by running the following command:
 +
 [source,terminal]
 ----
-$ oc new-project my-namespace
+$ oc new-project <my-namespace>
 ----
 
 .. Label the `my-namespace` namespace for pod security admission by running the following command:
 +
 [source,terminal]
 ----
-$ oc label ns my-namespace security.openshift.io/scc.podSecurityLabelSync=false pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged --overwrite
+$ oc label ns <my-namespace> security.openshift.io/scc.podSecurityLabelSync=false pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged --overwrite
 ----
 
 .. Create a service account for the pod deployment:
 +
 [source,terminal]
 ----
-$ oc create serviceaccount my-service-account --namespace=my-namespace
+$ oc create serviceaccount <my-service-account> --namespace=<my-namespace>
 ----
 
 .. Create a generic secret from the `key.json` file by running the following command:
 +
 [source,terminal]
 ----
-$ oc create secret generic secrets-store-creds -n my-namespace --from-file=key.json <1>
+$ oc create secret generic <secrets-store-creds> -n <my-namespace> --from-file=key.json <1>
 ----
 <1> You created this `key.json` file from the Google Secret Manager.
 
@@ -186,7 +186,7 @@ $ oc create secret generic secrets-store-creds -n my-namespace --from-file=key.j
 +
 [source,terminal]
 ----
-$ oc -n my-namespace label secret secrets-store-creds secrets-store.csi.k8s.io/used=true
+$ oc -n <my-namespace> label secret <secrets-store-creds> secrets-store.csi.k8s.io/used=true
 ----
 
 . Create a secret provider class to define your secrets store provider:
@@ -199,14 +199,14 @@ $ oc -n my-namespace label secret secrets-store-creds secrets-store.csi.k8s.io/u
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: my-gcp-provider                        <1>
-  namespace: my-namespace                      <2>
+  name: <my-gcp-provider> # <1>
+  namespace: <my-namespace> # <2>
 spec:
-  provider: gcp                                <3>
-  parameters:                                  <4>
+  provider: gcp # <3>
+  parameters: # <4>
     secrets: |
-      - resourceName: "projects/my-project/secrets/testsecret1/versions/1"
-        path: "testsecret1.txt"
+      - resourceName: "<projects/my-project/secrets/testsecret1/versions/1>"
+        path: "<testsecret1.txt>"
 ----
 <1> Specify the name for the secret provider class.
 <2> Specify the namespace for the secret provider class.
@@ -217,7 +217,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc create -f secret-provider-class-gcp.yaml
+$ oc create -f <secret-provider-class-gcp.yaml>
 ----
 
 . Create a deployment to use this secret provider class:
@@ -230,8 +230,8 @@ $ oc create -f secret-provider-class-gcp.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: my-gcp-deployment                              <1>
-  namespace: my-namespace                              <2>
+  name: <my-gcp-deployment> # <1>
+  namespace: <my-namespace> # <2>
 spec:
   replicas: 1
   selector:
@@ -242,7 +242,7 @@ spec:
       labels:
         app: my-storage
     spec:
-      serviceAccountName: my-service-account           <3>
+      serviceAccountName: <my-service-account> # <3>
       containers:
       - name: busybox
         image: k8s.gcr.io/e2e-test-images/busybox:1.29
@@ -259,9 +259,9 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: "my-gcp-provider"   <4>
+              secretProviderClass: "<my-gcp-provider>" # <4>
             nodePublishSecretRef:
-              name: secrets-store-creds                <5>
+              name: <secrets-store-creds> # <5>
 ----
 <1> Specify the name for the deployment.
 <2> Specify the namespace for the deployment. This must be the same namespace as the secret provider class.
@@ -273,7 +273,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc create -f deployment.yaml
+$ oc create -f <deployment.yaml>
 ----
 
 .Verification
@@ -284,7 +284,7 @@ $ oc create -f deployment.yaml
 +
 [source,terminal]
 ----
-$ oc exec my-gcp-deployment-<hash> -n my-namespace -- ls /mnt/secrets-store/
+$ oc exec <my-gcp-deployment>-<hash> -n <my-namespace> -- ls /mnt/secrets-store/
 ----
 +
 .Example output
@@ -297,7 +297,7 @@ testsecret1
 +
 [source,terminal]
 ----
-$ oc exec my-gcp-deployment-<hash> -n my-namespace -- cat /mnt/secrets-store/testsecret1
+$ oc exec <my-gcp-deployment>-<hash> -n <my-namespace> -- cat /mnt/secrets-store/<testsecret1>
 ----
 +
 .Example output

--- a/modules/secrets-store-vault.adoc
+++ b/modules/secrets-store-vault.adoc
@@ -6,7 +6,7 @@
 [id="secrets-store-vault_{context}"]
 = Mounting secrets from HashiCorp Vault
 
-You can use the {secrets-store-operator} to mount secrets from HashiCorp Vault to a Container Storage Interface (CSI) volume in {product-title}.
+You can use the {secrets-store-operator} to mount secrets from HashiCorp Vault external secrets store to a Container Storage Interface (CSI) volume in {product-title}.
 
 [IMPORTANT]
 ====
@@ -20,8 +20,8 @@ Other cloud providers might work, but have not been tested yet. Additional cloud
 
 .Prerequisites
 
-* You installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
-* You installed Helm.
+* You have installed the {secrets-store-operator}. For more information, see "Installing the {secrets-store-driver}".
+* You have installed the Helm package manager. For more information, see "Installing Helm".
 * You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
@@ -56,18 +56,18 @@ $ oc new-project vault
 $ oc label ns vault security.openshift.io/scc.podSecurityLabelSync=false pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged --overwrite
 ----
 
-.. Grant privileged access to the `vault` service account by running the following command:
+.. Grant privileged access to the `vault-service-account` service account by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm policy add-scc-to-user privileged -z vault -n vault
+$ oc adm policy add-scc-to-user privileged -z <vault-service-account> -n vault
 ----
 
 .. Grant privileged access to the `vault-csi-provider` service account by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm policy add-scc-to-user privileged -z vault-csi-provider -n vault
+$ oc adm policy add-scc-to-user privileged -z <vault-csi-provider> -n vault
 ----
 
 .. Deploy HashiCorp Vault by running the following command:
@@ -116,14 +116,14 @@ vault-csi-provider-smlv7   1/2     Running   0          5s
 +
 [source,terminal]
 ----
-$ oc exec vault-0 --namespace=vault -- vault kv put secret/example1 testSecret1=my-secret-value
+$ oc exec vault-0 --namespace=vault -- vault kv put secret/<example1> <testSecret1>=<my-secret-value>
 ----
 
-.. Verify that the secret is readable at the path `secret/example1` by running the following command:
+.. Verify that the secret is readable at the path `secret/<example1>` by running the following command:
 +
 [source,terminal]
 ----
-$ oc exec vault-0 --namespace=vault -- vault kv get secret/example1
+$ oc exec vault-0 --namespace=vault -- vault kv get secret/<example1>
 ----
 +
 .Example output
@@ -198,7 +198,7 @@ Success! Data written to: auth/kubernetes/config
 +
 [source,terminal]
 ----
-$ oc exec -i vault-0 --namespace=vault -- vault policy write csi -<<EOF
+$ oc exec -i vault-0 --namespace=vault -- vault policy write <csi> -<<EOF
   path "secret/data/*" {
   capabilities = ["read"]
   }
@@ -215,53 +215,17 @@ Success! Uploaded policy: csi
 +
 [source,terminal]
 ----
-$ oc exec -i vault-0 --namespace=vault -- vault write auth/kubernetes/role/csi \
+$ oc exec -i vault-0 --namespace=vault -- vault write auth/kubernetes/role/<csi> \
   bound_service_account_names=default \
   bound_service_account_namespaces=default,test-ns,negative-test-ns,my-namespace \
-  policies=csi \
-  ttl=20m
+  policies=<csi> \
+  ttl=<20m>
 ----
 +
 .Example output
 [source,terminal]
 ----
 Success! Data written to: auth/kubernetes/role/csi
-----
-
-.. Verify that all of the `vault` pods are running properly by running the following command:
-+
-[source,terminal]
-----
-$ oc get pods -n vault
-----
-+
-.Example output
-[source,terminal]
-----
-NAME                       READY   STATUS    RESTARTS   AGE
-vault-0                    1/1     Running   0          43m
-vault-csi-provider-87rgw   2/2     Running   0          19m
-vault-csi-provider-bd6hp   2/2     Running   0          19m
-vault-csi-provider-smlv7   2/2     Running   0          19m
-----
-
-.. Verify that all of the `secrets-store-csi-driver` pods are running properly by running the following command:
-+
-[source,terminal]
-----
-$ oc get pods -n openshift-cluster-csi-drivers | grep -E "secrets"
-----
-+
-.Example output
-[source,terminal]
-----
-secrets-store-csi-driver-node-46d2g                  3/3     Running   0             45m
-secrets-store-csi-driver-node-d2jjn                  3/3     Running   0             45m
-secrets-store-csi-driver-node-drmt4                  3/3     Running   0             45m
-secrets-store-csi-driver-node-j2wlt                  3/3     Running   0             45m
-secrets-store-csi-driver-node-v9xv4                  3/3     Running   0             45m
-secrets-store-csi-driver-node-vlz28                  3/3     Running   0             45m
-secrets-store-csi-driver-operator-84bd699478-fpxrw   1/1     Running   0             47m
 ----
 
 . Create a secret provider class to define your secrets store provider:
@@ -274,17 +238,17 @@ secrets-store-csi-driver-operator-84bd699478-fpxrw   1/1     Running   0        
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: my-vault-provider                   <1>
-  namespace: my-namespace                   <2>
+  name: <my-vault-provider> # <1>
+  namespace: <my-namespace> # <2>
 spec:
-  provider: vault                           <3>
-  parameters:                               <4>
+  provider: vault # <3>
+  parameters: # <4>
     roleName: "csi"
     vaultAddress: "http://vault.vault:8200"
     objects:  |
-      - secretPath: "secret/data/example1"
-        objectName: "testSecret1"
-        secretKey: "testSecret1"
+      - secretPath: "secret/data/<example1>"
+        objectName: "<testSecret1>"
+        secretKey: "<testSecret1>"
 ----
 <1> Specify the name for the secret provider class.
 <2> Specify the namespace for the secret provider class.
@@ -308,8 +272,8 @@ $ oc create -f secret-provider-class-vault.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: busybox-deployment                                    <1>
-  namespace: my-namespace                                     <2>
+  name: <busybox-deployment> # <1>
+  namespace: <my-namespace> # <2>
   labels:
     app: busybox
 spec:
@@ -340,7 +304,7 @@ spec:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-              secretProviderClass: "my-vault-provider"        <3>
+              secretProviderClass: "<my-vault-provider>" # <3>
 ----
 <1> Specify the name for the deployment.
 <2> Specify the namespace for the deployment. This must be the same namespace as the secret provider class.
@@ -355,13 +319,49 @@ $ oc create -f deployment.yaml
 
 .Verification
 
-* Verify that you can access the secrets from your HashiCorp Vault in the pod volume mount:
+. Verify that the status of all the `vault` pods is `Running` by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n vault
+----
++
+.Example output
+[source,terminal]
+----
+NAME                       READY   STATUS    RESTARTS   AGE
+vault-0                    1/1     Running   0          43m
+vault-csi-provider-87rgw   2/2     Running   0          19m
+vault-csi-provider-bd6hp   2/2     Running   0          19m
+vault-csi-provider-smlv7   2/2     Running   0          19m
+----
+
+. Verify that the status of all the `secrets-store-csi-driver` pods is `Running` by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-cluster-csi-drivers | grep -E "secrets"
+----
++
+.Example output
+[source,terminal]
+----
+secrets-store-csi-driver-node-46d2g                  3/3     Running   0             45m
+secrets-store-csi-driver-node-d2jjn                  3/3     Running   0             45m
+secrets-store-csi-driver-node-drmt4                  3/3     Running   0             45m
+secrets-store-csi-driver-node-j2wlt                  3/3     Running   0             45m
+secrets-store-csi-driver-node-v9xv4                  3/3     Running   0             45m
+secrets-store-csi-driver-node-vlz28                  3/3     Running   0             45m
+secrets-store-csi-driver-operator-84bd699478-fpxrw   1/1     Running   0             47m
+----
+
+. Verify that you can access the secrets from your HashiCorp Vault in the pod volume mount:
 
 .. List the secrets in the pod mount by running the following command:
 +
 [source,terminal]
 ----
-$ oc exec busybox-deployment-<hash> -n my-namespace -- ls /mnt/secrets-store/
+$ oc exec busybox-deployment-<hash> -n <my-namespace> -- ls /mnt/secrets-store/
 ----
 +
 .Example output
@@ -374,7 +374,7 @@ testSecret1
 +
 [source,terminal]
 ----
-$ oc exec busybox-deployment-<hash> -n my-namespace -- cat /mnt/secrets-store/testSecret1
+$ oc exec busybox-deployment-<hash> -n <my-namespace> -- cat /mnt/secrets-store/<testSecret1>
 ----
 +
 .Example output

--- a/nodes/pods/nodes-pods-secrets-store.adoc
+++ b/nodes/pods/nodes-pods-secrets-store.adoc
@@ -68,6 +68,10 @@ include::modules/secrets-store-google.adoc[leveloffset=+2]
 // Mounting secrets from HashiCorp Vault
 include::modules/secrets-store-vault.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../applications/working_with_helm_charts/installing-helm.adoc#installing-helm[Installing Helm]
+
 // Enabling synchronization of mounted content as Kubernetes secrets
 include::modules/secrets-store-sync-secrets.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-14994](https://issues.redhat.com/browse/OSDOCS-14994)

Link to docs preview:
[Mounting secrets from AWS Secrets Manager](https://95504--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-aws_nodes-pods-secrets-store)
[Mounting secrets from AWS Systems Manager Parameter Store](https://95504--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-aws_nodes-pods-secrets-store-parameter-store)
[Mounting secrets from Azure Key Vault](https://95504--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-azure_nodes-pods-secrets-store)
[Mounting secrets from Google Secret Manager](https://95504--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-google_nodes-pods-secrets-store)
[Mounting secrets from HashiCorp Vault](https://95504--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html#secrets-store-vault_nodes-pods-secrets-store)


QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
