### PR TITLE
[enterprise-4.14] OSDOCS-15341 NETOBSERV 1.9.1 release notes

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -2,7 +2,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-operator-release-notes"]
 = Network Observability Operator release notes
-:context: network-observability-operator-release-notes-v0
+:context: network-observability-operator-release-notes-v1-9-1
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
@@ -12,6 +12,24 @@ The Network Observability Operator enables administrators to observe and analyze
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
 For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#dependency-network-observability[About Network Observability Operator].
+
+[id="network-observability-operator-release-notes-1-9-1_{context}"]
+== Network Observability Operator 1.9.1
+The following advisory is available for the Network Observability Operator 1.9.1:
+
+* link:https://access.redhat.com/errata/RHEA-2025:12024[2025:12024 Network Observability Operator 1.9.1]
+
+[id="network-observability-operator-1-9-1-bug-fixes_{context}"]
+=== Bug fixes
+* Before this update, network flows were not observed on {product-title} 4.15 due to an incorrect attach mode setting. This stopped users from monitoring network flows correctly, especially with certain catalogs. With this release, the default attach mode for {product-title} versions older than 4.16.0 is set to `tc`, so flows are now observed on {product-title} 4.15. (link:https://issues.redhat.com/browse/NETOBSERV-2333[*NETOBSERV-2333*])
+
+* Before this update, if an IPFIX collector restarted, configuring an IPFIX exporter could lose its connection and stop sending network flows to the collector. With this release, the connection is restored, and network flows continue to be sent to the collector. (link:https://issues.redhat.com/browse/NETOBSERV-2315[*NETOBSERV-2315*])
+
+* Before this update, when you configured an IPFIX exporter, flows without port information (such as ICMP traffic) were ignored, which caused errors in logs. TCP flags and ICMP data were also missing from IPFIX exports. With this release, these details are now included. Missing fields (like ports) no longer cause errors and are part of the exported data. (link:https://issues.redhat.com/browse/NETOBSERV-2307[*NETOBSERV-2307*])
+
+* Before this update, the User Defined Networks (UDN) Mapping feature showed a configuration issue and warning on {product-title} 4.18 because the OpenShift version was incorrectly set in the code. This impacted the user experience. With this release, UDN Mapping now supports {product-title} 4.18 without warnings, making the user experience smooth. (link:https://issues.redhat.com/browse/NETOBSERV-2305[*NETOBSERV-2305*])
+
+* Before this update, the expand function on the *Network Traffic* page had compatibility problems with {product-title} Console 4.19. This resulted in empty menu space when expanding and an inconsistent user interface. With this release, the compatibility problem in the `NetflowTraffic` part and `theme hook` is resolved. The side menu in the *Network Traffic* view is now properly managed, which improves how you interact with the user interface. (link:https://issues.redhat.com/browse/NETOBSERV-2304[*NETOBSERV-2304*])
 
 [id="network-observability-operator-release-notes-1-9_{context}"]
 == Network Observability Operator 1.9


### PR DESCRIPTION
“Cherry Picked from 237159f5490a4e6922bee4beb5337bd3aa5b8f8d xref: https://github.com/openshift/openshift-docs/pull/96415/

Version(s):
4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
