### PR TITLE
OSDOCS-15849: fix unrendered attribute for RHEL

### DIFF
--- a/modules/microshift-greenboot-testing-workload-script.adoc
+++ b/modules/microshift-greenboot-testing-workload-script.adoc
@@ -6,7 +6,7 @@
 [id="microshift-greenboot-test-workload-health-check-script_{context}"]
 = Testing a workload health check script
 
-The output of the greenboot workload health check script varies with the host system type. Example outputs for {op-system-full} system types are included for reference only.
+The output of the greenboot workload health check script varies with the host system type. Example outputs for {op-system-base-full} system types are included for reference only.
 
 .Prerequisites
 

--- a/modules/microshift-install-rhde-compat-table.adoc
+++ b/modules/microshift-install-rhde-compat-table.adoc
@@ -6,6 +6,6 @@
 [id="microshift-install-rhde-compat-table_{context}"]
 = Compatibility table
 
-You must pair a supported version of {op-system-full} with the {microshift-short} version you are using as described in the following compatibility table.
+You must pair a supported version of {op-system-base-full} with the {microshift-short} version you are using as described in the following compatibility table.
 
 include::snippets/microshift-rhde-compatibility-table-snip.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-15849](https://issues.redhat.com/browse/OSDOCS-15849)

Link to docs preview:
[microshift-install-rhde-compat-table_microshift-install-get-ready](https://97612--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready.html#microshift-install-rhde-compat-table_microshift-install-get-ready)
[greenboot-test-workload-health-check-script](https://97612--ocpdocs-pr.netlify.app/microshift/latest/microshift_running_apps/microshift-greenboot-workload-health-checks.html#microshift-greenboot-test-workload-health-check-script_microshift-greenboot-workload-health-checks)

QE review:
- N/A internal doc bug

Additional information:
Fixes broken attribute noticed here, https://github.com/openshift/openshift-docs/pull/97534 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
