### PR TITLE
must-gather on oadp 1.4 for ocp 4.15 4.14

### DIFF
--- a/modules/using-must-gather.adoc
+++ b/modules/using-must-gather.adoc
@@ -55,9 +55,9 @@ $ oc adm must-gather --image={must-gather-v1-3} -- /usr/bin/gather --request-tim
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image={must-gather-v1-4} -- /usr/bin/gather_with_timeout <timeout> # <1>
+$ oc adm must-gather --image={must-gather-v1-4} -- /usr/bin/gather --request-timeout 1m # <1>
 ----
-<1> Specify a timeout value in seconds.
+<1> In this example, the timeout is 1 minute.
 
 * To use the insecure TLS connection flag with the `must-gather` tool, run one of the following commands:
 
@@ -72,9 +72,8 @@ $ oc adm must-gather --image={must-gather-v1-3} -- /usr/bin/gather --skip-tls
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image={must-gather-v1-4} -- /usr/bin/gather_without_tls <value> # <1>
+$ oc adm must-gather --image={must-gather-v1-4} -- /usr/bin/gather --skip-tls
 ----
-<1> By default, the value is `false`. Set to `true` to allow insecure TLS connections.
 
 * To use a combination of the insecure TLS connection, and the timeout flags with the `must-gather` tool, run one of the following commands:
 
@@ -90,9 +89,9 @@ $ oc adm must-gather --image={must-gather-v1-3} -- /usr/bin/gather --request-tim
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image={must-gather-v1-4} --skip_tls=true /usr/bin/gather_with_timeout <timeout_value_in_seconds> #<1>
+$ oc adm must-gather --image={must-gather-v1-4} -- /usr/bin/gather --request-timeout 15s --skip-tls #<1>
 ----
-<1> By default, the `--skip-tls` flag value is `false`. Set the value to `true` to allow insecure TLS connections. Specify a timeout value.
+<1> In this example, the timeout is 15 seconds. By default, the `--skip-tls` flag value is `false`. Set the value to `true` to allow insecure TLS connections.
 
 .Verification
 


### PR DESCRIPTION
## Jira 

*  [OADP-6216](https://issues.redhat.com/browse/OADP-6216)

OADP must-gather for OCP 4.15, 4.14

##  Version

* OCP 4.15
* OCP 4.14


## Preview

* [must-gather 4.15 4.14](https://95637--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting/using-the-must-gather-tool.html)

## QE Review

* [x] QE has approved this change.
