### PR TITLE
OSDOCS#15372: Update the z-stream RNs for 4.17.36

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2896,6 +2896,42 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.36
+[id="ocp-4-17-36_{context}"]
+=== RHSA-2025:11359 - {product-title} {product-version}.36 bug fix update and security
+
+Issued: 23 July 2025
+
+{product-title} release {product-version}.36 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:11359[RHSA-2025:11359] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:11360[RHBA-2025:11360] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.36 --pullspecs
+----
+
+[id="ocp-4-17-36-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, the initial loading time for the network plugin pages increased by 10 seconds. With this release, the initial loading time is reduced by correcting the network plugin page delay. (link:https://issues.redhat.com/browse/OCPBUGS-58318[OCPBUGS-58318])
+
+* Before this update, multiple plugins using the same `useModal` hook caused their modals to overwrite each other and led to a loss of functionality for multiple plugins in the user interface. With this release, unique identifiers are used and the modals do not overwrite each other. (link:https://issues.redhat.com/browse/OCPBUGS-58224[OCPBUGS-58224])
+
+* Before this update, a non-default boot image was not updated by the Machine Config Operator (MCO) without degradation, resulting in system instability. With this release, the MCO degradation for non-default boot image updates is fixed, and boot image update issues do not occur. (link:https://issues.redhat.com/browse/OCPBUGS-58219[OCPBUGS-58219])
+
+* Before this update, build failures occurred because of missing service account secrets retrieval. With this release, a fix prevents errors when retrieving service account secrets, and eliminates failures because of a `CannotRetrieveServiceAccount` error. (link:https://issues.redhat.com/browse/OCPBUGS-57950[OCPBUGS-57950])
+
+* Before this update, an OperatorGroup resource reconciliation caused unnecessary `ClusterRole` updates because of the changing order of aggregation rule selectors. As a result, unnecessary etcd writes and authentication cache invalidation occurred. With this release, a specific order in `ClusterRole` aggregation rule selectors reduces unnecessary API server writes. (link:https://issues.redhat.com/browse/OCPBUGS-57438[OCPBUGS-57438])
+
+* Before this update, the Keepalived script for an ingress Virtual IP (VIP) check failed because of a missing `SYS_CHROOT` permission in `chroot`. As a consequence, core ingress services were inaccessible due to incorrect VIP placement. With this release, `chroot` permissions are added to the Keepalived script for an ingress VIP check. As a result, incorrect `chk_default_ingress` permissions are fixed, resulting in correct ingress VIP placement. (link:https://issues.redhat.com/browse/OCPBUGS-56625[OCPBUGS-56625])
+
+[id="ocp-4-17-36-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.35
 [id="ocp-4-17-35_{context}"]
 === RHSA-2025:10294 - {product-title} {product-version}.35 bug fix update and security


### PR DESCRIPTION
Issue:
[OSDOCS-15372](https://issues.redhat.com//browse/OSDOCS-15372)

Link to docs preview:
[4.17.36](https://96512--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-36_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 07/23/25.
