### PR TITLE
OBSDOCS-2181 bug fix for intermittent failure when installing incident detection

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -20,9 +20,28 @@ The following table provides information about which features are available depe
 | COO Version   | OCP Versions       | Distributed tracing   | Logging   | Troubleshooting panel | ACM alerts | Incident detection
 | 1.1+          | 4.12 - 4.14        | ✔                     | ✔         | ✘                     | ✘          | ✘
 | 1.1+          | 4.15               | ✔                     | ✔         | ✘                     | ✔          | ✘
-| 1.1+          | 4.16 - 4.17        | ✔                     | ✔         | ✔                     | ✔          | ✘
-| 1.1+          | 4.18+              | ✔                     | ✔         | ✔                     | ✔          | ✔
+| 1.1+          | 4.16 - 4.18        | ✔                     | ✔         | ✔                     | ✔          | ✘
+| 1.2+          | 4.19+              | ✔                     | ✔         | ✔                     | ✔          | ✔
 |===
+
+[id="cluster-observability-operator-release-notes-1-2-2_{context}"]
+== {coo-full} 1.2.2
+
+[id="cluster-observability-operator-1-2-2-bug-fixes_{context}"]
+=== Bug fixes
+
+* Before this update, the installation of the incident detection feature could fail intermittently. The symptoms include the incident detection UI being visible but not including any data. In addition, the health-analyzer `ServiceMonitor` resource is in a failed state, with the error message `tls: failed to verify certificate: x509`. With this release, the incident detection feature installs correctly. (link:https://issues.redhat.com/browse/COO-1062[COO-1062])
++
+If you are upgrading from 1.2.1 where the bug was occurring, you must recreate the monitoring UI plugin to resolve the issue.
+
+[id="cluster-observability-operator-1-2-2-known-issues_{context}"]
+=== Known issues
+
+These are the known issues in {coo-full} 1.2.2:
+
+* When installing version 1.2.2 or when upgrading from version 1.2.0, the monitoring plugin's `UIPlugin` resource can be corrupted. This occurs when you have also deployed distributed tracing, the troubleshooting panel, and Advance Cluster Management (ACM), together with the monitoring UI plugin. You can resolve this issue by recreating the UI plugin. (link:https://issues.redhat.com/browse/COO-1051[COO-1051])
++
+If you have previously resolved the issue in 1.2.1 and then upgrade to 1.2.2, this issue will not reoccur.
 
 [id="cluster-observability-operator-release-notes-1-2-1_{context}"]
 == {coo-full} 1.2.1
@@ -37,7 +56,9 @@ The following table provides information about which features are available depe
 
 These are the known issues in {coo-full} 1.2.1:
 
-* Upgrading from version 1.2.0 to 1.2.1 corrupts the monitoring plugin's `UIPlugin` resource, when you have also deployed distributed tracing, the troubleshooting panel, and Advance Cluster Management (ACM), together with the monitoring UI plugin. You can resolve this issue by recreating the UI plugin. (link:https://issues.redhat.com/browse/COO-1051[COO-1051])
+* The installation of the incident detection feature could fail intermittently. The symptoms include the incident detection UI being visible but not including any data. In addition, the health-analyzer `ServiceMonitor` resource is in a failed state, with the error message `tls: failed to verify certificate: x509`.  You can resolve this issue by upgrading to 1.2.2 and recreating the monitoring UI plugin. (link:https://issues.redhat.com/browse/COO-1062[COO-1062])
+
+* Upgrading from version 1.2.0 corrupts the monitoring plugin's `UIPlugin` resource, when you have also deployed distributed tracing, the troubleshooting panel, and Advance Cluster Management (ACM), together with the monitoring UI plugin. You can resolve this issue by recreating the UI plugin. (link:https://issues.redhat.com/browse/COO-1051[COO-1051])
 
 [id="cluster-observability-operator-release-notes-1-2_{context}"]
 == {coo-full} 1.2


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-2181](https://issues.redhat.com//browse/OBSDOCS-2181)

Link to docs preview:
https://96195--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-release-notes.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
