### PR TITLE
Set ClusterRole for roleRef in unauth webook example

### DIFF
--- a/modules/unauthenticated-users-system-webhook.adoc
+++ b/modules/unauthenticated-users-system-webhook.adoc
@@ -37,7 +37,7 @@ metadata:
   namespace: <namespace> <1>
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: "system:webhook"
 subjects:
   - apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Otherwise my webhooks don't work and I get failure replies to my sent webhooks with messages like:

```
RBAC: role.rbac.authorization.k8s.io \"system:webhook\" not found.
```