### PR TITLE
OSDOCS-11585-415-fix: adds file to topic map

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -488,6 +488,8 @@ Topics:
   File: microshift-troubleshoot-backup-restore
 - Name: Troubleshoot the cluster
   File: microshift-troubleshoot-cluster
+- Name: Troubleshoot etcd
+  File: microshift-etcd-troubleshoot
 - Name: Troubleshoot updates
   File: microshift-troubleshoot-updates
 - Name: Checking audit logs


### PR DESCRIPTION
Version(s):
4.15

Additional information:
Adds assembly to topic map re: https://github.com/openshift/openshift-docs/pull/96977

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
