### PR TITLE
OSDOCS#15170:  Update the z-stream RNs for 4.12.78

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5204,3 +5204,28 @@ With this release, you can use the installation program to create an external cl
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.12.78
+[id="ocp-4-12-78_{context}"]
+=== RHSA-2025:10270 - {product-title} 4.12.78 bug fix and security update
+
+Issued: 10 July 2025
+
+{product-title} release 4.12.78 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:10270[RHSA-2025:10270] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:10271[RHSA-2025:10271] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.78 --pullspecs
+----
+
+[id="ocp-4-12-78-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, when you injected proxy environment variables in a build container, they replaced the default proxy settings and caused build failures due to external binary compatibility issues. Also, if no default variable was set, a null value was replaced, which caused applications to break. With this release, a check for a null proxy environment variable is added to the process and the injected proxy variables are added only if they are defined in the default variables and if the variable is not equal to a null value. (link:https://issues.redhat.com/browse/OCPBUGS-57171[OCPBUGS-57171])
+
+[id="ocp-4-12-78-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-15170](https://issues.redhat.com//browse/OSDOCS-15170)

Link to docs preview:
[4.12.78](https://95723--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-78_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream release notes.

Additional information:
The errata URLs will return 404 until the go-live date of 7/10/25.