### PR TITLE
OSDOCS-14341-12: Fixed unrendered IBM attributes in titles

### DIFF
--- a/applications/connecting_applications_to_services/getting-started-with-service-binding-ibm-power-ibm-z.adoc
+++ b/applications/connecting_applications_to_services/getting-started-with-service-binding-ibm-power-ibm-z.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="getting-started-with-service-binding-ibm-power-ibm-z"]
-= Getting started with service binding on {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName}
+= Getting started with service binding on IBM Power, IBM Z, and IBM LinuxONE
 include::_attributes/common-attributes.adoc[]
 include::_attributes/servicebinding-document-attributes.adoc[]
 :context: getting-started-with-service-binding-ibm-power-ibm-z

--- a/installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc
+++ b/installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="preparing-to-install-on-ibm-z"]
-= Preparing to install on IBM Z(R) and {linuxoneProductName}
+= Preparing to install on IBM Z and IBM LinuxONE
 include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-ibm-z
 
@@ -21,7 +21,7 @@ While this document refers only to {ibmzProductName}, all information in it also
 ====
 
 [id="choosing-an-method-to-install-ocp-on-ibm-z"]
-== Choosing a method to install {product-title} on {ibmzProductName} or {linuxoneProductName}
+== Choosing a method to install {product-title} on IBM Z or IBM LinuxONE
 
 You can install {product-title} with the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[{ai-full}]. This method requires no setup for the installer, and is ideal for connected environments like {ibmzProductName}.
 See xref:../../installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc#installing-on-prem-assisted[Installing an on-premise cluster using the {ai-full}] for additional details.
@@ -40,7 +40,7 @@ See the xref:../../architecture/architecture-installation.adoc#installation-proc
 The steps for performing a user-provisioned infrastructure installation are provided as an example only. Installing a cluster with infrastructure you provide requires knowledge of the {ibmzProductName} platform and the installation process of {product-title}. Use the user-provisioned infrastructure installation instructions as a guide; you are free to create the required resources through other methods.
 ====
 
-=== User-provisioned infrastructure installation of {product-title} on {ibmzProductName}
+=== User-provisioned infrastructure installation of {product-title} on IBM Z
 
 User-provisioned infrastructure requires the user to provision all resources required by {product-title}.
 

--- a/installing/installing_rhv/preparing-to-install-on-rhv.adoc
+++ b/installing/installing_rhv/preparing-to-install-on-rhv.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="preparing-to-install-on-rhv"]
-= Preparing to install on {rh-virtualization-first}
+= Preparing to install on Red Hat Virtualization (RHV)
 include::_attributes/common-attributes.adoc[]
 :context: preparing-to-install-on-rhv
 
@@ -14,7 +14,7 @@ toc::[]
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="choosing-an-method-to-install-ocp-on-rhv"]
-== Choosing a method to install {product-title} on {rh-virtualization}
+== Choosing a method to install {product-title} on RHV
 
 You can install {product-title} on installer-provisioned or user-provisioned infrastructure. The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provision. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
 

--- a/modules/distr-tracing-tempo-object-storage-setup-ibm-storage.adoc
+++ b/modules/distr-tracing-tempo-object-storage-setup-ibm-storage.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="distr-tracing-tempo-object-storage-setup-ibm-storage_{context}"]
-= Setting up {ibm-cloud-title} Object Storage
+= Setting up IBM Cloud Object Storage
 
 You can set up {ibm-cloud-title} Object Storage by using the {oc-first}.
 

--- a/modules/ibm-z-rhel-kvm-host-recommendations.adoc
+++ b/modules/ibm-z-rhel-kvm-host-recommendations.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="ibm-z-rhel-kvm-host-recommendations_{context}"]
-= {op-system-base} KVM on {ibmzProductName} host recommendations
+= {op-system-base} KVM on IBM Z host recommendations
 
 Optimizing a KVM virtual server environment strongly depends on the workloads of the virtual servers and on the available resources. The same action that enhances performance in one environment can have adverse effects in another. Finding the best balance for a particular setting can be a challenge and often involves experimentation.
 

--- a/modules/install-ibm-cloud-preparing-the-provisioner-node.adoc
+++ b/modules/install-ibm-cloud-preparing-the-provisioner-node.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="preparing-the-provisioner-node-for-openshift-install-on-ibm-cloud_{context}"]
-= Preparing the provisioner node on {ibmcloudBMProductName} infrastructure
+= Preparing the provisioner node on IBM Cloud Bare Metal (Classic) infrastructure
 
 Perform the following steps to prepare the provisioner node.
 

--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -50,7 +50,7 @@ See link:https://access.redhat.com/articles/rhel-limits[Red Hat Enterprise Linux
 The {product-title} installer creates the Ignition files, which are necessary for all the {op-system-first} virtual machines. The automated installation of {product-title} is performed by the bootstrap machine. It starts the installation of {product-title} on each node, starts the Kubernetes cluster, and then finishes. During this bootstrap, the virtual machine must have an established network connection either through a Dynamic Host Configuration Protocol (DHCP) server or static IP address.
 
 [id="ibm-z-network-connectivity_{context}"]
