### PR TITLE
[enterprise-4.16] OBSDOCS-2224a: fix oc CLI attribute

### DIFF
--- a/modules/monitoring-accessing-alerting-rules-for-your-project.adoc
+++ b/modules/monitoring-accessing-alerting-rules-for-your-project.adoc
@@ -12,7 +12,7 @@ To list alerting rules for a user-defined project, you must have been assigned t
 
 * You have enabled monitoring for user-defined projects.
 * You are logged in as a user that has the `monitoring-rules-view` cluster role for your project.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
+++ b/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
@@ -40,7 +40,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
 * You have created the secret to be configured in Alertmanager in the `{namespace-name}` project.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
+++ b/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
@@ -44,7 +44,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists in the `openshift-user-workload-monitoring` namespace. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -38,7 +38,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-choosing-a-metrics-collection-profile.adoc
+++ b/modules/monitoring-choosing-a-metrics-collection-profile.adoc
@@ -13,7 +13,7 @@ To choose a metrics collection profile for core {product-title} monitoring compo
 
 .Prerequisites
 
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 * You have enabled Technology Preview features by using the `FeatureGate` custom resource (CR).
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 * You have access to the cluster as a user with the `cluster-admin` cluster role.

--- a/modules/monitoring-configuring-a-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-persistent-volume-claim.adoc
@@ -38,7 +38,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-configuring-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-configuring-alert-routing-for-user-defined-projects.adoc
@@ -18,7 +18,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * Alert routing has been enabled for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 * You are logged in as a user that has the `alert-routing-edit` cluster role for the project for which you want to create alert routing.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc
+++ b/modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc
@@ -22,7 +22,7 @@ endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 endif::[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-configuring-external-alertmanagers.adoc
+++ b/modules/monitoring-configuring-external-alertmanagers.adoc
@@ -49,7 +49,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
+++ b/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
@@ -53,7 +53,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -37,7 +37,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 * You have set up a remote write compatible endpoint (such as Thanos) and know the endpoint URL. See the link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Prometheus remote endpoints and storage documentation] for information about endpoints that are compatible with the remote write feature.
 +
 [IMPORTANT]

--- a/modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc
@@ -19,7 +19,7 @@ You can create alerting rules for user-defined projects. Those alerting rules wi
 
 * You have enabled monitoring for user-defined projects.
 * You are logged in as a cluster administrator or as a user that has the `monitoring-rules-edit` cluster role for the project where you want to create an alerting rule.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
+++ b/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
@@ -48,7 +48,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `user-workload-monitoring-config` ConfigMap object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 * You have configured remote write storage.
 
 .Procedure

--- a/modules/monitoring-creating-cluster-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-cluster-monitoring-configmap.adoc
@@ -11,7 +11,7 @@ You can configure the core {product-title} monitoring components by creating and
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-creating-new-alerting-rules.adoc
+++ b/modules/monitoring-creating-new-alerting-rules.adoc
@@ -19,7 +19,7 @@ These alerting rules trigger alerts based on the values of chosen metrics.
 .Prerequisites
 
 * You have access to the cluster as a user that has the `cluster-admin` cluster role.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-creating-scrape-sample-alerts.adoc
+++ b/modules/monitoring-creating-scrape-sample-alerts.adoc
@@ -16,7 +16,7 @@ You can create alerts that notify you when:
 * You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
 * You have limited the number of samples that can be accepted per target scrape in user-defined projects, by using `enforcedSampleLimit`.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-creating-user-defined-workload-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-user-defined-workload-monitoring-configmap.adoc
@@ -18,7 +18,7 @@ You can configure the user workload monitoring components with the `user-workloa
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
+++ b/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
@@ -34,7 +34,7 @@ endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 endif::openshift-dedicated,openshift-rosa[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-disabling-the-local-alertmanager.adoc
+++ b/modules/monitoring-disabling-the-local-alertmanager.adoc
@@ -14,7 +14,7 @@ If you do not need the local Alertmanager, you can disable it by configuring the
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have created the `cluster-monitoring-config` config map.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
@@ -21,7 +21,7 @@ You must have access to the cluster as a user with the `cluster-admin` cluster r
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 * You have optionally created and configured the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project. You can add configuration options to this `ConfigMap` object for the components that monitor user-defined projects.
 +

--- a/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
+++ b/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
@@ -15,7 +15,7 @@ Because log rotation is not supported, only enable this feature temporarily when
 
 .Prerequisites
 
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 

--- a/modules/monitoring-enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing.adoc
@@ -12,7 +12,7 @@ You can allow users to create user-defined alert routing configurations that use
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * A cluster administrator has enabled monitoring for user-defined projects.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
@@ -19,7 +19,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 * You have enabled monitoring for user-defined projects.
 endif::[]
 * The user account that you are assigning the role to already exists.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc
@@ -12,7 +12,7 @@ As a cluster administrator, you can assign the `user-workload-monitoring-config-
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * The user account that you are assigning the role to already exists.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-installation-progress.adoc
+++ b/modules/monitoring-installation-progress.adoc
@@ -11,7 +11,7 @@ You can monitor high-level installation, bootstrap, and control plane logs as an
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 * You have SSH access to your hosts.
 * You have the fully qualified domain names of the bootstrap and control plane nodes.
 +

