### PR TITLE
OLS-1990 removed virtual machine, OKE is now a subscription service

### DIFF
--- a/modules/ols-about-subscription-requirements.adoc
+++ b/modules/ols-about-subscription-requirements.adoc
@@ -7,7 +7,7 @@
 
 {ols-official} requires an active and valid subscription to one of the following products:
 
-* {oke-first}, only supported for virtual machines
+* {oke-first}
 * {ove-first}
 * {ocp-product-title}
 * {opp-first}


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-1990
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://97254--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/install/ols-installing-openshift-lightspeed#about-subscription-requirements_ols-installing-openshift-lightspeed
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
