### PR TITLE
OSDOCS#13678:Update attributes and comp table in MicroShift v4.20

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -4,7 +4,7 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
-:ocp-version: 4.19
+:ocp-version: 4.20
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :ai-first: artificial intelligence (AI)
 //OpenShift Kubernetes Engine
@@ -14,7 +14,7 @@
 //gitops version for 4.17-4.19
 :gitops-ver: 1.16
 :product-registry: OpenShift image registry
-:product-version: 4.19
+:product-version: 4.20
 :rhel-major: rhel-9
 :rhoai-full: Red{nbsp}Hat OpenShift AI
 :rhoai: RHOAI
@@ -30,6 +30,6 @@
 :op-system-bundle: Red{nbsp}Hat Device Edge
 :ovms: OpenVINO Model Server
 :ov: OVMS
-:rpm-repo-version: rhocp-4.19
+:rpm-repo-version: rhocp-4.20
 :rhde-version: 4
 :VirtProductName: OpenShift Virtualization

--- a/microshift_cli_ref/microshift-usage-oc-kubectl.adoc
+++ b/microshift_cli_ref/microshift-usage-oc-kubectl.adoc
@@ -35,7 +35,7 @@ The additional command `oc new-app`, for example, makes it easier to get new app
 If you installed an earlier version of `oc`, you might not be able use it to complete all of the commands in {microshift-short} {product-version}. If you want the latest features, you must download and install the latest version of `oc` that corresponds with your {microshift-short} version.
 ====
 
-Using new capabilities often requires the latest `oc` binary. A 4.19 server might have additional capabilities that a 4.16 `oc` binary cannot use and a 4.19 `oc` binary might have additional capabilities that are unsupported by a 4.15 server.
+Using new capabilities often requires the latest `oc` binary. A 4.20 server might have additional capabilities that a 4.16 `oc` binary cannot use and a 4.20 `oc` binary might have additional capabilities that are unsupported by a 4.15 server.
 
 .Compatibility Matrix
 

--- a/microshift_networking/microshift_multiple_networks/microshift-cni-multus-using.adoc
+++ b/microshift_networking/microshift_multiple_networks/microshift-cni-multus-using.adoc
@@ -26,4 +26,4 @@ include::modules/microshift-cni-multus-troubleshoot.adoc[leveloffset=+1]
 == Additional resources
 * xref:../../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-cni-multus[About using multiple networks]
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking/multiple-networks#nw-multus-ipam-object_configuring-additional-network[Configuration of IP address assignment for an additional network]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/hardware_networks/configuring-sriov-net-attach#nw-multus-ipam-object_configuring-sriov-net-attach[Configuration of IP address assignment for a network attachment]

--- a/microshift_updating/microshift-update-rpms-manually.adoc
+++ b/microshift_updating/microshift-update-rpms-manually.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Updating {product-title} for non-image-based {op-system-base-full} systems requires updating the RPMs. For patch releases, such as 4.19.1 to 4.19.2, simply update the RPMs. For minor-version release updates, add the step of enabling the update repository using your subscription manager.
+Updating {product-title} for non-image-based {op-system-base-full} systems requires updating the RPMs. For patch releases, such as 4.20.1 to 4.20.2, simply update the RPMs. For minor-version release updates, add the step of enabling the update repository using your subscription manager.
 
 [NOTE]
 ====

--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -37,7 +37,7 @@ groups = []
 
 [[packages]]
 name = "microshift"
-version = "4.19.1" <3>
+version = "4.20.1" <3>
 
 [customizations.services]
 enabled = ["microshift"]
@@ -45,7 +45,7 @@ EOF
 ----
 <1> The name of the TOML file.
 <2> The name of the blueprint.
-<3> Substitute the value for the version you want. For example, insert `4.19.1` to download the {microshift-short} 4.19.1 RPMs.
+<3> Substitute the value for the version you want. For example, insert `4.20.1` to download the {microshift-short} 4.20.1 RPMs.
 
 . Optional. Use the blueprint installed in the `/usr/share/microshift/blueprint` directory that is specific to your platform architecture. See the following example snippet for an explanation of the blueprint sections:
 +

