### PR TITLE
OSDOCS-13089: adds 4.17.35 async release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -232,3 +232,12 @@ See the latest images included with {microshift-short} by xref:../microshift_upd
 ==== Bug fixes
 
 * Previously, an IPv6 configuration for {microshift-short} was created in the system at first start when an IP address was not configured. This was caused by an erroneous retrieval of the default node IP address because of the order in which the interfaces were listed. Consequentially, the misconfiguration resulted in the {microshift-short} service being unreachable. With this release, the correct node IP address is retrieved first. (link:https://issues.redhat.com/browse/OCPBUGS-52861[OCPBUGS-52861])
+
+[id="microshift-4-17-35-dp_{context}"]
+=== RHBA-2025:10331 - {microshift-short} 4.17.35 security advisory
+
+Issued: 9 July 2025
+
+{product-title} release 4.17.35 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:10331[RHBA-2025:10331] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:10294[RHSA-2025:10294] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13089](https://issues.redhat.com/browse/OSDOCS-13089)

Link to docs preview:
[microshift-4-17-35-dp_release-notes](https://95687--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-35-dp_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
