### PR TITLE
OSDOCS-15190: Updated the name of Egress Lockdown to Egress Zero.

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -1,12 +1,11 @@
-// common attributes
-:product-short-name: OpenShift Dedicated
+// General Service Delivery Attributes attributes
 :toc:
 :toc-title:
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
 :OCP-short: OpenShift
-:ocp-version: 4.14
+:ocp-version: 4.19
 :op-system-first: Red Hat Enterprise Linux CoreOS (RHCOS)
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :cluster-manager-first: Red Hat OpenShift Cluster Manager
@@ -37,7 +36,7 @@
 :es-op: OpenShift Elasticsearch Operator
 :logging-sd: Red Hat OpenShift Logging
 :log-plug: logging Console Plugin
-//
+//Serverless
 :ServerlessProductName: OpenShift Serverless
 :rh-openstack-first: Red Hat OpenStack Platform (RHOSP)
 :rh-openstack: RHOSP
@@ -49,20 +48,17 @@
 //Formerly known as CodeReady Containers and CodeReady Workspaces
 :openshift-local-productname: Red Hat OpenShift Local
 :openshift-dev-spaces-productname: Red Hat OpenShift Dev Spaces
+// ROSA with HCP specific attributes
+:product-title-short: ROSA with HCP
+:dedicated: OpenShift Dedicated
 :hcp: hosted control planes
+:hcp-title-first: Red Hat OpenShift Service on AWS (ROSA) with hosted control planes (HCP)
 :hcp-title: ROSA with HCP
-:hcp-title-first: {product-title} (ROSA) with {hcp} (HCP)
-:rosa-classic: ROSA (classic architecture)
-:rosa-classic-first: {product-title} (ROSA) (classic architecture)
-:egress-lockdown: {hcp-title} clusters with zero egress
-//ROSA CLI variables
-:zero-egress: zero egress
-//unclear whether this is going to be zero egress or egress lockdown
-// ROSA specific
-:rosa-first: Red{nbsp}Hat OpenShift Service on AWS (ROSA) with {hcp} (HCP)
-:rosa-short: ROSA with HCP
-:rosa-classic-first: {product-title} (ROSA) (classic architecture)
-:rosa-classic: Red{nbsp}Hat OpenShift Service on AWS (classic architecture)
+:rosa-classic-title: Red Hat OpenShift Service on AWS (classic architecture)
 :rosa-classic-short: ROSA (classic)
+:rosa-title: Red Hat OpenShift Service on AWS (ROSA) with hosted control planes (HCP)
+:rosa-short: ROSA with HCP
+:egress-zero: egress zero
+:egress-zero-title: {rosa-short} clusters with {egress-zero}
 :classic: {rosa-classic}
 :classic-short: {rosa-classic-short}

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -265,9 +265,8 @@ Topics:
   File: rosa-hcp-creating-cluster-with-aws-kms-key
 - Name: Creating a private cluster on ROSA with HCP
   File: rosa-hcp-aws-private-creating-cluster
-# Note the following title should use the same term as the {zero-egress} parameter does
-- Name: Creating a ROSA with HCP cluster with egress lockdown
-  File: rosa-hcp-egress-lockdown-install
+- Name: Creating ROSA with HCP clusters with egress zero
+  File: rosa-hcp-egress-zero-install
 - Name: Creating a ROSA with HCP cluster that uses direct authentication with an external OIDC identity provider
   File: rosa-hcp-sts-creating-a-cluster-ext-auth
 - Name: Creating ROSA with HCP clusters without a CNI plugin

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -194,9 +194,8 @@ Topics:
   File: rosa-hcp-creating-cluster-with-aws-kms-key
 - Name: Creating a private cluster on ROSA with HCP
   File: rosa-hcp-aws-private-creating-cluster
-# Note the following title should use the same term as the {zero-egress} parameter does
-- Name: Creating a ROSA with HCP cluster with egress lockdown
-  File: rosa-hcp-egress-lockdown-install
+- Name: Creating ROSA with HCP clusters with egress zero
+  File: rosa-hcp-egress-zero-install
 - Name: Creating a ROSA with HCP cluster that uses direct authentication with an external OIDC identity provider
   File: rosa-hcp-sts-creating-a-cluster-ext-auth
 ---

--- a/modules/rosa-hcp-create-network.adoc
+++ b/modules/rosa-hcp-create-network.adoc
@@ -1,11 +1,11 @@
 // Module included in the following assemblies:
 //
 // * rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
-// * rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
+// * rosa_hcp/rosa-hcp-egress-zero-install.adoc
 // * rosa_hcp/rosa-hcp-quickstart-guide.adoc
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
 
-ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :rosa-egress-lockdown:
 endif::[]
 :_mod-docs-content-type: PROCEDURE
@@ -433,6 +433,6 @@ TAGS    kubernetes.io/role/elb  <subnet_id>        subnet  1
 * link:https://github.com/openshift/rosa/blob/master/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml[Default VPC AWS CloudFormation template]
 endif::rosa-egress-lockdown[]
 
-ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :!rosa-egress-lockdown:
 endif::[]

--- a/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
@@ -3,7 +3,7 @@
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
 
 
-ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :egress-lockdown:
 endif::[]
 
@@ -70,6 +70,6 @@ ManagedOpenShift
 
 For more information regarding AWS managed IAM policies for ROSA, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol.html[AWS managed IAM policies for ROSA].
 
-ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :!egress-lockdown:
 endif::[]

--- a/modules/rosa-hcp-set-environment-variables.adoc
+++ b/modules/rosa-hcp-set-environment-variables.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 //
-// * rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
+// * rosa_hcp/rosa-hcp-egress-zero-install.adoc
 
-ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :rosa-egress-lockdown-install:
 endif::[]
 
@@ -66,6 +66,6 @@ ifdef::rosa-egress-lockdown-install[]
 |===
 endif::rosa-egress-lockdown-install[]
 
-ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :!rosa-egress-lockdown-install:
 endif::[]

--- a/modules/rosa-hcp-sts-creating-a-cluster-egress-lockdown-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-egress-lockdown-cli.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// * rosa_hcp/rosa-hcp-disconnected-install.adoc
+// * rosa_hcp/rosa-hcp-egress-zero-install.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-hcp-sts-creating-a-cluster-egress-lockdown-cli_{context}"]
-= Creating a {hcp-title} cluster with egress lockdown using the CLI
+= Creating {egress-zero-title} using the CLI
 
 When using the {product-title} (ROSA) command-line interface (CLI), `rosa`, to create a cluster, you can select the default options to create the cluster quickly.
 
@@ -53,7 +53,7 @@ If you specified custom ARN paths when you created the associated account-wide r
 <3> If your billing account is different from your user account, add this argument and specify the AWS account that is responsible for all billing.
 --
 
-* If you set the environment variables, create a cluster with egress lockdown that has a single, initial machine pool, using a privately available API, and a privately available Ingress by running the following command:
+* If you set the environment variables, create a cluster with {egress-zero} that has a single, initial machine pool, using a privately available API, and a privately available Ingress by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/rosa-hcp-vpc-manual.adoc
+++ b/modules/rosa-hcp-vpc-manual.adoc
@@ -2,7 +2,7 @@
 //
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
 
-ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :rosa-egress-lockdown:
 endif::[]
 
@@ -74,6 +74,6 @@ TAGS    kubernetes.io/role/elb  <subnet_id>        subnet  1
 ----
 endif::rosa-egress-lockdown[]
 
-ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :!rosa-egress-lockdown:
 endif::[]

--- a/modules/rosa-hcp-vpc-terraform.adoc
+++ b/modules/rosa-hcp-vpc-terraform.adoc
@@ -2,7 +2,7 @@
 //
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
 
-ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :rosa-egress-lockdown:
 endif::[]
 
@@ -188,6 +188,6 @@ TAGS    kubernetes.io/role/elb  <subnet_id>        subnet  1
 * link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC example]
 endif::rosa-egress-lockdown[]
 
-ifeval::["{context}" == "rosa-hcp-egress-lockdown-install"]
+ifeval::["{context}" == "rosa-hcp-egress-zero-install"]
 :!rosa-egress-lockdown:
 endif::[]

--- a/rosa_hcp/rosa-hcp-egress-zero-install.adoc
+++ b/rosa_hcp/rosa-hcp-egress-zero-install.adoc
@@ -1,23 +1,23 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="rosa-hcp-egress-lockdown-install"]
-= Creating a {product-title} cluster with egress lockdown
+[id="rosa-hcp-egress-zero-install"]
+= Creating {egress-zero-title}
 include::_attributes/attributes-openshift-dedicated.adoc[]
-:context: rosa-hcp-egress-lockdown-install
+:context: rosa-hcp-egress-zero-install
 toc::[]
 