--- a/modules/microshift-embed-microshift-image-offline-deploy.adoc
+++ b/modules/microshift-embed-microshift-image-offline-deploy.adoc
@@ -29,7 +29,7 @@ You can use image builder to create {op-system-ostree} images with embedded {mic
 ----
 $ sudo dnf install -y microshift-release-info-_<release_version>_
 ----
-Replace `_<release_version>_` with the numerical value of the release you are deploying, using the entire version number, such as `4.19.1`.
+Replace `_<release_version>_` with the numerical value of the release you are deploying, using the entire version number, such as `4.20.1`.
 
 .. List the contents of the `/usr/share/microshift/release` directory to verify the presence of the release information files by running the following command:
 +
@@ -55,12 +55,12 @@ If you installed the `microshift-release-info` RPM, proceed to step 4.
 ----
 $ sudo dnf download microshift-release-info-_<release_version>_ # <1>
 ----
-<1> Replace `_<release_version>_` with the numerical value of the release you are deploying, using the entire version number, such as `4.19.1`.
+<1> Replace `_<release_version>_` with the numerical value of the release you are deploying, using the entire version number, such as `4.20.1`.
 +
 .Example RPM output
 [source,terminal,subs="+quotes"]
 ----
-microshift-release-info-4.18.1.-202511101230.p0.g7dc6a00.assembly.4.18.1.el9.noarch.rpm
+microshift-release-info-4.20.1.-202512101230.p0.g7dc6a00.assembly.4.20.1.el9.noarch.rpm
 ----
 
 .. Unpack the RPM package without installing it by running the following command:

--- a/modules/microshift-oc-mirror-creating-imageset-config.adoc
+++ b/modules/microshift-oc-mirror-creating-imageset-config.adoc
@@ -43,10 +43,10 @@ storageConfig:
 mirror:
   platform: # <1>
     channels:
-    - name: stable-4.19
+    - name: stable-4.20
       type: ocp
   operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
     packages:
     - name: serverless-operator
       channels:
@@ -72,7 +72,7 @@ storageConfig: <1>
     skipTLS: false
 mirror:
   operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19 <3>
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20 <3>
     packages:
     - name: amq-broker-rhel8 <4>
       channels:

--- a/modules/microshift-updating-rpms-z.adoc
+++ b/modules/microshift-updating-rpms-z.adoc
@@ -6,7 +6,7 @@
 [id="microshift-applying-patch-updates-rpms_{context}"]
 = Applying patch updates using RPMs
 
-Updating {microshift-short} on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to upgrade from 4.19.1 to 4.19.2.
+Updating {microshift-short} on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to upgrade from 4.20.1 to 4.20.2.
 
 include::snippets/microshift-unsupported-config-warn.adoc[leveloffset=+1]
 

--- a/snippets/microshift-rhde-compatibility-table-snip.adoc
+++ b/snippets/microshift-rhde-compatibility-table-snip.adoc
@@ -7,7 +7,7 @@
 
 .{op-system-bundle} release compatibility matrix
 
-{op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.14 to 4.16 or an update from 4.18 to 4.19 requires a {op-system-base-full} update. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
+{op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.14 to 4.16 or an update from 4.19 to 4.20 requires a {op-system-base-full} update. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
 
 [%header,cols="3",cols="1,1,2"]
 |===
@@ -16,12 +16,16 @@
 ^|*Supported {microshift-short} Version{nbsp}&#8594;{nbsp}Version Updates*
 
 ^|9.6
+^|4.20
+^|4.20.0{nbsp}&#8594;{nbsp}4.20.z
+
+^|9.6
 ^|4.19
-^|4.19.0{nbsp}&#8594;{nbsp}4.19.z
+^|4.19.0{nbsp}&#8594;{nbsp}4.19.z, 4.19{nbsp}&#8594;{nbsp}4.20
 
 ^|9.4
 ^|4.18
-^|4.18.0{nbsp}&#8594;{nbsp}4.18.z, 4.18{nbsp}&#8594;{nbsp}4.19 on {op-system-base} 9.6
+^|4.18.0{nbsp}&#8594;{nbsp}4.18.z, 4.18{nbsp}&#8594;{nbsp}4.20 on {op-system-base} 9.6
 
 ^|9.4
 ^|4.17
@@ -31,11 +35,11 @@
 ^|4.16
 ^|4.16.0{nbsp}&#8594;{nbsp}4.16.z, 4.16{nbsp}&#8594;{nbsp}4.17, 4.16{nbsp}&#8594;{nbsp}4.18
 
-^|9.2, 9.3
+^|9.2
 ^|4.15
 ^|4.15.0{nbsp}&#8594;{nbsp}4.15.z, 4.15{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
 
-^|9.2, 9.3
+^|9.2
 ^|4.14
 ^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.15, 4.14{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
 |===


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-13678](https://issues.redhat.com//browse/OSDOCS-13678)

Link to docs preview:
[Compatibility table](https://96031--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready#get-ready-install-rhde-compatibility-table_microshift-install-get-ready)
[Hardware networks - Additional resources](https://96031--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus-using#microshift-cni-multus-add-network-example-config_microshift-cni-multus-using)
[Configuring and using multiple networks](https://96031--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus-using#additional-resources_microshift-cni-multus-using_microshift-cni-multus-using)
[Applying updates using RPMs](https://96031--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-manually#microshift-applying-patch-updates-rpms_microshift-update-rpms-manually)
[Creating an image set configuration file](https://96031--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift_operators/microshift-operators-oc-mirror#microshift-oc-mirror-creating-imageset-config_microshift-operators-oc-mirror)
[Embedding MicroShift containers for offline deployments](https://96031--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm_ostree/microshift-embed-in-rpm-ostree-offline-use#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use)


Reviews:
- [x] QE has approved this change.
