### PR TITLE
ROSA migration fixes

### DIFF
--- a/modules/rosa-sts-cluster-terraform-execute.adoc
+++ b/modules/rosa-sts-cluster-terraform-execute.adoc
@@ -11,7 +11,7 @@ endif::[]
 :_content-type: PROCEDURE
 
 [id="rosa-sts-cluster-terraform-execute_{context}"]
-= Using Terraform to create your ROSA cluster
+= Using Terraform to create your {product-title} cluster
 
 After you create the Terraform files, you must initiate Terraform to provide all of the required dependencies. Then apply the Terraform plan.
 
@@ -90,7 +90,7 @@ Do you want to perform these actions?
 ----
 endif::tf-rosa-classic[]
 +
-If you enter `yes`, your Terraform plan starts, creating your AWS account roles, Operator roles, and your ROSA Classic cluster.
+If you enter `yes`, your Terraform plan starts, creating your AWS account roles, Operator roles, and your {product-title} cluster.
 
 .Verification
 . Verify that your cluster was created by running the following command:
@@ -102,11 +102,20 @@ $ rosa list clusters
 +
 .Example output showing a cluster's ID, name, and status
 +
+ifdef::openshift-rosa-hcp[]
+[source,terminal]
+----
+ID                                NAME          STATE  TOPOLOGY
+27c3snjsupa9obua74ba8se5kcj11269  rosa-tf-demo  ready  Hosted CP
+----
+endif::openshift-rosa-hcp[]
+ifdef::openshift-rosa[]
 [source,terminal]
 ----
 ID                                NAME          STATE  TOPOLOGY
 27c3snjsupa9obua74ba8se5kcj11269  rosa-tf-demo  ready  Classic (STS)
 ----
+endif::openshift-rosa[]
 
 . Verify that your account roles were created by running the following command:
 +

--- a/modules/rosa-sts-cluster-terraform-setup.adoc
+++ b/modules/rosa-sts-cluster-terraform-setup.adoc
@@ -14,14 +14,7 @@ endif::[]
 [id="rosa-sts-cluster-terraform-setup_{context}"]
 = Preparing your environment for Terraform
 
-Before you can create your 
-ifdef::tf-classic-defaults[]
-{rosa-classic-short}
-endif::tf-classic-defaults[]
-ifdef::tf-hcp-defaults[]
-{rosa-short}
-endif::tf-hcp-defaults[]
-cluster by using Terraform, you need to export your link:https://console.redhat.com/openshift/token[offline {cluster-manager-first} token].
+Before you can create your {product-title} cluster by using Terraform, you need to export your link:https://console.redhat.com/openshift/token[offline {cluster-manager-first} token].
 
 .Procedure
 . *Optional*: Because the Terraform files get created in your current directory during this procedure, you can create a new directory to store these files and navigate into it by running the following command:

--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -24,28 +24,11 @@ endif::[]
 [id="rosa-sts-overview-of-the-default-cluster-specifications_{context}"]
 = Overview of the default cluster specifications
 
-ifndef::tf-classic,tf-hcp[]
-You can quickly create a
-ifdef::openshift-rosa-hcp[]
-{rosa-title} cluster by using the default installation options.
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-ifdef::hcp-quickstart,hcp[]
-{rosa-title} cluster by using the default installation options.
-endif::hcp-quickstart,hcp[]
-ifndef::hcp-quickstart,hcp[]
-{product-title} (ROSA) cluster with the {sts-first} by using the default installation options.
-endif::hcp-quickstart,hcp[]
-endif::openshift-rosa[]
-The following summary describes the default cluster specifications.
-endif::tf-classic,tf-hcp[]
+You can quickly create a {product-title} cluster by using the default installation options.
 
-ifdef::openshift-rosa-hcp,hcp[]
+The following summary describes the default cluster specifications.
+
 .Default {product-title} cluster specifications
-endif::openshift-rosa-hcp,hcp[]
-ifdef::openshift-rosa[]
-.Default ROSA with STS cluster specifications
-endif::openshift-rosa[]
 
 [cols=".^1,.^3a",options="header"]
 |===

--- a/modules/rosa-sts-terraform-prerequisites.adoc
+++ b/modules/rosa-sts-terraform-prerequisites.adoc
@@ -8,7 +8,7 @@
 
 To use link:https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs[the Red{nbsp}Hat Cloud Services provider] inside your Terraform configuration, you must meet the following prerequisites:
 
