### PR TITLE
OBSDOCS-2215 back-fill errata link, minor change for 1.2.1 known issue

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -27,6 +27,10 @@ The following table provides information about which features are available depe
 [id="cluster-observability-operator-release-notes-1-2-2_{context}"]
 == {coo-full} 1.2.2
 
+The following advisory is available for {coo-full} 1.2.2:
+
+* link:https://access.redhat.com/errata/RHBA-2025:11689[RHBA-2025:11689 {coo-full} 1.2.2]
+
 [id="cluster-observability-operator-1-2-2-bug-fixes_{context}"]
 === Bug fixes
 
@@ -58,7 +62,7 @@ These are the known issues in {coo-full} 1.2.1:
 
 * The installation of the incident detection feature could fail intermittently. The symptoms include the incident detection UI being visible but not including any data. In addition, the health-analyzer `ServiceMonitor` resource is in a failed state, with the error message `tls: failed to verify certificate: x509`.  You can resolve this issue by upgrading to 1.2.2 and recreating the monitoring UI plugin. (link:https://issues.redhat.com/browse/COO-1062[COO-1062])
 
-* Upgrading from version 1.2.0 corrupts the monitoring plugin's `UIPlugin` resource, when you have also deployed distributed tracing, the troubleshooting panel, and Advance Cluster Management (ACM), together with the monitoring UI plugin. You can resolve this issue by recreating the UI plugin. (link:https://issues.redhat.com/browse/COO-1051[COO-1051])
+* When installing version 1.2.1 or when upgrading from version 1.2.0, the monitoring plugin's `UIPlugin` resource can be corrupted. This occurs when you have also deployed distributed tracing, the troubleshooting panel, and Advance Cluster Management (ACM), together with the monitoring UI plugin. You can resolve this issue by recreating the UI plugin. (link:https://issues.redhat.com/browse/COO-1051[COO-1051])
 
 [id="cluster-observability-operator-release-notes-1-2_{context}"]
 == {coo-full} 1.2


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-2215](https://issues.redhat.com//browse/OBSDOCS-2215)

Link to docs preview:
https://96604--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/cluster_observability_operator/cluster-observability-operator-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
