### PR TITLE
OSDOCS#15617: Update the z-stream release notes for 4.15.56

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2797,6 +2797,32 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.56
+[id="ocp-4-15-56_{context}"]
+=== RHSA-2025:12370 - {product-title} 4.15.56 bug fix and security update
+
+Issued: 06 August 2025
+
+{product-title} release 4.15.56 is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:12370[RHSA-2025:12370] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:12371[RHBA-2025:12371] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.56 --pullspecs
+----
+
+[id="ocp-4-15-56-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, the loopback certificate expired because there was no validity period. With this release, a validity period is set and the loopback certificate does not expire. (link:https://issues.redhat.com/browse/OCPBUGS-59147[OCPBUGS-59147])
+
+[id="ocp-4-15-56-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.15.55
 [id="ocp-4-15-55_{context}"]
 === RHSA-2025:11351 - {product-title} 4.15.55 bug fix update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-15617](https://issues.redhat.com//browse/OSDOCS-15617)

Link to docs preview:
[4.15.56](https://97185--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-56_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 8/6/2025.
