### PR TITLE
OSDOCS-15516 added z-stream release notes

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2813,6 +2813,39 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.19.6
+[id="ocp-4-19-6_{context}"]
+=== RHSA-2025:11673 - {product-title} {product-version}.6 image release, bug fix, and security update advisory
+
+Issued: 29 July 2025
+
+{product-title} release {product-version}.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:11673[RHSA-2025:11673] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:11674[RHBA-2025:11674] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.6 --pullspecs
+----
+
+[id="ocp-4-19-6-enhancements_{context}"]
+==== Enhancements
+
+* The KubeVirt Container Storage Interface (CSI) driver now supports volume expansion. Users can dynamically increase the size of their persistent volumes in their tenant cluster. This capability simplifies storage management, allowing for more flexible and scalable infrastructure. (link:https://issues.redhat.com/browse/OCPBUGS-58239[OCPBUGS-58239])
+
+[id="ocp-4-19-6-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this release, the `/metrics/usage` endpoint was updated to include authentication and Cross-Site Request Forgery (CSRF) protections. Because of this, requests to this endpoint started failing with a "forbidden" error message because the requests lacked the necessary CSRF token in the request cookie. With this release, a CSRF token was added to the `/metrics/usage` request cookie, resolving the “forbidden” error message. (link:https://issues.redhat.com/browse/OCPBUGS-58331[OCPBUGS-58331])
+
+* Before this update, the `console.flag/model` extension point did not work, preventing flags from being properly set when their associated model was provided. With this release, the `console.flag/model` works as expected and properly sets a flag when the associated model is provided. (link:https://issues.redhat.com/browse/OCPBUGS-59513[OCPBUGS-59513])
+
+[id="ocp-4-19-6-updating_{context}"]
+==== Updating
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.19.5
 [id="ocp-4-19-5_{context}"]
 === RHSA-2025:11363 - {product-title} {product-version}.5 image release, bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-15516

Link to docs preview:
https://96712--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-6_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
The errata URLs will return 404 until the go-live date of 07/29/25

