### PR TITLE
OSDOCS-14580: adds ingress params relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-20-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-20-release-notes.adoc
@@ -12,6 +12,7 @@ toc::[]
 
 [id="microshift-4-20-about-this-release_{context}"]
 == About this release
+
 Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {ocp-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
 You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, and offline environments.
@@ -27,7 +28,7 @@ This release adds improvements related to the following components and concepts.
 
 //L3 major categories with features in each as L4s
 //[id="microshift-4-20-rhel_{context}"]
-=== {op-system-base-full}
+//=== {op-system-base-full}
 
 //[id="microshift-4-20-rhel-image-mode_{context}"]
 //==== {op-system-base} image mode delta updates available
@@ -41,15 +42,15 @@ Updating two minor EUS versions in a single step is supported in {product-versio
 //TODO add new features and enhancements as needed, follow doc TOC titles as L3s, then add L4 headings for each feature
 
 [id="microshift-4-20-configuring_{context}"]
-=== Configuring
+=== Configuring {microshift-short}
 
-//[id="microshift-4-20-ingress-controller-three-config_{context}"]
-//==== Inspect ingress for your use case with additional logging parameters
+[id="microshift-4-20-ingress-controller-three-config_{context}"]
+==== Inspect ingress for your use case with additional logging parameters
 
-//With this release, the logging parameters are added to the YAML configuration file for {microshift-short}. These parameters specify security settings for the ingress controller. For more information, see xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} cluster].
+With this release, you can configure custom error code pages and logging parameters in the router, and you can capture HTTP headers and cookies in the ingress controller access logs. For more information, see xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} cluster].
 
-[id="microshift-4-20-running-apps_{context}"]
-=== Running applications
+//[id="microshift-4-20-running-apps_{context}"]
+//=== Running applications
 
 //[id="microshift-4-20-new-feature_{context}"]
 //==== placeholder RAs feature
@@ -127,7 +128,7 @@ See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/lates
 
 [id="microshift-4-20-additional-release-notes-ocp_{context}"]
 === {OCP} release notes
-See the link:https://docs.openshift.com/container-platform/4.20/release_notes/ocp-4-20-release-notes.html[{OCP} Release Notes] for information about the Operator Lifecycle Manager and other components. Not all of the changes to {OCP} apply to {microshift-short}. See the specific {microshift-short} implementation of an Operator or function for more information.
+See the link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/release_notes/index[{OCP} Release Notes] for information about the Operator Lifecycle Manager and other components. Not all of the changes to {OCP} apply to {microshift-short}. See the specific {microshift-short} implementation of an Operator or function for more information.
 
 [id="microshift-4-20-additional-release-notes-rhel_{context}"]
 === {op-system-base-full} release notes


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-14580](https://issues.redhat.com/browse/OSDOCS-14580)

Link to docs preview:
[microshift-4-20-ingress-controller-three-config_release-notes](https://96175--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-20-release-notes.html#microshift-4-20-ingress-controller-three-config_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Feature PR](https://github.com/openshift/openshift-docs/pull/95759)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
