### PR TITLE
[enterprise-4.20] OSDOCS#15433: Updated the default namespace LVMS to openshift-lvm-storage

### DIFF
--- a/modules/lvms-creating-lvmcluster-using-rhacm.adoc
+++ b/modules/lvms-creating-lvmcluster-using-rhacm.adoc
@@ -27,6 +27,7 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: lvms
+  namespace: openshift-lvm-storage
 spec:
   object-templates:
   - complianceType: musthave
@@ -35,7 +36,7 @@ spec:
       kind: LVMCluster
       metadata:
         name: my-lvmcluster
-        namespace: openshift-storage
+        namespace: openshift-lvm-storage
       spec:
         storage:
           deviceClasses: <1>

--- a/modules/lvms-creating-lvms-cluster-using-cli.adoc
+++ b/modules/lvms-creating-lvms-cluster-using-cli.adoc
@@ -36,6 +36,7 @@ apiVersion: lvm.topolvm.io/v1alpha1
 kind: LVMCluster
 metadata:
   name: my-lvmcluster
+  namespace: openshift-lvm-storage
 spec:
 # ...
   storage:

--- a/modules/lvms-creating-lvms-cluster-using-web-console.adoc
+++ b/modules/lvms-creating-lvms-cluster-using-web-console.adoc
@@ -27,7 +27,7 @@ You can only create a single instance of the `LVMCluster` custom resource (CR) o
 
 . Log in to the {product-title} web console.
 . Click *Operators* -> *Installed Operators*.
-. In the `openshift-storage` namespace, click *LVM Storage*.
+. In the `openshift-lvm-storage` namespace, click *{lvms}*.
 . Click *Create LVMCluster* and select either *Form view* or *YAML view*.
 . Configure the required `LVMCluster` CR parameters.
 . Click *Create*.

