### PR TITLE
OSDOCS#15765: Update the RNs for the 4.14.55 z-stream 

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3400,6 +3400,28 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.55
+[id="ocp-4-14-55_{context}"]
+=== RHSA-2025:13289 - {product-title} 4.14.55 bug fix and security update
+
+Issued: 14 August 2025
+
+{product-title} release 4.14.55, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:13289[RHSA-2025:13289] advisory. There are no RPM packages for this update.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.55 --pullspecs
+----
+
+[id="ocp-4-14-55-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.54
 [id="ocp-4-14-54_{context}"]
 === RHSA-2025:11669 - {product-title} 4.14.54 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-15765](https://issues.redhat.com//browse/OSDOCS-15765)

Link to docs preview:
4.14.55

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 8/14/25.
