### PR TITLE
OCPBUGS-9216: Removed the reference to the default value for number of pods per core

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -25,9 +25,6 @@ Red Hat does not provide direct guidance on sizing your {product-title} cluster.
 | Number of pods per node
 | 2,500 ^[3]^
 
-| Number of pods per core
-| There is no default value.
-
 | Number of namespaces ^[4]^
 | 10,000
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-59216

Link to docs preview:
https://95972--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

No QE review required for this content removal
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
We decided to remove the entire line to avoid confusion vs. stating that the limit doesn't exist
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
