### PR TITLE
OSDOCS-15491: LocalQueueDefault docs

### DIFF
--- a/modules/configuring-localqueue-defaults.adoc
+++ b/modules/configuring-localqueue-defaults.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * /quotas_workloads/configuring-quotas.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-localqueue-defaults_{context}"]
+= Configuring a default local queue
+
+As a cluster administrator, you can improve quota enforcement in your cluster by managing all jobs in selected namespaces without needing to explicitly label each job. You can do this by creating a default local queue.
+
+A default local queue serves as the local queue for newly created jobs that do not have the `kueue.x-k8s.io/queue-name` label. After you create a default local queue, any new jobs created in the namespace without a `kueue.x-k8s.io/queue-name` label automatically update to have the `kueue.x-k8s.io/queue-name: default` label.
+
+[IMPORTANT]
+====
+Preexisting jobs in a namespace are not affected when you create a default local queue. If jobs already exist in the namespace before you create the default local queue, you must label those jobs explicitly to assign them to a queue.
+====
+
+.Prerequisites
+
+include::snippets/prereqs-snippet-yaml-1.1.adoc[]
+
+* You have created a `ClusterQueue` object.
+
+.Procedure
+
+. Create a `LocalQueue` object named `default` as a YAML file:
++
+.Example of a default `LocalQueue` object
+[source,yaml]
+----
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: team-namespace
+  name: default
+spec:
+  clusterQueue: cluster-queue
+----
+
+. Apply the `LocalQueue` object by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+. Create a job in the same namespace as the default local queue.
+. Observe that the job updates with the `kueue.x-k8s.io/queue-name: default` label.

--- a/quotas_workloads/configuring-quotas.adoc
+++ b/quotas_workloads/configuring-quotas.adoc
@@ -29,6 +29,8 @@ include::modules/configuring-resourceflavors.adoc[leveloffset=+1]
 
 include::modules/configuring-localqueues.adoc[leveloffset=+1]
 
+include::modules/configuring-localqueue-defaults.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="clusterqueues-additional-resources_{context}"]
 == Additional resources

--- a/snippets/prereqs-snippet-yaml-1.1.adoc
+++ b/snippets/prereqs-snippet-yaml-1.1.adoc
@@ -1,0 +1,13 @@
+// Text snippet included in the following modules:
+//
+// * modules/configuring-localqueue-defaults.adoc
+//
+// Text snippet included in the following assemblies:
+//
+// *
+
+:_mod-docs-content-type: SNIPPET
+
+* You have installed {product-title} version 1.1 on your cluster.
+* You have cluster administrator permissions or the `kueue-batch-admin-role` role.
+* You have installed the {oc-first}.


### PR DESCRIPTION
Version(s):
Kueue 1.1 (`kueue-docs` branch only)

Issue:
https://issues.redhat.com/browse/OSDOCS-15491

Link to docs preview:
https://97551--ocpdocs-pr.netlify.app/openshift-kueue/latest/quotas_workloads/configuring-quotas.html#configuring-localqueue-defaults_configuring-quotas

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
