### PR TITLE
Enterprise 4.19 Add back the OADP Features and Plugins Known Issues File

### DIFF
--- a/modules/oadp-features-plugins-known-issues.adoc
+++ b/modules/oadp-features-plugins-known-issues.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+// oadp-features-plugins-known-issues
+// * backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+// * backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+
+:_content-type: CONCEPT
+[id="oadp-features-plugins-known-issues_{context}"]
+= OADP plugins known issues
+
+The following section describes known issues in {oadp-first} plugins:
+
+[id="velero-plugin-panic_{context}"]
+== Velero plugin panics during imagestream backups due to a missing secret
+
+When the backup and the Backup Storage Location (BSL) are managed outside the scope of the Data Protection Application (DPA), the OADP controller, meaning the DPA reconciliation does not create the relevant `oadp-<BSL Name>-<BSL Provider>-registry-secret`.
+
+When the backup is run, the OpenShift Velero plugin panics on the imagestream backup, with a panic error:
+
+[source,terminal]
+----
+024-02-27T10:46:50.028951744Z time="2024-02-27T10:46:50Z" level=error msg="Error backing up item"
+backup=openshift-adp/<backup name> error="error executing custom action (groupResource=imagestreams.image.openshift.io,
+namespace=<BSL Name>, name=postgres): rpc error: code = Aborted desc = plugin panicked:
+runtime error: index out of range with length 1, stack trace: goroutine 94…
+----
+
+[id="velero-plugin-panic-workaround_{context}"]
+=== Workaround to avoid the panic error
+
+To avoid the Velero plugin panic error, perform the following steps:
+
+. Label the custom BSL with the relevant label
++
+[source,terminal]
+----
+$ oc label backupstoragelocations.velero.io <bsl_name> app.kubernetes.io/component=bsl
+----
+
+. After the BSL is labeled, wait until the DPA reconciles.
++
+[NOTE]
+====
+You can force the reconciliation by making any minor change to the DPA itself.
+====
+
+. When the DPA reconciles, confirm that the relevant `oadp-<BSL Name>-<BSL Provider>-registry-secret` has been created and that the correct registry data has been populated into it:
++
+[source,terminal]
+----
+$ oc -n openshift-adp get secret/oadp-<bsl_name>-<bsl_provider>-registry-secret -o json | jq -r '.data'
+----
+
+
+[id="openshift-adp-controller-manager-seg-fault_{context}"]
+== OpenShift ADP Controller segmentation fault
+
+If you configure a DPA with both `cloudstorage` and `restic` enabled, the `openshift-adp-controller-manager` pod crashes and restarts indefinitely until the pod fails with a crash loop segmentation fault.
+
+You can have either `velero` or `cloudstorage` defined, because they are mutually exclusive fields.
+
+* If you have both `velero` and  `cloudstorage` defined, the `openshift-adp-controller-manager` fails.
+* If you have neither `velero` nor `cloudstorage` defined, the `openshift-adp-controller-manager` fails.
+
+For more information about this issue, see link:https://issues.redhat.com/browse/OADP-1054[OADP-1054].
+
+
+[id="openshift-adp-controller-manager-seg-fault-workaround_{context}"]
+=== OpenShift ADP Controller segmentation fault workaround
+
+You must define either `velero` or `cloudstorage` when you configure a DPA. If you define both APIs in your DPA, the `openshift-adp-controller-manager` pod fails with a crash loop segmentation fault.


### PR DESCRIPTION
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

* 4.19, 4.20

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

The _oadp-features-plugins-known-issues.adoc_ file is required for me to complete my modularization work ([OADP-6353 Add role_abstract to intro paragraphs to mark them as DITA descriptions](https://issues.redhat.com/browse/OADP-6353)) in the enterprise-4.19 branch and the enterprise-4.20 branch. This PR restores the _oadp-features-plugins-known-issues.adoc_ file in the enterprise-4.19 branch and enterprise-420 branch.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
