### PR TITLE
CNV-49429: Adding a network interface can be live migrated, not just restarted

### DIFF
--- a/modules/virt-vm-creating-nic-web.adoc
+++ b/modules/virt-vm-creating-nic-web.adoc
@@ -21,4 +21,4 @@ You can configure a network interface for a virtual machine (VM) by using the {p
 . Click *Add network interface*.
 . Enter the interface name and select the network attachment definition from the *Network* list.
 . Click *Save*.
-. Restart the VM to apply the changes.
+. Restart or live migrate the VM to apply the changes.


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-49429

CNV 4.16+
OCP 4.16+

Preview:
https://95835--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-accessing-vm-ssh.html#virt-vm-creating-nic-web_virt-accessing-vm-ssh
https://95835--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge.html#virt-vm-creating-nic-web_virt-connecting-vm-to-linux-bridge