### PR TITLE
OSDOCS#15780: Update the range of oc-mirror parameters 

### DIFF
--- a/modules/oc-mirror-command-reference-v2-delete.adoc
+++ b/modules/oc-mirror-command-reference-v2-delete.adoc
@@ -49,10 +49,10 @@ The following tables describe the `oc mirror` subcommands and flags for deleting
 |Log level one of `info`, `debug`, `trace`, and `error`. The default value is `info`.
 
 |`--parallel-images <unit>`
-|Indicates the number of images deleted in parallel. The default value is `4`.
+|Indicates the number of images deleted in parallel. The value must be in the range of 1–10. The default value is `4`.
 
 |`--parallel-layers <unit>`
-|Indicates the number of image layers mirrored in parallel. The default value is `5`.
+|Indicates the number of image layers deleted in parallel. The value must be in the range of 1–10. The default value is `5`.
 
 |`-p <unit>`, `--port <unit>`
 |HTTP port used by oc-mirror's local storage instance. The default value is `55000`.

--- a/modules/oc-mirror-command-reference-v2.adoc
+++ b/modules/oc-mirror-command-reference-v2.adoc
@@ -63,10 +63,10 @@ The following tables describe the `oc mirror` subcommands and flags for oc-mirro
 |Determines the HTTP port used by oc-mirror plugin v2 local storage instance. The default value is `55000`.
 
 |`--parallel-images <unit>` 
-|Specifies the number of images mirrored in parallel. The default value is `4`.
+|Specifies the number of images mirrored in parallel. The value must be in the range of 1–10. The default value is `4`.
 
 |`--parallel-layers <unit>`           
-|Specifies the number of image layers mirrored in parallel. The default value is `5`.
+|Specifies the number of image layers mirrored in parallel. The value must be in the range of 1–10. The default value is `5`.
 
 |`--max-nested-paths <int>`
 |Specifies the maximum number of nested paths for destination registries that limit nested paths. The default value is `0`.


### PR DESCRIPTION
Version(s): 4.20+

Issue: https://issues.redhat.com/browse/OSDOCS-15780

Link to docs preview:

- https://97373--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/about-installing-oc-mirror-v2.html#oc-mirror-command-reference-v2_about-installing-oc-mirror-v2- 
- https://97373--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/about-installing-oc-mirror-v2.html#oc-mirror-command-reference-delete-v2_about-installing-oc-mirror-v2- 

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change. @nidangavali 
- [x] SME has approved this change. @lmzuccarelli 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
