### PR TITLE
[enterprise-4.15] [NETOBSERV] OSDOCS-15495 Vale updates for network-observability-loki-installation.adoc

### DIFF
--- a/modules/network-observability-loki-install.adoc
+++ b/modules/network-observability-loki-install.adoc
@@ -5,13 +5,14 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-loki-installation_{context}"]
 = Installing the {loki-op}
-The link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel8-operator/622b46bcae289285d6fcda39[{loki-op} versions 5.7+] are the supported {loki-op} versions for Network Observability; these versions provide the ability to create a `LokiStack` instance using the `openshift-network` tenant configuration mode and provide fully-automatic, in-cluster authentication and authorization support for Network Observability. There are several ways you can install Loki. One way is by using the {product-title} web console Operator Hub.
+
+The link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel9-operator/64479927e1820602a81cdf13[{loki-op} versions 5.7+] are the supported {loki-op} versions for Network Observability; these versions provide the ability to create a `LokiStack` instance using the `openshift-network` tenant configuration mode and provide fully-automatic, in-cluster authentication and authorization support for Network Observability. There are several ways you can install Loki. One way is by using the {product-title} web console Operator Hub.
 
 .Prerequisites
 
-* Supported Log Store (AWS S3, Google Cloud Storage, Azure, Swift, Minio, OpenShift Data Foundation)
+* Supported Log Store (AWS S3, Google Cloud Storage, Azure, Swift, Minio, {rh-storage})
 * {product-title} 4.10+
-* Linux Kernel 4.18+
+* Linux kernel 4.18+
 
 .Procedure
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.


### PR DESCRIPTION
Cherry picked from: 456ae956688369b4d24043c3adc155e36dc55eba xref: https://github.com/openshift/openshift-docs/pull/96548

Version(s):
4.15

Link to docs preview:
https://97013--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-loki-secret_network_observability

QE review:
QE is not required for this PR.

Additional information: