### PR TITLE
OSDOCS-14094: Applied changes to Preparing your Environment

### DIFF
--- a/modules/mos-network-prereqs-min-bandwidth.adoc
+++ b/modules/mos-network-prereqs-min-bandwidth.adoc
@@ -7,6 +7,13 @@
 [id="mos-network-prereqs-min-bandwidth_{context}"]
 = Minimum bandwidth
 
-During cluster deployment, {product-title} requires a minimum bandwidth of 120{nbsp}Mbps between cluster infrastructure and the public internet or private network locations that provide deployment artifacts and resources. When network connectivity is slower than 120{nbsp}Mbps (for example, when connecting through a proxy) the cluster installation process times out and deployment fails.
+During cluster deployment, 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+requires a minimum bandwidth of 120{nbsp}Mbps between cluster infrastructure and the public internet or private network locations that provide deployment artifacts and resources. When network connectivity is slower than 120{nbsp}Mbps (for example, when connecting through a proxy) the cluster installation process times out and deployment fails.
 
 After cluster deployment, network requirements are determined by your workload. However, a minimum bandwidth of 120{nbsp}Mbps helps to ensure timely cluster and operator upgrades.

--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -7,7 +7,7 @@
 :_mod-docs-content-type: PROCEDURE
 ifdef::openshift-rosa[]
 [id="rosa-classic-firewall-prerequisites_{context}"]
-= Firewall prerequisites for ROSA (classic architecture) clusters using STS
+= Firewall prerequisites for {rosa-classic-short} clusters using STS
 endif::openshift-rosa[]
 ifdef::openshift-dedicated[]
 [id="osd-aws-privatelink-firewall-prerequisites_{context}"]

--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -6,7 +6,14 @@
 [id="rosa-aws-policy-provisioned_{context}"]
 = Provisioned AWS Infrastructure
 
-This is an overview of the provisioned {AWS} components on a deployed {product-title} (ROSA) cluster.
+This is an overview of the provisioned {AWS} components on a deployed 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+cluster.
 
 [id="rosa-ec2-instances_{context}"]
 == EC2 instances
@@ -15,7 +22,12 @@ AWS EC2 instances are required to deploy
 ifndef::openshift-rosa-hcp[]
 the control plane and data plane functions for
 endif::openshift-rosa-hcp[]
-{product-title}.
+ifdef::openshift-rosa[]
+{rosa-classic-short}.
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}.
+endif::openshift-rosa-hcp[]
 
 ifndef::openshift-rosa-hcp[]
 Instance types can vary for control plane and infrastructure nodes, depending on the worker node count.
@@ -201,4 +213,11 @@ can add additional custom security groups during cluster creation. Custom securi
 
 * You must create the custom security groups in AWS before you create the cluster. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html[Amazon EC2 security groups for Linux instances].
 * You must associate the custom security groups with the VPC that the cluster will be installed into. Your custom security groups cannot be associated with another VPC.
-* You might need to request additional quota for your VPC if you are adding additional custom security groups. For information on AWS quota requirements for ROSA, see _Required AWS service quotas_ in _Prepare your environment_. For information on requesting an AWS quota increase, see link:https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html[Requesting a quota increase].
+* You might need to request additional quota for your VPC if you are adding additional custom security groups. For information on AWS quota requirements for 
+ifdef::openshift-rosa[]
+{rosa-classic-short}, 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}, 
+endif::openshift-rosa-hcp[]
+see _Required AWS service quotas_ in _Prepare your environment_. For information on requesting an AWS quota increase, see link:https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html[Requesting a quota increase].

--- a/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc
@@ -11,16 +11,16 @@ endif::[]
 [id="rosa-sts-creating-account-wide-sts-roles-and-policies_{context}"]
 = Creating the account-wide STS roles and policies
 
-Before you create your {hcp-title-first} cluster, you must create the required account-wide roles and policies.
+Before you create your {rosa-short} cluster, you must create the required account-wide roles and policies.
 
 [NOTE]
 ====
-Specific AWS-managed policies for {hcp-title} must be attached to each role. Customer-managed policies must not be used with these required account roles. For more information regarding AWS-managed policies for {hcp-title} clusters, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol-account-policies.html[AWS managed policies for ROSA].
+Specific AWS-managed policies for {rosa-short} must be attached to each role. Customer-managed policies must not be used with these required account roles. For more information regarding AWS-managed policies for {rosa-short} clusters, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/security-iam-awsmanpol-account-policies.html[AWS managed policies for ROSA].
 ====
 
 .Prerequisites
 
-* You have completed the AWS prerequisites for {hcp-title}.
+* You have completed the AWS prerequisites for {rosa-short}.
 * You have available AWS service quotas.
 * You have enabled the ROSA service in the AWS Console.
 * You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.

--- a/modules/rosa-hcp-firewall-prerequisites.adoc
+++ b/modules/rosa-hcp-firewall-prerequisites.adoc
@@ -6,9 +6,9 @@
 //TODO OSDOCS-11789: Why is this a procedure and not a reference?
 
 [id="rosa-hcp-firewall-prerequisites_{context}"]
-= Firewall prerequisites for {hcp-title}
+= Firewall prerequisites for {rosa-short}
 
-* If you are using a firewall to control egress traffic from {hcp-title-first}, your Virtual Private Cloud (VPC) must be able to complete requests from the cluster to the Amazon S3 service, for example, via an Amazon S3 gateway.
+* If you are using a firewall to control egress traffic from {rosa-short}, your Virtual Private Cloud (VPC) must be able to complete requests from the cluster to the Amazon S3 service, for example, via an Amazon S3 gateway.
 
 * You must also configure your firewall to grant access to the following domain and port combinations.
 //TODO OSDOCS-11789: From your deploy machine? From your cluster?

--- a/modules/rosa-operator-config.adoc
+++ b/modules/rosa-operator-config.adoc
@@ -1,18 +1,23 @@
 
 // Module included in the following assemblies:
 //