-Creating a {product-title} (ROSA) cluster with egress lockdown provides a way to enhance your cluster's stability and security by allowing your cluster to use the image registry in the local region if the cluster cannot access the internet. Your cluster first tries to pull the images from Quay, and when they aren't reached, it instead pulls the images from the image registry in the local region. 
+Creating {egress-zero-title} provides a way to enhance your cluster's stability and security by allowing your cluster to use the image registry in the local region if the cluster cannot access the internet. Your cluster first tries to pull the images from Quay, and when they aren't reached, it instead pulls the images from the image registry in the local region. 
 
-All public and private clusters with egress lockdown get their Red{nbsp}Hat container images from an Amazon Elastic Container Registry (ECR) located in the local region of the cluster instead of gathering these images from various endpoints and registries on the internet. ECR provides storage for OpenShift release images as well as Red{nbsp}Hat Operators. All requests for ECR are kept within your AWS network by serving them over a VPC endpoint within your cluster.
+All public and private clusters with {egress-zero} get their Red{nbsp}Hat container images from an Amazon Elastic Container Registry (ECR) located in the local region of the cluster instead of gathering these images from various endpoints and registries on the internet. ECR provides storage for OpenShift release images as well as Red{nbsp}Hat Operators. All requests for ECR are kept within your AWS network by serving them over a VPC endpoint within your cluster.
 
-ROSA clusters with egress lockdown use AWS ECR to provision ROSA with HCP clusters without the need for public internet. Because necessary cluster lifecycle processes occur over AWS private networking, AWS ECR serves as a critical service for core cluster platform images. For more information on AWS ECR, see link:https://aws.amazon.com/ecr/[Amazon Elastic Container Registry].
+{egress-zero-title} use AWS ECR to provision your clusters without the need for public internet. Because necessary cluster lifecycle processes occur over AWS private networking, AWS ECR serves as a critical service for core cluster platform images. For more information on AWS ECR, see link:https://aws.amazon.com/ecr/[Amazon Elastic Container Registry].
 
 You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster.
 
-See xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading {product-title} clusters] to upgrade clusters using egress lockdown. 
+See xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading {product-title} clusters] to upgrade clusters using {egress-zero}. 
 
 [NOTE]
 ====
-Clusters created in restricted network environments may be unable to use certain ROSA features including Red Hat Insights and Telemetry. These clusters may also experience potential failures for workloads that require public access to registries such as `quay.io`. When using clusters installed with egress lockdown, you can also install Red Hat-owned Operators from OperatorHub. For a complete list of Red Hat-owned Operators, see the link:https://catalog.redhat.com/search?searchType=software&target_platforms=Red%20Hat%20OpenShift&deployed_as=Operator&p=1&partnerName=Red%20Hat%2C%20Inc.%7CRed%20Hat[Red{nbsp}Hat Ecosystem Catalog]. Only the default Operator channel is mirrored for any Operator that is installed in egress lockdown.
+Clusters created in restricted network environments may be unable to use certain ROSA features including Red Hat Insights and Telemetry. These clusters may also experience potential failures for workloads that require public access to registries such as `quay.io`. When using clusters installed with {egress-zero}, you can also install Red Hat-owned Operators from OperatorHub. For a complete list of Red Hat-owned Operators, see the link:https://catalog.redhat.com/search?searchType=software&target_platforms=Red%20Hat%20OpenShift&deployed_as=Operator&p=1&partnerName=Red%20Hat%2C%20Inc.%7CRed%20Hat[Red{nbsp}Hat Ecosystem Catalog]. Only the default Operator channel is mirrored for any Operator that is installed with {egress-zero}.
 ====
 
 [discrete]
@@ -62,14 +62,14 @@ A physical connection might exist between machines on the internal network and a
 
 [IMPORTANT]
 ====
-* You can use egress lockdown on all supported versions of {product-title} that use the hosted control plane architecture; however, Red{nbsp}Hat suggests using the latest available z-stream release for each {ocp} version. 
+* You can use {egress-zero} on all supported versions of {product-title} that use the hosted control plane architecture; however, Red{nbsp}Hat suggests using the latest available z-stream release for each {ocp} version. 
 
