### PR TITLE
add-content-type-modules

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -33,7 +33,7 @@ include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc#configuring-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations[Configuring regions and zones for a VMware vCenter]
 * xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#agent-install-verifying-architectures_installing-with-agent-based-installer[Verifying the supported architecture for installing an Agent-based installer cluster]
-* xref:../../installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc#configuring-the-agent-based-installer-to-use-mirrored-images[Configuring the Agent-based Installer to use mirrored images]
+* xref:../../installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc#agent-install-configuring-for-disconnected-registry_understanding-disconnected-installation-mirroring[Configuring the Agent-based Installer to use mirrored images]
 
 [id="installing-ocp-agent-opt-manifests_{context}"]
 === Creating additional manifest files

--- a/modules/agent-install-configuring-for-disconnected-registry.adoc
+++ b/modules/agent-install-configuring-for-disconnected-registry.adoc
@@ -2,7 +2,8 @@
 //
 // * installing/installing_with_agent_based_installer/understanding-disconnected-installation-mirroring.adoc
 
-:_mod-docs-content-type: Procedure[id="agent-install-configuring-for-disconnected-registry_{context}"]
+:_mod-docs-content-type: PROCEDURE
+[id="agent-install-configuring-for-disconnected-registry_{context}"]
 = Configuring the Agent-based Installer to use mirrored images
 
 You must use the output of either the `oc adm release mirror` command or the oc-mirror plugin to configure the Agent-based Installer to use mirrored images.

--- a/modules/ai-sno-requirements-for-installing-worker-nodes.adoc
+++ b/modules/ai-sno-requirements-for-installing-worker-nodes.adoc
@@ -2,6 +2,7 @@
 //
 // * nodes/nodes/nodes-sno-worker-nodes.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="ai-sno-requirements-for-installing-worker-nodes_{context}"]
 = Requirements for installing {sno} worker nodes
 

--- a/modules/annotating-a-route-with-a-cookie-name.adoc
+++ b/modules/annotating-a-route-with-a-cookie-name.adoc
@@ -2,6 +2,7 @@
 //
 // *using-cookies-to-keep-route-statefulness
 
+:_mod-docs-content-type: PROCEDURE
 [id="annotating-a-route-with-a-cookie_{context}"]
 = Annotating a route with a cookie
 

--- a/modules/api-compatibility-exceptions.adoc
+++ b/modules/api-compatibility-exceptions.adoc
@@ -3,6 +3,7 @@
 // * rest_api/understanding-compatibility-guidelines.adoc
 // * microshift_rest_api/understanding-compatibility-guidelines.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="api-compatibility-exceptions_{context}"]
 = API compatibility exceptions
 

--- a/modules/api-support-deprecation-policy.adoc
+++ b/modules/api-support-deprecation-policy.adoc
@@ -2,6 +2,7 @@
 //
 // * rest_api/understanding-api-support-tiers.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="api-deprecation-policy_{context}"]
 = API deprecation policy
 

--- a/modules/api-support-tiers-mapping.adoc
+++ b/modules/api-support-tiers-mapping.adoc
@@ -2,6 +2,7 @@
 //
 // * rest_api/understanding-api-support-tiers.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="api-support-tiers-mapping_{context}"]
 = Mapping API tiers to API groups
 

--- a/modules/api-support-tiers.adoc
+++ b/modules/api-support-tiers.adoc
@@ -2,6 +2,7 @@
 //
 // * rest_api/understanding-api-support-tiers.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="api-tiers_{context}"]
 = API tiers
 

--- a/modules/applications-create-using-cli-image.adoc
+++ b/modules/applications-create-using-cli-image.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="applications-create-using-cli-image_{context}"]
 = Creating an application from an image
 

--- a/modules/applications-create-using-cli-source-code.adoc
+++ b/modules/applications-create-using-cli-source-code.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="applications-create-using-cli-source-code_{context}"]
 = Creating an application from source code
 

--- a/modules/applications-create-using-cli-template.adoc
+++ b/modules/applications-create-using-cli-template.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="applications-create-using-cli-template_{context}"]
 = Creating an application from a template
 

--- a/modules/architecture-container-application-benefits.adoc
+++ b/modules/architecture-container-application-benefits.adoc
@@ -2,6 +2,7 @@
 //
 // * architecture/architecture.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="architecture-container-application-benefits_{context}"]
 = The benefits of containerized applications
 

--- a/modules/authentication-api-impersonation.adoc
+++ b/modules/authentication-api-impersonation.adoc
@@ -4,6 +4,7 @@
 // * applications/projects/creating-project-other-user.adoc
 // * users_and_roles/impersonating-system-admin.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="authentication-api-impersonation_{context}"]
 = API impersonation
 

--- a/modules/builds-source-input-subman-config.adoc
+++ b/modules/builds-source-input-subman-config.adoc
@@ -2,6 +2,7 @@
 //
 //* builds/running-entitled-builds.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="builds-source-input-subman-config_{context}"]
 = Adding Subscription Manager configurations to builds
 

--- a/modules/builds-strategy-force-pull-procedure.adoc
+++ b/modules/builds-strategy-force-pull-procedure.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //* builds/build-strategies.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="builds-strategy-force-pull-procedure_{context}"]
 = Using the force pull flag
 

--- a/modules/cluster-logging-kibana-limits.adoc
+++ b/modules/cluster-logging-kibana-limits.adoc
@@ -2,6 +2,7 @@
 //
 // * observability/logging/cluster-logging-visualizer.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-kibana-limits_{context}"]
 = Configure the CPU and memory limits for the log visualizer
 

