### PR TITLE
OSDOCS#14883: Add MicroShift certificate manager information

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -211,6 +211,8 @@ Topics:
   File: microshift-applications
 - Name: Deleting or updating Kustomize manifest resources
   File: microshift-deleting-resource-manifests
+- Name: Using MicroShift certificate manager
+  File: microshift-cert-manager
 - Name: Configuring Observability
   File: microshift-observability-service
 - Name: Embedding applications on RHEL for Edge

--- a/microshift_running_apps/microshift-cert-manager.adoc
+++ b/microshift_running_apps/microshift-cert-manager.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-cert-manager"]
+= Using certificate manager on a {microshift-short} node
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-cert-manager
+
+toc::[]
+
+[role="_abstract"]
+The {microshift-short} certificate manager supports managing TLS certificates. This integration results in the issue, renewal, and management of certificate from certificate authorities.
+
+include::modules/microshift-cert-manager-tasks.adoc[leveloffset=+1]
+
+include::modules/microshift-install-cert-manager.adoc[leveloffset=+1]
+
+include::modules/microshift-install-cert-manager-olm.adoc[leveloffset=+1]

--- a/modules/microshift-cert-manager-tasks.adoc
+++ b/modules/microshift-cert-manager-tasks.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * microshift_running_apps/microshift-cert-manager.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-cert-manager-tasks_{context}"]
+= {microshift-short} certificate manager functions
+
+[role="_abstract"]
+With {microshift-short} certificate manager, you can complete the following tasks:
+
+* Automates certificate management: cert-manager creates or updates certificates and detects Kubernetes resources that are annotated with `cert-manager.io/kind`.
+* Supports multiple CAs: provides flexibility to select one that fits the security and operational needs.
+* Simplifies ingress certificates: cert-manager handles certificates for an ingress controller, which simplifies the configuration and management of secure communication channels.
+* Enhances security: certificate management is automated and the risk of error is reduced. Certificates are current and valid, which contribute to a secure environment.

--- a/modules/microshift-install-cert-manager-olm.adoc
+++ b/modules/microshift-install-cert-manager-olm.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+//  microshift_running_apps/microshift-cert-manager.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-install-cert-manager-olm_{context}"]
+= Installing and enabling the cert-manager Operator using OLM
+
+[role="_abstract"]
+You can install the optional `microshift-cert-manager` by using OLM at any time. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/running_applications/operators#microshift-operators-olm[Using Operator Lifecycle Manager with MicroShift] and link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#cert-manager-operator-install[Installing the cert-manager Operator for Red Hat OpenShift].

--- a/modules/microshift-install-cert-manager.adoc
+++ b/modules/microshift-install-cert-manager.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+//  microshift_running_apps/microshift-cert-manager.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-install-cert-manager_{context}"]
+= Installing and enabling the cert-manager Operator using RPM
+
+[role="_abstract"]
+The microshift-cert-manager RPM is an optional component that can be installed at any time. Follow these steps to install and verify the certificate manager:
+
+.Procedure
+
+. Install the `cert-manager-operator` using the `microshift-cert-manager` RPM by running the following command:
++
+[source,terminal]
+----
+$ sudo dnf install microshift-cert-manager
+----
+
+. Verify the certificate manager versions that are used by running the following command:
++
+[source,terminal]
+----
+$ rpm -qi microshift-cert-manager
+----
+
+. Restart {microshift-short} by running the following command:
++
+[source,terminal]
+----
+$ systemctl microshift restart
+----
+
+. Verify that the `microshift-cert-manager` RPM is installed by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment -n  cert-manager-operator
+----
++
+.Example output 
+[source,terminal]
+----
+NAME                                       READY   UP-TO-DATE   AVAILABLE   AGE
+cert-manager-operator-controller-manager   1/1     1            1           2d22h
+----
+
+. Verify that the`cert-manager` deployments are in a ready state and are up-to-date in the cert-manager namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment -n cert-manager
+----
++
+.Example output 
+[source,terminal]
+----
+NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
+cert-manager              1/1     1            1           2d22h
+cert-manager-cainjector   1/1     1            1           2d22h
+cert-manager-webhook      1/1     1            1           2d22h
+----
+
+. Verify that the pods are running in the `cert-manager` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n cert-manager
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                       READY   STATUS    RESTARTS   AGE
+cert-manager-7cfb4fbb84-qdmk8              1/1     Running   2          2d22h
+cert-manager-cainjector-854f669657-xzs8b   1/1     Running   2          2d22h
+cert-manager-webhook-68fd6d5f5c-j942h      1/1     Running   2          2d22h
+---- 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-14883](https://issues.redhat.com//browse/OSDOCS-14883)

Link to docs preview:
[Using certificate manager on a MicroShift node](https://97364--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-cert-manager.html)

QE review:
- [x ] QE has approved this change.
(Kasturi Narra)

Additional information:
N/A
