### PR TITLE
OSDOCS-15166: adds 4.17.37 async relnote to MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -241,3 +241,17 @@ Issued: 9 July 2025
 {product-title} release 4.17.35 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:10331[RHBA-2025:10331] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:10294[RHSA-2025:10294] advisory.
 
 See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-37-dp_{context}"]
+=== RHBA-2025:12508 - {microshift-short} 4.17.37 bug fix and enhancement update
+
+Issued: 7 Aug 2025
+
+{product-title} release 4.17.37 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:12508[RHBA-2025:12508] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:12437[RHSA-2025:12437] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-37-bug-fixes_{context}"]
+==== Bug fix
+
+* Before this update, {microshift-short} 4.17 used OpenVSwitch (OVS) 3.4. With this release, {microshift-short} now uses OVS 3.5, keeping OVS synchronized with OVN-Kubernetes. (link:https://issues.redhat.com/browse/OCPBUGS-58384[OCPBUGS-58384])


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-15166](https://issues.redhat.com/browse/OSDOCS-15166)

Link to docs preview:
[microshift-4-17-37-dp_release-notes](https://97169--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-37-dp_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
