### PR TITLE
OCPBUGS 59846 OCP image mode docs should use "bootc container lint"

### DIFF
--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -69,7 +69,7 @@ content: |-
                     https://example.com/files/systemd-udev-252-46.el9_4.x86_64.rpm \
                     https://example.com/files/systemd-rpm-macros-252-46.el9_4.noarch.rpm && \
       dnf clean all && \
-      ostree container commit
+      bootc container lint
 ----
 +
 .Example out-of-cluster Containerfile to apply a Hotfix
@@ -84,7 +84,7 @@ RUN dnf update -y https://example.com/files/systemd-252-46.el9_4.x86_64.rpm \
                   https://example.com/files/systemd-udev-252-46.el9_4.x86_64.rpm \
                   https://example.com/files/systemd-rpm-macros-252-46.el9_4.noarch.rpm && \
     dnf clean all && \
-    ostree container commit
+    bootc container lint
 ----
 // https://issues.redhat.com/browse/OCPBUGS-42838
 
@@ -97,7 +97,7 @@ RUN dnf update -y https://example.com/files/systemd-252-46.el9_4.x86_64.rpm \
 FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 # Install rsyslog package
 RUN dnf install -y rsyslog && \
-    ostree container commit
+    bootc container lint
 # Copy your custom configuration in
 ADD remote.conf /etc/rsyslog.d/remote.conf
 ----
@@ -121,7 +121,7 @@ FROM configs AS final
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     dnf install -y htop && \
     dnf clean all && \
-    ostree container commit
+    bootc container lint
 ----
 +
 .Example out-of-cluster Containerfile to apply a third-party package from EPEL
@@ -134,7 +134,7 @@ FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
     dnf install -y htop && \
     dnf clean all && \
-    ostree container commit
+    bootc container lint
 ----
 +
 This Containerfile installs the {op-system-base} fish program. Because fish requires additional {op-system-base} packages, the image must be built on an entitled {op-system-base} host. For {op-system-base} entitlements to work, you must copy the `etc-pki-entitlement` secret into the `openshift-machine-config-operator` namespace. 
@@ -148,7 +148,7 @@ FROM configs AS final
 # Install fish as third party package from EPEL
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/f/fish-3.3.1-3.el9.x86_64.rpm && \
     dnf clean all && \
-    ostree container commit
+    bootc container lint
 ----
 +
 .Example out-of-cluster Containerfile to apply a third-party package that has {op-system-base} dependencies
@@ -161,7 +161,7 @@ FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256...
 # Install fish as third party package from EPEL
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/Packages/f/fish-3.3.1-3.el9.x86_64.rpm && \
     dnf clean all && \
-    ostree container commit
+    bootc container lint
 ----
 
 After you create the machine config, the Machine Config Operator (MCO) performs the following steps:

--- a/modules/coreos-layering-configuring-on-modifying.adoc
+++ b/modules/coreos-layering-configuring-on-modifying.adoc
@@ -39,10 +39,10 @@ spec:
       RUN rpm-ostree install rng-tools && \
           systemctl enable rngd && \
           rpm-ostree cleanup -m && \
-          ostree container commit
+          bootc container lint
 
       RUN rpm-ostree install tree && \
-          ostree container commit
+          bootc container lint
   imageBuilder:
     imageBuilderType: PodImageBuilder
   baseImagePullSecret:

--- a/modules/coreos-layering-configuring-on-proc.adoc
+++ b/modules/coreos-layering-configuring-on-proc.adoc
@@ -51,7 +51,7 @@ spec:
       FROM configs AS final
       RUN dnf install -y cowsay && \
         dnf clean all && \
-        ostree container commit
+        bootc container lint
   imageBuilder: # <6>
     imageBuilderType: Job
   baseImagePullSecret: # <7>

--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -36,7 +36,7 @@ FROM quay.io/openshift-release/ocp-release@sha256... <1>
 #Install hotfix rpm
 RUN rpm-ostree override replace http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/kernel-{,core-,modules-,modules-core-,modules-extra-}5.14.0-295.el9.x86_64.rpm && \ <2>
     rpm-ostree cleanup -m && \
-    ostree container commit
+    bootc container lint
 ----
 <1> Specifies the {op-system} base image of your cluster.
 <2> Replaces the kernel packages.


### PR DESCRIPTION
Per Mark Russell: Docs should have `bootc container lint` everywhere it says `ostree container commit` in 4.19+ 
https://issues.redhat.com/browse/OCPBUGS-59846

Link to docs preview:
[Example Containerfiles](https://96758--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-examples_mco-coreos-layering) -- Updated examples throughout
[Using the on-cluster image mode to apply a custom layered image](https://96758--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on-proc_mco-coreos-layering) -- Updated example in Step 1.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
