### PR TITLE
OSDOCS-13364:adds ovn-k conditional for egress firewall

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -42,7 +42,7 @@ You configure an egress firewall policy by creating an {kind} custom resource (C
 ifdef::ovn[]
 - A port number
 - A protocol that is one of the following protocols: TCP, UDP, and SCTP
-endif::ovn[]
+
 
 [IMPORTANT]
 ====
@@ -75,6 +75,7 @@ To find the IP address for your API servers, run `oc get ep kubernetes -n defaul
 
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1988324[BZ#1988324].
 ====
+endif::ovn[]
 
 ifdef::openshift-sdn[]
 [IMPORTANT]
@@ -120,7 +121,7 @@ ifdef::openshift-sdn[]
 
   - Projects merged by using the `oc adm pod-network join-projects` command cannot use an egress firewall in any of the joined projects.
 
-* If you create a selectorless service and manually define endpoints or `EndpointSlices` that point to external IPs, traffic to the service IP might still be allowed, even if your `EgressNetworkPolicy` is configured to deny all egress traffic. This occurs because OpenShift SDN does not fully enforce egress network policies for these external endpoints. Consequently, this might result in unexpected access to external services. 
+* If you create a selectorless service and manually define endpoints or `EndpointSlices` that point to external IPs, traffic to the service IP might still be allowed, even if your `EgressNetworkPolicy` is configured to deny all egress traffic. This occurs because OpenShift SDN does not fully enforce egress network policies for these external endpoints. Consequently, this might result in unexpected access to external services.
 endif::openshift-sdn[]
 
 Violating any of these restrictions results in a broken egress firewall for the project. Consequently, all external network traffic is dropped, which can cause security risks for your organization.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-13364
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
SDN [docs](https://97444--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/configuring-egress-firewall.html)
OVN-K [docs](https://97444--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/egress_firewall/configuring-egress-firewall-ovn.html)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
