### PR TITLE
Update nw-ingress-configuring-application-domain.adoc

### DIFF
--- a/modules/nw-ingress-configuring-application-domain.adoc
+++ b/modules/nw-ingress-configuring-application-domain.adoc
@@ -65,14 +65,24 @@ Wait for the `openshift-apiserver` finish rolling updates before exposing the ro
 [source,terminal]
 ----
 $ oc expose service hello-openshift
-route.route.openshift.io/hello-openshift exposed
 ----
 +
 .Example output
+[source,terminal]
+----
+route.route.openshift.io/hello-openshift exposed
+----
++
+.. Get a list of routes by running the following command:
 +
 [source,terminal]
 ----
 $ oc get routes
+----
++
+.Example output
+[source,text]
+----
 NAME              HOST/PORT                                   PATH   SERVICES          PORT       TERMINATION   WILDCARD
 hello-openshift   hello_openshift-<my_project>.test.example.com
 hello-openshift   8080-tcp                 None


### PR DESCRIPTION
- Wrong structure of command needs to be corrected
- Here is the documentation link:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/networking/networking-operators#nw-ingress-configuring-application-domain_configuring-ingress  Here is the current look:

Expose the route:
~~~
$ oc expose service hello-openshift
route.route.openshift.io/hello-openshift exposed 
~~~

- The above command is not structured properly.
- We can use the above command as well, and it will execute perfectly. 
- But its structure is not as per our standard procedure. 
- Hence, it needs to be changed.
- 
Here is the updated look:
Expose the route:
~~~
$ oc expose service hello-openshift
  route.route.openshift.io/hello-openshift exposed
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.20, RHOCP 4.19, RHOCP 4.18, RHOCP 4.17, RHOCP 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-15294

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://96043--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html
https://96043--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/ingress-operator.html
https://96043--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/ingress-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
