### PR TITLE
OSDOCS-15517:Update the z-stream RNs for 4.18.21

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3023,6 +3023,50 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.21
+[id="ocp-4-18-21_{context}"]
+=== RHSA-2025:11677 - {product-title} {product-version}.21 bug fix and security update
+
+Issued: 30 July 2025
+
+{product-title} release {product-version}.21 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:11677[RHSA-2025:11677] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:11678[RHSA-2025:11678] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.21 --pullspecs
+----
+
+[id="ocp-4-18-21-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, the *Observe > Metrics > query > QueryKebab > Export as csv* drop-down item did not handle a undefined title element. As a consequence, you were unable to export the CSV file for certain queries on the *Metrics* tab of OpenShift Lister versions 4.16, 4.17, and 4.18. With this release, the metrics download for all queries correctly handles object properties in the drop-down menu items. As a result, the CSV export for all queries works on the *Metrics* page. (link:https://issues.redhat.com/browse/OCPBUGS-54314[OCPBUGS-54314])
+
+* Before this update, on outdated version of the {azure-first} API prevented specifying a Capacity Reservation Group for a `MachineSet`, if that group resided in a different subscription than the one originating the server creation. With this release, the most recent version of the {azure-short} API is used which allows a Capacity Reservation Group for a `MachineSet` to be specified, even when that group is located in a separate subscription from the server's creation point. (link:https://issues.redhat.com/browse/OCPBUGS-56167[OCPBUGS-56167])
+
+* Before this update, oc-mirror v2 did not use the custom credentials supplied by the `--authfile` parameter for the creation of a graph image. As a consequnce, authentication failures prevented the graph image creation. With this release, the `--authfile` parameter correctly uses the custom credentials for both mirroring and graph image creation. As a result, no authorization failures occur during the graph image creation. (link:https://issues.redhat.com/browse/OCPBUGS-57068[OCPBUGS-57068])
+
+* Before this update, when on-prem installer-provisioned infrastructure (IPI) deployments used the Cilium container network interface (CNI), the firewall rule that redirected traffic to the load balancer was ineffective. With this release, the rule works with the Cilium CNI and `OVNKubernetes`. (link:https://issues.redhat.com/browse/OCPBUGS-57782[OCPBUGS-57782])
+
+* Before this update, the build controller looked for secrets that were linked for general use, not specifically for the image pull. With this release, when searching for default image pull secrets, the builds use `ImagePullSecrets` that are linked to the service account. (link:https://issues.redhat.com/browse/OCPBUGS-57949[OCPBUGS-57949])
+
+* Before this update, `oc-mirror v2` sent a large number of requests to container registries. As a consequence, container registries rejected some requests with a `too many requests` error message. With this release, the default for the `maxParallelLayerDownloads` and `maxParallelImageDownloads` flags is reduced and the retry-times are increased. The retry-delay is also set to `0` to enable exp backoff. As a result, fewer requests are sent to container registries which results in fewer rejections of the requests. (link:https://issues.redhat.com/browse/OCPBUGS-58280[OCPBUGS-58280])
+
+* Before this update, a regression in {product-title} 4.15 caused forward slashes to not work in the 'href' values for the `console.tab/horizontalNav`parameter. With this release, forward slashes in the `href` values for the `console.tab/horizontalNav` parameter work as expected. (link:https://issues.redhat.com/browse/OCPBUGS-58457[OCPBUGS-58457])
+
+* Before this update, when you ran the oc-mirror v2 disk-to-mirror workflow without valid mirror tar files, the returned error messages did not correctly identify the problem. With this release, the oc-mirror v2 workflow returns an error message that states `no tar archives matching "mirror_[0-9]{6}\.tar" found in "<directory>"`. (link:https://issues.redhat.com/browse/OCPBUGS-59235[OCPBUGS-59235])
+
+ * Before this update, when a Machine Set was scaled down and had reached its minimum size, the Cluster Autoscaler could leave the last remaining node with a no schedule taint that prevented use of a node. This issue was caused by a counting error in the Cluster Autoscaler. With this release, the counting error has been fixed so that the Cluster Autoscaler works as expected when a Machine Set is scaled down and has reached its minimum size. (link:https://issues.redhat.com/browse/OCPBUGS-59260[OCPBUGS-59260])
+
+* Before this update, bundle unpack jobs did not inherit control-plane tolerances from the catalog-operator that created them. As a consequence, the bundle unpack jobs ran on only worker nodes. If no worker nodes were available due to taints, then admins are unable to install or upgrade Operators on the cluster. With this release, control-plane tolerations are adopted for bundle unpack jobs so that the jobs are executed on primary nodes as part of the control plane. (link:https://issues.redhat.com/browse/OCPBUGS-59421[OCPBUGS-59421])
+
+[id="ocp-4-18-21-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.20
 [id="ocp-4-18-20_{context}"]
 === RHSA-2025:10767 - {product-title} {product-version}.20 bug fix and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-15517

Link to docs preview:
https://96715--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html