### PR TITLE
OSDOCS-15470-multiple-hardware-networks: Removed unneccessary code blocks for …

### DIFF
--- a/modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc
+++ b/modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc
@@ -75,18 +75,11 @@ VRF functions correctly only when the resource is of type `netdevice`.
 $ oc create -f additional-network-attachment.yaml
 ----
 
-. Confirm that the CNO created the `NetworkAttachmentDefinition` CR by running the following command. Replace `<namespace>` with the namespace that you specified when configuring the network attachment, for example, `additional-network-1`.
+. Confirm that the CNO created the `NetworkAttachmentDefinition` CR by running the following command. Replace `<namespace>` with the namespace that you specified when configuring the network attachment, for example, `additional-network-1`. The expected output shows the name of the NAD CR and the creation age in minutes.
 +
 [source,terminal]
 ----
 $ oc get network-attachment-definitions -n <namespace>
-----
-+
-.Example output
-[source,terminal]
-----
-NAME                       AGE
-additional-network-1       14m
 ----
 +
 [NOTE]
@@ -121,33 +114,20 @@ spec:
 ----
 <1> Specify the name of the secondary network with the VRF instance.
 
-.. Create the `Pod` resource by running the following command:
+.. Create the `Pod` resource by running the following command. The expected output shows the name of the `Pod` resource and the creation age in minutes.
 +
 [source,terminal]
 ----
 $ oc create -f pod-additional-net.yaml
 ----
-+
-.Example output
-[source,terminal]
-----
-pod/test-pod created
-----
 
-. Verify that the pod network attachment is connected to the VRF secondary network. Start a remote session with the pod and run the following command:
+. Verify that the pod network attachment is connected to the VRF secondary network. Start a remote session with the pod and run the following command. The expected output shows the name of the VRF interface and its unique ID in the routing table.
 +
 [source,terminal]
 ----
 $ ip vrf show
 ----
-+
-.Example output
-[source,terminal]
-----
-Name              Table
------------------------
-vrf-1             1001
-----
+
 . Confirm that the VRF interface is the controller for the secondary interface:
 +
 [source,terminal]

--- a/modules/cnf-creating-an-additional-sriov-network-with-vrf-plug-in.adoc
+++ b/modules/cnf-creating-an-additional-sriov-network-with-vrf-plug-in.adoc
@@ -64,20 +64,13 @@ $ oc create -f sriov-network-attachment.yaml
 
 .Verifying that the `NetworkAttachmentDefinition` CR is successfully created
 
-* Confirm that the SR-IOV Network Operator created the `NetworkAttachmentDefinition` CR by running the following command:
+* Confirm that the SR-IOV Network Operator created the `NetworkAttachmentDefinition` CR by running the following command. The expected output shows the name of the NAD CR and the creation age in minutes.
 +
 [source,terminal]
 ----
 $ oc get network-attachment-definitions -n <namespace> <1>
 ----
 <1> Replace `<namespace>` with the namespace that you specified when configuring the network attachment, for example, `additional-sriov-network-1`.
-+
-.Example output
-[source,terminal]
-----
-NAME                            AGE
-additional-sriov-network-1      14m
-----
 +
 [NOTE]
 ====
@@ -90,20 +83,13 @@ To verify that the VRF CNI is correctly configured and that the additional SR-IO
 
 . Create an SR-IOV network that uses the VRF CNI.
 . Assign the network to a pod.
-. Verify that the pod network attachment is connected to the SR-IOV additional network. Remote shell into the pod and run the following command:
+. Verify that the pod network attachment is connected to the SR-IOV additional network. Remote shell into the pod and run the following command. The expected output shows the name of the VRF interface and its unique ID in the routing table.
 +
 [source,terminal]
 ----
 $ ip vrf show
 ----
-+
-.Example output
-[source,terminal]
-----
-Name              Table
------------------------
-red                 10
-----
+
 . Confirm that the VRF interface is `master` of the secondary interface by running the following command:
 +
 [source,terminal]

