### PR TITLE
OCPBUGS-57776 reordered cli uninstall commands

### DIFF
--- a/modules/zero-trust-manager-uninstall-resources.adoc
+++ b/modules/zero-trust-manager-uninstall-resources.adoc
@@ -18,11 +18,11 @@ After you have uninstalled the {zero-trust-full}, you have the option to delete 
 +
 [source,terminal]
 ----
-$ oc delete SpireServer cluster
-$ oc delete SpireAgent cluster
-$ oc delete SpiffeCSIDriver cluster
-$ oc delete SpireOIDCDiscoveryProvider cluster
 $ oc delete ZeroTrustWorkloadIdentityManager cluster
+$ oc delete SpireOIDCDiscoveryProvider cluster
+$ oc delete SpiffeCSIDriver cluster
+$ oc delete SpireAgent cluster
+$ oc delete SpireServer cluster
 ----
 
 . Delete the Persistent Volume Claim (PVC) and services by running each of the following commands:


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-57776

Link to docs preview:
https://95752--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-uninstall.html


QE review:
- [x] QE has approved this change.


Additional information:

