### PR TITLE
PR for SRVLOGIC-629: Upgrading operator via OCP Console from 1.35.0 to 1.36.0 fails with error

### DIFF
--- a/modules/serverless-logic-upgrading-1-36-osl-operator.adoc
+++ b/modules/serverless-logic-upgrading-1-36-osl-operator.adoc
@@ -6,7 +6,7 @@
 [id="serverless-logic-upgrading-1-36-osl-operator_{context}"]
 = Upgrading the {ServerlessLogicOperatorName} to 1.36.0
 
-To transition from {ServerlessLogicOperatorName} (OSL) version 1.35.0 to 1.36.0, you must upgrade the OSL using the {product-title} web console. This upgrade ensures compatibility with newer features and proper functioning of your workflows.
+You can upgrade the {ServerlessLogicOperatorName} from version 1.35.0 to 1.36.0 by performing the following steps.
 
 .Prerequisites
 
@@ -15,35 +15,62 @@ To transition from {ServerlessLogicOperatorName} (OSL) version 1.35.0 to 1.36.0,
 * You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You have access to the OpenShift Management Console for Operator upgrades.
 * You have installed the OpenShift CLI (`oc`).
+* You have version 1.35.0 of {ServerlessLogicOperatorName} installed.
 
 .Procedure
 
+. Patch the `ClusterServiceVersion` (CSV) for the 1.35.0 {ServerlessLogicOperatorName} to update the deployment labels by running the following command:
++
+[source,terminal]
+----
+$ oc patch csv logic-operator-rhel8.v1.35.0 \
+  -n openshift-serverless-logic \
+  --type=json \
+  -p='[
+    {
+      "op": "replace",
+      "path": "/spec/install/spec/deployments/0/spec/selector/matchLabels",
+      "value": {
+        "app.kubernetes.io/name": "sonataflow-operator"
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/spec/install/spec/deployments/0/label",
+      "value": {
+        "app.kubernetes.io/name": "sonataflow-operator"
+      }
+    },
+    {
+      "op": "replace",
+      "path": "/spec/install/spec/deployments/0/spec/template/metadata/labels",
+      "value": {
+        "app.kubernetes.io/name": "sonataflow-operator"
+      }
+    }
+  ]'
+----
+
+. Delete the current Operator deployment by running the following command:
++
+[source,terminal]
+----
+$ oc delete deployment logic-operator-rhel8-controller-manager -n openshift-serverless-logic
+----
+
 . In the web console, navigate to the *Operators* -> *OperatorHub* -> *Installed Operators* page.
-. Select the `openshift-serverless-logic` namespace from the *Installed Namespace* drop-down list.
+
 . In the list of installed Operators, find and click the Operator named {ServerlessLogicOperatorName}.
-. In the Operator details page, click on the *Subscription* tab. Click *Edit Subscription*.
-. In the *Upgrade status* tab, click the *Upgrade available* link.
-. Click the *Preview install plan* button and *Approve* to start the update.
-. To monitor the upgrade process, run the following command: 
-+
-[source,terminal]
-----
-$ oc get subscription logic-operator-rhel8 -n openshift-serverless-logic -o jsonpath='{.status.installedCSV}'
-----
-+
-.Example output
-[source,terminal]
-----
-logic-operator-rhel8.v1.36.0
-----
+
+. Initiate the {ServerlessLogicOperatorName} upgrade to version 1.36.0.
 
 .Verification
 
-* To verify that the new Operator version is installed, run the following command: 
+* After applying the upgrade, verify that the Operator is running and in the `Succeeded` phase, by running the following command: 
 +
 [source,terminal]
 ----
-$ oc get clusterserviceversion logic-operator-rhel8.v1.36.0 -n openshift-serverless-logic
+$ oc get clusterserviceversion logic-operator-rhel8.v1.36.0
 ----
 .Example output
 +


### PR DESCRIPTION
**Affected versions:** 

- `serverless-docs-1.37`
- `serverless-docs-1.36`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-629

**Doc preview:** [Upgrading the OpenShift Serverless Logic Operator to 1.36.0](https://96731--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-35-to-1-36.html#serverless-logic-upgrading-1-36-osl-operator_serverless-logic-upgrading-operator-from-1-35-to-1-36)

**Reviews:**

- [x] QE has approved this change.
- [x] SME has approved this change.
- [x] Peer has approved this change.