### PR TITLE
TELCODOCS-2379: Fix typo

### DIFF
--- a/modules/kmm-building-and-signing-a-kmod-image.adoc
+++ b/modules/kmm-building-and-signing-a-kmod-image.adoc
@@ -33,7 +33,7 @@ metadata:
   name: example-module-dockerfile
   namespace: <namespace> <1>
 data:
-  Dockerfile: |
+  dockerfile: |
     ARG DTK_AUTO
     ARG KERNEL_VERSION
     FROM ${DTK_AUTO} as builder

--- a/modules/kmm-building-in-cluster.adoc
+++ b/modules/kmm-building-in-cluster.adoc
@@ -10,7 +10,7 @@
 KMM can build kmod images in the cluster. Follow these guidelines:
 
 * Provide build instructions using the `build` section of a kernel mapping.
-* Copy the `Dockerfile` for your container image into a `ConfigMap` resource, under the `dockerfile` key.
+* Copy the Dockerfile for your container image into a `ConfigMap` resource, under the `dockerfile` key.
 * Ensure that the `ConfigMap` is located in the same namespace as the `Module`.
 
 KMM checks if the image name specified in the `containerImage` field exists. If it does, the build is skipped.

--- a/modules/kmm-using-driver-toolkit.adoc
+++ b/modules/kmm-using-driver-toolkit.adoc
@@ -12,7 +12,7 @@ It contains tools and libraries for the OpenShift version currently running in t
 
 .Procedure
 
-Use DTK as the first stage of a multi-stage `Dockerfile`.
+Use DTK as the first stage of a multi-stage Dockerfile.
 
 . Build the kernel modules.
 

--- a/modules/kmm-using-signing-with-kmm.adoc
+++ b/modules/kmm-using-signing-with-kmm.adoc
@@ -14,4 +14,4 @@ For more details on using Secure Boot, see link:https://access.redhat.com/docume
 
 * A public private key pair in the correct (DER) format.
 * At least one secure-boot enabled node with the public key enrolled in its MOK database.
-* Either a pre-built driver container image, or the source code and `Dockerfile` needed to build one in-cluster.
+* Either a pre-built driver container image, or the source code and Dockerfile needed to build one in-cluster.


### PR DESCRIPTION
BUG: Change `Dockerfile` to `dockerfile`.

Jira: https://issues.redhat.com/browse/TELCODOCS-2379

Version(s): 
openshift-4.20, openshift-4.19.z, openshift-4.19, openshift-4.18.z, openshift-4.18, openshift-4.17.z, openshift-4.17, openshift-4.16.z, openshift-4.15.z, openshift-4.14.z, openshift-4.13.z, openshift-4.12.z  

Preview: 
https://95781--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#about-kmm_kernel-module-management-operator

QE: @cdvultur 