### PR TITLE
OSSM-9913 Update Kiali version in release notes

### DIFF
--- a/modules/ossm-release-notes-3-0-3.adoc
+++ b/modules/ossm-release-notes-3-0-3.adoc
@@ -13,6 +13,8 @@ This release of {SMProductName} is included with the {SMProductName} Operator 3.
 
 * This enhancement updates {istio} to version 1.24.6. For more information, see link:https://issues.redhat.com/browse/OSSM-9758[OSSM-9758]
 
+* This enhancement updates Kiali operator to version 2.4.7.
+
 [id="ossm-bug-fixes-3-0-3_{context}"]
 == Bug fixes
 

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -28,6 +28,10 @@ See the following table for information about {SMProduct} 3.0.3 supported versio
 
 | `IstioCNI` resource
 | 1.24.6 ^[1]^
+
+|Kiali Operator
+|2.4.7
+
 |===
 
 . The `Istio` control plane and `IstioCNI` resources can be upgraded in any order, as long as their version difference is within one minor version.


### PR DESCRIPTION
Change type: Doc update; Update Kiali version in release notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-9913

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: https://95750--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html#ossm-release-3-0-3_ossm-release-notes
https://95750--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-0-3-supported-versions

QE Review: @mkralik3 
Peer Review: @mburke5678 

Additional information:
A change management email will accompany this change to the release notes.