--- a/modules/cluster-logging-troubleshooting-unknown.adoc
+++ b/modules/cluster-logging-troubleshooting-unknown.adoc
@@ -2,6 +2,7 @@
 //
 // * logging/cluster-logging-troublehsooting.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-troubleshooting-unknown_{context}"]
 = Troubleshooting a Kubernetes unknown error while connecting to Elasticsearch
 

--- a/modules/cluster-logging-visualizer-launch.adoc
+++ b/modules/cluster-logging-visualizer-launch.adoc
@@ -2,6 +2,7 @@
 //
 // * observability/logging/cluster-logging-visualizer.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-visualizer-launch_{context}"]
 = Launching the log visualizer
 

--- a/modules/cnf-creating-the-performance-profile-object.adoc
+++ b/modules/cnf-creating-the-performance-profile-object.adoc
@@ -2,6 +2,7 @@
 // Epic CNF-78
 // * scalability_and_performance/cnf-low-latency-tuning.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-creating-the-performance-profile-object_{context}"]
 = Creating the PerformanceProfile object
 

--- a/modules/cnf-scheduling-workload-onto-worker-with-real-time-capabilities.adoc
+++ b/modules/cnf-scheduling-workload-onto-worker-with-real-time-capabilities.adoc
@@ -2,6 +2,7 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-provisioning-low-latency-workloads.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-scheduling-workload-onto-worker-with-real-time-capabilities_{context}"]
 = Scheduling a low latency workload onto a worker with real-time capabilities
 

--- a/modules/configuring-hpa-based-on-application-metrics.adoc
+++ b/modules/configuring-hpa-based-on-application-metrics.adoc
@@ -2,6 +2,7 @@
 //
 // * machine_management/configuring-hpa-for-an-application.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-hpa-based-on-application-metrics_{context}"]
 = Configuring HPA based on application metrics
 

--- a/modules/creating-your-first-content.adoc
+++ b/modules/creating-your-first-content.adoc
@@ -7,6 +7,7 @@
 // * ID: [id="doing-procedure-a"]
 // * Title: = Doing procedure A
 
+:_mod-docs-content-type: PROCEDURE
 [id="creating-your-first-content_{context}"]
 = Creating your first content
 

--- a/modules/dedicated-accessing-your-cluster.adoc
+++ b/modules/dedicated-accessing-your-cluster.adoc
@@ -2,6 +2,7 @@
 //
 // * getting_started/accessing-your-services.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="dedicated-accessing-your-cluster_{context}"]
 = Accessing your cluster
 

--- a/modules/dedicated-cluster-admin-enable.adoc
+++ b/modules/dedicated-cluster-admin-enable.adoc
@@ -2,7 +2,8 @@
 //
 // * osd_cluster_admin/cluster-admin-role.adoc
 
-[id="dedicated-cluster-admin-enable"]
+:_mod-docs-content-type: PROCEDURE
+[id="dedicated-cluster-admin-enable_{context}"]
 = Enabling the cluster-admin role for your cluster
 
 The cluster-admin role must be enabled at the cluster level before it can be assigned to a user.

--- a/modules/dedicated-cluster-admin-grant.adoc
+++ b/modules/dedicated-cluster-admin-grant.adoc
@@ -2,7 +2,8 @@
 //
 // * osd_cluster_admin/cluster-admin-role.adoc
 
-[id="dedicated-cluster-admin-grant"]
+:_mod-docs-content-type: PROCEDURE
+[id="dedicated-cluster-admin-grant_{context}"]
 = Granting the cluster-admin role to users
 
 After enabling cluster-admin rights on your cluster, you can assign the role to users.

--- a/modules/dedicated-cluster-install-deploy.adoc
+++ b/modules/dedicated-cluster-install-deploy.adoc
@@ -2,8 +2,8 @@
 //
 // * logging/dedicated-cluster-deploying.adoc
 
-[id="dedicated-cluster-install-deploy"]
-
+:_mod-docs-content-type: PROCEDURE
+[id="dedicated-cluster-install-deploy_{context}"]
 = Installing OpenShift Logging and OpenShift Elasticsearch Operators
 
 You can use the {product-title} console to install OpenShift Logging by deploying instances of

--- a/modules/dedicated-creating-your-cluster.adoc
+++ b/modules/dedicated-creating-your-cluster.adoc
@@ -2,6 +2,7 @@
 //
 // * getting_started/accessing-your-services.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="dedicated-creating-your-cluster_{context}"]
 = Creating your cluster
 

--- a/modules/dedicated-enable-private-cluster-existing.adoc
+++ b/modules/dedicated-enable-private-cluster-existing.adoc
@@ -2,6 +2,7 @@
 //
 // * rosa_cluster_admin/cloud_infrastructure_access/dedicated-aws-private-cluster.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="dedicated-enable-private-cluster-existing"]
 = Enabling private cluster on an existing cluster
 

--- a/modules/dedicated-enable-private-cluster-new.adoc
+++ b/modules/dedicated-enable-private-cluster-new.adoc
@@ -2,6 +2,7 @@
 //
 // * rosa_cluster_admin/cloud_infrastructure_access/dedicated-aws-private-cluster.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="dedicated-enable-private-cluster-new"]
 = Enabling private cluster on a new cluster
 

