### PR TITLE
OSDOCS-15379: Incorrect statement in etcd description

### DIFF
--- a/modules/rosa-sdpolicy-security.adoc
+++ b/modules/rosa-sdpolicy-security.adoc
@@ -96,17 +96,10 @@ With {product-title}, AWS provides a standard DDoS protection on all load balanc
 [id="rosa-sdpolicy-etcd-encryption_{context}"]
 == etcd encryption
 
-In
-ifdef::openshift-rosa-hcp[]
-{hcp-title-first},
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-{product-title},
-endif::openshift-rosa-hcp[]
-the control plane storage is encrypted at rest by default and this includes encryption of the etcd volumes. This storage-level encryption is provided through the storage layer of the cloud provider.
+In {product-title}, the control plane storage is encrypted at rest by default, including encryption of the etcd volumes. This storage-level encryption is provided through the storage layer of the cloud provider.
 
 ifdef::openshift-rosa-hcp[]
-The etcd database is always encrypted by default. Customers might opt to provide their own custom AWS KMS keys for the purpose of encrypting the etcd database.
+Customers can also opt to encrypt the etcd database at build time or provide their own custom AWS KMS keys for the purpose of encrypting the etcd database.
 
 Etcd encryption will encrypt the following Kubernetes API server and OpenShift API server resources:
 endif::openshift-rosa-hcp[]


### PR DESCRIPTION
[OSDOCS-15379](https://issues.redhat.com//browse/OSDOCS-15379): Incorrect statement in etcd description

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-15379

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
No QE needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
