### PR TITLE
[OSDOCS-15293] Update nw-mutual-tls-auth.adoc

### DIFF
--- a/modules/nw-mutual-tls-auth.adoc
+++ b/modules/nw-mutual-tls-auth.adoc
@@ -30,9 +30,9 @@ If the `clientCA` value specifies an X509v3 certificate revocation list (CRL) di
 [source,terminal]
 ----
 $ oc create configmap \
-   router-ca-certs-default \
-   --from-file=ca-bundle.pem=client-ca.crt \// <1>
-   -n openshift-config
+  router-ca-certs-default \
+  --from-file=ca-bundle.pem=client-ca.crt \// <1>
+  -n openshift-config
 ----
 <1> The config map data key must be `ca-bundle.pem`, and the data value must be a CA certificate in PEM format.
 
@@ -61,9 +61,16 @@ $ oc edit IngressController default -n openshift-ingress-operator
       allowedSubjectPatterns:
       - "^/CN=example.com/ST=NC/C=US/O=Security/OU=OpenShift$"
 ----
+
 . Optional, get the Distinguished Name (DN) for `allowedSubjectPatterns` by entering the following command.
++
 [source,terminal]
 ----
-$ openssl  x509 -in custom-cert.pem  -noout -subject
-subject= /CN=example.com/ST=NC/C=US/O=Security/OU=OpenShift
+$ openssl x509 -in custom-cert.pem -noout -subject
+----
++
+.Example output
+[source,text]
+----
+subject=C=US, ST=NC, O=Security, OU=OpenShift, CN=example.com
 ----


### PR DESCRIPTION
- Wrong command structure in Configuring mutual TLS authentication

Here is the current look:

Procedure

1. In the openshift-config namespace, create a config map from your CA bundle:
~~~
$ oc create configmap \
   router-ca-certs-default \ --from-file=ca-bundle.pem=client-ca.crt \ 1  -n openshift-config 
~~~

4. Optional, get the Distinguished Name (DN) for allowedSubjectPatterns by entering the following command.
~~~
$ openssl  x509 -in custom-cert.pem  -noout -subject
subject= /CN=example.com/ST=NC/C=US/O=Security/OU=OpenShift
~~~

-  The above commands are not structured properly.
- We can use the above command as well, and it will execute perfectly. 
- But its structure is not as per our standard procedure. 
- Hence, it needs to be changed.

Here is the updated look:

1. In the openshift-config namespace, create a config map from your CA bundle:
~~~
$ oc create configmap \
  router-ca-certs-default \
  --from-file=ca-bundle.pem=client-ca.crt \ 1 
  -n openshift-config 
~~~

4. Optional, get the Distinguished Name (DN) for allowedSubjectPatterns by entering the following command.
~~~
$ openssl  x509 -in custom-cert.pem  -noout -subject
  subject= /CN=example.com/ST=NC/C=US/O=Security/OU=OpenShift
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.20, RHOCP 4.19, RHOCP 4.18, RHOCP 4.17, RHOCP 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-15293

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://96042--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html
https://96042--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/ingress-operator.html
https://96042--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/ingress-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