--- a/modules/dedicated-enable-public-cluster.adoc
+++ b/modules/dedicated-enable-public-cluster.adoc
@@ -2,6 +2,7 @@
 //
 // * rosa_cluster_admin/cloud_infrastructure_access/dedicated-aws-private-cluster.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="dedicated-enable-public-cluster"]
 = Enabling public cluster on a private cluster
 

--- a/modules/dedicated-storage-expanding-filesystem-pvc.adoc
+++ b/modules/dedicated-storage-expanding-filesystem-pvc.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/expanding-persistent-volume.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="dedicated-storage-expanding-filesystem-pvc_{context}"]
 = Expanding {product-title} Persistent Volume Claims (PVCs)
 

--- a/modules/developer-cli-odo-creating-a-java-microservice-jpa-application.adoc
+++ b/modules/developer-cli-odo-creating-a-java-microservice-jpa-application.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: PROCEDURE
+[id="creating-java-ms-jpa_{context}"]
 = Creating a Java MicroServices JPA application
 
 With `odo`, you can create and manage a sample Java MicroServices JPA application.

--- a/modules/developer-cli-odo-installing-odo-on-linux-on-ibm-power.adoc
+++ b/modules/developer-cli-odo-installing-odo-on-linux-on-ibm-power.adoc
@@ -2,6 +2,7 @@
 //
 // * cli_reference/developer_cli_odo/installing-odo.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="installing-odo-on-linux-on-ibm-power_{context}"]
 = Installing {odo-title} on Linux on {ibm-power-title}
 

--- a/modules/developer-cli-odo-installing-odo-on-linux-on-ibm-z.adoc
+++ b/modules/developer-cli-odo-installing-odo-on-linux-on-ibm-z.adoc
@@ -2,8 +2,8 @@
 //
 // * cli_reference/developer_cli_odo/installing-odo.adoc
 
-[id="installing-odo-on-linux-on-ibm-z"]
-
+:_mod-docs-content-type: PROCEDURE
+[id="installing-odo-on-linux-on-ibm-z_{context}"]
 = Installing {odo-title} on Linux on {ibm-z-title} and {ibm-linuxone-title}
 
 == Binary installation

--- a/modules/distr-tracing-removing-instance-cli.adoc
+++ b/modules/distr-tracing-removing-instance-cli.adoc
@@ -2,6 +2,7 @@
 //
 // * observability/distr_tracing/distr_tracing_jaeger/distr-tracing-removing.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="distr-tracing-removing-instance-cli_{context}"]
 = Removing a {JaegerShortName} instance by using the CLI
 

--- a/modules/dynamic-provisioning-change-default-class.adoc
+++ b/modules/dynamic-provisioning-change-default-class.adoc
@@ -3,6 +3,7 @@
 // * storage/dynamic-provisioning.adoc
 // * microshift_storage/dynamic-provisioning-microshift.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="change-default-storage-class_{context}"]
 = Changing the default storage class
 

--- a/modules/gitops-configuring-argo-cd-oidc.adoc
+++ b/modules/gitops-configuring-argo-cd-oidc.adoc
@@ -2,6 +2,7 @@
 //
 // * cicd/gitops/configuring-sso-for-argo-cd-on-openshift.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-argo-cd-oidc_{context}"]
 = Configuring Argo CD OIDC
 

--- a/modules/gitops-configuring-argo-cd-using-dex-github-conector.adoc
+++ b/modules/gitops-configuring-argo-cd-using-dex-github-conector.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-configuring-argo-cd-using-dex-github-connector_{context}"]
 = Configuring Argo CD SSO using Dex GitHub connector
 

--- a/modules/gitops-configuring-groups-and-argocd-rbac.adoc
+++ b/modules/gitops-configuring-groups-and-argocd-rbac.adoc
@@ -2,6 +2,7 @@
 //
 // * configuring-sso-for-argo-cd-on-openshift.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-groups-and-argocd-rbac_{context}"]
 = Configure groups and Argo CD RBAC
 

--- a/modules/gitops-configuring-the-groups-claim.adoc
+++ b/modules/gitops-configuring-the-groups-claim.adoc
@@ -2,6 +2,7 @@
 //
 // * configuring-sso-for-argo-cd-on-openshift.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-the-groups-claim_{context}"]
 = Configuring the groups claim
 

--- a/modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc
+++ b/modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc
@@ -2,6 +2,7 @@
 //
 // * /cicd/gitops/configuring-secure-communication-with-redis.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-configuring-tls-for-redis-with-autotls-disabled_{context}"]
 = Configuring TLS for Redis with autotls disabled
 

--- a/modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc
+++ b/modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc
@@ -2,6 +2,7 @@
 //
 // * /cicd/gitops/configuring-secure-communication-with-redis.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="gitops-configuring-tls-for-redis-with-autotls-enabled_{context}"]
 = Configuring TLS for Redis with autotls enabled
 

--- a/modules/gitops-creating-a-new-client-in-keycloak.adoc
+++ b/modules/gitops-creating-a-new-client-in-keycloak.adoc
@@ -2,6 +2,7 @@
 //
 // * configuring-sso-for-argo-cd-on-openshift
 
+:_mod-docs-content-type: PROCEDURE
 [id="creating-a-new-client-in-keycloak_{context}"]
 = Creating a new client in Keycloak
 

--- a/modules/gitops-enabling-dex.adoc
+++ b/modules/gitops-enabling-dex.adoc
@@ -2,6 +2,7 @@
 //
 // * configuring-sso-for-argo-cd-on-openshift
 
+:_mod-docs-content-type: PROCEDURE
 [id="enabling-dex_{context}"]
 = Enabling Dex
 

