### PR TITLE
OADP-6539: Document Netapp ontap s3 as fully supported

### DIFF
--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -21,6 +21,7 @@ The following AWS S3 compatible object storage providers are fully supported by 
 * Ceph RADOS Gateway (Ceph Object Gateway)
 * Red Hat Container Storage
 * {odf-full}
+* NetApp ONTAP S3 Object Storage
 
 [NOTE]
 ====


### PR DESCRIPTION
### JIRA
### JIRA

* [OADP-6539](https://issues.redhat.com/browse/OADP-6539)

### Version(s):

* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* [OADP-6539](https://issues.redhat.com/browse/OADP-6539)

### Version(s):

* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19
* OCP 4.20 → branch/enterprise-4.20
* OCP 4.21 → branch/enterprise-4.21

### Link to docs preview:

* [Supported backup storage providers](https://97629--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#oadp-s3-compatible-backup-storage-providers-supported)

### QE review:
- [X] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/97629#issuecomment-3264752162).
- [X] [Dev has approved this change](https://github.com/openshift/openshift-docs/pull/97629#pullrequestreview-3124094122).
