### PR TITLE
OCPBUGS#56085: Updated the name parameter in the configuring-localnet…

### DIFF
--- a/modules/configuring-localnet-switched-topology.adoc
+++ b/modules/configuring-localnet-switched-topology.adoc
@@ -54,7 +54,7 @@ The following JSON example configures a localnet secondary network that is named
 ----
 {
   "cniVersion": "0.3.1",
-  "name": "ns1-localnet-network",
+  "name": "localnet1",
   "type": "ovn-k8s-cni-overlay",
   "topology":"localnet",
   "physicalNetworkName": "localnet1",
@@ -114,7 +114,7 @@ The following JSON example configures a localnet secondary network that is named
 ----
 {
   "cniVersion": "0.3.1",
-  "name": "ns1-localnet-network",
+  "name": "localnet2",
   "type": "ovn-k8s-cni-overlay",
   "topology":"localnet",
   "physicalNetworkName": "localnet2",


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-56085](https://issues.redhat.com/browse/OCPBUGS-56085)

Link to docs preview:
* [Configuration for a localnet switched topology](https://95644--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.html#configuration-localnet-switched-topology_configuring-additional-network-ovnk)

- [x] SME has approved this change (Pablo Rod).
- [x] QE has approved this change (Jean Chen).

See https://github.com/openshift/openshift-docs/pull/92259 for past approvals. 
