### PR TITLE
OBSDOCS-2137: Add docinfo.xml to scheduling resources directory

### DIFF
--- a/scheduling_resources/docinfo.xml
+++ b/scheduling_resources/docinfo.xml
@@ -1,0 +1,12 @@
+<title>Scheduling logging resources</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Scheduling log forwarding and LokiStack resources</subtitle>
+<abstract>
+    <para>This document explains how to schedule OpenShift Logging resources using node selectors, taints, and affinity and anti-affinity settings.
+</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
Version(s): 6.0+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2137
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
