### PR TITLE
OCPBUGS-59950:  dns-resolver context in virt-example-nmstate-IP-manag…

### DIFF
--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -151,12 +151,12 @@ spec:
   desiredState:
     dns-resolver:
       config:
-        search:
-        - example.com
-        - example.org
         server:
         - 2001:db8:f::1
         - 192.0.2.251
+        search:
+        - example.com
+        - example.org
 # ...
 ----
 +
@@ -224,13 +224,13 @@ Storing DNS values at the network interface level might cause name resolution is
 # ...
 dns-resolver:
   config:
-    search:
-    - example.com
-    - example.org
     server:
     - 2001:db8:1::d1
     - 2001:db8:1::d2
     - 192.0.2.1
+    search:
+    - example.com
+    - example.org
 interfaces:
   - name: eth1
     type: ethernet
@@ -251,18 +251,28 @@ interfaces:
 # ...
 ----
 
-* If you want to set static DNS search domains and dynamic DNS name servers for your network interface, define the dynamic interface that runs either the Dynamic Host Configuration Protocol (DHCP) or the IPv6 Autoconfiguration (`autoconf`) mechanism in the network interface YAML configuration file.
+* If you want to set static DNS search domains and static DNS name servers for your network interface, define the static interface that runs either the Dynamic Host Configuration Protocol (DHCP) or the IPv6 Autoconfiguration (`autoconf`) mechanism in the network interface YAML configuration file.
 +
-.Example configuration that sets `example.com` and `example.org` static DNS search domains along with dynamic DNS name server settings
+[IMPORTANT]
+====
+Specifying the following `dns-resolver` configurations in the network interface YAML file might cause a race condition at reboot that prevents the `NodeNetworkConfigurationPolicy` (NNCP) from applying to pods that run in your cluster:
+
+* Setting static DNS search domains and dynamic DNS name servers for your network interface.
+* Specifying domain suffixes for the `search` parameter and not setting IP addresses for the `server` parameter.
+====
++
+.Example configuration that sets `example.com` and `example.org` static DNS search domains along with static DNS name server settings
 [source,yaml]
 ----
 # ...
 dns-resolver:
   config:
+    server:
+    - 2001:db8:f::1
+    - 192.0.2.251
     search:
     - example.com
     - example.org
-    server: []
 interfaces:
   - name: eth1
     type: ethernet


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPBUGS-59950](https://issues.redhat.com/browse/OCPBUGS-59950)

Link to docs preview:
* [DNS](https://96827--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-nmstate-IP-management-dns_k8s-nmstate-updating-node-network-config)

- [x] SME has approved this change (Mat K).
- [x] QE has approved this change (Gris Ge).
