### PR TITLE
[enterprise-4.12] OSDOCS-12623: Documented the Ansible playbook offline migration method

### DIFF
--- a/modules/nw-ovn-kubernetes-ansible-migration.adoc
+++ b/modules/nw-ovn-kubernetes-ansible-migration.adoc
@@ -1,0 +1,160 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+// * networking/ovn_kubernetee_network_provider/rollback-to-openshift-sdn.adoc
+
+ifeval::["{context}" == "rollback-to-openshift-sdn"]
+:rollback:
+endif::[]
+
+:_mod-docs-content-type: PROCEDURE
+ifndef::rollback[]
+[id="nw-ovn-kubernetes-ansible-migration-about_{context}"]
+= Using an Ansible playbook to migrate to the OVN-Kubernetes network plugin
+
+As a cluster administrator, you can use an Ansible collection, `network.offline_migration_sdn_to_ovnk`, to migrate from the OpenShift SDN Container Network Interface (CNI) network plugin to the OVN-Kubernetes plugin for your cluster. The Ansible collection includes the following playbooks:
+
+* `playbooks/playbook-migration.yml`: Includes playbooks that execute in a sequence where each playbook represents a step in the migration process. 
+* `playbooks/playbook-rollback.yml`: Includes playbooks that execute in a sequence where each playbook represents a step in the rollback process. 
+endif::rollback[]
+
+ifdef::rollback[]
+[id="nw-ovn-kubernetes-ansible-rollback_{context}"]
+= Using an Ansible playbook to roll back to the OpenShift SDN network plugin
+
+As a cluster administrator, you can use the `playbooks/playbook-rollback.yml` from the `network.offline_migration_sdn_to_ovnk` Ansible collection to roll back from the OVN-Kubernetes plugin to the OpenShift SDN Container Network Interface (CNI) network plugin.
+endif::rollback[]
+
+.Prerequisites
+
+* You installed the `python3` package, minimum version 3.10.
+* You installed the `jmespath` and `jq` packages.
+* You logged in to the {hybrid-console} and opened the link:https://console.redhat.com/ansible/ansible-dashboard[Ansible Automation Platform] web console.
+* You created a security group rule that allows User Datagram Protocol (UDP) packets on port `6081` for all nodes on all cloud platforms. If you do not do this task, your cluster might fail to schedule pods.
+ifndef::rollback[]
+* If the OpenShift-SDN plugin uses the `100.64.0.0/16` and `100.88.0.0/16` address ranges, you patched the address ranges. For more information, see "Patching OVN-Kubernetes address ranges" in the _Additional resources_ section.
+endif::rollback[]
+
+.Procedure
+
+. Install the `ansible-core` package, minimum version 2.15. The following example command shows how to install the `ansible-core` package on {op-system-base-full}:
++
+[source,terminal]
+----
+$ sudo dnf install -y ansible-core
+----
+
+. Create an `ansible.cfg` file and add information similar to the following example to the file. Ensure that file exists in the same directory as where the `ansible-galaxy` commands and the playbooks run.
++
+[source,ini,subs="attributes+"]
+----
+$ cat << EOF >> ansible.cfg
+[galaxy]
+server_list = automation_hub, validated
+
+[galaxy_server.automation_hub]
+url=https://console.redhat.com/api/automation-hub/content/published/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+token=
+
+#[galaxy_server.release_galaxy]
+#url=https://galaxy.ansible.com/
+
+[galaxy_server.validated]
+url=https://console.redhat.com/api/automation-hub/content/validated/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+token=
+EOF
+----
+
+. From the Ansible Automation Platform web console, go to the link:https://console.redhat.com/ansible/automation-hub/token/[Connect to Hub] page and complete the following steps:
++
+.. In the *Offline token* section of the page, click the *Load token* button.
++
+.. After the token loads, click the *Copy to clipboard* icon.
++
+.. Open the `ansible.cfg` file and paste the API token in the `token=` parameter. The API token is required for authenticating against the server URL specified in the `ansible.cfg` file.
+
+. Install the `network.offline_migration_sdn_to_ovnk` Ansible collection by entering the following `ansible-galaxy` command:
++
+[source,terminal]
+----
+$ ansible-galaxy collection install network.offline_migration_sdn_to_ovnk
+----
+
+. Verify that the `network.offline_migration_sdn_to_ovnk` Ansible collection is installed on your system:
++
+[source,terminal]
+----
+$ ansible-galaxy collection list | grep network.offline_migration_sdn_to_ovnk 
+----
++
+.Example output
++
+[source,terminal]
+----
+network.offline_migration_sdn_to_ovnk   1.0.2
+----
++
+The `network.offline_migration_sdn_to_ovnk` Ansible collection is saved in the default path of `~/.ansible/collections/ansible_collections/network/offline_migration_sdn_to_ovnk/`.
++
+ifndef::rollback[]
+. Configure migration features in the `playbooks/playbook-migration.yml` file:
++
+[source,yaml]
+----
+# ...
+    migration_interface_name: eth0
+    migration_disable_auto_migration: true
+    migration_egress_ip: false
+    migration_egress_firewall: false
+    migration_multicast: false
+    migration_mtu: 1400
+    migration_geneve_port: 6081
+    migration_ipv4_subnet: "100.64.0.0/16"
+# ...
+----
++
+`migration_interface_name`:: If you use an `NodeNetworkConfigurationPolicy` (NNCP) resource on a primary interface, specify the interface name in the `migration-playbook.yml` file so that the NNCP resource gets deleted on the primary interface during the migration process.
+`migration_disable_auto_migration`:: Disables the auto-migration of OpenShift SDN CNI plug-in features to the OVN-Kubernetes plugin. If you disable auto-migration of features, you must also set the `migration_egress_ip`, `migration_egress_firewall`, and `migration_multicast` parameters to `false`. If you need to enable auto-migration of features, set the parameter to `false`. 
+`migration_mtu`:: Optional parameter that sets a specific maximum transmission unit (MTU) to your cluster network after the migration process.
+`migration_geneve_port`:: Optional parameter that sets a Geneve port for OVN-Kubernetes. The default port is `6081`.
+`migration_ipv4_subnet`:: Optional parameter that sets an IPv4 address range for internal use by OVN-Kubernetes. The default value for the parameter is `100.64.0.0/16`.
+
+. To run the `playbooks/playbook-migration.yml` file, enter the following command:
++
+[source,terminal]
+----
+$ ansible-playbook -v playbooks/playbook-migration.yml
+----
+endif::rollback[]
+ifdef::rollback[]
+. Configure rollback features in the `playbooks/playbook-migration.yml` file:
++
+[source,terminal]
+----
+# ...
+    rollback_disable_auto_migration: true
+    rollback_egress_ip: false
+    rollback_egress_firewall: false
+    rollback_multicast: false
+    rollback_mtu: 1400
+    rollback_vxlanPort: 4790
+# ...
+----
++
+`rollback_disable_auto_migration`:: Disables the auto-migration of OVN-Kubernetes plug-in features to the OpenShift SDN CNI plug-in. If you disable auto-migration of features, you must also set the `rollback_egress_ip`, `rollback_egress_firewall`, and `rollback_multicast` parameters to `false`. If you need to enable auto-migration of features, set the parameter to `false`. 
+`rollback_mtu`:: Optional parameter that sets a specific maximum transmission unit (MTU) to your cluster network after the migration process.
+`rollback_vxlanPort`:: Optional parameter that sets a VXLAN (Virtual Extensible LAN) port for use by OpenShift SDN CNI plug-in. The default value for the parameter is `4790`.
+
+. To run the `playbooks/playbook-rollback.yml` file, enter the following command:
++
+[source,terminal]
+----
+$ ansible-playbook -v playbooks/playbook-rollback.yml
+----
+endif::rollback[]
+
+ifeval::["{context}" == "rollback-to-openshift-sdn"]
+:!rollback:
+endif::[]

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -27,6 +27,16 @@ include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
 // How the migration process works
 include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
 
