### PR TITLE
MCO Backport OCL to 4.18.20 RN

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2396,7 +2396,7 @@ In the following tables, features are marked with the following statuses:
 |On-cluster RHCOS image layering
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Node disruption policies
 |Technology Preview
@@ -3039,6 +3039,26 @@ You can view the container images in this release by running the following comma
 ----
 $ oc adm release info 4.18.20 --pullspecs
 ----
+
+[id="ocp-4-18-20-new-features-and-enhancements_{context}"]
+==== New features and enhancements
+
+[id="ocp-4-18-20-updating-machine-config-operator-ocl_{context}"]
+===== On-cluster layering changes is now generally available
+There are several important changes to the on-cluster layering feature:
+
+* The API version is now `machineconfiguration.openshift.io/v1`. The new version includes the following changes:
+** The `baseImagePullSecret` parameter is now optional. If not specified, the default `global-pull-secret-copy` is used.
+** The `buildInputs` parameter is no longer required. All parameters previously under the `buildInputs` parameter are promoted one level.
+** The `containerfileArch` parameter now supports multiple architectures. Previously, only `noarch` was supported.
+** The required `imageBuilderType` is now `Job`. Previously, the required builder was `PodImageBuilder`.
+** The `renderedImagePushspec` parameter is now `renderedImagePushSpec`.
+** The `buildOutputs` and `currentImagePullSecret` parameters are no longer required.
+* You can manually rebuild your custom layered image by applying an annotation to the `MachineOSConfig` object.
+* You can now automatically delete an on-cluster custom layered image by deleting the associated `MachineOSBuild` object.
+* On-cluster layering is now supported in disconnected environments.
+
+For more information, see xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-configuring-on_mco-coreos-layering[Using on-cluster layering to apply a custom layered image].
 
 [id="ocp-4-18-20-bug-fixes_{context}"]
 ==== Bug fixes


### PR DESCRIPTION
Release notes for https://issues.redhat.com/browse/OSDOCS-15319

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
4.18.20 -> T[echnology Preview features status](https://96507--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-technology-preview-tables_release-notes) -> Updated _Table 20. Machine Config Operator Technology Preview tracker_ to change _On-cluster RHCOS image layering_ to _General Availability_ for 4.18.	
4.18.20 -> [New features and enhancements](https://96507--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-20-new-features-and-enhancements_release-notes) -- [On-cluster layering changes is now generally available](https://96507--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-20-updating-machine-config-operator-ocl_release-notes) -- New section and entry

