### PR TITLE
OSDOCS-15764 created 4-16-46 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3371,6 +3371,33 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.46
+[id="ocp-4-16-46_{context}"]
+=== RHSA-2025:13336 - {product-title} {product-version}.46 bug fix and security update
+
+Issued: 13 August 2025
+
+{product-title} release {product-version}.46 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:13336[RHSA-2025:13336] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.46 --pullspecs
+----
+
+[id="ocp-4-16-46-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, the `catalog-operator` captured snapshots every five minutes, which caused CPU spikes when dealing with many namespaces, subscriptions, and large catalog sources. This increased load on the catalog source pods and prevented users from installing or upgrading operators. With this release, the catalog snapshot cache lifetime has been increased to 30 minutes allowing enough time for the catalog source to resolve attempts without causing an undue load and stabilizing the operator installation and upgrade process. (link:https://issues.redhat.com/browse/OCPBUGS-57429[OCPBUGS-57429])
+
+* Before this update, forward slashes were permitted in the `console.tab/horizontalNav` `href` values. Starting in 4.15, a regression resulted in the forward slashes no longer working correctly when used in `href` values. With this release, forward slashes in `console.tab/horizontalNav` `href` values continue to work as expected. (link:https://issues.redhat.com/browse/OCPBUGS-59358[OCPBUGS-59358])
+
+[id="ocp-4-16-46-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.45
 [id="ocp-4-16-45_{context}"]
 === RHSA-2025:11681 - {product-title} {product-version}.45 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-15764

Link to docs preview:
https://97378--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-46_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
The errata URLs will return 404 until the go-live date of 08/13/2025
