### PR TITLE
OCPBUGS#43062: Docs - updating the PVC config example

### DIFF
--- a/modules/lvms-provisioning-storage-using-logical-volume-manager-operator.adoc
+++ b/modules/lvms-provisioning-storage-using-logical-volume-manager-operator.adoc
@@ -37,7 +37,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  volumeMode: Block <2>
+  volumeMode: Filesystem <2>
   resources:
     requests:
       storage: 10Gi <3>
@@ -46,7 +46,7 @@ spec:
   storageClassName: lvms-vg1 <5>
 ----
 <1> Specify a name for the PVC.
-<2> To create a block PVC, set this field to `Block`. To create a file PVC, set this field to `Filesystem`.
+<2> To create a file PVC, set this field to `Filesystem`. To create a block PVC, set this field to `Block`.
 <3> Specify the storage size. If the value is less than the minimum storage size, the requested storage size is rounded to the minimum storage size. The total storage size you can provision is limited by the size of the Logical Volume Manager (LVM) thin pool and the over-provisioning factor.
 <4> Optional: Specify the storage limit. Set this field to a value that is greater than or equal to the minimum storage size. Otherwise, PVC creation fails with an error. 
 <5> The value of the `storageClassName` field must be in the format `lvms-<device_class_name>` where `<device_class_name>` is the value of the `deviceClasses.name` field in the `LVMCluster` CR.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-43062](https://issues.redhat.com/browse/OCPBUGS-43062)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Provisioning storage
](https://96918--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-provisioning-storage-using-lvms_logical-volume-manager-storage)
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->