### PR TITLE
OLS-1953: Create OLS 1.0.3 release notes

### DIFF
--- a/modules/ols-1-0-3-fixed-issues.adoc
+++ b/modules/ols-1-0-3-fixed-issues.adoc
@@ -1,0 +1,11 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-3-fixed-issues_{context}"]
+= Fixed issues
+
+The following issues are fixed with {ols-official} 1.0.3:
+
+* Before this update, the {ols-long} service could not reload BYO Knowledge images with floating tags. This condition occurred even after a restart because the `ImagePullPolicy` parameter was hardcoded to `PullIfNotPresent`. As a result, BYO Knowledge images failed to reload from the container registry, causing users to experience stale images. With this update, when the {ols-long} service restarts, it pulls the BYO Knowledge images from the container registry, ensuring consistent access to BYO Knowledge images.  link:https://issues.redhat.com/browse/OLS-1956[OLS-1956].

--- a/modules/ols-1-0-3-release-notes.adoc
+++ b/modules/ols-1-0-3-release-notes.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-3-release-notes_{context}"]
+= {ols-long} version 1.0.3
+
+{ols-official} 1.0.3 is now available on {ocp-product-title} 4.15 and later.
+
+[id="ols-1-0-3-enhancements_{context}"]
+== Enhancements
+
+The following enhancements are made with {ols-official} 1.0.3:
+
+* This release makes {ols-official} 1.0.3 generally available, and is supported on {ocp-product-title} 4.15 and later.
+
+
+* With this update, when you specify BYO Knowledge information sources in `OLSConfig.spec.ols.rag` specification file you only have to specify the URL path for the image. 
++
+The custom resource (CR) uses the following default settings:
++
+.Example configuration
+[source,yaml,subs="attributes,verbatim"]
+----
+spec:
+  ols: 
+    rag: 
+      - image: quay.io/<username>/my-byok-image:latest # <1>
+----
+<1> Where `image` specifies the tag for the image that was pushed to the image registry so that the {ols-long} Operator can access the custom content. The {ols-long} Operator can work with more than one RAG database that you create.
++
+Previously, the `indexPath` and `indexID` parameters were required. Now they are optional. The default values for the parameters are `/rag/vector_db` and `vector_db_index` respectively.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -13,6 +13,8 @@ The release notes highlight what is new and what has changed with each {ols-offi
 {ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
 ====
 
+include::modules/ols-1-0-3-release-notes.adoc[leveloffset=+1]
+include::modules/ols-1-0-3-fixed-issues.adoc[leveloffset=2]
 include::modules/ols-1-0-2-release-notes.adoc[leveloffset=+1]
 include::modules/ols-1-0-2-fixed-issues.adoc[leveloffset=2]
 include::modules/ols-1-0-1-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-1953
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://96545--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-1-0-3-release-notes_ols-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
