### PR TITLE
OSDOCS#15171: Update the z-stream RN for 4.15.54

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2786,13 +2786,39 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.54
+[id="ocp-4-15-54_{context}"]
+=== RHBA-2025:10306 - {product-title} 4.15.54 bug fix update
+
+Issued: 09 July 2025
+
+{product-title} release 4.15.54 is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHBA-2025:10306[RHBA-2025:10306] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:10307[RHBA-2025:10307] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.54 --pullspecs
+----
+
+[id="ocp-4-15-54-bug-fixes_{context}"]
+==== Bug fixes
+
+* Previously, proxy variables were not respected in Machine Config Daemon pods during in-place upgrades becuase of missing proxy configuration integration. As a consequence, failed upgrades occurred because of incorrect image pulls. With this release, proxy variables are respected in Machine Config Daemon pods during successful in-place upgrades. (link:https://issues.redhat.com/browse/OCPBUGS-57553[OCPBUGS-57553])
+
+[id="ocp-4-15-54-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.15.53
 [id="ocp-4-15-53_{context}"]
 === RHSA-2025:9259 - {product-title} 4.15.53 bug fix and security update
 
 Issued: 26 June 2025
 
-{product-title} release 4.15.53, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:9259[RHSA-2025:9259 ] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:9260[RHBA-2025:9260] advisory.
+{product-title} release 4.15.53, which includes security updates, is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:9259[RHSA-2025:9259] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:9260[RHBA-2025:9260] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 


### PR DESCRIPTION
Version(s):
4.15
Issue:
[OSDOCS-15171](https://issues.redhat.com//browse/OSDOCS-15171)

Link to docs preview:
[4.15.54](https://95739--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-54_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 7/9/25.

