### PR TITLE
OSDOCS#15518: Update the RN for the 4.16.45 z-stream

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3366,6 +3366,39 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.45
+[id="ocp-4-16-45_{context}"]
+=== RHSA-2025:11681 - {product-title} {product-version}.45 bug fix and security update
+
+Issued: 30 July 2025
+
+{product-title} release {product-version}.45 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:11681[RHSA-2025:11681] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.45 --pullspecs
+----
+
+[id="ocp-4-16-45-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, comma-separated value (CSV) export failures for queries in the *Metrics* tab occurred because of improper access to title properties. As a result, the CSV download failed for some metrics, and affected user data export tasks. With this release, the CSV export for specific metrics works correctly and the CSV file download for metrics is successful. (link:https://issues.redhat.com/browse/OCPBUGS-54316[OCPBUGS-54316])
+
+* Before this update, `iptables-alerter` pods consumed excessive CPU usage because of incorrect handling of local pods and caused resource exhaustion. With this release, the high CPU usage of `iptables-alerter` pods is reduced by optimizing script execution. As a result, `iptables-alerter` pods do not exceed the CPU limit. (link:https://issues.redhat.com/browse/OCPBUGS-56992[OCPBUGS-56992])
+
+* Before this update, Amazon Elastic Compute Cloud (Amazon EC2) instances were cloned in an incorrect subnet for shared virtual private cloud (VPC) {product-title} cluster primary nodes. As a consequence, primary node instances had connectivity issues. With this release, the primary node subnet is correct because the primary instances in a shared VPC cluster reside in correct subnets. (link:https://issues.redhat.com/browse/OCPBUGS-58290[OCPBUGS-58290])
+
+* Before this update, the Container Runtime Interface (CRI-O) failed to recognize terminated pods due to a persistent container process reference. As a consequence, the pod termination process failed, and caused a stateful set to remain in a terminating state indefinitely. With this release, the container `Process not found` issue in CRI-O is resolved by adding a flag to indicate the start of the termination loop. (link:https://issues.redhat.com/browse/OCPBUGS-58509[OCPBUGS-58509])
+
+* Before this update, multiple modals were overwritten because the `useModal` hook was reused. As a consequence, modals on different pages overlapped, and caused user interface issues in {ols-official}. With this release, multiple modals do not overwrite each other because distinct identifiers for modals are available. (link:https://issues.redhat.com/browse/OCPBUGS-59274[OCPBUGS-59274])
+
+[id="ocp-4-16-45-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.44
 [id="ocp-4-16-44_{context}"]
 === RHSA-2025:10781 - {product-title} {product-version}.44 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16
Issue:
[OSDOCS-15518](https://96825--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-45_release-notes)

Link to docs preview:
[4.16.45](https://96825--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-45_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 7/30/25.
