### PR TITLE
[enterprise-4.15] OSDOCS-15277 [NETOBSERV] Restructure of rel notes for 1.8.1 and 1.8.0 on enterprise-4.15

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3036,7 +3036,7 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
   Topics:
   - Name: Network Observability 1.8.1 release notes
-    File: network-observability-assembly_release-notes-1-8-1.adoc
+    File: network-observability-operator-assembly_release-notes-1-8-1
   - Name: Network Observability release notes
     File: network-observability-operator-release-notes
   - Name: Network Observability overview

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3035,6 +3035,8 @@ Topics:
   Dir: network_observability
   Distros: openshift-enterprise,openshift-origin
   Topics:
+  - Name: Network Observability 1.8.1 release notes
+    File: network-observability-assembly_release-notes-1-8-1.adoc
   - Name: Network Observability release notes
     File: network-observability-operator-release-notes
   - Name: Network Observability overview

--- a/modules/network-observability-ref_release-notes-bug-fix-1-8-1.adoc
+++ b/modules/network-observability-ref_release-notes-bug-fix-1-8-1.adoc
@@ -2,7 +2,7 @@
 // * network_observability/network-observability-assembly_release-notes-1-8-1.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="network-observability-ref_release-notes-bug fix-1-8-1_{context}"]
+[id="network-observability-ref_release-notes-bug-fix-1-8-1_{context}"]
 = Network Observability Operator 1.8.1 bug fix
 
 This release of the Network Observability Operator fixes the following issue:

--- a/modules/network-observability-ref_release-notes-bug-fix-1-8-1.adoc
+++ b/modules/network-observability-ref_release-notes-bug-fix-1-8-1.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-assembly_release-notes-1-8-1.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-ref_release-notes-bug fix-1-8-1_{context}"]
+= Network Observability Operator 1.8.1 bug fix
+
+This release of the Network Observability Operator fixes the following issue:
+
+* This fix ensures that the *Observe* menu appears only once in future versions of {product-title}. (link:https://issues.redhat.com/browse/NETOBSERV-2139[*NETOBSERV-2139*])

--- a/modules/network-observability-ref_release-notes-overview-1-8-1.adoc
+++ b/modules/network-observability-ref_release-notes-overview-1-8-1.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-assembly_release-notes-1-8-1.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-ref_release-notes-overview-1-8-1_{context}"]
+= Network Observability Operator 1.8.1 release notes overview
+
+This release of the Network Observability Operator includes an advisory, CVEs, and a bug fix.
+
+[id="network-observability-advisory-1-8-1_{context}"]
+== Network Observability Operator 1.8.1 advisory
+
+The following advisory is available for the Network Observability Operator 1.8.1:
+
+* link:https://access.redhat.com/errata/RHSA-2025:3867[Network Observability Operator 1.8.1]
+
+[id="network-observability-operator-CVE-1-8-1_{context}"]
+== CVEs
+
+The following CVEs are addressed in this release:
+
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]

--- a/observability/network_observability/network-observability-assembly_release-notes-1-8-1.adoc
+++ b/observability/network_observability/network-observability-assembly_release-notes-1-8-1.adoc
@@ -19,9 +19,10 @@ For an overview of the Network Observability Operator, see xref:../../observabil
 1.8.1 Bug fix
 ////
 
-include::/modules/network-observability-ref_release-notes-overview-1-8-1.adoc[leveloffset=+1]
-include::/modules/network-observability-ref_release-notes-bug-fix-1-8-1.adoc[leveloffset=+2]
+include::modules/network-observability-ref_release-notes-overview-1-8-1.adoc[leveloffset=+1]
+include::modules/network-observability-ref_release-notes-bug-fix-1-8-1.adoc[leveloffset=+2]
 
+////
 [id="network-observability-operator-release-notes-1-8-1_{context}"]
 == Network Observability Operator 1.8.1
 The following advisory is available for the Network Observability Operator 1.8.1:
