### PR TITLE
[OSDOCS-12845]: Adding HCP certs assembly and Kube API server module

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2548,6 +2548,8 @@ Topics:
     File: disconnected-install-ibmz-hcp
   - Name: Monitoring user workload in a disconnected environment
     File: hcp-dc-monitor
+- Name: Configuring certificates for hosted control planes
+  File: hcp-certificates
 - Name: Updating hosted control planes
   File: hcp-updating
 - Name: High availability for hosted control planes

--- a/hosted_control_planes/hcp-certificates.adoc
+++ b/hosted_control_planes/hcp-certificates.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="hcp-certificates"]
+include::_attributes/common-attributes.adoc[]
+= Configuring certificates for {hcp}
+:context: hcp-certificates
+
+toc::[]
+
+With {hcp}, the steps to configure certificates differ from those of standalone {product-title}.  
+
+include::modules/hcp-custom-cert.adoc[leveloffset=+1]
+
+include::modules/hcp-kube-api-server-cert.adoc[leveloffset=+1]
+
+include::modules/hcp-ts-custom-dns.adoc[leveloffset=+1]
+
+//include::modules/hcp-ingress-cert.adoc[leveloffset=+1]

--- a/modules/hcp-custom-cert.adoc
+++ b/modules/hcp-custom-cert.adoc
@@ -1,9 +1,6 @@
 // Module included in the following assemblies:
 //
-// * hosted-control-planes/hcp-deploy/hcp-deploy-aws.adoc
-// * hosted-control-planes/hcp-deploy/hcp-deploy-bm.adoc
-// * hosted-control-planes/hcp-deploy/hcp-deploy-non-bm.adoc
-// * hosted-control-planes/hcp-deploy/hcp-deploy-virt.adoc
+// * hosted-control-planes/hcp-certificates.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="hcp-custom-cert_{context}"]
@@ -20,7 +17,7 @@ You can configure a custom certificate during either day-1 or day-2 operations. 
  ** `tls.crt`: The certificate
  ** `tls.key`: The private key
 
-* If your `HostedCluster` configuration includes a service publishing strategy that uses a load balancer, ensure that the Subject Alternative Names (SANs) of the certificate do not conflict with the internal API endpoint (`api-int`). The internal API endpoint is automatically created and managed by your platform. If you use the same hostname in both the custom certificate and the internal API endpoint, routing conflictcs can occur. The only exception to this rule is when you use {aws-short} as the provider with either `Private` or `PublicAndPrivate` configurations. In those cases, the SAN conflict is managed by the platform.
+* If your `HostedCluster` configuration includes a service publishing strategy that uses a load balancer, ensure that the Subject Alternative Names (SANs) of the certificate do not conflict with the internal API endpoint (`api-int`). The internal API endpoint is automatically created and managed by your platform. If you use the same hostname in both the custom certificate and the internal API endpoint, routing conflicts can occur. The only exception to this rule is when you use {aws-short} as the provider with either `Private` or `PublicAndPrivate` configurations. In those cases, the SAN conflict is managed by the platform.
 
 * The certificate must be valid for the external API endpoint.
 
@@ -66,6 +63,6 @@ $ oc apply -f <hosted_cluster_config>.yaml
 
 * Check the API server pods to ensure that the new certificate is mounted.
 
-* Test the conncetion to the API server by using the custom domain name.
+* Test the connection to the API server by using the custom domain name.
 
 * Verify the certificate details in your browser or by using tools such as `openssl`.

