### PR TITLE
Integration Branch: Rebased ok no 1.9

### DIFF
--- a/modules/network-observability-con_filter-network-flows-at-ingestion.adoc
+++ b/modules/network-observability-con_filter-network-flows-at-ingestion.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+
+// * networking/network_observability/configuring-operators.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-filter-network-flows-at-ingestion_{context}"]
+= Filter network flows at ingestion
+
+You can create filters to reduce the number of generated network flows. Filtering network flows can reduce the resource usage of the Network Observability components.
+
+You can configure two kinds of filters:
+
+* eBPF agent filters
+* Flowlogs-pipeline filters
+
+[id="ebpf-agent-filters_{context}"]
+== eBPF agent filters
+
+eBPF agent filters maximize performance because they take effect at the earliest stage of the network flows collection process.
+
+To configure eBPF agent filters with the Network Observability Operator, see "Filtering eBPF flow data using multiple rules".
+
+[id="flowlogs-pipeline-filters_{context}"]
+== Flowlogs-pipeline filters
+
+Flowlogs-pipeline filters provide greater control over traffic selection because they take effect later in the network flows collection process. They are primarily used to improve data storage.
+
+Flowlogs-pipeline filters use a simple query language to filter network flow, as shown in the following example:
+
+[source,terminal]
+----
+(srcnamespace="netobserv" OR (srcnamespace="ingress" AND dstnamespace="netobserv")) AND srckind!="service"
+----
+
+The query language uses the following syntax:
+
+.Query language syntax
+[cols="1,3", options="header"]
+|===
+| Category
+| Operators
+
+| Logical boolean operators (not case-sensitive)
+| `and`, `or`
+
+| Comparison operators
+| `=` (equals), +
+`!=` (not equals), +
+`=~` (matches regexp), +
+`!~` (not matches regexp), +
+`<` / `\<=` (less than or equal to), +
+`>` / `>=` (greater than or equal to)
+
+| Unary operations
+| `with(field)` (field is present), +
+`without(field)` (field is absent)
+
+| Parenthesis-based priority
+|===
+
+You can configure flowlogs-pipeline filters in the `spec.processor.filters` section of the `FlowCollector` resource. For example:
+
+.Example YAML Flowlogs-pipeline filter
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  namespace: netobserv
+  agent:
+  processor:
+    filters:
+      - query: |
+          (SrcK8S_Namespace="netobserv" OR (SrcK8S_Namespace="openshift-ingress" AND DstK8S_Namespace="netobserv"))
+        outputTarget: Loki  <1>
+        sampling: 10  <2>
+----
+<1> Sends matching flows to a specific output, such as Loki, Prometheus, or an external system. When omitted, sends to all configured outputs.
+<2> Optional. Applies a sampling ratio to limit the number of matching flows to be stored or exported. For example, `sampling: 10` means 1/10 of the flows are kept.

--- a/modules/network-observability-con_filter-network-flows-at-ingestion.adoc
+++ b/modules/network-observability-con_filter-network-flows-at-ingestion.adoc
@@ -79,3 +79,5 @@ spec:
 ----
 <1> Sends matching flows to a specific output, such as Loki, Prometheus, or an external system. When omitted, sends to all configured outputs.
 <2> Optional. Applies a sampling ratio to limit the number of matching flows to be stored or exported. For example, `sampling: 10` means 1/10 of the flows are kept.
+
+

--- a/modules/network-observability-con_user-defined-networks.adoc
+++ b/modules/network-observability-con_user-defined-networks.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="network-observability-user-defined-networks_{context}"]
+= User-defined networks
+
+User-defined networks (UDN) improve the flexibility and segmentation capabilities of the default Layer 3 topology for a Kubernetes pod network by enabling custom Layer 2 and Layer 3 network segments, where all these segments are isolated by default. These segments act as primary or secondary networks for container pods and virtual machines that use the default OVN-Kubernetes CNI plugin.
+
+UDNs enable a wide range of network architectures and topologies, enhancing network flexibility, security, and performance.
+
+When the `UDNMapping` feature is enabled with Network Observability, the *Traffic* flow table has a *UDN labels* column. You can filter on *Source Network Name* and *Destination Network Name*.

--- a/modules/network-observability-ebpf-manager-operator.adoc
+++ b/modules/network-observability-ebpf-manager-operator.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-ebpf-manager-operator_{context}"]
+= Working with the eBPF Manager Operator
+
+The eBPF Manager Operator reduces the attack surface and ensures compliance, security, and conflict prevention by managing all eBPF programs. Network observability can use the eBPF Manager Operator to load hooks. As a result, you no longer need to provide the eBPF Agent with privileged mode or additional Linux capabilities such as `CAP_BPF` and `CAP_PERFMON`. The eBPF Manager Operator with network observability is only supported on 64-bit AMD architecture.
+
+:FeatureName: eBPF Manager Operator with network observability
+include::snippets/technology-preview.adoc[]
+
+.Procedure
+. In the web console, navigate to *Operators* -> *Operator Hub*.
+. Install *eBPF Manager*.
+. Check *Workloads* -> *Pods* in the `bpfman` namespace to make sure they are all up and running.
+. Configure the `FlowCollector` custom resource to use the eBPF Manager Operator:
++
+.Example `FlowCollector` configuration
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  agent:
+    ebpf:
+      features:
+        - EbpfManager
+----
+
+.Verification
+. In the web console, navigate to *Operators* -> *Installed Operators*.
+. Click *eBPF Manager Operator* -> *All instances* tab.
++
+For each node, verify that a `BpfApplication` named `netobserv` and a pair of `BpfProgram` objects, one for Traffic Control (TCx) ingress and another for TCx egress, exist. If you enable other eBPF Agent features, you might have more objects.

--- a/modules/network-observability-ebpf-rule-flow-filter.adoc
+++ b/modules/network-observability-ebpf-rule-flow-filter.adoc
@@ -5,13 +5,15 @@
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-ebpf-flow-rule-filter_{context}"]
 = eBPF flow rule filter
-You can use rule-based filtering to control the volume of packets cached in the eBPF flow table. For example, a filter can specify that only packets coming from port 100 should be recorded. Then only the packets that match the filter are cached and the rest are not cached. 
+You can use rule-based filtering to control the volume of packets cached in the eBPF flow table. For example, a filter can specify that only packets coming from port 100 should be captured. Then only the packets that match the filter are captured and the rest are dropped.
+
+You can apply multiple filter rules.
 
 [id="ingress-and-egress-traffic-filtering_{context}"]
 == Ingress and egress traffic filtering
-CIDR notation efficiently represents IP address ranges by combining the base IP address with a prefix length. For both ingress and egress traffic, the source IP address is first used to match filter rules configured with CIDR notation. If there is a match, then the filtering proceeds. If there is no match, then the destination IP is used to match filter rules configured with CIDR notation. 
+Classless Inter-Domain Routing (CIDR) notation efficiently represents IP address ranges by combining the base IP address with a prefix length. For both ingress and egress traffic, the source IP address is first used to match filter rules configured with CIDR notation. If there is a match, then the filtering proceeds. If there is no match, then the destination IP is used to match filter rules configured with CIDR notation.
 
-After matching either the source IP or the destination IP CIDR, you can pinpoint specific endpoints using the `peerIP` to differentiate the destination IP address of the packet. Based on the provisioned action, the flow data is either cached in the eBPF flow table or not cached. 
+After matching either the source IP or the destination IP CIDR, you can pinpoint specific endpoints using the `peerIP` to differentiate the destination IP address of the packet. Based on the provisioned action, the flow data is either cached in the eBPF flow table or not cached.
 
 [id="dashboard-and-metrics-integrations_{context}"]
 == Dashboard and metrics integrations

--- a/modules/network-observability-filtering-ebpf-rule.adoc
+++ b/modules/network-observability-filtering-ebpf-rule.adoc
@@ -8,7 +8,7 @@ You can configure the `FlowCollector` custom resource to filter eBPF flows using
 
 [IMPORTANT]
 ====
-* You cannot use duplicate CIDRs in filter rules.
+* You cannot use duplicate Classless Inter-Domain Routing (CIDRs) in filter rules.
 * When an IP address matches multiple filter rules, the rule with the most specific CIDR prefix (longest prefix) takes precedence.
 ====
 

--- a/modules/network-observability-filtering-ebpf-rule.adoc
+++ b/modules/network-observability-filtering-ebpf-rule.adoc
@@ -1,22 +1,28 @@
 // Module included in the following assemblies:
-//
 // network_observability/observing-network-traffic.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-filtering-ebpf-rule_{context}"]
