### PR TITLE
OCPBUGS-54709: Fixed the link to Assisted Installer docs on the Aliba…

### DIFF
--- a/installing/installing_alibaba/installing-alibaba-assisted-installer.adoc
+++ b/installing/installing_alibaba/installing-alibaba-assisted-installer.adoc
@@ -15,6 +15,6 @@ include::modules/alibaba-ai-installing.adoc[leveloffset=+1]
 
 .Additional resources
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.14/html/installing_openshift_container_platform_with_the_assisted_installer/index[Installing {product-title} with the {ai-full}]
+* link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2025[Installing {product-title} with the {ai-full}]
 
 include::modules/alibaba-ai-converting-image-to-qcow2.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixed a broken link. I don't think SME approvals are needed, but please feel free to change my mind. The Assisted Installer landing page is the same for all versions of OCP.

Version(s):
4.16+

Issue:
[OCPBUGS-54709](https://issues.redhat.com/browse/OCPBUGS-54709)

Link to docs preview:
[Process outline for creating a cluster with the Assisted Installer](https://96996--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-assisted-installer.html#alibaba-ai-installing_installing-alibaba-assisted-installer)

