### PR TITLE
[enterprise-4.16] OSDOCS-15731 [NETOBSERV] Add space between each include in all assemblies

### DIFF
--- a/observability/network_observability/configuring-operator.adoc
+++ b/observability/network_observability/configuring-operator.adoc
@@ -17,6 +17,7 @@ include::modules/network-observability-flowcollector-view.adoc[leveloffset=+1]
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-working-with-conversations_nw-observe-network-traffic[Working with conversation tracking]
 
 include::modules/network-observability-flowcollector-kafka-config.adoc[leveloffset=+1]
+
 include::modules/network-observability-enriched-flows.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -24,6 +25,7 @@ include::modules/network-observability-enriched-flows.adoc[leveloffset=+1]
 * xref:../../observability/network_observability/json-flows-format-reference.adoc#network-observability-flows-format_json_reference[Network flows format reference].
 
 include::modules/network-observability-configuring-FLP-sampling.adoc[leveloffset=+1]
+
 include::modules/network-observability-con_filter-network-flows-at-ingestion.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -31,8 +33,11 @@ include::modules/network-observability-con_filter-network-flows-at-ingestion.ado
 * xref:../network_observability/observing-network-traffic.adoc#network-observability-filtering-ebpf-rule_nw-observe-network-traffic[Filtering eBPF flow data using multiple rules]
 
 include::modules/network-observability-configuring-quickfilters-flowcollector.adoc[leveloffset=+1]
+
 include::modules/network-observability-resource-recommendations.adoc[leveloffset=+1]
+
 include::modules/network-observability-resources-table.adoc[leveloffset=+2]
+
 include::modules/network-observability-total-resource-usage.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/observability/network_observability/installing-operators.adoc
+++ b/observability/network_observability/installing-operators.adoc
@@ -22,6 +22,7 @@ include::modules/network-observability-without-loki.adoc[leveloffset=+1]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-enriched-flows_network_observability[Export enriched network flow data].
 
 include::modules/network-observability-loki-install.adoc[leveloffset=+1]
+
 include::modules/network-observability-loki-secret.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
@@ -31,11 +32,17 @@ include::modules/network-observability-loki-secret.adoc[leveloffset=+2]
 * xref:../../observability/logging/log_storage/installing-log-storage.adoc#logging-loki-storage_installing-log-storage[Loki object storage]
 
 include::modules/network-observability-lokistack-create.adoc[leveloffset=+2]
+
 include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+2]
+
 include::modules/logging-loki-log-access.adoc[leveloffset=+1,tags=CustomAdmin;NetObservMode;!LokiMode]
+
 include::modules/loki-deployment-sizing.adoc[leveloffset=+2]
+
 include::modules/network-observability-lokistack-ingestion-query.adoc[leveloffset=+2]
+
 include::modules/network-observability-operator-install.adoc[leveloffset=+1]
+
 include::modules/network-observability-multitenancy.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="additional-resources_configuring-flow-collector-considerations"]

--- a/observability/network_observability/metrics-alerts-dashboards.adoc
+++ b/observability/network_observability/metrics-alerts-dashboards.adoc
@@ -9,10 +9,15 @@ toc::[]
 The Network Observability Operator uses the `flowlogs-pipeline` to generate metrics from flow logs. You can utilize these metrics by setting custom alerts and viewing dashboards.
 
 include::modules/network-observability-viewing-dashboards.adoc[leveloffset=+1]
+
 include::modules/network-observability-predefined-metrics.adoc[leveloffset=+1]
+
 include::modules/network-observability-metrics-names.adoc[leveloffset=+1]
+
 include::modules/network-observability-includelist-example.adoc[leveloffset=+1]
+
 include::modules/network-observability-custom-metrics.adoc[leveloffset=+1]
+
 include::modules/network-observability-configuring-custom-metrics.adoc[leveloffset=+1]
 
 [IMPORTANT]
