### PR TITLE
OSDOCS-15630: bumping the maximum routes

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -34,8 +34,8 @@ Red Hat does not provide direct guidance on sizing your {product-title} cluster.
 | Number of pods per namespace ^[5]^
 | 25,000
 
-| Number of routes and back ends per Ingress Controller
-| 2,000 per router
+| Number of routes per default 2-router deployment
+| 9,000
 
 | Number of secrets
 | 80,000


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OSDOCS-15630

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
