### PR TITLE
OBSDOCS-1881 [POWERMON] Update attribute for PM Operator

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -181,7 +181,7 @@ endif::[]
 :PM-title: power monitoring for Red Hat OpenShift
 :PM-shortname: power monitoring
 :PM-shortname-c: Power monitoring
-:PM-operator: Power monitoring Operator
+:PM-operator: Power Monitoring Operator
 :PM-kepler: Kepler
 //serverless
 :ServerlessProductName: OpenShift Serverless


### PR DESCRIPTION
https://issues.redhat.com/browse/OBSDOCS-1881  [POWERMON] Update attribute for PM Operator

Version(s):
4.17+

Issue:
https://issues.redhat.com/browse/OBSDOCS-1881

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required for this PR. This is a style change to bring the Power Monitoring Operator attribute in line with OpenShift Docs style guidelines.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
