### PR TITLE
OCPBUGS#38977: Added a limitation for disabling IPv6 OVNK

### DIFF
--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -8,6 +8,8 @@
 
 The OVN-Kubernetes network plugin has the following limitations:
 
+* If you set the `ipv6.disable` parameter to `1` in the `kernelArgument` section of the `MachineConfig` custom resource (CR) for your cluster, OVN-Kubernetes pods enter a `CrashLoopBackOff` state. Additionally, updating your cluster to a later version of {product-title} fails because the Network Operator is stuck on a `Degraded` state. Red{nbsp}Hat does not support disabling IPv6 adddresses for your cluster so do not set the `ipv6.disable` parameter to `1`.
+
 // The foll limitation is also recorded in the installation section.
 ifndef::microshift[]
 * For clusters configured for dual-stack networking, both IPv4 and IPv6 traffic must use the same network interface as the default gateway.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-38977](https://issues.redhat.com/browse/OCPBUGS-38977)

Link to docs preview:

* [OCP Core](https://96014--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-limitations_about-ovn-kubernetes)
* [ROSA](https://96014--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-limitations_about-ovn-kubernetes)
* [Dedicated](https://96014--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-limitations_about-ovn-kubernetes)
* [MicroShift](https://96014--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-nw-ipv6-config.html#nw-ovn-kubernetes-limitations_microshift-nw-ipv6-config)

- [x] SME has approved this change.
- [x] QE has approved this change.

