### PR TITLE
OSDOCS#44070 - Docs for vLAN ID in localnet NAD

### DIFF
--- a/modules/virt-creating-localnet-nad-cli.adoc
+++ b/modules/virt-creating-localnet-nad-cli.adoc
@@ -60,14 +60,16 @@ spec:
             "name": "localnet-network", <2>
             "type": "ovn-k8s-cni-overlay", <3>
             "topology": "localnet", <4>
-            "netAttachDefName": "default/localnet-network" <5>
+            "vlanID": 200, <5>
+            "netAttachDefName": "default/localnet-network" <6>
     }
 ----
 <1> The CNI specification version. The required value is `0.3.1`.
 <2> The name of the network. This attribute must match the value of the `spec.desiredState.ovn.bridge-mappings.localnet` field of the `NodeNetworkConfigurationPolicy` object that defines the OVS bridge mapping.
 <3> The name of the CNI plug-in to be configured. The required value is `ovn-k8s-cni-overlay`.
 <4> The topological configuration for the network. The required value is `localnet`.
-<5> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
+<5> Optionally, for more fine-grained network management, you can configure a virtual LAN (VLAN) ID for the NAD. Pods that use this NAD will have have an interface whose traffic will be able to communicate only with other devices that use the same VLAN ID (`200` in this example).
+<6> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
 
 . Apply the manifest:
 +


### PR DESCRIPTION
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15 and later

Issue:
https://issues.redhat.com/browse/CNV-44070

Link to docs preview:
TBA

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