--- a/modules/nw-configure-sysctl-interface-sriov-network-bonded.adoc
+++ b/modules/nw-configure-sysctl-interface-sriov-network-bonded.adoc
@@ -126,15 +126,7 @@ $ oc create -f sriov-bond-network-interface.yaml
 ----
 $ oc get network-attachment-definitions -n <namespace> <1>
 ----
-<1> Replace `<namespace>` with the networkNamespace that you specified when configuring the network attachment, for example, `sysctl-tuning-test`.
-+
-.Example output
-[source,terminal]
-----
-NAME                          AGE
-bond-sysctl-network           22m
-allvalidflags                 47m
-----
+<1> Replace `<namespace>` with the networkNamespace that you specified when configuring the network attachment, for example, `sysctl-tuning-test`. Expected output shows the names of the NAD CRDs and the creation age in minutes.
 +
 [NOTE]
 ====
@@ -215,15 +207,9 @@ tunepod   1/1     Running   0          47s
 $ oc rsh -n sysctl-tuning-test tunepod
 ----
 
-. Verify the values of the configured `sysctl` flag. Find the value  `net.ipv6.neigh.IFNAME.base_reachable_time_ms` by running the following command::
+. Verify the values of the configured `sysctl` flag. Find the value  `net.ipv6.neigh.IFNAME.base_reachable_time_ms` by running the following command:
 +
 [source,terminal]
 ----
 $ sysctl net.ipv6.neigh.bond0.base_reachable_time_ms
-----
-+
-.Example output
-[source,terminal]
-----
-net.ipv6.neigh.bond0.base_reachable_time_ms = 20000
 ----

--- a/modules/nw-configure-sysctl-interface-sriov-network.adoc
+++ b/modules/nw-configure-sysctl-interface-sriov-network.adoc
@@ -72,14 +72,7 @@ $ oc create -f sriov-network-interface-sysctl.yaml
 ----
 $ oc get network-attachment-definitions -n <namespace> <1>
 ----
-<1> Replace `<namespace>` with the value for `networkNamespace` that you specified in the `SriovNetwork` object. For example, `sysctl-tuning-test`.
-+
-.Example output
-[source,terminal]
-----
-NAME                                  AGE
-onevalidflag                          14m
-----
+<1> Replace `<namespace>` with the value for `networkNamespace` that you specified in the `SriovNetwork` object. For example, `sysctl-tuning-test`. The expected output shows the name of the NAD CRD and the creation age in minutes.
 +
 [NOTE]
 ====
@@ -162,10 +155,4 @@ $ oc rsh -n sysctl-tuning-test tunepod
 [source,terminal]
 ----
 $ sysctl net.ipv4.conf.net1.accept_redirects
-----
-+
-.Example output
-[source,terminal]
-----
-net.ipv4.conf.net1.accept_redirects = 1
 ----

--- a/modules/nw-enable-all-multicast-mode-sriov-network.adoc
+++ b/modules/nw-enable-all-multicast-mode-sriov-network.adoc
@@ -126,14 +126,7 @@ $ oc create -f sriov-enable-all-multicast.yaml
 ----
 $ oc get network-attachment-definitions -n <namespace> <1>
 ----
-<1> Replace `<namespace>` with the value for `networkNamespace` that you specified in the `SriovNetwork` object. For this example, that is `enable-allmulti-test`.
-+
-.Example output
-[source,terminal]
-----
-NAME                                  AGE
-enableallmulti                        14m
-----
+<1> Replace `<namespace>` with the value for `networkNamespace` that you specified in the `SriovNetwork` object. For this example, that is `enable-allmulti-test`. The expected output shows the name of the NAD CR and the creation age in minutes.
 +
 [NOTE]
 ====

--- a/modules/nw-multi-network-policy-enable.adoc
+++ b/modules/nw-multi-network-policy-enable.adoc
@@ -27,15 +27,9 @@ spec:
   useMultiNetworkPolicy: true
 ----
 
-. Configure the cluster to enable multi-network policy:
+. Configure the cluster to enable multi-network policy. Successful output lists the name of the policy object and the `patched` status.
 +
 [source,terminal]
 ----
 $ oc patch network.operator.openshift.io cluster --type=merge --patch-file=multinetwork-enable-patch.yaml