--- a/modules/gitops-keycloak-identity-brokering-with-openshift-oauthclient.adoc
+++ b/modules/gitops-keycloak-identity-brokering-with-openshift-oauthclient.adoc
@@ -2,6 +2,7 @@
 //
 // *
 
+:_mod-docs-content-type: PROCEDURE
 [id="keycloak-identity-brokering-with-openshift-oauthclient_{context}"]
 = Keycloak Identity Brokering with {product-title}
 

--- a/modules/gitops-registering-an-additional-oauth-client.adoc
+++ b/modules/gitops-registering-an-additional-oauth-client.adoc
@@ -2,6 +2,7 @@
 //
 // * configuring-sso-for-argo-cd-on-openshift
 
+:_mod-docs-content-type: PROCEDURE
 [id="registering-an-additional-oauth-client_{context}"]
 = Registering an additional an OAuth client
 

--- a/modules/gitops-registering-an-oauth-client.adoc
+++ b/modules/gitops-registering-an-oauth-client.adoc
@@ -2,6 +2,7 @@
 //
 // * configuring-sso-for-argo-cd-on-openshift
 
+:_mod-docs-content-type: PROCEDURE
 [id="registering-an-additional-oauth-client_{context}"]
 = Registering an additional an OAuth client
 

--- a/modules/identity-provider-provisioning-user-lookup-mapping.adoc
+++ b/modules/identity-provider-provisioning-user-lookup-mapping.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/understanding-identity-provider.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="identity-provider-provisioning-user-lookup-mapping_{context}"]
 = Manually provisioning a user when using the lookup mapping method
 

--- a/modules/installation-creating-gcp-dns.adoc
+++ b/modules/installation-creating-gcp-dns.adoc
@@ -7,6 +7,7 @@ ifeval::["{context}" == "installing-gcp-user-infra-vpc"]
 :shared-vpc:
 endif::[]
 
+:_mod-docs-content-type: PROCEDURE
 [id="installation-creating-gcp-dns_{context}"]
 = Creating networking and load balancing components in GCP
 

--- a/modules/installation-creating-gcp-security.adoc
+++ b/modules/installation-creating-gcp-security.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_gcp/installing-gcp-user-infra.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="installation-creating-gcp-security_{context}"]
 = Creating firewall rules and IAM roles in GCP
 

--- a/modules/installation-creating-gcp-shared-vpc-ingress-firewall-rules.adoc
+++ b/modules/installation-creating-gcp-shared-vpc-ingress-firewall-rules.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="installation-creating-gcp-shared-vpc-ingress-firewall-rules_{context}"]
 = Creating ingress firewall rules for a shared VPC in GCP
 

--- a/modules/installation-creating-mirror-registry.adoc
+++ b/modules/installation-creating-mirror-registry.adoc
@@ -7,6 +7,7 @@ ifeval::["{context}" == "installing-mirroring-installation-images"]
 :restricted:
 endif::[]
 
+:_mod-docs-content-type: PROCEDURE
 [id="installation-creating-mirror-registry_{context}"]
 = Creating a mirror registry
 

--- a/modules/installation-local-registry-pull-secret.adoc
+++ b/modules/installation-local-registry-pull-secret.adoc
@@ -3,6 +3,7 @@
 // * installing/install_config/installing-restricted-networks-preparations.adoc
 // * openshift_images/samples-operator-alt-registry.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="installation-local-registry-pull-secret_{context}"]
 = Creating a pull secret for your mirror registry
 

--- a/modules/installation-osp-balancing-external-loads.adoc
+++ b/modules/installation-osp-balancing-external-loads.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/installing_openstack/installing-openstack-load-balancing.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="installation-osp-balancing-external-loads_{context}"]
 = Configuring a user-managed load balancer
 

--- a/modules/installation-osp-local-disk-deployment.adoc
+++ b/modules/installation-osp-local-disk-deployment.adoc
@@ -2,7 +2,7 @@
 //
 // * installing_openstack/deploying-openstack-with-rootVolume-etcd-on-local-disk.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="installation-osp-local-disk-deployment_{context}"]
 = Deploying {rh-openstack} on local disk
 

--- a/modules/installation-performing-disconnected-mirror-without-registry.adoc
+++ b/modules/installation-performing-disconnected-mirror-without-registry.adoc
@@ -2,7 +2,8 @@
 //
 // * installing/installing_restricted_networks/installing-restricted-networks-preparations.adoc
 
-[id="installation-performing-disconnected-mirror-without-registry"]
+:_mod-docs-content-type: PROCEDURE
+[id="installation-performing-disconnected-mirror-without-registry_{context}"]
 = Performing a mirror to disk for use in disconnected environments with a non-production mirror registry
 
 If a production mirror registry is not available, you can configure a simple mirror registry by using the disconnected procedure to serve container images that you downloaded to disk.

--- a/modules/installation-performing-disconnected-mirror.adoc
+++ b/modules/installation-performing-disconnected-mirror.adoc
@@ -2,7 +2,8 @@
 //
 // * installing/installing_restricted_networks/installing-restricted-networks-preparations.adoc
 
-[id="installation-performing-disconnected-mirror"]
+:_mod-docs-content-type: PROCEDURE
+[id="installation-performing-disconnected-mirror_{context}"]
 = Mirroring the {product-title} image registry contents to disk for use in disconnected environments
 
 When you mirror images to disk, you download images as files. Then, you move your