@@ -20,6 +25,7 @@ include::modules/network-observability-configuring-custom-metrics.adoc[leveloffs
 High cardinality can affect the memory usage of Prometheus. You can check whether specific labels have high cardinality in the xref:../../observability/network_observability/json-flows-format-reference.adocl#network-observability-flows-format_json_reference[Network Flows format reference].
 ====
 include::modules/network-observability-flowmetrics-charts.adoc[leveloffset=+1]
+
 include::modules/network-observability-tcp-flag-syn-flood.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/observability/network_observability/network-observability-network-policy.adoc
+++ b/observability/network_observability/network-observability-network-policy.adoc
@@ -9,6 +9,7 @@ toc::[]
 As a user with the `admin` role, you can create a network policy for the `netobserv` namespace to secure inbound access to the Network Observability Operator.
 
 include::modules/network-observability-deploy-network-policy.adoc[leveloffset=+1]
+
 include::modules/network-observability-create-network-policy.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/observability/network_observability/network-observability-operator-monitoring.adoc
+++ b/observability/network_observability/network-observability-operator-monitoring.adoc
@@ -9,10 +9,15 @@ toc::[]
 You can use the web console to monitor alerts related to the health of the Network Observability Operator.
 
 include::modules/network-observability-health-dashboard-overview.adoc[leveloffset=+1]
+
 include::modules/network-observability-health-alerts-overview.adoc[leveloffset=+1]
+
 include::modules/network-observability-viewing-alerts.adoc[leveloffset=+1]
+
 include::modules/network-observability-disabling-health-alerts.adoc[leveloffset=+2]
+
 include::modules/network-observability-rate-limit-alert.adoc[leveloffset=+1]
+
 include::modules/network-observability-ebpf-agent-alert.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -10,8 +10,11 @@ As an administrator, you can observe the network traffic in the {product-title} 
 
 //Overview
 include::modules/network-observability-network-traffic-overview-view.adoc[leveloffset=+1]
+
 include::modules/network-observability-working-with-overview.adoc[leveloffset=+2]
+
 include::modules/network-observability-configuring-options-overview.adoc[leveloffset=+2]
+
 include::modules/network-observability-pktdrop-overview.adoc[leveloffset=+2]
 
 [role="_additional-resources-packet-drops"]
@@ -33,6 +36,7 @@ include::modules/network-observability-RTT-overview.adoc[leveloffset=+2]
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-RTT_nw-observe-network-traffic[Working with RTT tracing]
 
 include::modules/network-observability-ebpf-rule-flow-filter.adoc[leveloffset=+2]
+
 include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+3]
 
 [role="_additional-resources-flow-filter-parameters"]
@@ -43,8 +47,11 @@ include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+
 
 //Traffic flows
 include::modules/network-observability-trafficflow.adoc[leveloffset=+1]
+
 include::modules/network-observability-working-with-trafficflow.adoc[leveloffset=+2]
+
 include::modules/network-observability-configuring-options-trafficflow.adoc[leveloffset=+2]
+
 include::modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc[leveloffset=+2]
 
 [role="_additional-resources-ipsec"]
@@ -53,20 +60,29 @@ include::modules/network-observability-proc_configuring-ipsec-with-flow-collecto
 
 //Traffic flows continued
 include::modules/network-observability-working-with-conversations.adoc[leveloffset=+2]
+
 include::modules/network-observability-packet-drops.adoc[leveloffset=+2]
+
 include::modules/network-observability-dns-tracking.adoc[leveloffset=+2]
+
 include::modules/network-observability-RTT.adoc[leveloffset=+2]
 
 //Traffic flows continued
 include::modules/network-observability-histogram-trafficflow.adoc[leveloffset=+2]
+
 include::modules/network-observability-working-with-zones.adoc[leveloffset=+2]
+
 include::modules/network-observability-filtering-ebpf-rule.adoc[leveloffset=+2]
+
 include::modules/network-observability-packet-translation-overview.adoc[leveloffset=+2]
+
 include::modules/network-observability-packet-translation.adoc[leveloffset=+2]
 
 //Topology
 include::modules/network-observability-topology.adoc[leveloffset=+1]
+
 include::modules/network-observability-working-with-topology.adoc[leveloffset=+2]
+
 include::modules/network-observability-configuring-options-topology.adoc[leveloffset=+2]
 
 //Quick filters


### PR DESCRIPTION
Cherry-picked from: ac4713de37e965576bb7acd6fcfe87ed31295559

Original PR: https://github.com/openshift/openshift-docs/pull/97377

Version(s):
4.15

QE review:
QE is not required for this PR.