### PR TITLE
#CNV -62298 -  CPU hotplug with networkInterfaceMultiqueue enabled

### DIFF
--- a/modules/virt-hot-plugging-cpu.adoc
+++ b/modules/virt-hot-plugging-cpu.adoc
@@ -19,3 +19,11 @@ You can increase or decrease the number of CPU sockets allocated to a virtual ma
 +
 If the VM is migratable, a live migration is triggered. If not, or if the changes cannot be live-updated, a `RestartRequired` condition is added to the VM.
 
+[NOTE]
+====
+If a VM has the `spec.template.spec.domain.devices.networkInterfaceMultiQueue` field enabled and CPUs are hot plugged, the following behavior occurs:
+
+* Existing network interfaces that you attach before the CPU hot plug retain their original queue count, even after you add more virtual CPUs (vCPUs). The underlying virtualization technology causes this expected behavior.  
+* To update the queue count of existing interfaces to match the new vCPU configuration, you can restart the VM. A restart is only necessary if the update improves performance.  
+* New VirtIO network interfaces that you hot plugged after the CPU hotplug automatically receive a queue count that matches the updated vCPU configuration.
+====


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/CNV-62298

Link to docs preview:
https://95585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-edit-vms.html#virt-hot-plugging-cpu_virt-edit-vms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

