### PR TITLE
[NETOBSERV] OSDOCS-15834 Upate Network Observability references in topic_map

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3243,9 +3243,9 @@ Topics:
   Dir: network_observability
   Distros: openshift-enterprise,openshift-origin
   Topics:
-  - Name: Network Observability release notes
+  - Name: Network observability release notes
     File: network-observability-operator-release-notes
-  - Name: Network Observability overview
+  - Name: Network observability overview
     File: network-observability-overview
   - Name: Installing the Network Observability Operator
     File: installing-operators
@@ -3280,7 +3280,7 @@ Topics:
     File: flowmetric-api
   - Name: Flows format reference
     File: json-flows-format-reference
-  - Name: Troubleshooting Network Observability
+  - Name: Troubleshooting network observability
     File: troubleshooting-network-observability
 - Name: Power Monitoring
   Dir: power_monitoring


### PR DESCRIPTION
[NETOBSERV] [OSDOCS-15834](https://issues.redhat.com//browse/OSDOCS-15834) Update Network Observability references in topic_map

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15834

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required for this PR. This PR addresses OPL issues only.

Additional information:
* Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures.
* I will manually verify content on each breach, and create manual cherry-picks accordingly.