### PR TITLE
[enterprise-4.15] OSDOCS-14020: Updated IPI/UPI vSphere vCenter data center explanations

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -4,6 +4,9 @@
 // * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
 
 // Note: The ifndef statements add content to IPI documents
+ifeval::["{context}" == "ipi-vsphere-installation-reqs"]
+:ipi:
+endif::[]
 ifeval::["{context}" == "upi-vsphere-installation-reqs"]
 :upi:
 endif::[]
@@ -129,8 +132,13 @@ endif::upi[]
 `VirtualMachine.Provisioning.MarkAsTemplate`
 `VirtualMachine.Provisioning.DeployTemplate`
 
-|vSphere vCenter Datacenter
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. See the "Minimum permissions for the Machine API" table.
+|vSphere vCenter data center
+ifdef::ipi[]
+|The installation program creates the virtual machine folder.
+endif::ipi[]
+ifdef::upi[]
+|`VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. See the "Minimum permissions for the Machine API" table.
+endif::upi[]
 |
 [%hardbreaks]
 `InventoryService.Tagging.ObjectAttachable`
@@ -259,8 +267,13 @@ endif::upi[]
 `"Virtual machine".Provisioning."Mark as template"`
 `"Virtual machine".Provisioning."Deploy template"`
 
-|vSphere vCenter Datacenter
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API.
+|vSphere vCenter data center
+ifdef::ipi[]
+|The installation program creates the virtual machine folder.
+endif::ipi[]
+ifdef::upi[]
+|`VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API.
+endif::upi[]
 |
 [%hardbreaks]
 `"vSphere Tagging"."Assign or Unassign vSphere Tag on Object"`
@@ -315,7 +328,8 @@ Additionally, the user requires some `ReadOnly` permissions, and some of the rol
 |False
 |Listed required privileges
 
-.2+|vSphere vCenter Datacenter
+ifdef::ipi[]
+.2+|vSphere vCenter data center
 |Existing folder
 |False
 |`ReadOnly` permission
@@ -323,6 +337,7 @@ Additionally, the user requires some `ReadOnly` permissions, and some of the rol
 |Installation program creates the folder
 |True
 |Listed required privileges
+endif::ipi[]
 
 .2+|vSphere vCenter Cluster
 |Existing resource pool
@@ -474,8 +489,8 @@ ifndef::upi[]
 `VirtualMachine.Provisioning.MarkAsTemplate`
 `VirtualMachine.Provisioning.DeployTemplate`
 
-|vSphere vCenter Datacenter
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
+|vSphere vCenter data center
+|If the virtual machine folder does not already exist, the installation program creates the virtual machine folder. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
 |
 [%hardbreaks]
 `Folder.Create`
@@ -586,8 +601,13 @@ endif::upi[]
 `VirtualMachine.Provisioning.Clone`
 `VirtualMachine.Provisioning.DeployTemplate`
 
-|vSphere vCenter Datacenter
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
+|vSphere vCenter data center
+ifdef::ipi[]
+|If the virtual machine folder does not already exist, the installation program creates the virtual machine folder.
+endif::ipi[]
+ifdef::upi[]
+|`VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
+endif::upi[]
 |
 [%hardbreaks]
 `Resource.AssignVMToPool`
@@ -654,8 +674,13 @@ endif::upi[]
 `VirtualMachine.Config.AddExistingDisk`
 `VirtualMachine.Config.AddRemoveDevice`
 
-|vSphere vCenter Datacenter
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
+|vSphere vCenter data center
+ifdef::ipi[]
+|If the virtual machine folder does not already exist, the installation program creates the virtual machine folder.
+endif::ipi[]
+ifdef::upi[]
+|`VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API. If your cluster does use the Machine API and you want to set the minimum set of permissions for the API, see the "Minimum permissions for the Machine API" table.
+endif::upi[]
 |
 [%hardbreaks]
 `VirtualMachine.Config.AddExistingDisk`
@@ -731,8 +756,13 @@ endif::upi[]
 `VirtualMachine.Provisioning.Clone`
 `VirtualMachine.Provisioning.DeployTemplate`
 
-|vSphere vCenter Datacenter
-|If the installation program creates the virtual machine folder. For user-provisioned infrastructure, `VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API.
+|vSphere vCenter data center
+ifdef::ipi[]
+|If the virtual machine folder does not already exist, the installation program creates the virtual machine folder.
+endif::ipi[]
+ifdef::upi[]
+|`VirtualMachine.Inventory.Create` and `VirtualMachine.Inventory.Delete` privileges are optional if your cluster does not use the Machine API.
+endif::upi[]
 |
 [%hardbreaks]
 `Resource.AssignVMToPool`
@@ -863,6 +893,9 @@ default. This record must be resolvable by both clients external to the cluster
 and from all the nodes within the cluster.
 |===
 
+ifeval::["{context}" == "ipi-vsphere-installation-reqs"]
+:!ipi:
+endif::[]
 ifeval::["{context}" == "upi-vsphere-installation-reqs"]
 :!upi:
 endif::[]

--- a/modules/machineset-vsphere-required-permissions.adoc
+++ b/modules/machineset-vsphere-required-permissions.adoc
@@ -67,8 +67,8 @@ If you cannot use an account with global administrative privileges, you must cre
 `VirtualMachine.Inventory.Delete`
 `VirtualMachine.Provisioning.Clone`
 
-|vSphere vCenter Datacenter
-|If the installation program creates the virtual machine folder
+|vSphere vCenter data center
+|If the installation program creates the virtual machine folder.
 |
 [%hardbreaks]
 `Resource.AssignVMToPool`


### PR DESCRIPTION
Cherry-pick of #92277 with commit da36564fa3c2c946eaf47242fd1ddc55fe1e4c04

Version(s):
4.15

Issue:
[OSDOCS-14886](https://issues.redhat.com/browse/OSDOCS-14886)

Link to docs preview:
[Optional VMware vSphere machine pool configuration parameters](https://96868--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-configuration-parameters-optional-vsphere_installing-vsphere-installer-provisioned-network-customizations)
