### PR TITLE
OSSM-9075: Minor updates for Kiali and Distributed Tracing

### DIFF
--- a/modules/ossm-config-otel-kiali.adoc
+++ b/modules/ossm-config-otel-kiali.adoc
@@ -29,7 +29,7 @@ spec:
       use_grpc: false
       internal_url: https://tempo-sample-gateway.tempo.svc.cluster.local:8080/api/traces/v1/default/tempo #<3>
       external_url: https://tempo-sample-gateway-tempo.apps-crc.testing/api/traces/v1/default/search #<4>
-      health_check_url: https://tempo-sample-gateway-tempo.apps-crc.testing/api/traces/v1/north/tempo/api/echo #<5>
+      health_check_url: https://tempo-sample-gateway-tempo.apps-crc.testing/api/traces/v1/default/tempo/api/echo #<5>
       auth: #<6>
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
         insecure_skip_verify: false
@@ -39,10 +39,10 @@ spec:
          url_format: "jaeger" #<7>
 ----
 <1> Specifies whether tracing is enabled.
-<2> Specifies either {TempoShortName} or {JaegerShortName}. Tempo can expose a Jaeger or Tempo API.
-<3> Specifies the internal URL for the Tempo API. If Tempo is deployed in a multi-tenant model, you must include the `tenant name` name.
-<4> Specifies the {ocp-short-name} route for the Jaeger UI. When deployed in a multi-tenant model, the gateway creates the route. Otherwise, you must create the route in the `Tempo` namespace. You can manually create the route for the `tempo-sample-query-frontend` service or update the `Tempo` CR with `.spec.template.queryFrontend.jaegerQuery.ingress.type: route`.
-<5> Specifies the health check URL. Not required by default. When Tempo is deployed in a multi-tenant model, Kiali does not expose the default health check URL. This is an example of a valid health URL.
+<2> Specifies either {TempoShortName} or {JaegerShortName}. The {DTShortName} can expose a Jaeger API or a Tempo API.
+<3> Specifies the internal URL for the Tempo API. When you deploy the {DTShortName} in multitenancy, include the tenant name in the URL path of the `internal_url` parameter. In this example, `default` represents the tenant name.
+<4> Specifies the {ocp-short-name} route for the Jaeger UI. When you deploy the {DTShortName} in multitenancy, the gateway creates the route. Otherwise, you must create the route in the `Tempo` namespace. You can manually create the route for the `tempo-sample-query-frontend` service or update the `Tempo` custom resource with `.spec.template.queryFrontend.jaegerQuery.ingress.type: route`.
+<5> Specifies the health check URL. Not required by default. When you deploy the {DTShortName} in multitenancy, it does not expose the default health check URL. This is an example of a valid health URL.
 <6> Specifies the configuration used when the access URL is `HTTPS` or requires authentication. Not required by default.
 <7> Specifies the configuration that defaults to `grafana`. Not required by default. Change to `jaeger` if the Kiali `View in tracing` link redirects to the Jaeger console UI.
 


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)
[service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

PR must be merged to service docs main and CP'd back to the 3.0 and 3.1 branches.

Version(s): 3.1

Issue: https://issues.redhat.com/browse/OSSM-9075#
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->](https://96406--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/kiali/ossm-kiali.html#ossm-config-otel-kiali_ossm-kiali)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
