### PR TITLE
[ROX-29710] Make delegated scanning req for mirroring more prominent

### DIFF
--- a/modules/redirecting-image-pulls-from-a-source-registry-to-a-mirrored-registry.adoc
+++ b/modules/redirecting-image-pulls-from-a-source-registry-to-a-mirrored-registry.adoc
@@ -10,10 +10,13 @@
 
 * `ImageContentSourcePolicy` (ICSP)
 * `ImageDigestMirrorSet` (IDMS)
-* `ImageTagMirrorSet` (ITMS) 
+* `ImageTagMirrorSet` (ITMS)
 
 For more information about how to configure image registry repository mirroring, see "Configuring image registry repository mirroring".
 
-You can automatically scan images from registry mirrors by using delegated image scanning.
+[IMPORTANT]
+====
+To scan images from registry mirrors, you must configure delegated image scanning.
+====
 
-For more information about how to configure delegated image scanning, see "Scanning images by using secured clusters".
+For more information about how to configure delegated image scanning, see "Accessing delegated image scanning".

--- a/operating/examine-images-for-vulnerabilities.adoc
+++ b/operating/examine-images-for-vulnerabilities.adoc
@@ -109,6 +109,8 @@ include::modules/redirecting-image-pulls-from-a-source-registry-to-a-mirrored-re
 
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-latest-version}/html/images/image-configuration#images-configuration-registry-mirror-configuring_image-configuration[Configuring image registry repository mirroring]
 
+* xref:../operating/examine-images-for-vulnerabilities.adoc#accessing-delegated-image-scanning_examine-images-for-vulnerabilities[Accessing delegated image scanning]
+
 * xref:../operating/examine-images-for-vulnerabilities.adoc#scanning-images-by-using-secured-clusters_examine-images-for-vulnerabilities[Scanning images by using secured clusters]
 
 include::modules/accessing-delegated-image-scanning.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.6+

[Issue
](https://issues.redhat.com/browse/ROX-29710)

[Link to docs preview
](https://96716--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities.html#redirecting-image-pulls-from-a-source-registry-to-a-mirrored-registry_examine-images-for-vulnerabilities)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
