### PR TITLE
CNV#50733: OCV Operator installation via CLI doesn't include the label `openshift.io/cluster-monitoring: "true"` in the `ns/openshift-cnv`

### DIFF
--- a/modules/virt-subscribing-cli.adoc
+++ b/modules/virt-subscribing-cli.adoc
@@ -26,6 +26,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {CNVNamespace}
+  labels:
+    openshift.io/cluster-monitoring: "true"
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup


### PR DESCRIPTION
Version(s): 4.14+

Issue: [CNV-50733](https://issues.redhat.com/browse/CNV-50733)

Link to docs preview: [Subscribing to the OpenShift Virtualization catalog by using the CLI](https://95865--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/installing-virt.html#virt-subscribing-cli_installing-virt)

QE review:
- [x] QE has approved this change.


