### PR TITLE
OCPBUGS#57827: Replaced duplicate title with required text in the 4.1…

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1610,7 +1610,7 @@ The `preserveBootstrapIgnition` parameter for {aws-short} in the `install-config
 In {product-title} {product-version}, `kube-apiserver` no longer gets a valid cloud configuration object. As a result, the `PersistentVolumeLabel` admission plugin rejects in-tree Google Compute Engine (GCE) persistent disk persistent volumes (PD PVs), that do not have the correct topology. (link:https://issues.redhat.com/browse/OCPBUGS-34544[OCPBUGS-34544])
 
 [id="ocp-4-17-web-console-patternfly_{context}"]
-==== kube-apiserver no longer gets a valid cloud configuration object
+==== Deprecation of Patternfly 4 and React Router 5
 
 In {product-title} 4.16, Patternfly 4 and React Router 5 were deprecated. The deprecated static remains the same for {product-title} {product-version}. All plugins should migrate to Patternfly 5 and React Router 6 as soon as possible. (link:https://issues.redhat.com/browse/OCPBUGS-34538[OCPBUGS-34538])
 


### PR DESCRIPTION
I do not think SME and QE reviews are needed here as I'm removing a duplicate title. Please let me know otherwise.

Version(s):
4.17

Issue:
[OCPBUGS-57827](https://issues.redhat.com/browse/OCPBUGS-57827)

Link to docs preview:
* [Deprecation of Patternfly 4 and React Router 5](https://97477--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-web-console-patternfly_release-notes)
