### PR TITLE
OBSDOCS-1804: Allow loki to use virtual-host-style as an explicit

### DIFF
--- a/modules/logging-loki-storage-aws.adoc
+++ b/modules/logging-loki-storage-aws.adoc
@@ -6,6 +6,8 @@
 [id="logging-loki-storage-aws_{context}"]
 = AWS storage
 
+You can create an object storage in {aws-first} to store logs. 
+
 .Prerequisites
 
 * You installed the {loki-op}.
@@ -19,18 +21,21 @@
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc create secret generic logging-loki-aws \
+$ oc create secret generic logging-loki-aws \ #<1>
   --from-literal=bucketnames="<bucket_name>" \
   --from-literal=endpoint="<aws_bucket_endpoint>" \
   --from-literal=access_key_id="<aws_access_key_id>" \
   --from-literal=access_key_secret="<aws_access_key_secret>" \
   --from-literal=region="<aws_region_of_your_bucket>"
+  --from-literal=forcepathstyle="true" # <2>
 ----
+<1> `logging-loki-aws` is the name of the secret.
+<2> {aws-short} endpoints (those ending in `.amazonaws.com`) use a virtual-hosted style by default, which is equivalent to setting the `forcepathstyle` attribute to `false`. Conversely, non-AWS endpoints use a path style, equivalent to setting  `forcepathstyle` attribute to `true`. If you need to use a virtual-hosted style with non-AWS S3 services, you must explicitly set `forcepathstyle` to `false`.
 
 [id="AWS_storage_STS_{context}"]
 == AWS storage for STS enabled clusters
 
-If your cluster has STS enabled, the Cloud Credential Operator (CCO) supports short-term authentication using AWS tokens.
+If your cluster has STS enabled, the Cloud Credential Operator (CCO) supports short-term authentication by using AWS tokens.
 
 You can create the Loki object storage secret manually by running the following command:
 [source,terminal,subs="+quotes"]

--- a/modules/logging-loki-storage-minio.adoc
+++ b/modules/logging-loki-storage-minio.adoc
@@ -6,6 +6,8 @@
 [id="logging-loki-storage-minio_{context}"]
 = Minio storage
 
+You can create an object storage in Minio to store logs.
+
 .Prerequisites
 
 * You installed the {loki-op}.
@@ -19,9 +21,12 @@
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc create secret generic logging-loki-minio \
+$ oc create secret generic logging-loki-minio \ # <1>
   --from-literal=bucketnames="<bucket_name>" \
   --from-literal=endpoint="<minio_bucket_endpoint>" \
   --from-literal=access_key_id="<minio_access_key_id>" \
   --from-literal=access_key_secret="<minio_access_key_secret>"
+  --from-literal=forcepathstyle="true" # <2>
 ----
+<1> `logging-loki-minio` is the name of the secret.
+<2> AWS endpoints (those ending in `.amazonaws.com`) use a virtual-hosted style by default, which is equivalent to setting the `forcepathstyle` attribute to `false`. Conversely, non-AWS endpoints use a path style, equivalent to setting  `forcepathstyle` attribute to `true`. If you need to use a virtual-hosted style with non-AWS S3 services, you must explicitly set `forcepathstyle` to `false`.

--- a/modules/logging-loki-storage-odf.adoc
+++ b/modules/logging-loki-storage-odf.adoc
@@ -6,6 +6,8 @@
 [id="logging-loki-storage-odf_{context}"]
 = {rh-storage} storage
 
+You can create an object storage in {rh-storage} storage to store logs.
+
 .Prerequisites
 
 * You installed the {loki-op}.
@@ -50,9 +52,12 @@ SECRET_ACCESS_KEY=$(oc get -n openshift-logging secret loki-bucket-odf -o jsonpa
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc create -n openshift-logging secret generic logging-loki-odf \
+$ oc create -n openshift-logging secret generic logging-loki-odf \ #<1>
 --from-literal=access_key_id="<access_key_id>" \
 --from-literal=access_key_secret="<secret_access_key>" \
 --from-literal=bucketnames="<bucket_name>" \
 --from-literal=endpoint="https://<bucket_host>:<bucket_port>"
+--from-literal=forcepathstyle="true" # <2>
 ----
+<1> `logging-loki-odf` is the name of the secret.
+<2> AWS endpoints (those ending in `.amazonaws.com`) use a virtual-hosted style by default, which is equivalent to setting the `forcepathstyle` attribute to `false`. Conversely, non-AWS endpoints use a path style, equivalent to setting  `forcepathstyle` attribute to `true`. If you need to use a virtual-hosted style with non-AWS S3 services, you must explicitly set `forcepathstyle` to `false`.


### PR DESCRIPTION
Version(s): 6.3
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OBSDOCS-1804](https://issues.redhat.com//browse/OBSDOCS-1804)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

- https://95688--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-the-log-store.html#logging-loki-storage-aws_configuring-the-log-store
- https://95688--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-the-log-store.html#logging-loki-storage-minio_configuring-the-log-store
- https://95688--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-the-log-store.html#logging-loki-storage-odf_configuring-the-log-store

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This needs to be cherry-picked to standalone-logging-docs-6.3
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
