### PR TITLE
OCPBUGS#57928: Added forbidden reserved interface names to various Nm

### DIFF
--- a/modules/node-network-configuration-policy-file.adoc
+++ b/modules/node-network-configuration-policy-file.adoc
@@ -10,6 +10,26 @@ A `NodeNetworkConfigurationPolicy` (NNCP) manifest file defines policies that th
 
 After you apply a node network policy to a node, the Kubernetes NMState Operator configures the networking configuration for nodes according to the node network policy details. 
 
+[WARNING]
+====
+The following list of interface names are reserved and you cannot use the names with NMstate configurations:
+
+* `br-ext`
+* `br-int`
+* `br-local`
+* `br-nexthop`
+* `br0`
+* `ext-vxlan`
+* `ext`
+* `genev_sys_*`
+* `int`
+* `k8s-*`
+* `ovn-k8s-*`
+* `patch-br-*`
+* `tun0`
+* `vxlan_sys_*`
+====
+
 You can create an NNCP by using either the {oc-first} or the {product-title} web console. As a postinstallation task you can create an NNCP or edit an existing NNCP.
 
 [NOTE]


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OCPBUGS-57938](https://issues.redhat.com/browse/OCPBUGS-57938)

Link to docs preview:
* [The NNCP manifest file](https://97365--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#node-network-configuration-policy-file_k8s-nmstate-updating-node-network-config)


- [x] SME has approved this change (Ben Nemec).
- [x] QE has approved this change.
