### PR TITLE
OCP 13956 GA for sigstore API

### DIFF
--- a/modules/nodes-sigstore-configure-cluster-policy.adoc
+++ b/modules/nodes-sigstore-configure-cluster-policy.adoc
@@ -15,31 +15,6 @@ The following example shows general guidelines on how to configure a `ClusterIma
 * You have a sigstore-supported public key infrastructure (PKI) or a link:https://docs.sigstore.dev/cosign/[Cosign public and private key pair] for signing operations.
 * You have a signing process in place to sign your images.
 * You have access to a registry that supports Cosign signatures, if you are using Cosign signatures.
-* You enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`:
-+
-[source,terminal]
-----
-$ oc edit featuregate cluster
-----
-+
-.Example `FeatureGate` CR
-[source,yaml]
-----
-apiVersion: config.openshift.io/v1
-kind: FeatureGate
-metadata:
-  name: cluster
-spec:
-  featureSet: TechPreviewNoUpgrade <1>
-----
-<1> Enables the required `SigstoreImageVerification` feature.
-+
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
-====
-+
-After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
 
 .Procedure
 
@@ -49,7 +24,7 @@ After you save the changes, new machine configs are created, the machine config 
 .Example cluster image policy object with a public key policy and the `MatchRepoDigestOrExact` match policy
 [source,yaml]
 ----
-apiVersion: config.openshift.io/v1alpha1
+apiVersion: config.openshift.io/v1
 kind: ClusterImagePolicy <1>
 metadata:
   name: p1
@@ -83,7 +58,7 @@ spec:
 .Example cluster image policy object with a Fulcio certificate policy and the `remapIdentity` match policy
 [source,yaml]
 ----
-apiVersion: config.openshift.io/v1alpha1
+apiVersion: config.openshift.io/v1
 kind: ClusterImagePolicy <1>
 metadata:
   name: p1

--- a/modules/nodes-sigstore-configure-image-policy.adoc
+++ b/modules/nodes-sigstore-configure-image-policy.adoc
@@ -30,32 +30,6 @@ $ oc image mirror quay.io/openshift-release-dev/ocp-release:sha256-1234567890abc
 mirror.com/image/repo:sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sig
 ----
 
-* You enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`:
-+
-[source,terminal]
-----
-$ oc edit featuregate cluster
-----
-+
-.Example `FeatureGate` CR
-[source,yaml]
-----
-apiVersion: config.openshift.io/v1
-kind: FeatureGate
-metadata:
-  name: cluster
-spec:
-  featureSet: TechPreviewNoUpgrade <1>
-----
-<1> Enables the required `SigstoreImageVerification` feature.
-+
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
-====
-+
-After you save the changes, new machine configs are created, the machine config pools are updated, and scheduling on each node is disabled while the change is being applied.
-
 .Procedure
 
 . Create an image policy object similar to the following examples. See "About cluster and image policy parameters" for specific details on these parameters.
@@ -64,7 +38,7 @@ After you save the changes, new machine configs are created, the machine config 
 .Example image policy object with a public key policy and the `MatchRepository` match policy
 [source,yaml]
 ----
-apiVersion: config.openshift.io/v1alpha1
+apiVersion: config.openshift.io/v1
 kind: ImagePolicy <1>
 metadata:
   name: p0
@@ -100,7 +74,7 @@ spec:
 .Example image policy object with a Fulcio certificate policy and the `ExactRepository` match policy
 [source,yaml]
 ----
-apiVersion: config.openshift.io/v1alpha1
+apiVersion: config.openshift.io/v1
 kind: ImagePolicy <1>
 metadata:
   name: p1

--- a/modules/nodes-sigstore-configure.adoc
+++ b/modules/nodes-sigstore-configure.adoc
@@ -22,7 +22,7 @@ If the image or repository in an image policy is nested under one of the images 
 .Example image policy with a conflicting image identity
 [source,yaml]
 ----
-API Version:  config.openshift.io/v1alpha1
+API Version:  config.openshift.io/v1
 Kind:         ImagePolicy
 Name:         p0
 Namespace:    mynamespace

--- a/nodes/nodes-sigstore-using.adoc
+++ b/nodes/nodes-sigstore-using.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 You can use link:https://www.sigstore.dev/[sigstore] with {product-title} to improve supply chain security.
 
-:FeatureName: sigstore support
-include::snippets/technology-preview.adoc[]
-
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
@@ -23,12 +20,12 @@ include::modules/nodes-sigstore-configure-cluster-policy.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-configure-parameters_nodes-sigstore-using[About cluster and image policy parameters]
+* xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-configure-parameters_nodes-sigstore-using[About cluster and image policy parameters]
 
 include::modules/nodes-sigstore-configure-image-policy.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-configure-parameters_nodes-sigstore-using[About cluster and image policy parameters]
+* xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-configure-parameters_nodes-sigstore-using[About cluster and image policy parameters]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15864

Link to docs preview:
[Creating a cluster image policy CR](https://97644--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#nodes-sigstore-configure-cluster-policy_nodes-sigstore-using) -- Removed TP feature gate prereq. Updated API name.
[Creating an image policy CR](https://97644--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#nodes-sigstore-configure-cluster-policy_nodes-sigstore-using) -- Removed TP feature gate prereq. Updated API name.
[Manage secure signatures with sigstore](https://97644--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using) -- Removed TP admonition. Updated API name. 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