-----
-+
-.Example output
-[source,text]
-----
-network.operator.openshift.io/cluster patched
 ----

--- a/modules/nw-multus-configuring-whereabouts-ip-reconciler-schedule.adoc
+++ b/modules/nw-multus-configuring-whereabouts-ip-reconciler-schedule.adoc
@@ -44,10 +44,6 @@ $ oc get all -n openshift-multus | grep whereabouts-reconciler
 ----
 pod/whereabouts-reconciler-2p7hw                   1/1     Running   0             4m14s
 pod/whereabouts-reconciler-76jk7                   1/1     Running   0             4m14s
-pod/whereabouts-reconciler-94zw6                   1/1     Running   0             4m14s
-pod/whereabouts-reconciler-mfh68                   1/1     Running   0             4m14s
-pod/whereabouts-reconciler-pgshz                   1/1     Running   0             4m14s
-pod/whereabouts-reconciler-xn5xz                   1/1     Running   0             4m14s
 daemonset.apps/whereabouts-reconciler          6         6         6       6            6           kubernetes.io/os=linux   4m16s
 ----
 

--- a/modules/nw-multus-create-master-interface-bridge-cni.adoc
+++ b/modules/nw-multus-create-master-interface-bridge-cni.adoc
@@ -53,19 +53,11 @@ spec:
 $ oc apply -f bridge-nad.yaml
 ----
 
-.  Verify that you successfully created a `NetworkAttachmentDefinition` CRD by entering the following command:
+.  Verify that you successfully created a `NetworkAttachmentDefinition` CRD by entering the following command. The expected output shows the name of the NAD CRD and the creation age in minutes.
 +
 [source,terminal]
 ----
 $ oc get network-attachment-definitions
-----
-+
-.Example output
-
-[source,terminal]
-----
-NAME             AGE
-bridge-network   15s
 ----
 
 . Using the following YAML example, create a file named `ipvlan-additional-network-configuration.yaml` for the IPVLAN secondary network configuration:
@@ -99,20 +91,11 @@ spec:
 $ oc apply -f ipvlan-additional-network-configuration.yaml
 ----
 
-. Verify that the `NetworkAttachmentDefinition` CRD has been created successfully by running the following command:
+. Verify that the `NetworkAttachmentDefinition` CRD has been created successfully by running the following command. The expected output shows the name of the NAD CRD and the creation age in minutes.
 +
 [source,terminal]
 ----
 $ oc get network-attachment-definitions
-----
-+
-.Example output
-
-[source,terminal]
-----
-NAME             AGE
-bridge-network   87s
-ipvlan-net       9s
 ----
 
 . Using the following YAML example, create a file named `pod-a.yaml` for the pod definition:

--- a/modules/nw-multus-create-network.adoc
+++ b/modules/nw-multus-create-network.adoc
@@ -6,7 +6,7 @@
 [id="nw-multus-create-network_{context}"]
 = Creating a primary network attachment with the Cluster Network Operator
 
-The Cluster Network Operator (CNO) manages additional network definitions. When you specify a primary network to create, the CNO creates the `NetworkAttachmentDefinition` CRD automatically.
+The Cluster Network Operator (CNO) manages additional network definitions. When you specify a primary network to create, the CNO creates the `NetworkAttachmentDefinition` custom resource definition (CRD) automatically.
 
 [IMPORTANT]
 ====
@@ -70,7 +70,7 @@ spec:
 
 .Verification
 
-* Confirm that the CNO created the `NetworkAttachmentDefinition` CRD by running the following command. There might be a delay before the CNO creates the CRD.
+* Confirm that the CNO created the `NetworkAttachmentDefinition` CRD by running the following command. A delay might exist before the CNO creates the CRD. The expected output shows the name of the NAD CRD and the creation age in minutes.
 +
 [source,terminal]
 ----
@@ -82,10 +82,3 @@ where:
 
 `<namespace>`:: Specifies the namespace for the network attachment that you added to the CNO configuration.
 --
-+
-.Example output
-[source,terminal]
-----
-NAME                 AGE
-test-network-1       14m
-----

