### PR TITLE
OSDOCS 15863 On Cluster Layering: Address Reboots

### DIFF
--- a/machine_configuration/machine-config-node-disruption.adoc
+++ b/machine_configuration/machine-config-node-disruption.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 By default, when you make certain changes to the fields in a `MachineConfig` object, the Machine Config Operator (MCO) drains and reboots the nodes associated with that machine config. However, you can create a _node disruption policy_ that defines a set of changes to some Ignition config objects that would require little or no disruption to your workloads.
 
+[NOTE]
+====
+Node disruption policies are not supported for on-cluster custom layered images.
+====
+
 A node disruption policy allows you to define the configuration changes that cause a disruption to your cluster, and which changes do not. This allows you to reduce node downtime when making small machine configuration changes in your cluster. To configure the policy, you modify the `MachineConfiguration` object, which is in the `openshift-machine-config-operator` namespace. See the example node disruption policies in the `MachineConfiguration` objects that follow.
 
 [NOTE]

--- a/modules/coreos-layering-configuring-on.adoc
+++ b/modules/coreos-layering-configuring-on.adoc
@@ -82,10 +82,15 @@ Note the following limitations when working with the on-cluster layering feature
 * {image-mode-os-on-caps} is not supported on multi-architecture compute machines.
 * Using multiple `MachineOSConfig` objects on the same machine config pool is not supported. You need a separate `MachineOSConfig` CR for each machine config pool where you want to use a distinct custom layered image. 
 * If you scale up a machine set that uses a custom layered image, the nodes reboot two times. The first, when the node is initially created with the base image and a second time when the custom layered image is applied.
-* Node disruption policies are not supported on nodes with a custom layered image. As a result the following configuration changes cause a node reboot:
+* Node disruption policies are not supported on nodes with a custom layered image. However, the following machine configuration changes do not cause a new image build or the reboot of a node with an on-cluster custom layered image:
 ** Modifying the configuration files in the `/var` or `/etc` directory
 ** Adding or modifying a systemd service
 ** Changing SSH keys
 ** Removing mirroring rules from `ICSP`, `ITMS`, and `IDMS` objects
 ** Changing the trusted CA, by updating the `user-ca-bundle` configmap in the `openshift-config` namespace
+* The following machine configuration changes do cause a new image build and a node reboot:
+** Changing the kernel arguments 
+** Changing the `OSImageURL` parameter 
+** Adding or removing extensions 
+
 * The images used in creating custom layered images take up space in your push registry. Always be aware of the free space in your registry and prune the images as needed. You can automatically remove an on-cluster custom layered image from the repository by deleting the `MachineOSBuild` object that created the image. Note that the credentials provided by the registry push secret must also grant permission to delete an image from the registry. For more information, see "Removing an on-cluster custom layered image".


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15863

Link to docs preview:
[Using node disruption policies to minimize disruption from machine config changes](https://97643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-node-disruption.html) -- Added note after first paragraph.
[About on-cluster image mode](https://97643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering#coreos-layering-configuring-on_mco-coreos-layering) -> On-cluster image mode known limitations -- 4th and 5th bullets
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
