### PR TITLE
OSDOCS-7857:RPM Uninstall Instructions

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -53,6 +53,8 @@ Distros: microshift
 Topics:
 - Name: Installing with an RPM package
   File: microshift-install-rpm
+- Name: Uninstalling MicroShift
+  File: microshift-uninstall-rpm
 ---
 Name: Installing optional RPM packages
 Dir: microshift_install_rpm_opt

--- a/microshift_install_rpm/microshift-install-rpm.adoc
+++ b/microshift_install_rpm/microshift-install-rpm.adoc
@@ -42,6 +42,7 @@ include::modules/microshift-accessing.adoc[leveloffset=+1]
 //additional resources for accessing module
 [role="_additional-resources"]
 .Additional resources
+
 * xref:../microshift_cli_ref/microshift-oc-cli-install.adoc#microshift-oc-cli-install[Installing the OpenShift CLI tool].
 
 include::modules/microshift-accessing-cluster-locally.adoc[leveloffset=+2]

--- a/microshift_install_rpm/microshift-uninstall-rpm.adoc
+++ b/microshift_install_rpm/microshift-uninstall-rpm.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-uninstall-rpm"]
+include::_attributes/attributes-microshift.adoc[]
+= Uninstalling {microshift-short}
+:context: microshift-uninstall-rpm
+
+toc::[]
+
+Before you uninstall {microshift-short}, clean up all the {microshift-short} data and configuration by running the `microshift-cleanup-data` script.
+
+include::modules/microshift-uninstall-microshift-rpms.adoc[leveloffset=+1]

--- a/modules/microshift-uninstall-microshift-rpms.adoc
+++ b/modules/microshift-uninstall-microshift-rpms.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// microshift_install_rpm/microshift-uninstall.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-uninstall-microshift-rpms_{context}"]
+= Uninstalling {microshift-short} from an RPM package
+
+.Prerequisites
+
+* You are logged into {microshift-short} as an administrator with root-user access.
+* You have filed a support case.
+* You have root access to the {microshift-short} cluster. 
+
+.Procedure
+
+. Clean all your data by running the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ sudo microshift-cleanup-data --all <1>
+----
+<1> When you run the script with the `--all` argument, you perform the following clean up actions:
+
+* Stop and disable all {microshift-short} services
+* Delete all {microshift-short} pods
+* Delete all container image storage
+* Reset network configuration
+* Delete the `/var/lib/microshift` data directory
+* Delete OVN-K networking configuration
++
+. Run the following command:
++
+[source,terminal,subs="+quotes"]
+----
+$ sudo dnf remove -y microshift*
+----
++


### PR DESCRIPTION
Version(s):
4.14, 4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-7857

Link to docs preview:
https://97625--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm/microshift-uninstall-rpm.html

QE review:
- [x] QE has approved this change.