### PR TITLE
OSDOCS-15168:Update the z-stream RNs for 4.19.3

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2813,6 +2813,40 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.19.3
+[id="ocp-4-19-3_{context}"]
+=== RHBA-2025:10290 - {product-title} {product-version}.3 image release, bug fix, and security update advisory
+
+Issued: 08 July 2025
+
+{product-title} release {product-version}.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:10290[RHBA-2025:10290] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:10291[RHSA-2025:10291] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.3 --pullspecs
+----
+
+[id="ocp-4-19-3-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, useful error messages were not generated when the `oc adm node-image create` command failed. With this release, the `oc adm node-image create` command provides error messages when the command fails. (link:https://issues.redhat.com/browse/OCPBUGS-58077[OCPBUGS-58077])
+
+* Previously, when on-prem installer-provisioned infrastructure (IPI) deployments used the Cilium container network interface (CNI), the firewall rule that redirected traffic to the load balancer was ineffective. With this release, the rule works with the Cilium CNI and `OVNKubernetes`. (link:https://issues.redhat.com/browse/OCPBUGS-57781[OCPBUGS-57781])
+
+* Previously, when you defined the `blockedImages` value in the `imageSetConfiguration` parameter for `oc-mirror v2`, you were required to provide an extensive list of image references for excluding images from mirroring. This requirement sometimes prevented the exclusion of images from mirroring because the image digests changed between executions. With this release, you can use regular expressions for the `blockedImages` value to facilitate the exclusion of images from mirroring. (link:https://issues.redhat.com/browse/OCPBUGS-56728[OCPBUGS-56728]) 
+
+* Previously, certain traffic patterns with large packets running between {product-title} nodes and pods triggered an {product-title} host to send Internet Control Message Protocol (ICMP) needs frag to another {product-title} host. This situation lowered the viable maximum transmission unit (MTU) in the cluster. As a consequence, executing the `ip route show cache` command generated a cached route with a lower MTU than the physical link. Packets were dropped and {product-title} components were degrading because the host did not send pod-to-pod traffic with the large packets. With this release, NF Tables rules prevent the {product-title} nodes from lowering their MTU in response to traffic patterns with large packets. (link:https://issues.redhat.com/browse/OCPBUGS-55997[OCPBUGS-55997])
+
+* Previously, you needed to update vSAN files to 8.0 P05 or later to enable clusters running {product-title} 4.19 to mount the network file system (NFS) volumes that were exported from the VMWare vSAN Files. With this release, you do not need to upgrade existing vSAN File Services versions to mount VMWare vSAN File volumes. (link:https://issues.redhat.com/browse/OCPBUGS-55978[OCPBUGS-55978])
+
+[id="ocp-4-19-3-updating_{context}"]
+==== Updating
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.19.2
 [id="ocp-4-19-2_{context}"]
 === RHSA-2025:9750 - {product-title} {product-version}.2 image release, bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-15168

Link to docs preview:
https://95617--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html