### PR TITLE
OCPBUGS#55692: Node description does not match OpenShift configuration

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -123,11 +123,6 @@ spec:
     - FRR
 ----
 
-|`spec.kubeProxyConfig`
-|`object`
-|
-The fields for this object specify the kube-proxy configuration.
-If you are using the OVN-Kubernetes cluster network plugin, the kube-proxy configuration has no effect.
 |====
 
 [IMPORTANT]

--- a/nodes/index.adoc
+++ b/nodes/index.adoc
@@ -38,11 +38,9 @@ Using the OpenShift CLI (`oc`) or the web console, you can perform the following
 
 The following components of a node are responsible for maintaining the running of pods and providing the Kubernetes runtime environment.
 
-Container runtime:: The container runtime is responsible for running containers. Kubernetes offers several runtimes such as containerd, cri-o, rktlet, and Docker.
+Container runtime:: The container runtime is responsible for running containers. {product-title} deploys the CRI-O container runtime on each of the {op-system-first} nodes in your cluster. The Windows Machine Config Operator (WMCO) deploys the containerd runtime on its Windows nodes. 	 
 
 Kubelet:: Kubelet runs on nodes and reads the container manifests. It ensures that the defined containers have started and are running. The kubelet process maintains the state of work and the node server. Kubelet manages network rules and port forwarding. The kubelet manages containers that are created by Kubernetes only.
-
-Kube-proxy:: Kube-proxy runs on every node in the cluster and maintains the network traffic between the Kubernetes resources. A Kube-proxy ensures that the networking environment is isolated and accessible.
 
 DNS:: Cluster DNS is a DNS server which serves DNS records for Kubernetes services. Containers started by Kubernetes automatically include this DNS server in their DNS searches.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-55692

**MERGE REVIEWER**: Can you PTAL while I try to determine which versions to cherrypick to?  

Previews:
Overview of nodes -> About nodes -> [Container runtime](https://96002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/) -- Updated text.
[Cluster Network Operator configuration object](https://96002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/cluster-network-operator#nw-operator-cr_cluster-network-operator) -> Cluster Network Operator configuration object table -- Removed the `spec.kubeProxyConfig` row (formerly, the final row).

QE review:
- [x] Aditi Sahay has approved this change for Node.
- [x] Zhanqi Zhao has approved this change for Node.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

