### PR TITLE
OSDOCS-14108: Review-Authentication & Authorization

### DIFF
--- a/modules/authentication-authorization-common-terms.adoc
+++ b/modules/authentication-authorization-common-terms.adoc
@@ -49,10 +49,10 @@ manual mode::
 In manual mode, a user manages cloud credentials instead of the Cloud Credential Operator (CCO).
 endif::openshift-dedicated,openshift-rosa[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 mint mode::
 Mint mode is the default and recommended best practice setting for the Cloud Credential Operator (CCO) to use on the platforms for which it is supported. In this mode, the CCO uses the provided administrator-level cloud credential to create new credentials for components in the cluster with only the specific permissions that are required.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 namespace::
 A namespace isolates specific system resources that are visible to all processes. Inside a namespace, only processes that are members of that namespace can see those resources.

--- a/modules/config-github-idp.adoc
+++ b/modules/config-github-idp.adoc
@@ -45,9 +45,16 @@ https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp
 +
 For example:
 +
+ifndef::openshift-rosa-hcp[]
 ----
 https://oauth-openshift.apps.openshift-cluster.example.com/oauth2callback/github
 ----
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+----
+https://oauth.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>
+----
+endif::openshift-rosa-hcp[]
 
 . link:https://docs.github.com/en/developers/apps/creating-an-oauth-app[Register an application on GitHub].
 

--- a/modules/config-gitlab-idp.adoc
+++ b/modules/config-gitlab-idp.adoc
@@ -33,9 +33,16 @@ You can also click the *Add Oauth configuration* link in the warning message dis
 . Enter a unique name for the identity provider. This name cannot be changed later.
 ** An *OAuth callback URL* is automatically generated in the provided field. You will provide this URL to GitLab.
 +
+ifndef::openshift-rosa-hcp[]
 ----
 https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>
 ----
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+----
+https://oauth.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>
+----
+endif::openshift-rosa-hcp[]
 +
 For example:
 +

--- a/modules/config-google-idp.adoc
+++ b/modules/config-google-idp.adoc
@@ -36,9 +36,16 @@ You can also click the *Add Oauth configuration* link in the warning message dis
 . Enter a unique name for the identity provider. This name cannot be changed later.
 ** An *OAuth callback URL* is automatically generated in the provided field. You will provide this URL to Google.
 +
+ifndef::openshift-rosa-hcp[]
 ----
 https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>
 ----
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+----
+https://oauth.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>
+----
+endif::openshift-rosa-hcp[]
 +
 For example:
 +

--- a/modules/config-openid-idp.adoc
+++ b/modules/config-openid-idp.adoc
@@ -73,9 +73,16 @@ You can also click the *Add Oauth configuration* link in the warning message dis
 . Enter a unique name for the identity provider. This name cannot be changed later.
 ** An *OAuth callback URL* is automatically generated in the provided field.
 +
+ifndef::openshift-rosa-hcp[]
 ----
 https://oauth-openshift.apps.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>
 ----
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa-hcp[]
+----
+https://oauth.<cluster_name>.<cluster_domain>/oauth2callback/<idp_provider_name>
+----
+endif::openshift-rosa-hcp[]
 +
 For example:
 +

--- a/modules/ldap-syncing-nesting.adoc
+++ b/modules/ldap-syncing-nesting.adoc
@@ -7,10 +7,7 @@
 == LDAP nested membership sync example
 
 Groups in {product-title} do not nest. The LDAP server must flatten group
-membership before the data can be consumed. Microsoft's Active Directory Server
-supports this feature via the
-link:https://msdn.microsoft.com/en-us/library/aa746475(v=vs.85).aspx[`LDAP_MATCHING_RULE_IN_CHAIN`]
-rule, which has the OID `1.2.840.113556.1.4.1941`. Furthermore, only explicitly
+membership before the data can be consumed. Microsoft's Active Directory Server supports this feature via the `LDAP_MATCHING_RULE_IN_CHAIN` rule, which has the OID `1.2.840.113556.1.4.1941`. Furthermore, only explicitly
 whitelisted groups can be synced when using this matching rule.
 
 This section has an example for the augmented Active Directory schema, which
@@ -86,10 +83,7 @@ with which to represent them in the internal {product-title} group records.
 Furthermore, certain changes are required in this configuration:
 
 - The `oc adm groups sync` command must explicitly whitelist groups.
-- The user's `groupMembershipAttributes` must include
-`"memberOf:1.2.840.113556.1.4.1941:"` to comply with the
-https://msdn.microsoft.com/en-us/library/aa746475(v=vs.85).aspx[`LDAP_MATCHING_RULE_IN_CHAIN`]
-rule.
+- The user's `groupMembershipAttributes` must include `"memberOf:1.2.840.113556.1.4.1941:"` to comply with the `LDAP_MATCHING_RULE_IN_CHAIN` rule.
 - The `groupUIDAttribute` must be set to `dn`.
 - The `groupsQuery`:
   * Must not set `filter`.
@@ -130,8 +124,7 @@ values are ignored. `groupsQuery` must set a valid `derefAliases`.
 <3> The attribute to use as the name of the group.
 <4> The attribute to use as the name of the user in the {product-title} group
 record. `mail` or `sAMAccountName` are preferred choices in most installations.
-<5> The attribute on the user that stores the membership information. Note the use
-of https://msdn.microsoft.com/en-us/library/aa746475(v=vs.85).aspx[`LDAP_MATCHING_RULE_IN_CHAIN`].
+<5> The attribute on the user that stores the membership information. Note the use of `LDAP_MATCHING_RULE_IN_CHAIN`.
 
 .Prerequisites
 

--- a/modules/oauth-server-overview.adoc
+++ b/modules/oauth-server-overview.adoc
@@ -7,7 +7,7 @@
 [id="oauth-server-overview_{context}"]
 = {product-title} OAuth server
 
-The {product-title} master includes a built-in OAuth server. Users obtain OAuth
+The {product-title} Control Plane includes a built-in OAuth server. Users obtain OAuth
 access tokens to authenticate themselves to the API.
 
 When a person requests a new OAuth token, the OAuth server uses the configured

--- a/modules/oauth-token-requests.adoc
+++ b/modules/oauth-token-requests.adoc
@@ -41,11 +41,13 @@ cannot display interactive login pages, such as the CLI. Therefore,
 {product-title} supports authenticating using a `WWW-Authenticate`
 challenge in addition to interactive login flows.
 
+ifndef::openshift-rosa-hcp[]
 If an authenticating proxy is placed in front of the
 `<namespace_route>/oauth/authorize` endpoint, it sends unauthenticated,
 non-browser user-agents `WWW-Authenticate` challenges rather than
 displaying an interactive login page or redirecting to an interactive
 login flow.
+endif::openshift-rosa-hcp[]
 
 [NOTE]
 ====

--- a/modules/rosa-create-cluster-admins.adoc
+++ b/modules/rosa-create-cluster-admins.adoc
@@ -43,6 +43,7 @@ cluster-admins    rh-rosa-test-user
 dedicated-admins  rh-rosa-test-user
 ----
 +
+ifndef::openshift-rosa-hcp[]
 . Enter the following command to verify that your user now has `cluster-admin` access. A cluster administrator can run this command without errors, but a dedicated administrator cannot.
 +
 [source,terminal]
@@ -62,3 +63,4 @@ service/api   ClusterIP   172.30.23.241   <none>        443/TCP   18h
 NAME                       DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
 daemonset.apps/apiserver   3         3         3       3            3           node-role.kubernetes.io/master=   18h
 ----
+endif::openshift-rosa-hcp[]

--- a/modules/setting-up-an-aws-iam-role-a-service-account.adoc
+++ b/modules/setting-up-an-aws-iam-role-a-service-account.adoc
@@ -45,7 +45,7 @@ In {product-title} with STS clusters, the OIDC provider is created during instal
     ]
 }
 ----
