### PR TITLE
OSDOCS#44070 - Docs for vLAN ID in localnet NAD #2

### DIFF
--- a/modules/virt-creating-localnet-nad-cli.adoc
+++ b/modules/virt-creating-localnet-nad-cli.adoc
@@ -61,7 +61,8 @@ spec:
             "type": "ovn-k8s-cni-overlay", <3>
             "topology": "localnet", <4>
             "mtu": 1500, <5>
-            "netAttachDefName": "default/localnet-network" <6>
+            "vlanID": 200, <6>
+            "netAttachDefName": "default/localnet-network" <7>
     }
 ----
 <1> The CNI specification version. The required value is `0.3.1`.
@@ -69,7 +70,8 @@ spec:
 <3> The name of the CNI plug-in to be configured. The required value is `ovn-k8s-cni-overlay`.
 <4> The topological configuration for the network. The required value is `localnet`.
 <5> Optional: The maximum transmission unit (MTU) value. If you do not set a value, the Cluster Network Operator (CNO) sets a default MTU value by calculating the difference among the underlay MTU of the primary network interface, the overlay MTU of the pod network, and byte capacity of any enabled features, such as IPsec.
-<6> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
+<6> Optionally, for more fine-grained network management, you can configure a virtual LAN (VLAN) ID for the NAD. VMs that use this NAD have an interface that can communicate only with devices that use the same VLAN ID (`200` in this example).
+<7> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
 
 . Apply the manifest:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15 - 4.18

Issue:
https://issues.redhat.com/browse/CNV-44070

Link to docs preview:
https://97319--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.html#virt-creating-localnet-nad-cli_virt-connecting-vm-to-ovn-secondary-network

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This aims to be a replacement for https://github.com/openshift/openshift-docs/pull/96699 , because the related changes likely are not relevant for 4.19 and later.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
