### PR TITLE
OSSM-9884: Create egress gateway using gateway API

### DIFF
--- a/gateways/ossm-directing-outbound-traffic.adoc
+++ b/gateways/ossm-directing-outbound-traffic.adoc
@@ -10,3 +10,4 @@ Using {istio} APIs, you can configure gateway proxies that were installed using 
 
 include::modules/ossm-about-directing-egress-traffic-through-a-gateway.adoc[leveloffset=+1]
 include::modules/ossm-directing-egress-traffic-through-a-gateway-using-istio-apis.adoc[leveloffset=+1]
+include::modules/ossm-directing-egress-traffic-through-a-gateway-using-kubernetes-gateway-api.adoc[leveloffset=+1]

--- a/modules/ossm-directing-egress-traffic-through-a-gateway-using-kubernetes-gateway-api.adoc
+++ b/modules/ossm-directing-egress-traffic-through-a-gateway-using-kubernetes-gateway-api.adoc
@@ -1,0 +1,205 @@
+// This procedure is used in the following assembly:
+// * service-mesh-docs-main/gateways/ossm-directing-outbound-traffic-through-a-gateway
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-directing-egress-traffic-through-a-gateway-using-kubernetes-gateway-api_{context}"]
+= Directing egress traffic through a gateway by using the {k8s} Gateway API
+
+Use the {k8s} Gateway API to direct outbound HTTP traffic through an egress gateway.
+
+.Prerequisites
+
+* You installed an {istio} control plane.
+
+* You configured the `Istio` and `IstioCNI` resources. 
+
+.Procedure
+
+. Optional: Enable the {k8} Gateway API custom resource definitions (CRDs). 
++
+[NOTE]
+====
+As of {k8s} 1.28 and {ocp-product-title} 4.18 or earlier version of {product-title}, the {k8s} Gateway API CRDs are not available by default and you must enabled the CRDs before you can use them. {ocp-product-title} 4.19 and later versions enable the CRDs by default.
+====
+
+.. Create a YAML file named `gateway-cr.yaml` that enables the Kubernetes Gateway API CRDs. 
++
+.Example {k8s} Gateway Custom Resource (CR) file
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: bookinfo-gateway
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bookinfo
+spec:
+  parentRefs:
+  - name: bookinfo-gateway
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /productpage
+    - path:
+        type: PathPrefix
+        value: /static
+    - path:
+        type: Exact
+        value: /login
+    - path:
+        type: Exact
+        value: /logout
+    - path:
+        type: PathPrefix
+        value: /api/v1/products
+    backendRefs:
+    - name: productpage
+      port: 9080
+----
+
+.. Apply the YAML file by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f gateway-cr.yaml
+----
+
+. Create a namespace called `egress-gateway` by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace egress-gateway
+----
+
+. Apply the `istio-injection` label to the namespace by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace egress-gateway istio-injection=enabled
+----
+
+. Create a YAML file named `egress-gateway-cr.yaml` that defines the egress gateway.
++
+.Example egress gateway CR file
+[source,yaml,subs="attributes,verbatim"]
+----
+# ServiceEntry to allow traffic to httpbin.org
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: httpbin-ext
+spec:
+  hosts:
+  - httpbin.org
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  location: MESH_EXTERNAL
+  resolution: DNS
+---
+# Gateway API Gateway for egress
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: httpbin-egress-gateway
+  annotations:
+    networking.istio.io/service-type: ClusterIP
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    hostname: httpbin.org
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+# HTTPRoute to direct traffic from sidecars to the egress gateway
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: direct-httpbin-to-egress-gateway
+spec:
+  parentRefs:
+  - kind: ServiceEntry
+    group: networking.istio.io
+    name: httpbin-ext
+  rules:
+  - backendRefs:
+    - name: httpbin-egress-gateway-istio
+      port: 80
+---
+# HTTPRoute to forward traffic from the egress gateway to httpbin.org
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: forward-httpbin-from-egress-gateway
+spec:
+  parentRefs:
+  - name: httpbin-egress-gateway
+  hostnames:
+  - httpbin.org
+  rules:
+  - backendRefs:
+    - kind: Hostname
+      group: networking.istio.io
+      name: httpbin.org
+      port: 80
+----
+
+.. Apply the YAML file by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f egress-gateway-cr.yaml
+----
+
+.Verification
+
+. Verify the status of the gateway configuration by running the following command:
++
+[source,terminal]
+----
+$ oc describe gateway -n egress-gateway
+----
++
+Desired output is indicated by `Programmed` showing in the `Status` column.
+
+. Create a `curl` pod in the `egress-gateway` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc run test-pod --image=curlimages/curl:latest -n egress-gateway --rm -it --restart=Never -- sh
+----
+
+. By using the `curl` client, verify that you can access `httpbin.org` through the egress gateway by entering following command:
++
+[source,terminal]
+----
+$ curl -v http://httpbin.org/get
+----
++
+Desired output shows a response from `httpbin.org` that indicates egress traffic routes through the configured gateway.
+
+[role="_additional-resources-egress"]
+.Additional resources
+
+* link:https://istio.io/latest/docs/tasks/traffic-management/egress/egress-gateway/[Egress gateways] (Istio documentation)
+
+* link:https://gateway-api.sigs.k8s.io/[Introduction] (Gateway API documentation)
+    


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) 
[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)
[service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

Version(s): 3.1

Issue: https://issues.redhat.com/browse/OSSM-9884

Link to docs preview:
https://95506--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/gateways/ossm-directing-outbound-traffic.html#ossm-directing-egress-traffic-through-a-gateway-using-kubernetes-gateway-api_ossm-directing-outbound-traffic-through-a-gateway

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
