### PR TITLE
OSDOCS-15743: updates blueprint docs MicroShift

### DIFF
--- a/microshift_install_rpm_ostree/microshift-embed-in-rpm-ostree-offline-use.adoc
+++ b/microshift_install_rpm_ostree/microshift-embed-in-rpm-ostree-offline-use.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Embedding {microshift-short} containers in an `rpm-ostree` commit means that you can run a cluster in air-gapped, disconnected, or offline environments. You can embed {product-title} containers in a {op-system-ostree-first} image so that container engines do not need to pull images over a network from a container registry. Workloads can start up immediately without network connectivity.
+Embedding {microshift-short} containers in an `rpm-ostree` commit means that you can run a cluster in air-gapped, disconnected, or offline environments. You can embed {product-title} containers in a {op-system-ostree-first} image so that container engines do not need to pull images over a network from a container registry. Workloads can start immediately without network connectivity.
 
 include::modules/microshift-embed-microshift-image-offline-deploy.adoc[leveloffset=+1]
 
@@ -22,7 +22,7 @@ include::modules/microshift-creating-ostree-iso.adoc[leveloffset=+2]
 [role="_additional-resources"]
 == Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/assembly_pushing-a-container-to-a-register-and-embedding-it-into-a-image_composing-a-customized-rhel-system-image#con_the-container-registry-credentials_assembly_pushing-a-container-to-a-register-and-embedding-it-into-a-image[Pushing a container to a registry and embedding it into an image]
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/assembly_pushing-a-container-to-a-register-and-embedding-it-into-a-image_composing-a-customized-rhel-system-image#proc_pushing-a-container-artifact-directly-to-a-container-registry_assembly_pushing-a-container-to-a-register-and-embedding-it-into-a-image[Pushing a container artifact directly to a container registry]
 * link:https://osbuild.org/docs/on-premises/installation/container-auth[Container registry credentials]
 * xref:../microshift_networking/microshift-disconnected-network-config.adoc#microshift-disconnected-network-config[Configuring network settings for fully disconnected hosts]
 * xref:../microshift_running_apps/microshift_operators/microshift-operators-olm.adoc#microshift-operators-olm[Using Operator Lifecycle Manager with {microshift-short}]

--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -9,59 +9,22 @@
 
 Adding the {microshift-short} RPM package to an image builder blueprint enables the build of a {op-system-ostree} image with {microshift-short} embedded.
 
-* Start with step 1 to create your own minimal blueprint file which results in a faster {microshift-short} installation.
-* Start with step 2 to use the generated blueprint for installation which includes all the RPM packages and container images. This is a longer installation process, but a faster start up because container references are accessed locally.
-+
-[IMPORTANT]
-====
-* Replace `_<microshift_blueprint.toml>_` in the following procedures with the name of the TOML file you are using.
-* Replace `_<microshift_blueprint>_` in the following procedures with the name you want to use for your blueprint.
-====
-
 .Procedure
 
-. Use the following example to create your own blueprint file:
-+
-.Custom image builder blueprint example
-+
-[source,text]
-[subs="+quotes"]
-----
-cat > __<microshift_blueprint.toml>__ <<EOF <1>
-name = "__<microshift_blueprint>__" <2>
-
-description = ""
-version = "0.0.1"
-modules = []
-groups = []
-
-[[packages]]
-name = "microshift"
-version = "4.20.1" <3>
-
-[customizations.services]
-enabled = ["microshift"]
-EOF
-----
-<1> The name of the TOML file.
-<2> The name of the blueprint.
-<3> Substitute the value for the version you want. For example, insert `4.20.1` to download the {microshift-short} 4.20.1 RPMs.
-
-. Optional. Use the blueprint installed in the `/usr/share/microshift/blueprint` directory that is specific to your platform architecture. See the following example snippet for an explanation of the blueprint sections:
+. Use the blueprint installed in the `/usr/share/microshift/blueprint` directory that is specific to your platform architecture. See the following example snippet for an explanation of the blueprint sections:
 +
 .Generated image builder blueprint example snippet
