### PR TITLE
OCPBUGS#60416 There is one more wrong example in FROM clause of image layering docs

### DIFF
--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -32,7 +32,7 @@ For example, the following Containerfile creates a custom layered image from an 
 [source,yaml,subs="+attributes"]
 ----
 # Using a {product-version}.0 image
-FROM quay.io/openshift-release/ocp-release@sha256... <1>
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256... <1>
 #Install hotfix rpm
 RUN rpm-ostree override replace http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/kernel-{,core-,modules-,modules-core-,modules-extra-}5.14.0-295.el9.x86_64.rpm && \ <2>
     rpm-ostree cleanup -m && \


### PR DESCRIPTION
Fixed one more mistaken example of how the base image for RHCOS layering is expected to look like.

Version(s):

4.12 and higher up to latest.

Issue:

https://issues.redhat.com/browse/OCPBUGS-60416

Link to docs preview:

https://97433--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html

QE review:
- [x] QE has approved this change.


Additional information:

Continuation of [OCPBUGS-33598](https://issues.redhat.com/browse/OCPBUGS-33598), because there was one more example to fix.