+// * rosa_hcp/rosa-hcp-cluster-no-cni.adoc
+// * rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
+// * rosa_hcp/rosa-hcp-quickstart-guide.adoc
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+// * rosa_hcp/rosa-hcp-egress-zero-install.adoc
+// * rosa_planning/rosa-hcp-prepare-iam-roles-resources.adoc
 
 :_content-type: PROCEDURE
 [id="rosa-operator-config_{context}"]
 = Creating Operator roles and policies
 
-When you deploy a {hcp-title} cluster, you must create the Operator IAM roles that are required for {hcp-title-first} deployments. The cluster Operators use the Operator roles and policies to obtain the temporary permissions required to carry out cluster operations, such as managing back-end storage and external access to a cluster.
+When you deploy a {rosa-short} cluster, you must create the Operator IAM roles. The cluster Operators use the Operator roles and policies to obtain the temporary permissions required to carry out cluster operations, such as managing back-end storage and external access to a cluster.
 
 .Prerequisites
 
-* You have completed the AWS prerequisites for {hcp-title}.
-* You have installed and configured the latest {product-title} ROSA CLI (`rosa`), on your installation host.
+* You have completed the AWS prerequisites for {rosa-short}.
+* You have installed and configured the latest ROSA CLI (`rosa`), on your installation host.
 * You created the account-wide AWS roles.
 
 .Procedure
@@ -36,11 +41,11 @@ $ rosa create operator-roles --hosted-cp
 +
 --
 <1> You must supply a prefix when creating these Operator roles. Failing to do so produces an error. See the Additional resources of this section for information on the Operator prefix.
-<2> This value is the OIDC configuration ID that you created for your {hcp-title} cluster.
+<2> This value is the OIDC configuration ID that you created for your {rosa-short} cluster.
 <3> This value is the installer role ARN that you created when you created the ROSA account roles.
 --
 +
-You must include the `--hosted-cp` parameter to create the correct roles for {hcp-title} clusters. This command returns the following information.
+You must include the `--hosted-cp` parameter to create the correct roles for {rosa-short} clusters. This command returns the following information.
 +
 .Example output
 +
@@ -69,10 +74,10 @@ I: To create a cluster with these roles, run the following command:
 +
 --
 <1> This field is prepopulated with the prefix that you set in the initial creation command.
-<2> This field requires you to select an OIDC configuration that you created for your {hcp-title} cluster.
+<2> This field requires you to select an OIDC configuration that you created for your {rosa-short} cluster.
 --
 +
-The Operator roles are now created and ready to use for creating your {hcp-title} cluster.
+The Operator roles are now created and ready to use for creating your {rosa-short} cluster.
 
 .Verification
 

--- a/modules/rosa-planning-environment-application-reqs.adoc
+++ b/modules/rosa-planning-environment-application-reqs.adoc
@@ -4,7 +4,14 @@
 [id="planning-environment-application-requirements_{context}"]
 = Planning your environment based on application requirements
 
-This document describes how to plan your {product-title} environment based on your application requirements.
+This document describes how to plan your 
+ifdef::openshift-rosa[]
+{rosa-classic-short}
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}
+endif::openshift-rosa-hcp[]
+environment based on your application requirements.
 
 Consider an example application environment:
 

--- a/modules/rosa-prereq-roles-overview.adoc
+++ b/modules/rosa-prereq-roles-overview.adoc
@@ -1,12 +1,28 @@
 // Module included in the following assemblies:
-// * rosa_planning/rosa-hcp-prepare-iam-resources.adoc
+// * rosa_planning/rosa-sts-ocm-role.adoc
+// * rosa_planning/rosa-hcp-prepare-iam-roles-resources.adoc
+
 :_mod-docs-content-type: MODULE
 [id="rosa-prereq-roles-overview"]
 = Overview of required roles
 
-To create and manage your {product-title} cluster, you must create several account-wide and cluster-wide roles. If you intend to use {cluster-manager} to create or manage your cluster, you need some additional roles.
+To create and manage your 
+ifdef::openshift-rosa[]
+{rosa-classic-short}
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}
+endif::openshift-rosa-hcp[]
+cluster, you must create several account-wide and cluster-wide roles. If you intend to use {cluster-manager} to create or manage your cluster, you need some additional roles.
 
-To create and manage clusters:: Several account-wide roles are required to create and manage ROSA clusters. These roles only need to be created once per AWS account, and do not need to be created fresh for each cluster. One or more AWS managed policies are attached to each role to grant that role the required capabilities. You can specify your own prefix, or use the default prefix (`ManagedOpenShift`).
+To create and manage clusters:: Several account-wide roles are required to create and manage 
+ifdef::openshift-rosa[]
+{rosa-classic-short}
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}
+endif::openshift-rosa-hcp[]
+clusters. These roles only need to be created once per AWS account, and do not need to be created fresh for each cluster. One or more AWS managed policies are attached to each role to grant that role the required capabilities. You can specify your own prefix, or use the default prefix (`ManagedOpenShift`).
 +
 [NOTE]
 ====
@@ -52,7 +68,7 @@ Role creation does not request your AWS access or secret keys. AWS Security Toke
 To use Operator-managed cluster capabilities:: Some cluster capabilities, including several capabilities provided by default, are managed using Operators. Cluster-specific Operator roles (`operator-roles` in the ROSA CLI) are required to use these capabilities. These roles are used to obtain the temporary permissions required to carry out cluster operations such as managing back-end storage, ingress, and registry. Obtaining these permissions requires the configuration of an OpenID Connect (OIDC) provider, which connects to AWS Security Token Service (STS) to authenticate Operator access to AWS resources.
 ifndef::openshift-rosa-hcp[]
 +
