### PR TITLE
CNV-62298#4.18: CPU hotplug with networkInterfaceMultiqueue enabled

### DIFF
--- a/modules/virt-hot-plugging-cpu.adoc
+++ b/modules/virt-hot-plugging-cpu.adoc
@@ -17,9 +17,12 @@ You can increase or decrease the number of CPU sockets allocated to a virtual ma
 . Select the *vCPU* radio button.
 . Enter the desired number of vCPU sockets and click *Save*.
 +
+If the VM is migratable, a live migration is triggered. If not, or if the changes cannot be live-updated, a `RestartRequired` condition is added to the VM.
 
 [NOTE]
 ====
-* You can apply memory hot-plug changes immediately by using an automatic migration. If the live migration is not triggered, you must restart the VM. You can adjust this behavior cluster-wide by using the `maxHotplugRatio` parameter or override it in your VM.
-* By default, you can hot-plug a VM with up to 4 times its initial CPU or memory configuration. For example, a VM with 1 vCPU and 2 GiB memory can scale up to 4 vCPUs and 8 GiB before a restart is needed. You can adjust this behavior cluster-wide by using the `maxHotplugRatio` parameter or override it in your VM.
+If a VM has the `spec.template.spec.domain.devices.networkInterfaceMultiQueue` field enabled and CPUs are hot plugged, the following behavior occurs:
+* Existing network interfaces that you attach before the CPU hot plug retain their original queue count, even after you add more virtual CPUs (vCPUs). The underlying virtualization technology causes this expected behavior.  
+* To update the queue count of existing interfaces to match the new vCPU configuration, you can restart the VM. A restart is only necessary if the update improves performance.  
+* New VirtIO network interfaces that you hot plugged after the CPU hotplug automatically receive a queue count that matches the updated vCPU configuration.
 ====


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/CNV-62298

Link to docs preview:
https://96182--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-edit-vms.html#virt-hot-plugging-cpu_virt-edit-vms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
A merge conflict appeared on the 4.18 branch. This is the manual PR I have created to resolve this issue. 
https://github.com/openshift/openshift-docs/pull/95585