### PR TITLE
CNV# 64080 - Documentation suggests annotating auto-memory-limits-ratio replace $

### DIFF
--- a/modules/virt-setting-resource-quota-limits-for-vms.adoc
+++ b/modules/virt-setting-resource-quota-limits-for-vms.adoc
@@ -12,7 +12,7 @@ You can customize the memory limit ratio for a specific namespace by adding the 
 
 [source,terminal]
 ----
-oc label ns/my-virtualization-project  alpha.kubevirt.io/auto-memory-limits-ratio=1.2
+$ oc label ns/my-virtualization-project  alpha.kubevirt.io/auto-memory-limits-ratio=1.2
 ----
 
 [WARNING]


### PR DESCRIPTION
When cherrypicking https://github.com/openshift/openshift-docs/pull/95589, I noticed I missed having the PR author replace the $ that was accidentally removed. This PR replaces the $.