### PR TITLE
OCPBUGS-56496-19: Removed the SR-IOV Operator from the 4.19 release n…

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -874,11 +874,6 @@ You must use the O-RAN compliant PTP events REST API v2 instead.
 
 For more information, see xref:../networking/advanced_networking/ptp/ptp-cloud-events-consumer-dev-reference-v2.adoc#ptp-cloud-events-consumer-dev-reference-v2[Developing PTP event consumer applications with the REST API v2].
 
-[id="ocp-4-19-sr-iov-arm_{context}"]
-==== Deploying the SR-IOV Network Operator on a cluster that runs on ARM architecture
-
-You can now deploy the SR-IOV Network Operator on a cluster that runs on ARM architecture. (link:https://issues.redhat.com/browse/OCPBUGS-56271[OCPBUGS-56271])
-
 [id="ocp-4-19-route-external-cert-feature-gate_{context}"]
 ==== Re-add a previously deleted secret with `RouteExternalCertificate` feature gate enabled
 


### PR DESCRIPTION
CM sent on the [15th of August](mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r29063303201495258). Merge on the 18th.

Version(s):
4.19

Issue:
[OCPBUGS-56496](https://issues.redhat.com/browse/OCPBUGS-56496) and [OCPBUGS-58291](https://issues.redhat.com/browse/OCPBUGS-58291)

Link to docs preview:
* [Removed release note location](https://97473--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-route-external-cert-feature-gate_release-notes)

- [x] SME has approved this change (William Zhao).
- [x] QE has approved this change (Zhiqiang Fang).
