### PR TITLE
OSDOCS#15184: cert-manager release notes

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,6 +12,34 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1-16-1_{context}"]
+== {cert-manager-operator} 1.16.1
+
+Issued: 2025-07-10
+
+The following advisories are available for the {cert-manager-operator} 1.16.1:
+
+* link:https://access.redhat.com/errata/RHBA-2025:10765[RHBA-2025:10765]
+* link:https://access.redhat.com/errata/RHBA-2025:10766[RHBA-2025:10766]
+* link:https://access.redhat.com/errata/RHBA-2025:10785[RHBA-2025:10785]
+
+Version `1.16.1` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.16.5`. For more information, see the link:https://cert-manager.io/docs/releases/release-notes/release-notes-1.16#v1165[cert-manager project release notes for v1.16.5].
+
+[id="cert-manager-operator-1-16-1-bugs_{context}"]
+=== Bug fixes
+
+Previously, {cert-manager-operator} failed to create the `cert-manager-tokenrequest` role due to insufficient RBAC permissions. This resulted in `RoleCreateFailed` errors and a degraded static-resource controller. With this release, the issue is resolved by adding the necessary `serviceaccounts/token` create permission to the  RBAC configuration. As a result, the `cert-manager-tokenrequest` role and role binding are now successfully created, and `RoleCreateFailed` errors no longer appear in the operator logs. link:https://issues.redhat.com/browse/OCPBUGS-56758[(OCPBUGS-56758)]
+
+[id="cert-manager-operator-1-16-1-CVEs_{context}"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-22871[CVE-2025-22871]
+* link:https://access.redhat.com/security/cve/CVE-2025-30204[CVE-2025-30204]
+* link:https://access.redhat.com/security/cve/CVE-2025-22872[CVE-2025-22872]
+* link:https://access.redhat.com/security/cve/CVE-2025-27144[CVE-2025-27144]
+* link:https://access.redhat.com/security/cve/CVE-2025-22870[CVE-2025-22870]
+
+
 [id="cert-manager-operator-release-notes-1-16-0_{context}"]
 == {cert-manager-operator} 1.16.0
 


### PR DESCRIPTION
Version(s): 4.14+

Issue: https://issues.redhat.com/browse/OSDOCS-15184

Link to docs preview:

QE review:
- [x] QE has approved this change.