### PR TITLE
OCPBUGS-58425 [NETOBSERV] Loki deployment namespace is not correct in the offical docs for netobserv

### DIFF
--- a/modules/nw-network-observability-operator.adoc
+++ b/modules/nw-network-observability-operator.adoc
@@ -62,17 +62,16 @@ netobserv-ebpf-agent-xf5jh   1/1     Running   0          151m
 
 `netobserv-ebpf-agent` pods monitor network interfaces of the nodes to get flows and send them to `flowlogs-pipeline` pods.
 
-. If you are using the {loki-op}, check the status of pods running in the `openshift-operators-redhat` namespace by entering the following command:
+. If you are using the {loki-op}, check the status of the `component` pods of `LokiStack` custom resource in the `netobserv` namespace by entering the following command:
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-operators-redhat
+$ oc get pods -n netobserv
 ----
 +
 .Example output
 ----
 NAME                                                READY   STATUS    RESTARTS   AGE
-loki-operator-controller-manager-5f6cff4f9d-jq25h   2/2     Running   0          18h
 lokistack-compactor-0                               1/1     Running   0          18h
 lokistack-distributor-654f87c5bc-qhkhv              1/1     Running   0          18h
 lokistack-distributor-654f87c5bc-skxgm              1/1     Running   0          18h


### PR DESCRIPTION
OCPBUGS-58425 [NETOBSERV] Loki deployment namespace is not correct in the offical docs for netobserv

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-58425

Link to docs preview:
https://96084--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/understanding-network-observability-operator.html#nw-network-observability-operator_nw-network-observability-operator

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
