### PR TITLE
Add `hypershiftPluginImageFqin` in unsupportedOverrides section

### DIFF
--- a/modules/dataprotectionapplicationspec-type.adoc
+++ b/modules/dataprotectionapplicationspec-type.adoc
@@ -23,7 +23,7 @@ The following are `DataProtectionApplicationSpec` {oadp-short} APIs:
 
 |`unsupportedOverrides`
 |map [ link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#UnsupportedImageKey[UnsupportedImageKey] ]  link:https://pkg.go.dev/builtin#string[string]
-|Can be used to override the deployed dependent images for development. Options are `veleroImageFqin`, `awsPluginImageFqin`, `openshiftPluginImageFqin`, `azurePluginImageFqin`, `gcpPluginImageFqin`, `csiPluginImageFqin`, `dataMoverImageFqin`, `resticRestoreImageFqin`, `kubevirtPluginImageFqin`, and `operator-type`.
+|Can be used to override the deployed dependent images for development. Options are `veleroImageFqin`, `awsPluginImageFqin`, `hypershiftPluginImageFqin`, `openshiftPluginImageFqin`, `azurePluginImageFqin`, `gcpPluginImageFqin`, `csiPluginImageFqin`, `dataMoverImageFqin`, `resticRestoreImageFqin`, `kubevirtPluginImageFqin`, and `operator-type`.
 
 |`podAnnotations`
 |map [ link:https://pkg.go.dev/builtin#string[string] ] link:https://pkg.go.dev/builtin#string[string]


### PR DESCRIPTION
## Jira 

* [OADP-6295](https://issues.redhat.com/browse/OADP-6295)

Add `hypershiftPluginImageFqin` in the description list in the `unsupportedOverrides` section .

##  Version

* OCP 4.19, 4.20

## Preview

* [unsupportedOverrides section](https://95740--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-api.html#dataprotectionapplicationspec-type_oadp-api)

## QE Review

* [x] QE has approved this change.
