### PR TITLE
OSDOSC-15511: Added Firewall rules into bastion host

### DIFF
--- a/modules/rosa-hcp-firewall-prerequisites.adoc
+++ b/modules/rosa-hcp-firewall-prerequisites.adoc
@@ -3,8 +3,6 @@
 // * rosa_planning/rosa-sts-aws-prereqs.adoc
 // * rosa_planning/rosa-hcp-prereqs.adoc <-- this is a symlink
 
-//TODO OSDOCS-11789: Why is this a procedure and not a reference?
-
 [id="rosa-hcp-firewall-prerequisites_{context}"]
 = Firewall prerequisites for {product-title}
 
@@ -127,4 +125,65 @@ Your workload may require access to other sites that provide resources for progr
 |`oso-rhc4tp-docker-registry.s3-us-west-2.amazonaws.com`
 | 443
 | Optional. Required for Sonatype Nexus, F5 Big IP operators.
+|===
+
+[id="firewall-cli-bastion_{context}"]
+== Outbound firewall rules for the {rosa-cli} for clusters with egress zero
+
+If you use a bastion host to connect to a private cluster with egress zero, you must add the following rules to your firewall so that it can connect and authenticate to the cluster.
+
+[cols="6,1,6,6",options="header"]
+|===
+|Domain | Port | From/To | Function
+|`sso.redhat.com`
+|443
+|ROSA CLI running on bastion host
+|The link:https://console.redhat.com/openshift[OpenShift console] uses authentication from `sso.redhat.com` to download the pull secret and use Red Hat SaaS solutions to facilitate monitoring of your subscriptions, cluster inventory, chargeback reporting, etc.
+
+|`api.openshift.com`
+|443
+|ROSA CLI running on bastion host
+|Required for registering a {product-title} cluster into {hybrid-console}.
+
+|`iam.amazonaws.com`
+|443
+|ROSA CLI running on bastion host
+|Used for creating IAM roles and attaching permissions.
+
+|`servicequotas.<your region>.amazonaws.com`
+|443
+|ROSA CLI running on bastion host
+|Checks AWS quotas to ensure they satisfy ROSA installation requirements. Alternatively, you can create a VPC endpoint for servicequota service to avoid whitelisting this URL from your firewall.
+
+|`sts.<your region>.amazonaws.com`
+|443
+|ROSA CLI running on bastion host
+|Used to get short-lived token to access AWS service. Alternatively, you can create a VPC endpoint for STS service to avoid whitelisting this url from your firewall.
+
+|`ec2.<your region>.amazonaws.com`
+|443
+|ROSA CLI running on bastion host
+|Used to retrieve EC2 instance related information such as subnets. Alternatively, you can create a VPC endpoint for EC2 service to avoid whitelisting this URL from your firewall.
+|===
+
+[id="firewall-hcm-bastion_{context}"]
+== Outbound firewall rules from {hybrid-console} for clusters with egress zero
+[cols="6,1,6,6",options="header"]
+|===
+|Domain | Port | From/To | Function
+
+|`sts.<your region>.amazonaws.com`
+|443
+|{product-title} cluster
+|Used to access the AWS Secure Token Service (STS) regional endpoint to retrieve a short-lived token to access AWS services. Alternatively, you can create a VPC endpoint for STS service to avoid whitelisting this URL from your firewall.
+
+|`console.redhat.com`
+|443
+|Any browser to access {hybrid-console}
+|To manage a {product-title} cluster from {hybrid-console-second}.
+
+|`sso.redhat.com`
+|443
+|Any browser to access {hybrid-console}
+|The link:https://console.redhat.com/openshift[{hybrid-console}] site uses authentication from `sso.redhat.com` to download the pull secret and use Red Hat SaaS solutions to facilitate monitoring of your subscriptions, cluster inventory, chargeback reporting, etc.
 |===

--- a/rosa_hcp/rosa-hcp-egress-zero-install.adoc
+++ b/rosa_hcp/rosa-hcp-egress-zero-install.adoc
@@ -58,6 +58,7 @@ A physical connection might exist between machines on the internal network and a
 * You have installed the ROSA v1.2.45+ CLI.
 * You have installed and configured the AWS CLI with the necessary credentials.
 * You have installed the git CLI.
+* You have enabled the necessary xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#firewall-cli-bastion_rosa-hcp-aws-prereqs[ROSA CLI firewall rules] and xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#firewall-hcm-bastion_rosa-hcp-aws-prereqs[{hybrid-console} firewall rules].
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Version(s):
`enterprise-4.19+`

Issue:
**[OSDOCS-15511](https://issues.redhat.com/browse/OSDOCS-15511)**

Link to docs preview:
- Link from [ROSA clusters with egress zero](https://97325--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-egress-zero-install.html) (on HCP)
    <img width="910" height="413" alt="image" src="https://github.com/user-attachments/assets/c3791d36-2b6e-4541-8f81-e2d29a64a5b9" />
  - HCP firewall rules (on Classic)
      - [Outbound firewall rules for ROSA CLI for clusters with egress zero](https://97325--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#firewall-cli-bastion_rosa-hcp-aws-prereqs)
      - [Outbound firewall rules from Red Hat Hybrid Cloud Console for clusters with egress zero](https://97325--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#firewall-hcm-bastion_rosa-hcp-aws-prereqs) 
  - HCP firewall rules (on HCP)
      - [Outbound firewall rules for ROSA CLI for clusters with egress zero](https://97325--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-sts-aws-prereqs.html#firewall-cli-bastion_rosa-hcp-aws-prereqs)
      - [Outbound firewall rules from Red Hat Hybrid Cloud Console for clusters with egress zero](https://97325--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-sts-aws-prereqs.html#firewall-hcm-bastion_rosa-hcp-aws-prereqs) 
        <img width="903" height="729" alt="image" src="https://github.com/user-attachments/assets/2d5c410e-2b71-4b86-b6ff-3c4a8bbede7e" />
        <img width="899" height="644" alt="image" src="https://github.com/user-attachments/assets/792cfec9-a30f-4f7a-93cf-a991e753576f" />

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updated the Firewall table for ROSA with HCP