### PR TITLE
[enterprise-4.17] Very manual CP 93993 OCP-55628

### DIFF
--- a/modules/nw-multus-bond-cni-object.adoc
+++ b/modules/nw-multus-bond-cni-object.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/multiple_networks/configuring-additional-network.adoc
-//TEST
+
 
 :_mod-docs-content-type: REFERENCE
 [id="nw-multus-bond-cni-object_{context}"]

--- a/modules/nw-multus-bond-cni-object.adoc
+++ b/modules/nw-multus-bond-cni-object.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/multiple_networks/configuring-additional-network.adoc
+//TEST
 
 :_mod-docs-content-type: REFERENCE
 [id="nw-multus-bond-cni-object_{context}"]

--- a/modules/nw-multus-bond-cni-object.adoc
+++ b/modules/nw-multus-bond-cni-object.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nw-multus-bond-cni-object_{context}"]
+= Configuration for a Bond CNI secondary network
+
+The Bond Container Network Interface (Bond CNI) enables the aggregation of multiple network interfaces into a single logical "bonded" interface within a container, enhancing network redundancy and fault tolerance. Only SR-IOV Virtual Functions (VFs) are supported for bonding with this plugin.
+
+The following table describes the configuration parameters for the Bond CNI plugin:
+
+.Bond CNI plugin JSON configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+
+|`name`
+|`string`
+|Specifies the name given to this CNI network attachment definition. This name is used to identify and reference the interface within the container.
+
+|`cniVersion`
+|`string`
+|The CNI specification version.
+
+|`type`
+|`string`
+|Specifies the name of the CNI plugin to configure: `bond`.
+
+|`miimon`
+|`string`
+|Specifies the address resolution protocol (ARP) link monitoring frequency in milliseconds. This parameter defines how often the bond interface sends ARP requests to check the availability of its aggregated interfaces.
+
+|`mtu`
+|`integer`
+|Optional: Specifies the maximum transmission unit (MTU) of the bond. The default is 1500. 
+
+|`failOverMac`
+|`integer`
+|Optional: Specifies the `failOverMac` setting for the bond. Default is 0.
+
+|`mode`
+|`string`
+|Specifies the bonding policy. 
+
+|`linksInContainer`
+|`boolean`
+|Optional: Specifies whether the network interfaces intended for bonding are expected to be created and available directly within the container's network namespace when the bond starts. If `false` which is the default, the CNI plugin looks for these interfaces on the host system first before attempting to form the bond.
+
+|`links`
+|`object`
+|Specifies the interfaces to be bonded.
+
+|`ipam`
+|`object`
+|The configuration object for the IPAM CNI plugin. The plugin manages IP address assignment for the attachment definition.
+
+|====
+
+[id="nw-multus-bond-cni-config-example_{context}"]
+== Bond CNI plugin configuration example
+
+The following example configures a secondary network named `bond-net1`:
+
+[source,json]
+----
+{
+ "type": "bond", 
+ "cniVersion": "0.3.1",
+ "name": "bond-net1",
+ "mode": "active-backup", 
+ "failOverMac": 1, 
+ "linksInContainer": true, 
+ "miimon": "100",
+ "mtu": 1500,
+ "links": [ 
+       {"name": "net1"},
+       {"name": "net2"}
+   ],
+  "ipam": {
+        "type": "host-local",
+        "subnet": "10.56.217.0/24",
+        "routes": [{
+        "dst": "0.0.0.0/0"
+        }],
+        "gateway": "10.56.217.1"
+    }
+}
+----

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -10,6 +10,7 @@ As a cluster administrator, you can configure a primary network for your cluster
 
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-bridge-object_configuring-additional-network[Bridge]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-host-device-object_configuring-additional-network[Host device]
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-bond-cni-object_configuring-additional-network[Bond CNI]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-vlan-object_configuring-additional-network[VLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[IPVLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[MACVLAN]
@@ -165,6 +166,9 @@ include::modules/nw-multus-bridge-object.adoc[leveloffset=+2]
 
 // Configuration for a host device additional network
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
+
+// Configuration for a Bond CNI additional network
+include::modules/nw-multus-bond-cni-object.adoc[leveloffset=+2]
 
 // Configuration for an VLAN additional network
 include::modules/nw-multus-vlan-object.adoc[leveloffset=+2]

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -57,7 +57,9 @@ networks in your cluster:
 
 * *bridge*: xref:../../networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc#nw-multus-bridge-object_configuring-additional-network-cni[Configure a bridge-based secondary network] to allow pods on the same host to communicate with each other and the host.
 
-* *host-device*: xref:../../networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc#nw-multus-host-device-object_configuring-additional-network-cni[Configure a host-device secondary network] to allow pods access to a physical Ethernet network device on the host system.
+* *bond-cni*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-bond-cni-object_configuring-additional-network[Configure a Bond CNI secondary network] to provide a method for aggregating multiple network interfaces into a single logical _bonded_ interface.
+
+* *host-device*: xref:../../networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc#nw-multus-host-device-object_configuring-additional-network-cni[Configure a host-device additional network] to allow pods access to a physical Ethernet network device on the host system.
 
 * *ipvlan*: xref:../../networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.adoc#nw-multus-ipvlan-object_configuring-additional-network-cni[Configure an ipvlan-based secondary network] to allow pods on a host to communicate with other hosts and pods on those hosts, similar to a macvlan-based secondary network. Unlike a macvlan-based secondary network, each pod shares the same MAC address as the parent physical network interface.
 


### PR DESCRIPTION
[OCPBUGS-55628]: No documentation existing so secondary network bond-cni

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-55628
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
https://97437--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html
https://97437--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
