### PR TITLE
OCPBUGS#60416 [enterprise-4.12] There is one more wrong example in FROM clause of image layering docs

### DIFF
--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -30,7 +30,7 @@ For example, the following Containerfile creates a custom layered image from an 
 [source,yaml]
 ----
 # Using a 4.12.0 image
-FROM quay.io/openshift-release/ocp-release@sha256... <1>
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256... <1>
 #Install hotfix rpm
 RUN rpm-ostree cliwrap install-to-root / && \ <2>
     rpm-ostree override replace http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/kernel-{,core-,modules-,modules-extra-}4.18.0-483.el8.x86_64.rpm && \ <3>


### PR DESCRIPTION
Fixed one more mistaken example of how the base image for RHCOS layering is expected to look like.

Manual enterprise-4.12 backport.

Version(s):

4.12 and higher up to latest (this concrete PR is for 4.12).

Issue:

https://issues.redhat.com/browse/OCPBUGS-60416

Original PR:

https://github.com/openshift/openshift-docs/pull/97433

Link to docs preview:

https://97568--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html

QE review:
- [ ] QE has approved this change.

Additional information:

This is a manual backport of [PR#97433](https://github.com/openshift/openshift-docs/pull/97433), because the commit could not be automatically cherry-picked by the bot.