### PR TITLE
TELCODOCS-2259: Add TP support for ARM dual-port OC

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-dual-port-oc.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-dual-port-oc.adoc
@@ -17,7 +17,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 * Install the OpenShift CLI (`oc`).
 * Log in as a user with `cluster-admin` privileges.
 * Install the PTP Operator.
-* The node uses an x86_64 architecture with a dual-port NIC.
+* Check the hardware requirements for using your dual-port NIC as an ordinary clock with added redundancy. For further information, see "Using dual-port NICs to improve redundancy for PTP ordinary clocks".
 
 .Procedure
 

--- a/modules/ptp-dual-ports-oc.adoc
+++ b/modules/ptp-dual-ports-oc.adoc
@@ -21,7 +21,21 @@ In this configuration, the ports in a dual-port NIC operate as follows:
 
 * If both ports become faulty, the clock state moves to the `HOLDOVER` state, then the `FREERUN` state when the holdover timeout expires, before resyncing to a leader clock.
 
-[NOTE]
-====
-You can configure PTP ordinary clocks with added redundancy on `x86` architecture nodes with dual-port NICs only.
-====
+[id="hardware-requirements_{context}"]
+== Hardware requirements
+
+You can configure PTP ordinary clocks with added redundancy on x86_64 or AArch64 architecture nodes.
+
+For x86_64 architecture nodes, the nodes must feature dual-port NICs that support PTP and expose a single PTP hardware clock (PHC) per NIC, such as the Intel E810.
+
+For AArch64 architecture nodes, you can use the following dual-port NICs only:
+
+* NVIDIA ConnectX-7 series
+
+* NVIDIA BlueField-3 series, in NIC mode
+
+** You must configure the NVIDIA BlueField-3 series DPU in NIC mode before configuring the interface as an ordinary clock with improved redundancy. For further information about configuring NIC mode, see link:https://docs.nvidia.com/networking/display/bluefielddpubspv422/modes+of+operation#src-141856548_ModesofOperation-NICModeforBlueField-3[NIC Mode for BlueField-3] (NVIDIA documentation), link:https://docs.nvidia.com/networking/display/bluefieldbmcv2504/bluefield+managementink[BlueField Management] (NVIDIA documentation), and link:https://docs.nvidia.com/networking/display/bluefielddpuosv470/modes+of+operation#src-2821766680_ModesofOperation-ConfiguringNICModeonBlueField-3fromHostHIIUEFI[Configuring NIC Mode on BlueField-3 from Host BIOS HII UEFI Menu] (NVIDIA documentation).
+
+** You must restart the card after changing to NIC mode. For more information about restarting the card, see link:https://docs.nvidia.com/doca/sdk/nvidia+bluefield+reset+and+reboot+procedures/index.html[NVIDIA BlueField Reset and Reboot Procedures] (NVIDIA documentation).
+
+* Use the latest supported NVIDIA drivers and firmware to ensure proper PTP support and to expose a single PHC per NIC.


### PR DESCRIPTION
[TELCODOCS-2259](https://issues.redhat.com//browse/TELCODOCS-2259): Add TP support for ARM dual-port OC

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2259

Link to docs preview:
- https://96925--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/about-ptp.html#ptp-dual-ports-oc_about-ptp
- https://96925--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/configuring-ptp.html#configuring-linuxptp-services-oc-dual-port_configuring-ptp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


