### PR TITLE
OLS-1955: Update BYOK configuration to reflect recent changes

### DIFF
--- a/modules/ols-providing-custom-knowledge-to-the-llm.adoc
+++ b/modules/ols-providing-custom-knowledge-to-the-llm.adoc
@@ -102,9 +102,7 @@ metadata:
 spec:
   ols:
     rag:
-      - image: quay.io/<username>/my-byok-image:latest # <1>
-        indexPath: /rag/vector_db
-        indexID: vector_db_index    
+      - image: quay.io/<username>/my-byok-image:latest # <1>  
 ----
 <1> Where `image` specifies the tag for the image that was pushed to the image registry so that the {ols-long} Operator can access the custom content. The {ols-long} Operator can work with more than one RAG database that you create.
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-1955

Link to docs preview:
https://96710--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#providing-custom-knowledge-to-the-llm_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
