### PR TITLE
OSDOCS-13386: adds 4.19.7 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -204,3 +204,22 @@ See the latest images included with {microshift-short} by using the following in
 
 * xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
 * xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-19-7-dp_{context}"]
+=== RHBA-2025:12745 - {microshift-short} 4.19.7 bug fix and update advisory
+
+Issued: 11 August 2025
+
+{product-title} release 4.19.7 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:12745[RHBA-2025:12745] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:12341[RHSA-2025:12341] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-19-7-dp-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, a bare-metal node reboot caused the deployment progress deadline to be surpassed. This resulted in the greenboot health check failing with a false-positive error. With this release, the full timeout duration is provided for the deployment to become ready, reducing false-positive greenboot health check errors. (https://issues.redhat.com/browse/OCPBUGS-59301[OCPBUGS-59301])
+
+* Before this update, the excessive polling frequency for the cloud pull secret in cluster telemetry caused telemetry failure messages to flood journald logs. The log flooding negatively impacted system performance. With this release, the telemetry collection interval is updated from 1 second to 30 seconds. As a result, log flooding has been minimized and no longer impacts system performance. (https://issues.redhat.com/browse/OCPBUGS-59240[OCPBUGS-59240])


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13386](https://issues.redhat.com/browse/OSDOCS-13386)

Link to docs preview:
[microshift-4-19-7-dp_release-notes](https://97082--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html#microshift-4-19-7-dp_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional info:
MicroShift released async with OCP this z-stream. The OCP image advisory and MicroShift advisories have different dates.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
