### PR TITLE
OCPBUGS-56952: Removed br-ex notes from networking DNS docs

### DIFF
--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -314,7 +314,6 @@ routes:
 
 [IMPORTANT]
 ====
-You cannot use the OVN-Kubernetes `br-ex` bridge as the next hop interface when configuring a static route unless you manually configured a customized `br-ex` bridge.
-
-For more information, see "Creating a manifest object that includes a customized br-ex bridge" in the _Deploying installer-provisioned clusters on bare metal_ document or the _Installing a user-provisioned cluster on bare metal_ document.
+You cannot use the OVN-Kubernetes `br-ex` bridge as the next hop interface when configuring a static route.
 ====
+


### PR DESCRIPTION
Version(s):
4.15 to 4.13

Issue:
[OCPBUGS-56952](https://issues.redhat.com/browse/OCPBUGS-56952)

Link to docs preview:

- [x] SME has approved this change.
- [x] QE has approved this change.

