### PR TITLE
OSSM-10509 Short notice pending tasks post 3.1 release

### DIFF
--- a/modules/ossm-release-notes-3-1-known-issues.adoc
+++ b/modules/ossm-release-notes-3-1-known-issues.adoc
@@ -9,8 +9,15 @@
 [id="pod-health-check-issues-ovn-k-cni-ambient-mode_{context}"]
 == Pod health check issues with OVN-K CNI in ambient mode
 
-There is currently a known issue where pod health checks (`liveness` and `readiness` probes) may fail in ambient mode when using the OVN-Kubernetes Container Network Interface (CNI) on OpenShift Container Platform (OCP) 4.18 and earlier releases, such as OCP 4.16. This issue causes pods to enter a `CrashLoopBackOff` state, even though the application containers are running as expected.
+There is currently a known issue where the liveness and readiness probes pod health checks might fail in ambient mode. When using the OVN-Kubernetes Container Network Interface (CNI) on {ocp-product-title} 4.18 and earlier, this issue causes pods to enter a CrashLoopBackOff state, even though the application containers are running as expected
 
 Workaround: Configure the OVN-Kubernetes CNI to use local gateway mode by setting the `routingViaHost` field as `true` in the `gatewayConfig` specification in the Cluster Network Operator.
 
 For configuration details, see “Configuring Gateway Mode”. link:https://issues.redhat.com/browse/OSSM-9053[OSSM-9053]
+
+[id="podDisruptionBudget-object-prevents-nodes-from-upgrading_{context}"]
+== `podDisruptionBudget` object that prevents nodes from upgrading
+
+There is currently a known issue that prevents {ocp-product-title} nodes from upgrading. The `podDisruptionBudget` resource prevents the draining of the node where the `istiod` pod is running, unless there are multiple replicas of the `istiod` pod.
+
+Workaround: Set the `.spec.values.global.defaultPodDisruptionBudget.enabled` field in the {istio} CR to `false`. Alternatively, you can temporarily increase the number of replicas for the `istiod` deployment. link:https://issues.redhat.com/browse/OSSM-9392[OSSM-9392]

--- a/modules/ossm-release-notes-3-1-new-features-enhancements.adoc
+++ b/modules/ossm-release-notes-3-1-new-features-enhancements.adoc
@@ -10,6 +10,8 @@ This release makes {SMProductName} 3.1 generally available, adds new features, a
 
 For a list of supported component versions and support features, see "Service Mesh 3.0 feature support tables".
 
+When upgrading from {SMProduct} 2.x, first you must migrate to version 3.0. Then, you can upgrade to version 3.1. For more information see, "Migrating from Service Mesh 2 to Service Mesh 3".
+
 [id="support-for-kubernetes-gateway-api_{context}"]
 == Support for Kubernetes Gateway API
 

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,8 +16,8 @@ For additional information about the {SMProductName} life cycle and supported pl
 //03/25/2025:
 //Gwynne is rotating off Service Mesh. For next writer and CS: Continue to refine the IA for rel notes. The structure and IA will likely make more sense as there are more z-streams and versions released, making it easier to see how best to lay rel notes out in docs.redhat. Should anything be its own tile to make it easier to find for users?
 
-include::modules/ossm-release-notes-3-1-technology-preview-features.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-1-new-features-enhancements.adoc[leveloffset=+1]
+include::modules/ossm-release-notes-3-1-technology-preview-features.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-1-fixed-issues.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-1-known-issues.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-1-deprecated-features.adoc[leveloffset=+1]
@@ -30,6 +30,7 @@ include::modules/ossm-release-notes-3-1-deprecated-features.adoc[leveloffset=+1]
 * xref:../install/ossm-istio-ambient-mode.adoc#ossm-istio-ambient-mode[Istio ambient mode]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/networking/ovn-kubernetes-network-plugin#configuring-gateway-mode[Configuring gateway mode]
 * link:https://istio.io/latest/docs/ops/configuration/traffic-management/dns-proxy/#address-auto-allocation[Address auto-allocation]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/migrating_from_service_mesh_2_to_service_mesh_3/ossm-migrating-from-service-mesh-2-to-3[Migrating from Service Mesh 2 to Service Mesh 3]
 
 include::modules/ossm-release-notes-3-0-3.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-0-2.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Short notice pending tasks post 3.1 release

Doc JIRA: https://issues.redhat.com/browse/OSSM-10509

Merge to: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

Doc Preview: 
Known Issue added: https://97216--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html#podDisruptionBudget-object-prevents-nodes-from-upgrading_ossm-release-notes

Information about Migration guides: https://97216--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html#ossm-release-3-1-new-features-enhancements_ossm-release-notes

QE Review: @pbajjuri20 
Peer Review: @rh-tokeefe 