### PR TITLE
[OSDOCS-15315]: Clarifying etcd note about control plane machine sets

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
@@ -21,6 +21,10 @@ include::modules/dr-restoring-cluster-state-sno.adoc[leveloffset=+1]
 // Restoring to a previous cluster state
 include::modules/dr-restoring-cluster-state.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
+
 // Restoring a cluster from etcd backup manually
 include::modules/manually-restoring-cluster-etcd-backup.adoc[leveloffset=+1]
 

--- a/etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
+++ b/etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
@@ -58,6 +58,10 @@ include::modules/dr-restoring-cluster-state-sno.adoc[leveloffset=+2]
 // Restoring to a previous cluster state
 include::modules/dr-restoring-cluster-state.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
+
 // Restoring a cluster from etcd backup manually
 include::modules/manually-restoring-cluster-etcd-backup.adoc[leveloffset=+2]
 

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -23,7 +23,7 @@ For high availability (HA) clusters, a three-node HA cluster requires you to shu
 
 [NOTE]
 ====
-If your cluster uses a control plane machine set, see "Troubleshooting the control plane machine set" for a more simple etcd recovery procedure. For {product-title} on a single node, see "Restoring to a previous cluster state for a single node".
+If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for an etcd recovery procedure. For {product-title} on a single node, see "Restoring to a previous cluster state for a single node".
 ====
 
 [IMPORTANT]

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -11,7 +11,7 @@ This procedure details the steps to replace an etcd member that is unhealthy eit
 
 [NOTE]
 ====
-If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for a more simple etcd recovery procedure.
+If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for an etcd recovery procedure.
 ====
 
 .Prerequisites


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+, will open separate PRs to apply changes to 4.12 - 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-15315
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Restoring to a previous cluster state for more than one node: https://96125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup-restore/etcd-disaster-recovery.html#dr-scenario-2-restoring-cluster-state_etcd-disaster-recovery (etcd book)
- Restoring to a previous cluster state for more than one node: https://96125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state (control plane backup and restore book)
- Replacing an unhealthy etcd member whose machine is not running or whose node is not ready: https://96125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state (control plane backup and restore book)
- Replacing an unhealthy etcd member whose machine is not running or whose node is not ready: https://96125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup-restore/replace-unhealthy-etcd-member#restore-replace-stopped-etcd-member_replace-unhealthy-etcd-member (etcd book)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
