### PR TITLE
fix: update README.adoc to use final documentation link without redirect (#91967)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@
 
 All OpenShift documentation is sourced in https://asciidoc.org/[AsciiDoc] and transformed into HTML/CSS and other formats through automation that is based on https://asciidoctor.org/[AsciiDoctor].
 
-The documentation published from these source files can be viewed at https://docs.openshift.com.
+The documentation published from these source files can be viewed at https://docs.redhat.com/en.
 
 == Contributing to OpenShift documentation
 // NOTE: This text is mirrored in ./CONTRIBUTING.adoc


### PR DESCRIPTION
This PR updates the documentation link in `README.adoc` from:

`https://docs.openshift.com` ➝ `https://docs.redhat.com/en`

Although both URLs currently open the same page, the former causes a redirect. This change helps:
- Avoid unnecessary redirect
- Improve clarity and user experience
- Reflect the current Red Hat documentation branding

Closes: #91967
