### PR TITLE
OSSM-9880 Update feature support table for 3.1

### DIFF
--- a/modules/ossm-release-notes-istio-ambient-mode.adoc
+++ b/modules/ossm-release-notes-istio-ambient-mode.adoc
@@ -12,5 +12,5 @@ Module included in the following assemblies:
 | Feature | Status
 
 | Istio ambient mode - all features
-| DP
+| TP
 |===

--- a/modules/ossm-release-notes-istio-deployment-lifecycle.adoc
+++ b/modules/ossm-release-notes-istio-deployment-lifecycle.adoc
@@ -36,7 +36,7 @@ Module included in the following assemblies:
 | GA
 
 | Dual stack IPv4/IPv6
-| TP
+| GA ^[4]^
 
 | Virtual machine (non-OpenShift) workload integration
 | NA
@@ -54,3 +54,4 @@ Module included in the following assemblies:
 . For more information, see "Support for Istioctl".
 . Installation is only supported by using the {SMProduct} 3 Operator, which uses the Istio Helm chart values for managing configuration.
 . The `ProxyConfig` API is supported with the exception of the image field, which is not supported.
+. Dual-Stack IPv4/IPv6 is supported on x86 environments only. On non-x86 environments, this feature remains a Technology Preview.

--- a/modules/ossm-release-notes-kubernetes-gateway-api.adoc
+++ b/modules/ossm-release-notes-kubernetes-gateway-api.adoc
@@ -18,13 +18,16 @@ Module included in the following assemblies:
 | GA
 
 | Kubernetes Gateway API custom resource definitions (CRDs)
-| DP ^[1]^
+| GA ^[1]^
 
 | Kubernetes Gateway API manual deployment
 | NA
 
 | Gateway network topology configuration
 | DP
+
+| Gateway inference extensions
+| TP
 |===
 
-. The use of Kubernetes Gateway API requires custom resource definitions (CRDs) that are not installed with {ocp-product-title} 4.18 and earlier releases.
+. The use of {k8s} Gateway API requires custom resource definitions (CRDs). The CRDs are present by default and generally available on {product-title} 4.19 and later releases. {product-title} 4.18 and earlier releases do not include or provide support for these CRDs.

--- a/modules/ossm-release-notes-sail-operator-apis.adoc
+++ b/modules/ossm-release-notes-sail-operator-apis.adoc
@@ -26,5 +26,5 @@ Module included in the following assemblies:
 | GA
 
 | ZTunnel
-| DP
+| TP
 |===

--- a/modules/ossm-release-notes-security-features.adoc
+++ b/modules/ossm-release-notes-security-features.adoc
@@ -31,6 +31,9 @@ Module included in the following assemblies:
 
 | Cert-Manager integration with the {cert-manager-operator}
 | GA
+
+| Kubernetes ClusterTrustBundles
+| DP
 |===
 
 [id="authorization-and-policy-enforcement_{context}"]

--- a/ossm-release-notes/ossm-release-notes-feature-support-tables.adoc
+++ b/ossm-release-notes/ossm-release-notes-feature-support-tables.adoc
@@ -1,6 +1,6 @@
 :_mod-docs_content-type: ASSEMBLY
 [id="ossm-release-notes-feature-support-tables"]
-= {SMProductShortName} {SMProductVersion} feature support tables
+= {SMProductShortName} feature support tables
 include::_attributes/common-attributes.adoc[]
 :context: ossm-release-notes-support-tables
 


### PR DESCRIPTION
Change type: Doc update; Update feature support table for 3.1

Doc JIRA: https://issues.redhat.com/browse/OSSM-9880

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

Doc Preview: https://96398--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-feature-support-tables.html

SME Review/QE Review: @longmuir @sridhargaddam @fjglira 
Peer Review: @rh-tokeefe 