### PR TITLE
OSDOCS 12581 CMA should support bound service account tokens

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-prometheus-config.adoc
+++ b/modules/nodes-cma-autoscaling-custom-prometheus-config.adoc
@@ -18,7 +18,6 @@ These steps are not required for an external Prometheus source.
 You must perform the following tasks, as described in this section:
 
 * Create a service account.
-* Create a secret that generates a token for the service account.
 * Create the trigger authentication.
 * Create a role.
 * Add that role to the service account.
@@ -45,7 +44,7 @@ $ oc project <project_name> <1>
 *  If you are using a trigger authentication, specify the project with the object you want to scale.
 *  If you are using a cluster trigger authentication, specify the `openshift-keda` project.
 
-. Create a service account and token, if your cluster does not have one:
+. Create a service account if your cluster does not have one:
 
 .. Create a `service account` object by using the following command:
 +
@@ -54,53 +53,6 @@ $ oc project <project_name> <1>
 $ oc create serviceaccount thanos <1>
 ----
 <1> Specifies the name of the service account.
-
-.. Create a `secret` YAML to generate a service account token:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: thanos-token
-  annotations:
-    kubernetes.io/service-account.name: thanos <1>
-type: kubernetes.io/service-account-token
-----
-<1> Specifies the name of the service account.
-
-.. Create the secret object by using the following command:
-+
-[source,terminal]
-----
-$ oc create -f <file_name>.yaml
-----
-
-.. Use the following command to locate the token assigned to the service account:
-+
-[source,terminal]
-----
-$ oc describe serviceaccount thanos <1>
-----
-+
-<1> Specifies the name of the service account.
-+
---
-.Example output
-[source,terminal]
-----
-Name:                thanos
-Namespace:           <namespace_name>
-Labels:              <none>
-Annotations:         <none>
-Image pull secrets:  thanos-dockercfg-nnwgj
-Mountable secrets:   thanos-dockercfg-nnwgj
-Tokens:              thanos-token <1>
-Events:              <none>
-
-----
-<1> Use this token in the trigger authentication.
---
 
 . Create a trigger authentication with the service account token:
 
@@ -113,23 +65,18 @@ kind: <authentication_method> <1>
 metadata:
   name: keda-trigger-auth-prometheus
 spec:
-  secretTargetRef: <2>
-  - parameter: bearerToken <3>
-    name: thanos-token <4>
-    key: token <5>
-  - parameter: ca
-    name: thanos-token
-    key: ca.crt
+  boundServiceAccountToken: <2>
+    - parameter: bearerToken <3>
+      serviceAccountName: thanos <4>
 ----
 <1> Specifies one of the following trigger authentication methods:
 +
 *  If you are using a trigger authentication, specify `TriggerAuthentication`. This example configures a trigger authentication.
 *  If you are using a cluster trigger authentication, specify `ClusterTriggerAuthentication`.
 +
-<2> Specifies that this object uses a secret for authorization.
-<3> Specifies the authentication parameter to supply by using the token.
-<4> Specifies the name of the token to use.
-<5> Specifies the key in the token to use with the specified parameter.
+<2> Specifies that this trigger authentication uses a bound service account token for authorization when connecting to the metrics endpoint.
+<3> Specifies the authentication parameter to supply by using the token. Here, the example uses bearer authentication.
+<4> Specifies the name of the service account to use.
 
 .. Create the CR object:
 +
@@ -221,3 +168,53 @@ You can now deploy a scaled object or scaled job to enable autoscaling for your 
 * `triggers.metadata.authModes` must be `bearer`
 * `triggers.metadata.namespace` must be set to the namespace of the object to scale
 * `triggers.authenticationRef` must point to the trigger authentication resource specified in the previous step
