### PR TITLE
OSDOCS 14716 Updated boot images: vSphere opt-in (tech preview)

### DIFF
--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -8,6 +8,19 @@ toc::[]
 
 include::snippets/mco-update-boot-images-intro.adoc[]
 
+:FeatureName: Boot image management on {vmw-short}
+include::snippets/technology-preview.adoc[]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+
 include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-disable_machine-configs-configure[Disabling boot image management]
+* xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images-configuring_machine-configs-configure[Enabling boot image management]
+
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+1]
 include::modules/mco-update-boot-images-configuring.adoc[leveloffset=+1]

--- a/modules/mco-update-boot-images-about.adoc
+++ b/modules/mco-update-boot-images-about.adoc
@@ -9,7 +9,12 @@
 
 By default, for {gcp-first} and {aws-first} clusters, the Machine Config Operator (MCO) updates the boot image in the machine sets in your cluster whenever you update your cluster.
 
-For {gcp-short} and {aws-short}, you can disable the boot image management feature, if needed. When the feature is disabled, the boot image no longer updates with the cluster. For example, with the feature disabled, if your cluster was originally created with {product-title} 4.16, the boot image that the MCO would use to create nodes is the same 4.16 version, even if your cluster is at a later version.
+For {vmw-first}, you can enable boot image management as a Technology Preview feature. For information on how to enable this feature, see "Enabling boot image management".
+
+:FeatureName: Boot image management on {vmw-short}
+include::snippets/technology-preview.adoc[]
+
+You can disable the boot image management feature, if needed. When the feature is disabled, the boot image no longer updates with the cluster. For example, with the feature disabled, if your cluster was originally created with {product-title} 4.16, the boot image that the MCO would use to create nodes is the same 4.16 version, even if your cluster is at a later version.
 
 However, using an older boot image could cause the following issues:
 
@@ -44,13 +49,15 @@ How the cluster behaves after disabling or re-enabling the feature, depends upon
 Because a boot image is used only when a node is scaled up, this feature has no effect on existing nodes.
 ====
 
-To view the current boot image used in your cluster, examine a machine set. 
+To view the current boot image used in your cluster, use one of the following methods, based on your platform:
 
+* For {gcp-short} and {aws-short}, you can examine a machine set.
++
 [NOTE]
 ====
 The location and format of the boot image within the machine set differs, based on the platform. However, the boot image is always listed in the `spec.template.spec.providerSpec.` parameter. 
 ====
-
++
 .Example {gcp-short} machine set with the boot image reference
 
 [source,yaml]
@@ -76,7 +83,7 @@ spec:
 # ...
 ----
 <1> This boot image is the same as the originally-installed {product-title} version, in this example {product-title} 4.12, regardless of the current version of the cluster. The way that the boot image is represented in the machine set depends on the platform, as the structure of the `providerSpec` field differs from platform to platform.
-
++
 .Example {aws-short} machine set with the boot image reference
 
 [source,yaml]
@@ -97,6 +104,22 @@ spec:
           ami:
             id: ami-0e8fd9094e487d1ff
 # ...
+----
+
+* For {vmw-first}, examine an affected node by opening an `oc debug` session to the node and using the `rpm-ostree status` command.
++
+[source,terminal]
+----
+sh-5.1# rpm-ostree status
+----
++
+.Example {aws-short} node with the boot image reference
++
+----
+State: idle
+Deployments:
+* ostree-unverified-registry:quay.io/my-registry/...
+                   Digest: sha256:...
 ----
 
 // The following admonition is intended to address https://issues.redhat.com/browse//OSDOCS-14592

--- a/modules/mco-update-boot-images-configuring.adoc
+++ b/modules/mco-update-boot-images-configuring.adoc
@@ -9,9 +9,42 @@
 
 By default, for {gcp-first} and {aws-first} clusters, the Machine Config Operator (MCO) updates the boot image in the machine sets in your cluster whenever you update your cluster.
 
-If you disabled the boot image management feature, so that the boot images are not updated, you can re-enable the feature by editing the `MachineConfiguration` object.  
+If you disabled the boot image management feature, so that the boot images are not updated, you can re-enable the feature by editing the `MachineConfiguration` object. 
+
+For {vmw-first}, you can enable boot image management as a Technology Preview feature.
+
+:FeatureName: Boot image management on {vmw-short}
+include::snippets/technology-preview.adoc[] 
 
 Enabling the feature updates the boot image to the current {product-title} version. If the cluster is again updated to a new {product-title} version in the future, the boot image is updated again. New nodes created after enabling the feature use the updated boot image. This feature has no effect on existing nodes.
+
+.Prerequisites
+
+* For {vmw-short}, enable the `TechPreviewNoUpgrade` feature set on the cluster. For more information, see "Enabling features using feature gates".
++
+[NOTE]
+====
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
+====
++
+Wait until the `managedBootImagesStatus` stanza displays in the `MachineConfiguration` object. 
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+metadata:
+  name: cluster
+# ...
+status:
+# ...
+  managedBootImagesStatus:
+    machineManagers:
+    - apiGroup: machine.openshift.io
+      resource: machinesets
+      selection:
+        mode: None
+----
 
 .Procedure
 

