### PR TITLE
OSDOCS-14482: Update CLI tools with HCP review feedback

### DIFF
--- a/cli_reference/rosa_cli/rosa-get-started-cli.adoc
+++ b/cli_reference/rosa_cli/rosa-get-started-cli.adoc
@@ -16,6 +16,8 @@ include::modules/rosa-configure.adoc[leveloffset=+1]
 
 * xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[Getting started with the OpenShift CLI]
 
+ifdef::openshift-rosa[]
 include::modules/rosa-initialize.adoc[leveloffset=+1]
+endif::openshift-rosa[]
 include::modules/rosa-using-bash-script.adoc[leveloffset=+1]
 include::modules/rosa-updating-rosa-cli.adoc[leveloffset=+1]

--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -6,6 +6,11 @@
 [id="rosa-create-objects_{context}"]
 = Create objects
 
+[NOTE]
+====
+To create a Hosted Control Plane cluster, include the '--hosted-cp' flag where necessary.
+====
+
 This section describes the `create` commands for clusters and resources.
 
 [id="rosa-create-account-roles_{context}"]
@@ -255,8 +260,11 @@ OVN-Kubernetes, the default network provider in ROSA 4.11 and later, uses the `1
 |--min-replicas <number_of_nodes>
 |Specifies the minimum number of compute nodes when enabling autoscaling. Default: `2`
 
+ifdef::openshift-rosa[]
+//this is being deprecated and will eventually be removed entirely.
 |--multi-az
 |Deploys to multiple data centers.
+endif::openshift-rosa[]
 
 |--no-cni
 |Creates a cluster without a Container Network Interface (CNI) plugin. Customers can then bring their own CNI plugin and install it after cluster creation.
@@ -274,9 +282,15 @@ OVN-Kubernetes, the default network provider in ROSA 4.11 and later, uses the `1
 
 |--private
 |Restricts primary API endpoint and application routes to direct, private connectivity.
+//To be added when available for HCP only.
+//ifdef::openshift-rosa-hcp[]
+//To allow public subnets on a private API cluster, you can use both the `--private` and `--private-ingress=false` arguments. 
+//endif::openshift-rosa-hcp[]
 
+ifdef::openshift-rosa[]
 |--private-link
 |Specifies to use AWS PrivateLink to provide private connectivity between VPCs and services. The `--subnet-ids` argument is required when using `--private-link`.
+endif::openshift-rosa[]
 
 |--region <region_name>
 |The name of the AWS region where your worker pool will be located, for example, `us-east-1`. This argument overrides the `AWS_REGION` environment variable.
@@ -295,13 +309,32 @@ a|Block of IP addresses (ipNet) for services, for example, `172.30.0.0/16`.
 OVN-Kubernetes, the default network provider in ROSA 4.11 and later, uses the `100.64.0.0/16` IP address range internally. If your cluster uses OVN-Kubernetes, do not include the `100.64.0.0/16` IP address range in any other CIDR definitions in your cluster.
 ====
 
+ifdef::openshift-rosa[]
 a|--sts \| --non-sts
 |Specifies whether to use AWS Security Token Service (STS) or IAM credentials (non-STS) to deploy your cluster.
+endif::openshift-rosa[]
 
+ifdef::openshift-rosa-hcp[]
+|--sts 
+|Specifies the use of AWS Security Token Service (STS) credentials to deploy your cluster.
+endif::openshift-rosa-hcp[]
+
+ifdef::openshift-rosa[]
 |--subnet-ids <aws_subnet_id>
 |The AWS subnet IDs that are used when installing the cluster, for example, `subnet-01abc234d5678ef9a`. Subnet IDs must be in pairs with one private subnet ID and one public subnet ID per availability zone. Subnets are comma-delimited, for example, `--subnet-ids=subnet-1,subnet-2`. Leave the value empty for installer-provisioned subnet IDs.
 
 When using `--private-link`, the `--subnet-ids` argument is required and only one private subnet is allowed per zone.
+endif::openshift-rosa[]
+
+ifdef::openshift-rosa-hcp[]
+|--subnet-ids <aws_subnet_id>
+|The AWS subnet IDs that are used when installing the cluster, for example, `subnet-01abc234d5678ef9a`. Subnet IDs must be in pairs with one private subnet ID and one public subnet ID per availability zone. Subnets are comma-delimited, for example, `--subnet-ids=subnet-1,subnet-2`. Leave the value empty for installer-provisioned subnet IDs.
+
+When using `--private` for "private API", the `--subnet-ids` argument is required and only one private subnet is allowed per zone.
+
+//To be added when available
+//To allow public subnets on a private API cluster, you can use both the `--private` and `--private-ingress=false` arguments. 
+endif::openshift-rosa-hcp[]
 
 |--support-role-arn string
 |The ARN of the role used by Red Hat Site Reliability Engineers (SREs) to enable access to the cluster account to provide support.
@@ -723,6 +756,13 @@ For more information about setting the PID limit for the cluster, see _Configuri
 == create machinepool
 
 Add a machine pool to an existing cluster.
+
+ifdef::openshift-rosa-hcp[]
+[TIP]
+====
+Machine pool is also referred to as node pool on hosted control plane clusters.
+====
+endif::openshift-rosa-hcp[]
 
 .Syntax
 [source,terminal]

--- a/modules/rosa-list-objects.adoc
+++ b/modules/rosa-list-objects.adoc
@@ -389,8 +389,10 @@ $ rosa list regions [arguments]
 |===
 |Option |Definition
 
+ifdef::openshift-rosa[]
 |--multi-az
 |Lists regions that provide support for multiple availability zones.
+endif::openshift-rosa[]
 |===
 
 .Optional arguments inherited from parent commands


### PR DESCRIPTION
Version(s):
4.19+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-14482 

Link to docs preview:
https://96122--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/rosa_cli/rosa-get-started-cli.html
https://96122--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html
https://96122--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-get-started-cli.html
https://96122--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