-* You have installed the {product-title} (ROSA) command-line interface (CLI) tool.
+* You have installed the {product-title} command-line interface (CLI) tool.
 * You have your offline link:https://console.redhat.com/openshift/token/rosa[{cluster-manager-first} token].
 * You have installed link:https://developer.hashicorp.com/terraform/downloads[Terraform version 1.4.6] or newer.
 * You have created your AWS account-wide IAM roles.

--- a/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
+++ b/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-hcp-aws-private-creating-cluster"]
-= Creating a private cluster on {hcp-title}
+= Creating a private cluster on {product-title}
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-aws-private-creating-cluster
 
 toc::[]
 
-For {rosa-title} workloads that do not require public internet access, you can create a private cluster.
+For {product-title} workloads that do not require public internet access, you can create a private cluster.
 
 //include::modules/osd-aws-privatelink-about.adoc[leveloffset=+1]
 //include::modules/osd-aws-privatelink-required-resources.adoc[leveloffset=+1]

--- a/rosa_hcp/rosa-hcp-cluster-no-cni.adoc
+++ b/rosa_hcp/rosa-hcp-cluster-no-cni.adoc
@@ -1,32 +1,25 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-hcp-cluster-no-cli"]
-= {hcp-title} clusters without a CNI plugin
+= {product-title} clusters without a CNI plugin
 include::_attributes/attributes-openshift-dedicated.adoc[]
 include::_attributes/common-attributes.adoc[]
 :context: rosa-hcp-cluster-no-cni
 
 toc::[]
 
-You can use your own Container Network Interface (CNI) plugin when creating a 
-ifdef::openshift-rosa[]
-{rosa-title}
-endif::openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{product-title}
-endif::openshift-rosa-hcp[]
-cluster. You can create a {rosa-short} cluster without a CNI and install your own CNI plugin after cluster creation.
+You can use your own Container Network Interface (CNI) plugin when creating a {product-title} cluster. You can create a {product-title} cluster without a CNI and install your own CNI plugin after cluster creation.
 
 [IMPORTANT]
 ====
 For customers who choose to use their own CNI, the responsibility of CNI plugin support belongs to the customer in coordination with their chosen CNI vendor.
 ====
 
-The default plugin for {rosa-short} is the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin]. This plugin is the only Red Hat supported CNI plugin for {rosa-short}.  
+The default plugin for {product-title} is the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin]. This plugin is the only Red Hat supported CNI plugin for {product-title}.  
 
-If you choose to use your own CNI for {rosa-short} clusters, it is strongly recommended that you obtain commercial support from the plugin vendor before creating your clusters. Red Hat support cannot assist with CNI-related issues such as pod to pod traffic for customers who choose to use their own CNI. Red Hat still provides support for all non-CNI issues. If you want CNI-related support from Red Hat, you must install the cluster with the default OVN-Kubernetes network plugin. For more information, see the xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#rosa-policy-responsibility-matrix[responsibility matrix].
+If you choose to use your own CNI for {product-title} clusters, it is strongly recommended that you obtain commercial support from the plugin vendor before creating your clusters. Red Hat support cannot assist with CNI-related issues such as pod to pod traffic for customers who choose to use their own CNI. Red Hat still provides support for all non-CNI issues. If you want CNI-related support from Red Hat, you must install the cluster with the default OVN-Kubernetes network plugin. For more information, see the xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#rosa-policy-responsibility-matrix[responsibility matrix].
 
 [id="rosa-hcp-no-cni-cluster-creation"]
-== Creating a {rosa-short} cluster without a CNI plugin
+== Creating a {product-title} cluster without a CNI plugin
 
 === Prerequisites
 * Ensure that you have completed the xref:../rosa_planning/rosa-hcp-aws-prereqs.adoc#rosa-hcp-aws-prereqs[AWS prerequisites].

--- a/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
+++ b/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
@@ -6,15 +6,15 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Create a {rosa-title} cluster using a custom AWS Key Management Service (KMS) key.
+Create a {product-title} cluster using a custom AWS Key Management Service (KMS) key.
 
 //include::modules/rosa-sts-creating-a-cluster-quickly-ocm.adoc[leveloffset=+1]
 //include::modules/rosa-sts-associating-your-aws-account.adoc[leveloffset=+2]
 
 [id="rosa-hcp-creating-cluster-with-aws-kms-key-prereqs"]