-= Filtering eBPF flow data using a global rule
-You can configure the `FlowCollector` to filter eBPF flows using a global rule to control the flow of packets cached in the eBPF flow table.
+= Filtering eBPF flow data using multiple rules
+You can configure the `FlowCollector` custom resource to filter eBPF flows using multiple rules to control the flow of packets cached in the eBPF flow table.
+
+[IMPORTANT]
+====
+* You cannot use duplicate CIDRs in filter rules.
+* When an IP address matches multiple filter rules, the rule with the most specific CIDR prefix (longest prefix) takes precedence.
+====
 
 .Procedure
 . In the web console, navigate to *Operators* -> *Installed Operators*.
 . Under the *Provided APIs* heading for *Network Observability*, select *Flow Collector*.
 . Select *cluster*, then select the *YAML* tab.
 . Configure the `FlowCollector` custom resource, similar to the following sample configurations:
-+
 
-[%collapsible]
-.Filter Kubernetes service traffic to a specific Pod IP endpoint
-====
+
+.Example YAML to sample all North-South traffic, and 1:50 East-West traffic
+
+By default, all other flows are rejected.
+
 [source, yaml]
 ----
 apiVersion: flows.netobserv.io/v1beta2
@@ -30,22 +36,29 @@ spec:
     type: eBPF
     ebpf:
       flowFilter:
-        action: Accept  <1>
-        cidr: 172.210.150.1/24 <2>
-        protocol: SCTP
-        direction: Ingress
-        destPortRange: 80-100
-        peerIP: 10.10.10.10
-        enable: true    <3>
+        enable: true <1>
+        rules:
+         - action: Accept <2>
+           cidr: 0.0.0.0/0 <3>
+           sampling: 1 <4>
+         - action: Accept
+           cidr: 10.128.0.0/14
+           peerCIDR: 10.128.0.0/14 <5>
+         - action: Accept
+           cidr: 172.30.0.0/16
+           peerCIDR: 10.128.0.0/14
+           sampling: 50
 ----
-<1> The required `action` parameter describes the action that is taken for the flow filter rule. Possible values are `Accept` or `Reject`. 
-<2> The required `cidr` parameter provides the IP address and CIDR mask for the flow filter rule and supports IPv4 and IPv6 address formats. If you want to match against any IP address, you can use `0.0.0.0/0` for IPv4 or `::/0` for IPv6.
-<3> You must set `spec.agent.ebpf.flowFilter.enable` to `true` to enable this feature.
-====
-+
-[%collapsible]
-.See flows to any addresses outside the cluster 
-====
+<1> To enable eBPF flow filtering, set `spec.agent.ebpf.flowFilter.enable` to `true`.
+<2> To define the action for the flow filter rule, set the required `action` parameter. Valid values are `Accept` or `Reject`.
+<3> To define the IP address and CIDR mask for the flow filter rule, set the required `cidr` parameter. This parameter supports both IPv4 and IPv6 address formats. To match any IP address, use `0.0.0.0/0` for IPv4 or ``::/0` for IPv6.
+<4> To define the sampling rate for matched flows and override the global sampling setting `spec.agent.ebpf.sampling`, set the `sampling` parameter.
+<5> To filter flows by Peer IP CIDR, set the `peerCIDR` parameter.
+
+.Example YAML to filter flows with packet drops
+
+By default, all other flows are rejected.
+
 [source, yaml]
 ----
 apiVersion: flows.netobserv.io/v1beta2
@@ -57,18 +70,19 @@ spec:
   deploymentModel: Direct
   agent:
     type: eBPF
-    ebpf:        
+    ebpf:
+      privileged: true <1>
+      features:
+        - PacketDrop <2>
       flowFilter:
-        action: Accept  <1>
-        cidr: 0.0.0.0/0 <2>
-        protocol: TCP
-        direction: Egress
-        sourcePort: 100
-        peerIP: 192.168.127.12 <3>
-        enable: true    <4>
-----       
-<1> You can `Accept` flows based on the criteria in the `flowFilter` specification.
-<2> The `cidr` value of `0.0.0.0/0` matches against any IP address.
-<3> See flows after `peerIP` is configured with `192.168.127.12`. 
-<4> You must set `spec.agent.ebpf.flowFilter.enable` to `true` to enable the feature.
-====
+        enable: true <3>
+        rules:
+        - action: Accept <4>
+          cidr: 172.30.0.0/16
+          pktDrops: true <5>
+----
+<1> To enable packet drops, set `spec.agent.ebpf.privileged` to `true`.
+<2> To report packet drops for each network flow, add the `PacketDrop` value to the `spec.agent.ebpf.features` list.
+<3> To enable eBPF flow filtering, set `spec.agent.ebpf.flowFilter.enable` to `true`.
+<4> To define the action for the flow filter rule, set the required `action` parameter. Valid values are `Accept` or `Reject`.
+<5> To filter flows containing drops, set `pktDrops` to `true`.

--- a/modules/network-observability-flowcollector-api-specifications.adoc
+++ b/modules/network-observability-flowcollector-api-specifications.adoc
@@ -444,7 +444,6 @@ To filter two ports, use a "port1,port2" in string format. For example, `ports: 
 | `rules` defines a list of filtering rules on the eBPF Agents.
 When filtering is enabled, by default, flows that don't match any rule are rejected.
 To change the default, you can define a rule that accepts everything: `{ action: "Accept", cidr: "0.0.0.0/0" }`, and then refine with rejecting rules.
-Unsupported *.
 
 | `sampling`
 | `integer`
@@ -470,7 +469,6 @@ Description::
 `rules` defines a list of filtering rules on the eBPF Agents.
 When filtering is enabled, by default, flows that don't match any rule are rejected.
 To change the default, you can define a rule that accepts everything: `{ action: "Accept", cidr: "0.0.0.0/0" }`, and then refine with rejecting rules.
-Unsupported *.
 --
 
 Type::
@@ -483,7 +481,7 @@ Type::
 Description::
 +
 --
-`EBPFFlowFilterRule` defines the desired eBPF agent configuration regarding flow filtering rule.
+`EBPFFlowFilterRules` defines the desired eBPF agent configuration regarding flow filtering rules.
 --
 
 Type::
@@ -1480,15 +1478,15 @@ Type::
 
 | `input`
 | `string`
-| 
+|
 
 | `multiplier`
 | `integer`
-| 
+|
 
 | `output`
 | `string`
-| 
+|
 
 |===
 == .spec.exporters[].openTelemetry.logs

--- a/modules/network-observability-flowcollector-api-specifications.adoc
+++ b/modules/network-observability-flowcollector-api-specifications.adoc
@@ -154,7 +154,7 @@ is set to `eBPF`.
 
 | `type`
 | `string`
-| `type` [deprecated *] selects the flows tracing agent. Previously, this field allowed to select between `eBPF` or `IPFIX`.
+| `type` [deprecated (*)] selects the flows tracing agent. Previously, this field allowed to select between `eBPF` or `IPFIX`.
 Only `eBPF` is allowed now, so this field is deprecated and is planned for removal in a future version of the API.
 
 |===
@@ -180,7 +180,8 @@ Type::
 | `object`
 | `advanced` allows setting some aspects of the internal configuration of the eBPF agent.
 This section is aimed mostly for debugging and fine-grained performance optimizations,
-such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+such as `GOGC` and `GOMAXPROCS` environment vars. Set these values at your own risk. You can also
+override the default Linux capabilities from there.
 
 | `cacheActiveTimeout`
 | `string`
@@ -205,25 +206,28 @@ Otherwise it is matched as a case-sensitive string.
 | List of additional features to enable. They are all disabled by default. Enabling additional features might have performance impacts. Possible values are: +
 
 - `PacketDrop`: Enable the packets drop flows logging feature. This feature requires mounting
-the kernel debug filesystem, so the eBPF agent pods must run as privileged.
-If the `spec.agent.ebpf.privileged` parameter is not set, an error is reported. +
+the kernel debug filesystem, so the eBPF agent pods must run as privileged via `spec.agent.ebpf.privileged`. +
 
 - `DNSTracking`: Enable the DNS tracking feature. +
 
 - `FlowRTT`: Enable flow latency (sRTT) extraction in the eBPF agent from TCP traffic. +
 
 - `NetworkEvents`: Enable the network events monitoring feature, such as correlating flows and network policies.
