### PR TITLE
OSDOCS-14901-ent13: Reverted modules/nw-ovn-kubernetes-migration.adoc…

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -451,13 +451,6 @@ $ oc patch Network.operator.openshift.io cluster --type='merge' \
 ----
 $ oc delete namespace openshift-sdn
 ----
-+
-.. After a successful migration operation, remove the `network.openshift.io/network-type-migration-` annotation from the `network.config` custom resource by entering the following command:
-+
-[source,terminal]
-----
-$ oc annotate network.config cluster network.openshift.io/network-type-migration-
-----
 
 .Next steps
 


### PR DESCRIPTION
Version(s):
4.13 and 4.12

Issue:
[OSDOCS-14901](https://issues.redhat.com/browse/OSDOCS-14901)

Link to docs preview:

* [Rolling back to the OVN-Kubernetes network plugin ](https://97570--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/rollback-to-ovn-kubernetes.html)
* [Migrating from the OpenShift SDN network plugin ](https://97570--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html)


- [x] SME has approved this change (Sanjay Tripathi).
- [x] QE has approved this change (Zhanqi Zhao).

