### PR TITLE
OSSM-8266: Installing Kiali in a multi-cluster mesh

### DIFF
--- a/install/ossm-multi-cluster-topologies.adoc
+++ b/install/ossm-multi-cluster-topologies.adoc
@@ -15,6 +15,14 @@ include::modules/ossm-applying-certificates-to-a-multi-cluster-topology.adoc[lev
 include::modules/ossm-installing-multi-primary-multi-network-mesh.adoc[leveloffset=+1]
 include::modules/ossm-verifying-multi-cluster-topology.adoc[leveloffset=+2]
 include::modules/ossm-removing-multi-cluster-installation-from-development-environment.adoc[leveloffset=+2]
+include::modules/ossm-installing-kiali-multi-cluster-mesh.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="ossm-kiali-multi-cluster-additional-resource_{context}"]
+.Additional resources
+
+* xref:../observability/kiali/ossm-kiali.adoc#ossm-kiali[Using Kiali Operator provided by Red Hat]
+
 include::modules/ossm-installing-primary-remote-multi-network-mesh.adoc[leveloffset=+1]
 [role="_next-steps"]
 .Next steps

--- a/modules/ossm-config-otel-kiali.adoc
+++ b/modules/ossm-config-otel-kiali.adoc
@@ -6,7 +6,7 @@
 [id="ossm-config-otel-kiali_{context}"]
 = Configuring {DTProductName} with {KialiProduct}
 
-After {KialiProduct} is integrated with {DTProductName}, you can view distributed traces in the Kiali console. Viewing these traces can provide insight into the communication between services within the service mesh, helping you understand how requests are flowing through your system and where potential issues might be.
+After you integrate {KialiProduct} with {DTProductName}, you can view distributed traces in the Kiali console. Viewing traces provides insight into the communication between services within the service mesh, helping you understand how requests are flowing through your system and where potential issues might reside.
 
 .Prerequisites
 

