### PR TITLE
TELCODOCS-2390: 2.4.1 upgrade

### DIFF
--- a/hardware_enablement/kmm-release-notes.adoc
+++ b/hardware_enablement/kmm-release-notes.adoc
@@ -33,7 +33,7 @@ toc::[]
 == Release notes for Kernel Module Management Operator 2.4
 === New features and enhancements
 // TELCODOCS-2311
-* In this release, you now have the option to configure the Kernel Module Management (KMM) module to not load an out-of-tree kernel driver and use the in-tree driver instead, and run only the device plugin. For more information see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-using-intree-modules_kernel-module-management-operator[Using in-tree modules with the device plugin].
+* In this release, you now have the option to configure the Kernel Module Management (KMM) module to not load an out-of-tree kernel driver and use the in-tree driver instead, and run only the device plugin. For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-using-intree-modules_kernel-module-management-operator[Using in-tree modules with the device plugin].
 
 // TELCODOCS-2304
 * In this release, KMM configurations are now persistent after cluster and KMM Operator upgrades and redeployments of KMM. 
@@ -297,7 +297,7 @@ For more information, see xref:../hardware_enablement/kmm-kernel-module-manageme
 
 === Known issues
 // MGMT-20453 changed security settings in jira
-* The `ModuleUnloaded` event does not appear when a module is `Unloaded``.
+* The `ModuleUnloaded` event does not appear when a module is `Unloaded`.
 
 ** *Cause*:  When a module is `Loaded` (using the create a `ModuleLoad` event) or `Unloaded ` (using the create a `ModuleUnloaded` event) the events might not appear. This happens when you load and unload the kernel module in a quick succession.
 
@@ -307,4 +307,11 @@ For more information, see xref:../hardware_enablement/kmm-kernel-module-manageme
 
 ** *Result:* Not yet available. 
 
+[id="kmm-2-4-1-RN"]
+== Release notes for Kernel Module Management Operator 2.4.1
 
+=== Known issues
+
+// TELCODOCS-2390
+// MGMT-21050
+If you are running KMM-hub version 2.3.0 or earlier and you are not running KMM, the upgrade to KMM-hub 2.4.0 is not reliable. Instead, you must upgrade to KMM-hub 2.4.1. KMM is not affected by this issue. For more information, see link:https://access.redhat.com/errata/RHEA-2025:10778[RHEA-2025:10778 - Product Enhancement Advisory].


### PR DESCRIPTION
[TELCODOCS-2390](https://issues.redhat.com//browse/TELCODOCS-2390): 2.4.1 upgrade
BUG: Addition to KMM Release Notes for KMM 2.4.1 for KMM-hub upgrade.

Version(s):
 openshift-4.20, openshift-4.19 

Issue:
https://issues.redhat.com/browse/TELCODOCS-2390

Link to docs preview:
https://95960--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-release-notes.html#kmm-2-4-1-RN

QE review: @cdvultur 
- [x] QE has approved this change.



