### PR TITLE
[enterprise-4.17] OSDOCS 15615 Clarity on bootimage changes on AWS and GCP

### DIFF
--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -23,9 +23,14 @@ include::snippets/technology-preview.adoc[]
 
 If you are not using the default user data secret, named `worker-user-data`, in your machine set, or you have modified the `worker-user-data` secret, you should not use managed boot image updates. This is because the Machine Config Operator (MCO) updates the machine set to use a managed version of the secret. By using the managed boot images feature, you are giving up the capability to customize the secret stored in the machine set object. 
 
-To view the current boot image used in your cluster, examine a machine set:
+To view the current boot image used in your cluster, examine a machine set.
 
-.Example machine set with the boot image reference
+[NOTE]
+====
+The location and format of the boot image within the machine set differs, based on the platform. However, the boot image is always listed in the `spec.template.spec.providerSpec.` parameter.
+====
+
+.Example GCP machine set with the boot image reference
 
 [source,yaml]
 ----
@@ -50,6 +55,28 @@ spec:
 # ...
 ----
 <1> This boot image is the same as the originally-installed {product-title} version, in this example {product-title} 4.12, regardless of the current version of the cluster. The way that the boot image is represented in the machine set depends on the platform, as the structure of the `providerSpec` field differs from platform to platform.
+
+.Example AWS machine set with the boot image reference
+
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  name: ci-ln-hmy310k-72292-5f87z-worker-a
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+    spec:
+# ...
+      providerSpec:
+         value:
+          ami:
+            id: ami-0e8fd9094e487d1ff
+# ...
+----
 
 If you configure your cluster to update your boot images, the boot image referenced in your machine sets matches the current version of the cluster.
 

--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -146,4 +146,4 @@ spec:
             image: projects/rhcos-cloud/global/images/<boot_image> <1>
 # ...
 ----
-<1> This boot image is the same as the current {product-title} version.
+<1> This boot image is the same as the current {product-title} version. The location and format of the boot image within the machine set differs, based on the platform. However, the boot image is always listed in the `spec.template.spec.providerSpec.` parameter. 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/97038
