### PR TITLE
[RHDEVDOCS-6493] Pipelines 1.19 release notes correction

### DIFF
--- a/modules/op-release-notes-1-19.adoc
+++ b/modules/op-release-notes-1-19.adoc
@@ -236,10 +236,6 @@ spec:
 
 * With this update, tasks in the {OCP} web console now include `displayName` properties instead of technical task names, providing clearer, more user-friendly names within the {pipelines-title} interface.
 
-* With this update, the {pipelines-title} entrypoint image includes support for FIPS compliance. The image is now built with appropriate cryptographic dependencies and configurations to meet FIPS requirements, ensuring compatibility in environments with strict security standards.
-
-* With this update, FIPS compliance is enhanced by adding `disable_spire` and `disable_tls` build tags to the entrypoint command compilation process. This enhancement ensures cryptographic symbols are properly removed from the entrypoint binary to meet compliance requirements.
-
 * With this update, the `/ok-to-test` memory feature is disabled by default. This precaution helps mitigate the risk of malicious code execution within testing environments.
 
 * With this update, dynamic variables can be expanded from remote pipeline definitions. This enhancement improves pipeline composition capabilities.
@@ -518,6 +514,8 @@ spec:
 * Before this update, the *PipelineRun details* page in the {OCP} web console failed to load correctly, preventing users from viewing pipeline run details. With this update, the web console displays the `PipelineRun` information correctly.
 
 * Before this update, the console plugin styling was outdated due to the upgrade to PatternFly 6 and the removal of deprecated `co-` classes. This caused alignment and spacing issues in the *Pipelines* section of the {OCP} web console. With this update, the console plugin styling is updated to use the appropriate PatternFly equivalent classes, ensuring consistent alignment and visual integration with the current {OCP} web console design standards
+
+* Before this update, the {pipelines-shortname} console plugin failed due to a default {tekton-results} TLS secret creation issue in {pipelines-shortname} 1.18. This caused the console to be inaccessible, making pipeline details unviewable. With this release, the default {tekton-results} TLS secret creation is skipped in {pipelines-shortname} 1.18, resolving the issue.
 
 * Before this update, links for `PipelineRun` in the {OCP} web console incorrectly pointed to the deprecated `v1beta1` {pipelines-title} APIs instead of the current `v1` APIs. With this update, the links point to the appropriate `v1` APIs.
 


### PR DESCRIPTION
Version(s):
pipelines-docs-1.19

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6493

Link to docs preview:
- [1.19 Release notes](https://96067--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-19.html)

QE review:
- [x] QE has approved this change.

Additional information:
_Corrections as requested here (Slack):_
- https://redhat-internal.slack.com/archives/CG5GV6CJD/p1752498733490749 - a new RN included
- https://redhat-internal.slack.com/archives/CG5GV6CJD/p1752498174228649 - FIPS compliance RNs removed