-This feature requires mounting the kernel debug filesystem, so the eBPF agent pods must run as privileged.
-It requires using the OVN-Kubernetes network plugin with the Observability feature. +
-IMPORTANT: This feature is available as a Technology Preview.
+This feature requires mounting the kernel debug filesystem, so the eBPF agent pods must run as privileged via `spec.agent.ebpf.privileged`.
+It requires using the OVN-Kubernetes network plugin with the Observability feature.
+IMPORTANT: This feature is available as a Technology Preview. +
 
 - `PacketTranslation`: Enable enriching flows with packet translation information, such as Service NAT. +
 
-- `EbpfManager`: Unsupported * . Use eBPF Manager to manage Network Observability eBPF programs. Pre-requisite: the eBPF Manager operator (or upstream bpfman operator) must be installed. +
+- `EbpfManager`: [Unsupported (*)]. Use eBPF Manager to manage Network Observability eBPF programs. Pre-requisite: the eBPF Manager operator (or upstream bpfman operator) must be installed. +
 
-- `UDNMapping`: Unsupported *. Enable interfaces mapping to User Defined Networks (UDN).  +
-This feature requires mounting the kernel debug filesystem, so the eBPF agent pods must run as privileged.
-It requires using the OVN-Kubernetes network plugin with the Observability feature.
+- `UDNMapping`: Enable interfaces mapping to User Defined Networks (UDN).  +
+
+This feature requires mounting the kernel debug filesystem, so the eBPF agent pods must run as privileged via `spec.agent.ebpf.privileged`.
+It requires using the OVN-Kubernetes network plugin with the Observability feature.  +
+
+- `IPSec`, to track flows between nodes with IPsec encryption.  +
+
 
 | `flowFilter`
 | `object`
@@ -255,7 +259,7 @@ Otherwise it is matched as a case-sensitive string.
 | `privileged`
 | `boolean`
 | Privileged mode for the eBPF Agent container. When ignored or set to `false`, the operator sets
-granular capabilities (BPF, PERFMON, NET_ADMIN, SYS_RESOURCE) to the container.
+granular capabilities (BPF, PERFMON, NET_ADMIN) to the container.
 If for some reason these capabilities cannot be set, such as if an old kernel version not knowing CAP_BPF
 is in use, then you can turn on this mode for more global privileges.
 Some agent features require the privileged mode, such as packet drops tracking (see `features`) and SR-IOV support.
@@ -267,7 +271,7 @@ For more information, see https://kubernetes.io/docs/concepts/configuration/mana
 
 | `sampling`
 | `integer`
-| Sampling rate of the flow reporter. 100 means one flow on 100 is sent. 0 or 1 means all flows are sampled.
+| Sampling ratio of the eBPF probe. 100 means one packet on 100 is sent. 0 or 1 means all packets are sampled.
 
 |===
 == .spec.agent.ebpf.advanced
@@ -276,7 +280,8 @@ Description::
 --
 `advanced` allows setting some aspects of the internal configuration of the eBPF agent.
 This section is aimed mostly for debugging and fine-grained performance optimizations,
-such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+such as `GOGC` and `GOMAXPROCS` environment vars. Set these values at your own risk. You can also
+override the default Linux capabilities from there.
 --
 
 Type::
@@ -288,6 +293,10 @@ Type::
 [cols="1,1,1",options="header"]
 |===
 | Property | Type | Description
+
+| `capOverride`
+| `array (string)`
+| Linux capabilities override, when not running as privileged. Default capabilities are BPF, PERFMON and NET_ADMIN.
 
 | `env`
 | `object (string)`
@@ -447,7 +456,7 @@ To change the default, you can define a rule that accepts everything: `{ action:
 
 | `sampling`
 | `integer`
-| `sampling` sampling rate for the matched flows, overriding the global sampling defined at `spec.agent.ebpf.sampling`.
+| `sampling` is the sampling ratio for the matched packets, overriding the global sampling defined at `spec.agent.ebpf.sampling`.
 
 | `sourcePorts`
 | `integer-or-string`
@@ -481,7 +490,7 @@ Type::
 Description::
 +
 --
-`EBPFFlowFilterRules` defines the desired eBPF agent configuration regarding flow filtering rules.
+`EBPFFlowFilterRule` defines the desired eBPF agent configuration regarding flow filtering rule.
 --
 
 Type::
@@ -549,7 +558,7 @@ To filter two ports, use a "port1,port2" in string format. For example, `ports: 
 
 | `sampling`
 | `integer`
-| `sampling` sampling rate for the matched flows, overriding the global sampling defined at `spec.agent.ebpf.sampling`.
+| `sampling` is the sampling ratio for the matched packets, overriding the global sampling defined at `spec.agent.ebpf.sampling`.
 
 | `sourcePorts`
 | `integer-or-string`
@@ -661,7 +670,7 @@ If set to `true`, the `providedCaFile` field is ignored.
 | Select the type of TLS configuration: +
 
 - `Disabled` (default) to not configure TLS for the endpoint.
-- `Provided` to manually provide cert file and a key file. Unsupported *.
+- `Provided` to manually provide cert file and a key file. [Unsupported (*)].
 - `Auto` to use {product-title} auto generated certificate using annotations.
 
 |===
@@ -791,7 +800,7 @@ Type::
 | `object`
 | `advanced` allows setting some aspects of the internal configuration of the console plugin.
 This section is aimed mostly for debugging and fine-grained performance optimizations,
-such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+such as `GOGC` and `GOMAXPROCS` environment vars. Set these values at your own risk.
 
 | `autoscaler`
 | `object`
@@ -833,7 +842,7 @@ Description::
 --
 `advanced` allows setting some aspects of the internal configuration of the console plugin.
 This section is aimed mostly for debugging and fine-grained performance optimizations,
-such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+such as `GOGC` and `GOMAXPROCS` environment vars. Set these values at your own risk.
 --
 
 Type::
@@ -1165,7 +1174,7 @@ Required::
 
 | `sasl`
 | `object`
-| SASL authentication configuration. Unsupported *.
+| SASL authentication configuration. [Unsupported (*)].
 
 | `tls`
 | `object`
@@ -1180,7 +1189,7 @@ Required::
 Description::
 +
 --
-SASL authentication configuration. Unsupported *.
+SASL authentication configuration. [Unsupported (*)].
 --
 
 Type::
@@ -1676,7 +1685,7 @@ Required::
 
 | `sasl`
 | `object`
-| SASL authentication configuration. Unsupported *.
+| SASL authentication configuration. [Unsupported (*)].
 
 | `tls`
 | `object`
@@ -1691,7 +1700,7 @@ Required::
 Description::
 +
 --
-SASL authentication configuration. Unsupported *.
+SASL authentication configuration. [Unsupported (*)].
 --
 
 Type::
@@ -2077,7 +2086,7 @@ Type::
 
 - `Forward` forwards the user token for authorization. +
 
-- `Host` [deprecated *] - uses the local pod service account to authenticate to Loki. +
+- `Host` [deprecated (*)] - uses the local pod service account to authenticate to Loki. +
 
 When using the Loki Operator, this must be set to `Forward`.
 
@@ -2693,7 +2702,7 @@ This feature requires the "topology.kubernetes.io/zone" label to be set on nodes
 | `object`
 | `advanced` allows setting some aspects of the internal configuration of the flow processor.
 This section is aimed mostly for debugging and fine-grained performance optimizations,
-such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+such as `GOGC` and `GOMAXPROCS` environment vars. Set these values at your own risk.
 
 | `clusterName`
 | `string`
@@ -2702,14 +2711,12 @@ such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
 | `deduper`
 | `object`
 | `deduper` allows you to sample or drop flows identified as duplicates, in order to save on resource usage.
-Unsupported *.
 
 | `filters`
 | `array`
 | `filters` lets you define custom filters to limit the amount of generated flows.
 These filters provide more flexibility than the eBPF Agent filters (in `spec.agent.ebpf.flowFilter`), such as allowing to filter by Kubernetes namespace,
 but with a lesser improvement in performance.
-Unsupported *.
 
 | `imagePullPolicy`
 | `string`
@@ -2743,9 +2750,9 @@ This setting is ignored when Kafka is disabled.
 
 - `Flows` to export regular network flows. This is the default. +
 
