### PR TITLE
OSDOCS-15178: Clarify admin permissions for labeling ns

### DIFF
--- a/configure/managing-workloads.adoc
+++ b/configure/managing-workloads.adoc
@@ -8,4 +8,5 @@ toc::[]
 
 {product-title} does not directly manipulate jobs that are created by users. Instead, Kueue manages `Workload` objects that represent the resource requirements of a job. {product-title} automatically creates a workload for each job, and syncs any decisions and statuses between the two objects.
 
+include::modules/label-namespaces.adoc[leveloffset=+1]
 include::modules/configuring-labelpolicy.adoc[leveloffset=+1]

--- a/modules/label-namespaces.adoc
+++ b/modules/label-namespaces.adoc
@@ -10,6 +10,12 @@ The {product-title} Operator uses an opt-in webhook mechanism to ensure that pol
 
 You must label the namespaces where you want {product-title} to manage jobs with the `kueue.openshift.io/managed=true` label.
 
+.Prerequisites
+
+* You have cluster administrator permissions.
+* The {product-title} Operator is installed on your cluster, and you have created a `Kueue` custom resource (CR).
+* You have installed the {oc-first}.
+
 .Procedure
 
 * Add the `kueue.openshift.io/managed=true` label to a namespace by running the following command:


### PR DESCRIPTION
Version(s):
- `kueue-docs`
- `kueue-docs-1.0`

Issue:
https://issues.redhat.com/browse/OSDOCS-15178

Link to docs preview:
- https://95758--ocpdocs-pr.netlify.app/openshift-kueue/latest/install/install-kueue.html#label-namespaces_install-kueue
- https://95758--ocpdocs-pr.netlify.app/openshift-kueue/latest/configure/managing-workloads.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
