### PR TITLE
OSDOCS-15618 created 4.17.37 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2896,6 +2896,36 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.37
+[id="ocp-4-17-37_{context}"]
+=== RHSA-2025:12437 - {product-title} {product-version}.37 bug fix update and security
+
+Issued: 06 August 2025
+
+{product-title} release {product-version}.37 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:12437[RHSA-2025:12437] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:12438[RHBA-2025:12438] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.37 --pullspecs
+----
+
+[id="ocp-4-17-37-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, the `catalog-operator` captured snapshots every five minutes, which caused CPU spikes when dealing with many namespaces, subscriptions, and large catalog sources. This increased load on the catalog source pods and prevented users from installing or upgrading Operators. With this release, the catalog snapshot cache lifetime has been increased to 30 minutes allowing enough time for the catalog source to resolve attempts without causing an undue load and stabilizing the Operator installation and upgrade process. (link:https://issues.redhat.com/browse/OCPBUGS-57428[OCPBUGS-57428])
+
+* Before this update, forward slashes were permitted in `console.tab/horizontalNav` `href` values. Starting in 4.15, a regression resulted in forward slashes no longer working correctly when used in `href` values. With this release, forward slashes in `console.tab/horizontalNav` `href` values work as expected. (link:https://issues.redhat.com/browse/OCPBUGS-59265[OCPBUGS-59265])
+
+* Before this update, the *Observe* -> *Metrics* -> *query* -> *QueryKebab* -> *Export as csv* drop-down item did not handle an undefined title element. As a consequence, users were unable to export the CSV file for certain queries on the *Metrics* tab of OpenShift Lister version 4.17. With this release, the metrics download for all queries correctly handles the object properties in the drop-down menu items allowing for successful CSV exports. (link:https://issues.redhat.com/browse/OCPBUGS-52592[OCPBUGS-52592])
+
+[id="ocp-4-17-37-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.36
 [id="ocp-4-17-36_{context}"]
 === RHSA-2025:11359 - {product-title} {product-version}.36 bug fix update and security


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-15618

Link to docs preview:
https://97044--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-37_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
