### PR TITLE
OSSM-10063  2.6.9 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -194,7 +194,7 @@ endif::[]
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.8
+:SMProductVersion: 2.6.9
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-5-12.adoc
+++ b/modules/ossm-release-2-5-12.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/servicemesh-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-5-12_{context}"]
+= {SMProductName} version 2.5.12
+
+This release of {SMProductName} is included with the {SMProductName} Operator 2.6.9 and is supported on {product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs).
+
+[id="ossm-release-2-5-12-components_{context}"]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.18.7
+
+|Envoy Proxy
+|1.26.8
+
+|Kiali Server
+|1.73.21
+|===

--- a/modules/ossm-release-2-6-9.adoc
+++ b/modules/ossm-release-2-6-9.adoc
@@ -3,16 +3,16 @@
 // * service_mesh/v2x/servicemesh-release-notes.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="ossm-release-2-6-8_{context}"]
-= {SMProductName} version 2.6.8
+[id="ossm-release-2-6-9_{context}"]
+= {SMProductName} version 2.6.9
 
-This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.8, and includes the following `ServiceMeshControlPlane` resource version updates: 2.6.8 and 2.5.11.
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.9, and includes the following `ServiceMeshControlPlane` resource version updates: 2.6.9 and 2.5.12.
 
 This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
 
 You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
-[id="ossm-release-2-6-8-components_{context}"]
+[id="ossm-release-2-6-9-components_{context}"]
 == Component updates
 
 |===

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -8,6 +8,10 @@ toc::[]
 
 // The following include statements pull in the module files that comprise 2.x release notes.
 
+include::modules/ossm-release-2-6-9.adoc[leveloffset=+1]
+
+include::modules/ossm-release-2-5-12.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-8.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-5-11.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.9 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-10063

Fix Version: 4.14+

Doc Preview: https://97282--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-release-2-6-9_ossm-release-notes

QE Review: @unsortedhashsets @mkralik3 
Peer Review: @kaldesai 