+
+////
+Hiding, might not need it. If so, place this as step 2.
+.. Create a `secret` YAML to generate a service account token:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thanos-token
+  annotations:
+    kubernetes.io/service-account.name: thanos <1>
+type: kubernetes.io/service-account-token
+----
+<1> Specifies the name of the service account.
+
+.. Create the secret object by using the following command:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
+
+.. Use the following command to locate the token assigned to the service account:
++
+[source,terminal]
+----
+$ oc describe serviceaccount thanos <1>
+----
++
+<1> Specifies the name of the service account.
++
+--
+.Example output
+[source,terminal]
+----
+Name:                thanos
+Namespace:           <namespace_name>
+Labels:              <none>
+Annotations:         <none>
+Image pull secrets:  thanos-dockercfg-nnwgj
+Mountable secrets:   thanos-dockercfg-nnwgj
+Tokens:              thanos-token <1>
+Events:              <none>
+
+----
+<1> Use this token in the trigger authentication.
+--
+////

--- a/modules/nodes-cma-autoscaling-custom-trigger-auth-using.adoc
+++ b/modules/nodes-cma-autoscaling-custom-trigger-auth-using.adoc
@@ -12,19 +12,46 @@ You use trigger authentications and cluster trigger authentications by using a c
 
 * The Custom Metrics Autoscaler Operator must be installed.
 
-* If you are using a secret, the `Secret` object must exist, for example:
+* If you are using a bound service account token, the service account must exist.
+
+* If you are using a bound service account token, a role-based access control (RBAC) object that enables the Custom Metrics Autoscaler Operator to request service account tokens from the service account must exist.
 +
-.Example secret
 [source,yaml]
 ----
-apiVersion: v1
-kind: Secret
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
 metadata:
-  name: my-secret
-data:
-  user-name: <base64_USER_NAME>
-  password: <base64_USER_PASSWORD>
+  name: keda-operator-token-creator
+  namespace: <namespace_name> <1>
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+  resourceNames:
+  - thanos <2>
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: keda-operator-token-creator-binding
+  namespace: <namespace_name> <3>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: keda-operator-token-creator
+subjects:
+- kind: ServiceAccount
+  name: keda-operator
+  namespace: openshift-keda
 ----
+<1> Specifies the namespace of the service account.
+<2> Specifies the name of the service account.
+<3> Specifies the namespace of the service account.
+
+* If you are using a secret, the `Secret` object must exist.
 
 .Procedure
 
@@ -32,23 +59,22 @@ data:
 
 .. Create a YAML file that defines the object:
 +
-.Example trigger authentication with a secret
+.Example trigger authentication with a bound service account token
 [source,yaml]
 ----
 kind: TriggerAuthentication
 apiVersion: keda.sh/v1alpha1
 metadata:
   name: prom-triggerauthentication
-  namespace: my-namespace
-spec:
-  secretTargetRef:
-  - parameter: user-name
-    name: my-secret
-    key: USER_NAME
-  - parameter: password
-    name: my-secret
-    key: USER_PASSWORD
+  namespace: my-namespace <1>
+  spec:
+  boundServiceAccountToken: <2>
+    - parameter: token
+      serviceAccountName: thanos <3>
 ----
+<1> Specifies the namespace of the object you want to scale.
+<2> Specifies that this trigger authentication uses a bound service account token for authorization when connecting to the metrics endpoint.
+<3> Specifies the name of the service account to use.
 
 .. Create the `TriggerAuthentication` object:
 +

--- a/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc
@@ -15,21 +15,40 @@ Alternatively, to share credentials between objects in multiple namespaces, you 
 
 Trigger authentications and cluster trigger authentication use the same configuration. However, a cluster trigger authentication requires an additional `kind` parameter in the authentication reference of the scaled object.
 
-.Example secret for Basic authentication
+.Example trigger authentication that uses a bound service account token
 [source,yaml]
 ----
-apiVersion: v1
-kind: Secret
+kind: TriggerAuthentication
+apiVersion: keda.sh/v1alpha1
 metadata:
-  name: my-basic-secret
-  namespace: default
-data:
-  username: "dXNlcm5hbWU=" <1>
-  password: "cGFzc3dvcmQ="
+  name: secret-triggerauthentication
+  namespace: my-namespace <1>
+spec:
+  boundServiceAccountToken: <2>
+    - parameter: bearerToken
+      serviceAccountName: thanos <3>
 ----
