### PR TITLE
OSDOCS-15175 [NETOBSERV] Fix NetObserv 1.9 advisory link 4.14+

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -17,7 +17,7 @@ For an overview of the Network Observability Operator, see xref:../../observabil
 == Network Observability Operator 1.9
 The following advisory is available for the Network Observability Operator 1.9:
 
-* link:https://access.redhat.com/errata/RHSA-2025:10020 [Network Observability Operator 1.9]
+* link:https://access.redhat.com/errata/RHSA-2025:10020[Network Observability Operator 1.9]
 
 [id="new-features-enhancements-1-9"]
 === New features and enhancements


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15175 [NETOBSERV] Fix NetObserv 1.9 advisory link 4.14+

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15175

Link to docs preview:
https://95709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html

QE review:
QE Review is not needed for this PR.

Additional information:
Found during cherry-picks. Applies to 4.14+ as it is fixed in 4.12 manual cp https://github.com/openshift/openshift-docs/pull/95608

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
