### PR TITLE
CNV #62606- VM CPU/Memory Hot Plugging

### DIFF
--- a/modules/virt-hot-plugging-cpu.adoc
+++ b/modules/virt-hot-plugging-cpu.adoc
@@ -17,5 +17,9 @@ You can increase or decrease the number of CPU sockets allocated to a virtual ma
 . Select the *vCPU* radio button.
 . Enter the desired number of vCPU sockets and click *Save*.
 +
-If the VM is migratable, a live migration is triggered. If not, or if the changes cannot be live-updated, a `RestartRequired` condition is added to the VM.
 
+[NOTE]
+====
+* You can apply memory hot-plug changes immediately by using an automatic migration. If the live migration is not triggered, you must restart the VM. You can adjust this behavior cluster-wide by using the `maxHotplugRatio` parameter or override it in your VM.
+* By default, you can hot-plug a VM with up to 4 times its initial CPU or memory configuration. For example, a VM with 1 vCPU and 2 GiB memory can scale up to 4 vCPUs and 8 GiB before a restart is needed. You can adjust this behavior cluster-wide by using the `maxHotplugRatio` parameter or override it in your VM.
+====

--- a/modules/virt-hot-plugging-memory.adoc
+++ b/modules/virt-hot-plugging-memory.adoc
@@ -20,5 +20,6 @@ The system applies these changes immediately. If the VM is migratable, a live mi
 
 [NOTE]
 ====
-Linux guests require a kernel version of 5.16 or later and Windows guests require the latest `viomem` drivers.
+* Linux guests require a kernel version of 5.16 or later and Windows guests require the latest `viomem` drivers.
+* By default, you can hot-plug a VM with up to 4 times its initial CPU or memory configuration. For example, a VM with 1 vCPU and 2 GiB memory can scale up to 4 vCPUs and 8 GiB before a restart is needed. You can adjust this behavior cluster-wide by using the `maxHotplugRatio` parameter or override it in your VM.
 ====


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/CNV-62606

Link to docs preview:

1. https://95584--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-edit-vms.html#virt-hot-plugging-memory_virt-edit-vms
2. https://95584--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-edit-vms.html#virt-hot-plugging-cpu_virt-edit-vms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR was initially created earlier, but the updates were intended specifically for the enterprise-4.18 branch, which I missed at the time. Therefore, I've created this new PR accordingly. Please note that both the QE and peer reviews have already been completed.
https://github.com/openshift/openshift-docs/pull/95019
