### PR TITLE
[enterprise-4.18] OSDOCS-15160 [NETOBSERV] Incorporate reviewer feedback rel notes

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -28,9 +28,7 @@ With this release, xref:../../networking/multiple_networks/understanding-multipl
 
 [id="filter-flowlogs-at-ingestion_{context}"]
 ==== Filter flowlogs at ingestion
-With this release, you can create filters to reduce the number of generated network flows and the resource usage of Network Observability components.
-
-You can configure the following filters:
+With this release, you can create filters to reduce the number of generated network flows and the resource usage of Network Observability components. The following filters can be configured:
 
 * eBPF Agent filters
 * Flowlogs-pipeline filters
@@ -47,20 +45,19 @@ This update brings the following enhancements to Network Observability when IPse
 ==== Network Observability CLI
 The following filtering options are now available for packets, flows, and metrics capture:
 
-* Track IPsec using `--enable_ipsec`
-* Value that determines the ratio of packets being sampled using `--sampling`
-* Filter flows using a custom query using `--query`
-* A comma separated list of interfaces to monitor using `--interfaces`
-* A comma separated list of interfaces to exclude using `--exclude_interfaces`
-* A comma separated list of metric names to generate using `--include_list`
+* Configure the ratio of packets being sampled by using the `--sampling` option.
+* Filter flows using a custom query by using the `--query` option.
+* Specify interfaces to monitor by using the `--interfaces` option.
+* Specify interfaces to exclude by using the `--exclude_interfaces` option.
+* Specify metric names to generate by using the `--include_list` option.
 
 For more information, see xref:../../observability/network_observability/netobserv_cli/netobserv-cli-reference.adoc#network-observability-netobserv-cli-reference_netobserv-cli-reference[Network Observability CLI reference].
 
 [id="notable-technical-changes-1-9_{context}"]
 === Notable technical changes
-* The `NetworkEvents` feature in Network Observability 1.9 has been updated to work with the newer Linux kernel of {product-title} 4.19. This update breaks compatibility with older kernels. As a result, the `NetworkEvents` feature can only be used with {product-title} 4.19. If you are using this feature with Network Observability 1.8 and {product-title} 4.18, consider avoiding a Network Observability upgrade or upgrading Network Observability to 1.9 and {product-title} to 4.19.
+* The `NetworkEvents` feature in Network Observability 1.9 has been updated to work with the newer Linux kernel of {product-title} 4.19. This update breaks compatibility with older kernels. As a result, the `NetworkEvents` feature can only be used with {product-title} 4.19. If you are using this feature with Network Observability 1.8 and {product-title} 4.18, consider avoiding a Network Observability upgrade or upgrade to Network Observability 1.9 and {product-title} to 4.19.
 
-* The `netobserv-reader` `clusterrole` has been renamed to `netobserv-loki-reader`.
+* The `netobserv-reader` cluster role has been renamed to `netobserv-loki-reader`.
 
 * Improved CPU performance of the eBPF agents.
 
@@ -72,9 +69,6 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 [id="ebpf-manager-operator-with-network-observability_{context}"]
 ==== eBPF Manager Operator with Network Observability
-
-:FeatureName: eBPF Manager Operator with Network Observability
-include::snippets/technology-preview.adoc[]
 
 The eBPF Manager Operator reduces the attack surface and ensures compliance, security, and conflict prevention by managing all eBPF programs. Network observability can use the eBPF Manager Operator to load hooks. This eliminates the need to provide the eBPF Agent with privileged mode or additional Linux capabilities like `CAP_BPF` and `CAP_PERFMON`. The eBPF Manager Operator with network observability is only supported on 64-bit AMD architecture.
 
