### PR TITLE
TELCODOCS-2278: Add transmit hash policy to bond CNI (Tech Preview)

### DIFF
--- a/modules/nw-multus-bond-cni-object.adoc
+++ b/modules/nw-multus-bond-cni-object.adoc
@@ -44,6 +44,10 @@ The following table describes the configuration parameters for the Bond CNI plug
 |`string`
 |Specifies the bonding policy. 
 
+|`xmitHashPolicy`
+|`string`
+|Specifies the transmit hash policy for load balancing across the aggregated interfaces. This parameter defaults to `layer2` and supports the following values: `layer2`, `layer2+3` and `layer3+4`.
+
 |`linksInContainer`
 |`boolean`
 |Optional: Specifies whether the network interfaces intended for bonding are expected to be created and available directly within the container's network namespace when the bond starts. If `false` which is the default, the CNI plugin looks for these interfaces on the host system first before attempting to form the bond.
@@ -57,6 +61,11 @@ The following table describes the configuration parameters for the Bond CNI plug
 |The configuration object for the IPAM CNI plugin. The plugin manages IP address assignment for the attachment definition.
 
 |====
+
+--
+:FeatureName: xmitHashPolicy
+include::snippets/technology-preview.adoc[]
+--
 
 [id="nw-multus-bond-cni-config-example_{context}"]
 == Bond CNI plugin configuration example
@@ -88,3 +97,34 @@ The following example configures a secondary network named `bond-net1`:
     }
 }
 ----
+
+The following example configures a secondary network named `bond-tlb-net` with the `xmitHashPolicy` feature enabled:
+
+[source,json]
+----
+{
+ "type": "bond",
+ "cniVersion": "0.3.1",
+ "name": "bond-tlb-net",
+ "mode": "tlb",         
+ "xmitHashPolicy": "layer2+3", <1>
+ "failOverMac": 0,         
+ "linksInContainer": true,
+ "miimon": "100",
+ "mtu": 1500,
+ "links": [
+       {"name": "net1"},
+       {"name": "net2"}
+   ],
+  "ipam": {
+        "type": "host-local",
+        "subnet": "10.57.218.0/24", 
+        "routes": [{
+        "dst": "0.0.0.0/0"
+        }],
+        "gateway": "10.57.218.1"
+    }
+}
+----
+
+<1> This parameter dictates how outgoing network traffic is distributed across the `net1` and `net2` active member interfaces within the bond. The hashing algorithm combines layer 2 information, specifically source and destination MAC addresses, with layer 3 information, which includes source and destination IP addresses.


### PR DESCRIPTION
[TELCODOCS-2278]: Add transmit hash policy to bond CNI (Tech Preview)

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2278
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://96525--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.html#nw-multus-bond-cni-object_configuring-additional-network-cni
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: No QE involved confirmed with Carlos and this set to TP. 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
