### PR TITLE
[NETOBSERV] OSDOCS-15285 Line breaks for network-observability-operator-monitoring.adoc assembly and its includes

### DIFF
--- a/modules/network-observability-disabling-health-alerts.adoc
+++ b/modules/network-observability-disabling-health-alerts.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-disable-alerts_{context}"]
 = Disabling health alerts
+
 You can opt out of health alerting by editing the `FlowCollector` resource:
 
 . In the web console, navigate to *Operators* -> *Installed Operators*.

--- a/modules/network-observability-rate-limit-alert.adoc
+++ b/modules/network-observability-rate-limit-alert.adoc
@@ -4,6 +4,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-netobserv-dashboard-rate-limit-alerts_{context}"]
 = Creating Loki rate limit alerts for the NetObserv dashboard
+
 You can create custom alerting rules for the *Netobserv* dashboard metrics to trigger alerts when Loki rate limits have been reached.
 
 .Prerequisites

--- a/modules/network-observability-viewing-alerts.adoc
+++ b/modules/network-observability-viewing-alerts.adoc
@@ -5,7 +5,8 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-dashboard-view_{context}"]
 = Viewing health information
-You can access metrics about health and resource usage of the Network Observability Operator from the *Dashboards* page in the web console. 
+
+You can access metrics about health and resource usage of the Network Observability Operator from the *Dashboards* page in the web console.
 
 .Prerequisites
 


### PR DESCRIPTION
[NETOBSERV] [OSDOCS-15285](https://issues.redhat.com//browse/OSDOCS-15285) Line breaks for network-observability-operator-monitoring.adoc assembly and its includes

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14, 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-15285

Link to docs preview:
https://96538--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-monitoring.html

QE review:
QE is not required. This PR addresses style/template issues.

Additional information:
Possible cherry-picks may fail to some OCP branches. Those failed cp's will be dealt with separately as the files need to be manually checked and verified if present on failed branches.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
