### PR TITLE
OSDOCS 15446 CMA 2.17.2 Changes from Upstream

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2677,6 +2677,8 @@ Topics:
     File: nodes-cma-autoscaling-custom-trigger
   - Name: Understanding custom metrics autoscaler trigger authentications
     File: nodes-cma-autoscaling-custom-trigger-auth
+  - Name: Understanding how to add custom metrics autoscalers
+    File: nodes-cma-autoscaling-custom-adding
   - Name: Pausing the custom metrics autoscaler
     File: nodes-cma-autoscaling-custom-pausing
   - Name: Gathering audit logs
@@ -2685,8 +2687,6 @@ Topics:
     File: nodes-cma-autoscaling-custom-debugging
   - Name: Viewing Operator metrics
     File: nodes-cma-autoscaling-custom-metrics
-  - Name: Understanding how to add custom metrics autoscalers
-    File: nodes-cma-autoscaling-custom-adding
   - Name: Removing the Custom Metrics Autoscaler Operator
     File: nodes-cma-autoscaling-custom-removing
 - Name: Controlling pod placement onto nodes (scheduling)

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -947,6 +947,8 @@ Topics:
     File: nodes-cma-autoscaling-custom-trigger
   - Name: Understanding the custom metrics autoscaler trigger authentications
     File: nodes-cma-autoscaling-custom-trigger-auth
+  - Name: Understanding how to add custom metrics autoscalers
+    File: nodes-cma-autoscaling-custom-adding
   - Name: Pausing the custom metrics autoscaler
     File: nodes-cma-autoscaling-custom-pausing
   - Name: Gathering audit logs
@@ -955,8 +957,6 @@ Topics:
     File: nodes-cma-autoscaling-custom-debugging
   - Name: Viewing Operator metrics
     File: nodes-cma-autoscaling-custom-metrics
-  - Name: Understanding how to add custom metrics autoscalers
-    File: nodes-cma-autoscaling-custom-adding
   - Name: Removing the Custom Metrics Autoscaler Operator
     File: nodes-cma-autoscaling-custom-removing
 - Name: Controlling pod placement onto nodes (scheduling)

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1322,6 +1322,8 @@ Topics:
     File: nodes-cma-autoscaling-custom-trigger
   - Name: Understanding the custom metrics autoscaler trigger authentications
     File: nodes-cma-autoscaling-custom-trigger-auth
+  - Name: Understanding how to add custom metrics autoscalers
+    File: nodes-cma-autoscaling-custom-adding
   - Name: Pausing the custom metrics autoscaler
     File: nodes-cma-autoscaling-custom-pausing
   - Name: Gathering audit logs
@@ -1330,8 +1332,6 @@ Topics:
     File: nodes-cma-autoscaling-custom-debugging
   - Name: Viewing Operator metrics
     File: nodes-cma-autoscaling-custom-metrics
-  - Name: Understanding how to add custom metrics autoscalers
-    File: nodes-cma-autoscaling-custom-adding
   - Name: Removing the Custom Metrics Autoscaler Operator
     File: nodes-cma-autoscaling-custom-removing
 - Name: Controlling pod placement onto nodes (scheduling)

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -986,6 +986,8 @@ Topics:
     File: nodes-cma-autoscaling-custom-trigger
   - Name: Understanding the custom metrics autoscaler trigger authentications
     File: nodes-cma-autoscaling-custom-trigger-auth
+  - Name: Understanding how to add custom metrics autoscalers
+    File: nodes-cma-autoscaling-custom-adding
   - Name: Pausing the custom metrics autoscaler
     File: nodes-cma-autoscaling-custom-pausing
   - Name: Gathering audit logs
@@ -994,8 +996,6 @@ Topics:
     File: nodes-cma-autoscaling-custom-debugging
   - Name: Viewing Operator metrics
     File: nodes-cma-autoscaling-custom-metrics
-  - Name: Understanding how to add custom metrics autoscalers
-    File: nodes-cma-autoscaling-custom-adding
   - Name: Removing the Custom Metrics Autoscaler Operator
     File: nodes-cma-autoscaling-custom-removing
 - Name: Controlling pod placement onto nodes (scheduling)

--- a/modules/nodes-cma-autoscaling-custom-creating-workload.adoc
+++ b/modules/nodes-cma-autoscaling-custom-creating-workload.adoc
@@ -104,12 +104,13 @@ spec:
   fallback: <11>
     failureThreshold: 3
     replicas: 6
-  pollingInterval: 30 <12>
+    behavior: static <12>
+  pollingInterval: 30 <13>
   advanced:
-    restoreToOriginalReplicaCount: false <13>
+    restoreToOriginalReplicaCount: false <14>
     horizontalPodAutoscalerConfig:
-      name: keda-hpa-scale-down <14>
-      behavior: <15>
+      name: keda-hpa-scale-down <15>
+      behavior: <16>
         scaleDown:
           stabilizationWindowSeconds: 300
           policies:
@@ -117,7 +118,7 @@ spec:
             value: 100
             periodSeconds: 15
   triggers:
-  - type: prometheus <16>
+  - type: prometheus <17>
     metadata:
       serverAddress: https://thanos-querier.openshift-monitoring.svc.cluster.local:9092
       namespace: kedatest
@@ -125,7 +126,7 @@ spec:
       threshold: '5'
       query: sum(rate(http_requests_total{job="test-app"}[1m]))
       authModes: basic
-    authenticationRef: <17>
+    authenticationRef: <18>
       name: prom-triggerauthentication
       kind: TriggerAuthentication
 ----
@@ -139,13 +140,18 @@ spec:
 <8> Optional: Specifies the maximum number of replicas when scaling up. The default is `100`.
 <9> Optional: Specifies the minimum number of replicas when scaling down.
 <10> Optional: Specifies the parameters for audit logs. as described in the "Configuring audit logging" section.
-<11> Optional: Specifies the number of replicas to fall back to if a scaler fails to get metrics from the source for the number of times defined by the `failureThreshold` parameter. For more information on fallback behavior, see the link:https://keda.sh/docs/2.7/concepts/scaling-deployments/#fallback[KEDA documentation].
-<12> Optional: Specifies the interval in seconds to check each trigger on. The default is `30`.
-<13> Optional: Specifies whether to scale back the target resource to the original replica count after the scaled object is deleted. The default is `false`, which keeps the replica count as it is when the scaled object is deleted.
-<14> Optional: Specifies a name for the horizontal pod autoscaler. The default is `keda-hpa-{scaled-object-name}`.
-<15> Optional: Specifies a scaling policy to use to control the rate to scale pods up or down, as described in the "Scaling policies" section.
-<16> Specifies the trigger to use as the basis for scaling, as described in the "Understanding the custom metrics autoscaler triggers" section. This example uses {product-title} monitoring.
-<17> Optional: Specifies a trigger authentication or a cluster trigger authentication. For more information, see _Understanding the custom metrics autoscaler trigger authentication_ in the _Additional resources_ section.
+<11> Optional: Specifies the number of replicas to fall back to if a scaler fails to get metrics from the source for the number of times defined by the `failureThreshold` parameter. For more information on fallback behavior, see the link:https://keda.sh/docs/latest/reference/scaledobject-spec/#fallback[KEDA documentation].
+<12> Optional: Specifies the replica count to be used if a fallback occurs. Enter one of the following options or omit the parameter:
+* Enter `static` to use the number of replicas specified by the `fallback.replicas` parameter. This is the default.
+* Enter `currentReplicas` to maintain the current number of replicas.
+* Enter `currentReplicasIfHigher` to maintain the current number of replicas, if that number is higher than the `fallback.replicas` parameter. If the current number of replicas is lower than the `fallback.replicas` parameter, use the `fallback.replicas` value.
+* Enter `currentReplicasIfLower` to maintain the current number of replicas, if that number is lower than the `fallback.replicas` parameter. If the current number of replicas is higher than the `fallback.replicas` parameter, use the `fallback.replicas` value.
+<13> Optional: Specifies the interval in seconds to check each trigger on. The default is `30`.
+<14> Optional: Specifies whether to scale back the target resource to the original replica count after the scaled object is deleted. The default is `false`, which keeps the replica count as it is when the scaled object is deleted.
+<15> Optional: Specifies a name for the horizontal pod autoscaler. The default is `keda-hpa-{scaled-object-name}`.
+<16> Optional: Specifies a scaling policy to use to control the rate to scale pods up or down, as described in the "Scaling policies" section.
+<17> Specifies the trigger to use as the basis for scaling, as described in the "Understanding the custom metrics autoscaler triggers" section. This example uses {product-title} monitoring.
+<18> Optional: Specifies a trigger authentication or a cluster trigger authentication. For more information, see _Understanding the custom metrics autoscaler trigger authentication_ in the _Additional resources_ section.
 * Enter `TriggerAuthentication` to use a trigger authentication. This is the default.
 * Enter `ClusterTriggerAuthentication` to use a cluster trigger authentication.
 

--- a/modules/nodes-cma-autoscaling-custom-trigger-prom.adoc
+++ b/modules/nodes-cma-autoscaling-custom-trigger-prom.adoc
@@ -35,6 +35,7 @@ spec:
       cortexOrgID: my-org <8>
       ignoreNullValues: "false" <9>
       unsafeSsl: "false" <10>
+      timeout: 1000 <11>
 ----
 <1> Specifies Prometheus as the trigger type.
 <2> Specifies the address of the Prometheus server. This example uses  {product-title} monitoring.
@@ -51,7 +52,10 @@ spec:
      * If `false`, the certificate check is performed. This is the default behavior.
      * If `true`, the certificate check is not performed.
 +
+--
 [IMPORTANT]
 ====
 Skipping the check is not recommended.
 ====
+--
+<11> Optional: Specifies an HTTP request timeout in milliseconds for the HTTP client used by this Prometheus trigger. This value overrides any global timeout setting.


### PR DESCRIPTION
**READY TO MERGE WHEN CUSTOM METRICS AUTOSCALER 2.17.2 RELEASES**

https://issues.redhat.com/browse/OSDOCS-15446

Link to docs preview:
[Understanding the Prometheus trigger](https://96544--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger#nodes-cma-autoscaling-custom-trigger-prom_nodes-cma-autoscaling-custom-trigger) -- Added call-out 11 only. No other changes to text.
[Adding a custom metrics autoscaler to a workload](https://96544--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-adding.html#nodes-cma-autoscaling-custom-creating-workload_nodes-cma-autoscaling-custom-adding) -- Added call-out 12 only. No other changes to text (other than to bump the call-out numbers).

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
