### PR TITLE
OLS-1924: OLS 1.0.2 release notes

### DIFF
--- a/modules/ols-1-0-2-fixed-issues.adoc
+++ b/modules/ols-1-0-2-fixed-issues.adoc
@@ -1,0 +1,11 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-2-fixed-issues_{context}"]
+= Fixed issues
+
+The following issues are fixed with {ols-official} 1.0.2:
+
+* Before this update, the cluster-wide proxy incorrectly routed large language model (LLM) provider connections, ignoring the `no_proxy` environment variable. This led to end users experiencing {ols-long} attempting to connect to the LLM provider through a proxy when the `no_proxy` variable was explicitly defined. In this release, {ols-short} now respects the `no_proxy` environment variable for LLM provider connections. As a result, {ols-short} ignores proxy settings when `no_proxy` is set, enhancing direct LLM provider connections. link:https://issues.redhat.com/browse/OLS-1861[OLS-1861].

--- a/modules/ols-1-0-2-release-notes.adoc
+++ b/modules/ols-1-0-2-release-notes.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-2-release-notes_{context}"]
+= {ols-long} version 1.0.2
+
+{ols-official} 1.0.2 is now available on {ocp-product-title} 4.15 and later.
+
+[id="ols-1-0-2-enhancements_{context}"]
+== Enhancements
+
+The following enhancements are made with {ols-official} 1.0.2:
+
+* This release makes {ols-official} 1.0.2 generally available, and is supported on {ocp-product-title} 4.15 and later.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -13,6 +13,8 @@ The release notes highlight what is new and what has changed with each {ols-offi
 {ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
 ====
 
+include::modules/ols-1-0-2-release-notes.adoc[leveloffset=+1]
+include::modules/ols-1-0-2-fixed-issues.adoc[leveloffset=2]
 include::modules/ols-1-0-1-release-notes.adoc[leveloffset=+1]
 include::modules/ols-1-0-1-known-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-1924
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://96180--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-1-0-2-release-notes_ols-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