--- a/modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc
+++ b/modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc
@@ -22,7 +22,7 @@ endif::[]
 ifndef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `cluster-admin` role.
 endif::[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-modifying-core-platform-alerting-rules.adoc
+++ b/modules/monitoring-modifying-core-platform-alerting-rules.adoc
@@ -12,7 +12,7 @@ For example, you can change the severity label of an alert, add a custom label, 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -50,7 +50,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
+++ b/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
@@ -18,7 +18,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -40,7 +40,7 @@ It is not permitted to move components to control plane or infrastructure nodes.
 // tag::CPM[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 // end::CPM[]
 
 // tag::UWM[]
@@ -52,7 +52,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 // end::UWM[]
 
 .Procedure

--- a/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
+++ b/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
@@ -29,7 +29,7 @@ If you need to forward large amounts of data outside the cluster, use remote wri
 
 .Prerequisites
 
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 * You have access to the cluster as a user with the `cluster-monitoring-view` cluster role or have obtained a bearer token with `get` permission on the `namespaces` resource.
 +
 [NOTE]

--- a/modules/monitoring-querying-metrics-for-all-projects-with-mon-dashboard.adoc
+++ b/modules/monitoring-querying-metrics-for-all-projects-with-mon-dashboard.adoc
@@ -35,7 +35,7 @@ endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role or with view permissions for all projects.
 endif::openshift-dedicated,openshift-rosa[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-removing-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-removing-alerting-rules-for-user-defined-projects.adoc
@@ -12,7 +12,7 @@ You can remove alerting rules for user-defined projects.
 
 * You have enabled monitoring for user-defined projects.
 * You are logged in as a cluster administrator or as a user that has the `monitoring-rules-edit` cluster role for the project where you want to create an alerting rule.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-resizing-a-persistent-volume.adoc
+++ b/modules/monitoring-resizing-a-persistent-volume.adoc
@@ -44,7 +44,7 @@ You can only expand the size of the PVC. Shrinking the storage size is not possi
 * A cluster administrator has enabled monitoring for user-defined projects.
 * You have configured at least one PVC for components that monitor user-defined projects.
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-resolving-the-kubepersistentvolumefillingup-alert-firing-for-prometheus.adoc
+++ b/modules/monitoring-resolving-the-kubepersistentvolumefillingup-alert-firing-for-prometheus.adoc
@@ -29,7 +29,7 @@ endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 endif::openshift-dedicated,openshift-rosa[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-setting-audit-log-levels-for-the-prometheus-adapter.adoc
+++ b/modules/monitoring-setting-audit-log-levels-for-the-prometheus-adapter.adoc
@@ -11,7 +11,7 @@ In default platform monitoring, you can configure the audit log level for the Pr
 
 .Prerequisites
 
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 

--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -55,7 +55,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-setting-query-log-file-for-prometheus.adoc
+++ b/modules/monitoring-setting-query-log-file-for-prometheus.adoc
@@ -46,7 +46,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-setting-scrape-sample-and-label-limits-for-user-defined-projects.adoc
+++ b/modules/monitoring-setting-scrape-sample-and-label-limits-for-user-defined-projects.adoc
@@ -23,7 +23,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::openshift-dedicated,openshift-rosa[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.adoc
+++ b/modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.adoc
@@ -21,7 +21,7 @@ Prometheus then considers this target to be down and sets its `up` metric value 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 

--- a/modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc
+++ b/modules/monitoring-specifying-limits-and-requests-for-monitoring-components.adoc
@@ -35,7 +35,7 @@ To configure CPU and memory resources, specify values for resource limits and re
 // tag::UWM[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 // end::UWM[]
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 


### PR DESCRIPTION
manual cherry-pick of https://github.com/openshift/openshift-docs/pull/97060 to 4.16