### PR TITLE
OSDOCS-15302: Create release notes for Kueue 1.0.1 patch release

### DIFF
--- a/modules/release-notes-1.0.1.adoc
+++ b/modules/release-notes-1.0.1.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * release_notes/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="release-notes-1.0.1_{context}"]
+= Release notes for {product-title} version 1.0.1
+
+{product-title} version 1.0.1 is a patch release that is supported on {platform} versions 4.18 and 4.19 on the 64-bit x86 architecture.
+
+{product-title} version 1.0.1 uses link:https://kueue.sigs.k8s.io/docs/overview/[Kueue] version 0.11.
+
+[id="release-notes-1.0.1-bug-fixes"]
+== Bug fixes in {product-title} version 1.0.1
+
+* Previously, leader election for {product-title} was not configured to tolerate disruption, which resulted in frequent crashing. With this release, the leader election values for {product-title} have been updated to match the durations recommended for {platform}. (link:https://issues.redhat.com/browse/OCPBUGS-58496[OCPBUGS-58496])
+
+* Previously, the `ReadyReplicas` count was not set in the reconciler, which meant that the {product-title} Operator status would report that there were no replicas ready. With this release, the `ReadyReplicas` count is based on the number of ready replicas for the deployment, which ensures that the Operator shows as ready in the {platform} console when the `kueue-controller-manager` pods are ready. (link:https://issues.redhat.com/browse/OCPBUGS-59261[OCPBUGS-59261])
+
+* Previously, when the `Kueue` custom resource (CR) was deleted from the `openshift-kueue-operator` namespace, the `kueue-manager-config` config map was not deleted automatically and could remain in the namespace. With this release, the `kueue-manager-config` config map, `kueue-webhook-server-cert` secret, and `metrics-server-cert` secret are deleted automatically when the `Kueue` CR is deleted. (link:https://issues.redhat.com/browse/OCPBUGS-57960[OCPBUGS-57960])

--- a/release_notes/release-notes.adoc
+++ b/release_notes/release-notes.adoc
@@ -8,4 +8,6 @@ toc::[]
 
 {product-title} is released as an Operator that is supported on {platform}.
 
+include::modules/release-notes-1.0.1.adoc[leveloffset=+1]
+
 include::modules/release-notes-1.0.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- `kueue-docs`
- `kueue-docs-1.0`

Issue:
https://issues.redhat.com/browse/OSDOCS-15302?src=confmacro

Link to docs preview:
https://96336--ocpdocs-pr.netlify.app/openshift-kueue/latest/release_notes/release-notes.html#release-notes-1.0.1_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
