### PR TITLE
OCP-4.18 cherry pick OADP-5784: Release Notes for OADP 1.4.5

### DIFF
--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -14,6 +14,7 @@ The release notes for {oadp-first} describe new features and enhancements, depre
 For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
 ====
 
+include::modules/oadp-1-4-5-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-4-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-3-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-2-release-notes.adoc[leveloffset=+1]

--- a/modules/oadp-1-4-5-release-notes.adoc
+++ b/modules/oadp-1-4-5-release-notes.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-5-release-notes_{context}"]
+= {oadp-short} 1.4.5 release notes
+
+The {oadp-first} 1.4.5 release notes lists new features and resolved issues.
+
+[id="new-features-1-4-5_{context}"]
+== New features
+
+.Collecting logs with the `must-gather` tool has been improved with a Markdown summary
+
+You can collect logs and information about {oadp-first} custom resources by using the `must-gather` tool. The `must-gather` data must be attached to all customer cases.
+This tool generates a Markdown output file with the collected information, which is located in the clusters directory of the `must-gather` logs.  link:https://issues.redhat.com/browse/OADP-5904[(OADP-5904)]
+
+[id="resolved-issues-1-4-5_{context}"]
+== Resolved issues
+
+{oadp-short} 1.4.5 fixes the following CVEs:: 
+
+* link:https://access.redhat.com/security/cve/CVE-2024-45337[CVE-2024-45337] 
+
+* link:https://access.redhat.com/security/cve/CVE-2024-45338[CVE-2024-45338] 
+
+* link:https://access.redhat.com/security/cve/CVE-2025-21613[CVE-2025-21613]
+
+* link:https://access.redhat.com/security/cve/CVE-2025-27144[CVE-2025-27144]
+
+* link:https://access.redhat.com/security/cve/CVE-2025-22868[CVE-2025-22868] 
+
+* link:https://access.redhat.com/security/cve/CVE-2025-22869[CVE-2025-22869] 
+
+* link:https://access.redhat.com/security/cve/CVE-2025-30204[CVE-2025-30204] 


### PR DESCRIPTION
### Cherry pick

Cherry Picked from https://github.com/openshift/openshift-docs/pull/92744 xref: f56196d926894af920f0f2da9fc1b93c40e1d555

### JIRA

* [OADP-5784](https://issues.redhat.com/browse/OADP-5784)

### Version(s):

* OCP 4.18 → branch/enterprise-4.18

### Link to docs preview:

* [Release Notes OADP 1.4.5](https://96429--ocpdocs-pr.netlify.app/openshift-rosa/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
