### PR TITLE
Telcodocs 2270: topology-aware scheduler: HA by default

### DIFF
--- a/modules/cnf-customizing-schedulder-ha-nro.adoc
+++ b/modules/cnf-customizing-schedulder-ha-nro.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="customizing-scheduler-replicas_{context}"]
+= Customizing scheduler replicas
+
+Set a specific number of scheduler replicas by updating the `spec.replicas` field in the `NUMAResourcesScheduler` custom resource. This overrides the default HA behavior.
+
+.Procedure
+
+. Create the `NUMAResourcesScheduler` CR with the following YAML named for example `custom-ha.yaml` that sets the number of replicas to 2:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: nodetopology.openshift.io/v1
+kind: NUMAResourcesScheduler
+metadata:
+  name: example-custom
+spec:
+  imageSpec: 'registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}'
+  replicas: 2
+----
+
+. Deploy the NUMA-aware pod scheduler by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f custom-ha.yaml
+----

--- a/modules/cnf-disabling-schedulder-ha-nro.adoc
+++ b/modules/cnf-disabling-schedulder-ha-nro.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="disabling-numa-aware-scheduling_{context}"]
+= Disabling NUMA-aware scheduling
+
+Disable the NUMA-aware scheduler, stopping all running scheduler pods and preventing new ones from starting.
+
+.Procedure
+
+. Save the following minimal required YAML in the `nro-disable-scheduler.yaml` file. Disable the scheduler by setting the `spec.replicas` field to `0`. 
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: nodetopology.openshift.io/v1
+kind: NUMAResourcesScheduler
+metadata:
+  name: example-disable
+spec:
+  imageSpec: 'registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}'
+  replicas: 0
+----
+
+. Disable the NUMA-aware pod scheduler by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f nro-disable-scheduler.yaml
+----

--- a/modules/cnf-managing-ha-nrop-scheduler.adoc
+++ b/modules/cnf-managing-ha-nrop-scheduler.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+:_mod-docs-content-type: CONCEPT
+[id="cnf-managing-ha-nrop_{context}"]
+= Managing high availability (HA) for the NUMA-aware scheduler
+
+--
+:FeatureName: Managing high availability
+include::snippets/technology-preview.adoc[]
+--
+
+The NUMA Resources Operator manages the high availability of the NUMA-aware secondary scheduler based on the `spec.replicas` field in the `NUMAResourcesScheduler` custom resource (CR). By default, the NUMA Resources Operator automatically enables HA mode by creating one scheduler replica for each control plane node, with a maximum of three replicas. 
+
+The following manifest demonstrates this default behavior. To automatically enable replica detection, omit the `replicas` field.
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: nodetopology.openshift.io/v1
+kind: NUMAResourcesScheduler
+metadata:
+  name: example-auto-ha
+spec:
+  imageSpec: 'registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}'
+  # The 'replicas' field is not included, enabling auto-detection.
+----
+
+You can control scheduler behavior by using one of the following options:
+
+* Customizing the number of replicas.
+* Disabling NUMA-aware scheduling.
+
+

--- a/modules/cnf-verifying-schedulder-ha-status.adoc
+++ b/modules/cnf-verifying-schedulder-ha-status.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="verifying-scheduler-ha-status_{context}"]
+= Verifying scheduler high availability (HA) status
+
+Verify the status of the NUMA-aware scheduler to ensure it is running with the expected number of replicas based on your configuration.
+
+.Procedure
+
+. List only the scheduler pods by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-numaresources -l app=secondary-scheduler
+----
++
+.Expected output
+
+Using the default HA mode, the number of pods equals the number of control-plane nodes. A standard HA {product-title} cluster typically has three control-plane nodes, and therefore displays three pods: 
++
+[source,terminal]
+----
+NAME                                   READY   STATUS    RESTARTS   AGE
+secondary-scheduler-5b8c9d479d-2r4p5   1/1     Running   0          5m
+secondary-scheduler-5b8c9d479d-k2f3p   1/1     Running   0          5m
+secondary-scheduler-5b8c9d479d-q8c7b   1/1     Running   0          5m
+----
++
+* If you **customized the replicas**, the number of pods matches the value you set.
+* If you **disabled the scheduler**, there are no running pods with this label.
++
+[NOTE]
+====
+A limit of 3 replicas is enforced for the NUMA-aware scheduler. On a hosted control planes cluster, the scheduler pods run on the worker nodes of the hosted-cluster.
+====
+
+. Verify the number of replicas and their status by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment secondary-scheduler -n openshift-numaresources
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
+secondary-scheduler   3/3     3            3           5m
+----
++
+In this output, 3/3 means 3 replicas are ready out of an expected 3 replicas.
+
+. For more detailed information run the following command:
++
+[source,terminal]
+----
+$ oc describe deployment secondary-scheduler -n openshift-numaresources
+----
++
+.Example output
+
+The `Replicas` line shows a deployment configured for 3 replicas, with all 3 updated and available.
++
+[source,yaml]
+----
+Replicas:        3 desired | 3 updated | 3 total | 3 available | 0 unavailable
+----

--- a/scalability_and_performance/cnf-numa-aware-scheduling.adoc
+++ b/scalability_and_performance/cnf-numa-aware-scheduling.adoc
@@ -40,6 +40,14 @@ include::modules/cnf-deploying-the-numa-aware-scheduler.adoc[leveloffset=+2]
 
 include::modules/cnf-configuring-single-numa-policy.adoc[leveloffset=+2]
 
+include::modules/cnf-managing-ha-nrop-scheduler.adoc[leveloffset=+2]
+
+include::modules/cnf-customizing-schedulder-ha-nro.adoc[leveloffset=+3]
+
+include::modules/cnf-disabling-schedulder-ha-nro.adoc[leveloffset=+3]
+
+include::modules/cnf-verifying-schedulder-ha-status.adoc[leveloffset=+3]
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
[TELCODOCS-2270]: topology-aware scheduler: HA by default

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2270
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://97613--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to](https://96669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/network) merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
