### PR TITLE
OSDOCS#15307: adds file name for CA bundle to ingress MicroShift

### DIFF
--- a/modules/microshift-ingress-controller-config.adoc
+++ b/modules/microshift-ingress-controller-config.adoc
@@ -7,7 +7,13 @@
 [id="microshift-ingress-control-config_{context}"]
 = Configuring ingress control in {microshift-short}
 
-You can use detailed ingress control settings by updating the {microshift-short} service configuration file.
+You can use detailed ingress control settings by updating the {microshift-short} service configuration file or using a configuration snippet.
+
+[IMPORTANT]
+====
+* A `config.yaml` configuration file takes precedence over built-in settings. The `config.yaml` file is read every time the {microshift-short} service starts.
+* Configuration snippet YAMLs take precedence over both built-in settings and the `config.yaml` configuration file.
+====
 
 .Prerequisites
 
@@ -20,18 +26,8 @@ You can use detailed ingress control settings by updating the {microshift-short}
 . Apply ingress control settings in one of the two following ways:
 
 .. Update the {microshift-short} `config.yaml` configuration file by making a copy of the provided `config.yaml.default` file in the `/etc/microshift/` directory, naming it `config.yaml` and keeping it in the source directory.
-+
-[IMPORTANT]
-====
-After you create the `config.yaml`, the configuration file takes precedence over built-in settings. The `config.yaml` file is read every time the {microshift-short} service starts.
-====
 
 .. Use a configuration snippet to apply the ingress control settings you want. To do this, create a configuration snippet YAML file and put it in the `/etc/microshift/config.d/` configuration directory.
-+
-[IMPORTANT]
-====
-Configuration snippet YAMLs take precedence over both built-in settings and the `config.yaml` configuration file.
-====
 
 . Replace the default values in the `ingress` section of the {microshift-short} YAML with your valid values, or create a configuration snippet file with the sections you need.
 +
@@ -235,7 +231,7 @@ When configured, this field must contain a valid expression or the {microshift-s
 ====
 
 |`clientTLS.clientCA`
-|Specifies a required config map that is in the `openshift-ingress` namespace. Required to enable client TLS. The config map must contain a certificate authority (CA) bundle.
+|Specifies a required config map that is in the `openshift-ingress` namespace. Required to enable client TLS. The config map must contain a certificate authority (CA) bundle named `ca-bundle.pem` or the deployment of the default router fails.
 
 |`clientTLS.clientCA.name`
 |The `metadata.name` of the config map referenced in the `clientTLS.clientCA` value.


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-15307](https://issues.redhat.com/browse/OSDOCS-15307)

Link to docs preview:
[microshift-ingress-control-config](https://97430--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-ingress-controller.html#microshift-ingress-control-config_microshift-ingress-controller)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
