### PR TITLE
[enterprise-4.13] OSDOCS-14886: Updated the description platform.vsphere.coresPerSocket…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2222,7 +2222,7 @@ The `platform.vsphere` parameter prefixes each parameter listed in the table.
 |Integer
 
 |`coresPerSocket`
-|The number of cores per socket in a virtual machine. The number of virtual sockets on the virtual machine is `platform.vsphere.cpus`/`platform.vsphere.coresPerSocket`. The default value for control plane nodes and worker nodes is `4` and `2`, respectively.
+|The number of cores per socket in a virtual machine, where `platform.vsphere.cpus` divided by `platform.vsphere.coresPerSocket` determines the number of virtual sockets on a virtual machine. Control plane nodes and compute nodes default to `4` virtual sockets on a virtual machine.
 |Integer
 
 |`memoryMB`


### PR DESCRIPTION
Cherry-pick of #96793 with commit a0cb3c9531b77af61c088ca8befe710765faabe2

Version(s):
4.13

Issue:
[OSDOCS-14886](https://issues.redhat.com/browse/OSDOCS-14886)


Link to docs preview:
[Optional VMware vSphere machine pool configuration parameters](https://96868--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-configuration-parameters-optional-vsphere_installing-vsphere-installer-provisioned-network-customizations)
