### PR TITLE
OSDOCS#14986: Added configuring operands for zero trust section

### DIFF
--- a/modules/zero-trust-manager-config-node-selectors-tolerations.adoc
+++ b/modules/zero-trust-manager-config-node-selectors-tolerations.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-configure-nodeselector-tolerations_{context}"]
+= Configuring node selectors and tolerations for {zero-trust-full} operands
+
+You can configure the `nodeSelector` and `tolerations` to run the SPIRE Agent operand on specific nodes, such as control plane nodes. Follow the procedure to manage workload placement in clusters where certain nodes are reserved or tainted.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have installed the {zero-trust-full}.
+
+.Procedure
+
+. Patch the `SpireAgent` custom resource by running the following command:
++
+[source,terminal]
+----
+$ oc patch SpireAgent cluster --type=merge -p="
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+"
+----
+
+. Verify the pod scheduling by running the following commands:
++
+[source,terminal]
+----
+$ oc get event -n zero-trust-workload-identity-manager --field-selector reason=Scheduled
+----
++
+[source,terminal]
+----
+$ oc get pod -l app.kubernetes.io/name=agent -n zero-trust-workload-identity-manager -o wide
+----

--- a/modules/zero-trust-manager-config-pod-affinity.adoc
+++ b/modules/zero-trust-manager-config-pod-affinity.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-configure-affinity_{context}"]
+= Configuring pod affinity for {zero-trust-full} operands
+
+You can configure pod anti-affinity for the SPIRE Server operand to prevent multiple pods from being scheduled on the same node. Distributing pods across nodes improves availability and reduces the risk of single-node failure.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have installed the {zero-trust-full}.
+
+.Procedure
+
+. Patch the `SpireServer` custom resource to apply anti-affinity:
++
+[source,terminal]
+----
+$ oc patch SpireServer cluster --type=merge -p="
+spec:
+  affinity:
+    podAntiAffinity: 
+      requiredDuringSchedulingIgnoredDuringExecution: 
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - server
+          topologyKey: kubernetes.io/hostname
+"
+----
+
+.Verifcation
+
+. Verify the scheduling by running the following commands:
++
+[source,terminal]
+----
+$ oc get event -n zero-trust-workload-identity-manager --field-selector reason=Scheduled
+----
++
+[source,terminal]
+----
+$ oc get pod spire-server-0 -n zero-trust-workload-identity-manager -o wide
+----

--- a/modules/zero-trust-manager-configuring-operands.adoc
+++ b/modules/zero-trust-manager-configuring-operands.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="zero-trust-manager-configure-container-resources_{context}"]
+= Configuring container resources for {zero-trust-full} operands
+
+You can configure the CPU and memory resources for {zero-trust-full} operands to ensure efficient pod scheduling and resource management.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have installed the {zero-trust-full}.
+
+.Procedure
+
+. Patch the `SpireServer` Custom Resource (CR) to set the CPU and memory requests and limits:
++
+[source,terminal]
+----
+$ oc patch SpireServer cluster --type=merge -p="
+spec:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 200m
+      memory: 128Mi
+"
+----
+
+.Verification
+. Verify that the resources were applied by running the following commands:
++
+[source,terminal]
+----
+$ oc get statefulset spire-server -n zero-trust-workload-identity-manager -o jsonpath="{.spec.template.spec.containers[*].resources}"
+----
++
+[source,terminal]
+----
+$ oc get pod -l app.kubernetes.io/name=server -n zero-trust-workload-identity-manager -o yaml
+----

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
@@ -32,4 +32,13 @@ include::modules/zero-trust-manager-spiffe-csidriver-config.adoc[leveloffset=+1]
 // Deploying and configuring OIDC Discovery Provider
 include::modules/zero-trust-manager-oidc-config.adoc[leveloffset=+1]
 
+// Configuring container resources for {zero-trust-full} operands
+include::modules/zero-trust-manager-configuring-operands.adoc[leveloffset=+1]
+
+// Configuring node selectors and tolerations for {zero-trust-full} operands
+include::modules/zero-trust-manager-config-node-selectors-tolerations.adoc[leveloffset=+1]
+
+// Configuring pod affinity for {zero-trust-full} operands
+include::modules/zero-trust-manager-config-pod-affinity.adoc[leveloffset=+1]
+
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-14986
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
