### PR TITLE
OCPBUGS-48242bis# Small insertion to update output example for 4.16

### DIFF
--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -73,6 +73,7 @@ Usage:
 
 Flags:
       --disable-ht                        Disable Hyperthreading
+      --enable-hardware-tuning            Enable setting maximum cpu frequencies
   -h, --help                              help for performance-profile-creator
       --info string                       Show cluster information; requires --must-gather-dir-path, ignore the other arguments. [Valid values: log, json] (default "log")
       --mcp-name string                   MCP name corresponding to the target machines (required)


### PR DESCRIPTION
OCPBUGS-48242bis:
Related to [95721](https://github.com/openshift/openshift-docs/pull/95721), small insertion to update output example for 4.16. Already merged for 4.17+

Version(s):
4.16

Issue:
[OCPBUGS-48242](https://issues.redhat.com/browse/OCPBUGS-48242)

Link to docs preview:
[Running the Performance Profile Creator using Podman](https://95991--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.html) Step 3

QE review:
- [x] QE has approved this change.

Additional information:
