### PR TITLE
OSDOCS-15515: Release notes for 4.14.54

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3400,6 +3400,35 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.54
+[id="ocp-4-14-54_{context}"]
+=== RHSA-2025:11669 - {product-title} 4.14.54 bug fix and security update
+
+Issued: 31 July 2025
+
+{product-title} release 4.14.54, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:11669[RHSA-2025:11669] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:11670[RHBA-2025:11670] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.54 --pullspecs
+----
+
+[id="ocp-4-14-54-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, when a port entered a faulty state, Precision Time Protocol (PTP) pods did not mask the initial summary metrics. As a result, a new interface appeared with a value that remained unchanged, displaying incorrect or stale data.
++
+With this update, PTP pods mask and alias the summary metrics correctly, ensuring that interface data is updated as expected. (link:https://issues.redhat.com/browse/OCPBUGS-55309[OCPBUGS-55309])
+
+[id="ocp-4-14-54-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.53
 [id="ocp-4-14-53_{context}"]
 === RHSA-2025:9759 - {product-title} 4.14.53 bug fix and security update


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-55309](https://issues.redhat.com/browse/OCPBUGS-55309)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [RHSA-2025:11669](https://96828--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-54_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 7/31/25.