### PR TITLE
TELCODOCS-2273 - Remove Tech Preview Notifications

### DIFF
--- a/modules/nw-metallb-bgppeer-cr.adoc
+++ b/modules/nw-metallb-bgppeer-cr.adoc
@@ -55,9 +55,6 @@ You must establish a point-to-point, layer 2 connection between the two BGP peer
 You can use unnumbered BGP peering with IPv4, IPv6, or dual-stack, but you must enable IPv6 RAs (Router Advertisements).
 Each interface is limited to one BGP connection.
 If you use this field, you cannot specify a value in the `spec.peerAddress` field.
-The `spec.bgp.routers.neighbors.interface` field is a Technology Preview feature only. 
-For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
-
 
 |`spec.sourceAddress`
 |`string`

--- a/modules/nw-metallb-example-bgppeer.adoc
+++ b/modules/nw-metallb-example-bgppeer.adoc
@@ -5,7 +5,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="nw-metallb-example-bgppeer_{context}"]
 = Example BGP peer configurations
-:FeatureName: The `spec.interface` field  
 
 [id="nw-metallb-example-limit-nodes-bgppeer_{context}"]
 == Example: Limit which nodes connect to a BGP peer
@@ -86,8 +85,6 @@ spec:
 
 [id="nw-metallb-example-unnumbered-bgp-peering_{context}"]
 == Example: Specify BGP peers for unnumbered BGP peering
-
-include::snippets/technology-preview.adoc[]
 
 To configure unnumbered BGP peering, specify the interface in the `spec.interface` field by using the following example configuration:
 

--- a/modules/nw-metallb-frr-k8s-configuration-crd.adoc
+++ b/modules/nw-metallb-frr-k8s-configuration-crd.adoc
@@ -6,8 +6,6 @@
 [id="nw-metallb-frrconfiguration-crd_{context}"]
 = Configuring the FRRConfiguration CRD
 
-:FeatureName: The `spec.bgp.routers.neighbors.interface` field  
-
 The following section provides reference examples that use the `FRRConfiguration` custom resource (CR).
 
 [id="nw-metallb-frrconfiguration-crd-routers_{context}"]
@@ -213,8 +211,6 @@ spec:
 [id="nw-metallb-frrconfiguration-crd-interface_{context}"]
 == The interface field
 
-include::snippets/technology-preview.adoc[]
-
 You can use the `interface` field to configure unnumbered BGP peering by using the following example configuration:
 
 .Example `FRRConfiguration` CR
@@ -314,8 +310,6 @@ Use this field to configure unnumbered BGP peering.
 There must be a point-to-point, layer 2 connection between the two BGP peers.
 You can use unnumbered BGP peering with IPv4, IPv6, or dual-stack, but you must enable IPv6 RAs (Router Advertisements).
 Each interface is limited to one BGP connection.
-The `spec.bgp.routers.neighbors.interface` field is a Technology Preview feature only.
-For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 
 |`spec.bgp.routers.neighbors.port`
 |`integer`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[TELCODOCS-2273](https://issues.redhat.com//browse/TELCODOCS-2273) - Remove Tech Preview Notifications
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2273
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[Configuring MetalLB BGP peers](https://96701--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-configure-bgp-peers.html)
    [The interface field](https://96701--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-frr-k8s.html#nw-metallb-frrconfiguration-crd-interface_configure-metallb-frr-k8s)
    [Example: Specify BGP peers for dual-stack networking](https://96701--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-configure-bgp-peers.html#nw-metallb-example-unnumbered-bgp-peering_configure-metallb-bgp-peers)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
