### PR TITLE
OCPBUGS#59565: Fixed imprting typo in 4.18 release notes

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1259,7 +1259,7 @@ This release introduces the following updates to the *Administrator* perspective
 
 * A new setting for hiding the *Getting started resources* card on the *Overview* page allowing for maximum use of the dashboard.
 * A *Start Job* option was added to the CronJob *List* and *Details* pages, so you can start individual CronJobs manually directly in the web console without having to use the `oc` CLI.
-* The *Import YAML* button in the masthead is now a *Quick Create* button that you can use for the rapid deployment of workloads by imprting from YAML, Git, or using container images.
+* The *Import YAML* button in the masthead is now a *Quick Create* button that you can use for the rapid deployment of workloads by importing from YAML, Git, or using container images.
 * You can build your own generative-AI chat bot with a chat bot sample. The generative-AI chat bot sample is deployed with Helm and includes a full CI/CD pipeline. You can also run this sample on your cluster with no CPUs.
 * You can import YAML into the console using {ols}.
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OCPBUGS-59565](https://issues.redhat.com/browse/OCPBUGS-59565)

Link to docs preview:
[Admin. perspective](https://96783--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-administrator-perspective_release-notes)
