### PR TITLE
OSDOCS 15312 removing cli manager 0.1.0 from ocp 4.19

### DIFF
--- a/cli_reference/cli_manager/cli-manager-release-notes.adoc
+++ b/cli_reference/cli_manager/cli-manager-release-notes.adoc
@@ -28,19 +28,3 @@ The following advisory is available for the {cli-manager} 0.1.1:
 === New features and enhancements
 
 This release of the CLI Manager updates the Kubernetes version to 1.32.
-
-[id="cli-manager-release-notes-0-1-0_{context}"]
-== {cli-manager} 0.1.0 (Technology Preview)
-
-Issued: 19 November 2024
-
-The following advisory is available for the {cli-manager} 0.1.0:
-
-* link:https://access.redhat.com/errata/RHEA-2024:8303[RHEA-2024:8303]
-
-[id="cli-manager-0-1-0-new-features-and-enhancements_{context}"]
-=== New features and enhancements
-
-* This version is the initial Technology Preview release of the {cli-manager}. For installation information, see xref:../../cli_reference/cli_manager/cli-manager-install.adoc#cli-manager-install[Installing the {cli-manager}].
-
-//* No bug fixes or known issues to list


### PR DESCRIPTION
Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-15312](https://issues.redhat.com/browse/OSDOCS-15312)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://96099--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/cli_manager/cli-manager-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Change management ACKs are below. Announce-only email after merge. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
