### PR TITLE
OCPBUGS-57928: Added forbidden reserved interface names to various Nm…

### DIFF
--- a/modules/virt-create-node-network-config-console.adoc
+++ b/modules/virt-create-node-network-config-console.adoc
@@ -4,7 +4,28 @@
 
 You can create a policy by using either a form or YAML in the web console.
 
+[WARNING]
+====
+The following list of interface names are reserved and you cannot use the names with NMstate configurations:
+
+* `br-ext`
+* `br-int`
+* `br-local`
+* `br-nexthop`
+* `br0`
+* `ext-vxlan`
+* `ext`
+* `genev_sys_*`
+* `int`
+* `k8s-*`
+* `ovn-k8s-*`
+* `patch-br-*`
+* `tun0`
+* `vxlan_sys_*`
+====
+
 .Procedure
+
 . Navigate to *Networking* → *NodeNetworkConfigurationPolicy*.
 
 . In the *NodeNetworkConfigurationPolicy* page, click *Create*, and select *From Form* option.

--- a/modules/virt-example-bridge-nncp.adoc
+++ b/modules/virt-example-bridge-nncp.adoc
@@ -9,6 +9,26 @@
 Create a Linux bridge interface on nodes in the cluster by applying a `NodeNetworkConfigurationPolicy` manifest
 to the cluster.
 
+[WARNING]
+====
+The following list of interface names are reserved and you cannot use the names with NMstate configurations:
+
+* `br-ext`
+* `br-int`
+* `br-local`
+* `br-nexthop`
+* `br0`
+* `ext-vxlan`
+* `ext`
+* `genev_sys_*`
+* `int`
+* `k8s-*`
+* `ovn-k8s-*`
+* `patch-br-*`
+* `tun0`
+* `vxlan_sys_*`
+====
+
 The following YAML file is an example of a manifest for a Linux bridge interface.
 It includes samples values that you must replace with your own information.
 


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OCPBUGS-57938](https://issues.redhat.com/browse/OCPBUGS-57938)

Link to docs preview:
* [Creating a policy](https://97249--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-create-node-network-config-console_k8s-nmstate-updating-node-network-config)
* [Example: Linux bridge interface node network configuration policy](https://97249--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-bridge-nncp_k8s-nmstate-updating-node-network-config)

- [ ] SME has approved this change.
- [ ] QE has approved this change.
