### PR TITLE
OSDOCS#34373: Making `update` permission optional for creating routes

### DIFF
--- a/modules/cert-manager-configuring-routes.adoc
+++ b/modules/cert-manager-configuring-routes.adoc
@@ -11,7 +11,7 @@ The following steps demonstrate the process of utilizing the {cert-manager-opera
 .Prerequisites
 
 * You have installed version 1.14.0 or later of the {cert-manager-operator}.
-* You have the `create` and `update` permissions on the `routes/custom-host` sub-resource.
+* You have `create permission` on the `routes/custom-host` sub-resource, which is used for both creating and updating routes.
 * You have a `Service` resource that you want to expose.
 
 .Procedure

--- a/modules/nw-ingress-route-secret-load-external-cert.adoc
+++ b/modules/nw-ingress-route-secret-load-external-cert.adoc
@@ -16,7 +16,7 @@ This feature applies to both edge routes and re-encrypt routes.
 .Prerequisites
 
 * You must enable the `RouteExternalCertificate` feature gate.
-* You must have the `create` and `update` permissions on the `routes/custom-host`.
+* You have `create permission` on the `routes/custom-host` sub-resource, which is used for both creating and updating routes.
 * You must have a secret containing a valid certificate/key pair in PEM-encoded format of type `kubernetes.io/tls`, which includes both `tls.key` and `tls.crt` keys.
 * You must place the referenced secret in the same namespace as the route you want to secure.
 


### PR DESCRIPTION
Version(s): 4.18+

Issue: https://issues.redhat.com/browse/OCPBUGS-34373

Link to docs preview: 

- https://96060--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/routes/secured-routes.html#nw-ingress-route-secret-load-external-cert_secured-routes
- https://96060--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-securing-routes.html

QE review:
- [x] QE has approved this change.
