### PR TITLE
OSDOCS-15288 [NETOBSERV] Line breaks for troubleshooting-network-observability.adoc and its includes

### DIFF
--- a/modules/troubleshooting-network-observability-loki-large-query-timeout.adoc
+++ b/modules/troubleshooting-network-observability-loki-large-query-timeout.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-troubleshooting-large-query-timeout_{context}"]
 = Running a large query results in Loki errors
+
 When running large queries for a long time, Loki errors can occur, such as a `timeout` or `too many outstanding requests`. There is no complete corrective for this issue, but there are several ways to mitigate it:
 
 Adapt your query to add an indexed filter::
@@ -12,7 +13,7 @@ Consider querying Prometheus rather than Loki::
 Prometheus is a better fit than Loki to query on large time ranges. However, whether or not you can use Prometheus instead of Loki depends on the use case. For example, queries on Prometheus are much faster than on Loki, and large time ranges do not impact performance. But Prometheus metrics do not contain as much information as flow logs in Loki. The Network Observability OpenShift web console automatically favors Prometheus over Loki if the query is compatible; otherwise, it defaults to Loki. If your query does not run against Prometheus, you can change some filters or aggregations to make the switch. In the OpenShift web console, you can force the use of Prometheus. An error message is displayed when incompatible queries fail, which can help you figure out which labels to change to make the query compatible. For example, changing a filter or an aggregation from *Resource* or *Pods* to *Owner*.
 
 Consider using the FlowMetrics API to create your own metric::
-If the data that you need isn't available as a Prometheus metric, you can use the FlowMetrics API to create your own metric. For more information, see "FlowMetrics API Reference" and "Configuring custom metrics by using FlowMetric API". 
+If the data that you need isn't available as a Prometheus metric, you can use the FlowMetrics API to create your own metric. For more information, see "FlowMetrics API Reference" and "Configuring custom metrics by using FlowMetric API".
 
 Configure Loki to improve the query performance::
 +

--- a/modules/troubleshooting-network-observability-loki-resource-exhausted.adoc
+++ b/modules/troubleshooting-network-observability-loki-resource-exhausted.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-troubleshooting-loki-resource-exhausted_{context}"]
 = Troubleshooting Loki ResourceExhausted error
+
 Loki may return a `ResourceExhausted` error when network flow data sent by network observability exceeds the configured maximum message size. If you are using the Red{nbsp}Hat {loki-op}, this maximum message size is configured to 100 MiB.
 
 .Procedure

--- a/modules/troubleshooting-network-observability-loki-tenant-rate-limit.adoc
+++ b/modules/troubleshooting-network-observability-loki-tenant-rate-limit.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-troubleshooting-loki-tenant-rate-limit_{context}"]
 = LokiStack rate limit errors
+
 A rate-limit placed on the Loki tenant can result in potential temporary loss of data and a 429 error: `Per stream rate limit exceeded (limit:xMB/sec) while attempting to ingest for stream`. You might consider having an alert set to notify you of this error. For more information, see "Creating Loki rate limit alerts for the NetObserv dashboard" in the Additional resources of this section.
 
 You can update the LokiStack CRD with the `perStreamRateLimit` and `perStreamRateLimitBurst` specifications, as shown in the following procedure.

--- a/modules/troubleshooting-network-observability-must-gather.adoc
+++ b/modules/troubleshooting-network-observability-must-gather.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-must-gather_{context}"]
 = Using the must-gather tool
+
 You can use the must-gather tool to collect information about the Network Observability Operator resources and cluster-wide resources, such as pod logs, `FlowCollector`, and `webhook` configurations.
 
 .Procedure

--- a/observability/network_observability/troubleshooting-network-observability.adoc
+++ b/observability/network_observability/troubleshooting-network-observability.adoc
@@ -25,11 +25,13 @@ include::modules/troubleshooting-network-observability-query-loki-manually.adoc[
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-resources-table_network_observability[Resource considerations]
 
 include::modules/troubleshooting-network-observability-loki-resource-exhausted.adoc[leveloffset=+1]
+
 include::modules/troubleshooting-network-observability-loki-empty-ring.adoc[leveloffset=+1]
 
 == Resource troubleshooting
 
 include::modules/troubleshooting-network-observability-loki-tenant-rate-limit.adoc[leveloffset=+1]
+
 include::modules/troubleshooting-network-observability-loki-large-query-timeout.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
[OSDOCS-15288](https://issues.redhat.com//browse/OSDOCS-15288) [NETOBSERV] Line breaks for troubleshooting-network-observability.adoc and its includes

Version(s):
4.12, 4.14+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-15288

Link to docs preview:
https://97156--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html

QE review:
QE review is not required for this PR. This PR addresses style and template issues.

Additional information:
* Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. I will verify and create manual cherry-picks accordingly.
* There seem to have been some extra spaces that in some files that are now removed.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
