### PR TITLE
OCPBUGS#59857: Added KBase link to modules/nw-configure-ingress-acces…

### DIFF
--- a/modules/nw-configure-ingress-access-logging.adoc
+++ b/modules/nw-configure-ingress-access-logging.adoc
@@ -157,8 +157,13 @@ spec:
   logging:
     access:
       destination:
-        type: Container
         container:
           maxLength: 8192
+        type: Container
+      httpCaptureHeaders:
+        request:
+        - maxLength: 128
+          name: X-Forwarded-For
 ----
 
+* To view the original client source IP address by using the `X-Forwarded-For` header in the `Ingress` access logs, see the "Capturing Original Client IP from the X-Forwarded-For Header in Ingress and Application Logs" Red{nbsp}Hat Knowledgebase solution.

--- a/networking/networking_operators/ingress-operator.adoc
+++ b/networking/networking_operators/ingress-operator.adoc
@@ -75,6 +75,11 @@ include::modules/nw-scaling-ingress-controller.adoc[leveloffset=+2]
 
 include::modules/nw-configure-ingress-access-logging.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/solutions/7096271[Capturing Original Client IP from the X-Forwarded-For Header in Ingress and Application Logs]
+
 include::modules/nw-ingress-setting-thread-count.adoc[leveloffset=+2]
 
 include::modules/nw-ingress-setting-internal-lb.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-59857](https://issues.redhat.com/browse/OCPBUGS-59857)

Link to docs preview:
* [Core](https://97479--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/ingress-operator.html#nw-configure-ingress-access-logging_configuring-ingress)
* [Dedicated](https://97479--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_operators/ingress-operator.html#nw-configure-ingress-access-logging_configuring-ingress)
* [ROSA](https://97479--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_operators/ingress-operator.html#nw-configure-ingress-access-logging_configuring-ingress)


- [x] SME has approved this change (Ramesh S.).
- [x] QE has approved this change (Hongan Li/Shudi Li).
