### PR TITLE
OLS-2006: OLS asciidoc content type checks

### DIFF
--- a/modules/ols-502-bad-gateway-errors.adoc
+++ b/modules/ols-502-bad-gateway-errors.adoc
@@ -1,7 +1,7 @@
 // This module is used in the following assemblies:
 // troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ols-502-bad-gateway-errors_{context}"]
 = 502 Bad Gateway Errors in the interface
 

--- a/modules/ols-feedback-collection-overview.adoc
+++ b/modules/ols-feedback-collection-overview.adoc
@@ -1,7 +1,7 @@
 // This module is used in the following assemblies:
 // about/ols-about-openshift-lightspeed.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ols-feedback-collection-overview_{context}"]
 = Feedback collection overview 
 

--- a/modules/ols-operator-missing-from-operatorhub-list.adoc
+++ b/modules/ols-operator-missing-from-operatorhub-list.adoc
@@ -1,7 +1,7 @@
 // This module is used in the following assemblies:
 // troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ols-operator-missing-from-operatorhub-list_{context}"]
 = Operator Missing from the Operator Hub list
 

--- a/modules/ols-remote-health-monitoring-overview.adoc
+++ b/modules/ols-remote-health-monitoring-overview.adoc
@@ -1,7 +1,7 @@
 // This module is used in the following assemblies:
 // about/ols-about-openshift-lightspeed.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ols-about-remote-health-monitoring-overview_{context}"]
 = Remote health monitoring overview
 

--- a/modules/ols-transcript-collection-overview.adoc
+++ b/modules/ols-transcript-collection-overview.adoc
@@ -1,7 +1,7 @@
 // This module is used in the following assemblies:
 // about/ols-about-openshift-lightspeed.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ols-transcript-collection-overview_{context}"]
 = Transcript collection overview 
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2006

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