-== {rosa-short} Prerequisites
+== {product-title} Prerequisites
 
-To create a {rosa-short} cluster, you must have the following items:
+To create a {product-title} cluster, you must have the following items:
 
 * A configured virtual private cloud (VPC)
 * Account-wide roles
@@ -22,9 +22,9 @@ To create a {rosa-short} cluster, you must have the following items:
 * Operator roles
 
 [id="rosa-hcp-creating-cluster-with-aws-kms-key-creating-vpc"]
-== Creating a Virtual Private Cloud for your {rosa-short} clusters
+== Creating a Virtual Private Cloud for your {product-title} clusters
 
-You must have a Virtual Private Cloud (VPC) to create {rosa-short} cluster. Use one of the following methods to create a VPC:
+You must have a Virtual Private Cloud (VPC) to create {product-title} cluster. Use one of the following methods to create a VPC:
 
 * Create a VPC using the ROSA command-line interface (CLI)
 * Create a VPC by using a Terraform template

--- a/rosa_hcp/rosa-hcp-deleting-cluster.adoc
+++ b/rosa_hcp/rosa-hcp-deleting-cluster.adoc
@@ -1,12 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="rosa-hcp-deleting-cluster"]
-= Deleting a {rosa-short} cluster
+= Deleting a {product-title} cluster
 :context: rosa-hcp-deleting-cluster
 
 toc::[]
 
-If you want to delete a {rosa-title} cluster, you can use either the {cluster-manager-first} or the ROSA command-line interface (CLI) (`rosa`). After deleting your cluster, you can also delete the AWS Identity and Access Management (IAM) resources that are used by the cluster.
+If you want to delete a {product-title} cluster, you can use either the {cluster-manager-first} or the ROSA command-line interface (CLI) (`rosa`). After deleting your cluster, you can also delete the AWS Identity and Access Management (IAM) resources that are used by the cluster.
 
 include::modules/rosa-hcp-deleting-cluster.adoc[leveloffset=+1]
 

--- a/rosa_hcp/rosa-hcp-egress-zero-install.adoc
+++ b/rosa_hcp/rosa-hcp-egress-zero-install.adoc
@@ -5,7 +5,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-egress-zero-install
 toc::[]
 
-Creating {rosa-title} with {egress-zero} provides a way to enhance your cluster's stability and security by allowing your cluster to use the image registry in the local region if the cluster cannot access the internet. Your cluster first tries to pull the images from Quay, and when they aren't reached, it instead pulls the images from the image registry in the local region. 
+Creating {product-title} with {egress-zero} provides a way to enhance your cluster's stability and security by allowing your cluster to use the image registry in the local region if the cluster cannot access the internet. Your cluster first tries to pull the images from Quay, and when they aren't reached, it instead pulls the images from the image registry in the local region. 
 
 All public and private clusters with {egress-zero} get their Red{nbsp}Hat container images from an Amazon Elastic Container Registry (ECR) located in the local region of the cluster instead of gathering these images from various endpoints and registries on the internet. ECR provides storage for OpenShift release images as well as Red{nbsp}Hat Operators. All requests for ECR are kept within your AWS network by serving them over a VPC endpoint within your cluster.
 
@@ -13,7 +13,7 @@ All public and private clusters with {egress-zero} get their Red{nbsp}Hat contai
 
 You can create a fully operational cluster that does not require a public egress by configuring a virtual private cloud (VPC) and using the `--properties zero_egress:true` flag when creating your cluster.
 
-See xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading {rosa-short} clusters] to upgrade clusters using {egress-zero}. 
+See xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading {product-title} clusters] to upgrade clusters using {egress-zero}. 
 
 [NOTE]
 ====
@@ -62,7 +62,7 @@ A physical connection might exist between machines on the internal network and a
 
 [IMPORTANT]
 ====
-* You can use {egress-zero} on all supported versions of {rosa-short} that use the hosted control plane architecture; however, Red{nbsp}Hat suggests using the latest available z-stream release for each {ocp} version. 
+* You can use {egress-zero} on all supported versions of {product-title} that use the hosted control plane architecture; however, Red{nbsp}Hat suggests using the latest available z-stream release for each {ocp} version. 
 
 * While you may install and upgrade your clusters as you would a regular cluster, due to an upstream issue with how the internal image registry functions in disconnected environments, your cluster that uses {egress-zero} will not be able to fully use all platform components, such as the image registry. You can restore these features by using the latest ROSA version when upgrading or installing your cluster.
 ====
