### PR TITLE
OSDOCS-15284 [NETOBSERV] Line breaks for network-observability-policy.adoc assembly and its includes

### DIFF
--- a/modules/network-observability-create-network-policy.adoc
+++ b/modules/network-observability-create-network-policy.adoc
@@ -6,6 +6,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-network-policy_{context}"]
 = Creating a network policy for Network Observability
+
 If you want to further customize the network policies for the `netobserv` and `netobserv-privileged` namespaces, you must disable the managed installation of the policy from the `FlowCollector` CR, and create your own. You can use the network policy resources that are enabled from the `FlowCollector` CR as a starting point for the procedure that follows:
 
 .Example `netobserv` network policy

--- a/modules/network-observability-deploy-network-policy.adoc
+++ b/modules/network-observability-deploy-network-policy.adoc
@@ -6,6 +6,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-deploy-network-policy_{context}"]
 = Configuring an ingress network policy by using the FlowCollector custom resource
+
 You can configure the `FlowCollector` custom resource (CR) to deploy an ingress network policy for Network Observability by setting the `spec.NetworkPolicy.enable` specification to `true`. By default, the specification is `false`.
 
 If you have installed Loki, Kafka or any exporter in a different namespace that also has a network policy, you must ensure that the Network Observability components can communicate with them. Consider the following about your setup:
@@ -16,7 +17,7 @@ If you have installed Loki, Kafka or any exporter in a different namespace that 
    * If you are using Loki and including it in the policy target, connection to an external object storage (as defined in your `LokiStack` related secret)
 
 .Procedure
-. . In the web console, go to *Operators* -> *Installed Operators* page.
+. In the web console, go to *Operators* -> *Installed Operators* page.
 . Under the *Provided APIs* heading for *Network Observability*, select *Flow Collector*.
 . Select *cluster* then select the *YAML* tab.
 . Configure the `FlowCollector` CR. A sample configuration is as follows:


### PR DESCRIPTION
[OSDOCS-15284](https://issues.redhat.com//browse/OSDOCS-15284) [NETOBSERV] Line breaks for network-observability-policy.adoc assembly and its includes


Version(s):
4.12, 4.14, 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-15284

Link to docs preview:
https://96537--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-network-policy.html

QE review:
QE review is not required. This PR addresses style/template issues.

Additional information:
Possible cherry-picks may fail to some OCP branches. Those failed cp's will be dealt with separately as the files need to be manually checked and verified if present on failed branches.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
