### PR TITLE
Update installing-aws-load-balancer-operator-cli.adoc

### DIFF
--- a/modules/installing-aws-load-balancer-operator-cli.adoc
+++ b/modules/installing-aws-load-balancer-operator-cli.adoc
@@ -95,8 +95,8 @@ $ oc apply -f subscription.yaml
 [source,terminal]
 ----
 $ oc -n aws-load-balancer-operator \
-    get subscription aws-load-balancer-operator \
-    --template='{{.status.installplan.name}}{{"\n"}}'
+  get subscription aws-load-balancer-operator \
+  --template='{{.status.installplan.name}}{{"\n"}}'
 ----
 
 . Check the status of the install plan:
@@ -104,8 +104,8 @@ $ oc -n aws-load-balancer-operator \
 [source,terminal]
 ----
 $ oc -n aws-load-balancer-operator \
-    get ip <install_plan_name> \
-    --template='{{.status.phase}}{{"\n"}}'
+  get ip <install_plan_name> \
+  --template='{{.status.phase}}{{"\n"}}'
 ----
 +
 The output must be `Complete`. 


### PR DESCRIPTION
Verification

1. Get the name of the install plan from the subscription:
~~~
$ oc -n aws-load-balancer-operator \
    get subscription aws-load-balancer-operator \
    --template='{{.status.installplan.name}}{{"\n"}}'  
~~~

2. Check the status of the install plan:
~~~
$ oc -n aws-load-balancer-operator \
    get ip <install_plan_name> \
    --template='{{.status.phase}}{{"\n"}}' 
~~~

The above commands are not structured properly.
We can use the above command as well, and it will execute perfectly. But it's structure is not as per our standard procedure. Hence it needs to be changed.
Here is the updated look:

Verification

1. Get the name of the install plan from the subscription:
~~~
$ oc -n aws-load-balancer-operator \
  get subscription aws-load-balancer-operator \
  --template='{{.status.installplan.name}}{{"\n"}}'  
~~~

2. Check the status of the install plan:
~~~
$ oc -n aws-load-balancer-operator \
  get ip <install_plan_name> \
  --template='{{.status.phase}}{{"\n"}}'
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.20, RHOCP 4.19, RHOCP 4.18, RHOCP 4.17, RHOCP 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-15192

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://95763--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/aws_load_balancer_operator/install-aws-load-balancer-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