@@ -70,9 +70,9 @@ A physical connection might exist between machines on the internal network and a
 include::modules/rosa-hcp-set-environment-variables.adoc[leveloffset=+1]
 
 [id="rosa-hcp-egress-zero-install-creating_{context}"]
-== Creating a Virtual Private Cloud for your {hcp-title} clusters 
+== Creating a Virtual Private Cloud for your {product-title} clusters 
 
-You must have a Virtual Private Cloud (VPC) to create a {rosa-short} cluster. To pull images from the local ECR mirror over your VPC endpoint, you must configure a privatelink service connection and modify the default security groups with specific tags. Use one of the following methods to create a VPC:
+You must have a Virtual Private Cloud (VPC) to create a {product-title} cluster. To pull images from the local ECR mirror over your VPC endpoint, you must configure a privatelink service connection and modify the default security groups with specific tags. Use one of the following methods to create a VPC:
 
 * Create a VPC using the ROSA command-line interface (CLI)
 * Create a VPC by using a Terraform template

--- a/rosa_hcp/rosa-hcp-quickstart-guide.adoc
+++ b/rosa_hcp/rosa-hcp-quickstart-guide.adoc
@@ -6,14 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Follow this guide to quickly create a 
-ifdef::openshift-rosa[]
-{rosa-title}
-endif::openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{product-title}
-endif::openshift-rosa-hcp[]
-cluster using the command-line interface (CLI), grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
+Follow this guide to quickly create a {product-title} cluster using the command-line interface (CLI), grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
 
 [discrete]
 include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[leveloffset=+2]
@@ -26,14 +19,14 @@ include::modules/rosa-getting-started-install-configure-cli-tools.adoc[leveloffs
 
 .Next steps
 
-Before you can use the {hybrid-console} to deploy {rosa-short} clusters, you must associate your AWS account with your Red{nbsp}Hat organization and create the required account-wide AWS IAM STS roles and policies for ROSA.
+Before you can use the {hybrid-console} to deploy {product-title} clusters, you must associate your AWS account with your Red{nbsp}Hat organization and create the required account-wide AWS IAM STS roles and policies for ROSA.
 
 include::modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+1]
 
 [id="rosa-hcp-quickstart-creating-vpc"]
-== Creating a Virtual Private Cloud for your {rosa-short} clusters
+== Creating a Virtual Private Cloud for your {product-title} clusters
 
-You must have an AWS Virtual Private Cloud (VPC) to create a {rosa-short} cluster. You can use the following methods to create a VPC:
+You must have an AWS Virtual Private Cloud (VPC) to create a {product-title} cluster. You can use the following methods to create a VPC:
 
 * Create a VPC using the ROSA CLI
 * Create a VPC by using a Terraform template

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -1,28 +1,28 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-hcp-sts-creating-a-cluster-ext-auth"]
-= Creating a {rosa-short} cluster that uses direct authentication with an external OIDC identity provider
+= Creating a {product-title} cluster that uses direct authentication with an external OIDC identity provider
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-sts-creating-a-cluster-ext-auth
 
 toc::[]
 
-You can create {rosa-title} clusters that use an external OpenID Connect (OIDC) identity provider to issue tokens for authentication, replacing the built-in OpenShift OAuth server. While the built-in OpenShift OAuth server supports integration with a variety of identity providers, including external OIDC identity providers, it is limited to the capabilities of the OAuth server itself. You can directly integrate external OIDC identity providers with {rosa-short} clusters in order to facilitate machine-to-machine workflows, such as CLI, and provide additional capabilities which are not available when using the built-in OpenShift OAuth server.
+You can create {product-title} clusters that use an external OpenID Connect (OIDC) identity provider to issue tokens for authentication, replacing the built-in OpenShift OAuth server. While the built-in OpenShift OAuth server supports integration with a variety of identity providers, including external OIDC identity providers, it is limited to the capabilities of the OAuth server itself. You can directly integrate external OIDC identity providers with {product-title} clusters in order to facilitate machine-to-machine workflows, such as CLI, and provide additional capabilities which are not available when using the built-in OpenShift OAuth server.
 
 [IMPORTANT]
 ====
