### PR TITLE
[OSDOCS-15315]: Backporting etcd note changes to 4.12

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
@@ -14,6 +14,10 @@ include::modules/dr-restoring-cluster-state-about.adoc[leveloffset=+1]
 // Restoring to a previous cluster state
 include::modules/dr-restoring-cluster-state.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
+
 // Restoring a cluster from etcd backup manually
 include::modules/manually-restoring-cluster-etcd-backup.adoc[leveloffset=+1]
 

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -12,7 +12,7 @@ You can use a saved etcd backup to restore a previous cluster state or restore a
 
 [NOTE]
 ====
-If your cluster uses a control plane machine set, see "Troubleshooting the control plane machine set" for a more simple etcd recovery procedure.
+If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for an etcd recovery procedure.
 ====
 
 [IMPORTANT]

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -10,7 +10,7 @@ This procedure details the steps to replace an etcd member that is unhealthy eit
 
 [NOTE]
 ====
-If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for a more simple etcd recovery procedure.
+If your cluster uses a control plane machine set, see "Recovering a degraded etcd Operator" in "Troubleshooting the control plane machine set" for an etcd recovery procedure.
 ====
 
 .Prerequisites


### PR DESCRIPTION
Applying changes from https://github.com/openshift/openshift-docs/pull/96125 to 4.12
