### PR TITLE
OADP-3149: Clarify example block titles in OADP 1.3.0 RNs

### DIFF
--- a/modules/oadp-verifying-upgrade-1-3-0.adoc
+++ b/modules/oadp-verifying-upgrade-1-3-0.adoc
@@ -74,13 +74,13 @@ dpa-sample-1   Available   1s               3d16h   true
 
 In OADP 1.3 you can start data movement off cluster per backup versus creating a `DataProtectionApplication` (DPA) configuration.
 
-.Example
+.Example command
 [source,terminal]
 ----
 $ velero backup create example-backup --include-namespaces mysql-persistent --snapshot-move-data=true
 ----
 
-.Example
+.Example configuration file
 [source,yaml]
 ----
 apiVersion: velero.io/v1


### PR DESCRIPTION
Version(s):
4.12-4.15

Issue:
[OADP-3149](https://issues.redhat.com/browse/OADP-3149)

Link to docs preview:
[Verifying the upgrade](https://97434--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html#verifying-upgrade-1-3-0_oadp-release-notes) for OADP 1.3.0

QE review:
Bypassing QE review since this is stylistic change only.

Additional information:
Differentiate 2 .Example block titles in modules/oadp-verifying-upgrade-1-3-0.adoc.
