### PR TITLE
[NETOBSERV] OSDOCS-15286 Line breaks for network-observability-scheduling-resources.adoc assembly and its includes

### DIFF
--- a/modules/network-observability-nodes-taints-tolerations.adoc
+++ b/modules/network-observability-nodes-taints-tolerations.adoc
@@ -5,14 +5,15 @@
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-multi-tenancy{context}"]
 = Network Observability deployment in specific nodes
-You can configure the `FlowCollector` to control the deployment of Network Observability components in specific nodes. The `spec.agent.ebpf.advanced.scheduling`, `spec.processor.advanced.scheduling`, and `spec.consolePlugin.advanced.scheduling` specifications have the following configurable settings: 
+
+You can configure the `FlowCollector` to control the deployment of Network Observability components in specific nodes. The `spec.agent.ebpf.advanced.scheduling`, `spec.processor.advanced.scheduling`, and `spec.consolePlugin.advanced.scheduling` specifications have the following configurable settings:
 
 * `NodeSelector`
 * `Tolerations`
 * `Affinity`
 * `PriorityClassName`
 
-.Sample `FlowCollector` resource for `spec.<component>.advanced.scheduling` 
+.Sample `FlowCollector` resource for `spec.<component>.advanced.scheduling`
 [source,yaml]
 ----
 apiVersion: flows.netobserv.io/v1beta2


### PR DESCRIPTION
[NETOBSERV] [OSDOCS-15286](https://issues.redhat.com//browse/OSDOCS-15286) Line breaks for network-observability-scheduling-resources.adoc assembly and its includes

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14, 4.16+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-15286

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required. This PR addresses style/template issues.

Additional information:
Possible cherry-picks may fail to some OCP branches. Those failed cp's will be dealt with separately as the files need to be manually checked and verified if present on failed branches.
