### PR TITLE
Updated Distro Map names

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -59,5 +59,5 @@
 :rosa-title: Red Hat OpenShift Service on AWS (ROSA) with hosted control planes (HCP)
 :rosa-short: ROSA with HCP
 :egress-zero: egress zero
-:egress-zero-title: {rosa-short} clusters with {egress-zero}
+:egress-zero-title: {product-title} clusters with {egress-zero}
 :classic-short: {rosa-classic-short}

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -199,7 +199,7 @@ openshift-aro:
       name: '4'
       dir: aro/4
 openshift-rosa:
-  name: Red Hat OpenShift Service on AWS (classic architecture) (ROSA (classic))
+  name: Red Hat OpenShift Service on AWS (classic architecture)
   author: OpenShift Documentation Project <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation
@@ -212,7 +212,7 @@ openshift-rosa:
       name: ''
       dir: rosa-preview/
 openshift-rosa-hcp:
-  name: Red Hat OpenShift Service on AWS (ROSA) with hosted control plane (HCP)
+  name: Red Hat OpenShift Service on AWS
   author: OpenShift Documentation Project <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation

--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -908,7 +908,7 @@ $ rosa create machinepool --cluster=mycluster --replicas=2 --instance-type=r5.2x
 [id="rosa-create-network_{context}"]
 == create network
 
-Create a network that creates any necessary AWS resources through AWS CloudFormation templates. This helper command is intended to help create and configure a VPC for use with {hcp-title}. This command also supports {zero-egress} clusters.
+Create a network that creates any necessary AWS resources through AWS CloudFormation templates. This helper command is intended to help create and configure a VPC for use with {hcp-title}. This command also supports {egress-zero} clusters.
 
 [IMPORTANT]
 ====

--- a/rosa_cluster_admin/rosa-cluster-autoscaling.adoc
+++ b/rosa_cluster_admin/rosa-cluster-autoscaling.adoc
@@ -9,7 +9,7 @@ toc::[]
 //Adding ROSA HCP commands 
 
 ifdef::openshift-rosa[]
-Applying autoscaling to {rosa-classic-first} clusters involves configuring a cluster autoscaler and then configuring a machine autoscaler for at least one machine pool in your cluster.
+Applying autoscaling to {product-title} clusters involves configuring a cluster autoscaler and then configuring a machine autoscaler for at least one machine pool in your cluster.
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-{product-title} (ROSA) is a fully-managed, turnkey application platform that allows you to focus on delivering value to your customers by building and deploying applications. Red{nbsp}Hat and AWS site reliability engineering (SRE) experts manage the underlying platform so you do not have to worry about the complexity of infrastructure management. ROSA provides seamless integration with a wide range of AWS compute, database, analytics, machine learning, networking, mobile, and other services to further accelerate the building and delivering of differentiating experiences to your customers.
+{product-title} is a fully-managed, turnkey application platform that allows you to focus on delivering value to your customers by building and deploying applications. Red{nbsp}Hat and AWS site reliability engineering (SRE) experts manage the underlying platform so you do not have to worry about the complexity of infrastructure management. ROSA provides seamless integration with a wide range of AWS compute, database, analytics, machine learning, networking, mobile, and other services to further accelerate the building and delivering of differentiating experiences to your customers.
 
 {product-title} clusters are available on the link:https://console.redhat.com/openshift[Hybrid Cloud Console]. With the Red{nbsp}Hat {cluster-manager} application for ROSA, you can deploy {product-title} clusters to cloud environments.
 


### PR DESCRIPTION
This PR changes the Distro names to align with the migration changes. I also fixed two broken variables that I noticed while doing checks.

**PREVIEWS**
- What's New - Classic: https://97645--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes
- What's New - HCP: https://97645--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes
- Cluster Autoscaling
    <img width="915" height="448" alt="image" src="https://github.com/user-attachments/assets/a7c92520-4190-4840-aaa6-430dd6e4e8b7" />
    - HCP: https://97645--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa-cluster-autoscaling#rosa-cluster-autoscaling
    - Classic: https://97645--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-cluster-autoscaling#rosa-cluster-autoscaling
- create network
    <img width="896" height="427" alt="image" src="https://github.com/user-attachments/assets/3f057bbd-138b-43ff-a4af-a2cd27b8afc6" />
    -  HCP: https://97645--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-create-network_rosa-managing-objects-cli
    - Classic: https://97645--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-create-network_rosa-managing-objects-cli