### PR TITLE
ROX-26559: correct upgrade instructions for central db

### DIFF
--- a/modules/operator-upgrade-modify-central-custom-resource.adoc
+++ b/modules/operator-upgrade-modify-central-custom-resource.adoc
@@ -3,10 +3,12 @@
 // * upgrading/upgrade-operator.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="operator-upgrade-modify-central-custom-resource_{context}"]
-= Modifying Central custom resource
+= Modifying the Central custom resource
 
 [role="_abstract"]
-The Central DB service requires persistent storage. If you have not configured a default storage class for the Central cluster that is an SSD or is high performance, you must update the `Central` custom resource to configure the storage class for the Central DB persistent volume claim (PVC).
+The Central DB service requires persistent storage. If you have not configured a default storage class for the Central cluster that is an SSD or is high performance, you must reinstall and configure the `Central` custom resource (CR) with the storage class for the Central DB persistent volume claim (PVC).
+
+When changing the `storageClassName`, because of limitations with the Kubernetes storage layer, you cannot modify a claim's storage class after it is bound; therefore, you must re-create the Central CR.
 
 [NOTE]
 ====
@@ -14,7 +16,9 @@ Skip this section if you have already configured a default storage class for Cen
 ====
 
 .Procedure
-* Update the central custom resource with the following configuration:
+. Back up and uninstall the Central instance.
+. Reinstall {product-title-short} and configure the Central custom resource as shown in the following example:
++
 [source,terminal]
 ----
 spec:
@@ -28,4 +32,6 @@ spec:
           storageClassName: <storage-class-name>
 ----
 <1> You must not change the value of `IsEnabled` to `Enabled`.
-<2> If this claim exists, your cluster uses the existing claim, otherwise it creates a new claim.
+<2> If this claim exists, your cluster uses the existing claim; otherwise, it creates a new claim.
+. Restore the Central database backup by using the `roxctl` CLI.
+

--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -30,6 +30,12 @@ include::modules/change-collection-method.adoc[leveloffset=+2]
 
 include::modules/operator-upgrade-modify-central-custom-resource.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../backup_and_restore/backing-up-acs.adoc#backing-up-acs[Backing up {product-title}]
+* xref:../backup_and_restore/restore-acs.adoc#restore-acs[Restoring from a backup]
+
 include::modules/operator-upgrade-modify-central-custom-resource-external-db.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s): 4.6+

[Issue](https://issues.redhat.com/browse/ROX-26559)

[Link to docs preview
](https://96763--ocpdocs-pr.netlify.app/openshift-acs/latest/upgrading/upgrade-operator.html#operator-upgrade-modify-central-custom-resource_upgrade-operator)

QE review: **ACS has no QE, approved by SMEs**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
