### PR TITLE
[RHACS] Upgrade guide disk space note

### DIFF
--- a/modules/rollback-central-forced.adoc
+++ b/modules/rollback-central-forced.adoc
@@ -15,7 +15,11 @@ Using forced rollback to switch back to a previous version might result in loss 
 
 .Prerequisites
 
-* Before you can perform a rollback, you must have free disk space available on your persistent storage. {product-title} uses disk space to keep a copy of databases during the upgrade. If the disk space is not enough to store a copy and the upgrade fails, you will not be able to roll back to an earlier version.
+* **Enough disk space**: Before you can perform a rollback, you must have free disk space available on your persistent storage. {product-title} uses disk space to keep a copy of databases during the upgrade. If the disk space is not enough to store a copy and the upgrade fails, you cannot perform a roll back to an earlier version.
+* **Internal database rollback (4.8 or earlier)**: If you are rolling back from {product-title-short} 4.8 to an earlier version and use the internal database (`central-db`), you must first restore the database from a PostgreSQL 13 backup.
+
+** To restore the database, add the `RESTORE_BACKUP=true` and `FORCE_OLD_BINARIES=true` environment variables to the `central-db` and `init-db` containers of the `central-db` component.
+** For details on injecting environment variables, see "Injecting an environment variable into the Central deployment".
 
 .Procedure
 
@@ -28,7 +32,7 @@ $ oc -n stackrox rollout undo deploy/central <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
 ** To forcefully rollback to a specific version:
-. Edit Central’s `ConfigMap`:
+. Edit the `ConfigMap` that belongs to Central:
 +
 [source,terminal]
 ----

--- a/modules/rollback-central-normal.adoc
+++ b/modules/rollback-central-normal.adoc
@@ -10,7 +10,11 @@ You can roll back to a previous version of Central if upgrading {product-title} 
 
 .Prerequisites
 
-* Before you can perform a rollback, you must have free disk space available on your persistent storage. {product-title} uses disk space to keep a copy of databases during the upgrade. If the disk space is not enough to store a copy and the upgrade fails, you might not be able to roll back to an earlier version.
+* **Enough disk space**: Before you can perform a rollback, you must have free disk space available on your persistent storage. {product-title} uses disk space to keep a copy of databases during the upgrade. If the disk space is not enough to store a copy and the upgrade fails, you cannot perform a roll back to an earlier version.
+* **Internal database rollback (4.8 or earlier)**: If you are rolling back from {product-title-short} 4.8 to an earlier version and use the internal database (`central-db`), you must first restore the database from a PostgreSQL 13 backup.
+
+** To restore the database, add the `RESTORE_BACKUP=true` and `FORCE_OLD_BINARIES=true` environment variables to the `central-db` and `init-db` containers of the `central-db` component.
+** For details on injecting environment variables, see "Injecting an environment variable into the Central deployment".
 
 .Procedure
 

--- a/upgrading/upgrade-helm.adoc
+++ b/upgrading/upgrade-helm.adoc
@@ -19,7 +19,9 @@ If you have installed {product-title-short} by using Helm charts, to upgrade to 
 
 [IMPORTANT]
 ====
-To ensure optimal functionality, use the same version for your secured-cluster-services Helm chart and central-services Helm chart.
+* To ensure optimal functionality, use the same version for your secured-cluster-services Helm chart and central-services Helm chart.
+* To upgrade to {product-title-short} 4.8, which includes an upgrade to PostgreSQL 15, you must free up disk space.
+Before beginning the upgrade, ensure you have free disk space that is at least double the size of your existing database.
 ====
 
 include::modules/back-up-central-database.adoc[leveloffset=+1]

--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -14,6 +14,12 @@ Follow these guidelines when upgrading:
 * If the version for Central is earlier than 3.74, you must upgrade to 3.74 before upgrading to a 4.x version. For upgrading Central to version 3.74, see the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.74/html/upgrading/index[upgrade documentation for version 3.74].
 * When upgrading Operator-based Central deployments from version 3.74, first ensure the Operator upgrade mode is set to `Manual`. Then, upgrade the Operator to version 4.0 following the procedure in the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/4.0/html/upgrading/upgrade-operator[upgrade documentation for version 4.0] and ensure that Central is online. After the upgrade to version 4.0 is complete, Red{nbsp}Hat recommends upgrading Central to the latest version for full functionality.
 
+[IMPORTANT]
+====
+To upgrade to {product-title-short} 4.8, which includes an upgrade to PostgreSQL 15, you must free up disk space.
+Before beginning the upgrade, ensure you have free disk space that is at least double the size of your existing database.
+====
+
 include::modules/prepare-operator-upgrades.adoc[leveloffset=+1]
 include::modules/change-collection-method.adoc[leveloffset=+2]
 

--- a/upgrading/upgrade-roxctl.adoc
+++ b/upgrading/upgrade-roxctl.adoc
@@ -13,6 +13,8 @@ You can upgrade to the latest version of {rh-rhacs-first} from a supported older
 ====
 * You need to perform the manual upgrade procedure only if you used the `roxctl` CLI to install {product-title-short}.
 * There are manual steps for each version upgrade that must be followed, for example, from version 3.74 to version 4.0, and from version 4.0 to version 4.1. Therefore, Red{nbsp}Hat recommends upgrading first from 3.74 to 4.0, then from 4.0 to 4.1, then 4.1 to 4.2, until the selected version is installed. For full functionality, Red{nbsp}Hat recommends upgrading to the most recent version.
+* Upgrading to {product-title-short} 4.8 includes an upgrade to PostgreSQL 15 and it requires additional free space on your disk.
+Before starting the upgrade, ensure you have enough free disk space, ideally almost double the size of your existing database.
 ====
 
 To upgrade {product-title-short} to the latest version, perform the following steps:
@@ -108,7 +110,17 @@ You can roll back to a previous version of Central if the upgrade to a new versi
 
 include::modules/rollback-central-normal.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_ocp/install-central-config-options-ocp.adoc#adding-an-environment-variable-to-a-deployment_install-central-config-options-ocp[Injecting an environment variable into the Central deployment]
+
 include::modules/rollback-central-forced.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_ocp/install-central-config-options-ocp.adoc#adding-an-environment-variable-to-a-deployment_install-central-config-options-ocp[Injecting an environment variable into the Central deployment]
 
 include::modules/verify-upgrades.adoc[leveloffset=+1]
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-29898

Rolling back from ACS 4.8 is more complicated due to major version upgrade. Describe this in the rollback section.


Preview: 
- https://95623--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-helm.html
- https://95623--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-operator.html
- https://95623--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl.html
- https://95623--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl#rollback-central-normal_upgrade-roxctl
- https://95623--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl#rollback-central-forced_upgrade-roxctl


