### PR TITLE
CNV#62112: Shared disk example has elements that don't exist

### DIFF
--- a/modules/virt-configuring-vm-disk-sharing.adoc
+++ b/modules/virt-configuring-vm-disk-sharing.adoc
@@ -3,7 +3,7 @@
 // * virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
 
 :_content-type: PROCEDURE
-[id="virt-configuring-vm-disk-sharing{context}"]
+[id="virt-configuring-vm-disk-sharing_{context}"]
 = Configuring disk sharing by using virtual machine disks
 
 You can configure block volumes so that multiple virtual machines (VMs) can share storage.
@@ -47,18 +47,15 @@ spec:
               bus: virtio
             name: rootdisk
             errorPolicy: report <1>
-            disk1: disk_one <2>
           - disk:
               bus: virtio
-            name: cloudinitdisk
-            disk2: disk_two
-            shareable: true <3>
+            name: cluster
+            shareable: true <2>
           interfaces:
           - masquerade: {}
             name: default
 ----
 <1> Identifies the error policy.
-<2> Identifies a device as a disk.
-<3> Identifies a shared disk.
+<2> Identifies a shared disk.
 
 . Save the `VirtualMachine` manifest file to apply your changes.


### PR DESCRIPTION
Version(s): 4.18+

Issue: [CNV-62112](https://issues.redhat.com/browse/CNV-62112)

Link to docs preview: https://96073--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virtual_disks/virt-configuring-shared-volumes-for-vms.html#virt-configuring-vm-disk-sharing_virt-configuring-shared-volumes-for-vms

QE review:
- [x] QE has approved this change.