-Since it is not possible to upgrade or convert existing {rosa-classic-short} clusters to a {hcp} architecture, you must create a new cluster to use {rosa-short} functionality. You also cannot convert a cluster that was created to use external authentication providers to use the internal OAuth2 server. You must also create a new cluster.
+Since it is not possible to upgrade or convert existing {rosa-classic-title} clusters to a {hcp} architecture, you must create a new cluster to use {product-title} functionality. You also cannot convert a cluster that was created to use external authentication providers to use the internal OAuth2 server. You must also create a new cluster.
 ====
 
 include::snippets/imp-rosa-hcp-no-shared-vpc-support.adoc[leveloffset=+0]
 
 [NOTE]
 ====
-{rosa-short} clusters only support {sts-first} authentication.
+{product-title} clusters only support {sts-first} authentication.
 ====
 
 .Further reading
 ifdef::openshift-rosa-hcp[]
-* For a comparison between {rosa-short} and {rosa-classic-short}, see the xref:../rosa_architecture/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
+* For a comparison between {product-title} and {rosa-classic-title}, see the xref:../rosa_architecture/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
 endif::openshift-rosa-hcp[]
 * See the AWS documentation for information about link:https://docs.aws.amazon.com/rosa/latest/userguide/getting-started-hcp.html[Getting started with ROSA with HCP using the ROSA CLI in auto mode].
 
@@ -31,9 +31,9 @@ endif::openshift-rosa-hcp[]
 //For a full list of the supported certificates, see the xref:#../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-compliance_rosa-policy-process-security[Compliance] section of "Understanding process and security for Red{nbsp}Hat OpenShift Service on AWS".
 
 [id="rosa-hcp-external-auth-prereqs"]
-== {rosa-short} Prerequisites
+== {product-title} Prerequisites
 
-To create a {rosa-short} cluster, you must have completed the following steps:
+To create a {product-title} cluster, you must have completed the following steps:
 
 ifndef::openshift-rosa-hcp[]
 * Completed the xref:../rosa_planning/rosa-hcp-aws-prereqs.adoc#rosa-hcp-aws-prereqs[AWS prerequisites]
