### PR TITLE
OBSDOCS-1938: Show how to increase metrics-server verbosity

### DIFF
--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -25,17 +25,20 @@
 :component-name: Thanos Ruler
 // end::UWM[]
 
+// tag::CPM[]
+You can configure the log level for Alertmanager, Prometheus Operator, Prometheus, and {component-name} and log verbosity for Metrics Server.
+// end::CPM[]
+// tag::UWM[]
 You can configure the log level for Alertmanager, Prometheus Operator, Prometheus, and {component-name}.
-
+// end::UWM[]
+You can use these settings for troubleshooting and to gain better insight into how the components are functioning.
 
 The following log levels can be applied to the relevant component in the `{configmap-name}` `ConfigMap` object:
 
 * `debug`. Log debug, informational, warning, and error messages.
-* `info`. Log informational, warning, and error messages.
+* `info` (default). Log informational, warning, and error messages.
 * `warn`. Log warning and error messages only.
 * `error`. Log error messages only.
-
-The default log level is `info`.
 
 .Prerequisites
 
@@ -65,7 +68,7 @@ endif::openshift-dedicated,openshift-rosa[]
 $ oc -n {namespace-name} edit configmap {configmap-name}
 ----
 
-. Add `logLevel: <log_level>` for a component under `data/config.yaml`:
+. Add log configuration for a component under `data/config.yaml`:
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -78,17 +81,29 @@ data:
   config.yaml: |
     <component>: # <1>
       logLevel: <log_level> # <2>
+# tag::CPM[]
+    metricsServer:
+      verbosity: <value> # <3>
+# end::CPM[]
+    # ...
 ----
-<1> The monitoring stack component for which you are setting a log level.
+<1> Specify the monitoring stack component for which you are setting a log level.
 Available component values are `{prometheus}`, `{alertmanager}`, `prometheusOperator`, and `{thanos}`.
-<2> The log level to set for the component.
+<2> Specify the log level for the component.
 The available values are `error`, `warn`, `info`, and `debug`.
 The default value is `info`.
+// tag::CPM[]
+<3> Specify the verbosity for Metrics Server.
+Valid values are positive integers.
+Increasing the number increases the amount of logged events, values over `10` are usually unnecessary.
+The default value is `0`.
+// end::CPM[]
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
 
-. Confirm that the log level has been applied by reviewing the deployment or pod configuration in the related project. 
-The following example checks the log level for the `prometheus-operator` deployment:
+. Verify that the log configuration is applied by reviewing the deployment or pod configuration in the related project. 
+
+** The following example checks the log level for the `prometheus-operator` deployment:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -96,12 +111,27 @@ $ oc -n {namespace-name} get deploy prometheus-operator -o yaml | grep "log-leve
 ----
 +
 .Example output
-[source,terminal,subs="attributes+"]
+[source,terminal]
 ----
         - --log-level=debug
 ----
 
-. Check that the pods for the component are running. The following example lists the status of pods:
+// tag::CPM[]
+** The following example checks the log verbosity for the `metrics-server` deployment:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring get deploy metrics-server -o yaml | grep -- '--v='
+----
++
+.Example output
+[source,terminal]
+----
+        - --v=3
+----
+// end::CPM[]
+
+. Verify that the pods for the component are running:
 +
 [source,terminal,subs="attributes+"]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1938
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* [Setting log levels for monitoring components](https://96526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/configuring-core-platform-monitoring/storing-and-recording-data.html#setting-log-levels-for-monitoring-components_storing-and-recording-data)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