--- a/modules/lvms-deleting-lvmcluster-using-cli.adoc
+++ b/modules/lvms-deleting-lvmcluster-using-cli.adoc
@@ -20,7 +20,7 @@ You can delete the `LVMCluster` custom resource (CR) using the OpenShift CLI (`o
 +
 [source,terminal]
 ----
-$ oc delete lvmcluster <lvm_cluster_name> -n openshift-storage
+$ oc delete lvmcluster <lvm_cluster_name> -n <namespace>
 ----
 
 .Verification
@@ -35,5 +35,5 @@ $ oc get lvmcluster -n <namespace>
 .Example output
 [source,terminal]
 ----
-No resources found in openshift-storage namespace.
+No resources found in openshift-lvm-storage namespace.
 ----

--- a/modules/lvms-deleting-lvmcluster-using-rhacm.adoc
+++ b/modules/lvms-deleting-lvmcluster-using-rhacm.adoc
@@ -56,7 +56,7 @@ spec:
                 apiVersion: lvm.topolvm.io/v1alpha1
                 metadata:
                   name: my-lvmcluster
-                  namespace: openshift-storage <2>
+                  namespace: openshift-lvm-storage <2>
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -87,7 +87,7 @@ spec:
           - myvalue
 ----
 <1> The `spec.remediationAction` in `policy-template` is overridden by the preceding parameter value for `spec.remediationAction`.
-<2> This `namespace` field must have the `openshift-storage` value.
+<2> This `namespace` field must have the `openshift-lvm-storage` value.
 <3> Configure the requirements to select the clusters. {lvms} is uninstalled on the clusters that match the selection criteria. 
 
 . Create the `Policy` CR by running the following command:
@@ -129,7 +129,7 @@ spec:
                 apiVersion: lvm.topolvm.io/v1alpha1
                 metadata:
                   name: my-lvmcluster
-                  namespace: openshift-storage <2>
+                  namespace: openshift-lvm-storage <2>
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
@@ -160,7 +160,7 @@ spec:
           - myvalue
 ----
 <1> The `policy-template` `spec.remediationAction` is overridden by the preceding parameter value for `spec.remediationAction`.
-<2> The `namespace` field must have the `openshift-storage` value.
+<2> The `namespace` field must have the `openshift-lvm-storage` value.
 
 . Create the `Policy` CR by running the following command:
 +

--- a/modules/lvms-deleting-lvmcluster-using-web-console.adoc
+++ b/modules/lvms-deleting-lvmcluster-using-web-console.adoc
@@ -17,7 +17,7 @@ You can delete the `LVMCluster` custom resource (CR) using the {product-title} w
 
 . Log in to the {product-title} web console.
 . Click *Operators* → *Installed Operators* to view all the installed Operators.
-. Click *LVM Storage* in the `openshift-storage` namespace.
+. Click *{lvms}* in the `openshift-lvm-storage` namespace.
 . Click the *LVMCluster* tab.
 . From the *Actions*, select *Delete LVMCluster*.
 . Click *Delete*.

--- a/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
@@ -8,6 +8,11 @@
 
 As a cluster administrator, you can install {lvms} by using the OpenShift CLI.
 
+[NOTE]
+====
+The default namespace for the {lvms} Operator is `openshift-lvm-storage`.
+====
+
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).
@@ -28,7 +33,7 @@ metadata:
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged
-  name: openshift-storage
+  name: openshift-lvm-storage
 ----
 
 . Create the namespace by running the following command:
@@ -47,7 +52,7 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: openshift-storage-operatorgroup
-  namespace: openshift-storage
+  namespace: openshift-lvm-storage
 spec:
   targetNamespaces:
   - openshift-storage
@@ -69,7 +74,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: lvms
-  namespace: openshift-storage
+  namespace: openshift-lvm-storage
 spec:
   installPlanApproval: Automatic
   name: lvms-operator
@@ -90,7 +95,7 @@ $ oc create -f <file_name>
 +
 [source,terminal]
 ----
-$ oc get csv -n openshift-storage -o custom-columns=Name:.metadata.name,Phase:.status.phase
+$ oc get csv -n openshift-lvm-storage -o custom-columns=Name:.metadata.name,Phase:.status.phase
 ----
 +
 .Example output

--- a/modules/lvms-installing-logical-volume-manager-operator-using-openshift-web-console.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-openshift-web-console.adoc
@@ -8,6 +8,11 @@
 
 You can install {lvms} by using the {product-title} web console.
 
+[NOTE]
+====
+The default namespace for the {lvms} Operator is `openshift-lvm-storage`.
+====
+
 .Prerequisites
 
 * You have access to the cluster.
@@ -22,7 +27,7 @@ You can install {lvms} by using the {product-title} web console.
 .. *Update Channel* as *stable-{product-version}*.
 .. *Installation Mode* as *A specific namespace on the cluster*.
 .. *Installed Namespace* as *Operator recommended namespace openshift-storage*.
-   If the `openshift-storage` namespace does not exist, it is created during the operator installation.
+   If the `openshift-lvm-storage` namespace does not exist, it is created during the operator installation.
 .. *Update approval* as *Automatic* or *Manual*.
 +
 [NOTE]

--- a/modules/lvms-installing-logical-volume-manager-operator-using-rhacm.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-rhacm.adoc
@@ -91,24 +91,24 @@ spec:
                 pod-security.kubernetes.io/enforce: privileged
                 pod-security.kubernetes.io/audit: privileged
                 pod-security.kubernetes.io/warn: privileged
-              name: openshift-storage
+              name: openshift-lvm-storage
         - complianceType: musthave
           objectDefinition: <3>
             apiVersion: operators.coreos.com/v1
             kind: OperatorGroup
             metadata:
               name: openshift-storage-operatorgroup
-              namespace: openshift-storage
+              namespace: openshift-lvm-storage
             spec:
               targetNamespaces:
-              - openshift-storage
+              - openshift-lvm-storage
         - complianceType: musthave
           objectDefinition: <4>
             apiVersion: operators.coreos.com/v1alpha1
             kind: Subscription
             metadata:
               name: lvms
-              namespace: openshift-storage
+              namespace: openshift-lvm-storage
             spec:
               installPlanApproval: Automatic
               name: lvms-operator
@@ -134,3 +134,8 @@ Upon creating the `Policy` CR, the following custom resources are created on the
 * `Namespace`
 * `OperatorGroup`
 * `Subscription`
+
+[NOTE]
+====
+The default namespace for the {lvms} Operator is `openshift-lvm-storage`.
+====

--- a/modules/lvms-scaling-storage-of-clusters-using-rhacm.adoc
+++ b/modules/lvms-scaling-storage-of-clusters-using-rhacm.adoc
@@ -42,7 +42,7 @@ spec:
          kind: LVMCluster
          metadata:
            name: my-lvmcluster
-           namespace: openshift-storage
+           namespace: openshift-lvm-storage
          spec:
            storage:
              deviceClasses:

--- a/modules/lvms-scaling-storage-of-clusters-using-web-console.adoc
+++ b/modules/lvms-scaling-storage-of-clusters-using-web-console.adoc
@@ -17,7 +17,7 @@ You can scale up the storage capacity of the worker nodes on a cluster by using 
 
 . Log in to the {product-title} web console.
 . Click *Operators* -> *Installed Operators*. 
-. Click *LVM Storage* in the `openshift-storage` namespace.
+. Click *{lvms}* in the `openshift-lvm-storage` namespace.
 . Click the *LVMCluster* tab to view the `LVMCluster` CR created on the cluster.
 . From the *Actions* menu, select *Edit LVMCluster*.
 . Click the *YAML* tab.

--- a/modules/lvms-troubleshooting-performing-a-forced-cleanup.adoc
+++ b/modules/lvms-troubleshooting-performing-a-forced-cleanup.adoc
@@ -21,11 +21,11 @@ If the disk or node-related problems persist even after you have completed the t
 
 .Procedure
 
-. Switch to the `openshift-storage` namespace by running the following command:
+. Switch to the namespace where you have installed the {lvms} Operator by running the following command:
 +
 [source,terminal]
 ----
-$ oc project openshift-storage
+$ oc project <namespace>
 ----
 
 . Check if the `LogicalVolume` custom resources (CRs) are present by running the following command:

--- a/modules/lvms-troubleshooting-recovering-from-missing-lvms-or-operator-components.adoc
+++ b/modules/lvms-troubleshooting-recovering-from-missing-lvms-or-operator-components.adoc
@@ -19,7 +19,7 @@ If you encounter the `storage class not found` error, check the `LVMCluster` cus
 +
 [source,terminal]
 ----
-$ oc get lvmcluster -n openshift-storage
+$ oc get lvmcluster -n <namespace>
 ----
 +
 .Example output
@@ -31,11 +31,11 @@ my-lvmcluster   65m
 
 . If the `LVMCluster` CR is not present, create an `LVMCluster` CR. For more information, see "Ways to create an LVMCluster custom resource".
 
-. In the `openshift-storage` namespace, check that all the {lvms} pods are in the `Running` state by running the following command:
+. In the namespace where the operator is installed, check that all the {lvms} pods are in the `Running` state by running the following command:
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-storage
+$ oc get pods -n <namespace>
 ----
 +
 .Example output
@@ -57,5 +57,5 @@ If the `vg-manager` pod is stuck while loading a configuration file, it is due t
 +
 [source,terminal]
 ----
-$ oc logs -l app.kubernetes.io/component=vg-manager -n openshift-storage
+$ oc logs -l app.kubernetes.io/component=vg-manager -n <namespace>
 ----

--- a/modules/lvms-troubleshooting-recovering-from-node-failure.adoc
+++ b/modules/lvms-troubleshooting-recovering-from-node-failure.adoc
@@ -21,7 +21,7 @@ To identify the failed node, you can examine the restart count of the `topolvm-n
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-storage
+$ oc get pods -n <namespace>
 ----
 +
 .Example output

--- a/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc
+++ b/modules/lvms-uninstalling-logical-volume-manager-operator-using-openshift-web-console.adoc
@@ -19,7 +19,7 @@ You can uninstall {lvms} using the {product-title} web console.
 
 . Log in to the {product-title} web console.
 . Click *Operators* → *Installed Operators*.
-. Click *LVM Storage* in the `openshift-storage` namespace.
+. Click *{lvms}* in the `openshift-lvm-storage` namespace.
 . Click the *Details* tab. 
 . From the *Actions* menu, select *Uninstall Operator*.
 . Optional: When prompted, select the *Delete all operand instances for this operator* checkbox to delete the operand instances for {lvms}. 

--- a/modules/lvms-uninstalling-logical-volume-manager-operator-using-rhacm.adoc
+++ b/modules/lvms-uninstalling-logical-volume-manager-operator-using-rhacm.adoc
@@ -82,24 +82,24 @@ spec:
             apiVersion: v1
             kind: Namespace
             metadata:
-              name: openshift-storage
+              name: openshift-lvm-storage
         - complianceType: mustnothave
           objectDefinition:
             apiVersion: operators.coreos.com/v1
             kind: OperatorGroup
             metadata:
               name: openshift-storage-operatorgroup
-              namespace: openshift-storage
+              namespace: openshift-lvm-storage
             spec:
               targetNamespaces:
-              - openshift-storage
+              - openshift-lvm-storage
         - complianceType: mustnothave
           objectDefinition:
             apiVersion: operators.coreos.com/v1alpha1
             kind: Subscription
             metadata:
               name: lvms-operator
-              namespace: openshift-storage
+              namespace: openshift-lvm-storage
         remediationAction: enforce
         severity: low
   - objectDefinition:

--- a/modules/lvms-updating-lvms.adoc
+++ b/modules/lvms-updating-lvms.adoc
@@ -8,6 +8,11 @@
 
 You can update {lvms} to ensure compatibility with the {product-title} version.
 
+[NOTE]
+====
+The default namespace for the {lvms} Operator is `openshift-lvm-storage`.
+====
+
 .Prerequisites
 
 * You have updated your {product-title} cluster.
@@ -26,7 +31,7 @@ You can update {lvms} to ensure compatibility with the {product-title} version.
 +
 [source,terminal]
 ----
-$ oc patch subscription lvms-operator -n openshift-storage --type merge --patch '{"spec":{"channel":"<update_channel>"}}' <1>
+$ oc patch subscription lvms-operator -n openshift-lvm-storage --type merge --patch '{"spec":{"channel":"<update_channel>"}}' <1>
 ----
 <1> Replace `<update_channel>` with the version of {lvms} that you want to install. For example, `stable-{product-version}`.
 
@@ -34,7 +39,7 @@ $ oc patch subscription lvms-operator -n openshift-storage --type merge --patch 
 +
 [source,terminal]
 ----
-$ oc get events -n openshift-storage
+$ oc get events -n openshift-lvm-storage
 ----
 +
 .Example output
@@ -56,7 +61,7 @@ $ oc get events -n openshift-storage
 +
 [source,terminal]
 ----
-$ oc get subscription lvms-operator -n openshift-storage -o jsonpath='{.status.installedCSV}'
+$ oc get subscription lvms-operator -n openshift-lvm-storage -o jsonpath='{.status.installedCSV}'
 ----
 +
 .Example output


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-15433](https://issues.redhat.com/browse/OSDOCS-15433)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Cherry-picked from: 098fbdb0e9e00858dd7c11aee40931738d333d1c

xref: https://github.com/openshift/openshift-docs/pull/96949