--- a/modules/installation-special-config-raid.adoc
+++ b/modules/installation-special-config-raid.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/install_config/installing-customizing.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="installation-special-config-raid_{context}"]
 == Configuring a RAID-enabled data volume
 

--- a/modules/ldap-failover-configure-apache.adoc
+++ b/modules/ldap-failover-configure-apache.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/configuring-ldap-failover.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="sssd-configuring-apache_{context}"]
 = Configuring Apache to use SSSD
 

--- a/modules/ldap-failover-configure-openshift.adoc
+++ b/modules/ldap-failover-configure-openshift.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/configuring-ldap-failover.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="sssd-for-ldap-configure-openshift_{context}"]
 = Configuring {product-title} to use SSSD as the basic remote authentication server
 

--- a/modules/ldap-failover-configure-sssd.adoc
+++ b/modules/ldap-failover-configure-sssd.adoc
@@ -2,8 +2,10 @@
 //
 // * authentication/configuring-ldap-failover.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="sssd-configuring-sssd_{context}"]
 = Configuring SSSD for LDAP failover
+
 Complete these steps on the remote basic authentication server.
 
 You can configure the SSSD to retrieve attributes, such as email addresses and

--- a/modules/ldap-failover-generate-certs.adoc
+++ b/modules/ldap-failover-generate-certs.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/configuring-ldap-failover.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="sssd-generating-certificates_{context}"]
 = Generating and sharing certificates with the remote basic authentication server
 

--- a/modules/machineset-osp-adding-bare-metal.adoc
+++ b/modules/machineset-osp-adding-bare-metal.adoc
@@ -1,5 +1,7 @@
+:_mod-docs-content-type: PROCEDURE
 [id="machineset-osp-adding-bare-metal_{context}"]
 = Adding bare-metal compute machines to a {rh-openstack} cluster
+
 // TODO
 // Mothballed
 // Reintroduce when feature is available.

--- a/modules/metering-install-operator.adoc
+++ b/modules/metering-install-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/metering-installing-metering.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-install-operator_{context}"]
 = Installing the Metering Operator
 

--- a/modules/metering-prometheus-connection.adoc
+++ b/modules/metering-prometheus-connection.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/configuring_metering/metering-configure-reporting-operator.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-prometheus-connection_{context}"]
 = Securing a Prometheus connection
 

--- a/modules/metering-store-data-in-azure.adoc
+++ b/modules/metering-store-data-in-azure.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/configuring_metering/metering-configure-persistent-storage.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-store-data-in-azure_{context}"]
 = Storing data in Microsoft Azure
 

--- a/modules/metering-store-data-in-gcp.adoc
+++ b/modules/metering-store-data-in-gcp.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/configuring_metering/metering-configure-persistent-storage.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-store-data-in-gcp_{context}"]
 = Storing data in Google Cloud Storage
 

--- a/modules/metering-store-data-in-s3-compatible.adoc
+++ b/modules/metering-store-data-in-s3-compatible.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/configuring_metering/metering-configure-persistent-storage.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-store-data-in-s3-compatible_{context}"]
 = Storing data in S3-compatible storage
 

--- a/modules/metering-store-data-in-s3.adoc
+++ b/modules/metering-store-data-in-s3.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/configuring_metering/metering-configure-persistent-storage.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-store-data-in-s3_{context}"]
 = Storing data in Amazon S3
 

--- a/modules/metering-store-data-in-shared-volumes.adoc
+++ b/modules/metering-store-data-in-shared-volumes.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/configuring_metering/metering-configure-persistent-storage.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-store-data-in-shared-volumes_{context}"]
 = Storing data in shared volumes
 

--- a/modules/metering-troubleshooting.adoc
+++ b/modules/metering-troubleshooting.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/metering-troubleshooting-debugging.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-troubleshooting_{context}"]
 = Troubleshooting metering
 

--- a/modules/metering-uninstall-crds.adoc
+++ b/modules/metering-uninstall-crds.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/metering-uninstall.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-uninstall-crds_{context}"]
 = Uninstalling metering custom resource definitions
 

--- a/modules/metering-uninstall.adoc
+++ b/modules/metering-uninstall.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/metering-uninstall.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-uninstall_{context}"]
 = Uninstalling a metering namespace
 

--- a/modules/metering-use-mysql-or-postgresql-for-hive.adoc
+++ b/modules/metering-use-mysql-or-postgresql-for-hive.adoc
@@ -2,6 +2,7 @@
 //
 // * metering/configuring_metering/metering-configure-hive-metastore.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="metering-use-mysql-or-postgresql-for-hive_{context}"]
 = Using MySQL or PostgreSQL for the Hive metastore
 

--- a/modules/metering-viewing-report-results.adoc
+++ b/modules/metering-viewing-report-results.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
 //
 // * metering/metering-using-metering.adoc
+
+:_mod-docs-content-type: PROCEDURE
 [id="metering-viewing-report-results_{context}"]
 = Viewing report results
 

--- a/modules/metering-writing-reports.adoc
+++ b/modules/metering-writing-reports.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
 //
 // * metering/metering-using-metering.adoc
+
+:_mod-docs-content-type: PROCEDURE
 [id="metering-writing-reports_{context}"]
 = Writing Reports
 

--- a/modules/microshift-firewall-add-services.adoc
+++ b/modules/microshift-firewall-add-services.adoc
@@ -2,7 +2,7 @@
 //
 // * microshift_networking/microshift-firewall.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="microshift-firewall-add-services_{context}"]
 = Adding services to open ports
 

--- a/modules/migration-creating-ca-bundle.adoc
+++ b/modules/migration-creating-ca-bundle.adoc
@@ -3,6 +3,7 @@
 // * migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
 // * migration_toolkit_for_containers/migrating-applications-with-mtc
 
+:_mod-docs-content-type: PROCEDURE
 [id="creating-ca-bundle_{context}"]
 = Creating a CA certificate bundle file for self-signed certificates
 

--- a/modules/migration-rsync-mig-migration-root-non-root.adoc
+++ b/modules/migration-rsync-mig-migration-root-non-root.adoc
@@ -2,6 +2,8 @@
 //
 // * migration_toolkit_for_containers/installing-mtc.adoc
 // * migration_toolkit_for_containers/installing-mtc-restricted.adoc
+
+:_mod-docs-content-type: PROCEDURE
 [id="migration-rsync-mig-migration-root-non-root_{context}"]
 == Configuring the MigMigration CR as root or non-root per migration
 

--- a/modules/migration-rsync-migration-controller-root-non-root.adoc
+++ b/modules/migration-rsync-migration-controller-root-non-root.adoc
@@ -2,6 +2,8 @@
 //
 // * migration_toolkit_for_containers/installing-mtc.adoc
 // * migration_toolkit_for_containers/installing-mtc-restricted.adoc
+
+:_mod-docs-content-type: PROCEDURE
 [id="migration-rsync-migration-controller-root-non-root_{context}"]
 == Configuring the MigrationController CR as root or non-root for all migrations
 

--- a/modules/nodes-scheduler-node-names-configuring.adoc
+++ b/modules/nodes-scheduler-node-names-configuring.adoc
@@ -2,6 +2,7 @@
 //
 // * nodes/nodes-scheduler-node-names.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="nodes-scheduler-node-name-configuring_{context}"]
 = Configuring the Pod Node Constraints admission controller to use names
 

--- a/modules/nodes-scheduler-node-projects-configuring.adoc
+++ b/modules/nodes-scheduler-node-projects-configuring.adoc
@@ -2,6 +2,7 @@
 //
 // * nodes/nodes-scheduler-node-projects.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="nodes-scheduler-node-projects-configuring_{context}"]
 = Configuring the Pod Node Selector admission controller to use projects
 

--- a/modules/nw-ingresscontroller-change-external.adoc
+++ b/modules/nw-ingresscontroller-change-external.adoc
@@ -2,6 +2,7 @@
 //
 // *networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="nw-ingresscontroller-change-external_{context}"]
 = Configuring the Ingress Controller endpoint publishing scope to External
 

--- a/modules/nw-ipfailover-configuring-keepalived-multicast.adoc
+++ b/modules/nw-ipfailover-configuring-keepalived-multicast.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/configuring-ipfailover.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="nw-ipfailover-configuring-keepalived-multicast_{context}"]
 = Configuring Keepalived multicast
 

--- a/modules/nw-metallb-operator-setting-pod-CPU-limits.adoc
+++ b/modules/nw-metallb-operator-setting-pod-CPU-limits.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/metallb/metallb-operator-install.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="nw-metallb-operator-setting-pod-CPU-limits_{context}"]
 = Configuring pod CPU limits in a MetalLB deployment
 

--- a/modules/nw-metallb-operator-setting-pod-priority-affinity.adoc
+++ b/modules/nw-metallb-operator-setting-pod-priority-affinity.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/metallb/metallb-operator-install.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="nw-metallb-operator-setting-pod-priority-affinity_{context}"]
 = Configuring pod priority and pod affinity in a MetalLB deployment
 

--- a/modules/nw-metallb-troubleshoot-bfd.adoc
+++ b/modules/nw-metallb-troubleshoot-bfd.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/metallb/metallb-troubleshoot-support.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="nw-metallb-troubleshoot-bfd_{context}"]
 = Troubleshooting BFD issues
 

--- a/modules/nw-metallb-troubleshoot-bgp.adoc
+++ b/modules/nw-metallb-troubleshoot-bgp.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/metallb/metallb-troubleshoot-support.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="nw-metallb-troubleshoot-bgp_{context}"]
 = Troubleshooting BGP issues
 

--- a/modules/nw-ovn-kubernetes-resources-con.adoc
+++ b/modules/nw-ovn-kubernetes-resources-con.adoc
@@ -2,7 +2,7 @@
 //
 // * networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="nw-kubernetes-resources-con_{context}"]
 = Resources in the OVN-Kubernetes project
 

--- a/modules/nw-pod-network-connectivity-configuration.adoc
+++ b/modules/nw-pod-network-connectivity-configuration.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/verifying-connectivity-endpoint.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="nw-pod-network-connectivity-configuration_{context}"]
 = Configuring pod connectivity check placement
 

--- a/modules/nw-sriov-add-pod-runtimeconfig.adoc
+++ b/modules/nw-sriov-add-pod-runtimeconfig.adoc
@@ -6,6 +6,7 @@
 // Deprecating in OCP; This is identical in practice to adding a pod
 // to an additional network.
 
+:_mod-docs-content-type: PROCEDURE
 [id="nw-sriov-add-pod-runtimeconfig_{context}"]
 = Configuring static MAC and IP addresses on additional SR-IOV networks
 

--- a/modules/oc-mirror-enclave-support.adoc
+++ b/modules/oc-mirror-enclave-support.adoc
@@ -2,7 +2,7 @@
 //
 // * installing/disconnected_install/installing-mirroring-disconnected-v2.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="oc-mirror-enclave-support_{context}"]
 = Mirroring to an enclave
 

