### PR TITLE
OSDOCS#15114:  Update the z-stream RN for 4.14.53

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3400,6 +3400,39 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.53
+[id="ocp-4-14-53_{context}"]
+=== RHSA-2025:9759 - {product-title} 4.14.53 bug fix and security update
+
+Issued: 02 July 2025
+
+{product-title} release 4.14.53, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:9759[RHSA-2025:9759] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:9760[RHBA-2025:9760] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.53 --pullspecs
+----
+
+[id="ocp-4-14-53-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when users added a custom certificate with a Subject Alternative Name (SAN) that conflicted with the Kubernetes API server (KAS) hostname defined in the `hc.spec.services.servicePublishingStrategy` parameter, the KAS certificate was not included in the new payload generation. This caused an issue with certificate validation for new nodes attempting to join the {hcp} cluster. With this release, a new validation is implemented to proactively identify and alert users about conflicts ensuring this bug no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-57321[OCPBUGS-57321])
+
+* Previously, the incorrect handling of proxy environment variables led to errors with external binaries and failed builds due to improperly formatted proxy settings. With this release, the issue is resolved by excluding proxy variables from the build process when they are not configured. This fix ensures that builds do not fail because of these variables. (link:https://issues.redhat.com/browse/OCPBUGS-56951[OCPBUGS-56951])
+
+* Previously, deploying {product-title} clusters with {hcp-capital} and a `Kyverno` policy engine for validation resulted in the `Konnectivity` service failing to proxy API pod requests to the validating webhook. This prevented the creation of additional groups within the cluster. With this release, the `Konnectivity` service proxy issue is resolved, which enables the successful creation of additional groups by users. (link:https://issues.redhat.com/browse/OCPBUGS-55936[OCPBUGS-55936])
+
+* Previously, during the Time-Grandmaster (T-GM) holdover, if the global navigation satellite system (GNSS) source was reacquired, the system would incorrectly announce a `T-GM-STATUS` of `S2` before the DPLL (Digital Phase-Locked Loop) had achieved a locked state. This premature announcement compromised T-GM stability and led to inaccurate status reports following GNSS reacquisition. With this release, the DPLL verifies the T-GM status against the GNSS source availability before declaring an `S2` state. This change improves T-GM stability and ensures status announcements are sent after the GNSS reacquisition. (link:https://issues.redhat.com/browse/OCPBUGS-55467[OCPBUGS-55467])
+
+[id="ocp-4-14-53-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.52
 [id="ocp-4-14-52_{context}"]
 === RHSA-2025:7702 - {product-title} 4.14.52 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-15114](https://issues.redhat.com//browse/OSDOCS-15114)

Link to docs preview:
[4.14.53](https://95510--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-53_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 7/2/25.
