### PR TITLE
[OCPBUGS-59795] Swap the order of troubleshooting nmstate DNS connectivity

### DIFF
--- a/modules/k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc
+++ b/modules/k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc
@@ -6,11 +6,11 @@
 [id="k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc_{context}"]
 = Creating a custom DNS host name to resolve DNS connectivity issues
 
-In a disconnected environment where the external DNS server cannot be reached, you can resolve Kubernetes NMState Operator health probe issues by specifying a custom DNS host name in the `NMState` custom resource definition (CRD). 
+In a disconnected environment where the external DNS server cannot be configured, you can resolve Kubernetes NMState Operator health probe issues by specifying a custom DNS host name in the `NMState` custom resource definition (CRD). 
 
 .Procedure
 
-. Add the DNS host name configuration to the `NMState` CRD of your cluster:
+. Replace the DNS host name with your own resolvable hostname in the `NMState` CRD of your cluster:
 +
 [source,yaml]
 ----
@@ -21,15 +21,16 @@ metadata:
 spec:
   probeConfiguration:
     dns:
-      host: redhat.com
+      host: redhat.com <1>
 # ...
 ----
+<1> The hostname that can be successfully resolved in your own DNS server
 
-. Apply the DNS host name configuration to your cluster network by running the following command. Ensure that you replace `<filename>` with the name of your CRD file.
+. To change the hostname, edit the DNS host name configuration to your cluster network by running the following command. 
 +
 [source,yaml]
 ----
-$ oc apply -f <filename>.yaml
+$ oc edit nmstate nmstate
 ----
 
 

--- a/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.adoc
@@ -20,8 +20,8 @@ include::modules/virt-troubleshooting-incorrect-policy-config.adoc[leveloffset=+
 // Troubleshooting DNS connectivity issues in a disconnected environment
 include::modules/k8s-nmstate-troubleshooting-dns-disconnected-env.adoc[leveloffset=+1]
 
-// Creating a custom DNS host name to resolve DNS connectivity issues
-include::modules/k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc[leveloffset=+2]
-
 // Configuring the dnsmasq DNS server
 include::modules/k8s-nmstate-troubleshooting-dns-disconnected-env-dnsmasq.adoc[leveloffset=+2]
+
+// Creating a custom DNS host name to resolve DNS connectivity issues
+include::modules/k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

4.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OCPBUGS-59795

Link to docs preview: https://96689--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-troubleshooting-node-network.html#k8s-nmstate-troubleshooting-dns-disconnected-env-resolv.adoc_k8s-nmstate-troubleshooting-node-network
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
