### PR TITLE
OSDOCS-15613: Alerted users to the removal of a cluster creation flag

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -13,16 +13,12 @@ toc::[]
 
 [id="rosa-new-changes-and-updates_{context}"]
 == New changes and updates
-//
-// This release note should remain hidden until the renaming project is completed to avoid confusion
-//
-// [id="rosa-q3-2025_{context}"]
-// === Q3 2025
+[id="rosa-q3-2025_{context}"]
+=== Q3 2025
 
-// * **Updated ROSA product titles**. Previously, the product names for {rosa-classic-short} and {rosa-first} in the documentation were inconsistent, potentially causing confusion for users. This release updates the product names as follows:
-// +
-// ** "Red Hat OpenShift on AWS (ROSA)" is now **{rosa-classic-short}** and abbreviated as {rosa-classic-short}
-// ** "Red Hat OpenShift on AWS (ROSA) with hosted control planes" is now **{rosa-first}** and abbreviated as **{rosa-short}**
+* **Deprecated `--private-link` flags for {rosa-short} clusters**. Architectural changes to the ROSA CLI 1.2.55 make networking more flexible for {rosa-short} clusters. The `--private-link` flag previously used when creating a {rosa-short} cluster is now deprecated in favor of the `--private` and `--default-ingress-private` flags. Now, users can choose to have a combination of a public or private API with a public or private ingress. For more information, see xref:../rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc#rosa-hcp-aws-private-create-cluster_rosa-hcp-aws-private-creating-cluster[Creating a private cluster on {rosa-short}].
+
+* **Changed default ingress listening method to begin with Day 1 operations**. Previously, the default ingress listening method was a Day 2 operation. Now, the default ingress listening method is a Day 1 operation.
 
 [id="rosa-q2-2025_{context}"]
 === Q2 2025


### PR DESCRIPTION
Version(s):
`enterprise-4.19+`

Issue:
**[OSDOCS-15613](https://issues.redhat.com//browse/OSDOCS-15613)**

Link to docs preview:
- [What's New in ROSA](https://96975--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html) (HCP)
- [What's New in ROSA](https://96975--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html) (classic)


 
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added a release note to note that the `--private-link` flag has been removed. I also updated the private-link docs accordingly.