### PR TITLE
OSDOCS#59806: Correct the bug text for OCPBUGS-55016 for 4.18

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3360,7 +3360,7 @@ $ oc adm release info 4.18.14 --pullspecs
 
 * Previously, a missing `afterburn` package resulted in the failure of the `gcp-hostname.service`, which caused the `scale-up` job to fail, impacting end-user deployments. With this release, the `afterburn` package is installed in the {op-system-base} `scale-up` job. This fix enables a successful `scale-up` action, resolving the `gcp-hostname` service failure. (link:https://issues.redhat.com/browse/OCPBUGS-55158[OCPBUGS-55158])
 
-* Previously, there was no communication between a `localnet` pod and a pod in the default network when both pods were on the same node. With this release, an update fixes the communication problem when pods are on the same node. (link:https://issues.redhat.com/browse/OCPBUGS-55016[OCPBUGS-55016])
+* Previously, a pod with a secondary interface in an OVN-Kubernetes `Localnet` network that was plugged into a `br-ex` interface bridge was out of reach by other pods on the same node, but used the default network for communication. The communication between pods on different nodes was not impacted. With this release, the communication between a `Localnet` pod and a default network pod running on the same node is possible, however the IP addresses that are used in the `Localnet` network must be within the same subnet as the host network. (link:https://issues.redhat.com/browse/OCPBUGS-55016[OCPBUGS-55016])
 
 * Previously, image pull timeouts occurred due to the `Zscaler` platform scanning all data transfers. This resulted in timed out image pulls. With this release, the image pull timeout is increased to 30 seconds, allowing successful updates. (link:https://issues.redhat.com/browse/OCPBUGS-54663[OCPBUGS-54663])
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
Original: OSDOCS-59806
4.18 relnote: OCPBUGS-55016

Link to docs preview:
[4.18.14](https://97153--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-14-bug-fixes_release-notes) 

QE review:
- [ ] QE has approved this change.
N/A for z-streams

Additional information:
This bug text has been vetted and merged for 4.19 and the same text is used for this 4.18 bug text. The original Jira request for the corrected text is OSDOCS-59806.
