### PR TITLE
OSDOCS-15807 [NETOBSERV] Aditi check: DiscreteHeading

### DIFF
--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -470,8 +470,7 @@ You can configure the `FlowCollector` resource to collect information about the 
 ==== Notable enhancements
 The 1.5 release of the Network Observability Operator adds improvements and new capabilities to the {product-title} web console plugin and the Operator configuration.
 
-[discrete]
-[id="performance-enhancements-1.5"]
+[id="performance-enhancements-1.5_{context}"]
 ===== Performance enhancements
 * The `spec.agent.ebpf.kafkaBatchSize` default is changed from `10MB` to `1MB` to enhance eBPF performance when using Kafka.
 +
@@ -480,8 +479,7 @@ The 1.5 release of the Network Observability Operator adds improvements and new 
 When upgrading from an existing installation, this new value is not set automatically in the configuration. If you monitor a performance regression with the eBPF Agent memory consumption after upgrading, you might consider reducing the `kafkaBatchSize` to the new value.
 =====
 
-[discrete]
-[id="web-console-enhancements-1.5"]
+[id="web-console-enhancements-1.5_{context}"]
 ===== Web console enhancements:
 
 * There are new panels added to the *Overview* view for DNS and RTT: Min, Max, P90, P99.
@@ -493,8 +491,7 @@ When upgrading from an existing installation, this new value is not set automati
 * There is enhanced visibility for the contents of the *Manage panels* and *Manage columns* pop-up windows.
 * The Differentiated Services Code Point (DSCP) field for egress QoS is available for filtering QoS DSCP in the web console *Network Traffic* page.
 
-[discrete]
-[id="configuration-enhancements-1.5"]
+[id="configuration-enhancements-1.5_{context}"]
 ===== Configuration enhancements:
 
 * The `LokiStack` mode in the `spec.loki.mode` specification simplifies installation by automatically setting URLs, TLS, cluster roles and a cluster role binding, as well as the `authToken` value. The `Manual` mode allows more control over configuration of these settings.
@@ -572,7 +569,6 @@ You must switch your channel from `v1.0.x` to `stable` to receive the latest Ope
 ==== Notable enhancements
 The 1.4 release of the Network Observability Operator adds improvements and new capabilities to the {product-title} web console plugin and the Operator configuration.
 
-[discrete]
 [id="web-console-enhancements-1.4_{context}"]
 ===== Web console enhancements:
 
@@ -585,7 +581,6 @@ The 1.4 release of the Network Observability Operator adds improvements and new 
 
 For more information, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-dashboards[Network observability metrics] and xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-quickfilter_nw-observe-network-traffic[Quick filters].
 
-[discrete]
 [id="configuration-enhancements-1.4_{context}"]
 ===== Configuration enhancements:
 

--- a/observability/network_observability/network-observability-secondary-networks.adoc
+++ b/observability/network_observability/network-observability-secondary-networks.adoc
@@ -8,9 +8,8 @@ toc::[]
 You can configure the Network Observability Operator to collect and enrich network flow data from secondary networks, such as SR-IOV and OVN-Kubernetes.
 
 // Note to tech review:
-// Is the existing SR-IOV example we have, "Configuring monitoring for SR-IOV interface traffic", an example of secondary network? If so, it is not through a VM, right? 
+// Is the existing SR-IOV example we have, "Configuring monitoring for SR-IOV interface traffic", an example of secondary network? If so, it is not through a VM, right?
 
-[discrete]
 [id="network-observability-secondary-network-prerequisites_{context}"]
 == Prerequisites
 * Access to an {product-title} cluster with an additional network interface, such as a secondary interface or an L2 network.
@@ -19,6 +18,6 @@ include::modules/network-observability-SRIOV-configuration.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-*xref:../../networking/hardware_networks/configuring-sriov-device.adoc#cnf-creating-an-additional-sriov-network-with-vrf-plug-in_configuring-sriov-device[Creating an additional SR-IOV network attachment with the CNI VRF plugin].
+* xref:../../networking/hardware_networks/configuring-sriov-device.adoc#cnf-creating-an-additional-sriov-network-with-vrf-plug-in_configuring-sriov-device[Configuring an SR-IOV network device]
 
 include::modules/network-observability-virtualization-configuration.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-15807](https://issues.redhat.com//browse/OSDOCS-15807) [NETOBSERV] Aditi check: DiscreteHeading

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15807

Link to docs preview:
* Network Obsevability Operator 1.5: https://97646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-enhanced-configuration-and-ui-1.5
* Secondary networks: https://97646--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-secondary-networks.html

QE review:
QE is not required for this PR. This PR addresses issues caught by the Aditi tool related to use of DiscreteHeading.

Additional information:
* Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. This will likely apply to release notes since it is 1 assembly file and not all content in release notes is applicable to all OCP branches.
* I will manually verify content on each breach, and create manual cherry-picks accordingly.
* Refactoring release notes is being handled by https://issues.redhat.com/browse/OSDOCS-14977
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
