### PR TITLE
OSDOCS-15282 [NETOBSERV] Line breaks for metrics-alerts-dashboards.adoc and its includes

### DIFF
--- a/modules/network-observability-configuring-custom-metrics.adoc
+++ b/modules/network-observability-configuring-custom-metrics.adoc
@@ -5,13 +5,14 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-configuring-custom-metrics_{context}"]
 = Configuring custom metrics by using FlowMetric API
+
 You can configure the `FlowMetric` API to create custom metrics by using flowlogs data fields as Prometheus labels. You can add multiple `FlowMetric` resources to a project to see multiple dashboard views.
 
 .Procedure
 
 . In the web console, navigate to *Operators* -> *Installed Operators*.
 . In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
-. In the *Project:*  dropdown list, select the project of the Network Observability Operator instance. 
+. In the *Project:*  dropdown list, select the project of the Network Observability Operator instance.
 . Click *Create FlowMetric*.
 . Configure the `FlowMetric` resource, similar to the following sample configurations:
 +
@@ -36,9 +37,9 @@ spec:
     matchType: Absence
 ----
 <1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
-<2> The name of the Prometheus metric, which in the web console appears with the prefix `netobserv-<metricName>`. 
+<2> The name of the Prometheus metric, which in the web console appears with the prefix `netobserv-<metricName>`.
 <3> The `type` specifies the type of metric. The `Counter` `type` is useful for counting bytes or packets.
-<4> The direction of traffic to capture. If not specified, both ingress and egress are captured, which can lead to duplicated counts. 
+<4> The direction of traffic to capture. If not specified, both ingress and egress are captured, which can lead to duplicated counts.
 <5> Labels define what the metrics look like and the relationship between the different entities and also define the metrics cardinality. For example, `SrcK8S_Name` is a high cardinality metric.
 <6> Refines results based on the listed criteria. In this example,  selecting only the cluster external traffic is done by matching only flows where `SrcSubnetLabel` is absent. This assumes the subnet labels feature is enabled (via `spec.processor.subnetLabels`), which is done by default.
 
@@ -78,7 +79,7 @@ spec:
 
 .Verification
 . Once the pods refresh, navigate to *Observe* -> *Metrics*.
-. In the *Expression* field, you can type the metric name to view the corresponding result. 
+. In the *Expression* field, you can type the metric name to view the corresponding result.
 ====
 
 

--- a/modules/network-observability-custom-metrics.adoc
+++ b/modules/network-observability-custom-metrics.adoc
@@ -5,4 +5,5 @@
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-custom-metrics_{context}"]
 = Custom metrics
-You can create custom metrics out of the flowlogs data using the `FlowMetric` API. In every flowlogs data that is collected, there are a number of fields labeled per log, such as source name and destination name. These fields can be leveraged as Prometheus labels to enable the customization of cluster information on your dashboard. 
+
+You can create custom metrics out of the flowlogs data using the `FlowMetric` API. In every flowlogs data that is collected, there are several fields labeled per log, such as source name and destination name. These fields can be leveraged as Prometheus labels to enable the customization of cluster information on your dashboard.

--- a/modules/network-observability-flowmetrics-charts.adoc
+++ b/modules/network-observability-flowmetrics-charts.adoc
@@ -5,14 +5,15 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-custom-charts-flowmetrics_{context}"]
 = Configuring custom charts using FlowMetric API
+
 You can generate charts for dashboards in the {product-title} web console, which you can view as an administrator in the *Dashboard* menu by defining the `charts` section of the `FlowMetric` resource.
 
 .Procedure
 . In the web console, navigate to *Operators* -> *Installed Operators*.
 . In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
-. In the *Project:*  dropdown list, select the project of the Network Observability Operator instance. 
+. In the *Project:*  dropdown list, select the project of the Network Observability Operator instance.
 . Click *Create FlowMetric*.
-. Configure the `FlowMetric` resource, similar to the following sample configurations: 
+. Configure the `FlowMetric` resource, similar to the following sample configurations:
 
 .Chart for tracking ingress bytes received from cluster external sources
 [%collapsible]

