### PR TITLE
Removing reference to resource that is causing build failure

### DIFF
--- a/scalability_and_performance/telco-hub-rds.adoc
+++ b/scalability_and_performance/telco-hub-rds.adoc
@@ -426,12 +426,13 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/app-project.yaml[]
 ----
 
-[id="telco-hub-argocd-openshift-gitops-patch-yaml_{context}"]
-.argocd-openshift-gitops-patch.json
-[source,json]
-----
-include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/argocd-openshift-gitops-patch.json[]
-----
+// [id="telco-hub-argocd-openshift-gitops-patch-yaml_{context}"]
+// .argocd-openshift-gitops-patch.json
+// [source,json]
+// ----
+// include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/argocd-openshift-gitops-patch.json[]
+// ----
+// Removing as this file no longer exists in the telco-hub repository.
 
 [id="telco-hub-clusters-app-yaml_{context}"]
 .clusters-app.yaml


### PR DESCRIPTION
Version: 4.19+

A reference to a resource in the hub cluster is causing this build failure

````
An include file wasn’t found: https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/argocd-openshift-gitops-patch.json
````

The resource was deleted in the engineering repo so commenting it out from our docs. 
