### PR TITLE
Updated the HCP topic map to include the No CNI guide.

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -207,6 +207,8 @@ Topics:
   File: rosa-hcp-egress-zero-install
 - Name: Creating a ROSA with HCP cluster that uses direct authentication with an external OIDC identity provider
   File: rosa-hcp-sts-creating-a-cluster-ext-auth
+- Name: Creating ROSA with HCP clusters without a CNI plugin
+  File: rosa-hcp-cluster-no-cni
 - Name: Deleting a ROSA with HCP cluster
   File: rosa-hcp-deleting-cluster
 ---

--- a/rosa_hcp/rosa-hcp-cluster-no-cni.adoc
+++ b/rosa_hcp/rosa-hcp-cluster-no-cni.adoc
@@ -14,7 +14,11 @@ You can use your own Container Network Interface (CNI) plugin when creating a {p
 For customers who choose to use their own CNI, the responsibility of CNI plugin support belongs to the customer in coordination with their chosen CNI vendor.
 ====
 
-The default plugin for {product-title} is the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin]. This plugin is the only Red Hat supported CNI plugin for {product-title}.  
+//
+// Leave commented out until the Networking book is published for HCP
+//
+//The default plugin for {product-title} is the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin]. This plugin is the only Red Hat supported CNI plugin for {product-title}.
+The default plugin for {product-title} is the OVN-Kubernetes network plugin. This plugin is the only Red Hat supported CNI plugin for {product-title}.  
 
 If you choose to use your own CNI for {product-title} clusters, it is strongly recommended that you obtain commercial support from the plugin vendor before creating your clusters. Red Hat support cannot assist with CNI-related issues such as pod to pod traffic for customers who choose to use their own CNI. Red Hat still provides support for all non-CNI issues. If you want CNI-related support from Red Hat, you must install the cluster with the default OVN-Kubernetes network plugin. For more information, see the xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc#rosa-policy-responsibility-matrix[responsibility matrix].
 
@@ -46,4 +50,7 @@ include::modules/rosa-hcp-sts-creating-a-cluster-cli-no-cni-plugin.adoc[leveloff
 == Next steps
 
 * Install your CNI plugin. The nodes will then change from the `not ready` to `ready` state.  
-* Access your ROSA cluster with the xref:../rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc#rosa-sts-accessing-cluster[Accessing a ROSA cluster] documentation.
+//
+// Leave commented out until we port the Accessing a ROSA cluster topic to HCP
+//
+//* Access your ROSA cluster with the xref:../rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc#rosa-sts-accessing-cluster[Accessing a ROSA cluster] documentation.


### PR DESCRIPTION
This PR adds the NO CNI guide to the ROSA with HCP topic map. The migration caused the link to this guide to break. I also commented out some of the links as they caused build issues.

Preview: https://97615--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-cluster-no-cni.html