### PR TITLE
OADP-6249 note for kubevirt restore using ceph

### DIFF
--- a/modules/oadp-restore-single-vm.adoc
+++ b/modules/oadp-restore-single-vm.adoc
@@ -40,3 +40,10 @@ spec:
 $ oc apply -f <restore_cr_file_name> # <1>
 ----
 <1> Specify the name of the `Restore` CR file.
++
+[NOTE]
+====
+When you restore a backup of VMs, you might notice that the Ceph storage capacity allocated for the restore is higher than expected. This behavior is observed only during the `kubevirt` restore and if the volume type of the VM is `block`.
+
+Use the `rbd sparsify` tool to reclaim space on target volumes. For more details, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/{product-version}/html/managing_and_allocating_storage_resources/reclaiming-space-on-target-volumes_rhodf[Reclaiming space on target volumes].
+====


### PR DESCRIPTION
## Jira 

* [OADP-6249](https://issues.redhat.com/browse/OADP-6249)

Added a note about the kubevirt restore behavior  in the virt section. 

##  Version

* OCP 4.19, 4.20

## Preview

* [note at the end of the section](https://97198--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-kubevirt.html#oadp-installing-dpa_installing-oadp-kubevirt)

<img width="1170" height="221" alt="image" src="https://github.com/user-attachments/assets/f384ae25-665d-4e73-889b-1a2a50bbc95a" />


## QE Review

* [x] QE has approved this change.