@@ -91,11 +85,11 @@ The eBPF Manager Operator reduces the attack surface and ensures compliance, sec
 
 * Previously, when the Operator checked for available Kubernetes APIs in order to adapt its behavior, if there was a stale API, this resulted in an error that prevented the Operator from starting normally. With this update, the Operator ignores error on unrelated APIs, logs errors on related APIs, and continues to run normally. (link:https://issues.redhat.com/browse/NETOBSERV-2240[*NETOBSERV-2240*])
 
-* Previously, users could not sort flows by *Bytes* or *Packets* in the *Traffic* flows view of the Console plugin. With this update, users can sort flows by *Bytes* and *Packets*.(link:https://issues.redhat.com/browse/NETOBSERV-2239[*NETOBSERV-2239*])
+* Previously, users could not sort flows by *Bytes* or *Packets* in the *Traffic* flows view of the Console plugin. With this update, users can sort flows by *Bytes* and *Packets*. (link:https://issues.redhat.com/browse/NETOBSERV-2239[*NETOBSERV-2239*])
 
 * Previously, when configuring the `FlowCollector` resource with an IPFIX exporter, MAC addresses in the IPFIX flows were truncated to their 2 first bytes. With this update, MAC addresses are fully represented in the IPFIX flows. (link:https://issues.redhat.com/browse/NETOBSERV-2208[*NETOBSERV-2208*])
 
-* Previously, some of the warnings sent from the Operator validation webhook could lack clarity, such as when not mentioning exactly which feature causes the warning, or what needed to be done. With this update, some of these messages have been reviewed and amended to make them more actionable. (link:https://issues.redhat.com/browse/NETOBSERV-2178[*NETOBSERV-2178*])
+* Previously, some of the warnings sent from the Operator validation webhook could lack clarity on what needed to be done. With this update, some of these messages have been reviewed and amended to make them more actionable. (link:https://issues.redhat.com/browse/NETOBSERV-2178[*NETOBSERV-2178*])
 
 * Previously, it was not obvious to figure out there was an issue when referencing a `LokiStack` from the `FlowCollector` resource, such as in case of typing error. With this update, the `FlowCollector` status clearly states that the referenced `LokiStack` is not found in that case. (link:https://issues.redhat.com/browse/NETOBSERV-2174[*NETOBSERV-2174*])
 
@@ -103,13 +97,13 @@ The eBPF Manager Operator reduces the attack surface and ensures compliance, sec
 
 * Previously, the console plugin for Network Observability 1.8.1 and earlier did not work with the {product-title} 4.19 web console, making the *Network Traffic* page inaccessible. With this update, the console plugin is compatible and the *Network Traffic* page is accessible in Network Observability 1.9.0. (link:https://issues.redhat.com/browse/NETOBSERV-2046[*NETOBSERV-2046*])
 
-* Previously, when using conversation tracking (`logTypes: Conversations` or `logTypes: All` in the `FlowCollector` resource), the *Traffic* rates metrics visible in the dashboards were flawed, wrongly showing an out-of-control increase in traffic. Now, the metrics show more accurate traffic rates. However, note that in `Conversations` and `EndedConversations` modes, these metrics are still not 100% accurate as they don't include long-standing connections. This information has been added to the documentation. The default mode `logTypes: Flows`, is recommended to avoid this kind of inaccuracy. (link:https://issues.redhat.com/browse/NETOBSERV-1955[*NETOBSERV-1955*])
+* Previously, when using conversation tracking (`logTypes: Conversations` or `logTypes: All` in the `FlowCollector` resource), the *Traffic* rates metrics visible in the dashboards were flawed, wrongly showing an out-of-control increase in traffic. Now, the metrics show more accurate traffic rates. However, note that in `Conversations` and `EndedConversations` modes, these metrics are still not completely accurate as they do not include long-standing connections. This information has been added to the documentation. The default mode `logTypes: Flows` is recommended to avoid these inaccuracy. (link:https://issues.redhat.com/browse/NETOBSERV-1955[*NETOBSERV-1955*])
 
 [id="network-observability-operator-1-9-known-issues_{context}"]
 === Known issues
 * The user-defined network (UDN) feature displays a configuration issue and a warning when used with {product-title} 4.18, even though it is supported. This warning can be ignored.  (link:https://issues.redhat.com/browse/NETOBSERV-2305[*NETOBSERV-2305*])
 
-* In some rare cases, the eBPF agent is unable to appropriately correlate flows with the involved interfaces when running in privileged modes with several network namespaces. A large part of these issues have been identified and resolved in this release, but some inconsistencies remain, especially with the `ens5` interface. (link:https://issues.redhat.com/browse/NETOBSERV-2287[*NETOBSERV-2287*])
+* In some rare cases, the eBPF agent is unable to appropriately correlate flows with the involved interfaces when running in `privileged` modes with several network namespaces. A large part of these issues have been identified and resolved in this release, but some inconsistencies remain, especially with the `ens5` interface. (link:https://issues.redhat.com/browse/NETOBSERV-2287[*NETOBSERV-2287*])
 
 [id="network-observability-operator-release-notes-1-8-1_{context}"]
 == Network Observability Operator 1.8.1


### PR DESCRIPTION
Cherry-pick: 45219d482b95e63b7fa9e17337d5a3b493ace7da

Original PR: https://github.com/openshift/openshift-docs/pull/95965

Version(s):
4.18


Link to docs preview:
https://96028--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html

QE review:
QE review is not required for this PR.

Additional information:
cherry-pick operation returned "nothing to commit, working tree clean".

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