-The following Operator roles are required for {product-title} clusters:
+The following Operator roles are required for {rosa-classic-short} clusters:
 
 ** `openshift-cluster-csi-drivers-ebs-cloud-credentials`
 ** `openshift-cloud-network-config-controller-cloud-credentials`
@@ -65,7 +81,7 @@ The following Operator roles are required for {product-title} clusters:
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa-hcp[]
 +
-For {hcp-title} clusters, you must create the following Operator roles and attach the indicated AWS Managed policies:
+For {rosa-short} clusters, you must create the following Operator roles and attach the indicated AWS Managed policies:
 +
 .Required Operator roles and AWS Managed policies for {hcp-title}
 [options="header"]
@@ -100,7 +116,6 @@ For {hcp-title} clusters, you must create the following Operator roles and attac
 +
 endif::openshift-rosa-hcp[]
 When you create Operator roles using the `rosa create operator-role` command, the roles created are named using the pattern `<cluster_name>-<hash>-<role_name>`, for example, `test-abc1-kube-system-control-plane-operator`. When your cluster name is longer than 15 characters, the role name is truncated.
-
 
 To use {cluster-manager}:: The web user interface, {cluster-manager}, requires you to create additional roles in your AWS account to create a trust relationship between that AWS account and the {cluster-manager}.
 +

--- a/modules/rosa-required-aws-service-quotas.adoc
+++ b/modules/rosa-required-aws-service-quotas.adoc
@@ -6,7 +6,14 @@
 [id="rosa-required-aws-service-quotas_{context}"]
 = Required AWS service quotas
 
-The table below describes the AWS service quotas and levels required to create and run one {product-title} cluster. Although most default values are suitable for most workloads, you might need to request additional quota for the following cases:
+The table below describes the AWS service quotas and levels required to create and run one 
+ifdef::openshift-rosa[]
+{rosa-classic-short}
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}
+endif::openshift-rosa-hcp[]
+cluster. Although most default values are suitable for most workloads, you might need to request additional quota for the following cases:
 
 * ROSA clusters require a minimum AWS EC2 service quota of
 ifndef::openshift-rosa-hcp[]

--- a/modules/rosa-requirements-deploying-in-opt-in-regions.adoc
+++ b/modules/rosa-requirements-deploying-in-opt-in-regions.adoc
@@ -5,7 +5,14 @@
 [id="rosa-requirements-deploying-in-opt-in-regions_{context}"]
 = Requirements for deploying a cluster in an opt-in region
 
-An AWS opt-in region is a region that is not enabled in your AWS account by default. If you want to deploy a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS) in an opt-in region, you must meet the following requirements:
+An AWS opt-in region is a region that is not enabled in your AWS account by default. If you want to deploy a 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+cluster that uses the AWS Security Token Service (STS) in an opt-in region, you must meet the following requirements:
 
 * The region must be enabled in your AWS account. For more information about enabling opt-in regions, see link:https://docs.aws.amazon.com/general/latest/gr/rande-manage.html[Managing AWS Regions] in the AWS documentation.
 * The security token version in your AWS account must be set to version 2. You cannot use version 1 security tokens for opt-in regions.

--- a/modules/rosa-setting-the-aws-security-token-version.adoc
+++ b/modules/rosa-setting-the-aws-security-token-version.adoc
@@ -6,7 +6,14 @@
 [id="rosa-setting-the-aws-security-token-version_{context}"]
 = Setting the AWS security token version
 
-If you want to create a {product-title} (ROSA) cluster with the AWS Security Token Service (STS) in an AWS opt-in region, you must set the security token version to version 2 in your AWS account.
+If you want to create a 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+cluster with the AWS Security Token Service (STS) in an AWS opt-in region, you must set the security token version to version 2 in your AWS account.
 
 .Prerequisites
 

--- a/modules/rosa-sts-about-ocm-role.adoc
+++ b/modules/rosa-sts-about-ocm-role.adoc
@@ -5,7 +5,7 @@
 [id="rosa-sts-about-ocm-role_{context}"]
 = About the ocm-role IAM resource
 
-You must create the `ocm-role` IAM resource to enable a Red{nbsp}Hat organization of users to create {product-title} (ROSA) clusters. Within the context of linking to AWS, a Red{nbsp}Hat organization is a single user within {cluster-manager}.
+You must create the `ocm-role` IAM resource to enable a Red{nbsp}Hat organization of users to create {rosa-classic-short} clusters. Within the context of linking to AWS, a Red{nbsp}Hat organization is a single user within {cluster-manager}.
 
 Some considerations for your `ocm-role` IAM resource are:
 

--- a/modules/rosa-sts-associating-your-aws-account.adoc
+++ b/modules/rosa-sts-associating-your-aws-account.adoc
@@ -21,19 +21,19 @@ ifeval::["{context}" == "rosa-sts-creating-a-cluster-quickly"]
 endif::[]
 
 Before using {cluster-manager-first} on the {hybrid-console-url} to create
-ifdef::rosa-hcp[]
-{hcp-title} clusters
-endif::rosa-hcp[]
-ifndef::rosa-hcp[]
-{product-title} (ROSA) clusters
-endif::rosa-hcp[]
-that use the AWS Security Token Service (STS), create an {cluster-manager} IAM role and link it to your Red{nbsp}Hat organization. Then, create a user IAM role and link it to your Red{nbsp}Hat user account in the same Red{nbsp}Hat organization.
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+clusters that use the AWS Security Token Service (STS), create an {cluster-manager} IAM role and link it to your Red{nbsp}Hat organization. Then, create a user IAM role and link it to your Red{nbsp}Hat user account in the same Red{nbsp}Hat organization.
 
 ifdef::quick-install[]
 .Prerequisites
 
 ifdef::rosa-hcp[]
-* You have completed the AWS prerequisites for {hcp-title}.
+* You have completed the AWS prerequisites for {rosa-short}.
 endif::rosa-hcp[]
 ifndef::rosa-hcp[]
 * You have completed the AWS prerequisites for ROSA with STS.