--- a/modules/network-observability-includelist-example.adoc
+++ b/modules/network-observability-includelist-example.adoc
@@ -4,6 +4,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-netobserv-dashboard-high-traffic-alert_{context}"]
 = Creating alerts
+
 You can create custom alerting rules for the Netobserv dashboard metrics to trigger alerts when some defined conditions are met.
 
 .Prerequisites

--- a/modules/network-observability-metrics-names.adoc
+++ b/modules/network-observability-metrics-names.adoc
@@ -5,12 +5,13 @@
 :_mod-docs-content-type: REFERENCE
 [id="network-observability-metrics_{context}"]
 = Network Observability metrics
+
 You can also create alerts by using the `includeList` metrics in Prometheus rules, as shown in the example "Creating alerts".
 
 When looking for these metrics in Prometheus, such as in the Console through *Observe* -> *Metrics*, or when defining alerts, all the metrics names are prefixed with `netobserv_`. For example, `netobserv_namespace_flows_total`. Available metrics names are as follows:
 
 includeList metrics names::
-Names followed by an asterisk `*` are enabled by default. 
+Names followed by an asterisk `*` are enabled by default.
 
 * `namespace_egress_bytes_total`
 * `namespace_egress_packets_total`

--- a/modules/network-observability-tcp-flag-syn-flood.adoc
+++ b/modules/network-observability-tcp-flag-syn-flood.adoc
@@ -5,14 +5,15 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-tcp-flag-syn-flood_{context}"]
 = Detecting SYN flooding using the FlowMetric API and TCP flags
-You can create an `AlertingRule` resouce to alert for SYN flooding. 
+
+You can create an `AlertingRule` resouce to alert for SYN flooding.
 
 .Procedure
 . In the web console, navigate to *Operators* -> *Installed Operators*.
 . In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
-. In the *Project*  dropdown list, select the project of the Network Observability Operator instance. 
+. In the *Project*  dropdown list, select the project of the Network Observability Operator instance.
 . Click *Create FlowMetric*.
-. Create `FlowMetric` resources to add the following configurations: 
+. Create `FlowMetric` resources to add the following configurations:
 +
 .Configuration counting flows per destination host and resource, with TCP flags
 [source,yaml]
@@ -81,5 +82,5 @@ metadata:
 .Verification
 . In the web console, click *Manage Columns* in the *Network Traffic* table view and click *TCP flags*.
 . In the *Network Traffic* table view, filter on *TCP protocol SYN TCPFlag*. A large number of flows with the same *byteSize* indicates a SYN flood.
-. Go to *Observe* -> *Alerting* and select the *Alerting Rules* tab. 
-. Filter on *netobserv-synflood-in alert*. The alert should fire when SYN flooding occurs. 
+. Go to *Observe* -> *Alerting* and select the *Alerting Rules* tab.
+. Filter on *netobserv-synflood-in alert*. The alert should fire when SYN flooding occurs.

--- a/modules/network-observability-viewing-dashboards.adoc
+++ b/modules/network-observability-viewing-dashboards.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-viewing-dashboards_{context}"]
 = Viewing Network Observability metrics dashboards
+
 On the *Overview* tab in the {product-title} console, you can view the overall aggregated metrics of the network traffic flow on the cluster. You can choose to display the information by node, namespace, owner, pod, and service. You can also use filters and display options to further refine the metrics.
 
 .Procedure
@@ -16,7 +17,7 @@ On the *Overview* tab in the {product-title} console, you can view the overall a
  * *DNS*
  * *RTT*
 
-. Select the *Netobserv/Health* dashboard. 
+. Select the *Netobserv/Health* dashboard.
 . View metrics about the health of the Operator in the following categories, with each having the subset per node, namespace, source, and destination.
 
 * *Flows*


### PR DESCRIPTION
[OSDOCS-15282](https://issues.redhat.com//browse/OSDOCS-15282) [NETOBSERV] Line breaks for metrics-alerts-dashboards.adoc and its includes

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14, 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-15282

Link to docs preview:
https://96425--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards.html

QE review:
QE is not required for this PR. This PR addresses style/template issues.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
