### PR TITLE
HCM remove nodes-cluster-cgroups-okd assembly from topic map

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1102,9 +1102,6 @@ Topics:
   - Name: Configuring the Linux cgroup version on your nodes
     File: nodes-cluster-cgroups-2
     Distros: openshift-enterprise
-  - Name: Configuring the Linux cgroup version on your nodes
-    File: nodes-cluster-cgroups-okd
-    Distros: openshift-origin
 #  The TechPreviewNoUpgrade Feature Gate is not allowed
 #  - Name: Enabling features using FeatureGates
 #    File: nodes-cluster-enabling-features

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1478,9 +1478,6 @@ Topics:
   - Name: Configuring the Linux cgroup version on your nodes
     File: nodes-cluster-cgroups-2
     Distros: openshift-enterprise
-  - Name: Configuring the Linux cgroup version on your nodes
-    File: nodes-cluster-cgroups-okd
-    Distros: openshift-origin
 #  The TechPreviewNoUpgrade Feature Gate is not allowed
 #  - Name: Enabling features using FeatureGates
 #    File: nodes-cluster-enabling-features

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1186,8 +1186,6 @@ Topics:
     File: nodes-cluster-overcommit
 #  - Name: Configuring the Linux cgroup version on your nodes
 #    File: nodes-cluster-cgroups-2
-#  - Name: Configuring the Linux cgroup version on your nodes
-#    File: nodes-cluster-cgroups-okd
 #  The TechPreviewNoUpgrade Feature Gate is not allowed
 #  - Name: Enabling features using FeatureGates
 #    File: nodes-cluster-enabling-features


### PR DESCRIPTION
The nodes-cluster-cgroups-okd.adoc assembly was [removed in 4.14](https://github.com/openshift/openshift-docs/pull/70086/files#diff-4532e2b5581b8c471b839ceb8e9eec1770f5cec80b93872b531b7d9f78ce8699). This PR removes the entries from the OCD, ROSA, and ROSA HCP topic maps.