### PR TITLE
CNV#59745: Document removing wasp-agent

### DIFF
--- a/modules/virt-removing-wasp-agent.adoc
+++ b/modules/virt-removing-wasp-agent.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-removing-wasp-agent_{context}"]
+= Removing the wasp-agent component
+
+If you no longer need memory overcommitment, you can remove the `wasp-agent` component and associated resources from your cluster.
+
+.Prerequisites
+
+* You are logged in to the cluster with the `cluster-admin` role.
+* You have installed the {oc-first}.
+
+.Procedure
+
+. Remove the `wasp-agent` DaemonSet:
++
+[source,terminal]
+----
+$ oc delete daemonset wasp-agent -n wasp
+----
+
+. If deployed, remove the alerting rules:
++
+[source,terminal]
+----
+$ oc delete prometheusrule wasp-rules -n wasp
+----
+
+. Optionally, delete the `wasp` namespace if no other resources depend on it:
++
+[source,terminal]
+----
+$ oc delete namespace wasp
+----
+
+. Revert the memory overcommitment configuration:
++
+[source,terminal]
+----
+$ oc -n openshift-cnv patch HyperConverged/kubevirt-hyperconverged \
+  --type='json' \
+  -p='[{"op": "remove", "path": "/spec/higherWorkloadDensity"}]'
+----
+
+. Delete the `MachineConfig` that provisions swap memory:
++
+[source,terminal]
+----
+$ oc delete machineconfig 90-worker-swap
+----
+
+. Delete the associated `KubeletConfig`:
++
+[source,terminal]
+----
+$ oc delete kubeletconfig custom-config
+----
+
+. Wait for the worker nodes to reconcile:
++
+[source,terminal]
+----
+$ oc wait mcp worker --for condition=Updated=True --timeout=-1s
+----
+
+.Verification
+
+* Confirm that the `wasp-agent` DaemonSet is removed:
++
+[source,terminal]
+----
+$ oc get daemonset -n wasp
+----
++
+No `wasp-agent` should be listed.
+
+* Confirm that swap is no longer enabled on a node:
++
+[source,terminal]
+----
+$ oc debug node/<selected_node> -- free -m
+----
++
+Ensure that the `Swap:` row shows `0` or that no swap space shows as provisioned.

--- a/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc
+++ b/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc
@@ -18,4 +18,6 @@ Memory overcommitment can lower workload performance on a highly utilized system
 
 include::modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc[leveloffset=+1]
 
+include::modules/virt-removing-wasp-agent.adoc[leveloffset=+1]
+
 include::modules/virt-wasp-agent-pod-eviction.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/CNV-59745

Link to docs preview:
https://95720--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.html#virt-removing-wasp-agent_virt-configuring-higher-vm-workload-density

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
