### PR TITLE
Update gathering-data-specific-features.adoc

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -378,8 +378,8 @@ endif::openshift-origin[]
 [source,terminal]
 ----
 $ oc adm must-gather \
- --image-stream=openshift/must-gather \ <1>
- --image=quay.io/kubevirt/must-gather <2>
+  --image-stream=openshift/must-gather \ <1>
+  --image=quay.io/kubevirt/must-gather <2>
 ----
 <1> The default {product-title} `must-gather` image
 <2> The must-gather image for KubeVirt
@@ -393,7 +393,7 @@ $ tar cvaf must-gather-`date +"%m-%d-%Y-%H-%M-%S"`-<cluster_id>.tar.gz <must_gat
 ----
 <1> Replace `<must_gather_local_dir>` with the actual directory name.
 
-. Attach the compressed file to your support case on the link:https://access.redhat.com/support/cases/#/case/list[the *Customer Support* page] of the Red Hat Customer Portal.
+. Attach the compressed file to your support case on the link:https://access.redhat.com/support/cases/#/case/list[*Customer Support*] page of the Red Hat Customer Portal.
 endif::openshift-origin[]
 
 ifeval::["{context}" == "gathering-cluster-data"]


### PR DESCRIPTION
Below is step 5:

5. Attach the compressed file to your support case on the the Customer Support page of the Red Hat Customer Portal.

- In the above sentence word `the` `the` is mentioned twice. Which is not required.
- We need to remove one word from it.
- Here is the updated look:

5. Attach the compressed file to your support case on the Customer Support page of the Red Hat Customer Portal.

Also, in step 3 command structure is wrong:

3. Run the oc adm must-gather command with one or more -image or -image-stream arguments. For example, the following command gathers both the default cluster data and information specific to KubeVirt:
~~~
$ oc adm must-gather \
 --image-stream=openshift/must-gather \
 --image=quay.io/kubevirt/must-gather 
 ~~~
 
- Here, the `- -` sign should be below `oc`.
- Command will as it is, but it is not as per our standard documentation rule. 
- Hence we need to change it.
Here is the updated look:

3. Run the oc adm must-gather command with one or more -image or -image-stream arguments. For example, the following command gathers both the default cluster data and information specific to KubeVirt:
~~~
$ oc adm must-gather \
  --image-stream=openshift/must-gather \
  --image=quay.io/kubevirt/must-gather
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOCP 4.20, RHOCP 4.19, RHOCP 4.18, RHOCP 4.17, RHOCP 4.16, RHOCP 4.15, RHOCP 4.14, RHOCP 4.13, RHOCP 4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-15334

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://96197--ocpdocs-pr.netlify.app/openshift-dedicated/latest/support/gathering-cluster-data.html
https://96197--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html
https://96197--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/support/gathering-cluster-data.html
https://96197--ocpdocs-pr.netlify.app/openshift-rosa/latest/support/gathering-cluster-data.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
