### PR TITLE
oc-mirror update for OKD

### DIFF
--- a/disconnected/mirroring/about-installing-oc-mirror-v2.adoc
+++ b/disconnected/mirroring/about-installing-oc-mirror-v2.adoc
@@ -103,11 +103,13 @@ include::modules/oc-mirror-dry-run-v2.adoc[leveloffset=+2]
 // Troubleshooting oc-mirror plugin v2 errors
 include::modules/oc-mirror-troubleshooting-v2.adoc[leveloffset=+1]
 
+ifndef::openshift-origin[]
 // Benefits of enclave support
 include::modules//oc-mirror-enclave-support-about.adoc[leveloffset=+1]
 
 // Mirroring to an enclave
 include::modules/oc-mirror-enclave-support.adoc[leveloffset=+2]
+endif::[]
 
 // Proxy support
 include::modules/oc-mirror-proxy-support.adoc[leveloffset=+1]
@@ -143,6 +145,11 @@ After you mirror images to your disconnected environment using oc-mirror plugin 
 
 * xref:../../disconnected/installing.adoc#installing-disconnected-environments[Installing a cluster in a disconnected environment]
 * xref:../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+ifndef::openshift-origin[]
 * xref:../../disconnected/updating/disconnected-update-osus.adoc#updating-disconnected-cluster-osus[Updating a cluster in a disconnected environment using the OpenShift Update Service]
+endif::[]
+ifdef::openshift-origin[]
+* xref:../../disconnected/updating/disconnected-update.adoc#updating-disconnected-cluster[Updating a cluster in a disconnected environment by using the CLI]
+endif::[]
 
 // Intentionally linking to the OSUS update procedure since we probably want to steer users to do that workflow as much as possible. But I can change to the index of the update section if I shouldn't be as prescriptive.


### PR DESCRIPTION
Version(s): 4.16+

This PR removes some oc-mirror content from the OKD distro because the support has not been explicitly tested for OKD.

QE review:
- [ ] QE has approved this change.

Previews:

- [Benefits of enclave support](https://97086--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/about-installing-oc-mirror-v2.html#oc-mirror-enclave-support-about_about-installing-oc-mirror-v2) (OCP docs, section is unchanged)
- [oc-mirror plugin v2 support proxy setting](https://file.corp.redhat.com/skopacz/oc-mirror-okd/disconnected/mirroring/about-installing-oc-mirror-v2.html#oc-mirror-proxy-support_about-installing-oc-mirror-v2) (okd docs where enclave section is excluded, VPN required)
