### PR TITLE
OLS-1790: Document the supported vLLM version in OLS

### DIFF
--- a/modules/ols-large-language-model-requirements.adoc
+++ b/modules/ols-large-language-model-requirements.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="ols-large-language-model-requirements"]
-= Large Language Model (LLM) requirements
+= Large language model (LLM) requirements
 :context: ols-large-language-model-requirements
 
-A large language model (LLM) is a type of machine learning model that can interpret and generate human-like language. When an LLM is used with a virtual assistant the LLM can interpret questions accurately and provide helpful answers in a conversational manner.
+A large language model (LLM) is a type of machine learning model that interprets and generates human-like language. When an LLM is used with a virtual assistant, the LLM can accurately interpret questions and provide helpful answers in a conversational manner.
 
-The {ols-long} service must have access to an LLM provider. The service does not provide an LLM for you, so the LLM must be configured prior to installing the {ols-long} Operator. 
+The {ols-long} service must have access to an LLM provider. The service does not provide an LLM for you, so you must configure the LLM prior to installing the {ols-long} Operator. 
 
 The {ols-long} service can rely on the following Software as a Service (SaaS) LLM providers: 
 
@@ -41,14 +41,17 @@ To use {azure-official} with {ols-official}, you need access to link:https://azu
 
 {rhelai} is OpenAI API-compatible, and is configured in a similar manner as the OpenAI provider. 
 
-You can configure {rhelai} as the (Large Language Model) LLM provider. 
+You can configure {rhelai} as the LLM provider. 
 
 Because the {rhel} is in a different environment than the {ols-long} deployment, the model deployment must allow access using a secure connection. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_ai/1.2/html-single/building_your_rhel_ai_environment/index#creating_secure_endpoint[Optional: Allowing access to a model from a secure endpoint].
 
+{ols-long} version 1.0 and later supports vLLM Server version 0.8.4 and later. When self-hosting an LLM with {rhelai}, you can use vLLM Server as the inference engine.
 
 [id="rhoai_{context}"]
 == {rhoai}
 
 {rhoai} is OpenAI API-compatible, and is configured largely the same as the OpenAI provider. 
 
-You need a Large Language Model (LLM) deployed on the single model-serving platform of {rhoai} using the Virtual Large Language Model (vLLM) runtime. If the model deployment is in a different {ocp-short-name} environment than the {ols-long} deployment, the model deployment must include a route to expose it outside the cluster. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2-latest/html/serving_models/serving-large-models_serving-large-models#about-the-single-model-serving-platform_serving-large-models[About the single-model serving platform].
+You must deploy an LLM on the {rhoai} single-model serving platform that uses the Virtual Large Language Model (vLLM) runtime. If the model deployment resides in a different {ocp-short-name} environment than the {ols-long} deployment, include a route to expose the model deployment outside the cluster. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2-latest/html/serving_models/serving-large-models_serving-large-models#about-the-single-model-serving-platform_serving-large-models[About the single-model serving platform].
+
+{ols-long} version 1.0 and later supports vLLM Server version 0.8.4 and later. When self-hosting an LLM with {rhoai}, you can use vLLM Server as the inference engine.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-1790

Link to docs preview:
https://96403--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/about/ols-about-openshift-lightspeed.html#ols-large-language-model-requirements

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