-- `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates. +
+- `Conversations` to generate events for started conversations, ended conversations as well as periodic "tick" updates. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations. +
 
-- `EndedConversations` to generate only ended conversations events. +
+- `EndedConversations` to generate only ended conversations events. Note that in this mode, Prometheus metrics are not accurate on long-standing conversations. +
 
 - `All` to generate both network flows and all conversations events. It is not recommended due to the impact on resources footprint. +
 
@@ -2775,7 +2782,7 @@ Description::
 --
 `advanced` allows setting some aspects of the internal configuration of the flow processor.
 This section is aimed mostly for debugging and fine-grained performance optimizations,
-such as `GOGC` and `GOMAXPROCS` env vars. Set these values at your own risk.
+such as `GOGC` and `GOMAXPROCS` environment vars. Set these values at your own risk.
 --
 
 Type::
@@ -2803,7 +2810,7 @@ This delay is ignored when a FIN packet is collected for TCP flows (see `convers
 
 | `dropUnusedFields`
 | `boolean`
-| `dropUnusedFields` [deprecated *] this setting is not used anymore.
+| `dropUnusedFields` [deprecated (*)] this setting is not used anymore.
 
 | `enableKubeProbes`
 | `boolean`
@@ -2910,7 +2917,8 @@ Description::
 +
 --
 Defines secondary networks to be checked for resources identification.
-To guarantee a correct identification, indexed values must form an unique identifier across the cluster. If the same index is used by several resources, those resources might be incorrectly labeled.
+To guarantee a correct identification, indexed values must form an unique identifier across the cluster.
+If the same index is used by several resources, those resources might be incorrectly labeled.
 --
 
 Type::
@@ -2955,7 +2963,6 @@ Description::
 +
 --
 `deduper` allows you to sample or drop flows identified as duplicates, in order to save on resource usage.
-Unsupported *.
 --
 
 Type::
@@ -2970,7 +2977,7 @@ Type::
 
 | `mode`
 | `string`
-| Set the Processor de-duplication mode. It comes in addition to the Agent-based deduplication because the Agent cannot de-duplicate same flows reported from different nodes. +
+| Set the Processor de-duplication mode. It comes in addition to the Agent-based deduplication, since the Agent cannot de-duplicate same flows reported from different nodes. +
 
 - Use `Drop` to drop every flow considered as duplicates, allowing saving more on resource usage but potentially losing some information such as the network interfaces used from peer, or network events. +
 
@@ -2981,7 +2988,7 @@ Type::
 
 | `sampling`
 | `integer`
-| `sampling` is the sampling rate when deduper `mode` is `Sample`.
+| `sampling` is the sampling ratio when deduper `mode` is `Sample`. For example, a value of `50` means that 1 flow in 50 is sampled.
 
 |===
 == .spec.processor.filters
@@ -2991,7 +2998,6 @@ Description::
 `filters` lets you define custom filters to limit the amount of generated flows.
 These filters provide more flexibility than the eBPF Agent filters (in `spec.agent.ebpf.flowFilter`), such as allowing to filter by Kubernetes namespace,
 but with a lesser improvement in performance.
-Unsupported *.
 --
 
 Type::
@@ -3017,64 +3023,17 @@ Type::
 |===
 | Property | Type | Description
 
-| `allOf`
-| `array`
-| `filters` is a list of matches that must be all satisfied in order to remove a flow.
-
 | `outputTarget`
 | `string`
-| If specified, these filters only target a single output: `Loki`, `Metrics` or `Exporters`. By default, all outputs are targeted.
+| If specified, these filters target a single output: `Loki`, `Metrics` or `Exporters`. By default, all outputs are targeted.
+
+| `query`
+| `string`
+| A query that selects the network flows to keep. More information about this query language in https://github.com/netobserv/flowlogs-pipeline/blob/main/docs/filtering.md.
 
 | `sampling`
 | `integer`
-| `sampling` is an optional sampling rate to apply to this filter.
-
-|===
-== .spec.processor.filters[].allOf
-Description::
-+
---
-`filters` is a list of matches that must be all satisfied in order to remove a flow.
---
-
-Type::
-  `array`
-
-
-
-
-== .spec.processor.filters[].allOf[]
-Description::
-+
---
-`FLPSingleFilter` defines the desired configuration for a single FLP-based filter.
---
-
-Type::
-  `object`
-
-Required::
-  - `field`
-  - `matchType`
-
-
-
-[cols="1,1,1",options="header"]
-|===
-| Property | Type | Description
-
-| `field`
-| `string`
-| Name of the field to filter on.
-Refer to the documentation for the list of available fields: https://github.com/netobserv/network-observability-operator/blob/main/docs/flows-format.adoc.
-
-| `matchType`
-| `string`
-| Type of matching to apply.
-
-| `value`
-| `string`
-| Value to filter on. When `matchType` is `Equal` or `NotEqual`, you can use field injection with `$(SomeField)` to refer to any other field of the flow.
+| `sampling` is an optional sampling ratio to apply to this filter. For example, a value of `50` means that 1 matching flow in 50 is sampled.
 
 |===
 == .spec.processor.kafkaConsumerAutoscaler
@@ -3199,7 +3158,7 @@ If set to `true`, the `providedCaFile` field is ignored.
 | Select the type of TLS configuration: +
 
 - `Disabled` (default) to not configure TLS for the endpoint.
-- `Provided` to manually provide cert file and a key file. Unsupported *.
+- `Provided` to manually provide cert file and a key file. [Unsupported (*)].
 - `Auto` to use {product-title} auto generated certificate using annotations.
 
 |===

--- a/modules/network-observability-flowmetric-api-specifications.adoc
+++ b/modules/network-observability-flowmetric-api-specifications.adoc
@@ -103,13 +103,12 @@ When set to `Egress`, it is equivalent to adding the regular expression filter o
 
 | `filters`
 | `array`
-| `filters` is a list of fields and values used to restrict which flows are taken into account. Oftentimes, these filters must
-be used to eliminate duplicates: `Duplicate != "true"` and `FlowDirection = "0"`.
+| `filters` is a list of fields and values used to restrict which flows are taken into account.
 Refer to the documentation for the list of available fields: https://docs.openshift.com/container-platform/latest/observability/network_observability/json-flows-format-reference.html.
 
 | `flatten`
 | `array (string)`
-| `flatten` is a list of list-type fields that must be flattened, such as Interfaces and NetworkEvents. Flattened fields generate one metric per item in that field.
+| `flatten` is a list of array-type fields that must be flattened, such as Interfaces or NetworkEvents. Flattened fields generate one metric per item in that field.
 For instance, when flattening `Interfaces` on a bytes counter, a flow having Interfaces [br-ex, ens5] increases one counter for `br-ex` and another for `ens5`.
 
 | `labels`
@@ -131,9 +130,10 @@ Refer to the documentation for the list of available fields: https://docs.opensh
 
 | `type`
 | `string`
-| Metric type: "Counter" or "Histogram".
+| Metric type: "Counter", "Histogram" or "Gauge".
 Use "Counter" for any value that increases over time and on which you can compute a rate, such as Bytes or Packets.
 Use "Histogram" for any value that must be sampled independently, such as latencies.
+Use "Gauge" for other values that don't necessitate accuracy over time (gauges are sampled only every N seconds when Prometheus fetches the metric).
 
 | `valueField`
 | `string`
@@ -261,8 +261,7 @@ To learn more about `promQL`, refer to the Prometheus documentation: https://pro
 Description::
 +
 --
-`filters` is a list of fields and values used to restrict which flows are taken into account. Oftentimes, these filters must
-be used to eliminate duplicates: `Duplicate != "true"` and `FlowDirection = "0"`.
+`filters` is a list of fields and values used to restrict which flows are taken into account.
 Refer to the documentation for the list of available fields: https://docs.openshift.com/container-platform/latest/observability/network_observability/json-flows-format-reference.html.
 --
 

--- a/modules/network-observability-flows-format.adoc
+++ b/modules/network-observability-flows-format.adoc
@@ -155,16 +155,9 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | no
 | fine
 | n/a
-| `Duplicate`
-| boolean
-| Indicates if this flow was also captured from another interface on the same host
-| n/a
-| no
-| fine
-| n/a
 | `Flags`
 | string[]
-| List of TCP flags comprised in the flow, according to RFC-9293, with additional custom flags to represent the following per-packet combinations: +
+| List of TCP flags comprised in the flow, as per RFC-9293, with additional custom flags to represent the following per-packet combinations: +
 - SYN_ACK +
 - FIN_ACK +
 - RST_ACK
@@ -182,6 +175,13 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | yes
 | fine
 | host.direction
+| `IPSecStatus`
+| string
+| Status of the IPsec encryption (on egress, given by the kernel xfrm_output function) or decryption (on ingress, via xfrm_input)
+| `ipsec_status`
+| no
+| fine
+| n/a
 | `IcmpCode`
 | number
 | ICMP code
@@ -242,7 +242,7 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | `Packets`
 | number
 | Number of packets
