### PR TITLE
OSDOCS-12711-16-rn: Documented the slb mode release note

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -700,9 +700,14 @@ For more information, see xref:../post_installation_configuration/changing-cloud
 === Networking
 
 [id="ocp-4-16-ipv6-default-ipvlan_{context}"]
-==== IPv6 unsolicited neighbor advertisements on IPVLAN CNI plugin (General Availability)
+==== IPv6 unsolicited neighbor advertisements on IPVLAN CNI plugin
 
 Pods created by using the `ipvlan` CNI plugin, where the IP address management CNI plugin has assigned IPs, now send IPv6 unsolicited neighbor advertisements by default onto the network. This feature has the General Availability status for {product-title} {product-version}.
+
+[id="ocp-4-16-networking-balance-slb-mode_{context}"]
+==== Enable OVS balance-slb mode for your cluster
+
+You can enable the Open vSwitch (OVS) `balance-slb` mode on infrastructure where your cluster runs so that two or more physical interfaces can share their network traffic. This feature has the General Availability status for {product-title} {product-version}. For more information, see xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#enabling-OVS-balance-slb-mode_ipi-install-installation-workflow[Enabling OVS balance-slb mode for your cluster].
 
 [id="ocp-4-16-sr-iov-network-metrics-exporter_{context}"]
 ==== Enabling the SR-IOV network metrics exporter


### PR DESCRIPTION
[CM SENT.](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r-5633795753090135082) - AIM TO MERGE PR ON the 11 of August.

Version(s):
4.16

Issue:
[4.16](https://issues.redhat.com/browse/OSDOCS-14925)

Link to docs preview:
* [SLB mode RN](https://97209--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-networking-balance-slb-mode_release-notes)


- [x] SME has approved this change.
- [x] QE has approved this change.