@@ -46,7 +46,7 @@ endif::rosa-hcp[]
 ====
 To successfully install
 ifdef::rosa-hcp[]
-{hcp-title}
+{rosa-short}
 endif::rosa-hcp[]
 ifndef::rosa-hcp[]
 ROSA
@@ -65,7 +65,7 @@ endif::[]
 ====
 To enable automatic deployment of the cluster-specific Operator roles and the OpenID Connect (OIDC) provider using the {cluster-manager} {hybrid-console-second}, you must apply the administrative privileges to the role by choosing the _Admin OCM role_ command in the *Accounts and roles* step of creating a
 ifdef::rosa-hcp[]
-{hcp-title}
+{rosa-short}
 endif::rosa-hcp[]
 ifndef::rosa-hcp[]
 ROSA
@@ -77,14 +77,14 @@ cluster. For more information about the basic and administrative privileges for 
 ====
 If you choose the _Basic OCM role_ command in the *Accounts and roles* step of creating a
 ifdef::rosa-hcp[]
-{hcp-title}
+{rosa-short}
 endif::rosa-hcp[]
 ifndef::rosa-hcp[]
 ROSA
 endif::rosa-hcp[]
 cluster in the {cluster-manager} {hybrid-console-second}, you must deploy a
 ifdef::rosa-hcp[]
-{hcp-title}
+{rosa-short}
 endif::rosa-hcp[]
 ifndef::rosa-hcp[]
 ROSA

--- a/modules/rosa-sts-aws-requirements-association-concept.adoc
+++ b/modules/rosa-sts-aws-requirements-association-concept.adoc
@@ -6,6 +6,13 @@
 [id="rosa-associating-concept_{context}"]
 = AWS account association
 
-When you provision {product-title} (ROSA) using {cluster-manager} (`console.redhat.com`), you must associate the `ocm-role` and `user-role` IAM roles with your AWS account using your Amazon Resource Name (ARN). This association process is also known as _account linking_.
+When you provision 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+using {cluster-manager} (`console.redhat.com`), you must associate the `ocm-role` and `user-role` IAM roles with your AWS account using your Amazon Resource Name (ARN). This association process is also known as _account linking_.
 
 The `ocm-role` ARN is stored as a label in your Red{nbsp}Hat organization while the `user-role` ARN is stored as a label inside your Red{nbsp}Hat user account. Red{nbsp}Hat uses these ARN labels to confirm that the user is a valid account holder and that the correct permissions are available to perform provisioning tasks in the AWS account.

--- a/modules/rosa-sts-aws-requirements-attaching-boundary-policy.adoc
+++ b/modules/rosa-sts-aws-requirements-attaching-boundary-policy.adoc
@@ -1,7 +1,9 @@
 // Module included in the following assemblies:
 //
-// * rosa_planning/rosa-sts-ocm-role.adoc
 // * rosa_architecture/rosa-sts-about-iam-resources.adoc
+// * rosa_planning/rosa-hcp-iam-resources.adoc
+// * rosa_planning/rosa-sts-ocm-role.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-sts-aws-requirements-attaching-boundary-policy_{context}"]
 = Permission boundaries for the installer role
@@ -11,15 +13,22 @@ You can use an AWS-managed policy or a customer-managed policy to set the bounda
 
 [NOTE]
 ====
-This feature is only supported on Red{nbsp}Hat OpenShift Service on AWS (classic architecture) clusters.
+This feature is only supported on {rosa-classic-short} clusters.
 ====
 
 The permission boundary policy files are as follows:
 
-* The _Core_ boundary policy file contains the minimum permissions needed for ROSA (classic architecture) installer to install an {product-title} cluster.
+* The _Core_ boundary policy file contains the minimum permissions needed for ROSA installer to install an 
+ifdef::openshift-rosa[]
+{rosa-classic-short}
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}
+endif::openshift-rosa-hcp[]
+cluster.
 The installer does not have permissions to create a virtual private cloud (VPC) or PrivateLink (PL). A VPC needs to be provided.
-* The _VPC_ boundary policy file contains the minimum permissions needed for ROSA (classic architecture) installer to create/manage the VPC. It does not include permissions for PL or core installation. If you need to install a cluster with enough permissions for the installer to install the cluster and create/manage the VPC, but you do not need to set up PL, then use the core and VPC boundary files together with the installer role.
-* The _PrivateLink (PL)_ boundary policy file contains the minimum permissions needed for ROSA (classic architecture) installer to create the AWS PL with a cluster. It does not include permissions for VPC or core installation. Provide a pre-created VPC for all PL clusters during installation.
+* The _VPC_ boundary policy file contains the minimum permissions needed for ROSA installer to create/manage the VPC. It does not include permissions for PL or core installation. If you need to install a cluster with enough permissions for the installer to install the cluster and create/manage the VPC, but you do not need to set up PL, then use the core and VPC boundary files together with the installer role.
+* The _PrivateLink (PL)_ boundary policy file contains the minimum permissions needed for ROSA installer to create the AWS PL with a cluster. It does not include permissions for VPC or core installation. Provide a pre-created VPC for all PL clusters during installation.
 
 When using the permission boundary policy files, the following combinations apply:
 
@@ -35,7 +44,14 @@ When using the permission boundary policy files, the following combinations appl
 ** You must have a customer-provided VPC.
 ** This is for a private cluster with PL.
 
-This example procedure is applicable for an installer role and policy with the most restriction of permissions, using only the _core_ installer permission boundary policy for ROSA. You can complete this with the AWS console or the AWS CLI. This example uses the AWS CLI and the following policy:
+This example procedure is applicable for an installer role and policy with the most restriction of permissions, using only the _core_ installer permission boundary policy for
+ifdef::openshift-rosa[]
+{rosa-classic-short}.
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}.
+endif::openshift-rosa-hcp[] 
+You can complete this with the AWS console or the AWS CLI. This example uses the AWS CLI and the following policy:
 
 .`sts_installer_core_permission_boundary_policy.json`
 [%collapsible]

