### PR TITLE
[RHACS] Add reference for customizing platform components in 4.8 release notes

### DIFF
--- a/release_notes/48-release-notes.adoc
+++ b/release_notes/48-release-notes.adoc
@@ -119,6 +119,8 @@ For more information, see xref:../operating/build-time-network-policy-tools.adoc
 
 {product-title-short} now allows you to view and modify the definition of platform components using the system menu in the user interface or through the API. Red Hat recommends updating the platform components definition if you install {ocp} Operators into non-default namespaces or if you want {product-title-short} to consider any third-party software as a "Platform component". You can focus on actionable data in the **User Workloads** tabs by customizing this definition.
 
+For more information, see xref:../configuration/customizing-platform-components.adoc#customizing-platform-components[Viewing and customizing platform components].
+
 //ROX-27858
 [id="policy-as-code-ga_{context}"]
 === Policy as code is now generally available


### PR DESCRIPTION
Minor update to add links to the docs for platform components. No review needed.

Cherrypick in `rhacs-docs-4.8`