### PR TITLE
OCPBUGS#59346: Agent encryption note

### DIFF
--- a/modules/installing-ocp-agent-encrypt.adoc
+++ b/modules/installing-ocp-agent-encrypt.adoc
@@ -8,6 +8,12 @@
 
 As an optional task, you can use this procedure to encrypt your disk or partition while installing {product-title} with the Agent-based Installer.
 
+[IMPORTANT]
+====
+If there are leftover TPM encryption keys from a previous operating system on the bare-metal host, the cluster deployment can get stuck.
+To avoid this situation, it is highly recommended to reset the TPM chip in the BIOS before booting the ISO.
+====
+
 .Prerequisites
 
 * You have created and configured the `install-config.yaml` and `agent-config.yaml` files, unless you are using ZTP manifests.


### PR DESCRIPTION
[OCPBUGS-59346](https://issues.redhat.com/browse/OCPBUGS-59346)

Version(s): 4.14+

This PR adds an important note to the disk encryption docs for the Agent-based Installer

QE review:
- [x] QE has approved this change.

Preview: [Encrypting the disk](https://96474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-encrypt_installing-with-agent-based-installer)