### PR TITLE
TRACING-5065: document OpenTelemetry Collector deployment modes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3221,6 +3221,8 @@ Topics:
       File: otel-collector-extensions
     - Name: Target Allocator
       File: otel-collector-target-allocator
+    - Name: Deployment Modes
+      File: otel-collector-deployment-modes
   - Name: Configuring the instrumentation
     File: otel-configuration-of-instrumentation
   - Name: Sending traces and metrics to the Collector

--- a/observability/otel/otel-collector/otel-collector-deployment-modes.adoc
+++ b/observability/otel/otel-collector/otel-collector-deployment-modes.adoc
@@ -1,0 +1,71 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="otel-collector-deployment-modes"]
+= Deployment Modes
+include::_attributes/common-attributes.adoc[]
+:context: otel-collector-deployment-modes
+
+toc::[]
+
+The OpenTelemetry Collector supports the following deployment modes: Deployment (default mode), DaemonSet, StatefulSet and Sidecar.
+
+== Configuring the Deployment Mode
+
+Deployment, DaemonSet and StatefulSet deploy the collector using the respective Kubernetes workload resource.
+The sidecar mode deploys the collector as a sidecar container to an existing pod.
+
+.OpenTelemetry Collector with DaemonSet deployment mode
+[source,yaml]
+----
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: otel
+spec:
+  mode: daemonset <1>
+----
+<1> The deployment mode. Supported values: `deployment` (default), `daemonset`, `statefulset` and `sidecar`
+
+== Sidecar Injection
+
+The collector can be injected into existing pod-based workloads by configuring the pod annotation `sidecar.opentelemetry.io/inject`.
+Injecting the collector as a sidecar allows accessing logfiles from inside a container, using a shared volume (for example an `emptyDir` volume) and the xref:./otel-collector-receivers.adoc#filelog-receiver_otel-collector-receivers[filelog receiver].
+Another use case is to configure the application to send telemetry data to the sidecar over localhost (the sidecar runs in the same pod as the application), and the collector forwards the telemetry data to an external service via an encrypted and authenticated connection.
+
+Example:
+
+.OpenTelemetry Collector with sidecar deployment mode
+[source,yaml]
+----
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: my-otel-sidecar
+spec:
+  mode: sidecar <1>
+----
+<1> Configure sidecar deployment mode.
+
+.Annotate an existing pod to inject the collector sidecar
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-app
+  annotations:
+    sidecar.opentelemetry.io/inject: "true" <1>
+spec:
+  containers:
+  - ...
+----
+<1> Enable sidecar injection. Supported values: `true`, `false`, `otelcol-instance-name`, `namespace/otelcol-instance-name`
+
+The `sidecar.opentelemetry.io/inject` annotation supports the following values:
+
+*true*:: Inject the collector with the configuration of the OpenTelemetryCollector resource in the same namespace
+*my-otel-sidecar*:: Inject the collector with the configuration of the `my-otel-sidecar` OpenTelemetryCollector resource in the same namespace.
+*my-namespace/my-otel-sidecar*:: Inject the collector with the configuration of the `my-otel-sidecar` OpenTelemetryCollector resource in the `my-namespace` namespace.
+*false*:: Do not inject the collector (default if the annotation is missing)
+
+Additionally, the `sidecar.opentelemetry.io/inject` annotation can be set on the namespace.
+If the annotation is set on both the namespace and the pod, the pod annotation takes precedence if it is set to an OpenTelemetryCollector instance name or to `false`.

