### PR TITLE
OCPBUGS#57358: Added compliance profile warning for disabling sshd im…

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -148,6 +148,11 @@ BSI (Bundesamt für Sicherheit in der Informationstechnik, Germany’s Federal O
 [id="fedramp-high-profiles_{context}"]
 == FedRAMP High compliance profiles
 
+[IMPORTANT]
+====
+Applying automatic remedations to any profile, such as `rhcos4-stig`, that uses the `service-sshd-disabled` rule, automatically disables the `sshd` service. This situation blocks SSH access to control plane nodes and compute nodes. To keep the SSH access enabled, create a `TailoredProfile` object and set the `rhcos4-service-sshd-disabled` rule value for the `disableRules` parameter.
+====
+
 .Supported FedRAMP High compliance profiles
 [cols="2,2,1,2,1,2", options="header"]
 
@@ -392,6 +397,11 @@ BSI (Bundesamt für Sicherheit in der Informationstechnik, Germany’s Federal O
 
 [id="stig-profiles_{context}"]
 == STIG compliance profiles
+
+[IMPORTANT]
+====
+Applying automatic remedations to any profile, such as `rhcos4-stig`, that uses the `service-sshd-disabled` rule, automatically disables the `sshd` service. This situation blocks SSH access to control plane nodes and compute nodes. To keep the SSH access enabled, create a `TailoredProfile` object and set the `rhcos4-service-sshd-disabled` rule value for the `disableRules` parameter.
+====
 
 .Supported STIG compliance profiles
 [cols="2,2,1,2,1,2", options="header"]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OCPBUGS-57358](https://issues.redhat.com/browse/OCPBUGS-57358)

Link to docs preview:
* [FedRAMP High compliance profiles](https://96440--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-supported-profiles.html#fedramp-high-profiles_compliance-operator-supported-profiles)

- [x] SME has approved this change (Vladislav Walek).
- [x] QE has approved this change (Xiaojie Yuan).

