### PR TITLE
OCPBUGS-48242#Updated output examples in this section

### DIFF
--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -68,13 +68,19 @@ $ podman run --rm --entrypoint performance-profile-creator registry.redhat.io/op
 ----
 A tool that automates creation of Performance Profiles
 
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  info        requires --must-gather-dir-path, ignores other arguments. [Valid values: log,json]
+
 Usage:
   performance-profile-creator [flags]
+performance-profile-creator [command]
 
 Flags:
       --disable-ht                        Disable Hyperthreading
+      --enable-hardware-tuning            Enable setting maximum cpu frequencies
   -h, --help                              help for performance-profile-creator
-      --info string                       Show cluster information; requires --must-gather-dir-path, ignore the other arguments. [Valid values: log, json] (default "log")
       --mcp-name string                   MCP name corresponding to the target machines (required)
       --must-gather-dir-path string       Must gather directory path (default "must-gather")
       --offlined-cpu-count int            Number of offlined CPUs
@@ -86,24 +92,28 @@ Flags:
       --split-reserved-cpus-across-numa   Split the Reserved CPUs across NUMA nodes
       --topology-manager-policy string    Kubelet Topology Manager Policy of the performance profile to be created. [Valid values: single-numa-node, best-effort, restricted] (default "restricted")
       --user-level-networking             Run with User level Networking(DPDK) enabled
+
+Use "performance-profile-creator [command] --help" for more information about a command.
 ----
 
 . To display information about the cluster, run the PPC tool with the `log` argument by running the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ podman run --entrypoint performance-profile-creator -v <path_to_must_gather>:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} --info log --must-gather-dir-path /must-gather
+$ podman run --entrypoint performance-profile-creator -v <path_to_must_gather>:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} info --must-gather-dir-path /must-gather
 ----
 +
 * `--entrypoint performance-profile-creator` defines the performance profile creator as a new entry point to `podman`.
 * `-v <path_to_must_gather>` specifies the path to either of the following components:
 ** The directory containing the `must-gather` data.
 ** An existing directory containing the `must-gather` decompressed .tar file.
-* `--info log` specifies a value for the output format.
 +
 .Example output
 [source,terminal]
 ----
+level=info msg="Nodes names targeted by master pool are: "
+level=info msg="Nodes names targeted by worker-cnf pool are: host2.example.com "
+level=info msg="Nodes names targeted by worker pool are: host.example.com host1.example.com "
 level=info msg="Cluster info:"
 level=info msg="MCP 'master' nodes:"
 level=info msg=---
@@ -179,6 +189,8 @@ spec:
     reserved: "0"
   machineConfigPoolSelector:
     machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
   numa:


### PR DESCRIPTION
OCPBUGS-48242: Added missing options and corrected example outputs to match actual ones

Version(s):
4.17+

Issue:
[OCPBUGS-48242](https://issues.redhat.com/browse/OCPBUGS-48242)


Link to docs preview:
[Running the Performance Profile Creator using Podman](https://95721--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.html#running-the-performance-profile-profile-cluster-using-podman_cnf-low-latency-perf-profile) -- Step 3 and 4.


QE review:
- [x] QE has approved this change.

Additional information:

