### PR TITLE
OSDOCS-15507-ms: removes discrete headings API docs MicroShift

### DIFF
--- a/microshift_rest_api/api_extensions_apis/api-extensions-apis-index.adoc
+++ b/microshift_rest_api/api_extensions_apis/api-extensions-apis-index.adoc
@@ -2,6 +2,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="api-extensions-apis"]
 = API Extensions APIs
+//adding a line space here breaks the TOC
 :toc: macro
 :toc-title:
 

--- a/microshift_rest_api/api_extensions_apis/customresourcedefinition-apiextensions-k8s-io-v1.adoc
+++ b/microshift_rest_api/api_extensions_apis/customresourcedefinition-apiextensions-k8s-io-v1.adoc
@@ -2,6 +2,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="customresourcedefinition-apiextensions-k8s-io-v1"]
 = CustomResourceDefinition [apiextensions.k8s.io/v1]
+//adding a line space here breaks the TOC
 :toc: macro
 :toc-title:
 
@@ -11,7 +12,7 @@ toc::[]
 Description::
 +
 --
-CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format <.spec.name>.<.spec.group>.
+CustomResourceDefinition represents a resource that should be exposed on the API server. Its name MUST be in the format <.spec.name>.<.spec.group>.
 --
 
 Type::
@@ -48,6 +49,7 @@ Required::
 | CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition
 
 |===
+//all API docs have L3s for .spec
 === .spec
 Description::
 +
@@ -772,10 +774,10 @@ Description::
 | Parameter | Type | Description
 | `allowWatchBookmarks`
 | `boolean`
-| allowWatchBookmarks requests watch events with type &quot;BOOKMARK&quot;. Servers that do not implement bookmarks may ignore this flag and bookmarks are sent at the server&#x27;s discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.
+| allowWatchBookmarks requests watch events with type &quot;BOOKMARK&quot;. Servers that do not implement bookmarks might ignore this flag and bookmarks are sent at the server&#x27;s discretion. Clients should not assume bookmarks are returned at any specific interval, nor may they assume the server will send any BOOKMARK event during a session. If this is not a watch, this field is ignored.
 | `continue`
 | `string`
-| The continue option should be set when retrieving more results from the server. Since this value is server defined, clients may only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the &quot;next key&quot;.
+| The continue option should be set when retrieving more results from the server. Since this value is server defined, clients might only use the continue value from a previous query result with identical query parameters (except for the value of continue) and the server may reject a continue value it does not recognize. If the specified continue value is no longer valid whether due to expiration (generally five to fifteen minutes) or a configuration change on the server, the server will respond with a 410 ResourceExpired error together with a continue token. If the client needs a consistent list, it must restart their list without the continue field. Otherwise, the client may send another list request with the token received with the 410 error, the server will respond with a list starting from the next key, but from the latest snapshot, which is inconsistent from the previous list results - objects that are created, modified, or deleted after the first list request will be included in the response, as long as their keys are after the &quot;next key&quot;.
 
 This field is not supported when watch is true. Clients may start a watch from the last resourceVersion value returned by the server and not miss any modifications.
 | `fieldSelector`

--- a/microshift_rest_api/objects/index.adoc
+++ b/microshift_rest_api/objects/index.adoc
@@ -23,8 +23,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -64,8 +63,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -105,8 +103,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -146,8 +143,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -187,8 +183,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -228,8 +223,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -269,8 +263,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -310,8 +303,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -351,8 +343,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -392,8 +383,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -433,8 +423,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -474,8 +463,7 @@ Type::
 Required::
   - `items`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -513,8 +501,7 @@ Type::
   `object`
 
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===
@@ -552,8 +539,7 @@ Type::
 Required::
   - `volumeID`
 
-[discrete]
-=== Schema
+Schema::
 
 [cols="1,1,1",options="header"]
 |===


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-15507](https://issues.redhat.com/browse/OSDOCS-15507)

Link to docs preview:
https://96789--ocpdocs-pr.netlify.app/microshift/latest/microshift_rest_api/api_extensions_apis/api-extensions-apis-index.html
https://96789--ocpdocs-pr.netlify.app/microshift/latest/microshift_rest_api/api_extensions_apis/customresourcedefinition-apiextensions-k8s-io-v1.html
https://96789--ocpdocs-pr.netlify.app/microshift/latest/microshift_rest_api/objects/index.html

QE review:
- N/A DITA migration prep issue; removes [discrete] headings and selected L3s from MicroShift API documentation

Additional information:
[96676 for initial core OCP removal](https://github.com/openshift/openshift-docs/pull/96676). Hope that all of the CPs do not fail, but if they do, I will create manual CPs.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
