### PR TITLE
opp-docs-main-content-types

### DIFF
--- a/modules/opp-architecture-architecture.adoc
+++ b/modules/opp-architecture-architecture.adoc
@@ -2,7 +2,7 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="opp-architecture-architecture_{context}"]
 = {product-title} description and architecture
 

--- a/modules/opp-architecture-compatibility-matrix.adoc
+++ b/modules/opp-architecture-compatibility-matrix.adoc
@@ -2,7 +2,7 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_module-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="opp-architecture-compatibility-matrix_{context}"]
 = {product-title} product release compatibility matrix
 

--- a/modules/opp-architecture-installation.adoc
+++ b/modules/opp-architecture-installation.adoc
@@ -2,7 +2,7 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="opp-architecture-installation_{context}"]
 = Install {product-title} products
 

--- a/modules/opp-architecture-installing-policyset.adoc
+++ b/modules/opp-architecture-installing-policyset.adoc
@@ -2,7 +2,7 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="opp-architecture-installing-policyset_{context}"]
 
 = Installing {product-title} by using policy sets

--- a/modules/opp-architecture-relnotes.adoc
+++ b/modules/opp-architecture-relnotes.adoc
@@ -2,7 +2,7 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_module-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="opp-architecture-relnotes_{context}"]
 = {product-title} product release notes
 

--- a/modules/opp-architecture-support.adoc
+++ b/modules/opp-architecture-support.adoc
@@ -2,7 +2,7 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_module-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="opp-architecture-support_{context}"]
 = Get support for {product-title}
 


### PR DESCRIPTION
Close by EOD Monday the 11th of August.

This PR fixes a few files module files that are missing the `mod-docs-content-type` tag. I also had to fix one link that was clearly not pointing to the target module. 

The main purpose of this PR is to test https://github.com/jhradilek/content-type-editor/tree/main

Version(s):
opp-docs-main

Issue:
N/A

Link to docs preview:
Too many files. 