-* While you may install and upgrade your clusters as you would a regular cluster, due to an upstream issue with how the internal image registry functions in disconnected environments, your cluster that uses egress lockdown will not be able to fully use all platform components, such as the image registry. You can restore these features by using the latest ROSA version when upgrading or installing your cluster.
+* While you may install and upgrade your clusters as you would a regular cluster, due to an upstream issue with how the internal image registry functions in disconnected environments, your cluster that uses {egress-zero} will not be able to fully use all platform components, such as the image registry. You can restore these features by using the latest ROSA version when upgrading or installing your cluster.
 ====
 
 include::modules/rosa-hcp-set-environment-variables.adoc[leveloffset=+1]
 
-[id="rosa-hcp-egress-lockdown-install-creating_{context}"]
+[id="rosa-hcp-egress-zero-install-creating_{context}"]
 == Creating a Virtual Private Cloud for your {hcp-title} clusters 
 
 You must have a Virtual Private Cloud (VPC) to create a {hcp-title} cluster. To pull images from the local ECR mirror over your VPC endpoint, you must configure a privatelink service connection and modify the default security groups with specific tags. Use one of the following methods to create a VPC:
@@ -97,7 +97,7 @@ include::snippets/vpc-troubleshooting.adoc[leveloffset=+2]
 * link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-getting-started.html[Get Started with Amazon VPC]
 * link:https://developer.hashicorp.com/terraform[HashiCorp Terraform documentation]
 * link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/deploy/subnet_discovery/[Subnet Auto Discovery]
-* link:https://github.com/openshift-cs/terraform-vpc-example/tree/main/zero-egress[Zero Egress Terraform VPC Example]
+* link:https://github.com/openshift-cs/terraform-vpc-example/tree/main/zero-egress[Egress zero Terraform VPC Example]
 
 include::modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+1]
 

--- a/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
+++ b/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
@@ -37,7 +37,7 @@ The machine that you run the installation process from must have access to the f
 * Amazon Web Services API and authentication service endpoints
 * Red Hat OpenShift API and authentication service endpoints (`api.openshift.com` and `sso.redhat.com`)
 * Internet connectivity to obtain installation artifacts during deployment
-//TODO OSDOCS-13133 update when zero egress is GA: "either during deployment or prior to deploying a cluster with egress lockdown enabled"
+//TODO OSDOCS-13133 update when zero egress is GA: "either during deployment or prior to deploying a cluster with egress zero enabled"
 
 //TODO OSDOCS-11789: This needs to be accessible from parts of the cluster, but not the deploying machine - omit entirely, or leave in place for Classic?
 ifdef::openshift-rosa[]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -103,12 +103,7 @@ ifdef::openshift-rosa[]
 // Removed as part of OSDOCS-13310, until figures are verified.
 //For more information, see xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[Limits and scalability].
 
-* **Egress lockdown is now available as a Technology Preview on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see xref:../rosa_hcp/rosa-hcp-egress-lockdown-install.adoc#rosa-hcp-egress-lockdown-install[Creating a {product-title} cluster with egress lockdown].
-+
-[IMPORTANT]
-====
-Egress lockdown is a Technology Preview feature.
-====
+* **Egress zero is now generally available on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see xref:../rosa_hcp/rosa-hcp-egress-zero-install.adoc#rosa-hcp-egress-zero-install[Creating a {egress-zero-title}].
 
 // * **{product-title} SDN network plugin blocks future major upgrades**
 * **Initiate live migration from OpenShift SDN to OVN-Kubernetes.**
@@ -124,12 +119,7 @@ endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
 * **ROSA with HCP now creates independent security groups for the AWS PrivateLink endpoint and worker nodes.** {hcp-title} clusters version 4.17.2 and greater can now add additional AWS security groups to the AWS PrivateLink endpoint to allow additional ingress traffic to the cluster's API. For more information, see xref:../rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc#rosa-hcp-aws-private-security-groups_rosa-hcp-aws-private-creating-cluster[Adding additional AWS security groups to the AWS PrivateLink endpoint].
 
-* **Egress lockdown is now available as a Technology Preview on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see xref:../rosa_hcp/rosa-hcp-egress-lockdown-install.adoc#rosa-hcp-egress-lockdown-install[Creating a {product-title} cluster with egress lockdown].
-+
---
-:FeatureName: Egress lockdown
-include::snippets/technology-preview.adoc[]
---
+* **Egress zero is now generally available on {product-title} clusters.** You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster. For more information, see xref:../rosa_hcp/rosa-hcp-egress-zero-install.adoc#rosa-hcp-egress-zero-install[Creating a {egress-zero-title}].
 endif::openshift-rosa-hcp[]
 
 //The following omits all earlier updates from HCP builds, right down to Known Issues; unclear if we want this long term or if it's a stop-gap while we split the HCP docs
