### PR TITLE
OCPBUGS-59206: Added proxy attribute to the Insights Operator configu…

### DIFF
--- a/modules/insights-operator-configuring.adoc
+++ b/modules/insights-operator-configuring.adoc
@@ -19,12 +19,12 @@ The `ConfigMap` object does not exist by default, so an {product-title} cluster 
 //====
 
 .ConfigMap object configuration structure
-This example of an *insights-config* `ConfigMap` object (`config.yaml` configuration) shows configuration options using standard YAML formatting.
+This example of an *insights-config* `ConfigMap` object (`config.yaml` configuration) shows configuration options by using standard YAML formatting.
 
 image::insights-operator-configmap-example.png[Example of Insights Operator ConfigMap object]
 
 .Configurable attributes and default values
-The table below describes the available configuration attributes:
+The following table describes the available configuration attributes:
 
 [NOTE]
 ====
@@ -32,15 +32,98 @@ The *insights-config* `ConfigMap` object follows standard YAML formatting, where
 ====
 
 .Insights Operator configurable attributes
-[options="header"]
+[cols=".^2l,.^3a,.^1a,.^1a",options="header"]
 |====
 |Attribute name|Description|Value type|Default value
-|`Obfuscation: - networking`|Enables the global obfuscation of IP addresses and the cluster domain name.|Boolean|`false`
-|`Obfuscation: - workload_names`|Obfuscate data coming from the Deployment Validation Operator if it is installed.|Boolean|`false`
-|`sca: interval`|Specifies the frequency of the simple content access entitlements download.|Time interval|`8h`
-|`sca: disabled`|Disables the simple content access entitlements download.|Boolean|`false`
-|`alerting: disabled`|Disables Insights Operator alerts to the cluster Prometheus instance.|Boolean|`false`
-|`httpProxy`, `httpsProxy`, `noProxy`|Set custom proxy for Insights Operator|URL|No default
+
+|alerting: 
+    disabled: false
+|Disables Insights Operator alerts to the cluster Prometheus instance.
+|Boolean
+|`false`
+
+|clusterTransfer: 
+    endpoint: <url>
+|The endpoint for checking and downloading cluster transfer data.
+|URL
+|https://api.openshift.com/api/accounts_mgmt/v1/cluster_transfers/
+
+|clusterTransfer: 
+    interval: 1h0m0s
+|Sets the frequency for checking available cluster transfers.
+|Time interval
+|`24h`
+
+|dataReporting:
+    interval: 30m0s
+|Sets the data gathering and upload frequency.
+|Time interval
+|`2h`
+
+|dataReporting:
+    uploadEndpoint: <url>
+|Sets the upload endpoint.
+|URL
+|https://console.redhat.com/api/ingress/v1/upload
+
+|dataReporting:
+    storagePath: <path>
+|Configures the path where archived data gets stored.
+|File path
+|/var/lib/insights-operator
+
+|dataReporting:
+    downloadEndpoint: <url>
+|Specifies the endpoint for downloading the latest Insights analysis.
+|URL
+|https://console.redhat.com/api/ingress/v1/download
+
+|dataReporting:
+    conditionalGathererEndpoint: <url>
+|Sets the endpoint for providing conditional gathering rule definitions.
+|URL
+|https://console.redhat.com/api/gathering/gathering_rules
+
+
+|dataReporting:
+    obfuscation:
+    - networking
+|Enables the global obfuscation of IP addresses and the cluster domain name.
+|String
+|Not applicable
+
+|dataReporting:
+    obfuscation:
+    - workload_names
+|Enables the obfuscation of Data Validation Operator data. The cluster resource the resource ID is only visible in the archive file and not the resource name.
+|String
+|Not applicable
+
+|proxy: 
+    httpProxy: http://example.com,
+    httpsProxy: http://example.com,
+    noProxy: test.org
+|Set custom proxy for Insights Operator.
+|URL
+|No default
+
+|sca: 
+    interval: 8h0m0s
+|Specifies the frequency of the simple content access (SCA) entitlements download.
+|Time interval
+|`2h`
+
+|sca: 
+    endpoint: <url>
+|Specifies the endpoint for downloading the simple content access (SCA) entitlements.
+|URL
+|https://api.openshift.com/api/accounts_mgmt/v1/entitlement_certificates
+
+|sca: 
+    disabled: false
+|Disables the simple content access entitlements download.
+|Boolean
+|`false`
 |====
 
 


### PR DESCRIPTION
Version(s):
4.16+

Raise a separate PR for 4.15 and 4.14.

Issue:
[OCPBUGS-59206](https://issues.redhat.com/browse/OCPBUGS-59206)

Link to docs preview:
* [Configuring Insights Operator](https://97478--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html#insights-operator-configuring_using-insights-operator)

- [x] SME has approved this change (Harshada Patil/Ondrej Pokorny ).
- [x] QE has approved this change (baiyang zhou) > Waiting on version support info.

* Also check https://issues.redhat.com/browse/OCPBUGS-56473. This PR might resolve this issue.
* [Resource](https://github.com/openshift/insights-operator/blob/master/docs/arch.md#how-the-insights-operator-reads-configuration)
