### PR TITLE
[enterprise-4.14] OSDOCS-15164 [NETOBSERV] Add IPsec to 4.14

### DIFF
--- a/modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc
+++ b/modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// network_observability/observing-network-traffic.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="network-observability-configuring-ipsec-with-flow-collector-resource_{context}"]
+= Configuring IPsec with the FlowCollector custom resource
+
+In {product-title}, IPsec is disabled by default. You can enable IPsec by following the instructions in "Configuring IPsec encryption".
+
+.Prerequisite
+
+* You have enabled IPsec encryption on {product-title}.
+
+.Procedure
+. In the web console, navigate to *Operators* -> *Installed Operators*.
+. Under the *Provided APIs* heading for the *NetObserv Operator*, select *Flow Collector*.
+. Select *cluster* then select the *YAML* tab.
+. Configure the `FlowCollector` custom resource for IPsec:
++
+.Example configuration of `FlowCollector` for IPsec
+[source, yaml]
+----
+apiVersion: flows.netobserv.io/v1beta2
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  namespace: netobserv
+  agent:
+    type: eBPF
+    ebpf:
+      features:
+      - "IPSec"
+----
+
+.Verification
+
+When IPsec is enabled:
+
+* A new column named *IPsec Status* is displayed in the network observability *Traffic flows* view to show whether a flow was successfully IPsec-encrypted or if there was an error during encryption/decryption.
+
+* A new dashboard showing the percent of encrypted traffic is generated.

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -14,28 +14,28 @@ include::modules/network-observability-working-with-overview.adoc[leveloffset=+2
 include::modules/network-observability-configuring-options-overview.adoc[leveloffset=+2]
 include::modules/network-observability-pktdrop-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-packet-drops"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-packet-drops_nw-observe-network-traffic[Working with packet drops]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 
 include::modules/network-observability-dns-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-dns-overview"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-dns-tracking_nw-observe-network-traffic[Working with DNS tracking]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 
 include::modules/network-observability-RTT-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
+[role="_additional-resources-rtt-overview"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-RTT_nw-observe-network-traffic[Working with RTT tracing]
 
 include::modules/network-observability-ebpf-rule-flow-filter.adoc[leveloffset=+2]
 include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+3]
 
-[role="_additional-resources"]
+[role="_additional-resources-flow-filter-parameters"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-filtering-ebpf-rule_nw-observe-network-traffic[Filtering eBPF flow data with rules]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
@@ -45,6 +45,12 @@ include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+
 include::modules/network-observability-trafficflow.adoc[leveloffset=+1]
 include::modules/network-observability-working-with-trafficflow.adoc[leveloffset=+2]
 include::modules/network-observability-configuring-options-trafficflow.adoc[leveloffset=+2]
+include::modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc[leveloffset=+2]
+
+[role="_additional-resources-ipsec"]
+.Additional resources
+* xref:../../networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption]
+
 
 //Traffic flows continued
 include::modules/network-observability-working-with-conversations.adoc[leveloffset=+2]
@@ -67,7 +73,7 @@ include::modules/network-observability-quickfilter.adoc[leveloffset=+1]
 
 Alternatively, you can access the traffic flow data in the *Network Traffic* tab of the *Namespaces*, *Services*, *Routes*, *Nodes*, and *Workloads* pages which provide the filtered data of the corresponding aggregations.
 
-[role="_additional-resources"]
+[role="_additional-resources-quickfilter"]
 .Additional resources
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]


### PR DESCRIPTION
 https://issues.redhat.com/browse/OSDOCS-15164

Was mistakenly removed from cherry-pick https://github.com/openshift/openshift-docs/pull/95571 to 4.14

Original PR: https://github.com/openshift/openshift-docs/pull/95552 

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-15164

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required for this PR.

Additional information:

Note to self: When this PR is merged, the cp-4.14 PR for Rel Notes will need to be rebased so it picks up these changes, and hopefully stops throwing errors related to the contents of this PR.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
