### PR TITLE
[OSDOCS-15295] Update nw-customize-ingress-error-pages.adoc

### DIFF
--- a/modules/nw-customize-ingress-error-pages.adoc
+++ b/modules/nw-customize-ingress-error-pages.adoc
@@ -27,8 +27,8 @@ If you use the {product-title} default 503 error code page as a template for you
 [source,terminal]
 ----
 $ oc -n openshift-config create configmap my-custom-error-code-pages \
---from-file=error-page-503.http \
---from-file=error-page-404.http
+  --from-file=error-page-503.http \
+  --from-file=error-page-404.http
 ----
 
 . Patch the Ingress Controller to reference the `my-custom-error-code-pages` config map by name:
@@ -79,7 +79,7 @@ Verify your custom error code HTTP response:
 +
 [source,terminal]
 ----
- $ oc new-project test-ingress
+$ oc new-project test-ingress
 ----
 +
 [source,terminal]


### PR DESCRIPTION
- Command correction in Customizing HAProxy error code response pages  
- Here is the documentation link:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/networking/networking-operators#nw-customize-ingress-error-pages_configuring-ingress 

Here is the current look:

Procedure

Create a config map named my-custom-error-code-pages in the openshift-config namespace: 
~~~
$ oc -n openshift-config create configmap my-custom-error-code-pages \
--from-file=error-page-503.http \
--from-file=error-page-404.http
~~~

- The above command is not structured properly.
- We can use the above command as well, and it will execute perfectly. 
- But its structure is not as per our standard procedure. Hence, it needs to be changed.

Here is the updated look:

Procedure

Create a config map named my-custom-error-code-pages in the openshift-config namespace: 
~~~
$ oc -n openshift-config create configmap my-custom-error-code-pages \
  --from-file=error-page-503.http \
  --from-file=error-page-404.http
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.20, RHOCP 4.19, RHOCP 4.18, RHOCP 4.17, RHOCP 4.16

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-15295

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://96044--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html
https://96044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/ingress-operator.html
https://96044--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/ingress-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
