### PR TITLE
OSDOCS-14125: Updated Logging to remove <6.0 content

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1554,116 +1554,59 @@ Topics:
   Dir: logging
   Distros: openshift-rosa
   Topics:
-  - Name: Release notes
-    Dir: logging_release_notes
-    Topics:
-    - Name: Logging 5.9
-      File: logging-5-9-release-notes
-    - Name: Logging 5.8
-      File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
-  - Name: Support
-    File: cluster-logging-support
-  - Name: Troubleshooting logging
-    Dir: troubleshooting
-    Topics:
-    - Name: Viewing Logging status
-      File: cluster-logging-cluster-status
-    - Name: Troubleshooting log forwarding
-      File: log-forwarding-troubleshooting
-    - Name: Troubleshooting logging alerts
-      File: troubleshooting-logging-alerts
-    - Name: Viewing the status of the Elasticsearch log store
-      File: cluster-logging-log-store-status
   - Name: About Logging
-    File: cluster-logging
-  - Name: Installing Logging
-    File: cluster-logging-deploying
-  - Name: Updating Logging
-    File: cluster-logging-upgrading
-  - Name: Visualizing logs
-    Dir: log_visualization
+    File: about-logging
+  - Name: Logging 6.2
+    Dir: logging-6.2
     Topics:
-    - Name: About log visualization
-      File: log-visualization
-    - Name: Log visualization with the web console
-      File: log-visualization-ocp-console
-    - Name: Viewing cluster dashboards
-      File: cluster-logging-dashboards
-    - Name: Log visualization with Kibana
-      File: logging-kibana
-  - Name: Configuring your Logging deployment
-    Dir: config
-    Topics:
-    - Name: Configuring CPU and memory limits for Logging components
-      File: cluster-logging-memory
-    #- Name: Configuring systemd-journald and Fluentd
-    #  File: cluster-logging-systemd
-  - Name: Log collection and forwarding
-    Dir: log_collection_forwarding
-    Topics:
-    - Name: About log collection and forwarding
-      File: log-forwarding
-    - Name: Log output types
-      File: logging-output-types
-    - Name: Enabling JSON log forwarding
-      File: cluster-logging-enabling-json-logging
+    - Name: Support
+      File: log62-cluster-logging-support
+    - Name: Release notes
+      File: log6x-release-notes-6.2
+    - Name: About logging 6.2
+      File: log6x-about-6.2
     - Name: Configuring log forwarding
-      File: configuring-log-forwarding
+      File: log6x-clf-6.2
     - Name: Configuring the logging collector
-      File: cluster-logging-collector
-    - Name: Collecting and storing Kubernetes events
-      File: cluster-logging-eventrouter
-  - Name: Log storage
-    Dir: log_storage
+      File: 6x-cluster-logging-collector-6.2
+    - Name: Configuring LokiStack storage
+      File: log6x-loki-6.2
+    - Name: Configuring LokiStack for OTLP
+      File: log6x-configuring-lokistack-otlp-6.2
+    - Name: Visualization for logging
+      File: log6x-visual-6.2
+  - Name: Logging 6.1
+    Dir: logging-6.1
     Topics:
-    - Name: About log storage
-      File: about-log-storage
-    - Name: Installing log storage
-      File: installing-log-storage
-    - Name: Configuring the LokiStack log store
-      File: cluster-logging-loki
-    - Name: Configuring the Elasticsearch log store
-      File: logging-config-es-store
-  - Name: Logging alerts
-    Dir: logging_alerts
+    - Name: Release notes
+      File: log6x-release-notes-6.1
+    - Name: About logging 6.1
+      File: log6x-about-6.1
+    - Name: Configuring log forwarding
+      File: log6x-clf-6.1
+    - Name: Configuring LokiStack storage
+      File: log6x-loki-6.1
+    - Name: Configuring LokiStack for OTLP
+      File: log6x-configuring-lokistack-otlp-6.1
+    - Name: OpenTelemetry data model
+      File: log6x-opentelemetry-data-model-6.1
+    - Name: Visualization for logging
+      File: log6x-visual-6.1
+  - Name: Logging 6.0
+    Dir: logging-6.0
     Topics:
