### PR TITLE
OSDOCS#15261: Update the z-stream RNs for 4.16.44 

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3366,6 +3366,39 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.44
+[id="ocp-4-16-44_{context}"]
+=== RHSA-2025:10781 - {product-title} {product-version}.44 bug fix and security update
+
+Issued: 16 July 2025
+
+{product-title} release {product-version}.44 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:10781[RHSA-2025:10781] advisory. 
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.44 --pullspecs
+----
+
+[id="ocp-4-16-44-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, Kubernetes API server loopback certificates expired prematurely. As the certificates were self-signed, their short lifespan caused them to terminate, resulting in communication problems in the API server. With this update, the validity period of the self-signed loopback certificate is extended, which prevents future certificate expiration and makes the API server more stable in Kubernetes version 4.16.z. (link:https://issues.redhat.com/browse/OCPBUGS-58054[OCPBUGS-58054])
+
+* Before this update, when you tried to install an {product-title} cluster on {aws-first} with primary nodes distributed across multiple subnets, the installation failed. This error occurred because the Network Load Balancer (NLB) had an incorrect security group configuration. With this update, the security group for the NLB is updated. During an {aws-short} cluster installation, security group traffic for all primary nodes is permitted, regardless of the subnet they are in, during an AWS cluster installation. As a result, your cluster installations successfully support multiple primary subnets. (link:https://issues.redhat.com/browse/OCPBUGS-57498[OCPBUGS-57498]) 
+
+* Before this update, if you tried to import an Open Virtual Appliance (OVA) into a cluster when an ESXi host within that cluster was powered off, the import failed. With this release, you can successfully import OVAs into your cluster when an ESXi host is powered off. (link:https://issues.redhat.com/browse/OCPBUGS-57460[OCPBUGS-57460])
+
+* Before this update, the Open Virtual Network (OVN) networking component created duplicate static routes on two cluster nodes. These duplicate routes caused network traffic to drop intermittently, and led to unreliable network communication. With this update, duplicate static routes in the OVN databases for cluster nodes are allowed, and the packet drops are eliminated. (link:https://issues.redhat.com/browse/OCPBUGS-57396[OCPBUGS-57396])
+
+* Before this update, no direct API controlled the way that the high availability proxy (HAProxy) handled idle connections during graceful shutdowns, which limited the flexibility of managing connection termination behavior. With this release, the management of the HAProxy connection during graceful shutdowns is fixed, and administrators can choose between preserving ongoing responses or closing idle connections. (link:https://issues.redhat.com/browse/OCPBUGS-56424[OCPBUGS-56424])
+
+[id="ocp-4-16-44-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.43
 [id="ocp-4-16-43_{context}"]
 === RHSA-2025:9765 - {product-title} {product-version}.43 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-15261](https://issues.redhat.com//browse/OSDOCS-15261)

Link to docs preview:
[4.16.44](https://96155--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-44_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 7/16/25.