--- a/modules/rosa-sts-aws-requirements-creating-association.adoc
+++ b/modules/rosa-sts-aws-requirements-creating-association.adoc
@@ -8,7 +8,7 @@
 [id="rosa-associating-account_{context}"]
 = Associating your AWS account with IAM roles
 
-You can associate or link your AWS account with existing IAM roles by using the {product-title} (ROSA) CLI, `rosa`.
+You can associate or link your AWS account with existing IAM roles by using the ROSA CLI, `rosa`.
 
 .Prerequisites
 

--- a/modules/rosa-sts-aws-requirements-creating-multi-association.adoc
+++ b/modules/rosa-sts-aws-requirements-creating-multi-association.adoc
@@ -7,7 +7,14 @@
 [id="rosa-associating-multiple-account_{context}"]
 = Associating multiple AWS accounts with your Red{nbsp}Hat organization
 
-You can associate multiple AWS accounts with your Red{nbsp}Hat organization. Associating multiple accounts lets you create {product-title} (ROSA) clusters on any of the associated AWS accounts from your Red{nbsp}Hat organization.
+You can associate multiple AWS accounts with your Red{nbsp}Hat organization. Associating multiple accounts lets you create 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+clusters on any of the associated AWS accounts from your Red{nbsp}Hat organization.
 
 With this capability, you can create clusters on different AWS profiles according to characteristics that make sense for your business, for example, by using one AWS profile for each region to create region-bound environments.
 
@@ -17,7 +24,13 @@ With this capability, you can create clusters on different AWS profiles accordin
 * You are using {cluster-manager-url} to create clusters.
 * You have the permissions required to install AWS account-wide roles.
 * You have installed and configured the latest AWS (`aws`) and ROSA (`rosa`) CLIs on your installation host.
-* You have created the `ocm-role` and `user-role` IAM roles for ROSA.
+* You have created the `ocm-role` and `user-role` IAM roles for 
+ifdef::openshift-rosa[]
+{rosa-classic-short}.
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}.
+endif::openshift-rosa-hcp[]
 
 .Procedure
 

--- a/modules/rosa-sts-aws-requirements-security-req.adoc
+++ b/modules/rosa-sts-aws-requirements-security-req.adoc
@@ -7,4 +7,7 @@
 = Security requirements
 //TODO OSDOCS-11789: Red Hat as in RHSRE? Red Hat as in RH services in the cluster?
 * Red{nbsp}Hat must have ingress access to EC2 hosts and the API server from allow-listed IP addresses.
-* Red{nbsp}Hat must have egress allowed to the domains documented in the "Firewall prerequisites" section. Clusters with {zero-egress} are exempt from this requirement.
+* Red{nbsp}Hat must have egress allowed to the domains documented in the "Firewall prerequisites" section. 
+ifdef::openshift-rosa-hcp[]
+Clusters with {egress-zero} are exempt from this requirement.
+endif::openshift-rosa-hcp[]

--- a/modules/rosa-sts-aws-requirements-support-req.adoc
+++ b/modules/rosa-sts-aws-requirements-support-req.adoc
@@ -7,4 +7,11 @@
 * Red{nbsp}Hat recommends that the customer have at least link:https://aws.amazon.com/premiumsupport/plans/[Business Support] from AWS.
 * Red{nbsp}Hat may have permission from the customer to request AWS support on their behalf.
 * Red{nbsp}Hat may have permission from the customer to request AWS resource limit increases on the customer's account.
-* Red{nbsp}Hat manages the restrictions, limitations, expectations, and defaults for all {product-title} clusters in the same manner, unless otherwise specified in this requirements section.
+* Red{nbsp}Hat manages the restrictions, limitations, expectations, and defaults for all 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+clusters in the same manner, unless otherwise specified in this requirements section.

--- a/modules/rosa-sts-byo-oidc.adoc
+++ b/modules/rosa-sts-byo-oidc.adoc
@@ -13,22 +13,22 @@
 
 When using a
 ifdef::openshift-rosa-hcp[]
-{hcp-title} cluster, you must
+{rosa-short}
 endif::openshift-rosa-hcp[]
 ifndef::openshift-rosa-hcp[]
-{product-title} cluster, you can
+{rosa-classic-short}
 endif::openshift-rosa-hcp[]
-create the OpenID Connect (OIDC) configuration prior to creating your cluster. This configuration is registered to be used with OpenShift Cluster Manager.
+cluster, you can create the OpenID Connect (OIDC) configuration prior to creating your cluster. This configuration is registered to be used with OpenShift Cluster Manager.
 
 .Prerequisites
 
 ifdef::openshift-rosa-hcp[]
-* You have completed the AWS prerequisites for {hcp-title}.
+* You have completed the AWS prerequisites for {rosa-short}.
 endif::openshift-rosa-hcp[]
 ifndef::openshift-rosa-hcp[]
-* You have completed the AWS prerequisites for {product-title}.
+* You have completed the AWS prerequisites for {rosa-classic-short}.
 endif::openshift-rosa-hcp[]
-* You have installed and configured the latest {product-title} (ROSA) CLI, `rosa`, on your installation host.
+* You have installed and configured the latest ROSA CLI, `rosa`, on your installation host.
 
 .Procedure
 

--- a/modules/rosa-sts-ocm-role-creation.adoc
+++ b/modules/rosa-sts-ocm-role-creation.adoc
@@ -14,7 +14,7 @@ You create your `ocm-role` IAM roles by using the command-line interface (CLI).
 * You have an AWS account.
 * You have Red{nbsp}Hat Organization Administrator privileges in the {cluster-manager} organization.
 * You have the permissions required to install AWS account-wide roles.
-* You have installed and configured the latest {product-title} (ROSA) CLI, `rosa`, on your installation host.
+* You have installed and configured the latest ROSA CLI, `rosa`, on your installation host.
 
 .Procedure
 * To create an ocm-role IAM role with basic privileges, run the following command:

--- a/modules/rosa-sts-operator-roles.adoc
+++ b/modules/rosa-sts-operator-roles.adoc
@@ -14,7 +14,7 @@ ifdef::openshift-rosa[]
 The Operator policies are tagged with the Operator and version they are compatible with. The correct policy for an Operator role is determined by using the tags.
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
-AWS managed Operator policies are versioned in AWS IAM. The latest version of an AWS managed policy is always used, so you do not need to manage or schedule upgrades for AWS managed policies used by {hcp-title}.
+AWS managed Operator policies are versioned in AWS IAM. The latest version of an AWS managed policy is always used, so you do not need to manage or schedule upgrades for AWS managed policies used by {rosa-short}.
 endif::openshift-rosa-hcp[]
 
 [NOTE]
@@ -55,7 +55,7 @@ ifdef::openshift-rosa[]
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
-.Required Operator roles and AWS Managed policies for {hcp-title}
+.Required Operator roles and AWS Managed policies for {rosa-short}
 [options="header"]
 |===
 | Role name | AWS Managed policy name | Role description

--- a/modules/rosa-sts-setting-up-environment.adoc
+++ b/modules/rosa-sts-setting-up-environment.adoc
@@ -6,7 +6,14 @@
 [id="rosa-sts-setting-up-environment_{context}"]
 = Setting up the environment for STS
 
-Before you create a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), complete the following steps to set up your environment.
+Before you create a 
+ifdef::openshift-rosa[]
+{rosa-classic-short}
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}
+endif::openshift-rosa-hcp[]
+cluster that uses the AWS Security Token Service (STS), complete the following steps to set up your environment.
 
 .Prerequisites
 
@@ -151,7 +158,14 @@ To login to your Red Hat account, get an offline access token at https://console
 I: Logged in as '<rh-rosa-user>' on 'https://api.openshift.com'
 ----
 
-. Verify that your AWS account has the necessary quota to deploy a ROSA cluster.
+. Verify that your AWS account has the necessary quota to deploy a 
+ifdef::openshift-rosa[]
+{rosa-classic-short}
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}
+endif::openshift-rosa-hcp[]
+cluster.
 +
 [source,terminal]
 ----

