### PR TITLE
TELCODOCS#2397

### DIFF
--- a/modules/nw-metallb-frr-k8s-configuration-crd.adoc
+++ b/modules/nw-metallb-frr-k8s-configuration-crd.adoc
@@ -241,6 +241,7 @@ The fields for the `FRRConfiguration` custom resource are described in the follo
 |`spec.bgp.routers.neighbors.asn`
 |`integer`
 |Specifies the ASN to use for the remote end of the session.
+|If you use this field, you cannot specify a value in the `spec.bgp.routers.neighbors.dynamicASN` field.
 
 |`spec.bgp.routers.neighbors.dynamicASN`
 |`string`

--- a/modules/nw-metallb-frr-k8s-configuration-crd.adoc
+++ b/modules/nw-metallb-frr-k8s-configuration-crd.adoc
@@ -12,7 +12,7 @@ The following section provides reference examples that use the `FRRConfiguration
 == The routers field
 
 You can use the `routers` field to configure multiple routers, one for each Virtual Routing and Forwarding (VRF) resource.
-For each router, you must define the Autonomous System Number (ASN). 
+For each router, you must define the Autonomous System Number (ASN).
 
 You can also define a list of Border Gateway Protocol (BGP) neighbors to connect to, as in the following example:
 
@@ -41,7 +41,7 @@ spec:
 [id="nw-metallb-frrconfiguration-crd-toadvertise_{context}"]
 == The toAdvertise field
 
-By default, `FRR-K8s` does not advertise the prefixes configured as part of a router configuration. 
+By default, `FRR-K8s` does not advertise the prefixes configured as part of a router configuration.
 In order to advertise them,  you use the `toAdvertise` field.
 
 You can advertise a subset of the prefixes, as in the following example:
@@ -104,7 +104,7 @@ spec:
 [id="nw-metallb-frrconfiguration-crd-toreceive_{context}"]
 == The toReceive field
 
-By default, `FRR-K8s` does not process any prefixes advertised by a neighbor. 
+By default, `FRR-K8s` does not process any prefixes advertised by a neighbor.
 You can use the `toReceive` field  to process such addresses.
 
 You can configure for a subset of the prefixes, as in this example:
@@ -161,7 +161,7 @@ spec:
 [id="nw-metallb-frrconfiguration-crd-bgp_{context}"]
 == The bgp field
 
-You can use the `bgp` field to define various `BFD` profiles and associate them with a neighbor. 
+You can use the `bgp` field to define various `BFD` profiles and associate them with a neighbor.
 In the following example, `BFD` backs up the `BGP` session and `FRR` can detect link failures:
 
 .Example FRRConfiguration CR
@@ -242,30 +242,36 @@ The fields for the `FRRConfiguration` custom resource are described in the follo
 |`integer`
 |Specifies the ASN to use for the remote end of the session.
 
+|`spec.bgp.routers.neighbors.dynamicASN`
+|`string`
+|Detects the ASN to use for the remote end of the session without explicitly setting it.
+Specify `internal` for a neighbor with the same ASN, or `external` for a neighbor with a different ASN.
+If you use this field, you cannot specify a value in the `spec.bgp.routers.neighbors.asn` field.
+
 |`spec.bgp.routers.neighbors.address`
 |`string`
 |Specifies the IP address to establish the session with.
 
 |`spec.bgp.routers.neighbors.port`
 |`integer`
-|Specifies the port to dial when establishing the session. 
+|Specifies the port to dial when establishing the session.
 Defaults to 179.
 
 |`spec.bgp.routers.neighbors.password`
 |`string`
-|Specifies the password to use for establishing the BGP session. 
+|Specifies the password to use for establishing the BGP session.
 `Password` and `PasswordSecret` are mutually exclusive.
 
 |`spec.bgp.routers.neighbors.passwordSecret`
 |`string`
-|Specifies the name of the authentication secret for the neighbor. 
-The secret must be of type "kubernetes.io/basic-auth", and in the same namespace as the FRR-K8s daemon. 
-The key "password" stores the password in the secret. 
+|Specifies the name of the authentication secret for the neighbor.
+The secret must be of type "kubernetes.io/basic-auth", and in the same namespace as the FRR-K8s daemon.
+The key "password" stores the password in the secret.
 `Password` and `PasswordSecret` are mutually exclusive.
 
 |`spec.bgp.routers.neighbors.holdTime`
 |`duration`
-|Specifies the requested BGP hold time, per RFC4271. 
+|Specifies the requested BGP hold time, per RFC4271.
 Defaults to 180s.
 
 |`spec.bgp.routers.neighbors.keepaliveTime`
@@ -283,7 +289,7 @@ Defaults to `60s`.
 
 |`spec.bgp.routers.neighbors.bfdProfile`
 |`string`
-|Specifies the name of the BFD Profile to use for the BFD session associated with the BGP session. 
+|Specifies the name of the BFD Profile to use for the BFD session associated with the BGP session.
 If not set, the BFD session is not set up.
 
 |`spec.bgp.routers.neighbors.toAdvertise.allowed`
@@ -292,18 +298,18 @@ If not set, the BFD session is not set up.
 
 |`spec.bgp.routers.neighbors.toAdvertise.allowed.prefixes`
 |`string array`
-|Specifies the list of prefixes to advertise to a neighbor. 
+|Specifies the list of prefixes to advertise to a neighbor.
 This list must match the prefixes that you define in the router.
 
 |`spec.bgp.routers.neighbors.toAdvertise.allowed.mode`
 |`string`
-|Specifies the mode to use when handling the prefixes. 
+|Specifies the mode to use when handling the prefixes.
 You can set to `filtered` to allow only the prefixes in the prefixes list.
 You can set to `all` to allow all the prefixes configured on the router.
 
 |`spec.bgp.routers.neighbors.toAdvertise.withLocalPref`
 |`array`
-|Specifies the prefixes associated with an advertised local preference. 
+|Specifies the prefixes associated with an advertised local preference.
 You must specify the prefixes associated with a local preference in the prefixes allowed to be advertised.
 
 |`spec.bgp.routers.neighbors.toAdvertise.withLocalPref.prefixes`
@@ -341,8 +347,8 @@ You must include the prefixes associated with a local preference in the list of 
 
 |`spec.bgp.routers.neighbors.toReceive.allowed.mode`
 |`string`
-|Specifies the mode to use when handling the prefixes. 
-When set to `filtered`, only the prefixes in the `prefixes` list are allowed. 
+|Specifies the mode to use when handling the prefixes.
+When set to `filtered`, only the prefixes in the `prefixes` list are allowed.
 When set to `all`, all the prefixes configured on the router are allowed.
 
 |`spec.bgp.routers.neighbors.disableMP`
@@ -363,27 +369,27 @@ When set to `all`, all the prefixes configured on the router are allowed.
 
 |`spec.bgp.bfdProfiles.receiveInterval`
 |`integer`
-|Specifies the minimum interval at which this system can receive control packets, in milliseconds. 
+|Specifies the minimum interval at which this system can receive control packets, in milliseconds.
 Defaults to `300ms`.
 
 |`spec.bgp.bfdProfiles.transmitInterval`
 |`integer`
-|Specifies the minimum transmission interval, excluding jitter, that this system wants to use to send BFD control packets, in milliseconds. 
+|Specifies the minimum transmission interval, excluding jitter, that this system wants to use to send BFD control packets, in milliseconds.
 Defaults to `300ms`.
 
 |`spec.bgp.bfdProfiles.detectMultiplier`
 |`integer`
-|Configures the detection multiplier to determine packet loss. 
+|Configures the detection multiplier to determine packet loss.
 To determine the connection loss-detection timer, multiply the remote transmission interval by this value.
 
 |`spec.bgp.bfdProfiles.echoInterval`
 |`integer`
-|Configures the minimal echo receive transmission-interval that this system can handle, in milliseconds. 
+|Configures the minimal echo receive transmission-interval that this system can handle, in milliseconds.
 Defaults to `50ms`.
 
 |`spec.bgp.bfdProfiles.echoMode`
 |`boolean`
-|Enables or disables the echo transmission mode. 
+|Enables or disables the echo transmission mode.
 This mode is disabled by default, and not supported on multihop setups.
 
 |`spec.bgp.bfdProfiles.passiveMode`
@@ -392,13 +398,13 @@ This mode is disabled by default, and not supported on multihop setups.
 
 |`spec.bgp.bfdProfiles.MinimumTtl`
 |`integer`
-|For multihop sessions only. 
+|For multihop sessions only.
 Configures the minimum expected TTL for an incoming BFD control packet.
 
 |`spec.nodeSelector`
 |`string`
-|Limits the nodes that attempt to apply this configuration. 
-If specified, only those nodes whose labels match the specified selectors attempt to apply the configuration. 
+|Limits the nodes that attempt to apply this configuration.
+If specified, only those nodes whose labels match the specified selectors attempt to apply the configuration.
 If it is not specified, all nodes attempt to apply this configuration.
 
 |`status`


### PR DESCRIPTION
[TELCODOCS#2397](https://issues.redhat.com/browse/TELCODOCS-2397): Manual cherry-pick of missing content from original cherry-pick after [TELCODOCS-2286](https://issues.redhat.com/browse/TELCODOCS-2286)

Version(s):
4.17

Issue:
[TELCODOCS#2397](https://issues.redhat.com/browse/TELCODOCS-2397)

Link to docs preview:
[The nodeSelector field](https://97012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-frr-k8s.html#nw-metallb-frrconfiguration-crd-nodeselector_configure-metallb-frr-k8s) Table 1

QE review:
Not needed.

Additional information:

