### PR TITLE
OSDOCS-14109: Updated Support docs for HCP migration

### DIFF
--- a/support/index.adoc
+++ b/support/index.adoc
@@ -16,7 +16,7 @@ ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [id='support-overview-remote-health-monitoring']
 == Remote health monitoring issues
 xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[Remote health monitoring issues]:
-{product-title} collects telemetry and configuration data about your cluster and reports it to Red Hat by using the Telemeter Client and the Insights Operator. Red Hat uses this data to understand and resolve issues in _connected cluster_. Similar to connected clusters, you can xref:../support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc#remote-health-reporting-from-restricted-network[Use remote health monitoring in a restricted network]. {product-title} collects data and monitors health using the following:
+{product-title} collects telemetry and configuration data about your cluster and reports it to Red Hat by using the Telemeter Client and the Insights Operator. Red Hat uses this data to understand and resolve issues in a _connected cluster_. Similar to connected clusters, you can xref:../support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc#remote-health-reporting-from-restricted-network[Use remote health monitoring in a restricted network]. {product-title} collects data and monitors health using the following:
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 // Removed sentence on restricted networks, not supported in ROSA/OSD
@@ -24,7 +24,7 @@ ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [id='support-overview-remote-health-monitoring']
 == Remote health monitoring issues
 xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[Remote health monitoring issues]:
-{product-title} collects telemetry and configuration data about your cluster and reports it to Red Hat by using the Telemeter Client and the Insights Operator. Red Hat uses this data to understand and resolve issues in _connected cluster_. {product-title} collects data and monitors health using the following:
+{product-title} collects telemetry and configuration data about your cluster and reports it to Red Hat by using the Telemeter Client and the Insights Operator. Red Hat uses this data to understand and resolve issues in a _connected cluster_. {product-title} collects data and monitors health using the following:
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 * *Telemetry*: The Telemetry Client gathers and uploads the metrics values to Red Hat every four minutes and thirty seconds. Red Hat uses this data to:
@@ -40,20 +40,22 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 You can xref:../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#showing-data-collected-by-remote-health-monitoring[review telemetry information].
 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 If you have enabled remote health reporting, xref:../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Use Insights to identify issues with your cluster]. You can optionally disable remote health reporting.
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 [id='support-overview-gather-data-cluster']
 == Gather data about your cluster
 xref:../support/gathering-cluster-data.adoc#gathering-cluster-data[Gather data about your cluster]: Red Hat recommends gathering your debugging information when opening a support case. This helps Red Hat Support to perform a root cause analysis. A cluster administrator can use the following to gather data about your cluster:
 
-* *The must-gather tool*: Use the `must-gather` tool to collect information about your cluster and to debug the issues.
+* *must-gather tool*: Use the `must-gather` tool to collect information about your cluster and to debug the issues.
 * *sosreport*:  Use the `sosreport` tool to collect configuration details, system information, and diagnostic data for debugging purposes.
 * *Cluster ID*: Obtain the unique identifier for your cluster, when providing information to Red Hat Support.
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * *Bootstrap node journal logs*: Gather `bootkube.service` `journald` unit logs and container logs from the bootstrap node to troubleshoot bootstrap-related issues.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * *Cluster node journal logs*: Gather `journald` unit logs and logs within `/var/log` on individual cluster nodes to troubleshoot node-related issues.
-* *A network trace*: Provide a network packet trace from a specific {product-title} cluster node or a container to Red Hat Support to help troubleshoot network-related issues.
+* *Network trace*: Provide a network packet trace from a specific {product-title} cluster node or a container to Red Hat Support to help troubleshoot network-related issues.
 
 [id='support-overview-troubleshooting-issues']
 == Troubleshooting issues

--- a/support/troubleshooting/sd-managed-resources.adoc
+++ b/support/troubleshooting/sd-managed-resources.adoc
@@ -40,8 +40,227 @@ include::https://raw.githubusercontent.com/openshift/managed-cluster-config/mast
 
 {product-title} core namespaces are installed by default during cluster installation.
 
