### PR TITLE
OADP-5702: Update AWS STS support and secret

### DIFF
--- a/modules/installing-oadp-aws-sts.adoc
+++ b/modules/installing-oadp-aws-sts.adoc
@@ -11,12 +11,20 @@ AWS Security Token Service (AWS STS) is a global web service that provides short
 
 [IMPORTANT]
 ====
-Restic and Kopia are not supported in the OADP {aws-short} {sts-short} environment. Verify that the Restic and Kopia node agent is disabled.
-For backing up volumes, OADP on {aws-short} {sts-short} supports only native snapshots and Container Storage Interface (CSI) snapshots.
+Restic is unsupported.
+
+Kopia file system backup (FSB) is supported when backing up file systems that do not support Container Storage Interface (CSI) snapshots.
+
+Example file systems include the following:
+
+* Amazon Elastic File System (EFS)
+* Network File System (NFS)
+* `emptyDir` volumes
+* Local volumes
+
+For backing up volumes, OADP on {aws-short} {sts-short} recommends native snapshots and Container Storage Interface (CSI) snapshots. Data Mover backups are supported, but can be slower than native snapshots.
 
 In an {aws-short} cluster that uses STS authentication, restoring backed-up data in a different {aws-short} region is not supported.
-
-The Data Mover feature is not currently supported in {aws-short} {sts-short} clusters. You can use native {aws-short} S3 tools for moving data.
 ====
 
 .Prerequisites
@@ -35,8 +43,10 @@ $ cat <<EOF > ${SCRATCH}/credentials
   [default]
   role_arn = ${ROLE_ARN}
   web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+  region = <aws_region> # <1>
 EOF
 ----
+<1> Replace `<aws_region>` with the AWS region to use for the {sts-short} endpoint.
 
 .. Create a namespace for OADP:
 +
@@ -168,12 +178,14 @@ $ cat << EOF | oc create -f -
         - openshift
         - aws
         - csi
-      restic:
+      nodeAgent: # <2>
         enable: false
+        uploaderType: kopia # <3>
 EOF
 ----
 <1> Set this field to `false` if you do not want to use image backup.
-
+<2> See the important note regarding the `nodeAgent` attribute at the end of this procedure.
+<3> The type of uploader. The built-in Data Mover uses Kopia as the default uploader mechanism regardless of the value of the `uploaderType` field.
 // . Create the `DataProtectionApplication` resource, which is used to configure the connection to the storage where the backups and volume snapshots are stored:
 
 .. If you are using CSI or non-CSI volumes, deploy a Data Protection Application by entering the following command:
@@ -221,7 +233,7 @@ $ cat << EOF | oc create -f -
 EOF
 ----
 <1> Set this field to `false` if you do not want to use image backup.
-<2> See the important note regarding the `nodeAgent` attribute.
+<2> See the important note regarding the `nodeAgent` attribute at the end of this procedure.
 <3> The `credentialsFile` field is the mounted location of the bucket credential on the pod.
 <4> The `enableSharedConfig` field allows the `snapshotLocations` to share or reuse the credential defined for the bucket.
 <5> Use the profile name set in the {aws-short} credentials file.

--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -14,7 +14,7 @@ AWS Security Token Service (AWS STS) is a global web service that provides short
 ====
 Restic is unsupported.
 
-Kopia file system backup (FSB) is supported when backing up file systems that do not have Container Storage Interface (CSI) snapshotting support.
+Kopia file system backup (FSB) is supported when backing up file systems that do not support Container Storage Interface (CSI) snapshots.
 
 Example file systems include the following:
 
@@ -23,11 +23,9 @@ Example file systems include the following:
 * `emptyDir` volumes
 * Local volumes
 
-For backing up volumes, OADP on ROSA with {aws-short} {sts-short} supports only native snapshots and Container Storage Interface (CSI) snapshots.
+For backing up volumes, OADP on ROSA with {aws-short} {sts-short} recommends native snapshots and Container Storage Interface (CSI) snapshots. Data Mover backups are supported, but can be slower than native snapshots.
 
 In an Amazon ROSA cluster that uses STS authentication, restoring backed-up data in a different {aws-short} region is not supported.
-
-The Data Mover feature is not currently supported in ROSA clusters. You can use native {aws-short} S3 tools for moving data.
 ====
 
 .Prerequisites
@@ -200,13 +198,13 @@ $ cat << EOF | oc create -f -
 EOF
 ----
 ifndef::openshift-rosa,openshift-rosa-hcp[]
-<1> ROSA supports internal image backup. Set this field to false if you do not want to use image backup.
+<1> ROSA supports internal image backup. Set this field to `false` if you do not want to use image backup.
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-<1> {product-title} supports internal image backup. Set this field to false if you do not want to use image backup.
+<1> {product-title} supports internal image backup. Set this field to `false` if you do not want to use image backup.
 endif::openshift-rosa,openshift-rosa-hcp[]
-<2> See the important note regarding the `nodeAgent` attribute.
-<3> The type of uploader. The possible values are `restic` or `kopia`. The built-in Data Mover uses Kopia as the default uploader mechanism regardless of the value of the `uploaderType` field.
+<2> See the important note regarding the `nodeAgent` attribute at the end of this procedure.
+<3> The type of uploader. The built-in Data Mover uses Kopia as the default uploader mechanism regardless of the value of the `uploaderType` field.
 +
 // . Create the `DataProtectionApplication` resource, which is used to configure the connection to the storage where the backups and volume snapshots are stored:
 
@@ -252,12 +250,12 @@ $ cat << EOF | oc create -f -
 EOF
 ----
 ifndef::openshift-rosa,openshift-rosa-hcp[]
-<1> ROSA supports internal image backup. Set this field to false if you do not want to use image backup.
+<1> ROSA supports internal image backup. Set this field to `false` if you do not want to use image backup.
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-<1> {product-title} supports internal image backup. Set this field to false if you do not want to use image backup.
+<1> {product-title} supports internal image backup. Set this field to `false` if you do not want to use image backup.
 endif::openshift-rosa,openshift-rosa-hcp[]
-<2> See the important note regarding the `nodeAgent` attribute.
+<2> See the important note regarding the `nodeAgent` attribute at the end of this procedure.
 <3> The `credentialsFile` field is the mounted location of the bucket credential on the pod.
 <4> The `enableSharedConfig` field allows the `snapshotLocations` to share or reuse the credential defined for the bucket.
 <5> Use the profile name set in the {aws-short} credentials file.


### PR DESCRIPTION
Version(s):
4.19-4.20

Issue:
[OADP-5702](https://issues.redhat.com/browse/OADP-5702)

Link to docs preview:
- [Installing the OADP Operator and providing the IAM role - OADP with AWS STS](https://96679--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/aws-sts/oadp-aws-sts.html#installing-oadp-aws-sts_oadp-aws-sts-backing-up-applications)
- [Installing the OADP Operator and providing the IAM role - OADP on ROSA with AWS STS](https://96679--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.html#installing-oadp-rosa-sts_oadp-rosa-backing-up-applications)

QE review:
- [x] QE has approved this change.

Changes:
- Update support note for OADP on ROSA with AWS STS env.
- Copy it for plain AWS STS env.
- Unify credential file for both ROSA with AWS STS env and plain AWS STS env.