### PR TITLE
OCPBUGS-56496-18: Documented the SR-IOV Operator for the 4.18 releas…

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -847,6 +847,11 @@ The Network Observability Operator releases updates independently from the OpenS
 [id="ocp-release-notes-networking_{context}"]
 === Networking
 
+[id="ocp-4-18-sr-iov-arm_{context}"]
+==== Deploying the SR-IOV Network Operator on a cluster that runs on ARM architecture
+
+You can now deploy the SR-IOV Network Operator on a cluster that runs on ARM architecture. (link:https://issues.redhat.com/browse/OCPBUGS-56496[OCPBUGS-56496])
+
 [id="ocp-4-18-holdover-in-grandmaster-clock_{context}"]
 ==== Holdover in a grandmaster clock with GNSS as the source
 


### PR DESCRIPTION
CM sent on the [15th of August](mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r29063303201495258). Merge on the 18th.

Version(s):
4.18

Issue:
[OCPBUGS-56496](https://issues.redhat.com/browse/OCPBUGS-56496) and [OCPBUGS-58291](https://issues.redhat.com/browse/OCPBUGS-58291)

Link to docs preview:
* [Deploying the SR-IOV Network Operator on a cluster that runs on ARM architectur](https://97472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-sr-iov-arm_release-notes)

- [x] SME has approved this change (William Zhao).
- [x] QE has approved this change (Zhiqiang Fang).