--- a/modules/hcp-kube-api-server-cert.adoc
+++ b/modules/hcp-kube-api-server-cert.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * hosted-control-planes/hcp-certificates.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-kube-api-server-cert_{context}"]
+= Configuring the Kubernetes API server for a hosted cluster
+
+If you want to customize the Kubernetes API server for your hosted cluster, complete the following steps.
+
+.Prerequisites
+
+* You have a running hosted cluster.
+
+* You have access to modify the `HostedCluster` resource.
+
+* You have a custom DNS domain to use for the Kubernetes API server.
++
+** The custom DNS domain must be properly configured and resolvable.
+** The DNS domain must have valid TLS certificates configured.
+** Network access to the domain must be properly configured in your environment.
+** The custom DNS domain must be unique across your hosted clusters.
+
+* You have a configured custom certificate. For more information, see "Configuring a custom API server certificate in a hosted cluster".
+
+.Procedure
+
+. In your provider platform, configure the DNS record so that the `kubeAPIServerDNSName` URL points to the IP address that the Kubernetes API server is being exposed to. The DNS record must be properly configured and resolvable from your cluster.
++
+.Example command to configure the DNS record
+[source,terminal]
+----
+$ dig + short kubeAPIServerDNSName
+----
+
+. In your `HostedCluster` specification, modify the `kubeAPIServerDNSName` field, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: hypershift.openshift.io/v1beta1
+kind: HostedCluster
+metadata:
+  name: <hosted_cluster_name>
+  namespace: <hosted_cluster_namespace>
+spec:
+  configuration:
+    apiServer:
+      servingCerts:
+        namedCertificates:
+        - names: <1>
+          - api-custom-cert-sample-hosted.sample-hosted.example.com
+          servingCertificate: <2>
+            name: sample-hosted-kas-custom-cert
+  kubeAPIServerDNSName: api-custom-cert-sample-hosted.sample-hosted.example.com <3>
+# ...
+----
+<1> The list of DNS names that the certificate is valid for. The names listed in this field cannot be the same as the names specified in the `spec.servicePublishingStrategy.*hostname` field.
+<2> The name of the secret that contains the custom certificate.
+<3> This field accepts a URI that will be used as the API server endpoint.
+
+. Apply the configuration by entering the following command:
++
+[source,terminal]
+----
+$ oc -f <hosted_cluster_spec>.yaml
+----
++
+After the configuration is applied, the HyperShift Operator generates a new `kubeconfig` secret that points to your custom DNS domain.
+
+. Retrieve the `kubeconfig` secret by using the CLI or the console.
++
+.. To retrieve the secret by using the CLI, enter the following command:
++
+[source,terminal]
+----
+$ kubectl get secret <hosted_cluster_name>-custom-admin-kubeconfig \
+  -n <cluster_namespace> \
+  -o jsonpath='{.data.kubeconfig}' | base64 -d
+----
+
++
+.. To retrieve the secret by using the console, go to your hosted cluster and click **Download Kubeconfig**.
++
+[NOTE]
+====
+You cannot consume the new `kubeconfig` secret by using the **show login command** option in the console.
+====

--- a/modules/hcp-ts-custom-dns.adoc
+++ b/modules/hcp-ts-custom-dns.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * hosted-control-planes/hcp-certificates.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-ts-custom-dns_{context}"]
+= Troubleshooting accessing a hosted cluster by using a custom DNS
+
+If you encounter issues when you access a hosted cluster by using a custom DNS, complete the following steps.
+
+.Procedure
+
+. Verify that the DNS record is properly configured and resolved.
+
+. Check that the TLS certificates for the custom domain are valid, verifying that the SAN is correct for your domain, by entering the following command:
++
+[source,terminal]
+----
+$ oc get secret \
+  -n clusters <serving_certificate_name> \
+  -o jsonpath='{.data.tls\.crt}' | base64 \
+  -d |openssl x509 -text -noout -
+----
+
+. Ensure that network connectivity to the custom domain is working.
+
+. In the `HostedCluster` resource, verify that the status shows the correct custom `kubeconfig` information, as shown in the following example:
++
+.Example `HostedCluster` status
+[source,yaml]
+----
+status:
+  customKubeconfig:
+    name: sample-hosted-custom-admin-kubeconfig
+----
+
+. Check the `kube-apiserver` logs in the `HostedControlPlane` namespace by entering the following command:
++
+[source,terminal]
+----
+$ oc logs -n <hosted_control_plane_namespace> \
+  -l app=kube-apiserver -f -c kube-apiserver
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15+ 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-12845
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://97408--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-certificates.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