-+
-[source,text]
+[source,text,subs="attributes+"]
 ----
 name = "microshift_blueprint"
-description = "MicroShift 4.17.1 on x86_64 platform"
+description = "MicroShift {ocp-version}.1 on x86_64 platform"
 version = "0.0.1"
 modules = []
 groups = []
 
 [[packages]] <1>
 name = "microshift"
-version = "4.17.1"
+version = "{ocp-version}.1"
 ...
 ...
 
@@ -69,7 +32,7 @@ version = "4.17.1"
 enabled = ["microshift"]
 
 [customizations.firewall]
-ports = ["22:tcp", "80:tcp", "443:tcp", "5353:udp", "6443:tcp", "30000-32767:tcp", "30000-32767:udp"]
+ports = ["ssh"]
 ...
 ...
 
@@ -84,45 +47,35 @@ EOF
 ----
 <1> References for all non-optional {microshift-short} RPM packages using the same version compatible with the `microshift-release-info` RPM.
 <2> References for automatically enabling {microshift-short} on system startup and applying default networking settings.
-<3> References for all non-optional {microshift-short} container images necessary for an offline deployment.
+<3> References for all non-optional {microshift-short} container images necessary for an offline deployment. The SHA depends on the release you are using.
 
 . Add the blueprint to the image builder by running the following command:
 +
 [source,terminal]
-[subs="+quotes"]
 ----
-$ sudo composer-cli blueprints push __<microshift_blueprint.toml>__ <1>
+$ sudo composer-cli blueprints push microshift_blueprint.toml
 ----
-<1> Replace `_<microshift_blueprint.toml>_` with the name of your TOML file.
 
 .Verification
 
 . Verify the image builder configuration listing only {microshift-short} packages by running the following command:
 +
 [source,terminal]
-[subs="+quotes"]
 ----
-$ sudo composer-cli blueprints depsolve __<microshift_blueprint>__ | grep microshift <1>
+$ sudo composer-cli blueprints depsolve microshift_blueprint | grep microshift
 ----
-<1> Replace `_<microshift_blueprint>_` with the name of your blueprint.
 +
 .Example output
-+
-[source,terminal]
+[source,terminal,subs="+attributes"]
 ----
 blueprint: microshift_blueprint v0.0.1
-    microshift-greenboot-4.17.1-202305250827.p0.g4105d3b.assembly.4.17.1.el9.noarch
-    microshift-networking-4.17.1-202305250827.p0.g4105d3b.assembly.4.17.1.el9.x86_64
-    microshift-release-info-4.17.1-202305250827.p0.g4105d3b.assembly.4.17.1.el9.noarch
-    microshift-4.17.1-202305250827.p0.g4105d3b.assembly.4.17.1.el9.x86_64
-    microshift-selinux-4.17.1-202305250827.p0.g4105d3b.assembly.4.17.1.el9.noarch
+    microshift-release-info-{ocp-version}.1-202511250827.p0.g4105d3b.assembly.{ocp-version}.1.el9.noarch
+    microshift-{ocp-version}.1-202511250827.p0.g4105d3b.assembly.{ocp-version}.1.el9.x86_64
 ----
-//need updated example output
-. Optional: Verify the image builder configuration listing all components to be installed by running the following command:
+
+. Optional: Verify the image builder configuration that lists all of the components to be installed by running the following command:
 +
-[source,terminal]
-[subs="+quotes"]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo composer-cli blueprints depsolve __<microshift_blueprint>__ <1>
+$ sudo composer-cli blueprints depsolve microshift_blueprint
 ----
-<1> Replace `_<microshift_blueprint>_` with the name of your blueprint.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-15743](https://issues.redhat.com/browse/OSDOCS-15743)

Link to docs preview:
[adding-microshift-service-to-blueprint](https://97429--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm_ostree/microshift-embed-in-rpm-ostree.html#adding-microshift-service-to-blueprint_microshift-embed-in-rpm-ostree)

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
