### PR TITLE
POWERMON-628 New assembly for Kepler power attribution guide

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3304,6 +3304,8 @@ Topics:
     File: visualizing-power-monitoring-metrics
   - Name: Uninstalling power monitoring
     File: uninstalling-power-monitoring
+  - Name: Power monitoring references
+    File: power-monitoring-references
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance

--- a/modules/power-monitoring-kepler-power-attribution-guide.adoc
+++ b/modules/power-monitoring-kepler-power-attribution-guide.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: REFERENCE
+[id="power-monitoring-kepler-power-attribution-guide_{context}"]
+== Power monitoring Kepler power attribution guide
+
+Kepler's power attribution system provides practical, proportional distribution of hardware energy consumption to individual workloads. While CPU-time-based attribution has inherent limitations due to modern CPU complexity, it offers a good balance between accuracy, simplicity, and performance overhead for most monitoring and optimization use cases.
+
+For more information about power attribution, see link:http://sustainable-computing.io/kepler/usage/power-attribution[Kepler Power Attribution Guide].

--- a/observability/power_monitoring/power-monitoring-references.adoc
+++ b/observability/power_monitoring/power-monitoring-references.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="power-monitoring-references_{context}"]
+= Power monitoring references
+include::_attributes/common-attributes.adoc[]
+:context: power-monitoring-references
+
+toc::[]
+
+:FeatureName: Power monitoring
+include::snippets/technology-preview.adoc[leveloffset=+2]
+
+include::modules/power-monitoring-kepler-power-attribution-guide.adoc[Leveloffset=+1]
+
+//move API reference here post release. There may need to be additional IA updates for GA to better incorporate reference material.


### PR DESCRIPTION
*TECHNOLOGY PREVIEW*

[POWERMON-628](https://issues.redhat.com//browse/POWERMON-628) New assembly for Kepler power attribution guide

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the `power-monitoring-0.5` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the Power Monitoring content just before its GA.

Note to self: applies to 4.17+

Issue:
https://issues.redhat.com/browse/POWERMON-628

Link to docs preview:
https://96322--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/power_monitoring/power-monitoring-kepler-power-attribution-guide.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
