### PR TITLE
OSDOCS#15113: Update the z-stream RNs for 4.16.43

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3360,6 +3360,43 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.43
+[id="ocp-4-16-43_{context}"]
+=== RHSA-2025:9765 - {product-title} {product-version}.43 bug fix and security update
+
+Issued: 02 July 2025
+
+{product-title} release {product-version}.43 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:9765[RHSA-2025:9765] advisory. 
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.43 --pullspecs
+----
+
+[id="ocp-4-16-43-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, Machine Config Daemon (MCD) pods did not properly respect proxy variables during in-place upgrades. This oversight in the reconciliation process led to missing proxy configurations, causing image pull failures for users. With this release, MCD pods correctly recognize the proxy variables during in-place upgrade strategies. As a result, users no longer experience image pull failures because of proxy configuration issues, improving the upgrade experience. (link:https://issues.redhat.com/browse/OCPBUGS-57494[OCPBUGS-57494])
+
+* Previously, the `/metrics` and `/metrics/cadvisor` endpoints were overlooked during testing procedures. This oversight led to intermittent failures in the `Component Readiness` test for `TargetDown` alerts,  and negatively impacted overall system stability. With this release, an update to the `Google-Cadvisor` package resolves the issue that caused these test failures, and significantly improves system stability and the reliability of component readiness checks. (link:https://issues.redhat.com/browse/OCPBUGS-57290[OCPBUGS-57290])
+
+* Previously, the network attachment definition (NAD) controller experienced a null pointer de-reference when it processed multiple large multi-layer network policies. This issue caused the controller to become unstable, and led to open virtual network (OVN) pod crashes. With this release, the null pointer de-reference issue is resolved. This fix prevents future OVN pod crashes, resulting in improved OVN pod stability and cluster functionality. (link:https://issues.redhat.com/browse/OCPBUGS-56242[OCPBUGS-56242])
+
+* Previously, if you added a custom certificate with a Subject Alternative Name (SAN) that conflicted with the Kubernetes API server (KAS) hostname defined in the `hc.spec.services.servicePublishingStrategy` parameter, the KAS certificate was not included when generating a new payload. All new nodes that attempted to join the {hcp} cluster had certificate validation issues. With this release, a validation step prevents these conflicts and informs the user about the problem. (link:https://issues.redhat.com/browse/OCPBUGS-55697[OCPBUGS-55697])
+
+* Previously, limited live migration from OpenShift SDN to OVN-Kubernetes stopped because the machine config pools (MCP) failed to properly drain nodes. This resulted in nodes remaining in a mixed Container Network Interface (CNI) state, and led to significant problems such as application unavailability and DNS resolution failures. With this release, limited live migration uses the MCP correctly to drain nodes, and ensures a seamless migration. This improvement results in smooth application availability and consistent service communication for users during the migration process. (link:https://issues.redhat.com/browse/OCPBUGS-55282[OCPBUGS-55282])
+
+* Previously, routes with secure hash algorithm (SHA-1) certificate authority (CA) certificates caused the high availability proxy (`HAProxy`) reload to fail. As a consequence, service interruptions occurred during reload operations. With this release, the validation is updated to reject routes with SHA-1 CA certificates. As a result, the `HAProxy`  prevents reload failures and ensures smooth operation.  (link:https://issues.redhat.com/browse/OCPBUGS-49391[OCPBUGS-49391])
+
+* Previously, large-scale {product-title} clusters with 4,000 egress firewall policies experienced failures in the ovn-kube controller during migration. This was due to excessively long synchronization times, which blocked migration processes and led to worker node reboots. With this release, the `InformerSyncTimeout` parameter for the `EgressFirewall` informer is increased to accommodate high-load scenarios. As a result, large-scale {product-title} cluster migrations are not halted by worker node reboots, ensuring a smoother and reliable migration operation. (link:https://issues.redhat.com/browse/OCPBUGS-48121[OCPBUGS-48121])
+
+[id="ocp-4-16-43-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.42
 [id="ocp-4-16-42_{context}"]
 === RHSA-2025:8556 - {product-title} {product-version}.42 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-15113](https://issues.redhat.com//browse/OSDOCS-15113)

Link to docs preview:
[4.16.43](https://95511--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-43_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 7/2/25.

