### PR TITLE
OSDOCS-14020-fix: Fixed misplaced ifdef statement

### DIFF
--- a/modules/installation-about-custom-azure-vnet.adoc
+++ b/modules/installation-about-custom-azure-vnet.adoc
@@ -170,9 +170,7 @@ the Cluster Version Operator on port `9099`.
 |IPsec NAT-T packets
 
 |`123`
-|Network Time Protocol (NTP) on UDP port `123`
-
-If you configure an external NTP time server, you must open UDP port `123`.
+|Network Time Protocol (NTP) on UDP port `123`. If you configure an external NTP time server, you must open UDP port `123`.
 
 |TCP/UDP
 |`30000`-`32767`

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -176,9 +176,7 @@ the Cluster Version Operator on port `9099`.
 |IPsec NAT-T packets
 
 |`123`
-|Network Time Protocol (NTP) on UDP port `123`
-
-If an external NTP time server is configured, you must open UDP port `123`.
+|Network Time Protocol (NTP) on UDP port `123`. If an external NTP time server is configured, you must open UDP port `123`.
 
 |TCP/UDP
 |`30000`-`32767`

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -328,6 +328,13 @@ Additionally, the user requires some `ReadOnly` permissions, and some of the rol
 |False
 |Listed required privileges
 
+ifdef::upi[]
+|vSphere vCenter data center
+|Existing folder
+|False
+|`ReadOnly` permission
+endif::upi[]
+
 ifdef::ipi[]
 .2+|vSphere vCenter data center
 |Existing folder

--- a/modules/installation-vsphere-installer-network-requirements.adoc
+++ b/modules/installation-vsphere-installer-network-requirements.adoc
@@ -26,7 +26,7 @@ Review the following details about the required network ports.
 |N/A
 |Network reachability tests
 
-.4+|TCP
+.3+|TCP
 |`1936`
 |Metrics
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-14020](https://issues.redhat.com/browse/OSDOCS-14020) and [OCPBUGS-59859](https://issues.redhat.com/browse/OCPBUGS-59859)

Link to docs preview:
* [IPI](https://97235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html)
* [UPI](https://97235--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.html)

- [x] SME has approved this change (Joe Callen).
- [x] QE has approved this change (Shang Gao).

https://github.com/openshift/installer/blob/main/pkg/types/vsphere/platform.go#L246-L252
https://github.com/openshift/installer/blob/730366cdf994addd363c50a45cc7da306c0d12b2/pkg/infrastructure/vsphere/clusterapi/clusterapi.go#L47-L57
