### PR TITLE
CNV#58595: Move prereqs into procedure modules

### DIFF
--- a/modules/virt-configuring-huge-pages-for-vms.adoc
+++ b/modules/virt-configuring-huge-pages-for-vms.adoc
@@ -22,7 +22,7 @@ If you edit a running virtual machine, the virtual machine must be rebooted for 
 
 .Prerequisites
 
-* Nodes must have pre-allocated huge pages configured. For instructions, see link:https://docs.openshift.com/container-platform/{product-version}/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.html#configuring-huge-pages_huge-pages[Configuring huge pages at boot time].
+* Nodes must have pre-allocated huge pages configured.
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/virt-enabling-dedicated-resources.adoc
+++ b/modules/virt-enabling-dedicated-resources.adoc
@@ -18,6 +18,12 @@ endif::[]
 
 You enable dedicated resources for a {object} in the *Details* tab. Virtual machines that were created from a Red Hat template can be configured with dedicated resources.
 
+.Prerequisites
+
+* The CPU Manager must be configured on the node. Verify that the node has the `cpumanager = true` label before scheduling virtual machine workloads.
+
+* The virtual machine must be powered off.
+
 .Procedure
 
 . In the {product-title} console, click *Virtualization* -> *{object-gui}s* from the side menu.

--- a/virt/managing_vms/advanced_vm_management/virt-configuring-pxe-booting.adoc
+++ b/virt/managing_vms/advanced_vm_management/virt-configuring-pxe-booting.adoc
@@ -12,14 +12,6 @@ operating system or other program without requiring a locally attached
 storage device. For example, you can use it to choose your desired OS
 image from a PXE server when deploying a new host.
 
-ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-== Prerequisites
-
-* A Linux bridge must be xref:../../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[connected].
-
-* The PXE server must be connected to the same VLAN as the bridge.
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-
 include::modules/virt-pxe-booting-with-mac-address.adoc[leveloffset=+1]
 
 include::modules/virt-networking-glossary.adoc[leveloffset=+1]

--- a/virt/managing_vms/advanced_vm_management/virt-dedicated-resources-vm.adoc
+++ b/virt/managing_vms/advanced_vm_management/virt-dedicated-resources-vm.adoc
@@ -10,10 +10,4 @@ To improve performance, you can dedicate node resources, such as CPU, to a virtu
 
 include::modules/virt-about-dedicated-resources.adoc[leveloffset=+1]
 
-== Prerequisites
-
-* The xref:../../../scalability_and_performance/using-cpu-manager.adoc[CPU Manager]  must be configured on the node. Verify that the node has the `cpumanager = true` label before scheduling virtual machine workloads.
-
-* The virtual machine must be powered off.
-
 include::modules/virt-enabling-dedicated-resources.adoc[leveloffset=+1]

--- a/virt/managing_vms/advanced_vm_management/virt-using-huge-pages-with-vms.adoc
+++ b/virt/managing_vms/advanced_vm_management/virt-using-huge-pages-with-vms.adoc
@@ -8,11 +8,6 @@ toc::[]
 
 You can use huge pages as backing memory for virtual machines in your cluster.
 
-== Prerequisites
-
-* Nodes must have xref:../../../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#configuring-huge-pages_huge-pages[pre-allocated huge pages configured].
-
-
 include::modules/what-huge-pages-do.adoc[leveloffset=+1]
 
 include::modules/virt-configuring-huge-pages-for-vms.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.18+

Issue: [CNV-58595](https://issues.redhat.com/browse/CNV-58595) (Note the no-qe label)

Links to docs preview:

- https://95736--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-dedicated-resources-vm.html#virt-enabling-dedicated-resources_virt-dedicated-resources-vm
- https://95736--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-using-huge-pages-with-vms.html#virt-configuring-huge-pages-for-vms_virt-using-huge-pages-with-vms
- https://95736--ocpdocs-pr.netlify.app/openshift-rosa/latest/virt/managing_vms/advanced_vm_management/virt-configuring-pxe-booting.html

QE review:  N/A (no QE review needed) 
This PR addresses these structure updates:
- Removing prerequisite(s) duplicated in an assembly and procedure module
- Relocating prerequisite(s) misplaced in an assembly instead of in the relevant procedure module 