--- a/modules/nw-multus-creating-whereabouts-reconciler-daemon-set.adoc
+++ b/modules/nw-multus-creating-whereabouts-reconciler-daemon-set.adoc
@@ -69,9 +69,5 @@ $ oc get all -n openshift-multus | grep whereabouts-reconciler
 ----
 pod/whereabouts-reconciler-jnp6g 1/1 Running 0 6s
 pod/whereabouts-reconciler-k76gg 1/1 Running 0 6s
-pod/whereabouts-reconciler-k86t9 1/1 Running 0 6s
-pod/whereabouts-reconciler-p4sxw 1/1 Running 0 6s
-pod/whereabouts-reconciler-rvfdv 1/1 Running 0 6s
-pod/whereabouts-reconciler-svzw9 1/1 Running 0 6s
 daemonset.apps/whereabouts-reconciler 6 6 6 6 6 kubernetes.io/os=linux 6s
 ----

--- a/modules/nw-multus-whereabouts-fast-ipam.adoc
+++ b/modules/nw-multus-whereabouts-fast-ipam.adoc
@@ -154,7 +154,7 @@ $ oc exec <pod_name> -- ip a
 ----
 <1> Pod is attached to the `192.168.2.1` IP address on the `net1` interface as expected.
 
-. Check that the node selector pool exists in the `openshift-multus` namespace by entering the following command:
+. Check that the node selector pool exists in the `openshift-multus` namespace by entering the following command. The expected output shows the name of the node selector pool and the creation age in minutes.
 +
 [source,terminal]
 ----

--- a/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
+++ b/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
@@ -74,7 +74,7 @@ spec:
 By default, if you do not specify a `namespaceSelector` parameter in the policy object, no namespaces get selected. This means the policy allows traffic only from the namespace where the network policy deployes.
 ====
 
-. Apply the policy by entering the following command:
+. Apply the policy by entering the following command. Successful output lists the name of the policy object and the `created` status.
 +
 [source,terminal]
 ----

--- a/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
+++ b/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
@@ -74,7 +74,7 @@ spec:
 <1> Applies the policy only to `app:web` pods in the default namespace.
 <2> Restricts traffic to only pods in namespaces that have the label `purpose=production`.
 
-. Apply the policy by entering the following command:
+. Apply the policy by entering the following command. Successful output lists the name of the policy object and the `created` status.
 +
 [source,terminal]
 ----

--- a/modules/nw-networkpolicy-allow-external-clients.adoc
+++ b/modules/nw-networkpolicy-allow-external-clients.adoc
@@ -73,7 +73,7 @@ spec:
     - {}
 ----
 
-. Apply the policy by entering the following command:
+. Apply the policy by entering the following command. Successful output lists the name of the policy object and the `created` status.
 +
 [source,terminal]
 ----

--- a/modules/nw-networkpolicy-create-cli.adoc
+++ b/modules/nw-networkpolicy-create-cli.adoc
@@ -210,7 +210,7 @@ where:
 endif::multi[]
 endif::multi[]
 
-. To create the {name} policy object, enter the following command:
+. To create the {name} policy object, enter the following command. Successful output lists the name of the policy object and the `created` status.
 +
 [source,terminal]
 ----

--- a/modules/nw-networkpolicy-delete-cli.adoc
+++ b/modules/nw-networkpolicy-delete-cli.adoc
@@ -37,7 +37,7 @@ endif::microshift[]
 
 .Procedure
 
-* To delete a {name} policy object, enter the following command:
+* To delete a {name} policy object, enter the following command. Successful output lists the name of the policy object and the `deleted` status.
 +
 [source,terminal,subs="attributes+"]
 ----

--- a/modules/nw-networkpolicy-deny-all-allowed.adoc
+++ b/modules/nw-networkpolicy-deny-all-allowed.adoc
@@ -78,7 +78,7 @@ ifndef::multi[]
 <3> There are no `ingress` rules specified. This causes incoming traffic to be dropped to all pods.
 endif::multi[]
 +
-. Apply the policy by entering the following command:
+. Apply the policy by entering the following command. Successful output lists the name of the policy object and the `created` status.
 +
 [source,terminal]
 ----