--- a/modules/ossm-installing-kiali-multi-cluster-mesh.adoc
+++ b/modules/ossm-installing-kiali-multi-cluster-mesh.adoc
@@ -1,0 +1,230 @@
+// This procedure is used in the following assembly:
+// * install/ossm-multi-cluster-topologies.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-installing-kiali-multi-cluster-mesh_{context}"]
+= Installing Kiali in a multi-cluster mesh
+
+Install Kiali in a multi-cluster mesh configuration on two {ocp-product-title} clusters.
+
+[NOTE]
+====
+In this procedure, `CLUSTER1` is the East cluster and `CLUSTER2` is the West cluster.
+====
+
+You can adapt these instructions for a mesh spanning more than two clusters.
+
+.Prerequisites
+
+* You have installed the latest Kiali Operator on each cluster.
+
+* Istio installed in a multi-cluster configuration on each cluster.
+
+* You have `istioctl` installed on the laptop you can use to run these instructions.
+
+* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
+
+* You have configured a metrics store so that Kiali can query metrics from all the clusters. Kiali queries metrics and traces from their respective endpoints.
+
+.Procedure
+
+. Install Kiali on the East cluster:
+
+.. Create a YAML file named `kiali.yaml` that creates a namespace for the Kiali deployment. 
++
+.Example configuration
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  version: default
+  external_services:
+    prometheus:
+      auth:
+        type: bearer
+        use_kiali_token: true
+      thanos_proxy:
+        enabled: true
+      url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+----
++
+[NOTE]
+====
+The endpoint for this example uses OpenShift Monitoring to configure metrics. For more information, see "Configuring OpenShift Monitoring with Kiali".
+====
+
+.. Apply the YAML file on the East cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context cluster1 apply -f kiali.yaml
+----
++
+.Example output
++
+[source,terminal]
+----
+kiali-istio-system.apps.example.com
+----
+
+. Ensure that the Kiali custom resource (CR) is ready by running the following command:
++
+[source,terminal]
+----
+$ oc wait --context cluster1 --for=condition=Successful kialis/kiali -n istio-system --timeout=3m
+----
++
+.Example output
++
+[source,terminal]
+----
+kiali.kiali.io/kiali condition met
+----
+
+. Display your Kiali Route hostname.
++
+[source,terminal]
+----
+$ oc --context cluster1 get route kiali -n istio-system -o jsonpath='{.spec.host}'
+----
+
+. Create a Kiali CR on the West cluster.
++
+.Example configuration
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+  namespace: istio-system
+spec:
+  version: default
+  auth:
+    openshift:
+      redirect_uris:
+        # Replace kiali-route-hostname with the hostname from the previous step.
+        - "https://{kiali-route-hostname}/api/auth/callback/cluster2"
+  deployment:
+    remote_cluster_resources_only: true
+----
++
+The Kiali Operator creates the resources necessary for the Kiali server on the East cluster to connect to the West cluster. The Kiali server is not installed on the West cluster.
+
+. Apply the YAML file on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context cluster2 apply -f kiali-remote.yaml
+----
+
+. Ensure that the Kiali CR is ready by running the following command:
++
+[source,terminal]
+----
+$ oc wait --context cluster2 --for=condition=Successful kialis/kiali -n istio-system --timeout=3m
+---- 
+
+. Create a remote cluster secret so that Kiali installation in the East cluster can access the West cluster.
+
+.. Create a long lived API token bound to the kiali-service-account in the West cluster. Kiali uses this token to authenticate to the West cluster.
++
+.Example configuration
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "kiali-service-account"
+  namespace: "istio-system"
+  annotations:
+    kubernetes.io/service-account.name: "kiali-service-account"
+type: kubernetes.io/service-account-token
+----
+
+.. Apply the YAML file on the West cluster by running the following command:
++
+[source,terminal]
+----
+$ oc --context cluster2 apply -f kiali-svc-account-token.yaml
+----
+
+.. Create a `kubeconfig` file and save it as a secret in the namespace on the East cluster where the Kiali deployment resides.
++
+To simplify this process, use the `kiali-prepare-remote-cluster.sh` script to generate the `kubeconfig` file by running the following `curl` command:
++
+[source,terminal]
+----
+$ curl -L -o kiali-prepare-remote-cluster.sh https://raw.githubusercontent.com/kiali/kiali/master/hack/istio/multicluster/kiali-prepare-remote-cluster.sh
+----
+
+.. Modify the script to make it executeable by running the following command:
++
+[source,terminal]
+----
+chmod +x kiali-prepare-remote-cluster.sh
+----
+
+.. Execute the script so that it passes the East and West cluster contexts to the `kubeconfig` file by running the following command: 
++
+[source,terminal]
+----
+$ ./kiali-prepare-remote-cluster.sh --kiali-cluster-context cluster1 --remote-cluster-context cluster2 --view-only false --kiali-resource-name kiali-service-account --remote-cluster-namespace istio-system --process-kiali-secret true --process-remote-resources false --remote-cluster-name cluster2
+----
++
+[NOTE]
+====
+Use the `--help` option to display additional details about how to use the script.
+====
+
+. Trigger the reconciliation loop so that the Kiali Operator registers the remote secret that the CR contains by running the following command:
++
+[source,terminal]
+----
+$ oc --context cluster1 annotate kiali kiali -n istio-system --overwrite kiali.io/reconcile="$(date)"
+----
+
+. Wait for Kiali resource to become ready by running the following command:
++
+[source,terminal]
+----
+oc --context cluster1 wait --for=condition=Successful --timeout=2m kialis/kiali -n istio-system
+----
+
+. Wait for Kiali server to become ready by running the following command:
++
+[source,terminal]
+----
+oc --context cluster1 rollout status deployments/kiali -n istio-system
+----
+
+. Log in to Kiali.
+
+.. When you first access Kiali, log in to the cluster that contains the Kiali deployment. In this example, access the `East` cluster.
+
+.. Display the hostname of the Kiali route by running the following command:
++
+[source,terminal]
+----
+oc --context cluster1 get route kiali -n istio-system -o jsonpath='{.spec.host}'
+----
+
+.. Navigate to the Kiali URL in your browser: https://<your-kiali-route-hostname>.
+
+. Log in to the West cluster through Kiali.
++
+In order to see other clusters in the Kiali UI, you must first login as a user to those clusters through Kiali. 
+
+.. Click on the user profile dropdown in the top right hand menu. 
+
+.. Select *Login to West*. You are redirected to an OpenShift login page and prompted for credentials for the West cluster.
+
+. Verify that Kiali shows information from both clusters.
+
+.. Click *Overview* and verify that you can see namespaces from both clusters.
+
+.. Click *Navigate* and verify that you see both clusters on the mesh graph.


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)
[service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

PR must be merged to service docs main and CP'd back to the 3.0 and 3.1 branches.

Version(s): 3.1

Issue: https://issues.redhat.com/browse/OSSM-8266
[<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->](https://issues.redhat.com/browse/OSSM-8266)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://96498--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html#ossm-installing-kiali-multi-cluster-mesh_ossm-multi-cluster-topologies

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
