### PR TITLE
rhde-docs-main-content-types

### DIFF
--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -2,7 +2,7 @@
 //
 // scalability_and_performance/managing-bare-metal-hosts.adoc
 
-:_content-type: CONCEPT
+:_mod-docs-content-type: CONCEPT
 [id="about-rhde_{context}"]
 = About {product-title}
 


### PR DESCRIPTION
Close by EOD Monday the 11th of August.

This PR fixes a few files module files that are missing the `mod-docs-content-type` tag. I also had to fix one link that was clearly not pointing to the target module. 

The main purpose of this PR is to test https://github.com/jhradilek/content-type-editor/tree/main

Version(s):
rhde-docs-main

Issue:
N/A

Link to docs preview:
Too many files. 