--- a/observability/otel/otel-collector/otel-collector-deployment-modes.adoc
+++ b/observability/otel/otel-collector/otel-collector-deployment-modes.adoc
@@ -6,7 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The OpenTelemetry Collector supports the following deployment modes: Deployment (default mode), DaemonSet, StatefulSet and Sidecar.
+The OpenTelemetry Collector supports the following deployment modes: Deployment (default mode), StatefulSet, DaemonSet, and Sidecar.
+
+The StatefulSet deployment mode is recommended for stateful workloads, for example when using the xref:./otel-collector-extensions.adoc#filestorage-extension_otel-collector-extensions[filestorage extension].
+
+When scraping telemetry data from every node (e.g. reading container logs with the xref:./otel-collector-receivers.adoc#filelog-receiver_otel-collector-receivers[filelog receiver]), the DaemonSet deployment mode is recommended.
+
+Injecting the collector as a sidecar allows accessing logfiles from inside a container, using a shared volume (for example an `emptyDir` volume) and the xref:./otel-collector-receivers.adoc#filelog-receiver_otel-collector-receivers[filelog receiver].
+Another use case for the sidecar mode is to configure the application to send telemetry data to the sidecar over localhost (the sidecar runs in the same pod as the application), and the collector forwards the telemetry data to an external service via an encrypted and authenticated connection.
 
 == Configuring the Deployment Mode
 
@@ -28,9 +35,6 @@ spec:
 == Sidecar Injection
 
 The collector can be injected into existing pod-based workloads by configuring the pod annotation `sidecar.opentelemetry.io/inject`.
-Injecting the collector as a sidecar allows accessing logfiles from inside a container, using a shared volume (for example an `emptyDir` volume) and the xref:./otel-collector-receivers.adoc#filelog-receiver_otel-collector-receivers[filelog receiver].
-Another use case is to configure the application to send telemetry data to the sidecar over localhost (the sidecar runs in the same pod as the application), and the collector forwards the telemetry data to an external service via an encrypted and authenticated connection.
-
 Example:
 
 .OpenTelemetry Collector with sidecar deployment mode

--- a/observability/otel/otel-collector/otel-collector-deployment-modes.adoc
+++ b/observability/otel/otel-collector/otel-collector-deployment-modes.adoc
@@ -8,11 +8,11 @@ toc::[]
 
 The OpenTelemetry Collector supports the following deployment modes: Deployment (default mode), StatefulSet, DaemonSet, and Sidecar.
 
-The StatefulSet deployment mode is recommended for stateful workloads, for example when using the xref:./otel-collector-extensions.adoc#filestorage-extension_otel-collector-extensions[filestorage extension].
+The StatefulSet deployment mode is recommended for stateful workloads, for example when using the xref:./otel-collector-extensions.adoc#filestorage-extension_otel-collector-extensions[File Storage Extension] or xref:./otel-collector-processors.adoc#tail-sampling-processor_otel-collector-processors[Tail Sampling Processor].
 
-When scraping telemetry data from every node (e.g. reading container logs with the xref:./otel-collector-receivers.adoc#filelog-receiver_otel-collector-receivers[filelog receiver]), the DaemonSet deployment mode is recommended.
+When scraping telemetry data from every node (e.g. reading container logs with the xref:./otel-collector-receivers.adoc#filelog-receiver_otel-collector-receivers[Filelog Receiver]), the DaemonSet deployment mode is recommended.
 
-Injecting the collector as a sidecar allows accessing logfiles from inside a container, using a shared volume (for example an `emptyDir` volume) and the xref:./otel-collector-receivers.adoc#filelog-receiver_otel-collector-receivers[filelog receiver].
+Injecting the collector as a sidecar allows accessing logfiles from inside a container, using a shared volume (for example an `emptyDir` volume) and the xref:./otel-collector-receivers.adoc#filelog-receiver_otel-collector-receivers[Filelog Receiver].
 Another use case for the sidecar mode is to configure the application to send telemetry data to the sidecar over localhost (the sidecar runs in the same pod as the application), and the collector forwards the telemetry data to an external service via an encrypted and authenticated connection.
 
 == Configuring the Deployment Mode


### PR DESCRIPTION
Version(s):
all supported OCP versions

Issue:
https://issues.redhat.com/browse/TRACING-5065

Link to docs preview:
https://95719--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-deployment-modes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
cc @pavolloffay @max-cx 
