### PR TITLE
OSDOCS-15140: Updated the release notes to note that Platform monitoring is deprecated

### DIFF
--- a/observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc
@@ -22,6 +22,14 @@ ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 ====
 
+ifdef::openshift-rosa-hcp[]
+[IMPORTANT]
+====
+You cannot disable workload monitoring due to requirements for the Cluster Monitoring Operator.
+====
+endif::openshift-rosa-hcp[]
+
+
 // Configurable monitoring components
 include::modules/monitoring-configurable-monitoring-components.adoc[leveloffset=+1,tags=**;!CPM;UWM]
 

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -366,6 +366,10 @@ include::modules/rosa-update-cli-tool.adoc[]
 == Deprecated and removed features
 Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
 
-* **{product-title} non-STS deployment mode.** {product-title} non-STS deployment mode is no longer the preferred method for new clusters. Instead, users must deploy {product-title} with the STS mode. This deprecation is in line with our new {product-title} provisioning wizard UI experience at https://console.redhat.com/openshift/create/rosa/wizard.
+ifdef::openshift-rosa-hcp[]
+* **Disable workload monitoring**. Previously, users could disable workload monitoring on {product-title} clusters. However, to allow users to own the full Cluster Monitoring Operator (CMO) stack on {product-title} clusters, the ability to disable workload monitoring has been deprecated. For more information, see xref:../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#preparing-to-configure-the-monitoring-stack-uwm[Preparing to configure the user workload monitoring stack].
+endif::openshift-rosa-hcp[]
+
+* **ROSA non-STS deployment mode.** ROSA non-STS deployment mode is no longer the preferred method for new clusters. Instead, users must deploy ROSA with the STS mode. This deprecation is in line with our new ROSA provisioning wizard UI experience on the link:https://console.redhat.com/openshift/create/rosa/wizard[Red Hat Hybrid Cloud Console].
 
 * **Label removal on core namespaces.** {product-title} is no longer labeling OpenShift core using the `name` label. Customers should migrate to referencing the `kubernetes.io/metadata.name` label if needed for Network Policies or other use cases.


### PR DESCRIPTION
Version(s):
`enterprise-4.19+`

Issue:
**[OSDOCS-15140](https://issues.redhat.com/browse/OSDOCS-15140)**

Link to docs preview:
- [What's New in ROSA](https://96436--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html#rosa-deprecated-removed-features_rosa-whats-new) (HCP)
- [What's New in ROSA](https://96436--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html#rosa-deprecated-removed-features_rosa-whats-new) (classic)
    <img width="879" height="123" alt="image" src="https://github.com/user-attachments/assets/117e5f0e-8289-4e73-8b4e-cbce68a7b444" />
- [Preparing to configure the user workload monitoring stack](https://96436--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm) (HCP)
    <img width="897" height="468" alt="image" src="https://github.com/user-attachments/assets/34f77dbf-3ea3-42d6-8032-420cc13e7697" />


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds a notice to the release notes about the deprecation of the CMO configuration as well as Platform Monitoring.