### PR TITLE
MCO OCL correct an annotation

### DIFF
--- a/modules/coreos-layering-configuring-on-remove.adoc
+++ b/modules/coreos-layering-configuring-on-remove.adoc
@@ -10,4 +10,4 @@ To prevent the custom layered images from taking up excessive space in your regi
 
 The credentials provided by the registry push secret that you added to the `MachineOSBuild` object must grant the permission for deleting an image from the registry. If the delete permission is not provided, the image is not removed when you delete the `MachineOSBuild` object.
 
-Note that the custom layered image is not deleted if the image is either currently in use on a node or is desired by the nodes, as indicated by the `machineconfiguration.openshift.io/currentConfig` or `machineconfiguration.openshift.io/desiredConfig` annotation on the node.
+The custom layered image is not deleted if the image is either currently in use on a node or is desired by the nodes, as indicated by the `machineconfiguration.openshift.io/currentImage` or `machineconfiguration.openshift.io/desiredImage` annotations on the node, which are added to the node when you create the `MachineOSConfig` object.


### PR DESCRIPTION
umohnani8 asked for this change in https://github.com/openshift/openshift-docs/pull/96116#discussion_r2208580684. That PR is 4.18 only. This PR brings the change to `main` and 4.19+. Dev and [QE](https://github.com/openshift/openshift-docs/pull/96116#issuecomment-3078855474) reviews in original PR.

Preview:
[Removing an on-cluster custom layered image](https://96184--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on-remove_mco-coreos-layering) - Edited closing paragraph.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
