### PR TITLE
OSDOCS-14886: Updated the description platform.vsphere.coresPerSocket…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -3341,7 +3341,7 @@ Optional VMware vSphere machine pool configuration parameters are described in t
 |platform:
   vsphere:
     coresPerSocket:
-|The number of cores per socket in a virtual machine. The number of virtual sockets on the virtual machine is `platform.vsphere.cpus`/`platform.vsphere.coresPerSocket`. The default value for control plane nodes and worker nodes is `4` and `2`, respectively.
+|The number of cores per socket in a virtual machine, where `platform.vsphere.cpus` divided by `platform.vsphere.coresPerSocket` determines the number of virtual sockets on a virtual machine. Control plane nodes and compute nodes default to `4` virtual sockets on a virtual machine.
 |Integer
 
 |platform:


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-14886](https://issues.redhat.com/browse/OSDOCS-14886)

Link to docs preview:
* [Optional VMware vSphere machine pool configuration parameters](https://96793--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-optional_installation-config-parameters-vsphere)
* [AWS: Optional configuration parameters](https://96793--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-optional_installation-config-parameters-aws)

- [x] SME has approved this change (Masafumi Matsuta).
- [x] QE has approved this change (Wenxin Wei).

[Additional resource](https://github.com/openshift/installer/blob/fdc62fc162b4d17f46ea7ddac37550e5eafda471/pkg/types/vsphere/validation/machinepool.go#L18-L19)

