### PR TITLE
PR2 for SRVLOGIC-617: Troubleshoot and fix publishing issue for "Managing Upgrades" section in the OSL docs.

### DIFF
--- a/modules/serverless-logic-upgrade-1-36-backing-up-data-index-database.adoc
+++ b/modules/serverless-logic-upgrade-1-36-backing-up-data-index-database.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-1-36-backing-up-job-service-database.adoc
+++ b/modules/serverless-logic-upgrade-1-36-backing-up-job-service-database.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-1-36-deleting-migrating-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-deleting-migrating-workflows-with-preview-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-1-36-deleting-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-deleting-workflows-with-dev-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-1-36-finalizing-data-index.adoc
+++ b/modules/serverless-logic-upgrade-1-36-finalizing-data-index.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-1-36-finalizing-job-service.adoc
+++ b/modules/serverless-logic-upgrade-1-36-finalizing-job-service.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-1-36-redeploying-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-redeploying-workflows-with-dev-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-1-36-restoring-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-restoring-workflows-with-preview-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-1-36-scaling-down-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-scaling-down-workflows-with-gitops-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-1-36-scaling-up-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-36-scaling-up-workflows-with-gitops-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-backing-up-data-index-database.adoc
+++ b/modules/serverless-logic-upgrade-backing-up-data-index-database.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-backing-up-job-service-database.adoc
+++ b/modules/serverless-logic-upgrade-backing-up-job-service-database.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-deleting-migrating-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-deleting-migrating-workflows-with-preview-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-deleting-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-deleting-workflows-with-dev-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-finalizing-data-index.adoc
+++ b/modules/serverless-logic-upgrade-finalizing-data-index.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-finalizing-job-service.adoc
+++ b/modules/serverless-logic-upgrade-finalizing-job-service.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-redeploying-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-redeploying-workflows-with-dev-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-restoring-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-restoring-workflows-with-preview-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-scaling-down-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-scaling-down-workflows-with-gitops-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrade-scaling-up-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-scaling-up-workflows-with-gitops-profile.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrading-1-36-osl-operator.adoc
+++ b/modules/serverless-logic-upgrading-1-36-osl-operator.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-upgrading-osl-operator.adoc
+++ b/modules/serverless-logic-upgrading-osl-operator.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/serverless-logic-verifying-the-1-35-0-upgrade.adoc
+++ b/modules/serverless-logic-verifying-the-1-35-0-upgrade.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.34-to-1.35
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-34-to-1-35
 
 
 :_mod-docs-content-type: PROCEDURE
-[id="serverless-logic-verifying-the-1.35.0-upgrade_{context}"]
+[id="serverless-logic-verifying-the-1-35-0-upgrade_{context}"]
 = Verifying the upgrade
 
 After restoring workflows and services, it is essential to verify that the upgrade was successful and that all components are functioning as expected.

--- a/modules/serverless-logic-verifying-the-1-36-0-upgrade.adoc
+++ b/modules/serverless-logic-verifying-the-1-36-0-upgrade.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * serverless-logic/serverless-logic-upgrading-operator-from-1.35-to-1.36
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-35-to-1-36
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-34-to-1-35.adoc
+++ b/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-34-to-1-35.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="serverless-logic-upgrading-operator-from-1.34-to-1.35"]
+[id="serverless-logic-upgrading-operator-from-1-34-to-1-35"]
 = Upgrading OpenShift Serverless Logic Operator from version 1.34.0 to 1.35.0
 include::_attributes/common-attributes.adoc[]
 :context: serverless-logic-upgrading-operator-from-1-34-to-1-35
@@ -61,4 +61,4 @@ include::modules/serverless-logic-upgrade-finalizing-job-service.adoc[leveloffse
 include::modules/serverless-logic-upgrade-redeploying-workflows-with-dev-profile.adoc[leveloffset=+2]
 include::modules/serverless-logic-upgrade-restoring-workflows-with-preview-profile.adoc[leveloffset=+2]
 include::modules/serverless-logic-upgrade-scaling-up-workflows-with-gitops-profile.adoc[leveloffset=+2]
-include::modules/serverless-logic-verifying-the-1.35.0-upgrade.adoc[leveloffset=+2]
+include::modules/serverless-logic-verifying-the-1-35-0-upgrade.adoc[leveloffset=+2]


### PR DESCRIPTION
**Notes for the reviewers:** The "Managing Upgrades" section is currently not visible on the page, although the content is present in both the main and serverless-docs-1.36 branches. Pantheon is throwing errors related to file names and/or ID conflicts, which are likely causing the issue. This PR aims to investigate and resolve these errors, ensuring the section is properly rendered and visible on the documentation site. 

**I have changed the `.` (dots) to the `-` (dash) in the ID and the file names.** Hopefully, it will get resolved. 

This PR does not require SME & QE review as the content is already acknowledged in the previous PRs. This is to troubleshoot the Pantheon side error. 

**Affected versions:** 

- `serverless-docs-1.37`
- `serverless-docs-1.36`
- `serverless-docs-1.35`


**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-617

**Doc preview:** 

- [Upgrading OpenShift Serverless Logic Operator from version 1.34.0 to 1.35.0](https://96059--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-34-to-1-35.html)
- [Upgrading OpenShift Serverless Logic Operator from version 1.35.0 to 1.36.0](https://96059--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-35-to-1-36)