--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -7,13 +7,13 @@
 [id="mco-update-boot-images-disable_{context}"]
 = Disabling boot image management
 
-By default, for {gcp-first} and {aws-first} clusters, the Machine Config Operator (MCO) manages and updates the boot image in the machine sets in your cluster whenever you update your cluster.
+By default, for {gcp-first} and {aws-first} clusters, the Machine Config Operator (MCO) manages and updates the boot image in the machine sets in your cluster whenever you update your cluster. For {vmw-first}, you can enable boot image management as a Technology Preview feature.
 
 You can disable the boot image management feature for your cluster by editing the `MachineConfiguration` object. When disabled, the Machine Config Operator (MCO) no longer manages the boot image in your cluster and no longer updates the boot image with each cluster update.
 
 Disabling this feature does not rollback the nodes or machine sets to the originally-installed boot image. The machine sets retain the boot image version that was present when the feature was disabled and is not updated if the cluster is upgraded to a new {product-title} version in the future. This feature has no effect on existing nodes.
 
-After disabling the feature in a {gcp-short} or {aws-short} cluster, you can re-enable the feature at any time. For more information, see "Enabling updated boot images".
+After disabling the feature, you can re-enable the feature at any time. For more information, see "Enabling updated boot images".
 
 .Procedure
 

--- a/nodes/nodes/nodes-update-boot-images.adoc
+++ b/nodes/nodes/nodes-update-boot-images.adoc
@@ -8,6 +8,13 @@ toc::[]
 
 include::snippets/mco-update-boot-images-intro.adoc[]
 
+:FeatureName: Boot image management on {vmw-short}
+include::snippets/technology-preview.adoc[]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+
 include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/snippets/mco-update-boot-images-intro.adoc
+++ b/snippets/mco-update-boot-images-intro.adoc
@@ -1,10 +1,12 @@
 // Text snippet included in the following assemblies:
 //
 // * machine_configuration/mco-update-boot-images.adoc
-// * nodes/nodes/nodes-update-boot-images-disable.adoc
+// * nodes/nodes/nodes-update-boot-images.adoc
 
 :_mod-docs-content-type: SNIPPET
 
 For {gcp-first} and {aws-first} clusters, by default the Machine Config Operator (MCO) manages and updates the boot image that is used to scale up your nodes. This means that by default, the MCO updates the boot images whenever you upgrade your cluster.
+
+For {vmw-first}, you can enable boot image management as a Technology Preview feature.
 
 For all other platforms, the MCO does not update the boot image with each cluster update.

--- a/snippets/mco-update-boot-images-verification.adoc
+++ b/snippets/mco-update-boot-images-verification.adoc
@@ -5,7 +5,7 @@
 
 :_mod-docs-content-type: SNIPPET
 
-* View the current state of the boot image management feature by viewing the machine configuration object:
+* When the affected nodes return to the `READY` state, view the current state of the boot image management feature by viewing the machine configuration object:
 +
 [source,terminal]
 ----
@@ -41,7 +41,9 @@ status:
         mode: All
 ----
 
-* Get the boot image version by running the following command. The location and format of the boot image within the machine set differs, based on the platform. However, the boot image is always listed in the `spec.template.spec.providerSpec.` parameter. 
+* When the affected nodes return to the `READY` state, check the current boot image by using one of the following methods: 
+
+** For {gcp-short} and {aws-short}, get the boot image version by running the following command. The location and format of the boot image within the machine set differs, based on the platform. However, the boot image is always listed in the `spec.template.spec.providerSpec.` parameter. 
 +
 [source,terminal]
 ----
@@ -76,3 +78,35 @@ spec:
 # ...
 ----
 <1> This boot image is the same as the current {product-title} version.
+
+** For {vmw-first}, get the boot image version from an affected node:
+
+.. Open an `oc debug` session to the node by running a command similar to the following:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+.. Set `/host` as the root directory within the debug shell by running the following command:
++
+[source,terminal]
+----
+sh-5.1# chroot /host
+----
+
+.. Run the `rpm-ostree status` command to view that the custom layered image is in use:
++
+[source,terminal]
+----
+sh-5.1# rpm-ostree status
+----
++
+.Example output
++
+----
+State: idle
+Deployments:
+* ostree-unverified-registry:quay.io/my-registry/...
+                   Digest: sha256:...
+----


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15858

Link to docs preview:
Machine Configuration -> [Boot image management](https://97519--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-update-boot-images.html) -- Various updates throughout.
Nodes -> Nodes -> [Boot image management](https://97519--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-update-boot-images) -- Various updates throughout. Same modules as the Machine Config assembly.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

