### PR TITLE
OSDOCS-15846 [NETOBSERV] Release notes 1.9.2

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3243,6 +3243,8 @@ Topics:
   Dir: network_observability
   Distros: openshift-enterprise,openshift-origin
   Topics:
+  - Name: Network observability release notes 1.9.2
+    File: network-observability-release-notes-1-9-2
   - Name: Network observability release notes
     File: network-observability-operator-release-notes
   - Name: Network observability overview

--- a/modules/network-observability-operator-release-notes-1-9-2-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-2-advisory.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes-1-9-2.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-2-advisory_{context}"]
+= Network Observability Operator 1.9.2 advisory
+
+The following advisory is available for the Network Observability Operator 1.9.2:
+
+* link:https://access.redhat.com/errata/RHEA-2025:14150[RHEA-2025:14150 Network Observability Operator 1.9.2]

--- a/modules/network-observability-release-notes-1-9-2-bug-fixes.adoc
+++ b/modules/network-observability-release-notes-1-9-2-bug-fixes.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes-1-9-2.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-release-notes-1-9-2-bug-fixes_{context}"]
+= Network observability 1.9.2 bug fixes
+
+* Before this update, {product-title} versions 4.15 and earlier did not support the `TC_ATTACH_MODE` configuration. This led to command-line interface (CLI) errors and prevented the observation of packets and flows. With this release, the Traffic Control eXtension (TCX) hook attachment mode has been adjusted for these older versions. This eliminates `tcx` hook errors and enables flow and packet observation.

--- a/observability/network_observability/network-observability-release-notes-1-9-2.adoc
+++ b/observability/network_observability/network-observability-release-notes-1-9-2.adoc
@@ -1,0 +1,18 @@
+//Network Observability Operator Release Notes
+:_mod-docs-content-type: ASSEMBLY
+[id="network-observability-operator-release-notes-1-9-2"]
+= Network Observability Operator release notes 1.9.2
+:context: network-observability-operator-release-notes-v1-9-2
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+The Network Observability Operator enables administrators to observe and analyze network traffic flows for {product-title} clusters.
+
+These release notes track the development of the Network Observability Operator in the {product-title}.
+
+For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-operator_network-observability-overview[Network Observability Operator].
+
+include::modules/network-observability-operator-release-notes-1-9-2-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-release-notes-1-9-2-bug-fixes.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-15846](https://issues.redhat.com//browse/OSDOCS-15846) [NETOBSERV] Release notes 1.9.2

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15846

Link to docs preview:
* Network Observability Operator release notes: https://97603--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-release-notes-1-9-2.html
* Network Observability Operator 1.9.2 advisory: https://97603--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-release-notes-1-9-2.html#network-observability-operator-release-notes-1-9-2-advisory_network-observability-operator-release-notes-v1-9-2
* Network observability release notes 1.9.2 bug fixes: https://97603--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-release-notes-1-9-2.html#network-observability-release-notes-1-9-2-bug-fixes_network-observability-operator-release-notes-v1-9-2

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Full modularization of release notes is being handled by https://issues.redhat.com/browse/OSDOCS-14977
* Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. This will likely apply to release notes since it has been 1 assembly file and not all content is applicable to all OCP branches.
* I will manually verify content on each breach, and create manual cherry-picks accordingly.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