--- a/modules/rosa-sts-user-role-creation.adoc
+++ b/modules/rosa-sts-user-role-creation.adoc
@@ -12,7 +12,7 @@ You can create your `user-role` IAM roles by using the command-line interface (C
 .Prerequisites
 
 * You have an AWS account.
-* You have installed and configured the latest {product-title} (ROSA) CLI, `rosa`, on your installation host.
+* You have installed and configured the latest ROSA CLI, `rosa`, on your installation host.
 
 .Procedure
 * To create a `user-role` IAM role with basic privileges, run the following command:

--- a/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
+++ b/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
@@ -3,10 +3,10 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-cloud-expert-prereq-checklist
 [id="rosa-cloud-expert-prereq-checklist"]
 ifndef::openshift-rosa-hcp[]
-= Prerequisites checklist for deploying ROSA using STS
+= Prerequisites checklist for deploying {rosa-classic-short} using STS
 endif::[]
 ifdef::openshift-rosa-hcp[]
-= Prerequisites checklist for deploying ROSA with HCP
+= Prerequisites checklist for deploying {rosa-short}
 endif::openshift-rosa-hcp[]
 
 toc::[]
@@ -23,13 +23,11 @@ toc::[]
 //  - Diana Sari
 //---
 
-This is a high level checklist of prerequisites needed to create a
+This is a high level checklist of prerequisites needed to create a {product-title} cluster
 ifdef::openshift-rosa[]
-{rosa-classic-first} cluster with link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[STS].
+ with link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html[STS]
 endif::openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{hcp-title-first} cluster.
-endif::openshift-rosa-hcp[]
+.
 
 //TODO OSDOCS-11789: Consider adding the following to a subsection about the initiating/control machine, along with CLI sections?
 The machine that you run the installation process from must have access to the following:
@@ -126,7 +124,14 @@ $ rosa whoami
 
 === OpenShift CLI (`oc`)
 
-The OpenShift CLI (`oc`) is not required to deploy a {product-title} cluster, but is a useful tool for interacting with your cluster after it is deployed.
+The OpenShift CLI (`oc`) is not required to deploy a 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+cluster, but is a useful tool for interacting with your cluster after it is deployed.
 
 . Download and install`oc` from the {cluster-manager} link:https://console.redhat.com/openshift/downloads#tool-oc[Command-line interface (CLI) tools] page, or follow the instructions in xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[Getting started with the OpenShift CLI].
 . Verify that the OpenShift CLI has been installed correctly by running the following command:
@@ -148,20 +153,33 @@ $ rosa verify quota
 +
 This command only checks the total quota allocated to your account; it does not reflect the amount of quota already consumed from that quota. Running this command is optional because your quota is verified during cluster deployment. However, Red Hat recommends running this command to confirm your quota ahead of time so that deployment is not interrupted by issues with quota availability.
 ifdef::openshift-rosa[]
-* For more information about resources provisioned during ROSA cluster deployment, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-aws-policy-provisioned_rosa-sts-aws-prereqs[Provisioned AWS Infrastructure].
+* For more information about resources provisioned during {rosa-classic-short} cluster deployment, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-aws-policy-provisioned_rosa-sts-aws-prereqs[Provisioned AWS Infrastructure].
 * For more information about the required AWS service quotas, see xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[Required AWS service quotas].
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
-* For more information about resources provisioned during ROSA cluster deployment, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-aws-policy-provisioned_rosa-hcp-prereqs[Provisioned AWS Infrastructure].
+* For more information about resources provisioned during {rosa-short} cluster deployment, see xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-aws-policy-provisioned_rosa-hcp-prereqs[Provisioned AWS Infrastructure].
 * For more information about the required AWS service quotas, see xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[Required AWS service quotas].
 endif::openshift-rosa-hcp[]
 
 == Service Control Policy (SCP) prerequisites
 
-ROSA clusters are hosted in an AWS account within an AWS organizational unit. A link:https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html[service control policy (SCP)] is created and applied to the AWS organizational unit that manages what services the AWS sub-accounts are permitted to access.
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+clusters are hosted in an AWS account within an AWS organizational unit. A link:https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html[service control policy (SCP)] is created and applied to the AWS organizational unit that manages what services the AWS sub-accounts are permitted to access.
 
 * Ensure that your organization's SCPs are not more restrictive than the roles and policies required by the cluster. For more information, see the xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-minimum-scp_rosa-sts-about-iam-resources[Minimum set of effective permissions for SCPs].
-* When you create a ROSA cluster, an associated AWS OpenID Connect (OIDC) identity provider is created.
+* When you create a 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+cluster, an associated AWS OpenID Connect (OIDC) identity provider is created.
 
 == Networking prerequisites
 
@@ -182,7 +200,7 @@ endif::openshift-rosa-hcp[]
 
 //Moving up prereqs that are actually required for deployment
 ifdef::openshift-rosa[]
-== VPC requirements for PrivateLink clusters
+=== VPC requirements for PrivateLink clusters
 
 If you choose to deploy a PrivateLink cluster, then be sure to deploy the cluster in the pre-existing BYO VPC:
 
@@ -206,13 +224,13 @@ xref:../networking/configuring-cluster-wide-proxy.adoc#configuring-cluster-wide-
 
 [NOTE]
 ====
-You can install a non-PrivateLink ROSA cluster in a pre-existing BYO VPC.
+You can install a non-PrivateLink {rosa-classic-short} cluster in a pre-existing BYO VPC.
 ====
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
 === Create VPC before cluster deployment
 
-{hcp-title} clusters must be deployed into an existing AWS Virtual Private Cloud (VPC).
+{rosa-short} clusters must be deployed into an existing AWS Virtual Private Cloud (VPC).
 
 include::snippets/rosa-existing-vpc-requirements.adoc[leveloffset=+0]
 
@@ -243,7 +261,14 @@ endif::openshift-rosa-hcp[]
 You can configure a custom domain name server and custom domain name for your cluster. To do so, complete the following prerequisites before you create the cluster:
 
 //TODO OSDOCS-11789: Needs verification from mmcneill
-* By default, ROSA clusters require you to set the `domain name servers` option to `AmazonProvidedDNS` to ensure successful cluster creation and operation.
+* By default, 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+clusters require you to set the `domain name servers` option to `AmazonProvidedDNS` to ensure successful cluster creation and operation.
 * To use a custom DNS server and domain name for your cluster, the ROSA installer must be able to use VPC DNS with default DHCP options so that it can resolve internal IPs and services. This means that you must create a custom DHCP option set to forward DNS lookups to your DNS server, and associate this option set with your VPC before you create the cluster.
 ifdef::openshift-rosa[]
 For more information, see xref:../cloud_experts_tutorials/cloud-experts-custom-dns-resolver.adoc#cloud-experts-custom-dns-resolver[Deploying ROSA with a custom DNS resolver].

--- a/rosa_planning/rosa-hcp-prepare-iam-roles-resources.adoc
+++ b/rosa_planning/rosa-hcp-prepare-iam-roles-resources.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-You must create several role resources on your AWS account in order to create and manage a {product-title} (ROSA) cluster.
+You must create several role resources on your AWS account in order to create and manage a {product-title} cluster.
 
 include::modules/rosa-prereq-roles-overview.adoc[leveloffset=+1]
 
@@ -43,7 +43,7 @@ endif::openshift-rosa-hcp[]
 [id="rosa-prepare-iam-resources-oidc"]
 == Resources required for OIDC authentication
 
-{product-title} clusters use OIDC and the AWS Security Token Service (STS) to authenticate Operator access to AWS resources they require to perform their functions. Each production cluster requires its own OIDC configuration.
+{rosa-short} clusters use OIDC and the AWS Security Token Service (STS) to authenticate Operator access to AWS resources they require to perform their functions. Each production cluster requires its own OIDC configuration.
 
 include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+2]
 

--- a/rosa_planning/rosa-planning-environment.adoc
+++ b/rosa_planning/rosa-planning-environment.adoc
@@ -9,4 +9,3 @@ toc::[]
 
 include::modules/rosa-planning-environment-cluster-max.adoc[leveloffset=+1]
 include::modules/rosa-planning-environment-application-reqs.adoc[leveloffset=+1]
-    

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -4,17 +4,17 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 ifndef::openshift-rosa-hcp[]
 :context: rosa-sts-aws-prereqs
 [id="rosa-sts-aws-prereqs"]
-= Detailed requirements for deploying ROSA (classic architecture) using STS
+= Detailed requirements for deploying {product-title} using STS
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa-hcp[]
 :context: rosa-hcp-prereqs
 [id="rosa-hcp-prereqs"]
-= Detailed requirements for deploying {hcp-title}
+= Detailed requirements for deploying {product-title}
 endif::openshift-rosa-hcp[]
 
 toc::[]
 
-{product-title} (ROSA) provides a model that allows Red{nbsp}Hat to deploy clusters into a customer’s existing Amazon Web Service (AWS) account.
+{product-title} provides a model that allows Red{nbsp}Hat to deploy clusters into a customer’s existing Amazon Web Service (AWS) account.
 
 ifndef::openshift-rosa-hcp[]
 include::snippets/rosa-sts.adoc[leveloffset=+0]
@@ -26,13 +26,13 @@ ifndef::openshift-rosa-hcp[]
 [id="rosa-sts-customer-requirements_{context}"]
 == Customer requirements when using STS for deployment
 