-== {ibmzProductName} network connectivity requirements
+== IBM Z network connectivity requirements
 
 To install on {ibmzProductName} under {op-system-base} KVM, you need:
 
@@ -74,7 +74,7 @@ Support for {op-system} functionality for IBM z13 all models, {linuxoneProductNa
 ====
 
 [id="minimum-ibm-z-system-requirements_{context}"]
-== Minimum {ibmzProductName} system environment
+== Minimum IBM Z system environment
 
 [discrete]
 === Hardware requirements
@@ -145,7 +145,7 @@ Each cluster virtual machine must meet the following minimum requirements:
 --
 
 [id="preferred-ibm-z-system-requirements_{context}"]
-== Preferred {ibmzProductName} system environment
+== Preferred IBM Z system environment
 
 [discrete]
 === Hardware requirements

--- a/modules/minimum-ibm-z-system-requirements.adoc
+++ b/modules/minimum-ibm-z-system-requirements.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="minimum-ibm-z-system-requirements_{context}"]
-= Minimum {ibmzProductName} system environment
+= Minimum IBM Z system environment
 
 You can install {product-title} version {product-version} on the following IBM hardware:
 
@@ -45,7 +45,7 @@ On your z/VM instance, set up:
 * One guest virtual machine for the temporary {product-title} bootstrap machine
 
 [discrete]
-== {ibmzProductName} network connectivity requirements
+== IBM Z network connectivity requirements
 
 To install on {ibmzProductName} under z/VM, you require a single z/VM virtual NIC in layer 2 mode. You also need:
 

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -346,7 +346,7 @@ One of the following additional audit log targets:
 |Set this field to `true` to send egress traffic from pods to the host networking stack.
 [NOTE]
 ====
-In {product-title} {version}, egress IP is only assigned to the primary interface. Consequentially, setting `routingViaHost` to `true` will not work for egress IP in {product-title} {version}.
+In {product-title} {product-version}, egress IP is only assigned to the primary interface. Consequentially, setting `routingViaHost` to `true` will not work for egress IP in {product-title} {product-version}.
 ====
 For highly-specialized installations and applications that rely on manually configured routes in the kernel routing table, you might want to route egress traffic to the host networking stack.
 By default, egress traffic is processed in OVN to exit the cluster and is not affected by specialized routes in the kernel routing table.

--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -101,7 +101,7 @@
 5. Cluster is scaled in iterations.
 --
 
-== {ibmzProductName} platform
+== IBM Z platform
 
 [options="header",cols="6*"]
 |===

--- a/modules/preferred-ibm-z-system-requirements.adoc
+++ b/modules/preferred-ibm-z-system-requirements.adoc
@@ -27,7 +27,7 @@ On your z/VM instances, set up:
 * To ensure the availability of integral components in an overcommitted environment, increase the priority of the control plane by using the CP command `SET SHARE`. Do the same for infrastructure nodes, if they exist. See link:https://www.ibm.com/docs/en/zvm/latest?topic=commands-set-share[SET SHARE] in IBM Documentation.
 
 [discrete]
-== {ibmzProductName} network connectivity requirements
+== IBM Z network connectivity requirements
 
 To install on {ibmzProductName} under z/VM, you require a single z/VM virtual NIC in layer 2 mode. You also need:
 

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -62,7 +62,7 @@ For information about how to enable the serial console, see the following docume
 * xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-machines-advanced-customizing-live-pxe-serial-console_installing-bare-metal[Modifying a live install PXE environment to enable the serial console].
 
 [id="ocp-4-12-secure-execution-z-linux-one_{context}"]
-==== IBM Secure Execution on {ibmzProductName} and LinuxONE (Technology Preview)
+==== IBM Secure Execution on IBM Z and LinuxONE (Technology Preview)
 {product-title} now supports configuring {op-system-first} nodes for IBM Secure Execution on {ibmzProductName} and LinuxONE (s390x architecture) as a Technology Preview feature. IBM Secure Execution is a hardware enhancement that protects memory boundaries for KVM guests. IBM Secure Execution provides the highest level of isolation and security for cluster workloads, and you can enable it by using an IBM Secure Execution-ready QCOW2 boot image.
 
 To use IBM Secure Execution, you must have host keys for your host machine(s) and they must be specified in your Ignition configuration file. IBM Secure Execution automatically encrypts your boot volumes using LUKS encryption.


### PR DESCRIPTION
I've tried various ways to get the IBM attributes to render in headings but no matter where I relocate the attributes include or the [guidance](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#assembly-file-metadata) from our doc, these changes do not work. Best to try hard-coding to avoid the unrendered attributes on docs.redhat.com.

I'm trialing the changes on the 4.13 branch as the ultimate test is publication on docs.redhat.com.

Version(s):
4.12

Issue:
[OSDOCS-14341](https://issues.redhat.com/browse/OSDOCS-14341)

Preview:
* [IBM titles](https://96439--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/install-ibm-cloud-prerequisites)
* [RHV](https://96439--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_rhv/preparing-to-install-on-rhv)


