### PR TITLE
moving package to root and enabling in modules/.vale.ini

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,7 +2,7 @@ StylesPath = .vale/styles
 
 MinAlertLevel = suggestion
 
-Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc
+Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc, https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip
 
 Vocab = OpenShiftDocs
 

--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -2,8 +2,6 @@ StylesPath = ../.vale/styles
 
 MinAlertLevel = suggestion
 
-Packages = https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip
-
 Vocab = OpenShiftDocs
 
 [[!.]*.adoc]


### PR DESCRIPTION
Additional information: moving package addition back to root config

Shauna's [test PR](https://github.com/openshift/openshift-docs/pull/97320) [build logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_openshift-docs/97320/pull-ci-openshift-openshift-docs-main-validate-asciidoc/1953492276860686336/artifacts/validate-asciidoc/openshift-docs-vale-review/build-log.txt) show that `AsciiDocDITA` package is successfully downloaded and synced when the package is included in the root `.vale.ini` file. 

however, the tests don't fire because the modified parts of the file where the error resides are not touched. this is different behavior locally where vale lints the whole file, vs. just the file changes in the git diff
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
