### PR TITLE
RHDEVDOCS-6529: Release Note added for the disable-affinity-assistant flag

### DIFF
--- a/modules/op-configuring-pipelines-control-plane.adoc
+++ b/modules/op-configuring-pipelines-control-plane.adoc
@@ -34,6 +34,7 @@ spec:
     metrics.taskrun.duration-type: histogram
     metrics.pipelinerun.duration-type: histogram
     await-sidecar-readiness: true
+    coschedule: workspaces
     params:
       - name: enableMetrics
         value: 'true'

--- a/modules/op-modifiable-fields-with-default-values.adoc
+++ b/modules/op-modifiable-fields-with-default-values.adoc
@@ -47,3 +47,5 @@ You can modify the default values of the following metrics fields in the `Tekton
 * `metrics.taskrun.level` (default: `task`): This field determines the level of the task run metrics. Acceptable value is `taskrun`, `task`, or `namespace`.
 
 * `metrics.pipelinerun.level` (default: `pipeline`): This field determines the level of the pipeline run metrics. Acceptable value is `pipelinerun`, `pipeline`, or `namespace`.
+
+* `coschedule (default: `workspaces`): This flag determines how `PipelineRun` pods are scheduled with the affinity assistant. Acceptable values are `workspaces` or `disabled`.

--- a/modules/op-release-notes-1-19.adoc
+++ b/modules/op-release-notes-1-19.adoc
@@ -473,6 +473,8 @@ The existing job-based pruner must be disabled before enabling the event-based p
 
 * With this release, the `opc results list` command is replaced with the `opc results result list` command.
 
+* With this update, the `disable-affinity-assistant` flag is removed from the {pipelines-title} Operator. This flag is deprecated in {pipelines-title} v1.13 and does not have any effect in {pipelines-title} v1.19. The `disable-affinity-assistant flag is still available in the `TektonConfig` custom resource (CR) for backward compatibility, but it does not impact the behavior of the {pipelines-title} Operator. To maintain the same behavior, set the `coschedule` feature flag to `disabled`.
+
 [id="known-issues-1-19_{context}"]
 == Known issues
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

pipelines-docs-1.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6529

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Modifiable fields with default values](https://97141--ocpdocs-pr.netlify.app/openshift-pipelines/latest/install_config/customizing-configurations-in-the-tektonconfig-cr#op-modifiable-fields-with-default-values_customizing-configurations-in-the-tektonconfig-cr)
[Configuring the Red Hat OpenShift Pipelines control plane](https://97141--ocpdocs-pr.netlify.app/openshift-pipelines/latest/install_config/customizing-configurations-in-the-tektonconfig-cr#op-configuring-pipelines-control-plane_customizing-configurations-in-the-tektonconfig-cr)
A release note in the [Breaking changes](https://97141--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-19.html#breaking-changes-1-19_op-release-notes) section

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: athorp@redhat.com
Peer review: @shivanisathe25 
QE review: @srivickynesh 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
