### PR TITLE
[enterprise-4.16] [NETOBSERV] OSDOCS-15626 Update Network Observability to network observability in release notes

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -40,18 +40,22 @@ The following advisory is available for the Network Observability Operator 1.9:
 [id="new-features-enhancements-1-9"]
 === New features and enhancements
 
+[id="user-defined-networks-with-network-observability_{context}"]
+==== User-defined networks with network observability
+With this release, xref:../../networking/multiple_networks/understanding-multiple-networks.adoc#understanding-multiple-networks[user-defined networks (UDN)] feature is generally available with network observability. When the `UDNMapping` feature is enabled in network observability, the *Traffic* flow table has a `UDN labels` column. You can filter logs on *Source Network Name* and *Destination Network Name* information.
+
 [id="filter-flowlogs-at-ingestion_{context}"]
 ==== Filter flowlogs at ingestion
-With this release, you can create filters to reduce the number of generated network flows and the resource usage of Network Observability components. The following filters can be configured:
+With this release, you can create filters to reduce the number of generated network flows and the resource usage of network observability components. The following filters can be configured:
 
 * eBPF Agent filters
 * Flowlogs-pipeline filters
 
 [id="ipsec-support_{context}"]
 ==== IPsec support
-This update brings the following enhancements to Network Observability when IPsec is enabled on {product-title}:
+This update brings the following enhancements to network observability when IPsec is enabled on {product-title}:
 
-* A new column named *IPsec Status* is displayed in the Network Observability *Traffic* flows view to show whether a flow was successfully IPsec-encrypted or if there was an error during encryption/decryption.
+* A new column named *IPsec Status* is displayed in the network observability *Traffic* flows view to show whether a flow was successfully IPsec-encrypted or if there was an error during encryption/decryption.
 
 * A new dashboard showing the percentage of encrypted traffic is generated.
 
@@ -69,7 +73,7 @@ For more information, see xref:../../observability/network_observability/netobse
 
 [id="notable-technical-changes-1-9_{context}"]
 === Notable technical changes
-* The `NetworkEvents` feature in Network Observability 1.9 has been updated to work with the newer Linux kernel of {product-title} 4.19. This update breaks compatibility with older kernels. As a result, the `NetworkEvents` feature can only be used with {product-title} 4.19. If you are using this feature with Network Observability 1.8 and {product-title} 4.18, consider avoiding a Network Observability upgrade or upgrade to Network Observability 1.9 and {product-title} to 4.19.
+* The `NetworkEvents` feature in network observability 1.9 has been updated to work with the newer Linux kernel of {product-title} 4.19. This update breaks compatibility with older kernels. As a result, the `NetworkEvents` feature can only be used with {product-title} 4.19. If you are using this feature with network observability 1.8 and {product-title} 4.18, consider avoiding a network observability upgrade or upgrade to network observability 1.9 and {product-title} to 4.19.
 
 * The `netobserv-reader` cluster role has been renamed to `netobserv-loki-reader`.
 
@@ -82,7 +86,7 @@ Some features in this release are currently in Technology Preview. These experim
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
 [id="ebpf-manager-operator-with-network-observability_{context}"]
-==== eBPF Manager Operator with Network Observability
+==== eBPF Manager Operator with network observability
 
 The eBPF Manager Operator reduces the attack surface and ensures compliance, security, and conflict prevention by managing all eBPF programs. Network observability can use the eBPF Manager Operator to load hooks. This eliminates the need to provide the eBPF Agent with privileged mode or additional Linux capabilities like `CAP_BPF` and `CAP_PERFMON`. The eBPF Manager Operator with network observability is only supported on 64-bit AMD architecture.
 
