### PR TITLE
OCPBUGS#59310: Changed default values of oc-mirror parameters

### DIFF
--- a/modules/oc-mirror-command-reference-v2-delete.adoc
+++ b/modules/oc-mirror-command-reference-v2-delete.adoc
@@ -49,10 +49,10 @@ The following tables describe the `oc mirror` subcommands and flags for deleting
 |Log level one of `info`, `debug`, `trace`, and `error`. The default value is `info`.
 
 |`--parallel-images <unit>`
-|Indicates the number of images deleted in parallel. The default value is `8`.
+|Indicates the number of images deleted in parallel. The default value is `4`.
 
 |`--parallel-layers <unit>`
-|Indicates the number of image layers mirrored in parallel. The default value is `10`.
+|Indicates the number of image layers mirrored in parallel. The default value is `5`.
 
 |`-p <unit>`, `--port <unit>`
 |HTTP port used by oc-mirror's local storage instance. The default value is `55000`.

--- a/modules/oc-mirror-command-reference-v2.adoc
+++ b/modules/oc-mirror-command-reference-v2.adoc
@@ -63,10 +63,10 @@ The following tables describe the `oc mirror` subcommands and flags for oc-mirro
 |Determines the HTTP port used by oc-mirror plugin v2 local storage instance. The default value is `55000`.
 
 |`--parallel-images <unit>` 
-|Specifies the number of images mirrored in parallel. The default value is `8`.
+|Specifies the number of images mirrored in parallel. The default value is `4`.
 
 |`--parallel-layers <unit>`           
-|Specifies the number of image layers mirrored in parallel. The default value is `10`.
+|Specifies the number of image layers mirrored in parallel. The default value is `5`.
 
 |`--max-nested-paths <int>`
 |Specifies the maximum number of nested paths for destination registries that limit nested paths. The default value is `0`.


### PR DESCRIPTION
Version(s): 4.18+

Issue: https://issues.redhat.com/browse/OCPBUGS-59310

Link to docs preview: 

- https://96095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/about-installing-oc-mirror-v2.html#oc-mirror-command-reference-v2_about-installing-oc-mirror-v2
- https://96095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/about-installing-oc-mirror-v2.html#oc-mirror-command-reference-delete-v2_about-installing-oc-mirror-v2

QE review:
- [x] QE has approved this change.