### PR TITLE
OSDOCS-15290: Added GA RN to 4.16 for IPv6 unsolicited neighbor adver…

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -699,6 +699,11 @@ For more information, see xref:../post_installation_configuration/changing-cloud
 [id="ocp-4-16-networking_{context}"]
 === Networking
 
+[id="ocp-4-16-ipv6-default-ipvlan_{context}"]
+==== IPv6 unsolicited neighbor advertisements on IPVLAN CNI plugin (General Availability)
+
+Pods created by using the `ipvlan` CNI plugin, where the IP address management CNI plugin has assigned IPs, now send IPv6 unsolicited neighbor advertisements by default onto the network. This feature has the General Availability status for {product-title} {product-version}.
+
 [id="ocp-4-16-sr-iov-network-metrics-exporter_{context}"]
 ==== Enabling the SR-IOV network metrics exporter
 


### PR DESCRIPTION
[CM sent on the 8 Aug](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r5142953149447565167).

Version(s):
4.16

Issue:
[OSDOCS-15290](https://issues.redhat.com/browse/OSDOCS-15290)

Link to docs preview:
* [4.16 RN](https://97343--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-ipv6-default-ipvlan)

- [x] SME has approved this change (Marcelo Guerrero Viveros).
- [x] QE has approved this change (Weibin Liang).
