### PR TITLE
OSDOCS-15233:RFE-bootc image mode for RHEL

### DIFF
--- a/microshift_install_bootc/microshift-about-rhel-image-mode.adoc
+++ b/microshift_install_bootc/microshift-about-rhel-image-mode.adoc
@@ -9,6 +9,8 @@ toc::[]
 You can embed {microshift-short} into an operating system image using image mode for {op-system-base-full}.
 
 include::modules/microshift-install-bootc-conc.adoc[leveloffset=+1]
+include::modules/microshift-preparing-for-image-building-bootc.adoc[leveloffset=+1]
+
 
 [id="_additional-resources_microshift-install-rhel-image-mode_{context}"]
 == Additional resources

--- a/modules/microshift-install-bootc-build-image.adoc
+++ b/modules/microshift-install-bootc-build-image.adoc
@@ -14,6 +14,7 @@ Build your {op-system-base-full} that contains {microshift-short} as a bootable 
 * You logged into the {op-system-base} {op-system-version} host by using the user credentials that have `sudo` permissions.
 * The `rhocp` and `fast-datapath` repositories are accessible in the host subscription. The repositories do not necessarily need to be enabled on the host.
 * You have a remote registry such as link:https://quay.io[Red Hat quay] for storing and accessing bootc images.
+* You used the `dnf install -y container-tools` command to install the `container-tools` meta-package on the host. The meta-package contains all container tools, such as Podman, Buildah, and Skopeo for additional support and troubleshooting. These tools are required for obtaining assistance from Red{nbsp}Hat Support when you are building and installing the image.
 
 .Procedure
 
@@ -61,7 +62,6 @@ WantedBy=multi-user.target
 EOF
 RUN systemctl enable microshift-make-rshared.service
 ----
-+
 [IMPORTANT]
 ====
 Podman uses the host subscription information and repositories inside the container when building the container image. If the `rhocp` and `fast-datapath` repositories are not available on the host, the build fails.

--- a/modules/microshift-preparing-for-image-building-bootc.adoc
+++ b/modules/microshift-preparing-for-image-building-bootc.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// microshift_install_bootc/microshift-about-rhel-image-mode
+
+:_mod-docs-content-type: CONCEPT
+[id="preparing-for-image-building_{context}"]
+= Preparing for image building
+
+Use the image builder tool to compose customized {microshift-short} bootc images optimized for edge deployments. You can run a {microshift-short} cluster with your applications on a {op-system-image} virtual machine for development and testing first, then use your whole solution in edge production environments.
+
+Use the following {op-system-base} documentation to understand the full details of using {op-system-image}:
+
+* Follow the instructions in link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/index[Using image mode for RHEL to build, deploy, and manage operating systems]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-15233

Link to docs preview:
https://96428--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-about-rhel-image-mode.html

QE review:
- [x] QE has approved this change.