### PR TITLE
RHDEVDOCS-6409: Procedures for Using OCI Artifacts as Source Missing

### DIFF
--- a/modules/ob-creating-a-build-with-oci-artifacts.adoc
+++ b/modules/ob-creating-a-build-with-oci-artifacts.adoc
@@ -1,0 +1,49 @@
+// This module is included in the following assembly:
+//
+// * work-with-builds/using-builds.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="Creating-a-build-with-OCI-artifacts_{context}"]
+= Creating a build with OCI artifacts
+
+You can create a build using an Open Container Initiative(OCI) artifact as your source code. An OCI artifact, also known as a scratch image, contains only the source code and is not intended to run as a container. You can pull the OCI artifact from a container registry and extract its contents to use as source code to run the build.
+
+.Prerequisites
+
+* You have installed the {builds-operator} on the {ocp-product-title} cluster.
+* You have installed the `oc` command-line interface (CLI).
+* You have installed the link:https://console.redhat.com/openshift/downloads[`shp` CLI].
+
+.Procedure
+
+. Create a `Build` resource and apply it to the {ocp-product-title} cluster. See the following example configuration:
++
+[source,yaml]
+----
+$ oc apply -f - <<EOF
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: my-oci-build #<1>
+spec:
+  source:
+    type: OCI
+    ociArtifact:
+      image: <quay.io/org/image:tag> #<2>
+  strategy:
+    name: <strategy-name> # <3>
+    kind: ClusterBuildStrategy
+  output: 
+    image: <target-image-registry/repository/image:tag> #<4>
+    pushSecret: <secret-name-for-credentials> #<5>
+EOF
+----
+<1> Defines the name of the `Build` resource.
+<2> Replace `<quay.io/org/image:tag>` with the location of the OCI artifact source image.
+<3> Replace `<strategy-name>` with the name of the build strategy to build the container (`buildah` or `source-to-image`).
+<4> Replace `<target-image-registry/repository/image:tag>` with the location where you want to push the built image.
+<5> Optional: Replace `<secret-name-for-credentials>` with the secret name that stores the credentials for pushing container images. To generate a secret for a private registry for authentication, see link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.5/html-single/authentication/index#ob-authentication-to-container-registries_understanding-authentication-at-runtime[Authentication to container registries]
+
+. Choose one of the following methods to upload your source code to the required registry and run the build:
+.. Use the shp CLI
+.. Manually upload the OCI artifact 

--- a/modules/ob-uploading-the-OCI-artifact-by-using-the-CLI.adoc
+++ b/modules/ob-uploading-the-OCI-artifact-by-using-the-CLI.adoc
@@ -1,0 +1,17 @@
+// This module is included in the following assembly:
+//
+// * work-with-builds/using-builds.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="uploading-the-OCI-artifact-by-using-the-CLI_{context}"]
+= Uploading the OCI artifact by using the CLI
+
+You can upload your source code to the required registry by using the CLI. 
+
+. Run the following command in the directory containing the local source code. It packages your source code into a scratch container image, pushes it to the required registry and runs the build:
++
+[source,terminal]
+----
+$ shp build upload my-oci-build <1>
+----
+<1> Defines the name of the `Build` resource.

--- a/modules/ob-uploading-the-OCI-artifact-manually.adoc
+++ b/modules/ob-uploading-the-OCI-artifact-manually.adoc
@@ -1,0 +1,41 @@
+// This module is included in the following assembly:
+//
+// * work-with-builds/using-builds.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="uploading-the-OCI-artifact-manually_{context}"]
+= Uploading the OCI artifact manually
+
+You can upload your source code manually to the required registry and run the build.
+
+. Create a `Containerfile` in the root directory of your source code and add the following content:
++
+[source,dockerfile]
+----
+FROM scratch
+COPY . /
+----
+
+. Run the following command in the root directory of your source code to build the container image using Podman:
++
+[source,terminal]
+----
+$ podman build -t <registry-path>/<image-name>:<tag> # <1>
+----
+<1> Replace <registry-path>/<image-name>:<tag> with the build location for the container image.
+
+. Push the container image to the required location using the following command:
++
+[source,terminal]
+----
+$ podman push <registry-path>/<image-name>:<tag>  # <1>
+----
+<1> Replace <registry-path>/<image-name>:<tag> with the location where you want to push the built image.
+
+. Run the build using the following command:
++
+[source,terminal]
+----
+$ shp build run my-oci-build # <1>
+----
+<1> Defines the name of the `Build` resource.

--- a/work_with_builds/using-builds.adoc
+++ b/work_with_builds/using-builds.adoc
@@ -24,7 +24,11 @@ include::modules/ob-deleting-a-resource.adoc[leveloffset=+1]
 
 include::modules/ob-creating-a-buildpacks-build.adoc[leveloffset=+1]
 
+include::modules/ob-creating-a-build-with-oci-artifacts.adoc[leveloffset=+1]
 
+include::modules/ob-uploading-the-OCI-artifact-by-using-the-CLI.adoc[leveloffset=+2]
+
+include::modules/ob-uploading-the-OCI-artifact-manually.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources_using-builds"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):  build-docs-1.3, build-docs-1.4, build-docs-1.5, build-docs-1.6
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/RHDEVDOCS-6409
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://97426--ocpdocs-pr.netlify.app/openshift-builds/latest/work_with_builds/using-builds.html#Creating-a-build-with-OCI-artifacts_using-builds
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
 
SME review: @avinal  
QE review: Builds doesnot have a QE
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
