### PR TITLE
OSDOCS 15252 MachineOSConfig name should match MachineConfigPool

### DIFF
--- a/modules/coreos-layering-configuring-on-modifying.adoc
+++ b/modules/coreos-layering-configuring-on-modifying.adoc
@@ -30,7 +30,7 @@ metadata:
   name: layered-image
 spec:
   machineConfigPool:
-    name: worker
+    name: layered-image
   containerFile:
   - containerfileArch: noarch
     content: |- <1>

--- a/modules/coreos-layering-configuring-on-proc.adoc
+++ b/modules/coreos-layering-configuring-on-proc.adoc
@@ -13,6 +13,8 @@ To apply a custom layered image to your cluster by using the on-cluster build pr
 * where the final image should be pushed and pulled from
 * the push and pull secrets to use
 
+You can create only one `MachineOSConfig` CR for each machine config pool.
+
 .Prerequisites
 
 * You have the pull secret in the `openshift-machine-config-operator` namespace that the Machine Config Operator (MCO) needs in order to pull the base operating system image from your repository. By default, the MCO uses the cluster global pull secret, which it synchronizes into the `openshift-machine-config-operator` namespace. You can add your pull secret to the {product-title} global pull secret or you can use a different pull secret. For information on modifying the global pull secret, see "Updating the global cluster pull secret".
@@ -44,7 +46,7 @@ metadata:
   name: layered-image <2>
 spec:
   machineConfigPool:
-    name: layered <3>
+    name: layered-image <3>
   containerFile: # <4>
   - containerfileArch: NoArch <5>
     content: |-
@@ -61,8 +63,8 @@ spec:
     name: builder-dockercfg-mtcl23
 ----
 <1> Specifies the `machineconfiguration.openshift.io/v1` API that is required for `MachineConfig` CRs.
-<2> Specifies a name for the `MachineOSConfig` object. This name is used with other [image-mode-os-on-lower] resources. The examples in this documentation use the name `layered-image`. 
-<3> Specifies the name of the machine config pool associated with the nodes where you want to deploy the custom layered image. The examples in this documentation use the `layered` machine config pool.
+<2> Specifies a name for the `MachineOSConfig` object. The name must match the name of the associated machine config pool. This name is used with other {image-mode-os-on-lower} resources. The examples in this documentation use the name `layered-image`. 
+<3> Specifies the name of the machine config pool associated with the nodes where you want to deploy the custom layered image. The examples in this documentation use the `layered-image` machine config pool.
 <4> Specifies the Containerfile to configure the custom layered image.
 <5> Specifies the architecture this containerfile is to be built for: `ARM64`, `AMD64`, `PPC64LE`, `S390X`, or `NoArch`. The default is `NoArch`, which defines a Containerfile that can be applied to any architecture. 
 <6> Specifies the name of the image builder to use. This must be `Job`, which is a reference to the `job` object that is managing the image build.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15604

**Might need to manually CP to 4.18. Made structural changes to the modules for the 4.19 GA release.**

**Don't merge until https://github.com/openshift/api/pull/2399 is merged**

Link to docs preview:
[Using the on-cluster image mode to apply a custom layered image](https://96902--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on-proc_mco-coreos-layering) -- New second paragraph (after bullets); updated step 1a, callout 2.
[Modifying an on-cluster custom layered image](https://96902--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring-on-modifying_mco-coreos-layering) -- Updated namespace in example under step 1a. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