-The following prerequisites must be complete before you deploy a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS).
+The following prerequisites must be complete before you deploy a {rosa-classic-short} cluster that uses the AWS Security Token Service (STS).
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa-hcp[]
 [id="rosa-hcp-customer-requirements_{context}"]
-== Customer requirements for all {hcp-title} clusters
+== Customer requirements for all {rosa-short} clusters
 
-The following prerequisites must be complete before you deploy a {hcp-title} cluster.
+The following prerequisites must be complete before you deploy a {rosa-short} cluster.
 endif::openshift-rosa-hcp[]
 
 include::modules/rosa-sts-aws-requirements-account.adoc[leveloffset=+2]
@@ -81,7 +81,7 @@ ifdef::openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
 [id="additional-resources_creating-association_{context}"]
 == Additional resources
-* See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference] for a list of IAM roles needed for cluster creation.
+* xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference]
 endif::openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/rosa-sts-aws-requirements-creating-multi-association.adoc[leveloffset=+2]
@@ -115,18 +115,26 @@ include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
 
 include::modules/mos-network-prereqs-min-bandwidth.adoc[leveloffset=+2]
 
-// Keeping existing ID to prevent link breakage
-ifdef::openshift-rosa[]
-//[id="osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs"]
-//=== AWS firewall prerequisites
+[id="osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs"]
+=== AWS firewall prerequisites
 
-//If you are using a firewall to control egress traffic from your {product-title}, you must configure your firewall to grant access to the certain domain and port combinations below. {product-title} requires this access to provide a fully managed OpenShift service.
+If you are using a firewall to control egress traffic from your 
+ifdef::openshift-rosa[]
+{rosa-classic-short}, 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short}, 
+endif::openshift-rosa-hcp[]
+you must configure your firewall to grant access to the certain domain and port combinations below. 
+ifdef::openshift-rosa[]
+{rosa-classic-short} 
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+{rosa-short} 
+endif::openshift-rosa-hcp[]
+requires this access to provide a fully managed OpenShift service.
 
 include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
-// TODO HCP SPLIT - remove openshift-rosa from below condition when HCP docs are published
-include::modules/rosa-hcp-firewall-prerequisites.adoc[leveloffset=+2]
-endif::openshift-rosa[]
-
 ifdef::openshift-rosa-hcp[]
 include::modules/rosa-hcp-firewall-prerequisites.adoc[leveloffset=+2]
 endif::openshift-rosa-hcp[]

--- a/rosa_planning/rosa-sts-ocm-role.adoc
+++ b/rosa_planning/rosa-sts-ocm-role.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-You must create several role resources on your AWS account in order to create and manage a {product-title} (ROSA) cluster.
+You must create several role resources on your AWS account in order to create and manage a {product-title} cluster.
 
 include::modules/rosa-prereq-roles-overview.adoc[leveloffset=+1]
 

--- a/rosa_planning/rosa-sts-setting-up-environment.adoc
+++ b/rosa_planning/rosa-sts-setting-up-environment.adoc
@@ -14,22 +14,17 @@ endif::openshift-rosa-hcp[]
 
 toc::[]
 
-After you meet the AWS prerequisites, set up your environment and install {product-title} (ROSA).
+After you meet the AWS prerequisites, set up your environment and install {product-title}.
 
 //For ROSA clusters
 ifndef::openshift-rosa-hcp[]
-
 include::snippets/rosa-sts.adoc[leveloffset=+0]
-
 include::modules/rosa-sts-setting-up-environment.adoc[leveloffset=+1]
-
 endif::openshift-rosa-hcp[]
 
 //For HCP clusters
 ifdef::openshift-rosa-hcp[]
-
 include::modules/rosa-getting-started-install-configure-cli-tools.adoc[leveloffset=+1]
-
 endif::openshift-rosa-hcp[]
 
 [id="next-steps_rosa-sts-setting-up-environment"]

--- a/snippets/rosa-sts.adoc
+++ b/snippets/rosa-sts.adoc
@@ -2,5 +2,5 @@
 
 [TIP]
 ====
-AWS Security Token Service (STS) is the recommended credential mode for installing and interacting with clusters on {product-title} because it provides enhanced security.
+AWS Security Token Service (STS) is the recommended credential mode for installing and interacting with clusters on {rosa-classic-short} because it provides enhanced security.
 ====


### PR DESCRIPTION
Version(s):
`enterprise-4.19+`

Issue:
**[OSDOCS-14094](https://issues.redhat.com/browse/OSDOCS-14094)**

Link to docs preview:
- ROSA (classic) topics:
    - [Prerequisites checklist for deploying ROSA (classic) using STS](https://95850--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-cloud-expert-prereq-checklist)
    - [Detailed requirements for deploying Red Hat OpenShift Service on AWS](https://95850--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html)
    - [ROSA IAM role resources](https://95850--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-ocm-role)
    - [Planning your environment](https://95850--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-planning-environment)
    - [Required AWS service quota](https://95850--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-required-aws-service-quotas)
    - [Setting up your environment](https://95850--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-setting-up-environment#rosa-sts-setting-up-environment_rosa-sts-setting-up-environment)
- ROSA with HCP topics:
     - [Prerequisites checklist for deploying ROSA with HCP](https://95850--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-cloud-expert-prereq-checklist)
     - [Detailed requirements for deploying Red Hat OpenShift Service on AWS](https://95850--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-sts-aws-prereqs.html)
     - [Required IAM roles and resources](https://95850--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-hcp-prepare-iam-roles-resources)
     - [Required AWS service quota](https://95850--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-sts-required-aws-service-quotas)
     - [Setting up your environment](https://95850--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-sts-setting-up-environment)
     - [Planning resource usage in your cluster](https://95850--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-planning-environment)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR applies changes to the Preparing your Environment book.