### PR TITLE
TRACING-5422: Add an example OpenTelemetry Collector CR with filelog receiver that parses OpenShift cluster logs

### DIFF
--- a/observability/otel/otel-collector/otel-collector-receivers.adoc
+++ b/observability/otel/otel-collector/otel-collector-receivers.adoc
@@ -645,6 +645,90 @@ include::snippets/technology-preview.adoc[]
 <1> A list of file glob patterns that match the file paths to be read.
 <2> An array of Operators. Each Operator performs a simple task such as parsing a timestamp or JSON. To process logs into a desired format, chain the Operators together.
 
+.OpenTelemetry Collector custom resource with enabled Filelog Receiver that parses OpenShift cluster logs
+[source,yaml]
+----
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: otel-clusterlogs-collector-scc <1>
+allowPrivilegedContainer: false
+requiredDropCapabilities:
+- ALL
+allowHostDirVolumePlugin: true
+volumes:
+- configMap
+- emptyDir
+- hostPath
+- projected
+- secret
+defaultAllowPrivilegeEscalation: false
+allowPrivilegeEscalation: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+readOnlyRootFilesystem: true
+forbiddenSysctls:
+- '*'
+seccompProfiles:
+- runtime/default
+users:
+- system:serviceaccount:observability:clusterlogs-collector <2>
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: clusterlogs
+  namespace: observability
+spec:
+  mode: daemonset
+  config:
+    receivers:
+      filelog:
+        include:
+        - "/var/log/pods/*/*/*.log"
+        exclude:
+        - "/var/log/pods/*/otc-container/*.log" <3>
+        - "/var/log/pods/*/*/*.gz"
+        - "/var/log/pods/*/*/*.log.*"
+        - "/var/log/pods/*/*/*.tmp"
+        include_file_path: true
+        include_file_name: false
+        operators:
+        - type: container
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          exporters: [debug]
+  securityContext:
+    runAsUser: 0
+    seLinuxOptions:
+      type: spc_t
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
+  volumeMounts:
+  - name: varlogpods
+    mountPath: /var/log/pods
+    readOnly: true
+  volumes:
+  - name: varlogpods
+    hostPath:
+      path: /var/log/pods
+----
+<1> Configure a Security Context Constraint (SCC) to allow accessing files on the host
+<2> Assign the SCC to the collector Service Account (the OpenTelemetry Operator creates this Service Account)
+<3> Exclude logs from the collector container. In this example configuration, the container prints all cluster logs to stdout for demonstration purposes, which would create a loop.
+
 [id="journald-receiver_{context}"]
 == Journald Receiver
 


### PR DESCRIPTION
Version(s):
all supported OCP versions

Issue:
https://issues.redhat.com/browse/TRACING-5422

Link to docs preview:
https://95995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-receivers.html#filelog-receiver_otel-collector-receivers

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

cc @max-cx 