### PR TITLE
OSDOCS-15289 [NETOBSERV] Line breaks for understanding-network-observability-operator.adoc assembly

### DIFF
--- a/observability/network_observability/understanding-network-observability-operator.adoc
+++ b/observability/network_observability/understanding-network-observability-operator.adoc
@@ -9,6 +9,7 @@ toc::[]
 Network Observability is an OpenShift operator that deploys a monitoring pipeline to collect and enrich network traffic flows that are produced by the Network Observability eBPF agent.
 
 include::modules/nw-network-observability-operator.adoc[leveloffset=+1]
+
 include::modules/network-observability-architecture.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
[OSDOCS-15289](https://issues.redhat.com//browse/OSDOCS-15289) [NETOBSERV] Line breaks for understanding-network-observability-operator.adoc assembly

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15289

Link to docs preview:
https://97157--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/understanding-network-observability-operator.html

QE review:
QE review is not required for this PR. This PR addresses style and template issues.

Additional information:
* Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. I will verify and create manual cherry-picks accordingly.
* There seem to have been some extra spaces that in some files that are now removed.
