### PR TITLE
HCM remove nodes-cluster-cgroups-2 assembly from topic map

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1099,9 +1099,6 @@ Topics:
   - Name: Configuring your cluster to place pods on overcommited nodes
     File: nodes-cluster-overcommit
     Distros: openshift-dedicated
-  - Name: Configuring the Linux cgroup version on your nodes
-    File: nodes-cluster-cgroups-2
-    Distros: openshift-enterprise
 #  The TechPreviewNoUpgrade Feature Gate is not allowed
 #  - Name: Enabling features using FeatureGates
 #    File: nodes-cluster-enabling-features

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1475,9 +1475,6 @@ Topics:
   - Name: Configuring your cluster to place pods on overcommited nodes
     File: nodes-cluster-overcommit
     Distros: openshift-rosa
-  - Name: Configuring the Linux cgroup version on your nodes
-    File: nodes-cluster-cgroups-2
-    Distros: openshift-enterprise
 #  The TechPreviewNoUpgrade Feature Gate is not allowed
 #  - Name: Enabling features using FeatureGates
 #    File: nodes-cluster-enabling-features

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1184,8 +1184,6 @@ Topics:
     File: nodes-cluster-resource-configure
   - Name: Configuring your cluster to place pods on overcommited nodes
     File: nodes-cluster-overcommit
-#  - Name: Configuring the Linux cgroup version on your nodes
-#    File: nodes-cluster-cgroups-2
 #  The TechPreviewNoUpgrade Feature Gate is not allowed
 #  - Name: Enabling features using FeatureGates
 #    File: nodes-cluster-enabling-features


### PR DESCRIPTION
The nodes-cluster-cgroups-2.adoc assembly was [removed in 4.19](https://github.com/openshift/openshift-docs/pull/92278/files#diff-ea93b5b1f6daa8c7d27f318da4098fdbace3f7202be1fc98df6f21293e5051bc). This PR removes the entries from the OCD, ROSA, and ROSA HCP topic maps. 
