### PR TITLE
OSDOCS#15262: Update the z-stream RNs for 4.13.59

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4556,3 +4556,31 @@ $ oc adm release info 4.13.58 --pullspecs
 [id="ocp-4-13-58-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.13.59
+[id="ocp-4-13-59_{context}"]
+=== RHSA-2025:10747 - {product-title} 4.13.59 bug fix and security updates
+
+Issued: 17 July 2025
+
+{product-title} release 4.13.59, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:10747[RHSA-2025:10747] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:10748[RHBA-2025:10748] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.59 --pullspecs
+----
+
+[id="ocp-4-13-59-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, an {product-title} upgrade bug from product version 4.12 to 4.13 caused network policies to incorrectly block traffic that was supposed to be allowed on the host network. Because of this bug, the pods on different nodes could not communicate with each other. With this release, during upgrades from 4.12 to 4.14, network policies work correctly, and pods communicate across different nodes. (link:https://issues.redhat.com/browse/OCPBUGS-57051[OCPBUGS-57051])
+
+* Before this update, during the 4.13 upgrade, {product-title} software-defined networking (SDN) incorrectly assigned the virtual network identifier (VNID) of the host network instead of VNID 0 for network policy enforcement flows. As a result, network policies that allowed host network traffic failed during the upgrade, limiting pod access to the same node. With this release, the network policy plug-in correctly assigns VNID 0 for the host network namespace during upgrades. The network policy functionality is restored during 4.12 to 4.14 upgrades, allowing pods to communicate across nodes. (link:https://issues.redhat.com/browse/OCPBUGS-55758[OCPBUGS-55758])
+
+[id="ocp-4-13-59-updating_{context}"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-15262](https://issues.redhat.com//browse/OSDOCS-15262)

Link to docs preview:
[4.13.59](https://96192--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-59_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
The errata URLs will return 404 until the go-live date of 7/17/25.
