### PR TITLE
OCPBUGS#57322: Update the default MTU statement in OVNK docs

### DIFF
--- a/modules/configuration-ovnk-network-plugin-json-object.adoc
+++ b/modules/configuration-ovnk-network-plugin-json-object.adoc
@@ -47,7 +47,7 @@ When omitted, the logical switch implementing the network only provides layer 2 
 |`mtu`
 |`string`
 |
-The maximum transmission unit (MTU). The default value, `1300`, is automatically set by the kernel.
+The maximum transmission unit (MTU). If you do not set a value, the Cluster Network Operator (CNO) sets a default MTU value by calculating the difference among the underlay MTU of the primary network interface, the overlay MTU of the pod network, such as the Geneve (Generic Network Virtualization Encapsulation), and byte capacity of any enabled features, such as IPsec. 
 
 |`netAttachDefName`
 |`string`

--- a/modules/configuring-localnet-switched-topology.adoc
+++ b/modules/configuring-localnet-switched-topology.adoc
@@ -48,7 +48,7 @@ spec:
 <4> The name of the OVS bridge on the node. This value is required only if you specify `state: present`.
 <5> The state for the mapping. Must be either `present` to add the bridge or `absent` to remove the bridge. The default value is `present`.
 +
-The following JSON example configures a localnet secondary network that is named `localnet1`:
+The following JSON example configures a localnet secondary network that is named `localnet1`. Note that the value for the `mtu` parameter must match the MTU value that was set for the secondary network interface that is mapped to the `br-ex` bridge interface.
 +
 [source,json]
 ----
@@ -108,7 +108,7 @@ spec:
 <7> Specifies the name of the OVS bridge on the node. The value is required only when `state: present` is set.
 <8> Specifies the state of the mapping. Valid values are `present` to add the bridge or `absent` to remove the bridge. The default value is `present`.
 +
-The following JSON example configures a localnet secondary network that is named `localnet2`:
+The following JSON example configures a localnet secondary network that is named `localnet2`. Note that the value for the `mtu` parameter must match the MTU value that was set for the `eth1` secondary network interface.
 +
 [source,json]
 ----

--- a/modules/virt-creating-layer2-nad-cli.adoc
+++ b/modules/virt-creating-layer2-nad-cli.adoc
@@ -38,7 +38,7 @@ spec:
 <2> The name of the network. This attribute is not namespaced. For example, you can have a network named `l2-network` referenced from two different `NetworkAttachmentDefinition` objects that exist in two different namespaces. This feature is useful to connect VMs in different namespaces.
 <3> The name of the CNI plug-in to be configured. The required value is `ovn-k8s-cni-overlay`.
 <4> The topological configuration for the network. The required value is `layer2`.
-<5> Optional: The maximum transmission unit (MTU) value. The default value is automatically set by the kernel.
+<5> Optional: The maximum transmission unit (MTU) value. If you do not set a value, the Cluster Network Operator (CNO) sets a default MTU value by calculating the difference among the underlay MTU of the primary network interface, the overlay MTU of the pod network, such as the Geneve (Generic Network Virtualization Encapsulation), and byte capacity of any enabled features, such as IPsec.
 <6> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
 +
 [NOTE]

--- a/modules/virt-creating-localnet-nad-cli.adoc
+++ b/modules/virt-creating-localnet-nad-cli.adoc
@@ -60,14 +60,16 @@ spec:
             "name": "localnet-network", <2>
             "type": "ovn-k8s-cni-overlay", <3>
             "topology": "localnet", <4>
-            "netAttachDefName": "default/localnet-network" <5>
+            "mtu": 1500, <5>
+            "netAttachDefName": "default/localnet-network" <6>
     }
 ----
 <1> The CNI specification version. The required value is `0.3.1`.
 <2> The name of the network. This attribute must match the value of the `spec.desiredState.ovn.bridge-mappings.localnet` field of the `NodeNetworkConfigurationPolicy` object that defines the OVS bridge mapping.
 <3> The name of the CNI plug-in to be configured. The required value is `ovn-k8s-cni-overlay`.
 <4> The topological configuration for the network. The required value is `localnet`.
-<5> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
+<5> Optional: The maximum transmission unit (MTU) value. If you do not set a value, the Cluster Network Operator (CNO) sets a default MTU value by calculating the difference among the underlay MTU of the primary network interface, the overlay MTU of the pod network, and byte capacity of any enabled features, such as IPsec.
+<6> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
 
 . Apply the manifest:
 +


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-57322](https://issues.redhat.com/browse/OCPBUGS-57322)

Link to docs preview:
* [OVN-Kubernetes network plugin JSON configuration table](https://96102--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.html#configuration-ovnk-network-plugin-json-object_configuring-additional-network-ovnk)
* [Creating a NAD for layer 2 topology using the CLI](https://96102--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.html#virt-creating-layer2-nad-cli_virt-connecting-vm-to-ovn-secondary-network)


- [x] SME has approved this change [Enrique Llorente Pastora].
- [x] QE has approved this change [Weibin Liang]


Additional information:
* https://github.com/openshift/openshift-docs/pulls
