### PR TITLE
OCPBUGS#58363-19: Updated the 4.19 RN docs to mark VRF NNCP GA

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2411,7 +2411,7 @@ In the following tables, features are marked with the following statuses:
 |VRF specification in `NodeNetworkConfigurationPolicy` custom resource
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Host network settings for SR-IOV VFs
 |General Availability


### PR DESCRIPTION
**[CM sent](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r5741682856885294593) on the July 4th.** Approvals on [#95605](https://github.com/openshift/openshift-docs/pull/95605).

Version(s):
4.19

Issue:
[OCPBUGS-58363](https://issues.redhat.com/browse/OCPBUGS-58363)

Link to docs preview:
* [TP table for VRF specification in NodeNetworkConfigurationPolicy custom resource](https://95607--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-technology-preview-tables_release-notes)


- [x] SME has approved this change.
- [x] QE has approved this change.

