### PR TITLE
[enterprise-4.15]OCPBUGS-9216: Removed the reference to the default value for number of pods per core

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -25,9 +25,6 @@ Red Hat does not provide direct guidance on sizing your {product-title} cluster.
 | Number of pods per node
 | 2,500 ^[3][4]^
 
-| Number of pods per core
-| There is no default value.
-
 | Number of namespaces ^[5]^
 | 10,000
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/95972