### PR TITLE
OCP-4.20 cherry pick: MIG-1755: MTC 1.8.9 release notes

### DIFF
--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,6 +15,8 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-9.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-8.adoc[leveloffset=+1]
 
 include::modules/migration-mtc-release-notes-1-8-7.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-9.adoc
+++ b/modules/migration-mtc-release-notes-1-8-9.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes-1-7.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-9_{context}"]
+= {mtc-full} 1.8.9 release notes
+
+[id="resolved-issues-1-8-9_{context}"]
+== Resolved issues
+
+{mtc-first} 1.8.9 has the following major resolved issues:
+
+.VM restarts migration after the MigPlan deletion
+
+Before this update, deleting the `MigPlan` triggered unnecessary virtual machine (VM) migrations. This caused the VMs to resume, leading to migration failures. This release introduces a fix that prevents VMs from migrating when the `MigPlan` is actively removed. As a result, VMs no longer unintentionally migrate when MigPlans are deleted, ensuring a stable environment for users. link:https://issues.redhat.com/browse/MIG-1749[(MIG-1749)]
+
+.Virt-launcher pod remain in pending after migrating the VM from hostpath-csi-basic to hostpath-csi-pvc-block
+
+Before this update, the `virt-launcher` pod stalled after migrating a VM due to pod anti-affinity conflicts with bound volumes. This resulted in a failed VM migration, causing the virt-launcher pod to get stuck. This release resolves the pod anti-affinity issue, allowing for scheduling on different nodes. As a result, you can now migrate VMs from `hostpath-csi-basic` to `hostpath-csi-pvc-block` without pods getting stuck in a pending state, thereby improving the overall migration process efficiency. link:https://issues.redhat.com/browse/MIG-1750[(MIG-1750)]
+
+.Migration-controller panics due to LimitRange "NIL" found in source project
+
+Before this update, the missing `Min` spec in a LimitRange within the `openshift-migration` namespace caused a panic in the migration-controller pod, disrupting the user experience and preventing successful volume migration. With this release, the migration-controller pod no longer crashes when encountering a LimitRange set to `Nil`. As a result, `rsync` pods now comply with the specified limits, improving the migration process stability and eliminating crashloopbacks in source namespaces.


### PR DESCRIPTION
### Cherrypick

* Cherry Picked from c948d5aafeccab5c11b105222e0a72f87f6e43fe xref: https://github.com/openshift/openshift-docs/pull/97371

### JIRA

* [MIG-1755](https://issues.redhat.com/browse/MIG-1755)

### Version(s):

* OCP 4.20

### Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
* [MTC 1.8.9 release notes](https://97598--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes.html#migration-mtc-release-notes-1-8-9_mtc-release-notes)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
