### PR TITLE
CNV#52697: Fixes to USB config docs

### DIFF
--- a/modules/virt-configuring-vm-use-usb-device.adoc
+++ b/modules/virt-configuring-vm-use-usb-device.adoc
@@ -4,33 +4,58 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-configuring-vm-use-usb-device_{context}"]
-= Configuring a virtual machine connection to a USB device
+= Connecting a USB device to a virtual machine
 
-You can configure virtual machine (VM) access to a USB device. This configuration allows a guest to connect to actual USB hardware that is attached to an {product-title} node, as if the hardware and the VM are physically connected.
+You can configure virtual machine (VM) access to a USB device. This configuration enables the VM to connect to USB hardware that is attached to an {product-title} node, as if the hardware and the VM are physically connected.
 
 .Prerequisites
 
 * You have installed the {oc-first}.
+* You have attached the required USB device as a resource at the cluster level.
 
 .Procedure
 
-. Locate the USB device by running the following command:
+. In the `HyperConverged` custom resource (CR), find the assigned resource name of the USB device:
 +
 [source,terminal]
 ----
-$ oc /dev/serial/by-id/usb-VENDOR_device_name
+$ oc get hyperconverged kubevirt-hyperconverged -n openshift-cnv
+----
++
+*Example output*
++
+[source, yaml]
+----
+# ...
+  spec:  
+    permittedHostDevices:
+      usbHostDevices:
+        - resourceName: kubevirt.io/peripherals
+          selectors:
+            - vendor: "045e"
+              product: "07a5"
+            - vendor: "062a"
+              product: "4102"
+            - vendor: "072f"
+              product: "b100"
 ----
 
-. Open the virtual machine instance custom resource (CR) by running the following command:
+. Open the VM instance CR:
 +
 [source,terminal]
 ----
-$ oc edit vmi vmi-usb
+$ oc edit vmi <vmi_usb>
 ----
-
-. Edit the CR by adding a USB device, as shown in the following example:
 +
-.Example configuration
+where:
+
+<vmi_usb>:: Specifies the name of the `VirtualMachineInstance` CR.
+
+
+. Edit the CR by adding the USB device, as shown in the following example:
++
+*Example configuration*
++
 [source, yaml]
 ----
 apiVersion: kubevirt.io/v1
@@ -38,13 +63,24 @@ kind: VirtualMachineInstance
 metadata:
   labels:
     special: vmi-usb
-  name: vmi-usb <1>
+  name: vmi-usb
 spec:
   domain:
     devices:
       hostDevices:
       - deviceName: kubevirt.io/peripherals
-        name: local-peripherals
+        name: local-peripherals <1>
 # ...
 ----
 <1> The name of the USB device.
+
+. Apply the modifications to the VM configurations:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
++
+where:
+
+<filename>:: Specifies the name of the `VirtualMachineInstance` manifest YAML file.

--- a/modules/virt-enabling-usb-host-passthrough.adoc
+++ b/modules/virt-enabling-usb-host-passthrough.adoc
@@ -6,9 +6,9 @@
 [id="virt-enabling-usb-host-passthrough_{context}"]
 = Enabling USB host passthrough
 
-You can enable USB host passthrough at the cluster level.
+To attach a USB device to a virtual machine (VM), you must first enable USB host passthrough at the cluster level.
 
-You specify a resource name and USB device name for each device you want first to add and then assign to a virtual machine (VM). You can allocate more than one device, each of which is known as a `selector` in the HyperConverged (HCO) custom resource (CR), to a single resource name. If you have multiple, identical USB devices on the cluster, you can choose to allocate a VM to a specific device.
+To do this, specify a resource name and USB device name for each device you want first to add and then assign to a VM. You can allocate more than one device, each of which is known as a `selector` in the `HyperConverged` custom resource (CR), to a single resource name. If you have multiple identical USB devices on the cluster, you can choose to allocate a VM to a specific device.
 
 .Prerequisites
 
@@ -17,24 +17,92 @@ You specify a resource name and USB device name for each device you want first t
 
 .Procedure
 
-. Identify the USB device vendor and product by running the following command:
+. Ensure that the `HostDevices` feature gate is enabled:
++
+[source,terminal]
+----
+$ oc get featuregate cluster -o yaml
+----
++
+*Successful output*
++
+[source,yaml]
+----
+  featureGates:
+# ...
+    enabled:
+    - name: HostDevices
+----
+
+. Identify the USB device vendor and product:
 +
 [source,terminal]
 ----
 $ lsusb
 ----
-
-. Open the HCO CR by running the following command:
++
+*Example output*
 +
 [source,terminal]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+Bus 003 Device 007: ID 1b1c:0a60 example_manufacturer example_product_name
 ----
 
-. Add a USB device to the `permittedHostDevices` stanza, as shown in the following example:
-
+** If you cannot use the `lsusb` command, inspect the USB device configurations in the host's `/sys/bus/usb/devices/` directory:
 +
-.Example YAML snippet
+[source,terminal]
+----
+for dev in *; do
+    if [[ -f "$dev/idVendor" && -f "$dev/idProduct" ]]; then
+        echo "Device: $dev"
+        echo -n "  Manufacturer : "; cat "$dev/manufacturer"
+        echo -n "  Product: "; cat "$dev/product"
+        echo -n "  Vendor ID : "; cat "$dev/idVendor"
+        echo -n "  Product ID: "; cat "$dev/idProduct"
+        echo
+    fi
+done
+----
++
+*Example output*
++
+[source,terminal]
+----
+Device: 3-7
+  Manufacturer : example_manufacturer
+  Product: example_product_name
+  Vendor ID : 1b1c
+  Product ID: 0a60
+----
+
+
+. Add the required USB device to the `permittedHostDevices` stanza of the `HyperConvered` CR. The following example adds a device with vendor ID `045e` and product ID `07a5`: 
++
+[source,terminal]
+----
+oc patch hyperconverged kubevirt-hyperconverged \
+  -n openshift-cnv \
+  --type=merge \
+  -p '{
+    "metadata": {
+      "annotations": {
+        "kubevirt.kubevirt.io/jsonpatch": "[{\"op\": \"add\", \"path\": \"/spec/permittedHostDevices/usbHostDevices/-\", \"value\": {\"resourceName\": \"kubevirt.io/peripherals\", \"selectors\": [{\"vendor\": \"045e\", \"product\": \"07a5\"}]}}]"
+      }
+    }
+  }'
+----
+
+.Verification
+
+* Ensure that the HCO CR contains the required USB devices:
++
+[source,terminal]
+----
+$ oc get hyperconverged kubevirt-hyperconverged -n openshift-cnv
+----
++
+*Example output*
++
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
@@ -43,7 +111,6 @@ metadata:
    name: kubevirt-hyperconverged
    namespace: {CNVNamespace}
 spec:
-  configuration:
     permittedHostDevices: <1>
       usbHostDevices: <2>
         - resourceName: kubevirt.io/peripherals <3>

--- a/virt/managing_vms/advanced_vm_management/virt-configuring-usb-host-passthrough.adoc
+++ b/virt/managing_vms/advanced_vm_management/virt-configuring-usb-host-passthrough.adoc
@@ -6,9 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can expose USB devices in a cluster, making them available for virtual machine (VM) owners to assign to VMs. Enabling this passthrough of USB devices allows a guest to connect to actual USB hardware that is attached to an {product-title} node, as if the hardware and the VM are physically connected.
+As a cluster administrator, you can expose USB devices in a cluster, which makes the devices available for virtual machine (VM) owners to assign to VMs. Enabling this passthrough of USB devices allows a VM to connect to USB hardware that is attached to an {product-title} node, as if the hardware and the VM are physically connected.
 
-You can expose a USB device by first enabling host passthrough and then configuring the VM to use the USB device.
+To expose a USB device, first enable host passthrough and then configure the VM to use the USB device.
 
 include::modules/virt-enabling-usb-host-passthrough.adoc[leveloffset=+1]
 include::modules/virt-configuring-vm-use-usb-device.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.17 and later

Issue:
https://issues.redhat.com/browse/CNV-52697

Link to docs preview:
https://97142--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-configuring-usb-host-passthrough.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->