### PR TITLE
OCPBUGS#44816: ABI Vsphere permissions note

### DIFF
--- a/installing/installing_vsphere/installing-vsphere-agent-based-installer.adoc
+++ b/installing/installing_vsphere/installing-vsphere-agent-based-installer.adoc
@@ -10,8 +10,10 @@ The Agent-based installation method provides the flexibility to boot your on-pre
 
 Agent-based installation is a subcommand of the {product-title} installer. It generates a bootable ISO image containing all of the information required to deploy an {product-title} cluster with an available release image.
 
-[role="_additional-resources"]
-[id="additional-resources_installing-vsphere-agent-based-installer"]
-== Additional resources
+For more information about installing a cluster using the Agent-based Installer, see xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer].
 
-* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer]
+[IMPORTANT]
+====
+Your vSphere account must include privileges for reading and creating the resources required to install an {product-title} cluster.
+For more information about privileges, see xref:../../installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc#installation-vsphere-installer-infra-requirements_upi-vsphere-installation-reqs[vCenter requirements].
+====


### PR DESCRIPTION
NOTE TO MERGE REVIEWER: I have merge rights, feel free to leave merging to me after your review.

[OCPBUGS-44816](https://issues.redhat.com/browse/OCPBUGS-44816)

Version(s): 4.14+

This PR adds a note in the ABI vsphere docs, pointing users to information about vsphere privileges required for an installation.

QE review:
- [x] QE has approved this change.

Preview: [Agent-based Installer](https://96563--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-agent-based-installer)
