### PR TITLE
OSDOCS-12623-update: Added extra parameters to the Ansible migration …

### DIFF
--- a/modules/nw-ovn-kubernetes-ansible-migration.adoc
+++ b/modules/nw-ovn-kubernetes-ansible-migration.adoc
@@ -32,6 +32,8 @@ endif::rollback[]
 * You logged in to the {hybrid-console} and opened the link:https://console.redhat.com/ansible/ansible-dashboard[Ansible Automation Platform] web console.
 * You created a security group rule that allows User Datagram Protocol (UDP) packets on port `6081` for all nodes on all cloud platforms. If you do not do this task, your cluster might fail to schedule pods.
 ifndef::rollback[]
+* Check if your cluster uses static routes or routing policies in the host network. 
+** If true, a later procedure step requires that you set the `routingViaHost` parameter to `true` and the `ipForwarding` parameter to `Global` in the `gatewayConfig` section of the `playbooks/playbook-migration.yml` file.
 * If the OpenShift-SDN plugin uses the `100.64.0.0/16` and `100.88.0.0/16` address ranges, you patched the address ranges. For more information, see "Patching OVN-Kubernetes address ranges" in the _Additional resources_ section.
 endif::rollback[]
 
@@ -109,6 +111,10 @@ ifndef::rollback[]
     migration_egress_ip: false
     migration_egress_firewall: false
     migration_multicast: false
+    migration_routing_via_host: true
+    migration_ip_forwarding: Global 
+    migration_cidr: "10.240.0.0/14"
+    migration_prefix: 23
     migration_mtu: 1400
     migration_geneve_port: 6081
     migration_ipv4_subnet: "100.64.0.0/16"
@@ -117,6 +123,10 @@ ifndef::rollback[]
 +
 `migration_interface_name`:: If you use an `NodeNetworkConfigurationPolicy` (NNCP) resource on a primary interface, specify the interface name in the `migration-playbook.yml` file so that the NNCP resource gets deleted on the primary interface during the migration process.
 `migration_disable_auto_migration`:: Disables the auto-migration of OpenShift SDN CNI plug-in features to the OVN-Kubernetes plugin. If you disable auto-migration of features, you must also set the `migration_egress_ip`, `migration_egress_firewall`, and `migration_multicast` parameters to `false`. If you need to enable auto-migration of features, set the parameter to `false`. 
+`migration_routing_via_host`:: Set to `true` to configure local gateway mode or `false` to configure shared gateway mode for nodes in your cluster. The default value is `false`. In local gateway mode, traffic is routed through the host network stack. In shared gateway mode, traffic is not routed through the host network stack.
+`migration_ip_forwarding`:: If you configured local gateway mode, set IP forwarding to `Global` if you need the host network of the node to act as a router for traffic not related to OVN-Kubernetes.
+`migration_cidr`:: Specifies a Classless Inter-Domain Routing (CIDR) IP address block for your cluster. You cannot use any CIDR block that overlaps the `100.64.0.0/16` CIDR block, because the OVN-Kubernetes network provider uses this block internally. 
+`migration_prefix`:: Ensure that you specify a prefix value, which is the slice of the CIDR block apportioned to each node in your cluster.
 `migration_mtu`:: Optional parameter that sets a specific maximum transmission unit (MTU) to your cluster network after the migration process.
 `migration_geneve_port`:: Optional parameter that sets a Geneve port for OVN-Kubernetes. The default port is `6081`.
 `migration_ipv4_subnet`:: Optional parameter that sets an IPv4 address range for internal use by OVN-Kubernetes. The default value for the parameter is `100.64.0.0/16`.


### PR DESCRIPTION
Version(s):
4.12 to 4.16

Issue:
[OSDOCS-12623](https://issues.redhat.com/browse/OSDOCS-12623)

Link to docs preview:
* [Using an Ansible playbook to migrate to the OVN-Kubernetes network plugin](https://95989--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-ansible-migration-about_migrate-from-openshift-sdn)
* [Using an Ansible playbook to roll back to the OpenShift SDN network plugin](https://95989--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.html#nw-ovn-kubernetes-ansible-rollback_rollback-to-openshift-sdn)

- [X] SME has approved this change [Miheer Salunke].
- [x] QE has approved this change. [Meina Li]