-ifdef::openshift-rosa,openshift-dedicated[]
 .List of core namespaces
+ifdef::openshift-rosa[]
+[%collapsible]
+====
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocp-namespaces
+  namespace: openshift-monitoring
+data:
+  managed_namespaces.yaml: |
+    Resources:
+      Namespace:
+      - name: dedicated-admin
+      - name: default
+      - name: kube-node-lease
+      - name: kube-public
+      - name: kube-system
+      - name: openshift
+      - name: openshift-addon-operator
+      - name: openshift-apiserver
+      - name: openshift-apiserver-operator
+      - name: openshift-aqua
+      - name: openshift-authentication
+      - name: openshift-authentication-operator
+      - name: openshift-backplane
+      - name: openshift-backplane-cee
+      - name: openshift-backplane-csa
+      - name: openshift-backplane-cse
+      - name: openshift-backplane-csm
+      - name: openshift-backplane-managed-scripts
+      - name: openshift-backplane-mcs-tier-two
+      - name: openshift-backplane-mobb
+      - name: openshift-backplane-srep
+      - name: openshift-backplane-tam
+      - name: openshift-catalogd
+      - name: openshift-cloud-controller-manager
+      - name: openshift-cloud-controller-manager-operator
+      - name: openshift-cloud-credential-operator
+      - name: openshift-cloud-network-config-controller
+      - name: openshift-cloud-platform-infra
+      - name: openshift-cluster-csi-drivers
+      - name: openshift-cluster-machine-approver
+      - name: openshift-cluster-node-tuning-operator
+      - name: openshift-cluster-olm-operator
+      - name: openshift-cluster-samples-operator
+      - name: openshift-cluster-storage-operator
+      - name: openshift-cluster-version
+      - name: openshift-codeready-workspaces
+      - name: openshift-config
+      - name: openshift-config-managed
+      - name: openshift-config-operator
+      - name: openshift-console
+      - name: openshift-console-operator
+      - name: openshift-console-user-settings
+      - name: openshift-controller-manager
+      - name: openshift-controller-manager-operator
+      - name: openshift-custom-domains-operator
+      - name: openshift-customer-monitoring
+      - name: openshift-deployment-validation-operator
+      - name: openshift-dns
+      - name: openshift-dns-operator
+      - name: openshift-etcd
+      - name: openshift-etcd-operator
+      - name: openshift-host-network
+      - name: openshift-image-registry
+      - name: openshift-infra
+      - name: openshift-ingress
+      - name: openshift-ingress-canary
+      - name: openshift-ingress-operator
+      - name: openshift-insights
+      - name: openshift-kni-infra
+      - name: openshift-kube-apiserver
+      - name: openshift-kube-apiserver-operator
+      - name: openshift-kube-controller-manager
+      - name: openshift-kube-controller-manager-operator
+      - name: openshift-kube-scheduler
+      - name: openshift-kube-scheduler-operator
+      - name: openshift-kube-storage-version-migrator
+      - name: openshift-kube-storage-version-migrator-operator
+      - name: openshift-logging
+      - name: openshift-machine-api
+      - name: openshift-machine-config-operator
+      - name: openshift-managed-node-metadata-operator
+      - name: openshift-managed-upgrade-operator
+      - name: openshift-marketplace
+      - name: openshift-monitoring
+      - name: openshift-multus
+      - name: openshift-must-gather-operator
+      - name: openshift-network-console
+      - name: openshift-network-diagnostics
+      - name: openshift-network-node-identity
+      - name: openshift-network-operator
+      - name: openshift-node
+      - name: openshift-nutanix-infra
+      - name: openshift-oauth-apiserver
+      - name: openshift-observability-operator
+      - name: openshift-ocm-agent-operator
+      - name: openshift-openstack-infra
+      - name: openshift-operator-controller
+      - name: openshift-operator-lifecycle-manager
+      - name: openshift-operators
+      - name: openshift-operators-redhat
+      - name: openshift-osd-metrics
+      - name: openshift-ovirt-infra
+      - name: openshift-ovn-kubernetes
+      - name: openshift-package-operator
+      - name: openshift-rbac-permissions
+      - name: openshift-route-controller-manager
+      - name: openshift-route-monitor-operator
+      - name: openshift-security
+      - name: openshift-service-ca
+      - name: openshift-service-ca-operator
+      - name: openshift-splunk-forwarder-operator
+      - name: openshift-sre-pruning
+      - name: openshift-user-workload-monitoring
+      - name: openshift-validation-webhook
+      - name: openshift-vsphere-infra
+----
+====
+endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+[%collapsible]
+====
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ocp-namespaces
+  namespace: openshift-monitoring
+data:
+  managed_namespaces.yaml: |
+    Resources:
+      Namespace:
+      - name: dedicated-admin
+      - name: default
+      - name: kube-node-lease
+      - name: kube-public
+      - name: kube-system
+      - name: open-cluster-management-agent
+      - name: open-cluster-management-agent-addon
+      - name: openshift
+      - name: openshift-apiserver
+      - name: openshift-apiserver-operator
+      - name: openshift-authentication
+      - name: openshift-authentication-operator
+      - name: openshift-backplane
+      - name: openshift-backplane-cee
+      - name: openshift-backplane-cse
+      - name: openshift-backplane-csm
+      - name: openshift-backplane-lpsre
+      - name: openshift-backplane-managed-scripts
+      - name: openshift-backplane-mcs-tier-two
+      - name: openshift-backplane-mobb
+      - name: openshift-backplane-srep
+      - name: openshift-backplane-tam
+      - name: openshift-cloud-controller-manager
+      - name: openshift-cloud-credential-operator
+      - name: openshift-cloud-network-config-controller
+      - name: openshift-cluster-csi-drivers
+      - name: openshift-cluster-machine-approver
+      - name: openshift-cluster-node-tuning-operator
+      - name: openshift-cluster-samples-operator
+      - name: openshift-cluster-storage-operator
+      - name: openshift-cluster-version
+      - name: openshift-config
+      - name: openshift-config-managed
+      - name: openshift-config-operator
+      - name: openshift-console
+      - name: openshift-console-operator
+      - name: openshift-console-user-settings
+      - name: openshift-controller-manager
+      - name: openshift-controller-manager-operator
+      - name: openshift-customer-monitoring
+      - name: openshift-deployment-validation-operator
+      - name: openshift-dns
+      - name: openshift-dns-operator
+      - name: openshift-etcd
+      - name: openshift-host-network
+      - name: openshift-image-registry
+      - name: openshift-infra
+      - name: openshift-ingress
+      - name: openshift-ingress-canary
+      - name: openshift-ingress-operator
+      - name: openshift-insights
+      - name: openshift-kube-apiserver
+      - name: openshift-kube-apiserver-operator
+      - name: openshift-kube-controller-manager
+      - name: openshift-kube-controller-manager-operator
+      - name: openshift-kube-scheduler
+      - name: openshift-kube-scheduler-operator
+      - name: openshift-kube-storage-version-migrator
+      - name: openshift-kube-storage-version-migrator-operator
+      - name: openshift-logging
+      - name: openshift-machine-api
+      - name: openshift-machine-config-operator
+      - name: openshift-marketplace
+      - name: openshift-monitoring
+      - name: openshift-multus
+      - name: openshift-must-gather-operator
+      - name: openshift-network-console
+      - name: openshift-network-diagnostics
+      - name: openshift-network-node-identity
+      - name: openshift-network-operator
+      - name: openshift-node
+      - name: openshift-operator-lifecycle-manager
+      - name: openshift-operators
+      - name: openshift-operators-redhat
+      - name: openshift-ovn-kubernetes
+      - name: openshift-package-operator
+      - name: openshift-route-controller-manager
+      - name: openshift-service-ca
+      - name: openshift-service-ca-operator
+      - name: openshift-user-workload-monitoring
+----
+====
+endif::openshift-rosa-hcp[]
+ifdef::openshift-dedicated[]
 [%collapsible]
 ====
 [source,yaml]
