### PR TITLE
[RHDEVDOCS-6500] Invalid onError values in 1.19 release notes

### DIFF
--- a/modules/op-release-notes-1-19.adoc
+++ b/modules/op-release-notes-1-19.adoc
@@ -246,7 +246,7 @@ spec:
 
 * With this update, the Git resolver included in the remote resolution feature now uses the native git binary instead of the pure Go `go-git` library. This change reduces memory consumption and improves clone performance, especially for large repositories. This enhancement uses shallow-clone flags, for example `--depth 1`, to reduce resource usage. No changes to pipeline manifests are required.
 
-* With this update, the `onError` field in {pipelines-title} supports Tekton parameter substitution. Previously, the `onError` filed only accepted literal values, such as `continue`, `stop`, or `finally`. You can use substitution tokens, such as `$(params.strategy)`, to dynamically determine failure handling behavior at runtime. This allows a single Pipeline definition to adapt its `onError` policy based on parameters, context, or results.
+* With this update, the `onError` field in {pipelines-title} supports Tekton parameter substitution. Previously, the `onError` field only accepted the literal values `stopAndFail` and `continue`. You can use the `$(params.strategy)` substitution token to dynamically determine failure handling behavior at runtime. This allows a single Pipeline definition to adapt its `onError` policy based on parameters, context, or results.
 
 * With this release, `StepAction` definitions are updated from alpha to stable and are now enabled by default. The  `enable-step-actions` flag used in the earlier versions is no longer used and will be removed in a future release.
 


### PR DESCRIPTION
Version(s):
pipelines-docs-1.19

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6500

Link to docs preview:
- [Operator](https://96543--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-19.html#Operator-new-features-1-19_op-release-notes)

QE review:
- [ ] QE has approved this change.

Additional info:
- [Jul 31] Reverted changes from Jul 30
- [Jul 30] Based on the [1.19 support cases raised by Ford document](https://docs.google.com/document/d/1zBcd8Ab-dBTxWPLorQiCIq6WQzdp5N4-iz5_qWRZeXk/edit?tab=t.0#bookmark=id.vg2249ke1nx2), I'm removing the RN in its entirety.

