### PR TITLE
OSDOCS-15608-re: Updated curl command in containers-signature-verify-…

### DIFF
--- a/modules/containers-signature-verify-skopeo.adoc
+++ b/modules/containers-signature-verify-skopeo.adoc
@@ -42,9 +42,9 @@ $ curl -o pub.key https://access.redhat.com/security/data/fd431d51.txt
 +
 [source,terminal]
 ----
-$ curl -o signature-1 https://mirror.openshift.com/pub/openshift-v4/signatures/openshift-release-dev/ocp-release/sha256%<sha_from_version>/signature-1 \ <1>
+$ curl -o signature-1 https://mirror.openshift.com/pub/openshift-v4/signatures/openshift-release-dev/ocp-release/sha256=<sha_from_version>/signature-1 \ <1>
 ----
-<1> Replace `<sha_from_version>` with SHA value from the full link to the mirror site that matches the SHA of your release. For example, the link to the signature for the 4.12.23 release is `https://mirror.openshift.com/pub/openshift-v4/signatures/openshift-release-dev/ocp-release/sha256%e73ab4b33a9c3ff00c9f800a38d69853ca0c4dfa5a88e3df331f66df8f18ec55/signature-1`, and the SHA value is `e73ab4b33a9c3ff00c9f800a38d69853ca0c4dfa5a88e3df331f66df8f18ec55`.
+<1> Replace `<sha_from_version>` with SHA value from the full link to the mirror site that matches the SHA of your release. For example, the link to the signature for the 4.12.23 release is `https://mirror.openshift.com/pub/openshift-v4/signatures/openshift-release-dev/ocp-release/sha256=e73ab4b33a9c3ff00c9f800a38d69853ca0c4dfa5a88e3df331f66df8f18ec55/signature-1`, and the SHA value is `e73ab4b33a9c3ff00c9f800a38d69853ca0c4dfa5a88e3df331f66df8f18ec55`.
 
 . Get the manifest for the release image by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-15608](https://issues.redhat.com/browse/OSDOCS-15608)

Link to docs preview:
* [Using skopeo to verify signatures of Red Hat container images](https://97569--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/container_security/security-container-signature.html#containers-signature-verify-skopeo_security-container-signature)

[x] SME has approved this change (Luke Meyer).
[x] QE has approved this change (Min LI).

