### PR TITLE
OLS-2007: Remove early access language

### DIFF
--- a/modules/ols-openshift-lightspeed-overview.adoc
+++ b/modules/ols-openshift-lightspeed-overview.adoc
@@ -6,7 +6,3 @@
 = OpenShift Lightspeed overview 
 
 {ols-official} is a generative AI-powered virtual assistant for {ocp-product-title}. {ols-short} functionality uses a natural-language interface in the {ocp-short-name} web console to provide answers to questions that you ask about the product.
-
-This early access program exists so that customers can provide feedback on the user experience, features and capabilities, issues encountered, and any other aspects of the product so that {ols-short} can become more aligned with your needs when it is released and made generally available.
-
-


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2007

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