-<1> User name and password to supply to the trigger authentication. The values in a `data` stanza must be base-64 encoded.
+<1> Specifies the namespace of the object you want to scale.
+<2> Specifies that this trigger authentication uses a bound service account token for authorization when connecting to the metrics endpoint.
+<3> Specifies the name of the service account to use.
 
-.Example trigger authentication using a secret for Basic authentication
+.Example cluster trigger authentication that uses a bound service account token
+[source,yaml]
+----
+kind: ClusterTriggerAuthentication
+apiVersion: keda.sh/v1alpha1
+metadata:
+  name: bound-service-account-token-triggerauthentication <1>
+spec:
+  boundServiceAccountToken: <2>
+    - parameter: bearerToken
+      serviceAccountName: thanos <3>
+----
+<1> Specifies the namespace of the object you want to scale.
+<2> Specifies that this cluster trigger authentication uses a bound service account token for authorization when connecting to the metrics endpoint.
+<3> Specifies the name of the service account to use.
+
+.Example trigger authentication that uses a secret for Basic authentication
 [source,yaml]
 ----
 kind: TriggerAuthentication
@@ -49,48 +68,24 @@ spec:
 <1> Specifies the namespace of the object you want to scale.
 <2> Specifies that this trigger authentication uses a secret for authorization when connecting to the metrics endpoint.
 <3> Specifies the authentication parameter to supply by using the secret.
-<4> Specifies the name of the secret to use.
+<4> Specifies the name of the secret to use. See the following example secret for Basic authentication.
 <5> Specifies the key in the secret to use with the specified parameter.
 
-.Example cluster trigger authentication with a secret for Basic authentication
-[source,yaml]
-----
-kind: ClusterTriggerAuthentication
-apiVersion: keda.sh/v1alpha1
-metadata: <1>
-  name: secret-cluster-triggerauthentication
-spec:
-  secretTargetRef: <2>
-  - parameter: username <3>
-    name: my-basic-secret <4>
-    key: username <5>
-  - parameter: password
-    name: my-basic-secret
-    key: password
-----
-<1> Note that no namespace is used with a cluster trigger authentication.
-<2> Specifies that this trigger authentication uses a secret for authorization when connecting to the metrics endpoint.
-<3> Specifies the authentication parameter to supply by using the secret.
-<4> Specifies the name of the secret to use.
-<5> Specifies the key in the secret to use with the specified parameter.
-
-.Example secret with certificate authority (CA) details
+.Example secret for Basic authentication
 [source,yaml]
 ----
 apiVersion: v1
 kind: Secret
 metadata:
-  name: my-secret
-  namespace: my-namespace
-data: 
-  ca-cert.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0... <1>
-  client-cert.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0... <2>
-  client-key.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0t...
+  name: my-basic-secret
+  namespace: default
+data:
+  username: "dXNlcm5hbWU=" <1>
+  password: "cGFzc3dvcmQ="
 ----
-<1> Specifies the TLS CA Certificate for authentication of the metrics endpoint. The value must be base-64 encoded.
-<2> Specifies the TLS certificates and key for TLS client authentication. The values must be base-64 encoded.
+<1> User name and password to supply to the trigger authentication. The values in the `data` stanza must be base-64 encoded.
 
-.Example trigger authentication using a secret for CA details
+.Example trigger authentication that uses a secret for CA details
 [source,yaml]
 ----
 kind: TriggerAuthentication
@@ -113,10 +108,10 @@ spec:
 <4> Specifies the name of the secret to use.
 <5> Specifies the key in the secret to use with the specified parameter.
 <6> Specifies the authentication parameter for a custom CA when connecting to the metrics endpoint.
-<7> Specifies the name of the secret to use.
+<7> Specifies the name of the secret to use. See the following example secret with certificate authority (CA) details.
 <8> Specifies the key in the secret to use with the specified parameter.
 