-    - Name: Default logging alerts
-      File: default-logging-alerts
-    - Name: Custom logging alerts
-      File: custom-logging-alerts
-  - Name: Performance and reliability tuning
-    Dir: performance_reliability
-    Topics:
-    - Name: Flow control mechanisms
-      File: logging-flow-control-mechanisms
-    - Name: Filtering logs by content
-      File: logging-content-filtering
-    - Name: Filtering logs by metadata
-      File: logging-input-spec-filtering
-  - Name: Scheduling resources
-    Dir: scheduling_resources
-    Topics:
-    - Name: Using node selectors to move logging resources
-      File: logging-node-selectors
-    - Name: Using tolerations to control logging pod placement
-      File: logging-taints-tolerations
-  - Name: Uninstalling Logging
-    File: cluster-logging-uninstall
-  - Name: Exported fields
-    File: cluster-logging-exported-fields
-  - Name: API reference
-    Dir: api_reference
-    Topics:
-  #  - Name: 5.8 Logging API reference
-  #    File: logging-5-8-reference
-  #  - Name: 5.7 Logging API reference
-  #    File: logging-5-7-reference
-    - Name: 5.6 Logging API reference
-      File: logging-5-6-reference
-  - Name: Glossary
-    File: logging-common-terms
+    - Name: Release notes
+      File: log6x-release-notes
+    - Name: About logging 6.0
+      File: log6x-about
+    - Name: Upgrading to Logging 6.0
+      File: log6x-upgrading-to-6
+    - Name: Configuring log forwarding
+      File: log6x-clf
+    - Name: Configuring LokiStack storage
+      File: log6x-loki
+    - Name: Visualization for logging
+      File: log6x-visual
 ---
 Name: Service Mesh
 Dir: service_mesh

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1217,116 +1217,59 @@ Topics:
   Dir: logging
   Distros: openshift-rosa-hcp
   Topics:
-  - Name: Release notes
-    Dir: logging_release_notes
-    Topics:
-    - Name: Logging 5.9
-      File: logging-5-9-release-notes
-    - Name: Logging 5.8
-      File: logging-5-8-release-notes
-    - Name: Logging 5.7
-      File: logging-5-7-release-notes
-  - Name: Support
-    File: cluster-logging-support
-  - Name: Troubleshooting logging
-    Dir: troubleshooting
-    Topics:
-    - Name: Viewing Logging status
-      File: cluster-logging-cluster-status
-    - Name: Troubleshooting log forwarding
-      File: log-forwarding-troubleshooting
-    - Name: Troubleshooting logging alerts
-      File: troubleshooting-logging-alerts
-    - Name: Viewing the status of the Elasticsearch log store
-      File: cluster-logging-log-store-status
   - Name: About Logging
-    File: cluster-logging
-  - Name: Installing Logging
-    File: cluster-logging-deploying
-  - Name: Updating Logging
-    File: cluster-logging-upgrading
-  - Name: Visualizing logs
-    Dir: log_visualization
+    File: about-logging
+  - Name: Logging 6.2
+    Dir: logging-6.2
     Topics:
-    - Name: About log visualization
-      File: log-visualization
-    - Name: Log visualization with the web console
-      File: log-visualization-ocp-console
-    - Name: Viewing cluster dashboards
-      File: cluster-logging-dashboards
-    - Name: Log visualization with Kibana
-      File: logging-kibana
-  - Name: Configuring your Logging deployment
-    Dir: config
-    Topics:
-    - Name: Configuring CPU and memory limits for Logging components
-      File: cluster-logging-memory
-    #- Name: Configuring systemd-journald and Fluentd
-    #  File: cluster-logging-systemd
-  - Name: Log collection and forwarding
-    Dir: log_collection_forwarding
-    Topics:
-    - Name: About log collection and forwarding
-      File: log-forwarding
-    - Name: Log output types
-      File: logging-output-types
-    - Name: Enabling JSON log forwarding
-      File: cluster-logging-enabling-json-logging
+    - Name: Support
+      File: log62-cluster-logging-support
+    - Name: Release notes
+      File: log6x-release-notes-6.2
+    - Name: About logging 6.2
+      File: log6x-about-6.2
     - Name: Configuring log forwarding
-      File: configuring-log-forwarding
+      File: log6x-clf-6.2
     - Name: Configuring the logging collector
-      File: cluster-logging-collector
-    - Name: Collecting and storing Kubernetes events
-      File: cluster-logging-eventrouter
-  - Name: Log storage
-    Dir: log_storage
+      File: 6x-cluster-logging-collector-6.2
+    - Name: Configuring LokiStack storage
+      File: log6x-loki-6.2
+    - Name: Configuring LokiStack for OTLP
+      File: log6x-configuring-lokistack-otlp-6.2
+    - Name: Visualization for logging
+      File: log6x-visual-6.2
+  - Name: Logging 6.1
+    Dir: logging-6.1
     Topics:
-    - Name: About log storage
-      File: about-log-storage
-    - Name: Installing log storage
-      File: installing-log-storage
-    - Name: Configuring the LokiStack log store
-      File: cluster-logging-loki
-    - Name: Configuring the Elasticsearch log store
-      File: logging-config-es-store
-  - Name: Logging alerts
-    Dir: logging_alerts
+    - Name: Release notes
+      File: log6x-release-notes-6.1
+    - Name: About logging 6.1
+      File: log6x-about-6.1
+    - Name: Configuring log forwarding
+      File: log6x-clf-6.1
+    - Name: Configuring LokiStack storage
+      File: log6x-loki-6.1
+    - Name: Configuring LokiStack for OTLP
+      File: log6x-configuring-lokistack-otlp-6.1
+    - Name: OpenTelemetry data model
+      File: log6x-opentelemetry-data-model-6.1
+    - Name: Visualization for logging
+      File: log6x-visual-6.1
+  - Name: Logging 6.0
+    Dir: logging-6.0
     Topics:
