### PR TITLE
OSDOCS-15306: Update minimum cluster version for SDN-to-OVN migration

### DIFF
--- a/modules/migrate-sdn-ovn-osd.adoc
+++ b/modules/migrate-sdn-ovn-osd.adoc
@@ -7,7 +7,7 @@
 
 [WARNING]
 ====
-You can only initiate migration on clusters that are version 4.16.24 and above.
+You can only initiate migration on clusters that are version 4.16.43 and above.
 ====
 
 .Prerequisites

--- a/modules/migrate-sdn-ovn.adoc
+++ b/modules/migrate-sdn-ovn.adoc
@@ -7,7 +7,7 @@
 
 [WARNING]
 ====
-You can only initiate migration on clusters that are version 4.16.24 and above.
+You can only initiate migration on clusters that are version 4.16.43 and above.
 ====
 
 To initiate the migration, run the following command:

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.adoc
@@ -11,7 +11,7 @@ As an {product-title} cluster administrator, you can initiate the migration from
 
 Some considerations before starting migration initiation are:
 
-* The cluster version must be 4.16.24 and above.
+* The cluster version must be 4.16.43 and above.
 * The migration process cannot be interrupted.
 * Migrating back to the SDN network plugin is not possible.
 * Cluster nodes will be rebooted during migration.

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -11,7 +11,7 @@ As a {rosa-classic-first} cluster administrator, you can initiate the migration 
 
 Some considerations before starting migration initiation are:
 
-* The cluster version must be 4.16.24 and above.
+* The cluster version must be 4.16.43 and above.
 
 * The migration process cannot be interrupted.
 

--- a/osd_whats_new/osd-whats-new.adoc
+++ b/osd_whats_new/osd-whats-new.adoc
@@ -18,13 +18,20 @@ With its foundation in Kubernetes, {product-title} is a complete {OCP} cluster p
 [id="osd-q2-2025_{context}"]
 === Q2 2025
 
+// * **{product-title} SDN network plugin blocks future major upgrades**
+* **Updated version requirements for migration from OpenShift SDN to OVN-Kubernetes.**
+Your cluster version must be 4.16.43 or above to initiate live migration from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin. 
++
+If your cluster uses the OpenShift SDN network plugin, you cannot upgrade to future major versions of {product-title} without migrating to OVN-Kubernetes.
++
+For more information about migrating to OVN-Kubernetes, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.adoc#migrate-from-openshift-sdn[Migrating from OpenShift SDN network plugin to OVN-Kubernetes network plugin].
+
 * **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.19 are now available for new clusters.
 // re-add once upgrade to 4.19 is available
 // For more information about upgrading to this latest version, see xref:../upgrading/osd-upgrades.adoc#osd-upgrades[Red Hat OpenShift Dedicated cluster upgrades].
 
 * **Support for enabling and disabling Secure Boot for Shielded VMs on a per machine basis.**
 {product-title} on {GCP} users can now enable or disable Secure Boot for Shielded VMs on a per machine basis. For more information, see xref:../osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.adoc#osd-managing-worker-nodes[Managing compute nodes].
-
 
 [id="osd-q1-2025_{context}"]
 === Q1 2025

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -26,12 +26,24 @@ toc::[]
 
 [id="rosa-q2-2025_{context}"]
 === Q2 2025
+
+// * **{product-title} SDN network plugin blocks future major upgrades**
+* **Updated version requirements for migration from OpenShift SDN to OVN-Kubernetes.**
+Your cluster version must be 4.16.43 or above to initiate live migration from the OpenShift SDN network plugin to the OVN-Kubernetes network plugin. 
++
+If your cluster uses the OpenShift SDN network plugin, you cannot upgrade to future major versions of {product-title} without migrating to OVN-Kubernetes.
+//remove conditional when networking book is merged
+ifdef::openshift-rosa[]
++
+For more information about migrating to OVN-Kubernetes, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#migrate-from-openshift-sdn[Migrating from OpenShift SDN network plugin to OVN-Kubernetes network plugin].
+endif::openshift-rosa[]
+
 ifdef::openshift-rosa[]
 * **AWS Trainium and Inferentia instance types now supported.** You can now use {AWS} Trainium and Inferentia instance types for your {rosa-classic-short} clusters. For more information, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-instance-types.adoc#rosa-sdpolicy-aws-instance-types[Red Hat OpenShift Service on AWS instance types].
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
-* **AWS Trainium and Inferentia instance types now supported.** You can now use {AWS} Trainium and Inferentia instance types for your {hcp-title} clusters. For more information, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc#[Red Hat OpenShift Service on AWS (ROSA) with hosted control planes (HCP) instance types].
+* **AWS Trainium and Inferentia instance types now supported.** You can now use {AWS} Trainium and Inferentia instance types for your {hcp-title} clusters. For more information, see xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-instance-types.adoc#rosa-hcp-instance-types[Red Hat OpenShift Service on AWS (ROSA) with hosted control planes (HCP) instance types].
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa[]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-15306

Link to docs preview:
**OSD**
What's new (release notes): https://96333--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new#osd-q2-2025_osd-whats-new
OSD migration content: https://96333--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.html

**ROSA**
What's new (release notes): https://96333--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html#rosa-q2-2025_rosa-whats-new
What's new (release notes - classic): https://96333--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html#rosa-q2-2025_rosa-whats-new
* Note: I am aware that the product title is rendering a bit off, that is a separate issue

ROSA migration content: https://96333--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
