### PR TITLE
OSSM-9881 Update version support table for 3.1

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,14 +17,14 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.0.3
+:SMProductVersion: 3.1.0
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.7
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio
-:istio-latest: 1.24.6
+:istio-latest: 1.26.2
 //update istio-latest as necessary
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat
@@ -101,9 +101,6 @@
 //Version-agnostic OLM
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-//service mesh v2
-:SMProductVersion: 3.0.3
-:MaistraVersion: 3.0
 //Jaeger
 //Deprecated
 :JaegerName: Red{nbsp}Hat OpenShift distributed tracing platform (Jaeger)

--- a/install/ossm-supported-platforms-configurations.adoc
+++ b/install/ossm-supported-platforms-configurations.adoc
@@ -11,13 +11,13 @@ Before you can install {SMProductName} {SMProductVersion}, you must subscribe to
 [id="ossm-supported-platforms_{context}"]
 == Supported platforms
 
-Version {MaistraVersion} {SMProductShortName} control planes are supported on the following platform versions:
+The following platform versions support {SMProductShortName} control plane version {SMProductVersion}:
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat OpenShift Container Platform version 4.14 or later
+* Red Hat OpenShift Container Platform version 4.16 or later
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat {ocp-product-title} version 4.14 or later
+* Red Hat {ocp-product-title} version 4.16 or later
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * {product-dedicated} version 4
 * Azure Red Hat OpenShift (ARO) version 4

--- a/modules/ossm-release-notes-3-1-new-features-enhancements.adoc
+++ b/modules/ossm-release-notes-3-1-new-features-enhancements.adoc
@@ -6,7 +6,7 @@
 [id="ossm-release-3-1-new-features-enhancements_{context}"]
 = {SMProductName} version 3.1 new features and enhancements
 
-This release makes {SMProductName} 3.1 generally available, adds new features, addresses Common Vulnerabilities and Exposures (CVEs), and is supported on {ocp-product-title} 4.14 and later.
+This release makes {SMProductName} 3.1 generally available, adds new features, addresses Common Vulnerabilities and Exposures (CVEs), and is supported on {ocp-product-title} 4.16 and later.
 
 For a list of supported component versions and support features, see "Service Mesh 3.0 feature support tables".
 

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -6,6 +6,34 @@
 [id="ossm-release-notes-supported-versions_{context}"]
 = {SMProduct} supported versions
 
+See the following table for information about {SMProduct} 3.1.0 supported versions.
+
+== {SMProduct} 3.1.0 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.1.0
+
+|{SMProduct} `Istio` control plane resource
+|1.26.2
+
+|{ocp-product-title}
+|4.16 and later
+
+| Envoy proxy
+| 1.34.2
+
+| `IstioCNI` resource
+| 1.26.2
+
+|Kiali Operator
+|2.11.1
+
+|===
+
 See the following table for information about {SMProduct} 3.0.3 supported versions.
 
 == {SMProduct} 3.0.3 supported versions
@@ -84,16 +112,16 @@ See the following table for information about {SMProduct} 3.0.1 supported versio
 | 1.24.4 ^[1]^
 |===
 
-See the following table for information about {SMProduct} 3 supported versions.
+See the following table for information about {SMProduct} 3.0.0 supported versions.
 
-== {SMProduct} 3.0 supported versions
+== {SMProduct} 3.0.0 supported versions
 
 [cols="1,1"]
 |===
 | Feature | Supported versions
 
 |{SMProduct} 3 Operator
-|3.0
+|3.0.0
 
 |{SMProduct} `Istio` control plane resource
 |1.24.3

--- a/observability/kiali/ossm-console-plugin.adoc
+++ b/observability/kiali/ossm-console-plugin.adoc
@@ -20,6 +20,8 @@ You can install the {SMPluginShort} with the Kiali Operator by creating a `OSSMC
 |===
 |OSSM version |Kiali Server version |OSSMC plugin version |OCP version
 
+|3.1 |v2.11 |v2.11 |4.16+
+
 |3.0 |v2.4 |v2.4 |4.15+
 
 |2.6 |v1.73 |v1.73 |4.15-4.18


### PR DESCRIPTION
Change type: Doc update; Update version support table for 3.1

Doc JIRA: https://issues.redhat.com/browse/OSSM-9881

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

Doc Previews:
OSSM version support table: https://96787--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-1-supported-versions

OSSMC version compatibility table: https://96787--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/kiali/ossm-console-plugin#ossm-install-console-plugin_ossm-console-plugin

SME Review/QE Review: @ferhoyos @longmuir 
Peer Review: @rh-tokeefe 