@@ -49,95 +268,7 @@ ifdef::openshift-rosa,openshift-dedicated[]
 include::https://raw.githubusercontent.com/openshift/managed-cluster-config/master/deploy/osd-managed-resources/ocp-namespaces.ConfigMap.yaml[]
 ----
 ====
-endif::openshift-rosa,openshift-dedicated[]
-ifdef::openshift-rosa-hcp[]
-.List of core namespaces
-[%collapsible]
-====
-[source,yaml]
-----
-default
-kube-node-lease
-kube-public
-kube-system
-open-cluster-management-agent
-open-cluster-management-agent-addon
-openshift
-openshift-apiserver
-openshift-apiserver-operator
-openshift-authentication
-openshift-authentication-operator
-openshift-backplane
-openshift-backplane-cee
-openshift-backplane-cse
-openshift-backplane-csm
-openshift-backplane-lpsre
-openshift-backplane-managed-scripts
-openshift-backplane-mcs-tier-two
-openshift-backplane-mobb
-openshift-backplane-srep
-openshift-backplane-tam
-openshift-cloud-controller-manager
-openshift-cloud-credential-operator
-openshift-cloud-network-config-controller
-openshift-cluster-csi-drivers
-openshift-cluster-machine-approver
-openshift-cluster-node-tuning-operator
-openshift-cluster-samples-operator
-openshift-cluster-storage-operator
-openshift-cluster-version
-openshift-config
-openshift-config-managed
-openshift-config-operator
-openshift-console
-openshift-console-operator
-openshift-console-user-settings
-openshift-controller-manager
-openshift-controller-manager-operator
-openshift-customer-monitoring
-openshift-deployment-validation-operator
-openshift-dns
-openshift-dns-operator
-openshift-etcd
-openshift-host-network
-openshift-image-registry
-openshift-infra
-openshift-ingress
-openshift-ingress-canary
-openshift-ingress-operator
-openshift-insights
-openshift-kube-apiserver
-openshift-kube-apiserver-operator
-openshift-kube-controller-manager
-openshift-kube-controller-manager-operator
-openshift-kube-scheduler
-openshift-kube-scheduler-operator
-openshift-kube-storage-version-migrator
-openshift-kube-storage-version-migrator-operator
-openshift-logging
-openshift-machine-api
-openshift-machine-config-operator
-openshift-marketplace
-openshift-monitoring
-openshift-multus
-openshift-must-gather-operator
-openshift-network-console
-openshift-network-diagnostics
-openshift-network-node-identity
-openshift-network-operator
-openshift-node
-openshift-operator-lifecycle-manager
-openshift-operators
-openshift-operators-redhat
-openshift-ovn-kubernetes
-openshift-package-operator
-openshift-route-controller-manager
-openshift-service-ca
-openshift-service-ca-operator
-openshift-user-workload-monitoring
-----
-====
-endif::openshift-rosa-hcp[]
+endif::openshift-dedicated[]
 
 ifdef::openshift-rosa,openshift-dedicated[]
 [id="sd-add-on-managed-namespaces_{context}"]


### PR DESCRIPTION
Version(s):
`enterprise-4.19+`

Issue:
**[OSDOCS-14109](https://issues.redhat.com/browse/OSDOCS-14109)**

Link to docs preview:
- Support Overview (HCP)
- Support Overview (Classic)

Additional information:
Updated Support docs to cover the HCP product distro.