@@ -313,10 +303,10 @@ endif::openshift-rosa[]
 
 // These notes need to be duplicated until the ROSA with HCP split out is completed.
 ifdef::openshift-rosa[]
-* While egress lockdown works across all supported versions of ROSA, Red Hat suggests you upgrade your cluster or build a cluster to the latest z-stream for your {ocp}. Due to an upstream issue with the internal image registry functionality in disconnected environments, you may experience issues with various {ocp} components within your cluster until you upgrade your version of HCP to the latest z-stream. If you are using older z-stream ROSA clusters with the egress lockdown feature, you must include a public route to the internet from your cluster. See link:https://issues.redhat.com/browse/OCPBUGS-44314[OCPBUGS-44314] for further details.
+* While {egress-zero} works across all supported versions of ROSA, Red Hat suggests you upgrade your cluster or build a cluster to the latest z-stream for your {ocp}. Due to an upstream issue with the internal image registry functionality in disconnected environments, you may experience issues with various {ocp} components within your cluster until you upgrade your version of HCP to the latest z-stream. If you are using older z-stream ROSA clusters with the {egress-zero} feature, you must include a public route to the internet from your cluster. See link:https://issues.redhat.com/browse/OCPBUGS-44314[OCPBUGS-44314] for further details.
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
-* While egress lockdown works across all supported versions of ROSA, Red Hat suggests you upgrade your cluster or build a cluster to the latest z-stream for your {ocp}. Due to an upstream issue with the internal image registry functionality in disconnected environments, you may experience issues with various {ocp} components within your cluster until you upgrade your version of HCP to the latest z-stream. If you are using older z-stream ROSA clusters with the egress lockdown feature, you must include a public route to the internet from your cluster. See link:https://issues.redhat.com/browse/OCPBUGS-44314[OCPBUGS-44314] for further details.
+* While {egress-zero} works across all supported versions of ROSA, Red Hat suggests you upgrade your cluster or build a cluster to the latest z-stream for your {ocp}. Due to an upstream issue with the internal image registry functionality in disconnected environments, you may experience issues with various {ocp} components within your cluster until you upgrade your version of HCP to the latest z-stream. If you are using older z-stream ROSA clusters with the {egress-zero} feature, you must include a public route to the internet from your cluster. See link:https://issues.redhat.com/browse/OCPBUGS-44314[OCPBUGS-44314] for further details.
 endif::openshift-rosa-hcp[]
 
 * {OCP} 4.14 introduced an updated HAProxy image from 2.2 to 2.6. This update created a change in behavior enforcing strict RFC 7230 compliance, rejecting requests with multiple `Transfer-Encoding` headers. This may cause exposed pods in {product-title} 4.14 clusters sending multiple `Transfer-Encoding` headers to respond with a `502 Bad Gateway` or `400 Bad Request error`. To avoid this issue, ensure that your applications are not sending multiple `Transfer-Encoding` headers. For more information, see link:https://access.redhat.com/solutions/7055002[Red Hat Knowledgebase article]. (link:https://issues.redhat.com/browse/OCPBUGS-43095[*OCPBUGS-43095*])

--- a/snippets/vpc-troubleshooting.adoc
+++ b/snippets/vpc-troubleshooting.adoc
@@ -1,7 +1,7 @@
 // Snippet included in the following assemblies:
 //
 // * rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
-// * rosa_hcp/rosa-hcp-egress-lockdown-install.adoc
+// * rosa_hcp/rosa-hcp-egress-zero-install.adoc
 // * rosa_hcp/rosa-hcp-quickstart-guide.adoc
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
 


### PR DESCRIPTION
Version(s):
`enterprise-4.19+`

Issue:
**[OSDOCS-15190](https://issues.redhat.com/browse/OSDOCS-15190)**

Link to docs preview:
- [Prerequisites checklist for deploying ROSA with HCP](https://95762--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-cloud-expert-prereq-checklist.html)
- [ROSA release notes](https://95762--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html)
- [ROSA with HCP with egress zero](https://95762--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-egress-zero-install)
    - [Module for egress zero](https://95762--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-egress-zero-install#rosa-hcp-sts-creating-a-cluster-egress-lockdown-cli_rosa-hcp-egress-lockdown-install)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR updates the name of Egress Lockdown to Egress Zero. I also updated the attribute sheet to prepare for #95488 