@@ -109,7 +113,7 @@ The eBPF Manager Operator reduces the attack surface and ensures compliance, sec
 
 * Previously, in the console plugin *Traffic flows* view, in case of text overflow, text ellipses sometimes hid much of the text to be displayed. With this update, it displays as much text as possible. (link:https://issues.redhat.com/browse/NETOBSERV-2119[*NETOBSERV-2119*])
 
-* Previously, the console plugin for Network Observability 1.8.1 and earlier did not work with the {product-title} 4.19 web console, making the *Network Traffic* page inaccessible. With this update, the console plugin is compatible and the *Network Traffic* page is accessible in Network Observability 1.9.0. (link:https://issues.redhat.com/browse/NETOBSERV-2046[*NETOBSERV-2046*])
+* Previously, the console plugin for network observability 1.8.1 and earlier did not work with the {product-title} 4.19 web console, making the *Network Traffic* page inaccessible. With this update, the console plugin is compatible and the *Network Traffic* page is accessible in network observability 1.9.0. (link:https://issues.redhat.com/browse/NETOBSERV-2046[*NETOBSERV-2046*])
 
 * Previously, when using conversation tracking (`logTypes: Conversations` or `logTypes: All` in the `FlowCollector` resource), the *Traffic* rates metrics visible in the dashboards were flawed, wrongly showing an out-of-control increase in traffic. Now, the metrics show more accurate traffic rates. However, note that in `Conversations` and `EndedConversations` modes, these metrics are still not completely accurate as they do not include long-standing connections. This information has been added to the documentation. The default mode `logTypes: Flows` is recommended to avoid these inaccuracy. (link:https://issues.redhat.com/browse/NETOBSERV-1955[*NETOBSERV-1955*])
 
@@ -146,6 +150,13 @@ The following advisory is available for the Network Observability Operator 1.8.0
 [id="network-observability-operator-pkt-xlat-1-8_{context}"]
 ==== Packet translation
 You can now enrich network flows with translated endpoint information, showing not only the service but also the specific backend pod, so you can see which pod served a request.
+
+For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-packet-translation-overview_nw-observe-network-traffic[Endpoint translation (xlat)] and xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-packet-translation_nw-observe-network-traffic[Working with endpoint translation (xlat)].
+
+[id="network-observability-operator-ebpf-perf-improvements-1-8_{context}"]
+==== eBPF performance improvements in 1.8
+
+* Network observability now uses hash maps instead of per-CPU maps. This means that network flows data is now tracked in the kernel space and new packets are also aggregated there. The de-duplication of network flows can now occur in the kernel, so the size of data transfer between the kernel and the user spaces yields better performance. With these eBPF performance improvements, there is potential to observe a CPU resource reduction between 40% and 57% in the eBPF Agent.
 
 [id="network-observability-cli-1-8_{context}"]
 ==== Network Observability CLI
@@ -219,19 +230,19 @@ The following advisory is available for the Network Observability Operator 1.7.0
 You can now export enriched network flows to a compatible OpenTelemetry endpoint, such as the Red{nbsp}Hat build of OpenTelemetry. For more information see xref:../../observability/network_observability/configuring-operator.adoc#network-observability-enriched-flows_network_observability[Export enriched network flow data].
 
 [id="network-observability-operator-developer-perspective-1-7_{context}"]
-==== Network Observability Developer perspective
-You can now use Network Observability in the *Developer* perspective. For more information, see xref:../../observability/network_observability/network-observability-overview.adoc#no-console-integration[{product-title} console integration].
+==== Network observability Developer perspective
+You can now use network observability in the *Developer* perspective. For more information, see xref:../../observability/network_observability/network-observability-overview.adoc#no-console-integration[{product-title} console integration].
 
 ==== TCP flags filtering
 You can now use the `tcpFlags` filter to limit the volume of packets processed by the eBPF program. For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-flowcollector-flowfilter-parameters_nw-observe-network-traffic[Flow filter configuration parameters], xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-ebpf-flow-rule-filter_nw-observe-network-traffic[eBPF flow rule filter], and xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-tcp-flag-syn-flood_metrics-dashboards-alerts[Detecting SYN flooding using the FlowMetric API and TCP flags].
 
 [id="network-observability-virtualization_{context}"]
-==== Network Observability for OpenShift Virtualization
-You can observe networking patterns on an {VirtProductName} setup by identifying eBPF-enriched network flows coming from VMs that are connected to secondary networks, such as through Open Virtual Network (OVN)-Kubernetes. For more information, see xref:../../observability/network_observability/network-observability-secondary-networks.adoc#network-observability-virtualization-config_network-observability-secondary-networks[Configuring virtual machine (VM) secondary network interfaces for Network Observability].
+==== Network observability for OpenShift Virtualization
+You can observe networking patterns on an {VirtProductName} setup by identifying eBPF-enriched network flows coming from VMs that are connected to secondary networks, such as through Open Virtual Network (OVN)-Kubernetes. For more information, see xref:../../observability/network_observability/network-observability-secondary-networks.adoc#network-observability-virtualization-config_network-observability-secondary-networks[Configuring virtual machine (VM) secondary network interfaces for network observability].
 
 [id="network-observability-network-policy-1-7_{context}"]
 ==== Network policy deploys in the FlowCollector custom resource (CR)
-With this release, you can configure the `FlowCollector` CR to deploy a network policy for Network Observability. Previously, if you wanted a network policy, you had to manually create one. The option to manually create a network policy is still available. For more information, see xref:../../observability/network_observability/network-observability-network-policy.adoc#network-observability-deploy-network-policy_network_observability[Configuring an ingress network policy by using the FlowCollector custom resource].
+With this release, you can configure the `FlowCollector` CR to deploy a network policy for network observability. Previously, if you wanted a network policy, you had to manually create one. The option to manually create a network policy is still available. For more information, see xref:../../observability/network_observability/network-observability-network-policy.adoc#network-observability-deploy-network-policy_network_observability[Configuring an ingress network policy by using the FlowCollector custom resource].
 
 [id="network-observability-fips-compliance-1-7_{context}"]
 ==== FIPS compliance
@@ -278,7 +289,7 @@ For more information, see xref:../../observability/network_observability/netobse
 
 [id="network-observability-operator-1-7-known-issues_{context}"]
 === Known issues
-* WWhen you use the must-gather tool with Network Observability, logs are not collected when the cluster has FIPS enabled. (link:https://issues.redhat.com/browse/NETOBSERV-1830[*NETOBSERV-1830*])
+* WWhen you use the must-gather tool with network observability, logs are not collected when the cluster has FIPS enabled. (link:https://issues.redhat.com/browse/NETOBSERV-1830[*NETOBSERV-1830*])
 * When the `spec.networkPolicy` is enabled in the `FlowCollector`, which installs a network policy on the `netobserv` namespace, it is impossible to use the `FlowMetrics` API. The network policy blocks calls to the validation webhook. As a workaround, use the following network policy:
 +
 [source,yaml]
@@ -317,7 +328,7 @@ The following advisory is available for the Network Observability Operator 1.6.2
 * When the secondary interface support was added, there was a need to iterate multiple times to register the per network namespace with the netlink to learn about interface notifications. At the same time, unsuccessful handlers caused a leaking file descriptor because with TCX hook, unlike TC, handlers needed to be explicitly removed when the interface went down. Now, there is no longer leaking file descriptors when creating and deleting pods. (link:https://issues.redhat.com/browse/NETOBSERV-1805[*NETOBSERV-1805*])
 
 === Known issues
-There was a compatibility issue with console plugins that would have prevented Network Observability from being installed on future versions of an {product-title} cluster. By upgrading to 1.6.2, the compatibility issue is resolved and Network Observability can be installed as expected. (link:https://issues.redhat.com/browse/NETOBSERV-1737[*NETOBSERV-1737*])
+There was a compatibility issue with console plugins that would have prevented network observability from being installed on future versions of an {product-title} cluster. By upgrading to 1.6.2, the compatibility issue is resolved and network observability can be installed as expected. (link:https://issues.redhat.com/browse/NETOBSERV-1737[*NETOBSERV-1737*])
 
 [id="network-observability-operator-release-notes-1-6-1_{context}"]
 == Network Observability Operator 1.6.1
@@ -360,7 +371,7 @@ Before upgrading to the latest version of the Network Observability Operator, yo
 
 [id="network-observability-lokiless-enhancements-1.6_{context}"]
 ==== Enhanced use of Network Observability Operator without Loki
-You can now use Prometheus metrics and rely less on Loki for storage when using the Network Observability Operator. For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-without-loki_network_observability[Network Observability without Loki].
+You can now use Prometheus metrics and rely less on Loki for storage when using the Network Observability Operator. For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-without-loki_network_observability[Network observability without Loki].
 
 [id="network-observability-custom-metrics-1.6_{context}"]
 ==== Custom metrics API
@@ -435,11 +446,11 @@ You can use TCP handshake Round-Trip Time (RTT) captured from the `fentry/tcp_rc
 
 [id="network-observability-metrics-dashboard-enhancements"]
 ==== Metrics, dashboards, and alerts enhancements
-The Network Observability metrics dashboards in *Observe* → *Dashboards* → *NetObserv* have new metrics types you can use to create Prometheus alerts. You can now define available metrics in the `includeList` specification. In previous releases, these metrics were defined in the `ignoreTags` specification. For a complete list of these metrics, see xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability Metrics].
+The network observability metrics dashboards in *Observe* → *Dashboards* → *NetObserv* have new metrics types you can use to create Prometheus alerts. You can now define available metrics in the `includeList` specification. In previous releases, these metrics were defined in the `ignoreTags` specification. For a complete list of these metrics, see xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network observability Metrics].
 
 [id="network-observability-improved-lokistack-integration"]
-==== Improvements for Network Observability without Loki
-You can create Prometheus alerts for the *Netobserv* dashboard using DNS, Packet drop, and RTT metrics, even if you don't use Loki. In the previous version of Network Observability, 1.4, these metrics were only available for querying and analysis in the *Network Traffic*, *Overview*, and *Topology* views, which are not available without Loki. For more information, see xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability Metrics].
+==== Improvements for network observability without Loki
+You can create Prometheus alerts for the *Netobserv* dashboard using DNS, Packet drop, and RTT metrics, even if you don't use Loki. In the previous version of network observability, 1.4, these metrics were only available for querying and analysis in the *Network Traffic*, *Overview*, and *Topology* views, which are not available without Loki. For more information, see xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network observability Metrics].
 
 [id="network-observability-zones"]
 ==== Availability zones
@@ -499,7 +510,7 @@ With this fix, the status only becomes `Ready` when all of the underlying compon
 === Known issues
 * When trying to access the web console, cache issues on OCP 4.14.10 prevent access to the *Observe* view. The web console shows the error message: `Failed to get a valid plugin manifest from /api/plugins/monitoring-plugin/`. The recommended workaround is to update the cluster to the latest minor version. If this does not work, you need to apply the workarounds described in this link:https://access.redhat.com/solutions/7052408[Red Hat Knowledgebase article].(link:https://issues.redhat.com/browse/NETOBSERV-1493[*NETOBSERV-1493*])
 
-* Since the 1.3.0 release of the Network Observability Operator, installing the Operator causes a warning kernel taint to appear. The reason for this error is that the Network Observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive.
+* Since the 1.3.0 release of the Network Observability Operator, installing the Operator causes a warning kernel taint to appear. The reason for this error is that the network observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive.
 
 [id="network-observability-operator-release-notes-1-4-2"]
 == Network Observability Operator 1.4.2
@@ -557,12 +568,12 @@ The 1.4 release of the Network Observability Operator adds improvements and new 
 
 * In the *Query Options*, the *Duplicate flows* checkbox is added to choose whether or not to show duplicated flows.
 * You can now filter source and destination traffic with image:arrow-up-long-solid.png[,10] *One-way*, image:arrow-up-long-solid.png[,10] image:arrow-down-long-solid.png[,10] *Back-and-forth*, and *Swap* filters.
-* The Network Observability metrics dashboards in *Observe* -> *Dashboards* -> *NetObserv* and *NetObserv / Health* are modified as follows:
+* The network observability metrics dashboards in *Observe* -> *Dashboards* -> *NetObserv* and *NetObserv / Health* are modified as follows:
 ** The *NetObserv* dashboard shows top bytes, packets sent, packets received per nodes, namespaces, and workloads. Flow graphs are removed from this dashboard.
 ** The *NetObserv / Health* dashboard shows flows overhead as well as top flow rates per nodes, namespaces, and workloads.
 ** Infrastructure and Application metrics are shown in a split-view for namespaces and workloads.
 
-For more information, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-dashboards[Network Observability metrics] and xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-quickfilter_nw-observe-network-traffic[Quick filters].
+For more information, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-dashboards[Network observability metrics] and xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-quickfilter_nw-observe-network-traffic[Quick filters].
 
 [discrete]
 [id="configuration-enhancements-1.4_{context}"]
@@ -574,8 +585,8 @@ For more information, see xref:../../observability/network_observability/network
 For more information, see xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource] and xref:../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference].
 
 [id="network-observability-without-loki-1.4"]
-==== Network Observability without Loki
-The Network Observability Operator is now functional and usable without Loki. If Loki is not installed, it can only export flows to KAFKA or IPFIX format and provide metrics in the Network Observability metrics dashboards. For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-without-loki_network_observability[Network Observability without Loki].
+==== Network observability without Loki
+The Network Observability Operator is now functional and usable without Loki. If Loki is not installed, it can only export flows to KAFKA or IPFIX format and provide metrics in the network observability metrics dashboards. For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-without-loki_network_observability[Network observability without Loki].
 
 [id="network-observability-dns-tracking-1.4"]
 ==== DNS tracking
@@ -600,7 +611,7 @@ Network Observability Operator can now run on `s390x` architecture. Previously i
 
 [id="network-observability-operator-1.4.0-bug-fixes"]
 === Bug fixes
-* Previously, the Prometheus metrics exported by Network Observability were computed out of potentially duplicated network flows. In the related dashboards, from *Observe* -> *Dashboards*, this could result in potentially doubled rates. Note that dashboards from the *Network Traffic* view were not affected. Now, network flows are filtered to eliminate duplicates before metrics calculation, which results in correct traffic rates displayed in the dashboards. (link:https://issues.redhat.com/browse/NETOBSERV-1131[*NETOBSERV-1131*])
+* Previously, the Prometheus metrics exported by network observability were computed out of potentially duplicated network flows. In the related dashboards, from *Observe* -> *Dashboards*, this could result in potentially doubled rates. Note that dashboards from the *Network Traffic* view were not affected. Now, network flows are filtered to eliminate duplicates before metrics calculation, which results in correct traffic rates displayed in the dashboards. (link:https://issues.redhat.com/browse/NETOBSERV-1131[*NETOBSERV-1131*])
 
 * Previously, the Network Observability Operator agents were not able to capture traffic on network interfaces when configured with Multus or SR-IOV, non-default network namespaces. Now, all available network namespaces are recognized and used for capturing flows, allowing capturing traffic for SR-IOV. There are xref:../../observability/network_observability/network-observability-secondary-networks.adoc#network-observability-SR-IOV-config_network-observability-secondary-networks[configurations needed] for the `FlowCollector` and `SRIOVnetwork` custom resource to collect traffic.
 (link:https://issues.redhat.com/browse/NETOBSERV-1283[*NETOBSERV-1283*])
@@ -623,7 +634,7 @@ Network Observability Operator can now run on `s390x` architecture. Previously i
 
 * Currently, when the `processor.metrics.server.tls.type` is configured to use a `PROVIDED` certificate, the operator enters an unsteady state that might affect its performance and resource consumption. It is recommended to not use a `PROVIDED` certificate until this issue is resolved, and instead using an auto-generated certificate, setting `processor.metrics.server.tls.type` to `AUTO`. (link:https://issues.redhat.com/browse/NETOBSERV-1293)[*NETOBSERV-1293*]
 
-* Since the 1.3.0 release of the Network Observability Operator, installing the Operator causes a warning kernel taint to appear. The reason for this error is that the Network Observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive.
+* Since the 1.3.0 release of the Network Observability Operator, installing the Operator causes a warning kernel taint to appear. The reason for this error is that the network observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive.
 
 [id="network-observability-operator-release-notes-1-3"]
 == Network Observability Operator 1.3.0
@@ -639,16 +650,16 @@ You must switch your channel from `v1.0.x` to `stable` to receive future Operato
 === New features and enhancements
 
 [id="multi-tenancy-1.3"]
-==== Multi-tenancy in Network Observability
-* System administrators can allow and restrict individual user access, or group access, to the flows stored in Loki. For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-multi-tenancy_network_observability[Multi-tenancy in Network Observability].
+==== Multi-tenancy in network observability
+* System administrators can allow and restrict individual user access, or group access, to the flows stored in Loki. For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-multi-tenancy_network_observability[Multi-tenancy in network observability].
 
 [id="flow-based-dashboard-1.3"]
 ==== Flow-based metrics dashboard
-* This release adds a new dashboard, which provides an overview of the network flows in your {product-title} cluster. For more information, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-dashboards[Network Observability metrics].
+* This release adds a new dashboard, which provides an overview of the network flows in your {product-title} cluster. For more information, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-dashboards[Network observability metrics].
 
 [id="must-gather-1.3"]
 ==== Troubleshooting with the must-gather tool
-* Information about the Network Observability Operator can now be included in the must-gather data for troubleshooting. For more information, see xref:../../observability/network_observability/troubleshooting-network-observability.adoc#network-observability-must-gather_network-observability-troubleshooting[Network Observability must-gather].
+* Information about the Network Observability Operator can now be included in the must-gather data for troubleshooting. For more information, see xref:../../observability/network_observability/troubleshooting-network-observability.adoc#network-observability-must-gather_network-observability-troubleshooting[Network observability must-gather].
 
 [id="multi-arch-1.3"]
 ==== Multiple architectures now supported
@@ -667,7 +678,7 @@ The release of Network Observability Operator 1.3 deprecates the `spec.Loki.auth
 
 * Since version 1.2, the Network Observability Operator can raise alerts when a problem occurs with the flows collection. Previously, due to a bug, the related configuration to disable alerts, `spec.processor.metrics.disableAlerts` was not working as expected and sometimes ineffectual. Now, this configuration is fixed so that it is possible to disable the alerts. (link:https://issues.redhat.com/browse/NETOBSERV-976[*NETOBSERV-976*])
 
-* Previously, when Network Observability was configured with `spec.loki.authToken` set to `DISABLED`, only a `kubeadmin` cluster administrator was able to view network flows. Other types of cluster administrators received authorization failure. Now, any cluster administrator is able to view network flows. (link:https://issues.redhat.com/browse/NETOBSERV-972[*NETOBSERV-972*])
+* Previously, when network observability was configured with `spec.loki.authToken` set to `DISABLED`, only a `kubeadmin` cluster administrator was able to view network flows. Other types of cluster administrators received authorization failure. Now, any cluster administrator is able to view network flows. (link:https://issues.redhat.com/browse/NETOBSERV-972[*NETOBSERV-972*])
 
 * Previously, a bug prevented users from setting `spec.consolePlugin.portNaming.enable` to `false`. Now, this setting can be set to `false` to disable port-to-service name translation. (link:https://issues.redhat.com/browse/NETOBSERV-971[*NETOBSERV-971*])
 
@@ -675,9 +686,9 @@ The release of Network Observability Operator 1.3 deprecates the `spec.Loki.auth
 
 * Previously, when `processor.metrics.tls` was set to `AUTO` in the `FlowCollector`, the `flowlogs-pipeline servicemonitor` did not adapt the appropriate TLS scheme, and metrics were not visible in the web console. Now the issue is fixed for AUTO mode. (link:https://issues.redhat.com/browse/NETOBSERV-1070[*NETOBSERV-1070*])
 
-* Previously, certificate configuration, such as used for Kafka and Loki, did not allow specifying a namespace field, implying that the certificates had to be in the same namespace where Network Observability is deployed. Moreover, when using Kafka with TLS/mTLS, the user had to manually copy the certificate(s) to the privileged namespace where the `eBPF` agent pods are deployed and manually manage certificate updates, such as in the case of certificate rotation. Now, Network Observability setup is simplified by adding a namespace field for certificates in the `FlowCollector` resource. As a result, users can now install Loki or Kafka in different namespaces without needing to manually copy their certificates in the Network Observability namespace. The original certificates are watched so that the copies are automatically updated when needed. (link:https://issues.redhat.com/browse/NETOBSERV-773[*NETOBSERV-773*])
+* Previously, certificate configuration, such as used for Kafka and Loki, did not allow specifying a namespace field, implying that the certificates had to be in the same namespace where network observability is deployed. Moreover, when using Kafka with TLS/mTLS, the user had to manually copy the certificate(s) to the privileged namespace where the `eBPF` agent pods are deployed and manually manage certificate updates, such as in the case of certificate rotation. Now, network observability setup is simplified by adding a namespace field for certificates in the `FlowCollector` resource. As a result, users can now install Loki or Kafka in different namespaces without needing to manually copy their certificates in the network observability namespace. The original certificates are watched so that the copies are automatically updated when needed. (link:https://issues.redhat.com/browse/NETOBSERV-773[*NETOBSERV-773*])
 
-* Previously, the SCTP, ICMPv4 and ICMPv6 protocols were not covered by the Network Observability agents, resulting in a less comprehensive network flows coverage. These protocols are now recognized to improve the flows coverage. (link:https://issues.redhat.com/browse/NETOBSERV-934[*NETOBSERV-934*])
+* Previously, the SCTP, ICMPv4 and ICMPv6 protocols were not covered by the network observability agents, resulting in a less comprehensive network flows coverage. These protocols are now recognized to improve the flows coverage. (link:https://issues.redhat.com/browse/NETOBSERV-934[*NETOBSERV-934*])
 
 [id="network-observability-operator-1.3.0-known-issues"]
 === Known issues
@@ -685,7 +696,7 @@ The release of Network Observability Operator 1.3 deprecates the `spec.Loki.auth
 
 * Since the 1.2.0 release of the Network Observability Operator, using {loki-op} 5.6, a Loki certificate change periodically affects the `flowlogs-pipeline` pods and results in dropped flows rather than flows written to Loki. The problem self-corrects after some time, but it still causes temporary flow data loss during the Loki certificate change. This issue has only been observed in large-scale environments of 120 nodes or greater.(link:https://issues.redhat.com/browse/NETOBSERV-980[*NETOBSERV-980*])
 
-* When you install the Operator, a warning kernel taint can appear. The reason for this error is that the Network Observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive.
+* When you install the Operator, a warning kernel taint can appear. The reason for this error is that the network observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive.
 
 [id="network-observability-operator-release-notes-1-2"]
 == Network Observability Operator 1.2.0
@@ -709,7 +720,7 @@ The subscription of an installed Operator specifies an update channel that track
 * You can now query flows by *Log Type*, which enables grouping network flows that are part of the same conversation. For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-working-with-conversations_nw-observe-network-traffic[Working with conversations].
 
 [id="health-alerts-feature-1.2"]
-==== Network Observability health alerts
+==== Network observability health alerts
 * The Network Observability Operator now creates automatic alerts if the `flowlogs-pipeline` is dropping flows because of errors at the write stage or if the Loki ingestion rate limit has been reached. For more information, see xref:../../observability/network_observability/network-observability-operator-monitoring.adoc#network-observability-health-dashboard-overview_network_observability[Health dashboards].
 
 [id="network-observability-operator-1.2.0-bug-fixes"]


### PR DESCRIPTION
Cherry-pick: dcc8ddc243a4866666c70725e9c40ff65bd69799

Original PR: https://github.com/openshift/openshift-docs/pull/97453/

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

QE review:
QE is not required for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
