### PR TITLE
POWERMON-579 Visualizing power monitoring metrics doc updates

### DIFF
--- a/modules/power-monitoring-accessing-dashboards-admin.adoc
+++ b/modules/power-monitoring-accessing-dashboards-admin.adoc
@@ -6,7 +6,7 @@
 [id="power-monitoring-accessing-dashboards-admin_{context}"]
 = Accessing {PM-shortname} dashboards as a cluster administrator
 
-You can access {PM-shortname} dashboards from the *Administrator* perspective of the {product-title} web console.
+You can access {PM-shortname} dashboards of the {product-title} web console.
 
 .Prerequisites
 
@@ -18,8 +18,8 @@ You can access {PM-shortname} dashboards from the *Administrator* perspective of
 
 .Procedure
 
-. In the *Administrator* perspective of the web console, go to *Observe* -> *Dashboards*.
+. In the web console, go to *Observe* -> *Dashboards*.
 
-. From the *Dashboard* drop-down list, select the {PM-shortname} dashboard you want to see: 
-** *Power Monitoring / Overview*
-** *Power Monitoring / Namespace*
+. From the *Dashboard* drop-down list, select the {PM-shortname} dashboard you want to see:
+** *Power Monitor / Overview*
+** *Power Monitor / Namespace (Pods)*

--- a/modules/power-monitoring-accessing-dashboards-developer.adoc
+++ b/modules/power-monitoring-accessing-dashboards-developer.adoc
@@ -6,7 +6,7 @@
 [id="power-monitoring-accessing-dashboards-developer_{context}"]
 = Accessing {PM-shortname} dashboards as a developer
 
-You can access {PM-shortname} dashboards from the *Developer* perspective of the {product-title} web console.
+You can access {PM-shortname} dashboards from {product-title} web console.
 
 .Prerequisites
 
@@ -19,7 +19,7 @@ You can access {PM-shortname} dashboards from the *Developer* perspective of the
 
 .Procedure
 
-. In the *Developer* perspective of the web console, go to *Observe* -> *Dashboard*.
+. In the web console, go to *Observe* -> *Dashboard*.
 
 . From the *Dashboard* drop-down list, select the {PM-shortname} dashboard you want to see:
-** *Power Monitoring / Overview*
+** *Power Monitor / Overview*

--- a/modules/power-monitoring-dashboards-overview.adoc
+++ b/modules/power-monitoring-dashboards-overview.adoc
@@ -8,38 +8,21 @@
 
 There are two types of {PM-shortname} dashboards. Both provide different levels of details around power consumption metrics for a single cluster:
 
-[discrete]
-== Power Monitoring / Overview dashboard
+[id="power-monitoring-overview-dashboard_{context}"]
+== Power Monitor / Overview dashboard
 
-With this dashboard, you can observe the following information:
+This dashboard allows you to view the following information:
 
-* An aggregated view of CPU architecture and its power source (`rapl-sysfs`, `rapl-msr`, or `estimator`) along with total nodes with this configuration
+Cluster-wide power consumption:: View current total, active, and idle CPU power consumption, grouped by zones.
+Node-level power details:: Analyze historical and current power consumption (total, active, and idle) for individual nodes.
+Hardware information:: Display CPU model and core counts for each node in the cluster.
+Time-series analysis:: Track power consumption trends over time with graphs that can be filtered by node and zone. This provides a comprehensive view of your cluster's energy usage.
 
-* Total energy consumption by a cluster in the last 24 hours (measured in kilowatt-hour)
+[id="power-monitor-namespace-pods-dashboard_{context}"]
+== Power Monitor / Namespace (Pods) dashboard
 
-* The amount of power consumed by the top 10 namespaces in a cluster in the last 24 hours
+This dashboard allows you to monitor and analyze power consumption for Kubernetes namespaces and pods. It provides the following information:
 
-* Detailed node information, such as its CPU architecture and component power source
-
-These features allow you to effectively monitor the energy consumption of the cluster without needing to investigate each namespace separately.
-
-[WARNING]
-====
-Ensure that the *Components Source* column does not display `estimator` as the power source.
-
-.The Detailed Node Information table with `rapl-sysfs` as the component power source
-image::power-monitoring-component-power-source.png[]
-
-If {PM-kepler} is unable to obtain hardware power consumption metrics, the *Components Source* column displays `estimator` as the power source, which is not supported in Technology Preview. If that happens, then the values from the nodes are not accurate.
-====
-
-[discrete]
-== Power Monitoring / Namespace dashboard
-
-This dashboard allows you to view metrics by namespace and pod. You can observe the following information:
-
-* The power consumption metrics, such as consumption in DRAM and PKG
-
-* The energy consumption metrics in the last hour, such as consumption in DRAM and PKG for core and uncore components
-
-This feature allows you to investigate key peaks and easily identify the primary root causes of high consumption.
+Top ten power consuming namespaces:: A real-time table showing the top ten namespaces based on their current power usage. This helps you quickly identify the most resource-intensive workloads.
+Total namespace power consumption:: A historical graph showing the total power consumption of pods within a selected namespace over time, grouped by zone. This helps you see trends and understand an application's or service's total power use.
+Individual pod power consumption:: A detailed graph showing the power consumption of individual pods, so you can analyze them in detail.

--- a/observability/power_monitoring/visualizing-power-monitoring-metrics.adoc
+++ b/observability/power_monitoring/visualizing-power-monitoring-metrics.adoc
@@ -14,7 +14,7 @@ You can visualize {PM-shortname} metrics in the {product-title} web console by a
 include::modules/power-monitoring-dashboards-overview.adoc[leveloffset=+1]
 include::modules/power-monitoring-accessing-dashboards-admin.adoc[leveloffset=+1]
 include::modules/power-monitoring-accessing-dashboards-developer.adoc[leveloffset=+1]
-include::modules/power-monitoring-metrics-overview.adoc[leveloffset=+1]
+//include::modules/power-monitoring-metrics-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_visualizing-power-monitoring-metrics"]


### PR DESCRIPTION
https://issues.redhat.com/browse/POWERMON-579 Visualizing power monitoring metrics doc updates

Version(s):
Merge to only the `power-monitoring-0.5` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the Power Monitoring content just before its GA.

Note to self: applies to 4.17+

Issue:
https://issues.redhat.com/browse/POWERMON-579

Link to docs preview:
https://95534--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/power_monitoring/visualizing-power-monitoring-metrics.html 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Removal of [discrete] is being handled by https://github.com/openshift/openshift-docs/pull/96676/ 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
