### PR TITLE
ROX-29793: Add compliance v2 access rights info

### DIFF
--- a/operating/manage-compliance/compliance-feature-overview.adoc
+++ b/operating/manage-compliance/compliance-feature-overview.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The compliance feature ensures that your Kubernetes clusters adhere to industry standards and regulatory requirements. It provides automated compliance checks that enable you to continuously monitor your clusters against predefined benchmarks such as CIS, PCI-DSS, HIPAA, and so on. 
+The compliance feature ensures that your Kubernetes clusters adhere to industry standards and regulatory requirements. It provides automated compliance checks that enable you to continuously monitor your clusters against predefined benchmarks such as CIS, PCI-DSS, HIPAA, and so on.
 
 The feature includes detailed reports and remediation guidance to help administrators quickly identify and resolve compliance issues. You can view the compliance results associated with your cluster by using the compliance feature in the {rh-rhacs-first} portal.
 
@@ -27,6 +27,11 @@ Formerly known as _Compliance 2.0_, summarizes the compliance information in a s
 * You can now use the new OpenShift infrastructure compliance feature to assess compliance across your entire OpenShift cluster fleet and ensure consistent adherence to the security policies of your organization. {product-title-short} now generates reports even if some clusters in a scheduled scan fail, so that you can maintain visibility into the compliance status of successfully scanned clusters without data gaps.
 +
 For more information, see xref:../../operating/manage-compliance/using-openshift-compliance.adoc#using-openshift-compliance[Using OpenShift compliance].
+====
+
+[NOTE]
+====
+To access the Compliance menu and API, a user must have at least read permissions for the `Compliance` resource and read permissions for the `Cluster` resource. Additionally, to use email notifiers in the scan schedule configuration, the user requires read permissions for the `Integration` resource.
 ====
 
 [id="dashboard_{context}"]


### PR DESCRIPTION
This PR is adding additional clarification about the required access rights for a user to use the compliance v2 feature.

Related to PR: https://github.com/stackrox/stackrox/pull/15883

Version(s):
RHACS 4.9.+

Issue:
https://issues.redhat.com/browse/ROX-29793

Link to docs preview:
https://96487--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-compliance/compliance-feature-overview.html

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
