### PR TITLE
OSDOCS-12711-19-rn: Removed slb mode note as it was GA in 4.16

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -803,11 +803,6 @@ For more information, see xref:../updating/preparing_for_updates/updating-cluste
 ==== Updates to Gateway API custom resource definitions (CRDs)
 {product-title} {product-version} updates {SMProductName} to version 3.0.2, and Gateway API to version 1.2.1. See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/release_notes/ossm-release-notes[{SMProductShortName} 3.0.0 release notes] and the link:https://github.com/kubernetes-sigs/gateway-api/blob/main/CHANGELOG/1.2-CHANGELOG.md#v121[Gateway API 1.2.1 changelog] for more information.
 
-[id="ocp-4-19-networking-balance-slb-mode_{context}"]
-==== Enable OVS balance-slb mode for your cluster (General Availability)
-
-You can enable the Open vSwitch (OVS) `balance-slb` mode on infrastructure where your cluster runs so that two or more physical interfaces can share their network traffic. For more information, see xref:../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#enabling-OVS-balance-slb-mode_ipi-install-installation-workflow[Enabling OVS balance-slb mode for your cluster].
-
 [id="ocp-4-19-networking-allocate-load-balancers-to-specific-subnets_{context}"]
 ==== Allocate API and ingress load balancers to specific subnets
 With this release, you can now allocate load balancers to customize deployments when installing an {product-title} cluster on AWS. This feature ensures optimal traffic distribution, high application availability, uninterrupted service, and network segmentation.


### PR DESCRIPTION
[CM SENT.](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r-5633795753090135082)

Version(s):
4.19

Issue:
[OSDOCS-14925](https://issues.redhat.com/browse/OSDOCS-14925)

Link to docs preview:
* [SLB mode RN](https://97276--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html)


- [x] SME has approved this change.
- [x] QE has approved this change.
