### PR TITLE
[enterprise-4.18] CNV-66175: Removed virtctl prereq and command from NIC hot plug proce…

### DIFF
--- a/modules/virt-hot-plugging-bridge-network-interface-cli.adoc
+++ b/modules/virt-hot-plugging-bridge-network-interface-cli.adoc
@@ -11,24 +11,14 @@ Hot plug a secondary network interface to a virtual machine (VM) while the VM is
 .Prerequisites
 
 * A network attachment definition is configured in the same namespace as your VM.
+* The VM to which you want to hot plug the network interface is running.
 * You have installed the `virtctl` tool.
-* You have installed the OpenShift CLI (`oc`).
+* You have permission to create and list `VirtualMachineInstanceMigration` objects.
+* You have installed the {oc-first}.
 
 .Procedure
 
-. If the VM to which you want to hot plug the network interface is not running, start it by using the following command:
-+
-[source,terminal]
-----
-$ virtctl start <vm_name> -n <namespace>
-----
-
-. Use the following command to add the new network interface to the running VM. Editing the VM specification adds the new network interface to the VM and virtual machine instance (VMI) configuration but does not attach it to the running VM.
-+
-[source,terminal]
-----
-$ oc edit vm <vm_name>
-----
+. Use your preferred text editor to edit the `VirtualMachine` manifest, as shown in the following example:
 +
 .Example VM configuration
 [source,yaml]


### PR DESCRIPTION
…dure

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-66175](https://issues.redhat.com//browse/CNV-66175)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Cherry picked from https://github.com/openshift/openshift-docs/commit/a7960ca5e511aa8bcae1a5222c1d7891547097fc xref: https://github.com/openshift/openshift-docs/pull/97079
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
