### PR TITLE
CNV#39976: [enterprise-4.15] Issue in file virt/about_virt/about-virt.adoc

### DIFF
--- a/modules/virt-about-storage-volumes-for-vm-disks.adoc
+++ b/modules/virt-about-storage-volumes-for-vm-disks.adoc
@@ -9,6 +9,8 @@
 
 If you use the storage API with known storage providers, the volume and access modes are selected automatically. However, if you use a storage class that does not have a storage profile, you must configure the volume and access mode.
 
+For a list of known storage providers for {VirtProductName}, see link:https://catalog.redhat.com/search?searchType=software&badges_and_features=OpenShift+Virtualization&subcategories=Storage[the Red Hat Ecosystem Catalog].
+
 For best results, use the `ReadWriteMany` (RWX) access mode and the `Block` volume mode. This is important for the following reasons:
 
 * `ReadWriteMany` (RWX) access mode is required for live migration.

--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -30,6 +30,8 @@ ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 You can check your {VirtProductName} cluster for compliance issues by installing the Compliance Operator and running a scan with the `ocp4-moderate` and `ocp4-moderate-node` profiles. The Compliance Operator uses OpenSCAP, a link:https://www.nist.gov/[NIST-certified tool], to scan and enforce security policies.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
+For information about partnering with Independent Software Vendors (ISVs) and Services partners for specialized storage, networking, backup, and additional functionality, see link:https://red.ht/workswithvirt[the Red Hat Ecosystem Catalog].
+
 include::modules/virt-vmware-comparison.adoc[leveloffset=+1]
 
 include::modules/virt-supported-cluster-version.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.15+

Issue: [CNV-39976](https://issues.redhat.com/browse/CNV-39976)

Links to docs previews:
[About volume and access modes for virtual machine disks](https://96709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html#virt-about-storage-volumes-for-vm-disks_preparing-cluster-for-virt)
[About OpenShift Virtualization](https://96709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/about_virt/about-virt.html)


QE review:
- [x] QE has approved this change.

