### PR TITLE
Release notes for patch 4.8.2

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -59,7 +59,8 @@ endif::[]
 :osp: Red{nbsp}Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.8.1
+:rhacs-version: 4.8.2
+:ga-date-482: 18 August 2025
 :ocp-supported-version: 4.12
 :ocp-latest-version: 4.17
 :plugin-acs-latest-version: 0.0.4

--- a/release_notes/48-release-notes.adoc
+++ b/release_notes/48-release-notes.adoc
@@ -17,6 +17,7 @@ toc::[]
 
 |`4.8.0` | 9 July 2025
 |`4.8.1` | 28 July 2025
+|`4.8.2` | {ga-date-482}
 
 |====
 
@@ -395,5 +396,27 @@ This release of {product-title-short} 4.8 provides the following bug fixes:
 * Before this update, excessive logging of telemetry collection status resulted in an abundance of log entries. This update configures telemetry collection to not emit repeated logs continuously, resolving the issue and significantly reducing log volume.
 //ROX-29613 - Olivier
 * Before this update, Central sometimes stored external IPs in the database even after users deleted their corresponding deployments. This resulted in inaccessible and stale data, leading to a loss of storage and memory and potential memory exhaustion. With this release, Central no longer stores external IP information for deleted deployments, resolving these issues.
+//ROX-30366
+* Before this update, the upgrade to Golang gRPC 1.67 and later caused problems with gRPC connections that affected multiple users. This issue prevented gRPC connections and blocked communications between Central and Sensor. With this release, the `GRPC_ENFORCE_ALPN_ENABLED` flag has been added in {product-title-short}. The default value disables the Application-Layer Protocol Negotiation (ALPN) enforcement, and therefore allows the connection between Sensor and Central as well as the communication between the components.
+
+[id="about-this-release-482_{context}"]
+== About release 4.8.2
+
+*Release date* {ga-date-482}
+
+This release of {product-title-short} 4.8 provides the following bug fixes:
+
+//ROX-30339 - does not need to be included
+//ROX-30307 & ROX-30289
+* The initialization of image rankers is moved from the critical startup path. Additionally, the query pattern is improved to stop retrieving excessive data. These changes improve startup time for Central and the {product-title-short} portal and reduce memory consumption.
+//ROX-26366 - removing deprecated single-bundle vulnerability file update variables - probably does not need to be included
+
+This release also addresses the following security vulnerabilities:
+
+* Requests HTTP library flaw (link:https://access.redhat.com/security/cve/CVE-2024-47081[CVE-2024-47081])
+* Memory corruption flaw in SQLite (link:https://access.redhat.com/security/cve/CVE-2025-6965[CVE-2025-6965])
+* Double-free vulnerability in glibc (link:https://access.redhat.com/security/cve/CVE-2025-8058[CVE-2025-8058])
+* Flaw in libxml2 library (link:https://access.redhat.com/security/cve/CVE-2025-32415[CVE-2025-32415])
+* Perl standard library threads component flaw (link:https://access.redhat.com/security/cve/CVE-2025-40909[CVE-2025-40909])
 
 include::modules/image-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.8

[Issue](https://issues.redhat.com/browse/ROX-30520):

[Link to docs preview
](https://97599--ocpdocs-pr.netlify.app/openshift-acs/latest/release_notes/48-release-notes)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Added [ROX-30366](https://issues.redhat.com//browse/ROX-30366) to 4.8.1 release because it was included in that release but missed in previous version of release notes.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
