### PR TITLE
OBSDOCS-2136 back-fill advisory for COO 1.2.1

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc
@@ -50,6 +50,10 @@ If you have previously resolved the issue in 1.2.1 and then upgrade to 1.2.2, th
 [id="cluster-observability-operator-release-notes-1-2-1_{context}"]
 == {coo-full} 1.2.1
 
+The following advisory is available for {coo-full} 1.2.1:
+
+* link:https://access.redhat.com/errata/RHBA-2025:10696[RHBA-2025:10696 {coo-full} 1.2.1]
+
 [id="cluster-observability-operator-1-2-1-bug-fixes_{context}"]
 === Bug fixes
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OBSDOCS-2136](https://issues.redhat.com//browse/OBSDOCS-2136)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
