### PR TITLE
OCPBUGS#58363: Updated the VRF for NNCP to be GA for 4.19+

### DIFF
--- a/modules/virt-example-host-vrf.adoc
+++ b/modules/virt-example-host-vrf.adoc
@@ -8,9 +8,6 @@
 
 Associate a Virtual Routing and Forwarding (VRF) instance with a network interface by applying a `NodeNetworkConfigurationPolicy` custom resource (CR).
 
-:FeatureName: Associating a VRF instance with a network interface
-include::snippets/technology-preview.adoc[]
-
 By associating a VRF instance with a network interface, you can support traffic isolation, independent routing decisions, and the logical separation of network resources.
 
 [WARNING]


### PR DESCRIPTION
**[CM sent](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r5741682856885294593) on the July 4th.**

Version(s):
4.19+

Issue:
[OCPBUGS-58363](https://issues.redhat.com/browse/OCPBUGS-58363)

Link to docs preview:
* [Example: Network interface with a VRF instance node network configuration policy](https://95605--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-host-vrf_k8s-nmstate-updating-node-network-config)


- [x] SME has approved this change.
- [x] QE has approved this change.