--- a/modules/odc-customizing-available-cluster-roles-using-the-web-console.adoc
+++ b/modules/odc-customizing-available-cluster-roles-using-the-web-console.adoc
@@ -2,6 +2,7 @@
 //
 // applications/projects/working-with-projects.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="odc-customizing-available-cluster-roles-using-the-web-console_{context}"]
 = Customizing the available cluster roles using the web console
 

--- a/modules/op-configuring-eventlisteners-to-serve-multiple-namespaces.adoc
+++ b/modules/op-configuring-eventlisteners-to-serve-multiple-namespaces.adoc
@@ -2,6 +2,7 @@
 //
 // *openshift_pipelines/creating-applications-with-cicd-pipelines.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="configuring-eventlisteners-to-serve-multiple-namespaces_{context}"]
 = Configuring event listeners to serve multiple namespaces
 

--- a/modules/op-defining-and-creating-pipelineresources.adoc
+++ b/modules/op-defining-and-creating-pipelineresources.adoc
@@ -2,6 +2,7 @@
 //
 // *openshift_pipelines/creating-applications-with-cicd-pipelines.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="defining-and-creating-pipelineresources_{context}"]
 = Defining and creating PipelineResources
 

--- a/modules/osd-gcp-psc-firewall-prerequisites.adoc
+++ b/modules/osd-gcp-psc-firewall-prerequisites.adoc
@@ -2,7 +2,7 @@
 //
 // * osd_planning/gcp-ccs.adoc
 
-
+:_mod-docs-content-type: PROCEDURE
 [id="osd-gcp-psc-firewall-prerequisites_{context}"]
 = GCP firewall prerequisites
 

--- a/modules/ossm-tutorial-prometheus-querying-metrics.adoc
+++ b/modules/ossm-tutorial-prometheus-querying-metrics.adoc
@@ -3,6 +3,7 @@ This PROCEDURE module included in the following assemblies:
 - ossm-tutorial-prometheus.adoc
 ////
 
+:_mod-docs-content-type: PROCEDURE
 [id="ossm-tutorial-prometheus-querying-metrics_{context}"]
 = Querying Prometheus metrics
 

--- a/modules/persistent-storage-csi-cinder-storage-class.adoc
+++ b/modules/persistent-storage-csi-cinder-storage-class.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/container_storage_interface/persistent-storage-csi-cinder.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-csi-cinder_{context}"]
 = Making OpenStack Cinder CSI the default storage class
 

--- a/modules/persistent-storage-csi-ebs-operator-install-driver.adoc
+++ b/modules/persistent-storage-csi-ebs-operator-install-driver.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/container_storage_interface/persistent-storage-csi-ebs.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-csi-ebs-operator-install-driver_{context}"]
 = Installing the AWS Elastic Block Store CSI driver
 

--- a/modules/persistent-storage-csi-ebs-operator-install.adoc
+++ b/modules/persistent-storage-csi-ebs-operator-install.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/container_storage_interface/persistent-storage-csi-ebs.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-csi-ebs-operator-install_{context}"]
 = Installing the AWS Elastic Block Store CSI Driver Operator
 

--- a/modules/persistent-storage-csi-manila-install-operator.adoc
+++ b/modules/persistent-storage-csi-manila-install-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/container_storage_interface/persistent-storage-csi-manila.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-csi-manila-install-operator_{context}"]
 = Installing the Manila CSI Driver Operator
 

--- a/modules/persistent-storage-csi-manila-uninstall-operator.adoc
+++ b/modules/persistent-storage-csi-manila-uninstall-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/container_storage_interface/persistent-storage-csi-manila.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-csi-manila-uninstall-operator_{context}"]
 = Uninstalling the Manila CSI Driver Operator
 

--- a/modules/persistent-storage-csi-vsphere-encryption-datastore-url.adoc
+++ b/modules/persistent-storage-csi-vsphere-encryption-datastore-url.adoc
@@ -3,7 +3,7 @@
 // * storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
 //
 
-:content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-csi-vsphere-encryption-datastore-url_{context}"]
 = Using datastore URL
 

--- a/modules/persistent-storage-csi-vsphere-encryption-tag-based.adoc
+++ b/modules/persistent-storage-csi-vsphere-encryption-tag-based.adoc
@@ -3,7 +3,7 @@
 // storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
 //
 
-:content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-csi-vsphere-encryption-tag-based_{context}"]
 = Using tag-based placement
 

--- a/modules/persistent-storage-manila-install.adoc
+++ b/modules/persistent-storage-manila-install.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/persistent_storage/persistent-storage-manila.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-manila-install_{context}"]
 = Installing the external provisioner
 

--- a/modules/persistent-storage-manila-usage.adoc
+++ b/modules/persistent-storage-manila-usage.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/persistent_storage/persistent-storage-manila.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="persistent-storage-manila-usage_{context}"]
 = Provisioning an {rh-openstack} Manila persistent volume
 

--- a/modules/registry-configuring-storage-openstack-user-infra.adoc
+++ b/modules/registry-configuring-storage-openstack-user-infra.adoc
@@ -2,6 +2,7 @@
 //
 // * registry/configuring_registry_storage-openstack-user-infrastructure.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="registry-configuring-storage-openstack-user-infra_{context}"]
 = Registry storage for {rh-openstack} with user-provisioned infrastructure
 