@@ -36,7 +37,9 @@ The following advisory is available for the Network Observability Operator 1.8.1
 [id="network-observability-operator-1-8-1-bug-fixes_{context}"]
 === Bug fixes
 * This fix ensures that the *Observe* menu appears only once in future versions of {product-title}. (link:https://issues.redhat.com/browse/NETOBSERV-2139[*NETOBSERV-2139*])
+////
 
+////
 [id="network-observability-operator-release-notes-1-8_{context}"]
 == Network Observability Operator 1.8.0
 The following advisory is available for the Network Observability Operator 1.8.0:
@@ -107,3 +110,4 @@ For more information, see xref:../../observability/network_observability/netobse
 * If there is traffic that uses overlapping subnets in your cluster, there is a small risk that the eBPF Agent mixes up the flows from overlapped IPs. This can happen if different connections happen to have the exact same source and destination IPs and if ports and protocol are within a 5 seconds time frame and happening on the same node. This should not be possible unless you configured secondary networks or UDN. Even in that case, it is still very unlikely in usual traffic, as source ports are usually a good differentiator. (link:https://issues.redhat.com/browse/NETOBSERV-2115[*NETOBSERV-2115*])
 
 * After selecting a type of exporter to configure in the `FlowCollector` resource `spec.exporters` section from the {product-title} web console form view, the detailed configuration for that type does not show up in the form. The workaround is to configure directly the YAML. (link:https://issues.redhat.com/browse/NETOBSERV-1981[*NETOBSERV-1981*])
+////

--- a/observability/network_observability/network-observability-assembly_release-notes-1-8-1.adoc
+++ b/observability/network_observability/network-observability-assembly_release-notes-1-8-1.adoc
@@ -1,0 +1,109 @@
+//Network Observability Operator Release Notes
+:_mod-docs-content-type: ASSEMBLY
+[id="network-observability-operator-release-notes"]
+= Network Observability Operator release notes
+:context: network-observability-operator-release-notes-v0
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+The Network Observability Operator enables administrators to observe and analyze network traffic flows for {product-title} clusters.
+
+These release notes track the development of the Network Observability Operator in the {product-title}.
+
+For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#dependency-network-observability[About Network Observability Operator].
+
+//need the following:
+////
+1.8.1 Overview (include Advisory and CVE?)
+1.8.1 Bug fix
+////
+
+include::/modules/network-observability-ref_release-notes-overview-1-8-1.adoc[leveloffset=+1]
+include::/modules/network-observability-ref_release-notes-bug-fix-1-8-1.adoc[leveloffset=+2]
+
+[id="network-observability-operator-release-notes-1-8-1_{context}"]
+== Network Observability Operator 1.8.1
+The following advisory is available for the Network Observability Operator 1.8.1:
+
+* link:https://access.redhat.com/errata/RHSA-2025:3867[Network Observability Operator 1.8.1]
+
+[id="network-observability-operator-CVE-1-8-1_{context}"]
+=== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
+
+[id="network-observability-operator-1-8-1-bug-fixes_{context}"]
+=== Bug fixes
+* This fix ensures that the *Observe* menu appears only once in future versions of {product-title}. (link:https://issues.redhat.com/browse/NETOBSERV-2139[*NETOBSERV-2139*])
+
+[id="network-observability-operator-release-notes-1-8_{context}"]
+== Network Observability Operator 1.8.0
+The following advisory is available for the Network Observability Operator 1.8.0:
+
+* link:https://access.redhat.com/errata/RHEA-2025:1940[Network Observability Operator 1.8.0]
+
+[id="network-observability-operator-1.8.0-features-enhancements_{context}"]
+=== New features and enhancements
+
+[id="network-observability-operator-pkt-xlat-1-8_{context}"]
+==== Packet translation
+You can now enrich network flows with translated endpoint information, showing not only the service but also the specific backend pod, so you can see which pod served a request.
+
+[id="network-observability-cli-1-8_{context}"]
+==== Network Observability CLI
+
+The following new features, options, and filters are added to the Network Observability CLI for this release:
+
+* Capture metrics with filters enabled by running the `oc netobserv metrics` command.
+* Run the CLI in the background by using the `--background` option with flows and packets capture and running `oc netobserv follow` to see the progress of the background run and `oc netobserv copy` to download the generated logs.
+* Enrich flows and metrics capture with Machines, Pods, and Services subnets by using the `--get-subnets` option.
+* New filtering options available with packets, flows, and metrics capture:
+
+** eBPF filters on IPs, Ports, Protocol, Action, TCP Flags and more.
+** Custom nodes using `--node-selector`
+** Drops only using `--drops`
+** Any field using `--regexes`
+
+For more information, see xref:../../observability/network_observability/netobserv_cli/netobserv-cli-reference.adoc#network-observability-netobserv-cli-reference_netobserv-cli-reference[Network Observability CLI reference].
+
+[id="network-observability-operator-1-8-bug-fixes_{context}"]
+=== Bug fixes
+* Previously, the Network Observability Operator came with a "kube-rbac-proxy" container to manage RBAC for its metrics server. Since this external component is deprecated, it was necessary to remove it. It is now replaced with direct TLS and RBAC management through Kubernetes controller-runtime, without the need for a side-car proxy. (link:https://issues.redhat.com/browse/NETOBSERV-1999[*NETOBSERV-1999*])
+
+* Previously in the {product-title} console plugin, filtering on a key that was not equal to multiple values would not filter anything. With this fix, the expected results are returned, which is all flows not having any of the filtered values. (link:https://issues.redhat.com/browse/NETOBSERV-1990[*NETOBSERV-1990*])
+
+* Previously in the {product-title} console plugin with disabled Loki, it was very likely to generate a "Can't build query" error due to selecting an incompatible set of filters and aggregations. Now this error is avoided avoid by automatically disabling incompatible filters while still making the user aware of the filter incompatibility. (link:https://issues.redhat.com/browse/NETOBSERV-1977[*NETOBSERV-1977*])
+
+* Previously, when viewing flow details from the console plugin, the ICMP info was always displayed in the side panel, showing "undefined" values for non-ICMP flows. With this fix, ICMP info is not displayed for non-ICMP flows. (link:https://issues.redhat.com/browse/NETOBSERV-1969[*NETOBSERV-1969*])
+
+* Previously, the "Export data" link from the *Traffic flows* view did not work as intended, generating empty CSV reports. Now, the export feature is restored, generating non-empty CSV data. (link:https://issues.redhat.com/browse/NETOBSERV-1958[*NETOBSERV-1958*])
+
+* Previously, it was possible to configure the `FlowCollector` with `processor.logTypes` `Conversations`, `EndedConversations` or `All` with `loki.enable` set to `false`, despite the conversation logs being only useful when Loki is enabled. This resulted in resource usage waste. Now, this configuration is invalid and is rejected by the validation webhook. (link:https://issues.redhat.com/browse/NETOBSERV-1957[*NETOBSERV-1957*])
+
+* Configuring the `FlowCollector` with `processor.logTypes` set to `All` consumes much more resources, such as CPU, memory and network bandwidth, than the other options. This was previously not documented. It is now documented, and triggers a warning from the validation webhook. (link:https://issues.redhat.com/browse/NETOBSERV-1956[*NETOBSERV-1956*])
+
+* Previously, under high stress, some flows generated by the eBPF agent were mistakenly dismissed, resulting in traffic bandwidth under-estimation. Now, those generated flows are not dismissed. (link:https://issues.redhat.com/browse/NETOBSERV-1954[*NETOBSERV-1954*])
+
+* Previously, when enabling the network policy in the `FlowCollector` configuration, the traffic to the Operator webhooks was blocked, breaking the `FlowMetrics` API validation. Now traffic to the webhooks is allowed. (link:https://issues.redhat.com/browse/NETOBSERV-1934[*NETOBSERV-1934*])
+
+* Previously, when deploying the default network policy, namespaces `openshift-console` and `openshift-monitoring` were set by default in the `additionalNamespaces` field, resulting in duplicated rules. Now there is no additional namespace set by default, which helps avoid getting duplicated rules.(link:https://issues.redhat.com/browse/NETOBSERV-1933[*NETOBSERV-1933*])
+
+* Previously from the {product-title} console plugin, filtering on TCP flags would match flows having only the exact desired flag. Now, any flow having at least the desired flag appears in filtered flows. (link:https://issues.redhat.com/browse/NETOBSERV-1890[*NETOBSERV-1890*])
+
+* When the eBPF agent runs in privileged mode and pods are continuously added or deleted, a file descriptor (FD) leak occurs. The fix ensures proper closure of the FD when a network namespace is deleted. (link:https://issues.redhat.com/browse/NETOBSERV-2063[*NETOBSERV-2063*])
+
+* Previously, the CLI agent `DaemonSet` did not deploy on master nodes. Now, a  toleration is added on the agent `DaemonSet` to schedule on every node when taints are set. Now, CLI agent `DaemonSet` pods run on all nodes. (link:https://issues.redhat.com/browse/NETOBSERV-2030[*NETOBSERV-2030*])
+
+* Previously, the *Source Resource* and *Source Destination* filters autocomplete were not working when using Prometheus storage only. Now this issue is fixed and suggestions displays as expected. (link:https://issues.redhat.com/browse/NETOBSERV-1885[*NETOBSERV-1885*])
+
+* Previously, a resource using multiple IPs was displayed separately in the *Topology* view. Now, the resource shows as a single topology node in the view. (link:https://issues.redhat.com/browse/NETOBSERV-1818[*NETOBSERV-1818*])
+
+* Previously, the console refreshed the *Network traffic* table view contents when the mouse pointer hovered over the columns. Now, the display is fixed, so row height remains constant with a mouse hover. (link:https://issues.redhat.com/browse/NETOBSERV-2049[*NETOBSERV-2049*])
+
+[id="network-observability-operator-1-8-known-issues_{context}"]
+=== Known issues
+
+* If there is traffic that uses overlapping subnets in your cluster, there is a small risk that the eBPF Agent mixes up the flows from overlapped IPs. This can happen if different connections happen to have the exact same source and destination IPs and if ports and protocol are within a 5 seconds time frame and happening on the same node. This should not be possible unless you configured secondary networks or UDN. Even in that case, it is still very unlikely in usual traffic, as source ports are usually a good differentiator. (link:https://issues.redhat.com/browse/NETOBSERV-2115[*NETOBSERV-2115*])
+
+* After selecting a type of exporter to configure in the `FlowCollector` resource `spec.exporters` section from the {product-title} web console form view, the detailed configuration for that type does not show up in the form. The workaround is to configure directly the YAML. (link:https://issues.redhat.com/browse/NETOBSERV-1981[*NETOBSERV-1981*])

--- a/observability/network_observability/network-observability-operator-assembly_release-notes-1-8-1.adoc
+++ b/observability/network_observability/network-observability-operator-assembly_release-notes-1-8-1.adoc
@@ -1,7 +1,7 @@
 //Network Observability Operator Release Notes
 :_mod-docs-content-type: ASSEMBLY
-[id="network-observability-operator-release-notes"]
-= Network Observability Operator release notes
+[id="network-observability-operator-1-8-1-release-notes"]
+= Network Observability Operator 1.8.1 release notes
 :context: network-observability-operator-release-notes-v0
 include::_attributes/common-attributes.adoc[]
 

--- a/observability/network_observability/network-observability-operator-assembly_release-notes-1-8-1.adoc
+++ b/observability/network_observability/network-observability-operator-assembly_release-notes-1-8-1.adoc
@@ -2,7 +2,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-operator-1-8-1-release-notes"]
 = Network Observability Operator 1.8.1 release notes
-:context: network-observability-operator-release-notes-v0
+:context: network-observability-operator-release-notes-v1-8-1
 include::_attributes/common-attributes.adoc[]
 
 toc::[]

--- a/observability/network_observability/network-observability-operator-assembly_release-notes-1-8-1.adoc
+++ b/observability/network_observability/network-observability-operator-assembly_release-notes-1-8-1.adoc
@@ -23,23 +23,6 @@ include::modules/network-observability-ref_release-notes-overview-1-8-1.adoc[lev
 include::modules/network-observability-ref_release-notes-bug-fix-1-8-1.adoc[leveloffset=+2]
 
 ////
-[id="network-observability-operator-release-notes-1-8-1_{context}"]
-== Network Observability Operator 1.8.1
-The following advisory is available for the Network Observability Operator 1.8.1:
-
-* link:https://access.redhat.com/errata/RHSA-2025:3867[Network Observability Operator 1.8.1]
-
-[id="network-observability-operator-CVE-1-8-1_{context}"]
-=== CVEs
-* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
-* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
-
-[id="network-observability-operator-1-8-1-bug-fixes_{context}"]
-=== Bug fixes
-* This fix ensures that the *Observe* menu appears only once in future versions of {product-title}. (link:https://issues.redhat.com/browse/NETOBSERV-2139[*NETOBSERV-2139*])
-////
-
-////
 [id="network-observability-operator-release-notes-1-8_{context}"]
 == Network Observability Operator 1.8.0
 The following advisory is available for the Network Observability Operator 1.8.0:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15277 [OSDOCS-15277](https://issues.redhat.com//browse/OSDOCS-15277) [NETOBSERV] Restructure of rel notes for 1.8.1 and 1.8.0 on enterprise-4.15

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-15277

Link to docs preview:
* 1.8.1 rel notes overview: https://96012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-assembly_release-notes-1-8-1.html#network-observability-ref_release-notes-overview-1-8-1_network-observability-operator-release-notes-v1-8-1
* 1.8.1 rel notes advisory: https://96012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-assembly_release-notes-1-8-1.html#network-observability-advisory-1-8-1_network-observability-operator-release-notes-v1-8-1
* 1.8.1 rel notes CVEs: https://96012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-assembly_release-notes-1-8-1.html#network-observability-operator-CVE-1-8-1_network-observability-operator-release-notes-v1-8-1
* 1.8.1 rel notes bug fix: https://96012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-assembly_release-notes-1-8-1.html#network-observability-ref_release-notes-bug-fix-1-8-1_network-observability-operator-release-notes-v1-8-1

QE review:
QE review is not required for this PR as it is refactoring/restructuring existing content.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
