### PR TITLE
add error level vale DITA rule to modules vale.ini

### DIFF
--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -8,7 +8,7 @@ Vocab = OpenShiftDocs
 BasedOnStyles = OpenShiftAsciiDoc, AsciiDoc, RedHat
 
 # Enabling certain DITA rules (YES)
-AsciiDocDITA.AdmonitionTitle = YES
+AsciiDocDITA.TaskExample = YES
 
 # Use local OpenShiftDocs Vocab terms
 Vale.Terms = YES


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OSDOCS-15673
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Additional information: follow up POC for:
- #96908
- #97092

the CI bot doesn't flag anything below an error level alert. the previous rule was a warning level alert, so this PR chooses a new rule that will produce an error

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