-| `pkt_drop_cause`
+| n/a
 | no
 | avoid
 | packets
@@ -423,35 +423,35 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | n/a
 | `XlatDstAddr`
 | string
-| Packet translation destination address
+| packet translation destination address
 | `xlat_dst_address`
 | no
 | avoid
 | n/a
 | `XlatDstPort`
 | number
-| Packet translation destination port
+| packet translation destination port
 | `xlat_dst_port`
 | no
 | careful
 | n/a
 | `XlatSrcAddr`
 | string
-| Packet translation source address
+| packet translation source address
 | `xlat_src_address`
 | no
 | avoid
 | n/a
 | `XlatSrcPort`
 | number
-| Packet translation source port
+| packet translation source port
 | `xlat_src_port`
 | no
 | careful
 | n/a
 | `ZoneId`
 | number
-| Packet translation zone id
+| packet translation zone id
 | `xlat_zone_id`
 | no
 | avoid
@@ -470,4 +470,4 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | yes
 | fine
 | n/a
-|=== 
+|===

--- a/modules/network-observability-multitenancy.adoc
+++ b/modules/network-observability-multitenancy.adoc
@@ -5,7 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-multi-tenancy_{context}"]
 = Enabling multi-tenancy in Network Observability
-Multi-tenancy in the Network Observability Operator allows and restricts individual user access, or group access, to the flows stored in Loki and or Prometheus. Access is enabled for project administrators. Project administrators who have limited access to some namespaces can access flows for only those namespaces. 
+Multi-tenancy in the Network Observability Operator allows and restricts individual user access, or group access, to the flows stored in Loki and or Prometheus. Access is enabled for project administrators. Project administrators who have limited access to some namespaces can access flows for only those namespaces.
 
 For Developers, multi-tenancy is available for both Loki and Prometheus but requires different access rights.
 
@@ -15,11 +15,11 @@ For Developers, multi-tenancy is available for both Loki and Prometheus but requ
 
 .Procedure
 
-*  For per-tenant access, you must have the `netobserv-reader` cluster role and the `netobserv-metrics-reader` namespace role to use the developer perspective. Run the following commands for this level of access:
+*  For per-tenant access, you must have the `netobserv-loki-reader` cluster role and the `netobserv-metrics-reader` namespace role to use the developer perspective. Run the following commands for this level of access:
 +
 [source,terminal]
 ----
-$ oc adm policy add-cluster-role-to-user netobserv-reader <user_group_or_name>
+$ oc adm policy add-cluster-role-to-user netobserv-loki-reader <user_group_or_name>
 ----
 +
 [source,terminal]
@@ -27,11 +27,11 @@ $ oc adm policy add-cluster-role-to-user netobserv-reader <user_group_or_name>
 $ oc adm policy add-role-to-user netobserv-metrics-reader <user_group_or_name> -n <namespace>
 ----
 
-* For cluster-wide access, non-cluster-administrators must have the `netobserv-reader`, `cluster-monitoring-view`, and `netobserv-metrics-reader` cluster roles. In this scenario, you can use either the admin perspective or the developer perspective. Run the following commands for this level of access:
+* For cluster-wide access, non-cluster-administrators must have the `netobserv-loki-reader`, `cluster-monitoring-view`, and `netobserv-metrics-reader` cluster roles. In this scenario, you can use either the admin perspective or the developer perspective. Run the following commands for this level of access:
 +
 [source,terminal]
 ----
-$ oc adm policy add-cluster-role-to-user netobserv-reader <user_group_or_name>
+$ oc adm policy add-cluster-role-to-user netobserv-loki-reader <user_group_or_name>
 ----
 +
 [source,terminal]

