### PR TITLE
must gather attribute fix

### DIFF
--- a/modules/using-must-gather.adoc
+++ b/modules/using-must-gather.adoc
@@ -16,7 +16,7 @@ The `must-gather` tool generates a Markdown output file with the collected infor
 
 For more information about the supported flags, use the help flag with the `must-gather` tool as shown in the following example:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ oc adm must-gather --image={must-gather-v1-5} -- /usr/bin/gather -h
 ----


### PR DESCRIPTION
## Jira 

*  [OADP-6216](https://issues.redhat.com/browse/OADP-6216)

this PR fixes an attribute error for must-gather for OADP 1.5.0 on OCP 4.19

##  Version

* OCP 4.19, 4.20

## Preview

* [must-gather 4.19](https://95591--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting/using-the-must-gather-tool.html)

## QE Review

* [x] QE has approved this change.
