### PR TITLE
OSDOCS#13677: Remove references to RHEL 9.3 in the About topic

### DIFF
--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -25,8 +25,6 @@ The latest release notes for each product that is part of {product-title} are av
 
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.2_release_notes/index[{op-system-first}] 9.2 release notes.
 
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.3_release_notes/index[{op-system-first}] 9.3 release notes.
-
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.4_release_notes/index[{op-system-first}] 9.4 release notes.
 
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.6_release_notes/index[{op-system-first}] 9.6 release notes.
@@ -64,11 +62,11 @@ The latest release notes for each product that is part of {product-title} are av
 ^|4.16
 ^|4.16.0{nbsp}&#8594;{nbsp}4.16.z, 4.16{nbsp}&#8594;{nbsp}4.17, 4.16{nbsp}&#8594;{nbsp}4.18
 
-^|9.2, 9.3
+^|9.2
 ^|4.15
 ^|4.15.0{nbsp}&#8594;{nbsp}4.15.z, 4.15{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
 
-^|9.2, 9.3
+^|9.2
 ^|4.14
 ^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.15, 4.14{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
 |===


### PR DESCRIPTION
Version(s):
RHDE 4

Issue:
[OSDOCS-13677](https://issues.redhat.com//browse/OSDOCS-13677)

Link to docs preview:
[RHDE overview](https://96493--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html)

QE review:
- [ ] QE has approved this change.
QE not required.

Additional information:
[Original PR](https://github.com/openshift/openshift-docs/pull/95064)
