### PR TITLE
OSDOCS-15475: Updated the Life cycle dates to exclude 4.14 for OSD, ROSA Classic, and ROSA with HCP

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -19,15 +19,15 @@ endif::[]
 |4.17       |Oct 14, 2024           |Feb 14, 2026
 |4.16       |Jul 2, 2024            |Nov 2, 2025
 |4.15       |Feb 27, 2024           |Aug 27, 2025
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp,rosa-with-hcp[]
 |4.14       |Oct 31, 2023           |Jun 1, 2025
-ifndef::rosa-with-hcp[]
 |4.13       |May 17, 2023           |Sep 17, 2024
 |4.12       |Jan 17, 2023           |Jul 17, 2024
 |4.11       |Aug 10, 2022           |Dec 10, 2023
 |4.10       |Mar 10, 2022           |Sep 10, 2023
 |4.9        |Oct 18, 2021           |Dec 18, 2022
 |4.8        |Jul 27, 2021           |Sep 27, 2022
-endif::rosa-with-hcp[]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp,rosa-with-hcp[]
 |===
 
 ifeval::["{context}" == "rosa-hcp-life-cycle"]


### PR DESCRIPTION
Version(s):
`enterprise-4.19+`

Issue:
**[OSDOCS-15475](https://issues.redhat.com/browse/OSDOCS-15475)**

Link to docs preview:
- [Life cycle dates](https://96476--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html#sd-life-cycle-dates_rosa-hcp-life-cycle) (ROSA classic)
- [Life cycle dates](https://96476--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html#sd-life-cycle-dates_rosa-hcp-life-cycle) (ROSA with HCP)
- [Life cycle dates](https://96476--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-life-cycle.html#sd-life-cycle-dates_osd-life-cycle) (OSD)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updated the life cycle dates.