### PR TITLE
WMCO remove [discrete] tags in prep for DITA migration

### DIFF
--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
@@ -8,8 +8,7 @@ toc::[]
 
 You can create a Windows `MachineSet` object to serve a specific purpose in your {product-title} cluster on Amazon Web Services (AWS). For example, you might create infrastructure Windows machine sets and related machines so that you can move supporting Windows workloads to the new Windows machines.
 
-[discrete]
-== Prerequisites
+.Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You are using a supported Windows Server as the operating system image.

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
@@ -8,8 +8,7 @@ toc::[]
 
 You can create a Windows `MachineSet` object to serve a specific purpose in your {product-title} cluster on Microsoft Azure. For example, you might create infrastructure Windows machine sets and related machines so that you can move supporting Windows workloads to the new Windows machines.
 
-[discrete]
-== Prerequisites
+.Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You are using a supported Windows Server as the operating system image.

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
@@ -8,8 +8,7 @@ toc::[]
 
 You can create a Windows `MachineSet` object to serve a specific purpose in your {product-title} cluster on Google Cloud Platform (GCP). For example, you might create infrastructure Windows machine sets and related machines so that you can move supporting Windows workloads to the new Windows machines.
 
-[discrete]
-== Prerequisites
+.Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You are using a supported Windows Server as the operating system image.

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix.adoc
@@ -8,8 +8,7 @@ toc::[]
 
 You can create a Windows `MachineSet` object to serve a specific purpose in your {product-title} cluster on Nutanix. For example, you might create infrastructure Windows machine sets and related machines so that you can move supporting Windows workloads to the new Windows machines.
 
-[discrete]
-== Prerequisites
+.Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You are using a supported Windows Server as the operating system image.

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
@@ -8,8 +8,7 @@ toc::[]
 
 You can create a Windows `MachineSet` object to serve a specific purpose in your {product-title} cluster on VMware vSphere. For example, you might create infrastructure Windows machine sets and related machines so that you can move supporting Windows workloads to the new Windows machines.
 
-[discrete]
-== Prerequisites
+.Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You are using a supported Windows Server as the operating system image.

--- a/windows_containers/disabling-windows-container-workloads.adoc
+++ b/windows_containers/disabling-windows-container-workloads.adoc
@@ -12,7 +12,6 @@ include::modules/uninstalling-wmco.adoc[leveloffset=+1]
 
 include::modules/deleting-wmco-namespace.adoc[leveloffset=+1]
 
-[discrete]
 [role="_additional-resources"]
 == Additional resources
 

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -13,8 +13,7 @@ Before adding Windows workloads to your cluster, you must install the Windows Ma
 Dual NIC is not supported on WMCO-managed Windows instances.
 ====
 
-[discrete]
-== Prerequisites
+.Prerequisites
 
 * You have access to an {product-title} cluster using an account with `cluster-admin` permissions.
 

--- a/windows_containers/scheduling-windows-workloads.adoc
+++ b/windows_containers/scheduling-windows-workloads.adoc
@@ -8,8 +8,7 @@ toc::[]
 
 You can schedule Windows workloads to Windows compute nodes.
 
-[discrete]
-== Prerequisites
+.Prerequisites
 
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You are using a Windows container as the OS image.
@@ -17,7 +16,6 @@ You can schedule Windows workloads to Windows compute nodes.
 
 include::modules/windows-pod-placement.adoc[leveloffset=+1]
 
-[discrete]
 [role="_additional-resources"]
 === Additional resources
 


### PR DESCRIPTION
Demoting instances of `== Prerequisites` to `.Prerequisites`  and removing the associated `[discrete]` tag to prep for DITA migration. See https://github.com/openshift/openshift-docs/pull/96676

Previews
[Creating a Windows machine set on AWS](https://96757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html) 
[Creating a Windows machine set on Azure](https://96757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
[Creating a Windows machine set on GCP](https://96757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
[Creating a Windows MachineSet object on Nutanix](https://96757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-nutanix.html[)
[Creating a Windows machine set on vSphere](https://96757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html) 
[Disabling Windows container workloads](https://96757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/disabling-windows-container-workloads.html)
[Enabling Windows container workloads](https://96757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html)
[Scheduling Windows container workloads](https://96757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/scheduling-windows-workloads.html)