### PR TITLE
oadp s3 bucket version support

### DIFF
--- a/modules/oadp-support-backup-data-immutability.adoc
+++ b/modules/oadp-support-backup-data-immutability.adoc
@@ -4,26 +4,27 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="oadp-support-backup-data-immutability_{context}"]
-= OADP does not support backup data immutability
+= OADP support for backup data immutability
 
-Starting with {oadp-short} 1.3, backups might not function as expected when the target object storage has an immutability option configured. These immutability options are referred to by different names, for example:
+[role="_abstract"]
+Starting with {oadp-short} 1.4, you can store {oadp-short} backups in an {aws-short} S3 bucket with enabled versioning. The versioning support is only for {aws-short} S3 buckets and not for S3-compatible buckets.
+
+See the following list for specific cloud provider limitations:
+
+* AWS S3 service supports backups because an S3 object lock applies only to versioned buckets. You can still update the object data for the new version. However, when backups are deleted, old versions of the objects are not deleted.
+
+* {oadp-short} backups are not supported and might not work as expected when you enable immutability on Azure Storage Blob.
+
+* GCP Cloud storage policy only supports bucket-level immutability. Therefore, it is not feasible to implement it in the GCP environment.
+
+
+Depending on your storage provider, the immutability options are called differently:
 
 * S3 object lock
 * Object retention
 * Bucket versioning
 * Write Once Read Many (WORM) buckets
 
-The primary reason for the absence of support is that {oadp-short} initially saves the state of a backup as _finalizing_ and then scrutinizes whether any asynchronous operations are in progress. 
+The primary reason for the absence of support for other S3-compatible object storage is that {oadp-short} initially saves the state of a backup as _finalizing_ and then verifies whether any asynchronous operations are in progress. 
 
-With versions before {oadp-short} 1.3, object storage with an immutability configuration was also not supported. You might see some problems even though backups are working. For example, version objects are not deleted when a backup is deleted.
 
-[NOTE]
-====
-Depending on the specific provider and configuration, backups might work in some cases.
-====
-
-* AWS S3 service supports backups because an S3 object lock only applies to versioned buckets. You can still update the object data for the new version. However, when backups are deleted, old versions of the objects are not deleted.
-
-* Azure Storage Blob supports both versioned-level immutability and container-level immutability. In a versioned-level situation, data immutability can still work in {oadp-short}, but not at the container level.
-
-* GCP Cloud storage policy only supports bucket-level immutability. Therefore, it is not feasible to implement it in the GCP environment.


### PR DESCRIPTION
## Jira 

* [OADP-5974](https://issues.redhat.com/browse/OADP-5974)

AWS S3 bucket versioning support

##  Version

* OCP 4.14 → OCP 4.20

## Preview

* [AWS S3 versioning support](https://97094--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#oadp-support-backup-data-immutability_about-installing-oadp)

## QE Review

* [x] QE has approved this change.