-<1> Replace `<oidc_provider_arn>` with the ARN of your OIDC provider, for example `arn:aws:iam::<aws_account_id>:oidc-provider/rh-oidc.s3.us-east-1.amazonaws.com/1v3r0n44npxu4g58so46aeohduomfres`.
+<1> Replace `<oidc_provider_arn>` with the ARN of your OIDC provider, for example, `arn:aws:iam::<aws_account_id>:oidc-provider/rh-oidc.s3.us-east-1.amazonaws.com/1v3r0n44npxu4g58so46aeohduomfres`. You can retrieve the ARN by using the `rosa describe cluster` CLI command.
 <2> Limits the role to the specified project and service account. Replace `<oidc_provider_name>` with the name of your OIDC provider, for example `rh-oidc.s3.us-east-1.amazonaws.com/1v3r0n44npxu4g58so46aeohduomfres`. Replace `<project_name>:<service_account_name>` with your project name and service account name, for example `my-project:test-service-account`.
 +
 [NOTE]


### PR DESCRIPTION
[OSDOCS-14108](https://issues.redhat.com//browse/OSDOCS-14108): Review-Authentication & Authorization
Name change **NOT** included. This can be picked up in the pruning tasks.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-14108

Link to docs preview:
Overview: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/
Understanding: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/understanding-authentication
Managing: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/managing-oauth-access-tokens
Configuring IDP: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/sd-configuring-identity-providers
Using RBAC: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/using-rbac
Understanding service accounts: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/understanding-and-creating-service-accounts
Using Service accounts: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/using-service-accounts-in-applications
Service account as OAuth: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/using-service-accounts-as-oauth-client
Assuming AWS IAM role: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/assuming-an-aws-iam-role-for-a-service-account
Scoping tokens: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/tokens-scoping
Using bound service tokens: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/bound-service-account-tokens
Managing security context: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/managing-security-context-constraints
Pod security: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/understanding-and-managing-pod-security-admission
Syncing LDAP groups: https://96304--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/ldap-syncing

QE review:
No QE needed.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
