### PR TITLE
[RHDEVDOCS-6541] Release notes for Pipelines 1.19.2

### DIFF
--- a/modules/op-release-notes-1-19-2.adoc
+++ b/modules/op-release-notes-1-19-2.adoc
@@ -1,0 +1,25 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-19.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-19-2_{context}"]
+= Release notes for {pipelines-title} 1.19.2
+
+With this update, {pipelines-title} General Availability (GA) 1.19.2 is available on {OCP} 4.15 and later versions.
+
+[id="fixed-issues-1-19-2_{context}"]
+== Fixed issues
+
+* Before this update, when you installed the {pipelines-shortname} Operator 1.19.0 by using the web console, the `Tekton Pruner` API was incorrectly visible in the _Details_ section. With this update, the `Tekton Pruner`` API is no longer visible in the web console, as intended by the pruner design.
+
+* Before this update, there were only limited tasks fetched from ArtifactHUB in the pipeline builder page, and on search for a task, if the task was not available in the first fetched list, then that task was not displayed. With this update, UI makes an API call to ArtifactHub to search for a task in Pipeline builder quick search and lists them to install.
+
+* Before this update, the Pipeline Builder page only fetched a limited number of tasks from Artifact Hub. If a searched task was not included in that initial list, it would not appear in the results. With this update, the UI now makes a direct API call to Artifact Hub during quick search, allowing users to find and list additional tasks for installation.
+
+* Before this update, the _Events_ tab for a `PipelineRun` did not display any events. With this update, the tab now correctly shows events, allowing you to view relevant activity for each `PipelineRun`.
+
+* Before this update, `onError` variable substitution did not work with the `v1beta1` API. With this update, the issue has been fixed. 
+
+* Before this update, the Git resolver did not use the provided `gitToken` and `gitTokenKey` for remote authentication, which caused HTTP token-based authentication to fail. With this update, all Git resolver operations now use the provided `gitToken` for remote authentication.
+
+

--- a/release_notes/op-release-notes-1-19.adoc
+++ b/release_notes/op-release-notes-1-19.adoc
@@ -34,3 +34,5 @@ include::modules/op-release-notes-1-19.adoc[leveloffset=+1]
 // Release notes for Red Hat OpenShift Pipelines 1.19.1 
 include::modules/op-release-notes-1-19-1.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.19.2 
+include::modules/op-release-notes-1-19-2.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
pipelines-docs-1.19

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6541

Link to docs preview:
- [1.19.2 Release notes](https://97246--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-19.html#op-release-notes-1-19-2_op-release-notes)

QE review:
- [ ] QE has approved this change.