--- a/modules/nw-sriov-configure-exclude-topology-manager.adoc
+++ b/modules/nw-sriov-configure-exclude-topology-manager.adoc
@@ -48,17 +48,11 @@ spec:
 If multiple `SriovNetworkNodePolicy` resources target the same SR-IOV network resource, the `SriovNetworkNodePolicy` resources must have the same value as the `excludeTopology` specification. Otherwise, the conflicting policy is rejected.
 ====
 
-.. Create the `SriovNetworkNodePolicy` resource by running the following command:
+.. Create the `SriovNetworkNodePolicy` resource by running the following command. Successful output lists the name of the `SriovNetworkNodePolicy` resource and the `created` status.
 +
 [source,terminal]
 ----
 $ oc create -f sriov-network-node-policy.yaml
-----
-+
-.Example output
-[source,terminal]
-----
-sriovnetworknodepolicy.sriovnetwork.openshift.io/policy-for-numa-0 created
 ----
 
 . Create the `SriovNetwork` CR:
@@ -85,17 +79,11 @@ spec:
 <3> Enter the namespace for your SR-IOV network resource.
 <4> Enter the IP address management configuration for the SR-IOV network.
 
-.. Create the `SriovNetwork` resource by running the following command:
+.. Create the `SriovNetwork` resource by running the following command. Successful output lists the name of the `SriovNetwork` resource and the `created` status.
 +
 [source,terminal]
 ----
 $ oc create -f sriov-network.yaml
-----
-+
-.Example output
-[source,terminal]
-----
-sriovnetwork.sriovnetwork.openshift.io/sriov-numa-0-network created
 ----
 
 . Create a pod and assign the SR-IOV network resource from the previous step:
@@ -124,17 +112,11 @@ spec:
 ----
 <1> This is the name of the `SriovNetwork` resource that uses the `SriovNetworkNodePolicy` resource.
 
-.. Create the `Pod` resource by running the following command:
+.. Create the `Pod` resource by running the following command. The expected output shows the name of the `Pod` resource and the `created` status.
 +
 [source,terminal]
 ----
 $ oc create -f sriov-network-pod.yaml
-----
-+
-.Example output
-[source,terminal]
-----
-pod/example-pod created
 ----
 
 .Verification

--- a/modules/nw-sriov-configuring-multiple-nodes.adoc
+++ b/modules/nw-sriov-configuring-multiple-nodes.adoc
@@ -161,11 +161,3 @@ openshift-sriov-network-operator   worker-1   InProgress    Drain_Required      
 ----
 +
 When the draining process is complete, the `SYNC STATUS` changes to `Succeeded`, and the `DESIRED SYNC STATE` and `CURRENT SYNC STATE` values return to `IDLE`.
-+
-.Example output
-[source,terminal]
-----
-NAMESPACE                          NAME       SYNC STATUS   DESIRED SYNC STATE   CURRENT SYNC STATE   AGE
-openshift-sriov-network-operator   worker-0   Succeeded     Idle                 Idle                 3d10h
-openshift-sriov-network-operator   worker-1   Succeeded     Idle                 Idle                 3d10h
-----

--- a/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
+++ b/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
@@ -63,11 +63,9 @@ $ oc get nodes
 NAME       STATUS   ROLES                   AGE   VERSION
 master-0   Ready    master                  2d    v1.32.3
 master-1   Ready    master                  2d    v1.32.3
-master-2   Ready    master                  2d    v1.32.3
 worker-0   Ready    worker                  2d    v1.32.3
 worker-1   Ready    worker                  2d    v1.32.3
 worker-2   Ready    mcp-offloading,worker   47h   v1.32.3
-worker-3   Ready    mcp-offloading,worker   47h   v1.32.3
 ----
 --
 

--- a/modules/nw-sriov-interface-level-sysctl-basic-node-policy.adoc
+++ b/modules/nw-sriov-interface-level-sysctl-basic-node-policy.adoc
@@ -69,15 +69,9 @@ $ oc create -f policyoneflag-sriov-node-network.yaml
 +
 After applying the configuration update, all the pods in `sriov-network-operator` namespace change to the `Running` status.
 +