@@ -65,7 +65,7 @@ include::modules/rosa-hcp-sts-creating-a-break-glass-cred-cli.adoc[leveloffset=+
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc#rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli_rosa-hcp-sts-creating-a-cluster-ext-auth[Creating a {rosa-short} cluster that uses direct authentication with an external OIDC identity provider]
+* xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc#rosa-hcp-sts-creating-a-cluster-external-auth-cluster-cli_rosa-hcp-sts-creating-a-cluster-ext-auth[Creating a {product-title} cluster that uses direct authentication with an external OIDC identity provider]
 //* For more information about CLI configurations, see xref:#../cli_reference/openshift_cli/managing-cli-profiles.adoc#managing-cli-profiles[Managing CLI profiles].
 
 include::modules/rosa-hcp-sts-accessing-a-break-glass-cred-cli.adoc[leveloffset=+1]

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -2,36 +2,36 @@
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-sts-creating-a-cluster-quickly
 [id="rosa-hcp-sts-creating-a-cluster-quickly"]
-= Creating {rosa-short} clusters using the default options
+= Creating {product-title} clusters using the default options
 
 toc::[]
 
 ifndef::openshift-rosa-hcp[]
 [NOTE]
 ====
-If you are looking for a quickstart guide for {rosa-classic-short}, see xref:../rosa_getting_started/rosa-quickstart-guide-ui.adoc#rosa-quickstart-guide-ui[{rosa-classic-title} quickstart guide].
+If you are looking for a quickstart guide for {rosa-classic-title}, see xref:../rosa_getting_started/rosa-quickstart-guide-ui.adoc#rosa-quickstart-guide-ui[{rosa-classic-title} quickstart guide].
 ====
 endif::openshift-rosa-hcp[]
 
-{rosa-title} offers a more efficient and reliable architecture for creating {rosa-short} clusters. With {rosa-short}, each cluster has a dedicated control plane that is isolated in the ROSA service AWS account.
+{product-title} offers a more efficient and reliable architecture for creating {product-title} clusters. With {product-title}, each cluster has a dedicated control plane that is isolated in the ROSA service AWS account.
 
-Create a {rosa-short} cluster quickly by using the default options and automatic AWS Identity and Access Management (IAM) resource creation. You can deploy your cluster by using the ROSA CLI (`rosa`).
+Create a {product-title} cluster quickly by using the default options and automatic AWS Identity and Access Management (IAM) resource creation. You can deploy your cluster by using the ROSA CLI (`rosa`).
 
 [IMPORTANT]
 ====
-Since it is not possible to upgrade or convert existing {rosa-classic-short} clusters to hosted control plane architecture, you must create a new cluster to use {rosa-short} functionality.
+Since it is not possible to upgrade or convert existing {rosa-classic-title} clusters to hosted control plane architecture, you must create a new cluster to use {product-title} functionality.
 ====
 
 include::snippets/imp-rosa-hcp-no-shared-vpc-support.adoc[leveloffset=+0]
 
 [NOTE]
 ====
-{rosa-short} clusters only support AWS IAM Security Token Service (STS) authentication.
+{product-title} clusters only support AWS IAM Security Token Service (STS) authentication.
 ====
 
 ifndef::openshift-rosa-hcp[]
 .Further reading
-* For a comparison between {hcp-title} and ROSA Classic, see the xref:../architecture/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
+* For a comparison between {product-title} and {rosa-classic-title}, see the xref:../architecture/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
 * See the AWS documentation for information about link:https://docs.aws.amazon.com/rosa/latest/userguide/getting-started-hcp.html[Getting started with ROSA with HCP using the ROSA CLI in auto mode].
 
 [role="_additional-resources"]
@@ -61,9 +61,9 @@ include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[le
 
 //TODO OSDOCS-11789: Move these out of the deployment doc and into the prepare doc? Keep in both locations?
 [id="rosa-hcp-prereqs"]
-== {rosa-short} Prerequisites
+== {product-title} Prerequisites
 
-To create a {hcp-title} cluster, you must have the following items:
+To create a {product-title} cluster, you must have the following items:
 
 * A configured virtual private cloud (VPC)
 * Account-wide roles
@@ -71,9 +71,9 @@ To create a {hcp-title} cluster, you must have the following items:
 * Operator roles
 
 [id="rosa-hcp-creating-vpc"]
-=== Creating a Virtual Private Cloud for your {hcp-title} clusters
+=== Creating a Virtual Private Cloud for your {product-title} clusters
 
-You must have a Virtual Private Cloud (VPC) to create {rosa-short} cluster. You can use the following methods to create a VPC:
+You must have a Virtual Private Cloud (VPC) to create {product-title} cluster. You can use the following methods to create a VPC:
 
 * Create a VPC using the ROSA CLI
 * Create a VPC by using a Terraform template

--- a/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc
+++ b/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc
@@ -1,14 +1,14 @@
 :_content-type: ASSEMBLY
 [id="rosa-hcp-creating-a-cluster-quickly-terraform"]
-= Creating a default ROSA cluster using Terraform
+= Creating a default {product-title} cluster using Terraform
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-creating-a-cluster-quickly-terraform
 
 toc::[]
 
-Create a {rosa-title} cluster quickly by using a Terraform cluster template that is configured with the default cluster options.
+Create a {product-title} cluster quickly by using a Terraform cluster template that is configured with the default cluster options.
 
-The cluster creation process described below uses a Terraform configuration that prepares a {rosa-short} cluster with the following resources:
+The cluster creation process described below uses a Terraform configuration that prepares a {product-title} cluster with the following resources:
 
 * An OIDC provider with a managed `oidc-config` configuration
 * Prerequisite IAM Operator roles with associated AWS Managed ROSA Policies
@@ -23,7 +23,7 @@ include::modules/rosa-sts-terraform-considerations.adoc[leveloffset=+1]
 include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[leveloffset=+1]
 
 [id="rosa-hcp-creating-a-cluster-quickly-terraform-procedure"]
-== Creating a default {rosa-short} cluster using Terraform
+== Creating a default {product-title} cluster using Terraform
 
 The cluster creation process outlined below shows how to use Terraform to create your account-wide IAM roles and a ROSA cluster with a managed OIDC configuration.
 


### PR DESCRIPTION
This PR fixes some of the titles in the ROSA migration as well as removing instances of Classic from the ROSA product docs.

Previews: https://97550--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform