### PR TITLE
CNV-63765_GA: Remove TP notice for bulk storage class migration RNs 

### DIFF
--- a/virt/release_notes/virt-4-19-release-notes.adoc
+++ b/virt/release_notes/virt-4-19-release-notes.adoc
@@ -101,6 +101,9 @@ As a cluster administrator, you can prevent users from enabling VM delete protec
 //CNV-55497 Doc: PVC source support for DataImportCron
 * You can now use a PVC as the source of a custom `DataImportCron` in the `dataImportCronTemplates` section of the `HyperConverged` custom resource (CR). See xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates] for more information.
 
+//CNV-58547 UI - Bulk Storage Class Migration within a single cluster
+* By using the {product-title} web console, you can now xref:../../virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.adoc#virt-migrating-bulk-vms-different-storage-class-web_virt-migrating-vms-in-single-cluster-to-different-storage-class[migrate VMs in bulk from one storage class to another storage class].
+
 [id="virt-4-19-web_{context}"]
 === Web console
 
@@ -220,9 +223,6 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 //CNV-62829
 * You can now deploy {VirtProductName} on IPv6 single-stack clusters. Support for IPv6 single-stack is limited to the OVN-Kubernetes localnet and Linux bridge Container Network Interface (CNI) plugins.
-
-//CNV-58547 UI - Bulk Storage Class Migration within a single cluster
-* By using the {product-title} web console, you can now xref:../../virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.adoc#virt-migrating-bulk-vms-different-storage-class-web_virt-migrating-vms-in-single-cluster-to-different-storage-class[migrate VMs in bulk from one storage class to another storage class].
 
 //[id="virt-4-19-bug-fixes_{context}"]
 //== Bug fixes


### PR DESCRIPTION
Version(s): 4.19

Issue: [CNV-63765](https://issues.redhat.com//browse/CNV-63765)

Link to docs preview: https://97514--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-19-release-notes.html

QE review:


