### PR TITLE
OSSM-10533 [DOC] Update for Pod healthchecks not working in ambient mode with OVN-K CNI

### DIFF
--- a/install/ossm-istio-ambient-mode.adoc
+++ b/install/ossm-istio-ambient-mode.adoc
@@ -16,6 +16,7 @@ include::modules/ossm-installing-istio-ambient-mode.adoc[leveloffset=+2]
 .Next steps
 * xref:../install/ossm-istio-ambient-mode.adoc#ossm-scoping-sm-discovery-selectors-istio-ambient-mode_ossm-istio-ambient-mode[Scoping Service Mesh with discovery selectors in Istio ambient mode]
 * xref:../install/ossm-istio-ambient-mode.adoc#ossm-deploying-bookinfo-application-istio-ambient-mode_ossm-istio-ambient-mode[Deploying the Bookinfo application in Istio ambient mode]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/ovn-kubernetes_network_plugin/configuring-gateway-mode[Configuring gateway mode]
 
 include::modules/ossm-about-discovery-selectors-istio-ambient-mode.adoc[leveloffset=+1]
 

--- a/modules/ossm-installing-istio-ambient-mode.adoc
+++ b/modules/ossm-installing-istio-ambient-mode.adoc
@@ -13,6 +13,7 @@ You can install {istio} ambient mode on {ocp-product-title} 4.19 or later and {S
 * You have deployed a cluster on {ocp-product-title} 4.19 or later.
 * You have installed the {SMProduct} Operator 3.1.0 or later in the {ocp-product-title} cluster.
 * You are logged in to the {ocp-product-title} cluster either through the web console as a user with the `cluster-admin` role, or with the `oc login` command, depending on the installation method.
+* You have configured the OVN-Kubernetes Container Network Interface (CNI) to use local gateway mode by setting the `routingViaHost` field as `true` in the `gatewayConfig` specification for the Cluster Network Operator. For more information, see "Configuring gateway mode".
 
 .Procedure
 

--- a/modules/ossm-release-notes-3-1-known-issues.adoc
+++ b/modules/ossm-release-notes-3-1-known-issues.adoc
@@ -6,15 +6,6 @@
 [id="ossm-release-3-1-known-issues_{context}"]
 = {SMProductName} 3.1 known issues
 
-[id="pod-health-check-issues-ovn-k-cni-ambient-mode_{context}"]
-== Pod health check issues with OVN-K CNI in ambient mode
-
-There is currently a known issue where the liveness and readiness probes pod health checks might fail in ambient mode. When using the OVN-Kubernetes Container Network Interface (CNI) on {ocp-product-title} 4.18 and earlier, this issue causes pods to enter a CrashLoopBackOff state, even though the application containers are running as expected
-
-Workaround: Configure the OVN-Kubernetes CNI to use local gateway mode by setting the `routingViaHost` field as `true` in the `gatewayConfig` specification in the Cluster Network Operator.
-
-For configuration details, see “Configuring Gateway Mode”. link:https://issues.redhat.com/browse/OSSM-9053[OSSM-9053]
-
 [id="podDisruptionBudget-object-prevents-nodes-from-upgrading_{context}"]
 == `podDisruptionBudget` object that prevents nodes from upgrading
 

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -28,7 +28,6 @@ include::modules/ossm-release-notes-3-1-deprecated-features.adoc[leveloffset=+1]
 * xref:../ossm-release-notes/ossm-release-notes-version-support-tables.adoc#ossm-release-notes-version-support-tables[Service Mesh version support]
 * xref:../ossm-release-notes/ossm-release-notes-feature-support-tables.adoc#ossm-release-notes-feature-support-tables[Service Mesh feature support tables]
 * xref:../install/ossm-istio-ambient-mode.adoc#ossm-istio-ambient-mode[Istio ambient mode]
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/networking/ovn-kubernetes-network-plugin#configuring-gateway-mode[Configuring gateway mode]
 * link:https://istio.io/latest/docs/ops/configuration/traffic-management/dns-proxy/#address-auto-allocation[Address auto-allocation]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/migrating_from_service_mesh_2_to_service_mesh_3/ossm-migrating-from-service-mesh-2-to-3[Migrating from Service Mesh 2 to Service Mesh 3]
 


### PR DESCRIPTION
Change type: Doc update; Update for Pod healthchecks not working in ambient mode with OVN-K CNI

Doc JIRA: https://issues.redhat.com/browse/OSSM-10533

Merge to:
[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

Doc Preview:

- https://97567--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-istio-ambient-mode.html
- https://97567--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html

QE Review: @MaxBab 
Peer Review: @rh-tokeefe 