### PR TITLE
OSDOCS-14459:adds 4.14.53 relnotes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -713,3 +713,12 @@ Issued: 30 April 2025
 {product-title} release 4.14.51 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4219[RHBA-2025:4219] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:4177[RHSA-2025:4177] advisory.
 
 For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].
+
+[id="microshift-4-14-53-dp_{context}"]
+=== RHBA-2025:9874 - {microshift-short} 4.14.53 bug fix and enhancement advisory
+
+Issued: 2 July 2025
+
+{product-title} release 4.14.53 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:9874[RHBA-2025:9874] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:9759[RHSA-2025:9759] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-14459](https://issues.redhat.com/browse/OSDOCS-14459)

Link to docs preview:
https://95915--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html#microshift-4-14-53-dp_release-notes

QE review:
- N/A stock text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
