### PR TITLE
TELCODOCS-2339: Fixing optionality for community.yaml

### DIFF
--- a/modules/telco-core-crs-networking.adoc
+++ b/modules/telco-core-crs-networking.adoc
@@ -17,7 +17,7 @@ Load Balancer,`addr-pool.yaml`,Configures MetalLB to manage a pool of IP address
 Load Balancer,`bfd-profile.yaml`,"Configures bidirectional forwarding detection (BFD) with customized intervals, detection multiplier, and modes for quicker network fault detection and load balancing failover.",No
 Load Balancer,`bgp-advr.yaml`,"Defines a BGP advertisement resource for MetalLB, specifying how an IP address pool is advertised to BGP peers. This enables fine-grained control over traffic routing and announcements.",No
 Load Balancer,`bgp-peer.yaml`,"Defines a BGP peer in MetalLB, representing a BGP neighbor for dynamic routing.",No
-Load Balancer,`community.yaml`,"Defines a MetalLB community, which groups one or more BGP communities under a named resource. Communities can be applied to BGP advertisements to control routing policies and change traffic routing.",No
+Load Balancer,`community.yaml`,"Defines a MetalLB community, which groups one or more BGP communities under a named resource. Communities can be applied to BGP advertisements to control routing policies and change traffic routing.",Yes
 Load Balancer,`metallb.yaml`,Defines the MetalLB resource in the cluster.,No
 Load Balancer,`metallbNS.yaml`,Defines the metallb-system namespace in the cluster.,No
 Load Balancer,`metallbOperGroup.yaml`,Defines the Operator group for the MetalLB Operator.,No


### PR DESCRIPTION
[TELCODOCS-2339](https://issues.redhat.com//browse/TELCODOCS-2339): Fixing optionality for community.yaml

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2339

Link to docs preview:
https://95636--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-core-rds.html#networking-crs_telco-core

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