--- a/modules/registry-operator-config-resources-secret-openstack.adoc
+++ b/modules/registry-operator-config-resources-secret-openstack.adoc
@@ -2,7 +2,7 @@
 //
 // * registry/configuring-registry-operator.adoc
 
-
+:_mod-docs-content-type: PROCEDURE
 [id="registry-operator-config-resources-secret-openstack_{context}"]
 = Configuring a secret for the Image Registry Operator
 

--- a/modules/running-cluster-loader.adoc
+++ b/modules/running-cluster-loader.adoc
@@ -2,6 +2,7 @@
 //
 // scalability_and_performance/using-cluster-loader.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="running_cluster_loader_{context}"]
 = Running Cluster Loader
 

--- a/modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc
+++ b/modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc
@@ -2,6 +2,7 @@
 //
 // * serverless/functions/serverless-functions-accessing-secrets-configmaps.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-functions-all-values-in-configmap-to-env-variables_{context}"]
 = Setting environment variables from all values defined in a config map
 

--- a/modules/service-accounts-enabling-authentication.adoc
+++ b/modules/service-accounts-enabling-authentication.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/using-service-accounts.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="service-accounts-enabling-authentication_{context}"]
 = Enabling service account authentication
 

--- a/modules/service-accounts-using-credentials-inside-a-container.adoc
+++ b/modules/service-accounts-using-credentials-inside-a-container.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/using-service-accounts.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="service-accounts-using-credentials-inside-a-container_{context}"]
 = Using a service account's credentials inside a container
 

--- a/modules/storage-persistent-storage-creating-volume-claim.adoc
+++ b/modules/storage-persistent-storage-creating-volume-claim.adoc
@@ -2,6 +2,8 @@
 //
 // * storage/persistent_storage-aws.adoc
 
+:_mod-docs-content-type: PROCEDURE
+[id="creating-volume-claim_{context}"]
 = Creating the persistent volume claim
 
 .Prerequisites

--- a/modules/storage-persistent-storage-efs-authorization.adoc
+++ b/modules/storage-persistent-storage-efs-authorization.adoc
@@ -2,6 +2,7 @@
 //
 // storage/persistent_storage/persistent-storage-efs.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="efs-authorization_{context}"]
 = Configuring authorization for EFS volumes
 

--- a/modules/storage-persistent-storage-efs-configmap.adoc
+++ b/modules/storage-persistent-storage-efs-configmap.adoc
@@ -2,6 +2,7 @@
 //
 // storage/persistent_storage/persistent-storage-efs.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="efs-creating-configmap_{context}"]
 = Store the EFS variables in a config map
 

--- a/modules/storage-persistent-storage-efs-provisioner.adoc
+++ b/modules/storage-persistent-storage-efs-provisioner.adoc
@@ -2,6 +2,7 @@
 //
 // storage/persistent_storage/persistent-storage-efs.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="efs-provisioner_{context}"]
 = Create the EFS provisioner
 

--- a/modules/storage-persistent-storage-efs-storage-class.adoc
+++ b/modules/storage-persistent-storage-efs-storage-class.adoc
@@ -2,6 +2,7 @@
 //
 // storage/persistent_storage/persistent-storage-efs.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="efs-storage-class_{context}"]
 = Create the EFS storage class
 

--- a/modules/telco-update-creating-mcp-groups-for-the-cluster.adoc
+++ b/modules/telco-update-creating-mcp-groups-for-the-cluster.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="telco-update-creating-mcp-groups-for-the-cluster_{context}"]
 = Creating MachineConfigPool groups for the cluster
 

--- a/modules/telco-update-reviewing-configured-cluster-mcp-roles.adoc
+++ b/modules/telco-update-reviewing-configured-cluster-mcp-roles.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="telco-update-reviewing-configured-cluster-mcp-roles_{context}"]
 = Reviewing configured cluster MachineConfigPool roles
 

--- a/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
@@ -2,6 +2,7 @@
 //
 // * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="update-using-custom-machine-config-pools-mcp-remove_{context}"]
 = Moving a node to the original machine config pool
 

--- a/modules/update-using-custom-machine-config-pools-mcp.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp.adoc
@@ -2,6 +2,7 @@
 //
 // * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="update-using-custom-machine-config-pools-mcp_{context}"]
 = Creating machine config pools to perform a canary rollout update
 

--- a/modules/update-using-custom-machine-config-pools-pause.adoc
+++ b/modules/update-using-custom-machine-config-pools-pause.adoc
@@ -2,6 +2,7 @@
 //
 // * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="update-using-custom-machine-config-pools-pause_{context}"]
 = Pausing the machine config pools
 

--- a/modules/update-using-custom-machine-config-pools-unpause.adoc
+++ b/modules/update-using-custom-machine-config-pools-unpause.adoc
@@ -2,6 +2,7 @@
 //
 // * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="update-using-custom-machine-config-pools-unpause_{context}"]
 = Unpausing the machine config pools
 

--- a/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
+++ b/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
@@ -2,6 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="enabling-assisted-installer-service-on-bare-metal_{context}"]
 = Enabling the assisted service
 


### PR DESCRIPTION
Close by EOD Monday the 11th of August.

This PR fixes a few files module files that are missing the `mod-docs-content-type` tag. I also had to fix one link that was clearly not pointing to the target module. 

The main purpose of this PR is to test https://github.com/jhradilek/content-type-editor/tree/main

Version(s):
4.12+

Issue:
[OSDOCS-15601](https://issues.redhat.com/browse/OSDOCS-15601)

Link to docs preview:
Too many files. 
