### PR TITLE
TELCODOCS-2357#Update supported number of nodes/clusterinstance per ArgoCD applications to 1000

### DIFF
--- a/modules/telco-core-gitops-operator-and-ztp-plugins.adoc
+++ b/modules/telco-core-gitops-operator-and-ztp-plugins.adoc
@@ -34,7 +34,7 @@ Customer or partner supplied CRs can be provided in a parallel directory to the 
 
 Limits and requirements::
 // Scale results ACM-17868
-* Each ArgoCD application supports up to 800 nodes.
+* Each ArgoCD application supports up to 1000 nodes.
 Multiple ArgoCD applications can be used to achieve the maximum number of clusters supported by a single hub cluster.
 * The `SiteConfig` CR must use the `extraManifests.searchPaths` field to reference the reference manifests.
 +

--- a/modules/telco-ran-gitops-operator-and-ztp-plugins.adoc
+++ b/modules/telco-ran-gitops-operator-and-ztp-plugins.adoc
@@ -28,7 +28,7 @@ To maintain multiple per-version policies simultaneously, use Git to manage the 
 
 Limits and requirements::
 // Scale results ACM-17868
-* 800 `ClusterInstance` CRs per ArgoCD application.
+* 1000 `ClusterInstance` CRs per ArgoCD application.
 Multiple applications can be used to achieve the maximum number of clusters supported by a single hub cluster
 * Content in the `source-crs/` directory in Git overrides content provided in the ZTP plugin container, as Git takes precedence in the search path.
 * The `source-crs/` directory must be located in the same directory as the `kustomization.yaml` file, which includes `PolicyGenerator` CRs as a generator.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19, 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2357
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://95751--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-core-rds.html#telco-core-gitops-operator-and-ztp-plugins_telco-core
- https://95751--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#telco-ran-gitops-operator-and-ztp-plugins_telco-ran-du

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
