### PR TITLE
PR for SRVKE-1634: Removed the TP note from the "advanced trigger filters" section as the feature is GA

### DIFF
--- a/eventing/triggers/advanced-trigger-filters.adoc
+++ b/eventing/triggers/advanced-trigger-filters.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 The advanced trigger filters give you advanced options for more precise event routing. You can filter events by exact matches, prefixes, or suffixes, as well as by CloudEvent extensions. This added control makes it easier to fine-tune how events flow ensuring that only relevant events trigger specific actions.
 
-:FeatureName: Advanced trigger filters feature
-include::snippets/technology-preview.adoc[]
-
 include::modules/advanced-trigger-filter-overview.adoc[leveloffset=+1]
 include::modules/triggers-supported-filter-dialects.adoc[leveloffset=+1]
 include::modules/triggers-conflict-current-filter-field.adoc[leveloffset=+1]

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -69,10 +69,10 @@ The following table provides information about which {ServerlessProductName} fea
 |TP
 |TP
 
-|`new-trigger-filters`
+|Advanced trigger filters
 |TP
 |TP
-|TP
+|GA
 
 |Go function using S2I builder
 |TP


### PR DESCRIPTION
**Affected versions:** 

- `serverless-docs-1.37`
- `serverless-docs-1.36`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVKE-1634

**Doc preview:** [Advanced trigger filters](https://96730--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/triggers/advanced-trigger-filters.html)

**Reviews:**

- [x] QE has approved this change.
- [x] SME has approved this change.



