### PR TITLE
[CNV#66620] IBM Z network interfaces not supported

### DIFF
--- a/modules/virt-networking-wizard-fields-web.adoc
+++ b/modules/virt-networking-wizard-fields-web.adoc
@@ -17,6 +17,8 @@
 |Model
 |Indicates the model of the network interface controller. Supported values are *e1000e* and *virtio*.
 
+On {ibm-z-name}, the only valid NIC model option is *virtio*. *e1000e* is not supported.
+
 |Network
 |List of available network attachment definitions.
 
@@ -26,6 +28,8 @@ a|List of available binding methods. Select the binding method suitable for the 
 * Default pod network: `masquerade`
 * Linux bridge network: `bridge`
 * SR-IOV network: `SR-IOV`
++
+On {ibm-z-name}, `SR-IOV` is not supported.
 
 |MAC Address
 |MAC address for the network interface controller. If a MAC address is not specified, one is assigned automatically.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/CNV-66620
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
