### PR TITLE
OCPBUGS-57824 added Known Issues section to cert-manager release notes

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -85,6 +85,11 @@ The peak memory use of the cert-manager components when they start up is optimiz
 * link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338]
 * link:https://access.redhat.com/security/cve/CVE-2025-22866[CVE-2025-22866]
 
+[id="cert-manager-operator-1-16-0-known-issues_{context}"]
+=== Known Issues
+
+When using the Venafi issuer with username and password authentication in cert-manager version 1.16.0, the default client ID is hard-coded as `cert-manager.io` and cannot be customized. This limitation can affect users requiring a specific client ID for authentication with the Venafi platform.
+
 [id="cert-manager-operator-release-notes-1-15-1_{context}"]
 == {cert-manager-operator} 1.15.1
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-57824

Link to docs preview:
https://96128--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes.html


QE review:
- [x] QE has approved this change.


Additional information:

