### PR TITLE
OADP-2227: Update supported backup

### DIFF
--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -38,7 +38,6 @@ The following AWS S3 compatible object storage providers, are known to work with
 * DigitalOcean
 * NooBaa, unless installed using Multicloud Object Gateway (MCG)
 * Tencent Cloud
-* Ceph RADOS v12.2.7
 * Quobyte
 * Cloudian HyperStore
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
[OADP-2227](https://issues.redhat.com/browse/OADP-2227)

Link to docs preview:
[Supported backup storage providers](https://96353--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#oadp-s3-compatible-backup-storage-providers-unsupported)

QE review:
- [x] QE has approved this change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
