### PR TITLE
[RHACS] Added upcoming change for 4.9 in rel notes

### DIFF
--- a/modules/understanding-platform-components.adoc
+++ b/modules/understanding-platform-components.adoc
@@ -18,5 +18,5 @@ You can view the platform components definition in the {product-title-short} por
 The **Platform components configuration** section lists platform components in the following categories:
 
 * **Core system components**: These components are part of the core {ocp} and Kubernetes namespaces. {product-title-short} includes them in the platform definition by default. You cannot customize these definitions. These definitions might change when you upgrade the system.
-* **Red{nbsp}Hat layered products**: Components found in Red{nbsp}Hat layered and partner product namespaces are included in the platform definition by default. You must update the definition if you install Red{nbsp}Hat products, including {product-title-short}, into a non-default namespace.
+* **Red{nbsp}Hat layered products**: Components found in Red{nbsp}Hat layered and partner product namespaces are included in the platform definition by default. Ensure that you update the definition if you install Red{nbsp}Hat products, including {product-title-short}, into a non-default namespace.
 * **Custom components**: You can extend the platform definition by defining namespaces for additional applications and products. You can use it to classify other namespaces as **Platform**, such as third-party applications, to exclude them from the focused **User workloads** views.

--- a/release_notes/48-release-notes.adoc
+++ b/release_notes/48-release-notes.adoc
@@ -365,4 +365,12 @@ As a result, the Scanner V4 now accurately identifies critical CVEs in Java work
 This lack of feedback occurred because the button only reset the form for unpersisted changes.
 This update introduces an **Edit** button to initiate editing, making the **Save** and **Cancel** buttons visible and enabled only when you make changes.
 
+[id="upcoming-changes_49"]
+== Upcoming admission controller enforcement changes in version 4.9.0
+
+{product-title-short} 4.9 streamlines the admission controller configuration by consolidating the existing `listen` and `enforce` settings into a single **Enforcement** option. You can select the following settings for the **Enforcement** option for create, update, and scale events:
+
+* `Yes` to enable enforcement for events.
+* `No` to disable enforcement for events.
+
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Based off a Slack discussions, 
* add a note related to an upcoming change in the next version. 
* soften the language around updating definitions for platform components.


Cherry-pick in `rhacs-docs-4.8`