### PR TITLE
OCPBUGS#55904: Fix typo for interruptible-instance in machineset-crea…

### DIFF
--- a/modules/machineset-creating-non-guaranteed-instances.adoc
+++ b/modules/machineset-creating-non-guaranteed-instances.adoc
@@ -69,7 +69,7 @@ providerSpec:
     preemptible: true
 ----
 +
-If `preemptible` is set to `true`, the machine is labelled as an `interruptable-instance` after the instance is launched.
+If `preemptible` is set to `true`, the machine is labeled as an `interruptible-instance` after the instance is launched.
 
 endif::gcp[]
 


### PR DESCRIPTION
Fixed a typo.

Version(s):
4.12+

Issue:
[OCPBUGS-55904](https://issues.redhat.com/browse/OCPBUGS-55904)

Link to docs preview:
* [Creating preemptible VM instances by using compute machine sets](https://96705--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html)

