### PR TITLE
[RHDEVDOCS-6497] Known issue with pruner missing from 1.19 RN

### DIFF
--- a/modules/op-release-notes-1-19.adoc
+++ b/modules/op-release-notes-1-19.adoc
@@ -246,7 +246,7 @@ spec:
 
 * With this update, the Git resolver included in the remote resolution feature now uses the native git binary instead of the pure Go `go-git` library. This change reduces memory consumption and improves clone performance, especially for large repositories. This enhancement uses shallow-clone flags, for example `--depth 1`, to reduce resource usage. No changes to pipeline manifests are required.
 
-* With this update, the `onError` field in {pipelines-title} supports Tekton parameter substitution. Previously, the `onError` filed only accepted literal values, such as `continue`, `stop`, or `finally`. You can use substitution tokens, such as `$(params.strategy)`, to dynamically determine failure handling behavior at runtime. This allows a single Pipeline definition to adapt its `onError` policy based on parameters, context, or results.
+* With this update, the `onError` field in {pipelines-title} supports Tekton parameter substitution. Previously, the `onError` field only accepted the literal values `stopAndFail` and `continue`. You can use the `$(params.strategy)` substitution token to dynamically determine failure handling behavior at runtime. This allows a single Pipeline definition to adapt its `onError` policy based on parameters, context, or results.
 
 * With this release, `StepAction` definitions are updated from alpha to stable and are now enabled by default. The  `enable-step-actions` flag used in the earlier versions is no longer used and will be removed in a future release.
 
@@ -433,7 +433,10 @@ platforms:
 * With this update, when you set the `on-cel-expression`, `on-event`, or `on-target-branch` annotations in a repository, the `on-cel-expression` annotation takes precedence. The `on-event` and `on-target-branch` annotations are ignored in this case. To alert users, a warning log and Kubernetes event are generated to indicate this behavior.
 
 [id="pruner-new-features-1-19_{context}"]
-=== Pruner
+=== Event-based Pruner
+
+:FeatureName: The Pruner component
+include::snippets/technology-preview.adoc[]
 
 * With this update, the `Pruner` component introduces automated cleanup of `PipelineRun` and `TaskRun` resources in {pipelines-title}. It supports the following features:
 
@@ -450,25 +453,17 @@ platforms:
 *** Global. This option applies to all namespaces except those prefixed with `kube-` and `openshift-`. 
 *** Namespace. This option applies to all resources in a specific namespace
 +
---
-:FeatureName: The Pruner component
-include::snippets/technology-preview.adoc[]
 [NOTE]
 ====
 In this release, only `Global` and `Namespace` configurations are available.
 ====
---
 
-* With this update, the event-based pruner can now be enabled or disabled through the `TektonConfig` CR by setting the `spec.tektonpruner.disabled` parameter to `false`. Fine-grained configuration is not yet available through the `TektonConfig` CR and should be managed using config maps.
+* With this update, you can disable or enable the event-based pruner in the `TektonConfig` CR by setting `spec.tektonpruner.disabled` to `true` or `false`. Fine-grained configuration is not yet supported in the `TektonConfig` CR and must be managed through config maps.
 +
---
-:FeatureName: The Pruner component
-include::snippets/technology-preview.adoc[]
 [NOTE]
 ====
 The existing job-based pruner must be disabled before enabling the event-based pruner.
 ====
---
 
 [id="breaking-changes-1-19_{context}"]
 == Breaking changes
@@ -478,6 +473,11 @@ The existing job-based pruner must be disabled before enabling the event-based p
 * With this release, support for `ClusterTask` objects is removed. As a result, the `tkn clustertask` and `tkn task create` commands are no longer available.
 
 * With this release, the `opc results list` command is replaced with the `opc results result list` command.
+
+[id="known-issues-1-19_{context}"]
+== Known issues
+
+* Currently, the event-based pruner does not strictly validate the contents of the `tekton-pruner-default-spec` config map. If invalid configuration keys or malformed values with incorrect field names are provided, the configuration is ignored. As a result, the pruner might fall back to default behavior or skip pruning altogether.
 
 [id="fixed-issues-1-19_{context}"]
 == Fixed issues


### PR DESCRIPTION
Version(s):
pipelines-docs-1.19

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6497

Link to docs preview:
- [Pruner TP](https://96547--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-19.html#pruner-new-features-1-19_op-release-notes)
- [Known issues](https://96547--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-19.html#known-issues-1-19_op-release-notes)

QE review:
- [ ] QE has approved this change.

Additional information:
Included content from [RHDEVDOCS-6500] for Operator to avoid conflicts.