+// Using an Ansible playbook to migrate to the OVN-Kubernetes network plugin
+include::modules/nw-ovn-kubernetes-ansible-migration.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#nw-ovn-kubernetes-ansible-migration-about_migrate-from-openshift-sdn[Patching OVN-Kubernetes address ranges]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/latest[Getting started with playbooks (Red Hat Ansible Automation Platform documentation)]
+
 // Migrating to the OVN-Kubernetes network plugin
 include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
 

--- a/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.adoc
@@ -8,4 +8,13 @@ toc::[]
 
 As a cluster administrator, you can rollback to the OpenShift SDN from the OVN-Kubernetes network plugin only after the migration to the OVN-Kubernetes network plugin is completed and successful.
 
+// Using the offline migration method to roll back to the OpenShift SDN network plugin
 include::modules/nw-ovn-kubernetes-rollback.adoc[leveloffset=+1]
+
+// Using an Ansible playbook to roll back to the OpenShift SDN network plugin
+include::modules/nw-ovn-kubernetes-ansible-migration.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#nw-ovn-kubernetes-ansible-migration-about_migrate-from-openshift-sdn[Patching OVN-Kubernetes address ranges]


### PR DESCRIPTION
Git cherry-pick #90108 of with commit ID 7f108fa03bdda20a1bdbb79e0cd534f8f00b8660

Version(s):
4.12

Issue:
[OSDOCS-12623](https://issues.redhat.com/browse/OSDOCS-12623)
