### PR TITLE
[NETOBSERV] OSDOCS-15503 Vale updates for network-observability-loki-secret.adoc

### DIFF
--- a/modules/network-observability-loki-secret.adoc
+++ b/modules/network-observability-loki-secret.adoc
@@ -6,9 +6,10 @@
 [id="network-observability-loki-secret_{context}"]
 = Creating a secret for Loki storage
 
-The {loki-op} supports a few log storage options, such as AWS S3, Google Cloud Storage, Azure, Swift, Minio, OpenShift Data Foundation. The following example shows how to create a secret for AWS S3 storage. The secret created in this example, `loki-s3`, is referenced in "Creating a LokiStack resource". You can create this secret in the web console or CLI.
+The {loki-op} supports a few log storage options, such as AWS S3, Google Cloud Storage, Azure, Swift, Minio, {rh-storage}. The following example shows how to create a secret for AWS S3 storage. The secret created in this example, `loki-s3`, is referenced in "Creating a LokiStack custom resource". You can create this secret in the web console or CLI.
 
-. Using the web console, navigate to the *Project* -> *All Projects* dropdown and select *Create Project*. Name the project `netobserv` and click *Create*.
+. Using the web console, navigate to the *Project* -> *All Projects* dropdown and select *Create Project*.
+. Name the project `netobserv` and click *Create*.
 . Navigate to the Import icon, *+*, in the top right corner. Paste your YAML file into the editor.
 +
 The following shows an example secret YAML file for S3 storage:
@@ -30,4 +31,4 @@ stringData:
 <1> The installation examples in this documentation use the same namespace, `netobserv`, across all components. You can optionally use a different namespace for the different components
 
 .Verification
-* Once you create the secret, you should see it listed under *Workloads* -> *Secrets* in the web console.
+* After you create the secret, you view the secret listed under *Workloads* -> *Secrets* in the web console.

--- a/observability/network_observability/installing-operators.adoc
+++ b/observability/network_observability/installing-operators.adoc
@@ -20,6 +20,7 @@ include::modules/network-observability-loki-install.adoc[leveloffset=+1]
 include::modules/network-observability-loki-secret.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
+* xref:../../observability/network_observability/installing-operators.adoc#network-observability-lokistack-create_network_observability[Creating a LokiStack custom resource]
 * xref:../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]
 //* xref :../../observability/logging/log_storage/installing-log-storage.adoc#logging-loki-storage_installing-log-storage[Loki object storage]


### PR DESCRIPTION
[NETOBSERV] [OSDOCS-15503](https://issues.redhat.com//browse/OSDOCS-15503) Vale updates for network-observability-loki-secret.adoc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15503

Link to docs preview:
https://96559--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-loki-secret_network_observability

QE review:
QE review is not required for this PR. This PR is addressing style issues.

Additional information:
Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. I will verify and create manual cherry-picks accordingly.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
