### PR TITLE
OSDOCS-15305 [NETOBSERV] Update nw-network-observability-operator to fit proc template

### DIFF
--- a/modules/nw-network-observability-operator.adoc
+++ b/modules/nw-network-observability-operator.adoc
@@ -39,8 +39,8 @@ flowlogs-pipeline-hh6kf           1/1     Running   0          147m
 flowlogs-pipeline-w7vv5           1/1     Running   0          147m
 netobserv-plugin-cdd7dc6c-j8ggp   1/1     Running   0          147m
 ----
-
-`flowlogs-pipeline` pods collect flows, enriches the collected flows, then send flows to the Loki storage.
++
+The `flowlogs-pipeline` pods collect flows, enriches the collected flows, then send flows to the Loki storage.
 `netobserv-plugin` pods create a visualization plugin for the {product-title} Console.
 
 . Check the status of pods running in the namespace `netobserv-privileged` by entering the following command:
@@ -59,8 +59,8 @@ netobserv-ebpf-agent-klpl9   1/1     Running   0          151m
 netobserv-ebpf-agent-vrcnf   1/1     Running   0          151m
 netobserv-ebpf-agent-xf5jh   1/1     Running   0          151m
 ----
-
-`netobserv-ebpf-agent` pods monitor network interfaces of the nodes to get flows and send them to `flowlogs-pipeline` pods.
++
+The `netobserv-ebpf-agent` pods monitor network interfaces of the nodes to get flows and send them to `flowlogs-pipeline` pods.
 
 . If you are using the {loki-op}, check the status of the `component` pods of `LokiStack` custom resource in the `netobserv` namespace by entering the following command:
 +


### PR DESCRIPTION
[OSDOCS-15305](https://issues.redhat.com//browse/OSDOCS-15305) [NETOBSERV] Update nw-network-observability-operator to fit proc template

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15305

Link to docs preview:
https://97379--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/understanding-network-observability-operator.html#nw-network-observability-operator_nw-network-observability-operator 

QE review:
QE review is not required for this PR. This PR addresses format and style issues.

Additional information:
* Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. I will verify files on each branch, and create manual cherry-picks as necessary.
* Most likely cherry-pick failures are on 4.15.
* See comments: https://github.com/openshift/openshift-docs/pull/97157#discussion_r2255171606 and https://github.com/openshift/openshift-docs/pull/96084#pullrequestreview-3037728851
