### PR TITLE
OCPBUGS#54405 removing invalid parameters from AWS

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -895,23 +895,6 @@ such as `io1`.
 |A list of valid AWS availability zones, such as `us-east-1c`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
-|compute:
-  aws:
-    region:
-|The AWS region that the installation program creates compute resources in.
-|Any valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`. You can use the AWS CLI to access the regions available based on your selected instance type. For example:
-[source,terminal]
-----
-aws ec2 describe-instance-type-offerings --filters Name=instance-type,Values=c7g.xlarge
-----
-ifndef::openshift-origin[]
-[IMPORTANT]
-====
-When running on ARM based AWS instances, ensure that you enter a region where AWS Graviton processors are available. See link:https://aws.amazon.com/ec2/graviton/#Global_availability[Global availability] map in the AWS documentation. Currently, AWS Graviton3 processors are only available in some regions.
-====
-endif::openshift-origin[]
-
-
 |controlPlane:
   platform:
     aws:
@@ -981,12 +964,6 @@ such as `io1`.
 control plane machine pool.
 |A list of valid AWS availability zones, such as `us-east-1c`, in a link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
-|controlPlane:
-  aws:
-    region:
-|The AWS region that the installation program creates control plane resources in.
-|Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`.
-
 |platform:
   aws:
     amiID:
@@ -1005,6 +982,22 @@ belong to the same region as the cluster. This is required for regions that requ
     hostedZoneRole:
 |An Amazon Resource Name (ARN) for an existing IAM role in the account containing the specified hosted zone. The installation program and cluster operators will assume this role when performing operations on the hosted zone. This parameter should only be used if you are installing a cluster into a shared VPC.
 |String, for example `arn:aws:iam::1234567890:role/shared-vpc-role`.
+
+|platform:
+  aws:
+    region:
+|The AWS region that the installation program creates all cluster resources in.
+|Any valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`. You can use the AWS CLI to access the regions available based on your selected instance type by running the following command:
+[source,terminal]
+----
+$ aws ec2 describe-instance-type-offerings --filters Name=instance-type,Values=c7g.xlarge
+----
+ifndef::openshift-origin[]
+[IMPORTANT]
+====
+When running on ARM based AWS instances, ensure that you enter a region where AWS Graviton processors are available. See link:https://aws.amazon.com/ec2/graviton/#Global_availability[Global availability] map in the AWS documentation. Currently, AWS Graviton3 processors are only available in some regions.
+====
+endif::openshift-origin[]
 
 |platform:
   aws:


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-54405

Link to docs preview:
https://97449--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-optional-aws_installation-config-parameters-aws

QE review:
- [x] QE has approved this change.

Removing the `compute.platform.aws.region` and `controlPlane.platform.aws.region` parameters and replacing them with the `platform.aws.region` parameter. 
Verified with the latest `openshift-install` binary that the first two parameters do not exist.