### PR TITLE
OLS-1908: Add the BYOK content to the docs

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -28,6 +28,8 @@ include::modules/ols-about-lightspeed-and-role-based-access-control.adoc[levelof
 include::modules/ols-granting-access-to-individual-users.adoc[leveloffset=+2]
 include::modules/ols-granting-access-to-user-group.adoc[leveloffset=+2]
 include::modules/ols-filtering-and-redacting-information.adoc[leveloffset=+1]
+include::modules/ols-about-the-byo-knowledge-tool.adoc[leveloffset=+1]
+include::modules/ols-providing-custom-knowledge-to-the-llm.adoc[leveloffset=+2]
 include::modules/ols-about-cluster-interaction.adoc[leveloffset=+1]
 include::modules/ols-enabling-cluster-interaction.adoc[leveloffset=+2]
 include::modules/ols-tokens-and-token-quota-limits.adoc[leveloffset=+1]

--- a/modules/ols-providing-custom-knowledge-to-the-llm.adoc
+++ b/modules/ols-providing-custom-knowledge-to-the-llm.adoc
@@ -18,7 +18,9 @@ include::snippets/technology-preview.adoc[]
 
 * You have configured the LLM provider.
 
-* The custom information you want to add resides as a collection of Markdown files. No other file format is supported.
+* The custom information you want to add resides as a collection of Markdown files with `.md` extensions. No other file format is supported.
+
+*  You have logged in to `registry.redhat.io` by using Podman.
 
 * You have an account for a container image registry, such as `quay.io`.
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-1908
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://95810--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#about-the-byo-knowledge-tool_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
