### PR TITLE
OBSDOCS-2161: Loki object storage command format

### DIFF
--- a/modules/logging-loki-storage-azure.adoc
+++ b/modules/logging-loki-storage-azure.adoc
@@ -36,7 +36,7 @@ You can create the Loki object storage secret manually by running the following 
 [source,terminal,subs="+quotes"]
 ----
 $ oc -n openshift-logging create secret generic logging-loki-azure \
---from-literal=environment="<azure_environment>" \
---from-literal=account_name="<storage_account_name>" \
---from-literal=container="<container_name>"
+  --from-literal=environment="<azure_environment>" \
+  --from-literal=account_name="<storage_account_name>" \
+  --from-literal=container="<container_name>"
 ----

--- a/modules/logging-loki-storage-odf.adoc
+++ b/modules/logging-loki-storage-odf.adoc
@@ -53,11 +53,11 @@ SECRET_ACCESS_KEY=$(oc get -n openshift-logging secret loki-bucket-odf -o jsonpa
 [source,terminal,subs="+quotes"]
 ----
 $ oc create -n openshift-logging secret generic logging-loki-odf \ #<1>
---from-literal=access_key_id="<access_key_id>" \
---from-literal=access_key_secret="<secret_access_key>" \
---from-literal=bucketnames="<bucket_name>" \
---from-literal=endpoint="https://<bucket_host>:<bucket_port>"
---from-literal=forcepathstyle="true" # <2>
+  --from-literal=access_key_id="<access_key_id>" \
+  --from-literal=access_key_secret="<secret_access_key>" \
+  --from-literal=bucketnames="<bucket_name>" \
+  --from-literal=endpoint="https://<bucket_host>:<bucket_port>"
+  --from-literal=forcepathstyle="true" # <2>
 ----
 <1> `logging-loki-odf` is the name of the secret.
 <2> AWS endpoints (those ending in `.amazonaws.com`) use a virtual-hosted style by default, which is equivalent to setting the `forcepathstyle` attribute to `false`. Conversely, non-AWS endpoints use a path style, equivalent to setting  `forcepathstyle` attribute to `true`. If you need to use a virtual-hosted style with non-AWS S3 services, you must explicitly set `forcepathstyle` to `false`.


### PR DESCRIPTION
Version(s): 6.3
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2161
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://96168--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-the-log-store.html#logging-loki-storage-azure_configuring-the-log-store
- https://96168--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-the-log-store.html#logging-loki-storage-odf_configuring-the-log-store

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not required as this is only a cosmetic change. 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