--- a/modules/network-observability-netobserv-cli-reference.adoc
+++ b/modules/network-observability-netobserv-cli-reference.adoc
@@ -86,7 +86,7 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--query|                     filter flows using a custom query          | –
+|--query|                     filter flows by using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
@@ -134,7 +134,7 @@ $ oc netobserv packets [<option>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--query|                     filter flows using a custom query          | –
+|--query|                     filter flows by using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
@@ -184,7 +184,7 @@ $ oc netobserv metrics [<option>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--query|                     filter flows using a custom query          | –
+|--query|                     filter flows by using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –

--- a/modules/network-observability-netobserv-cli-reference.adoc
+++ b/modules/network-observability-netobserv-cli-reference.adoc
@@ -7,8 +7,8 @@
 You can use the Network Observability CLI (`oc netobserv`) to pass command-line arguments to capture flows data, packets data, and metrics for further analysis and enable features supported by the Network Observability Operator.
 
 [id="cli-syntax_{context}"]
-== Syntax 
-The basic syntax for `oc netobserv` commands: 
+== Syntax
+The basic syntax for `oc netobserv` commands:
 
 .`oc netobserv` syntax
 [source,terminal]
@@ -57,12 +57,14 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 | Option | Description | Default
 |--enable_all|                enable all eBPF features                   | false
 |--enable_dns|                enable DNS tracking                        | false
+|--enable_ipsec|              enable IPsec tracking                      | false
 |--enable_network_events|     enable network events monitoring           | false
 |--enable_pkt_translation|    enable packet translation                  | false
 |--enable_pkt_drop|           enable packet drop                         | false
 |--enable_rtt|                enable RTT tracking                        | false
 |--enable_udn_mapping|        enable User Defined Network mapping | false
 |--get-subnets|               get subnets information                   | false
+|--sampling|                  value that determines the ratio of packets being sampled | 1
 |--background|                run in background                          | false
 |--copy|                      copy the output files locally              | prompt
 |--log-level|                 components logs                            | info
@@ -84,12 +86,13 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--regexes|                   filter flows using regular expression      | –
+|--query|                     filter flows using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
 |--tcp_flags|                 filter TCP flags                           | –
-|--interfaces|                interfaces to monitor                      | –
+|--interfaces|                list of interfaces to monitor, comma separated     | –
+|--exclude_interfaces|        list of interfaces to exclude, comma separated     | lo
 |===
 
 .Example running flows capture on TCP protocol and port 49051 with PacketDrop and RTT features enabled:
@@ -131,7 +134,7 @@ $ oc netobserv packets [<option>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--regexes|                   filter flows using regular expression      | –
+|--query|                     filter flows using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
@@ -157,12 +160,14 @@ $ oc netobserv metrics [<option>]
 | Option | Description | Default
 |--enable_all|                enable all eBPF features                   | false
 |--enable_dns|                enable DNS tracking                        | false
+|--enable_ipsec|              enable IPsec tracking                      | false
 |--enable_network_events|     enable network events monitoring           | false
 |--enable_pkt_translation|    enable packet translation                  | false
 |--enable_pkt_drop|           enable packet drop                         | false
 |--enable_rtt|                enable RTT tracking                        | false
 |--enable_udn_mapping|        enable User Defined Network mapping | false
 |--get-subnets|               get subnets information                   | false
+|--sampling|                  value that defines the ratio of packets being sampled | 1
 |--action|                    filter action                              | Accept
 |--cidr|                      filter CIDR                                | 0.0.0.0/0
 |--direction|                 filter direction                           | –
@@ -179,16 +184,50 @@ $ oc netobserv metrics [<option>]
 |--port|                      filter port                                | –
 |--ports|                     filter on either of two ports              | –
 |--protocol|                  filter protocol                            | –
-|--regexes|                   filter flows using regular expression      | –
+|--query|                     filter flows using a custom query          | –
 |--sport_range|               filter source port range                   | –
 |--sport|                     filter source port                         | –
 |--sports|                    filter on either of two source ports       | –
 |--tcp_flags|                 filter TCP flags                           | –
-|--interfaces|                interfaces to monitor                      | –
+|--include_list|              list of metric names to generate, comma separated           | namespace_flows_total,node_ingress_bytes_total,node_egress_bytes_total,workload_ingress_bytes_total
+|--interfaces|                list of interfaces to monitor, comma separated     | –
+|--exclude_interfaces|        list of interfaces to exclude, comma separated     | lo
 |===
 
 .Example running metrics capture for TCP drops
 [source,terminal]
 ----
-$ oc netobserv metrics --enable_pkt_drop --protocol=TCP 
+$ oc netobserv metrics --enable_pkt_drop --protocol=TCP
+----
+
+.Example running metrics capture for list of metric names to generate
+[source,terminal]
+----
+$ oc netobserv metrics --include_list=node,workload
+----
+
+[source,terminal]
+----
+$ oc netobserv metrics --include_list=node_egress_bytes_total,workload_egress_packets_total
+----
+
+[source,terminal]
+----
+$ oc netobserv metrics --enable_all --include_list=node,namespace,workload
+----
+
+.Example output for list of metric names
+[source, terminal]
+----
+opt: include_list, value: node,workload
+Matching metrics:
+ - node_egress_bytes_total
+ - node_ingress_bytes_total
+ - workload_egress_bytes_total
+ - workload_ingress_bytes_total
+ - workload_egress_packets_total
+ - workload_ingress_packets_total
+ - workload_flows_total
+ - workload_drop_packets_total
+ - workload_drop_bytes_total
 ----

--- a/modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc
+++ b/modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc
@@ -3,8 +3,8 @@
 // network_observability/observing-network-traffic.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="network-observability-working-with-ipsec_{context}"]
-= Working with IPsec
+[id="network-observability-configuring-ipsec-with-flow-collector-resource_{context}"]
+= Configuring IPsec with the FlowCollector custom resource
 
 In {product-title}, IPsec is disabled by default. You can enable IPsec by following the instructions in "Configuring IPsec encryption".
 

--- a/modules/network-observability-proc_working-with-udn.adoc
+++ b/modules/network-observability-proc_working-with-udn.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-working-with-udn_{context}"]
+= Working with user-defined networks
+
+You can enable user-defined networks (UDN) in Network Observability resources.
+The following example shows the configuration for the `FlowCollector` resource.
+
+.Prerequisite
+* You have configured UDN in {openshift-networking}. For more information, see "Creating a UserDefinedNetwork by using the CLI" or "Creating a UserDefinedNetwork by using the web console."
+
+.Procedure
+. Edit the Network Observability `FlowCollector` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit flowcollector
+----
+
+. Configure the `ebpf` section of the `FlowCollector` resource:
++
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  agent:
+    ebpf:
+      sampling: 1  <1>
+      privileged: true
+      features:
+      - UDNMapping
+----
+<1> Recommended so all flows are observed.
+
+.Verification
+
+* Refresh the *Network Traffic* page to view updated UDN information in the *Traffic Flow* and *Topology* views:
+
+** In *Network Traffic* > *Traffic flows*, you can view UDNs under the `SrcK8S_NetworkName` and `DstK8S_NetworkName` fields.
+** In the *Topology* view, you can set *Network* as *Scope* or *Group*.

--- a/modules/network-observability-viewing-network-events.adoc
+++ b/modules/network-observability-viewing-network-events.adoc
@@ -15,10 +15,10 @@ You can edit the `FlowCollector` to view information about network traffic event
 * `BaselineNetworkPolicy`
 * `EgressFirewall`
 * `UserDefinedNetwork` isolation
-* Multicast ACLs 
+* Multicast ACLs
 
 .Prerequisites
-* You must have `OVNObservability` enabled by setting the `TechPreviewNoUpgrade` feature set in the `FeatureGate` custom resource (CR) named `cluster`. For more information, see "Enabling feature sets using the CLI" and "Checking OVN-Kubernetes network traffic with OVS sampling using the CLI". 
+* You must have `OVNObservability` enabled by setting the `TechPreviewNoUpgrade` feature set in the `FeatureGate` custom resource (CR) named `cluster`. For more information, see "Enabling feature sets using the CLI" and "Checking OVN-Kubernetes network traffic with OVS sampling using the CLI".
 * You have created at least one of the following network APIs: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinedNetwork` isolation, multicast, or `EgressFirewall`.
 
 .Procedure
@@ -44,15 +44,15 @@ spec:
       features:
        - "NetworkEvents"
 ----
-<1> Optional: The `sampling` parameter is set to a value of 1 so that all network events are captured. If sampling `1` is too resource heavy, set sampling to something more appropriate for your needs. 
+<1> Optional: The `sampling` parameter is set to a value of 1 so that all network events are captured. If sampling `1` is too resource heavy, set sampling to something more appropriate for your needs.
 <2> The `privileged` parameter is set to `true` because the `OVN observability` library needs to access local Open vSwitch (OVS) socket and OpenShift Virtual Network (OVN) databases.
 
 .Verification
-. Navigate to the *Network Traffic* view and select the *Traffic flows* table. 
-. You should see the new column, *Network Events*, where you can view information about impacts of one of the following network APIs you have enabled: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinedNetwork` isolation, multicast, or egress firewalls. 
+. Navigate to the *Network Traffic* view and select the *Traffic flows* table.
+. You should see the new column, *Network Events*, where you can view information about impacts of one of the following network APIs you have enabled: `NetworkPolicy`, `AdminNetworkPolicy`, `BaselineNetworkPolicy`, `UserDefinedNetwork` isolation, multicast, or egress firewalls.
 
 An example of the kind of events you could see in this column is as follows:
-+
+
 .Example of Network Events output
 [source,text]
 ----

--- a/modules/proc_network-observability-working-with-ipsec.adoc
+++ b/modules/proc_network-observability-working-with-ipsec.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-working-with-ipsec_{context}"]
+= Working with IPsec
+
+In {product-title}, IPsec is disabled by default. You can enable IPsec by following the instructions in "Configuring IPsec encryption".
+
+.Prerequisite
+
+* You have enabled IPsec encryption on {product-title}.
+
+.Procedure
+. In the web console, navigate to *Operators* -> *Installed Operators*.
+. Under the *Provided APIs* heading for the *NetObserv Operator*, select *Flow Collector*.
+. Select *cluster* then select the *YAML* tab.
+. Configure the `FlowCollector` custom resource for IPsec:
++
+.Example configuration of `FlowCollector` for IPsec
+[source, yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  namespace: netobserv
+  agent:
+    type: eBPF
+    ebpf:
+      features:
+      - "IPSec"
+----
+
+.Verification
+
+When IPsec is enabled:
+
+* A new column named *IPsec Status* is displayed in the network observability *Traffic flows* view to show whether a flow was successfully IPsec-encrypted or if there was an error during encryption/decryption.
+
+* A new dashboard showing the percent of encrypted traffic is generated.
+

--- a/observability/network_observability/configuring-operator.adoc
+++ b/observability/network_observability/configuring-operator.adoc
@@ -24,6 +24,12 @@ include::modules/network-observability-enriched-flows.adoc[leveloffset=+1]
 * xref:../../observability/network_observability/json-flows-format-reference.adoc#network-observability-flows-format_json_reference[Network flows format reference].
 
 include::modules/network-observability-configuring-FLP-sampling.adoc[leveloffset=+1]
+include::modules/network-observability-con_filter-network-flows-at-ingestion.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../network_observability/observing-network-traffic.adoc#network-observability-filtering-ebpf-rule_nw-observe-network-traffic[Filtering eBPF flow data using multiple rules]
+
 include::modules/network-observability-configuring-quickfilters-flowcollector.adoc[leveloffset=+1]
 include::modules/network-observability-resource-recommendations.adoc[leveloffset=+1]
 include::modules/network-observability-resources-table.adoc[leveloffset=+2]

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -2,7 +2,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-operator-release-notes"]
 = Network Observability Operator release notes
-:context: network-observability-operator-release-notes-v0
+:context: network-observability-operator-release-notes-v1-9
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
@@ -12,6 +12,104 @@ The Network Observability Operator enables administrators to observe and analyze
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
 For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#dependency-network-observability[About Network Observability Operator].
+
+[id="network-observability-operator-release-notes-1-9_{context}"]
+== Network Observability Operator 1.9
+The following advisory is available for the Network Observability Operator 1.9:
+
+* link:https://access.redhat.com/errata/RHSA-2025:10020 [Network Observability Operator 1.9]
+
+[id="new-features-enhancements-1-9"]
+=== New features and enhancements
+
+[id="user-defined-networks-with-network-observability_{context}"]
+==== User-defined networks with Network Observability
+With this release, xref:../../networking/multiple_networks/understanding-multiple-networks.adoc#understanding-multiple-networks[user-defined networks (UDN)] feature is generally available with Network Observability. When the `UDNMapping` feature is enabled in Network Observability, the *Traffic* flow table has a `UDN labels` column. You can filter logs on *Source Network Name* and *Destination Network Name* information.
+
+[id="filter-flowlogs-at-ingestion_{context}"]
+==== Filter flowlogs at ingestion
+With this release, you can create filters to reduce the number of generated network flows and the resource usage of Network Observability components.
+
+You can configure the following filters:
+
+* eBPF Agent filters
+* Flowlogs-pipeline filters
+
+[id="ipsec-support_{context}"]
+==== IPsec support
+This update brings the following enhancements to Network Observability when IPsec is enabled on {product-title}:
+
+* A new column named *IPsec Status* is displayed in the Network Observability *Traffic* flows view to show whether a flow was successfully IPsec-encrypted or if there was an error during encryption/decryption.
+
+* A new dashboard showing the percentage of encrypted traffic is generated.
+
+[id="network-observability-cli-1-9_{context}"]
+==== Network Observability CLI
+The following filtering options are now available for packets, flows, and metrics capture:
+
+* Track IPsec using `--enable_ipsec`
+* Value that determines the ratio of packets being sampled using `--sampling`
+* Filter flows using a custom query using `--query`
+* A comma separated list of interfaces to monitor using `--interfaces`
+* A comma separated list of interfaces to exclude using `--exclude_interfaces`
+* A comma separated list of metric names to generate using `--include_list`
+
+For more information, see xref:../../observability/network_observability/netobserv_cli/netobserv-cli-reference.adoc#network-observability-netobserv-cli-reference_netobserv-cli-reference[Network Observability CLI reference].
+
+[id="notable-technical-changes-1-9_{context}"]
+=== Notable technical changes
+* The `NetworkEvents` feature in Network Observability 1.9 has been updated to work with the newer Linux kernel of {product-title} 4.19. This update breaks compatibility with older kernels. As a result, the `NetworkEvents` feature can only be used with {product-title} 4.19. If you are using this feature with Network Observability 1.8 and {product-title} 4.18, consider avoiding a Network Observability upgrade or upgrading Network Observability to 1.9 and {product-title} to 4.19.
+
+* The `netobserv-reader` `clusterrole` has been renamed to `netobserv-loki-reader`.
+
+* Improved CPU performance of the eBPF agents.
+
+[id="network-observability-technology-preview-1-9_{context}"]
+=== Technology Preview features
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+[id="ebpf-manager-operator-with-network-observability_{context}"]
+==== eBPF Manager Operator with Network Observability
+
+:FeatureName: eBPF Manager Operator with Network Observability
+include::snippets/technology-preview.adoc[]
+
+The eBPF Manager Operator reduces the attack surface and ensures compliance, security, and conflict prevention by managing all eBPF programs. Network observability can use the eBPF Manager Operator to load hooks. This eliminates the need to provide the eBPF Agent with privileged mode or additional Linux capabilities like `CAP_BPF` and `CAP_PERFMON`. The eBPF Manager Operator with network observability is only supported on 64-bit AMD architecture.
+
+[id="network-observability-operator-CVE-1-9_{context}"]
+=== CVE
+
+* link:https://access.redhat.com/security/cve/CVE-2025-26791[*CVE-2025-26791*]
+
+[id="network-observability-operator-1-9-bug-fixes_{context}"]
+=== Bug fixes
+* Previously, when filtering by source or destination IP from the console plugin, using a Classless Inter-Domain Routing (CIDR) notation such as `10.128.0.0/24` did not work, returning results that should be filtered out. With this update, it is now possible to use a CIDR notation, with the results being filtered as expected. (link:https://issues.redhat.com/browse/NETOBSERV-2276[*NETOBSERV-2276*])
+
+* Previously, network flows might have incorrectly identified the network interfaces in use, especially with a risk of mixing up `eth0` and `ens5`. This issue only occurred when the eBPF agents were configured as `Privileged`. With this update, it has been fixed partially, and almost all network interfaces are correctly identified. Refer to the known issues below for more details. (link:https://issues.redhat.com/browse/NETOBSERV-2257[*NETOBSERV-2257*])
+
+* Previously, when the Operator checked for available Kubernetes APIs in order to adapt its behavior, if there was a stale API, this resulted in an error that prevented the Operator from starting normally. With this update, the Operator ignores error on unrelated APIs, logs errors on related APIs, and continues to run normally. (link:https://issues.redhat.com/browse/NETOBSERV-2240[*NETOBSERV-2240*])
+
+* Previously, users could not sort flows by *Bytes* or *Packets* in the *Traffic* flows view of the Console plugin. With this update, users can sort flows by *Bytes* and *Packets*.(link:https://issues.redhat.com/browse/NETOBSERV-2239[*NETOBSERV-2239*])
+
+* Previously, when configuring the `FlowCollector` resource with an IPFIX exporter, MAC addresses in the IPFIX flows were truncated to their 2 first bytes. With this update, MAC addresses are fully represented in the IPFIX flows. (link:https://issues.redhat.com/browse/NETOBSERV-2208[*NETOBSERV-2208*])
+
+* Previously, some of the warnings sent from the Operator validation webhook could lack clarity, such as when not mentioning exactly which feature causes the warning, or what needed to be done. With this update, some of these messages have been reviewed and amended to make them more actionable. (link:https://issues.redhat.com/browse/NETOBSERV-2178[*NETOBSERV-2178*])
+
+* Previously, it was not obvious to figure out there was an issue when referencing a `LokiStack` from the `FlowCollector` resource, such as in case of typing error. With this update, the `FlowCollector` status clearly states that the referenced `LokiStack` is not found in that case. (link:https://issues.redhat.com/browse/NETOBSERV-2174[*NETOBSERV-2174*])
+
+* Previously, in the console plugin *Traffic flows* view, in case of text overflow, text ellipses sometimes hid much of the text to be displayed. With this update, it displays as much text as possible. (link:https://issues.redhat.com/browse/NETOBSERV-2119[*NETOBSERV-2119*])
+
+* Previously, the console plugin for Network Observability 1.8.1 and earlier did not work with the {product-title} 4.19 web console, making the *Network Traffic* page inaccessible. With this update, the console plugin is compatible and the *Network Traffic* page is accessible in Network Observability 1.9.0. (link:https://issues.redhat.com/browse/NETOBSERV-2046[*NETOBSERV-2046*])
+
+* Previously, when using conversation tracking (`logTypes: Conversations` or `logTypes: All` in the `FlowCollector` resource), the *Traffic* rates metrics visible in the dashboards were flawed, wrongly showing an out-of-control increase in traffic. Now, the metrics show more accurate traffic rates. However, note that in `Conversations` and `EndedConversations` modes, these metrics are still not 100% accurate as they don't include long-standing connections. This information has been added to the documentation. The default mode `logTypes: Flows`, is recommended to avoid this kind of inaccuracy. (link:https://issues.redhat.com/browse/NETOBSERV-1955[*NETOBSERV-1955*])
+
+[id="network-observability-operator-1-9-known-issues_{context}"]
+=== Known issues
+* The user-defined network (UDN) feature displays a configuration issue and a warning when used with {product-title} 4.18, even though it is supported. This warning can be ignored.  (link:https://issues.redhat.com/browse/NETOBSERV-2305[*NETOBSERV-2305*])
+
+* In some rare cases, the eBPF agent is unable to appropriately correlate flows with the involved interfaces when running in privileged modes with several network namespaces. A large part of these issues have been identified and resolved in this release, but some inconsistencies remain, especially with the `ens5` interface. (link:https://issues.redhat.com/browse/NETOBSERV-2287[*NETOBSERV-2287*])
 
 [id="network-observability-operator-release-notes-1-8-1_{context}"]
 == Network Observability Operator 1.8.1

--- a/observability/network_observability/network-observability-overview.adoc
+++ b/observability/network_observability/network-observability-overview.adoc
@@ -22,13 +22,11 @@ The Network Observability Operator provides the Flow Collector API custom resour
 [id="no-console-integration"]
 == {product-title} console integration
 
-{product-title} console integration offers overview, topology view, and traffic flow tables in both *Administrator* and *Developer* perspectives.
-
-In the *Administrator* perspective, you can find the Network Observability *Overview*, *Traffic flows*, and *Topology* views by clicking *Observe* -> *Network Traffic*. In the *Developer* perspective, you can view this information by clicking *Observe*. The Network Observability metrics dashboards in *Observe* -> *Dashboards* are only available to administrators. 
+{product-title} console integration offers an overview, a topology view, and traffic flow tables. The Network Observability metrics dashboards in *Observe* -> *Dashboards* are available only to users with administrator access.
 
 [NOTE]
 ====
-To enable multi-tenancy for the developer perspective and for administrators with limited access to namespaces, you must specify permissions by defining roles. For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-multi-tenancy_network_observability[Enabling multi-tenancy in Network Observability].
+To enable multi-tenancy for developer access and for administrators with limited access to namespaces, you must specify permissions by defining roles. For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-multi-tenancy_network_observability[Enabling multi-tenancy in Network Observability].
 ====
 
 [id="network-observability-dashboards"]
@@ -51,4 +49,4 @@ The *Traffic flow* table view provides a view for raw flows, non aggregated filt
 
 [id="network-observability-cli"]
 == Network Observability CLI
-You can quickly debug and troubleshoot networking issues with Network Observability by using the Network Observability CLI (`oc netobserv`). The Network Observability CLI is a flow and packet visualization tool that relies on eBPF agents to stream collected data to an ephemeral collector pod. It requires no persistent storage during the capture. After the run, the output is transferred to your local machine. This enables quick, live insight into packets and flow data without installing the Network Observability Operator.  
+You can quickly debug and troubleshoot networking issues with Network Observability by using the Network Observability CLI (`oc netobserv`). The Network Observability CLI is a flow and packet visualization tool that relies on eBPF agents to stream collected data to an ephemeral collector pod. It requires no persistent storage during the capture. After the run, the output is transferred to your local machine. This enables quick, live insight into packets and flow data without installing the Network Observability Operator.

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -41,6 +41,14 @@ include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 * xref:../../observability/network_observability/network-observability-operator-monitoring.adoc#network-observability-health-dashboard-overview_network_observability[Health dashboards]
 
+include::modules/network-observability-con_user-defined-networks.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#about-user-defined-networks[About user-defined networks]
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr-ui_about-user-defined-networks[Creating a UserDefinedNetwork by using the web console]
+* xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-working-with-udn_nw-observe-network-traffic[Working with user-defined networks]
+
 include::modules/network-observability-networking-events-overview.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
@@ -50,6 +58,13 @@ include::modules/network-observability-networking-events-overview.adoc[leveloffs
 include::modules/network-observability-trafficflow.adoc[leveloffset=+1]
 include::modules/network-observability-working-with-trafficflow.adoc[leveloffset=+2]
 include::modules/network-observability-configuring-options-trafficflow.adoc[leveloffset=+2]
+include::modules/proc_network-observability-working-with-ipsec.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+*xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
+
+//Traffic flows continued
 include::modules/network-observability-working-with-conversations.adoc[leveloffset=+2]
 include::modules/network-observability-packet-drops.adoc[leveloffset=+2]
 include::modules/network-observability-dns-tracking.adoc[leveloffset=+2]
@@ -59,6 +74,13 @@ include::modules/network-observability-working-with-zones.adoc[leveloffset=+2]
 include::modules/network-observability-filtering-ebpf-rule.adoc[leveloffset=+2]
 include::modules/network-observability-packet-translation-overview.adoc[leveloffset=+2]
 include::modules/network-observability-packet-translation.adoc[leveloffset=+2]
+include::modules/network-observability-proc_working-with-udn.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
+* xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr-ui_about-user-defined-networks[Creating a UserDefinedNetwork by using the web console]
+
 include::modules/network-observability-viewing-network-events.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -78,5 +100,5 @@ Alternatively, you can access the traffic flow data in the *Network Traffic* tab
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters] 
+* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -14,35 +14,35 @@ include::modules/network-observability-working-with-overview.adoc[leveloffset=+2
 include::modules/network-observability-configuring-options-overview.adoc[leveloffset=+2]
 include::modules/network-observability-pktdrop-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-packet-drops"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-packet-drops_nw-observe-network-traffic[Working with packet drops]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 
 include::modules/network-observability-dns-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-dns-overview"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-dns-tracking_nw-observe-network-traffic[Working with DNS tracking]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 
 include::modules/network-observability-RTT-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-rtt-overview"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-RTT_nw-observe-network-traffic[Working with RTT tracing]
 
 include::modules/network-observability-ebpf-rule-flow-filter.adoc[leveloffset=+2]
 include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+3]
 
-[role="_additional-resources"]
+[role="_additional-resources-flow-filter-parameters"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-filtering-ebpf-rule_nw-observe-network-traffic[Filtering eBPF flow data with rules]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 * xref:../../observability/network_observability/network-observability-operator-monitoring.adoc#network-observability-health-dashboard-overview_network_observability[Health dashboards]
 
 include::modules/network-observability-con_user-defined-networks.adoc[leveloffset=+2]
-[role="_additional-resources"]
+[role="_additional-resources-udn"]
 .Additional resources
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#about-user-defined-networks[About user-defined networks]
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
@@ -50,7 +50,7 @@ include::modules/network-observability-con_user-defined-networks.adoc[leveloffse
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-working-with-udn_nw-observe-network-traffic[Working with user-defined networks]
 
 include::modules/network-observability-networking-events-overview.adoc[leveloffset=+2]
-[role="_additional-resources"]
+[role="_additional-resources-networking-events-overview"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-viewing-network-events_nw-observe-network-traffic[Viewing network events]
 
@@ -60,7 +60,7 @@ include::modules/network-observability-working-with-trafficflow.adoc[leveloffset
 include::modules/network-observability-configuring-options-trafficflow.adoc[leveloffset=+2]
 include::modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-ipsec"]
 .Additional resources
 * xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
 
@@ -84,14 +84,14 @@ include::modules/network-observability-packet-translation-overview.adoc[leveloff
 include::modules/network-observability-packet-translation.adoc[leveloffset=+2]
 include::modules/network-observability-proc_working-with-udn.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-working-with-udn"]
 .Additional resources
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr_about-user-defined-networks[Creating a UserDefinedNetwork by using the CLI]
 * xref:../../networking/multiple_networks/primary_networks/about-user-defined-networks.adoc#nw-udn-cr-ui_about-user-defined-networks[Creating a UserDefinedNetwork by using the web console]
 
 include::modules/network-observability-viewing-network-events.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-viewing-network-events"]
 .Additional resources
 * xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli_nodes-cluster-enabling[Enabling feature sets using the CLI]
 * xref:../../networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc#nw-ovn-kubernetes-observability_ovn-kubernetes-sources-of-troubleshooting-information[Checking OVN-Kubernetes network traffic with OVS sampling using the CLI]
@@ -106,7 +106,7 @@ include::modules/network-observability-quickfilter.adoc[leveloffset=+1]
 
 Alternatively, you can access the traffic flow data in the *Network Traffic* tab of the *Namespaces*, *Services*, *Routes*, *Nodes*, and *Workloads* pages which provide the filtered data of the corresponding aggregations.
 
-[role="_additional-resources"]
+[role="_additional-resources-quickfilter"]
 .Additional resources
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -58,11 +58,11 @@ include::modules/network-observability-networking-events-overview.adoc[leveloffs
 include::modules/network-observability-trafficflow.adoc[leveloffset=+1]
 include::modules/network-observability-working-with-trafficflow.adoc[leveloffset=+2]
 include::modules/network-observability-configuring-options-trafficflow.adoc[leveloffset=+2]
-include::modules/proc_network-observability-working-with-ipsec.adoc[leveloffset=+2]
+include::modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-*xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
+* xref:../../networking/network_security/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
 
 //Traffic flows continued
 include::modules/network-observability-working-with-conversations.adoc[leveloffset=+2]

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -69,6 +69,14 @@ include::modules/network-observability-working-with-conversations.adoc[leveloffs
 include::modules/network-observability-packet-drops.adoc[leveloffset=+2]
 include::modules/network-observability-dns-tracking.adoc[leveloffset=+2]
 include::modules/network-observability-RTT.adoc[leveloffset=+2]
+include::modules/network-observability-ebpf-manager-operator.adoc[leveloffset=+2]
+
+//eBPF Manager Operator in OCP > Networking
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/networking_operators/ebpf_manager/ebpf-manager-operator-install.adoc[Installing the eBPF Manager Operator]
+
+//Traffic flows continued
 include::modules/network-observability-histogram-trafficflow.adoc[leveloffset=+2]
 include::modules/network-observability-working-with-zones.adoc[leveloffset=+2]
 include::modules/network-observability-filtering-ebpf-rule.adoc[leveloffset=+2]


### PR DESCRIPTION
Integration Branch for release branch `no-1.9` 

This PR integrates all commits to the `no-1.9` release branch with `main` and enterprise-4.12, enterprise-4.14, enterprise-4.16+ 

All commits in this PR have been SME/QE, Peer and merge reviewed. This PR is for merging only.

Version(s):
Cherry-pick to OCP 4.12, 4.14, 4.16+


QE review:
- [x] QE has approved this change. All content in this release branch has been peer review/merge review/QE/SME ack'd before it was merged into the `no-1.9` branch. This PR simply integrates all that merged content into `main`  and enterprise-4.12, enterprise-4.14, enterprise-4.16+  on NetObserv GA, 7/02/25.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
