### PR TITLE
[NETOBSERV] OSDOCS-15504 Vale updates to logging-loki-log-access.adoc

### DIFF
--- a/modules/logging-loki-log-access.adoc
+++ b/modules/logging-loki-log-access.adoc
@@ -7,7 +7,7 @@
 [id="logging-loki-log-access_{context}"]
 = Fine grained access for Loki logs
 
-In {logging} 5.8 and later, the {clo} does not grant all users access to logs by default. As an administrator, you must configure your users' access unless the Operator was upgraded and prior configurations are in place. Depending on your configuration and need, you can configure fine grain access to logs using the following:
+In {logging} 5.8 and later, the {clo} does not grant all users access to logs by default. As an administrator, you must configure your users' access unless the Operator was upgraded and prior configurations are in place. Depending on your configuration and need, you can configure fine grain access to logs by using the following:
 
 * Cluster wide policies
 * Namespace scoped policies
@@ -23,7 +23,7 @@ If you have upgraded from a prior version, an additional cluster role `logging-a
 
 [NOTE]
 ====
-Users with access by namespace must provide a namespace when querying application logs.
+Users with access by namespace must give a namespace when querying application logs.
 ====
 
 == Cluster wide access
@@ -75,14 +75,14 @@ subjects:
 == Custom admin group access
 
 // tag::LokiMode[]
-If you have a large deployment with several users who require broader permissions, you can create a custom group using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` CR are considered administrators. 
+If you have a large deployment with several users who require broader permissions, you can create a custom group by using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` CR are considered administrators.
 // end::LokiMode[]
 
 // tag::NetObservMode[]
-If you need to see cluster-wide logs without necessarily being an administrator, or if you already have any group defined that you want to use here, you can specify a custom group using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` custom resource (CR) have the same read access to logs as administrators. 
+If you need to see cluster-wide logs without necessarily being an administrator, or if you already have any group defined that you want to use here, you can specify a custom group by using the `adminGroup` field. Users who are members of any group specified in the `adminGroups` field of the `LokiStack` custom resource (CR) have the same read access to logs as administrators.
 // end::NetObservMode[]
 
-// tag::LokiMode[] 
+// tag::LokiMode[]
 Administrator users have access to all application logs in all namespaces, if they also get assigned the `cluster-logging-application-view` role.
 // end::LokiMode[]
 


### PR DESCRIPTION
[NETOBSERV] [OSDOCS-15504](https://issues.redhat.com//browse/OSDOCS-15504) Vale updates to logging-loki-log-access.adoc

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15504

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required. This PR addresses style issues.

Additional information:
Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. I will verify and create manual cherry-picks accordingly.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