-    - Name: Default logging alerts
-      File: default-logging-alerts
-    - Name: Custom logging alerts
-      File: custom-logging-alerts
-  - Name: Performance and reliability tuning
-    Dir: performance_reliability
-    Topics:
-    - Name: Flow control mechanisms
-      File: logging-flow-control-mechanisms
-    - Name: Filtering logs by content
-      File: logging-content-filtering
-    - Name: Filtering logs by metadata
-      File: logging-input-spec-filtering
-  - Name: Scheduling resources
-    Dir: scheduling_resources
-    Topics:
-    - Name: Using node selectors to move logging resources
-      File: logging-node-selectors
-    - Name: Using tolerations to control logging pod placement
-      File: logging-taints-tolerations
-  - Name: Uninstalling Logging
-    File: cluster-logging-uninstall
-  - Name: Exported fields
-    File: cluster-logging-exported-fields
-  - Name: API reference
-    Dir: api_reference
-    Topics:
-  #  - Name: 5.8 Logging API reference
-  #    File: logging-5-8-reference
-  #  - Name: 5.7 Logging API reference
-  #    File: logging-5-7-reference
-    - Name: 5.6 Logging API reference
-      File: logging-5-6-reference
-  - Name: Glossary
-    File: logging-common-terms
+    - Name: Release notes
+      File: log6x-release-notes
+    - Name: About logging 6.0
+      File: log6x-about
+    - Name: Upgrading to Logging 6.0
+      File: log6x-upgrading-to-6
+    - Name: Configuring log forwarding
+      File: log6x-clf
+    - Name: Configuring LokiStack storage
+      File: log6x-loki
+    - Name: Visualization for logging
+      File: log6x-visual
 ---
 Name: Service Mesh
 Dir: service_mesh

--- a/observability/logging/logging-6.0/log6x-visual.adoc
+++ b/observability/logging/logging-6.0/log6x-visual.adoc
@@ -2,10 +2,16 @@
 [id="log6x-visual"]
 = Visualization for logging
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: logging-6x
 
 toc::[]
 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 Visualization for logging is provided by deploying the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the xref:../../../observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator], which requires Operator installation.
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+Visualization for logging is provided by deploying the Logging UI Plugin of the Cluster Observability Operator, which requires Operator installation.
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 include::snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc[]

--- a/observability/logging/logging-6.1/log6x-visual-6.1.adoc
+++ b/observability/logging/logging-6.1/log6x-visual-6.1.adoc
@@ -2,10 +2,17 @@
 [id="log6x-visual-6-1"]
 = Visualization for logging
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: logging-6x-6.1
 
 toc::[]
 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 Visualization for logging is provided by deploying the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the xref:../../../observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator], which requires Operator installation.
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+Visualization for logging is provided by deploying the Logging UI Plugin of the Cluster Observability Operator, which requires Operator installation.
+endif::openshift-rosa,openshift-rosa-hcp[]
+
 
 include::snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc[]

--- a/observability/logging/logging-6.2/log6x-visual-6.2.adoc
+++ b/observability/logging/logging-6.2/log6x-visual-6.2.adoc
@@ -2,10 +2,16 @@
 [id="log6x-visual-6-2"]
 = Visualization for logging
 include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: logging-6x-6.2
 
 toc::[]
 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 Visualization for logging is provided by deploying the xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the xref:../../../observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator], which requires Operator installation.
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+Visualization for logging is provided by deploying the Logging UI Plugin of the Cluster Observability Operator, which requires Operator installation.
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 include::snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc[]

--- a/snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc
+++ b/snippets/logging-support-exception-for-cluster-observability-operator-due-to-logging-ui-plugin.adoc
@@ -6,5 +6,12 @@
 
 [IMPORTANT]
 ====
-Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
+Until the approaching General Availability (GA) release of the Cluster Observability Operator (COO), which is currently in link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] (TP), Red{nbsp}Hat provides support to customers who are using Logging 6.0 or later with the COO for its 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+xref:../../../observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] 
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+Logging UI Plugin 
+endif::openshift-rosa,openshift-rosa-hcp[]
+on {product-title} 4.14 or later. This support exception is temporary as the COO includes several independent features, some of which are still TP features, but the Logging UI Plugin is ready for GA.
 ====


### PR DESCRIPTION
Version(s):
`enterprise-4.19+`

Issue:
- **[OSDOCS-14125](https://issues.redhat.com/browse/OSDOCS-14125)**
- **[OSDOCS-9653](https://issues.redhat.com/browse/OSDOCS-9653)**

Link to docs preview:
- [About Logging](https://95616--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/logging/about-logging) (HCP)
- [About Logging](https://95616--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/about-logging) (classic)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR updates the Logging content for ROSA and ROSA Classic to remove all logging versions older than 6.0.