-.Example secret with a bearer token
+.Example secret with certificate authority (CA) details
 [source,yaml]
 ----
 apiVersion: v1
@@ -125,11 +120,14 @@ metadata:
   name: my-secret
   namespace: my-namespace
 data: 
-  bearerToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXV" <1>
+  ca-cert.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0... <1>
+  client-cert.pem: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0... <2>
+  client-key.pem: LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0t...
 ----
-<1> Specifies a bearer token to use with bearer authentication. The value in a `data` stanza must be base-64 encoded.
+<1> Specifies the TLS CA Certificate for authentication of the metrics endpoint. The value must be base-64 encoded.
+<2> Specifies the TLS certificates and key for TLS client authentication. The values must be base-64 encoded.
 
-.Example trigger authentication with a bearer token
+.Example trigger authentication that uses a bearer token
 [source,yaml]
 ----
 kind: TriggerAuthentication
@@ -146,10 +144,23 @@ spec:
 <1> Specifies the namespace of the object you want to scale.
 <2> Specifies that this trigger authentication uses a secret for authorization when connecting to the metrics endpoint.
 <3> Specifies the type of authentication to use.
-<4> Specifies the name of the secret to use.
+<4> Specifies the name of the secret to use. See the following example secret for a bearer token.
 <5> Specifies the key in the token to use with the specified parameter.
 
-.Example trigger authentication with an environment variable
+.Example secret for a bearer token
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+  namespace: my-namespace
+data: 
+  bearerToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXV" <1>
+----
+<1> Specifies a bearer token to use with bearer authentication. The value must be base-64 encoded.
+
+.Example trigger authentication that uses an environment variable
 [source,yaml]
 ----
 kind: TriggerAuthentication
@@ -169,7 +180,7 @@ spec:
 <4> Specify the name of the environment variable.
 <5> Optional: Specify a container that requires authentication. The container must be in the same resource as referenced by `scaleTargetRef` in the scaled object.
 
-.Example trigger authentication with pod authentication providers
+.Example trigger authentication that uses pod authentication providers
 [source,yaml]
 ----
 kind: TriggerAuthentication
@@ -189,7 +200,8 @@ spec:
 // ifndef::openshift-rosa,openshift-dedicated[]
 .Additional resources
 
-* For information about {product-title} secrets, see xref:../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets[Providing sensitive data to pods].
+* xref:../../authentication/understanding-and-creating-service-accounts.adoc#understanding-service-accounts[Understanding and creating service accounts]
+* xref:../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets[Providing sensitive data to pods].
 // endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/nodes-cma-autoscaling-custom-trigger-auth-using.adoc[leveloffset=+1]


### PR DESCRIPTION
**READY TO MERGE WHEN CUSTOM METRICS AUTOSCALER 2.17.2 RELEASES**

https://issues.redhat.com/browse/OSDOCS-12581

Link to docs preview:
[Understanding custom metrics autoscaler trigger authentications](https://96335--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth) -- Added three example trigger authentications that use bound service account tokens. Moved example secret to after the associated trigger auth example.  [Current docs for comparison](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator#nodes-cma-autoscaling-custom-trigger-auth).

[Using trigger authentications](https://96335--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.html#nodes-cma-autoscaling-custom-trigger-auth-using_nodes-cma-autoscaling-custom-trigger-auth) -- Updated example trigger auth to use bound service token. [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator#nodes-cma-autoscaling-custom-trigger-auth-using_nodes-cma-autoscaling-custom-trigger-auth)

[Configuring the custom metrics autoscaler to use OpenShift Container Platform monitoring](https://96335--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger#nodes-cma-autoscaling-custom-prometheus-config_nodes-cma-autoscaling-custom-trigger) -- Updated example trigger auth to use bound service token; removed prereq to have a secret (not needed for new token). [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator#nodes-cma-autoscaling-custom-prometheus-config_nodes-cma-autoscaling-custom-trigger).


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