-. To verify that the SR-IOV network device is configured, enter the following command. Replace `<node_name>` with the name of a node with the SR-IOV network device that you just configured.
+. To verify that the SR-IOV network device is configured, enter the following command. Replace `<node_name>` with the name of a node with the SR-IOV network device that you just configured. Expected output shows `Succeeded`.
 +
 [source,terminal]
 ----
 $ oc get sriovnetworknodestates -n openshift-sriov-network-operator <node_name> -o jsonpath='{.status.syncStatus}'
-----
-+
-.Example output
-[source,terminal]
-----
-Succeeded
 ----

--- a/modules/nw-sriov-interface-level-sysctl-bonded-node-policy.adoc
+++ b/modules/nw-sriov-interface-level-sysctl-bonded-node-policy.adoc
@@ -69,16 +69,9 @@ $ oc create -f policyallflags-sriov-node-network.yaml
 +
 After applying the configuration update, all the pods in sriov-network-operator namespace change to the `Running` status.
 +
-. To verify that the SR-IOV network device is configured, enter the following command. Replace `<node_name>` with the name of a node with the SR-IOV network device that you just configured.
+. To verify that the SR-IOV network device is configured, enter the following command. Replace `<node_name>` with the name of a node with the SR-IOV network device that you just configured. Expected output shows `Succeeded`
 +
 [source,terminal]
 ----
 $ oc get sriovnetworknodestates -n openshift-sriov-network-operator <node_name> -o jsonpath='{.status.syncStatus}'
-----
-+
-.Example output
-+
-[source,terminal]
-----
-Succeeded
 ----

--- a/modules/proc-switching-bf2-nic.adoc
+++ b/modules/proc-switching-bf2-nic.adoc
@@ -20,18 +20,17 @@ Currently, only switching Bluefield-2 from DPU to NIC mode is supported. Switchi
 
 .Procedure
 
-. Add the following labels to each of your worker nodes by entering the following commands:
+. Add the following label to each of your compute nodes by entering the following command. You must run the command for each compute node.
 +
 [source,terminal]
 ----
-$ oc label node <example_node_name_one> node-role.kubernetes.io/sriov=
+$ oc label node <node_name> node-role.kubernetes.io/sriov=
 ----
-+
-[source,terminal]
-----
-$ oc label node <example_node_name_two> node-role.kubernetes.io/sriov=
+--
+where:
 
-----
+`node_name`:: Refers to the name of a compute node.
+--
 
 . Create a machine config pool for the SR-IOV Network Operator, for example:
 +
@@ -51,7 +50,7 @@ spec:
       node-role.kubernetes.io/sriov: ""
 ----
 
-. Apply the following `machineconfig.yaml` file to the worker nodes:
+. Apply the following `machineconfig.yaml` file to the compute nodes:
 +
 [source,yaml]
 ----
@@ -92,6 +91,6 @@ spec:
 ----
 <1> Optional: The PCI address of a specific card can optionally be specified, for example `ExecStart=/bin/bash -c '/etc/default/switch_in_sriov_config_daemon.sh nic 0000:5e:00.0 || echo done'`. By default, the first device is selected. If there is more than one device, you must specify which PCI address to be used. The PCI address must be the same on all nodes that are switching Bluefield-2 from DPU mode to NIC mode.
 
-. Wait for the worker nodes to restart. After restarting, the Bluefield-2 network device on the worker nodes is switched into NIC mode.
+. Wait for the compute nodes to restart. After restarting, the Bluefield-2 network device on the compute nodes is switched into NIC mode.
 
 . Optional: You might need to restart the host hardware because most recent Bluefield-2 firmware releases require a hardware restart to switch into NIC mode. 


### PR DESCRIPTION
This PR removes low-level code blocks from the Multiple networks and Hardware networks docs. Tried to remove passive from some files but this might distract from the core task.

Version(s):
4.16+

Issue:
[OSDOCS-15470](https://issues.redhat.com/browse/OSDOCS-15470)

Link to docs preview:
* [Understanding multiple networks](https://96464--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks)

- [x] QE has approved this change (Zhiqiang Fang SRIOV).

Epic = https://issues.redhat.com/browse/OSDOCS-15186
