### PR TITLE
OCPBUGS-59147#Add RN for extended loopback cert validity for kube-api server

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1196,6 +1196,12 @@ When making changes to your worker nodes through a machine config, the changes a
 
 With this update, machine config changes made to a custom node take precedence over machine config changes made to a worker node, regardless of the machine config names. 
 
+[discrete]
+[id="ocp-4-15-notable-technical-changes-loopback-cert_{context}"]
+=== Extended loopback certificate validity to three years for kube-apiserver
+
+Previously, the self-signed loopback certificate for the Kubernetes API Server expired after one year. With this release, the expiration date of the certificate is extended to three years.
+
 [id="ocp-4-15-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-59147
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Already in 4.19 and 4.18 https://github.com/openshift/openshift-docs/pull/94947 and in 4.17 https://github.com/openshift/openshift-docs/pull/95476, and 4.16 https://github.com/openshift/openshift-docs/pull/96069
- LGTMs in 4.18 issue: https://issues.redhat.com/browse/OCPBUGS-56835
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
