### PR TITLE
OCPBUGS#57333-18: Added operators.openshift.io/must-gather-image to o…

### DIFF
--- a/modules/must-gather-flags.adoc
+++ b/modules/must-gather-flags.adoc
@@ -15,7 +15,7 @@ The flags listed in the following table are available to use with the `oc adm mu
 
 |`--all-images`
 |`oc adm must-gather --all-images=false`
-|Collect `must-gather` data using the default image for all Operators on the cluster that are annotated with `operators.openshift.io/must-gather-image`.
+|Collect `must-gather` data by using the default image for all Operators on the cluster that are annotated with `operators.openshift.io/must-gather-image`.
 
 |`--dest-dir`
 |`oc adm must-gather --dest-dir='<directory_name>'`

--- a/modules/osdk-csv-annotations-other.adoc
+++ b/modules/osdk-csv-annotations-other.adoc
@@ -24,11 +24,14 @@ The following Operator annotations are optional.
 |`operatorframework.io/suggested-namespace-template`
 |Set a manifest for a `Namespace` object with the default node selector for the namespace specified.
 
+|`operators.operatorframework.io/internal-objects`
+|Hides CRDs in the UI that are not meant for user manipulation.
+
 |`operators.openshift.io/valid-subscription`
 |Free-form array for listing any specific subscriptions that are required to use the Operator. For example, `'["3Scale Commercial License", "Red Hat Managed Integration"]'`.
 
-|`operators.operatorframework.io/internal-objects`
-|Hides CRDs in the UI that are not meant for user manipulation.
+|`operators.openshift.io/must-gather-image`
+|Collect must-gather data by using the default image for all Operators on the cluster that are annotated with `operators.openshift.io/must-gather-image`. 
 
 |===
 


### PR DESCRIPTION
Version(s):
4.17 and 4.18

Issue:
[OCPBUGS-57333](https://issues.redhat.com/browse/OCPBUGS-57333)

Link to docs preview:
* [Developing Operators-core](https://96061--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs.html)
* [Developing Operators-dedicated](https://96061--ocpdocs-pr.netlify.app/openshift-dedicated/latest/operators/operator_sdk/osdk-generating-csvs.html)
* [Developing Operators-AWS](https://96061--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/operator_sdk/osdk-generating-csvs.html)


- [x] SME has approved this change (Eric Rich.
- [x] QE has approved this change (Ying Zhou).

