### PR TITLE
OSDOCS 15615 Clarity on bootimage changes on AWS and GCP

### DIFF
--- a/modules/mco-update-boot-images-about.adoc
+++ b/modules/mco-update-boot-images-about.adoc
@@ -44,9 +44,14 @@ How the cluster behaves after disabling or re-enabling the feature, depends upon
 Because a boot image is used only when a node is scaled up, this feature has no effect on existing nodes.
 ====
 
-To view the current boot image used in your cluster, examine a machine set:
+To view the current boot image used in your cluster, examine a machine set. 
 
-.Example machine set with the boot image reference
+[NOTE]
+====
+The location and format of the boot image within the machine set differs, based on the platform. However, the boot image is always listed in the `spec.template.spec.providerSpec.` parameter. 
+====
+
+.Example {gcp-short} machine set with the boot image reference
 
 [source,yaml]
 ----
@@ -71,6 +76,28 @@ spec:
 # ...
 ----
 <1> This boot image is the same as the originally-installed {product-title} version, in this example {product-title} 4.12, regardless of the current version of the cluster. The way that the boot image is represented in the machine set depends on the platform, as the structure of the `providerSpec` field differs from platform to platform.
+
+.Example {aws-short} machine set with the boot image reference
+
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: ci-ln-hmy310k-72292-5f87z-worker-a
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+    spec:
+# ...
+      providerSpec:
+         value:
+          ami:
+            id: ami-0e8fd9094e487d1ff
+# ...
+----
 
 // The following admonition is intended to address https://issues.redhat.com/browse//OSDOCS-14592
 [IMPORTANT]

--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -84,39 +84,3 @@ $ oc label machineset.machine ci-ln-hmy310k-72292-5f87z-worker-a region: "east" 
 .Verification
 
 include::snippets/mco-update-boot-images-verification.adoc[]
-
-* Get the boot image version by running the following command:
-+
-[source,terminal]
-----
-$ oc get machinesets <machineset_name> -n openshift-machine-api -o yaml
-----
-+
-.Example machine set with the boot image reference
-+
-[source,yaml]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: MachineSet
-metadata:
-  labels:
-    machine.openshift.io/cluster-api-cluster: ci-ln-77hmkpt-72292-d4pxp
-    update-boot-image: "true"
-  name: ci-ln-77hmkpt-72292-d4pxp-worker-a
-  namespace: openshift-machine-api
-spec:
-# ...
-  template:
-# ...
-    spec:
-# ...
-      providerSpec:
-# ...
-        value:
-          disks:
-          - autoDelete: true
-            boot: true
-            image: projects/rhcos-cloud/global/images/<boot_image> <1>
-# ...
-----
-<1> This boot image is the same as the current {product-title} version.

--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -84,39 +84,3 @@ spec:
 .Verification
 
 include::snippets/mco-update-boot-images-verification.adoc[]
-
-* Get the boot image version by running the following command:
-+
-[source,terminal]
-----
-$ oc get machinesets <machineset_name> -n openshift-machine-api -o yaml
-----
-+
-.Example machine set with the boot image reference
-+
-[source,yaml]
-----
-apiVersion: machine.openshift.io/v1beta1
-kind: MachineSet
-metadata:
-  labels:
-    machine.openshift.io/cluster-api-cluster: ci-ln-77hmkpt-72292-d4pxp
-    update-boot-image: "true"
-  name: ci-ln-77hmkpt-72292-d4pxp-worker-a
-  namespace: openshift-machine-api
-spec:
-# ...
-  template:
-# ...
-    spec:
-# ...
-      providerSpec:
-# ...
-        value:
-          disks:
-          - autoDelete: true
-            boot: true
-            image: projects/rhcos-cloud/global/images/rhcos-9-6-20250402-0-gcp-x86-64 <1>
-# ...
-----
-<1> This boot image is the same as the current {product-title} version.

--- a/snippets/mco-update-boot-images-verification.adoc
+++ b/snippets/mco-update-boot-images-verification.adoc
@@ -40,3 +40,39 @@ status:
       selection:
         mode: All
 ----
+
+* Get the boot image version by running the following command. The location and format of the boot image within the machine set differs, based on the platform. However, the boot image is always listed in the `spec.template.spec.providerSpec.` parameter. 
++
+[source,terminal]
+----
+$ oc get machinesets <machineset_name> -n openshift-machine-api -o yaml
+----
++
+.Example machine set with the boot image reference
++
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: ci-ln-77hmkpt-72292-d4pxp
+    update-boot-image: "true"
+  name: ci-ln-77hmkpt-72292-d4pxp-worker-a
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+    spec:
+# ...
+      providerSpec:
+# ...
+        value:
+          disks:
+          - autoDelete: true
+            boot: true
+            image: projects/rhcos-cloud/global/images/<boot_image> <1>
+# ...
+----
+<1> This boot image is the same as the current {product-title} version.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15615

Link to docs preview:
[About boot image management](https://97038--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images_machine-configs-configure) -- New note; new AWS machine set example.

**No QE review needed of the following changes:**
[Enabling boot image management](https://97038--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-configuring_machine-configs-configure) -- Moved verification bullet 2 to snippet.
[Disabling boot image management](https://97038--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html#mco-update-boot-images-disable_machine-configs-configure) -- Moved verification bullet 2 to snippet.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
