### PR TITLE
OCPNODE 3039 Tech Preview Support BYOPKI for image verification in OCP

### DIFF
--- a/modules/nodes-sigstore-configure-cluster-policy.adoc
+++ b/modules/nodes-sigstore-configure-cluster-policy.adoc
@@ -17,7 +17,7 @@ include::snippets/technology-preview.adoc[]
 
 .Prerequisites
 // Taken from https://issues.redhat.com/browse/OCPSTRAT-918
-* You have a sigstore-supported public key infrastructure (PKI) or a link:https://docs.sigstore.dev/cosign/[Cosign public and private key pair] for signing operations.
+* You have a sigstore-supported public key infrastructure (PKI) key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or provide a link:https://docs.sigstore.dev/cosign/signing/overview/[Cosign public and private key pair] for signing operations.
 * You have a signing process in place to sign your images.
 * You have access to a registry that supports Cosign signatures, if you are using Cosign signatures.
 * If registry mirrors are configured for the {product-title} release image repositories, `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev`, before enabling the Technology Preview feature set, you must mirror the sigstore signatures for the {product-title} release images into your mirror registry. Otherwise, the default `openshift` cluster image policy, which enforces signature verification for the release repository, blocks the ability of the Cluster Version Operator to move the CVO pod to new nodes, preventing the node update that results from the feature set change.
@@ -29,6 +29,30 @@ You can use the `oc image mirror` command to mirror the signatures. For example:
 $ oc image mirror quay.io/openshift-release-dev/ocp-release:sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sig \
 mirror.com/image/repo:sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sig
 ----
+
+* If you are using a BYOPKI certificate as the root of trust, you enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`:
++
+[source,terminal]
+----
+$ oc edit featuregate cluster
+----
++
+.Example `FeatureGate` CR
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: TechPreviewNoUpgrade <1>
+----
+<1> Enables the required `SigstoreImageVerificationPKI` feature.
++
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
+====
 
 .Procedure
 
@@ -58,7 +82,7 @@ spec:
 <2> Defines a list of repositories or images assigned to this policy. In a cluster image policy, make sure that the policy does not block the deployment of the {product-title} images in the `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev` repositories. Images in these repositories are required for cluster operation.
 <3> Specifies the parameters that define how the images are verified.
 <4> Defines a root of trust for the policy.
-<5> Specifies the policy types that define the root of trust, either a public key or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certifice]. Here, a public key with Rekor verification.
+<5> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. This example uses a public key with Rekor verification.
 <6> For a public key policy, specifies a base64-encoded public key in the PEM format. The maximum length is 8192 characters.
 <7> Optional: Specifies a base64-encoded Rekor public key in the PEM format. The maximum length is 8192 characters.
 <8> Optional: Specifies one of the following processes to verify the identity in the signature and the actual image identity:
@@ -66,6 +90,41 @@ spec:
 * `MatchRepository`.
 * `ExactRepository`. The `exactRepository` parameter must be specified.
 * `RemapIdentity`. The `prefix` and `signedPrefix` parameters must be specified.
+--
++
+--
+.Example cluster image policy object for a BYOPKI policy and the `MatchRepository` match policy
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1alpha1
+kind: ClusterImagePolicy <1>
+metadata:
+  name: pki-policy
+spec:
+  scopes:
+  - example.io <2>
+  policy: <3>
+    rootOfTrust: <4>
+      policyType: PKI <5>
+      pki: <6>
+        caRootsData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk....URS0tLS0t
+        caIntermediatesData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1J....lDQVRFLS0tLS0=
+        pkiCertificateSubject: <7>
+          email: email@example.com
+          hostname: myhost.example.com
+    signedIdentity:
+      matchPolicy: MatchRepository <8>
+----
+<1> Creates a `ClusterImagePolicy` object.
+<2> Defines a list of repositories or images assigned to this policy. In a cluster image policy, make sure that the policy does not block the deployment of the {product-title} images in the `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev` repositories. Images in these repositories are required for cluster operation.
+<3> Specifies the parameters that define how the images are verified.
+<4> Defines a root of trust for the policy.
+<5> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. This example uses a BYOPKI certificate.
+<6> For a BYOPKI certificate, specify `caRootsData`. This parameter specifies a base64-encoded CA root certificate in the PEM format. The maximum length is 8192 characters. Optionally with `caIntermediatesData`, specifies a base64-encoded intermediate CA root certificate in the PEM format. The maximum length is 8192 characters.
+<7> Specifies a subject alternative name (SAN) to authenticate the user’s identity by using a hostname and an email address: 
+* `email`. Specifies the email address specified when the certificate was generated.
+* `hostname`. Specifies the hostname specified when the certificate was generated.
+<8> For a BYOPKI certificate, specify the `MatchRepository` parameter to verify the identity in the signature and the actual image identity. The default signed identity is `matchRepoDigestOrExact`, which requires a digest reference in the signature identity for verification. The signature identity in this case uses a repository reference, and does not include the image digest.
 --
 +
 --
@@ -98,7 +157,7 @@ spec:
 <2> Defines a list of repositories or images assigned to this policy. In a cluster image policy, make sure that the policy does not block the deployment of the {product-title} images in the `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev` repositories. Images in these repositories are required for cluster operation.
 <3> Specifies the parameters that define how the images are verified.
 <4> Defines a root of trust for the policy.
-<5> Specifies the policy types that define the root of trust, either a public key or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. Here, a Fulcio certificate with required Rekor verification.
+<5> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. This example uses a Fulcio certificate with required Rekor verification.
 <6> For a Fulcio certificate policy, the following parameters are required:
 * `fulcioCAData`: Specifies a base64-encoded Fulcio certificate in the PEM format. The maximum length is 8192 characters.
 * `fulcioSubject`: Specifies the OIDC issuer and the email of the Fulcio authentication configuration.
@@ -119,7 +178,7 @@ spec:
 $ oc create -f <file_name>.yaml
 ----
 +
-The Machine Config Operator (MCO) updates the machine config pools (MCP) in your cluster.
+The Machine Config Operator (MCO) updates the machine config pools (MCP) in your cluster. Scheduling on each node is disabled as the change is being applied.
 
 .Verification
 
@@ -164,6 +223,29 @@ sh-5.1# cat /etc/containers/policy.json
         }
       ],
 # ...
+----
++
+.Example output for the cluster image policy object for a BYOPKI certificate showing the new cluster image policy
+[source,json]
+----
+# ...
+  "transports": {
+# ...
+    "docker": {
+      "example.io": [
+        {
+          "type": "sigstoreSigned",
+          "pki": {
+            "caRootsData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk....URS0tLS0t",
+            "caIntermediatesData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1J....lDQVRFLS0tLS0=",
+            "subjectEmail": "email@example.com",
+            "subjectHostname": "myhost.example.com"
+          },
+          "signedIdentity": {
+            "type": "matchRepository"
+          }
+        }
+      ],
 ----
 +
 .Example output for the cluster image policy object with a Fulcio certificate showing the new cluster image policy

--- a/modules/nodes-sigstore-configure-image-policy.adoc
+++ b/modules/nodes-sigstore-configure-image-policy.adoc
@@ -17,9 +17,32 @@ The following example shows general guidelines on how to configure an `ImagePoli
 
 .Prerequisites
 // Taken from https://issues.redhat.com/browse/OCPSTRAT-918
-* You have a sigstore-supported public key infrastructure (PKI) or provide link:https://docs.sigstore.dev/cosign/[Cosign public and private key pair] for signing operations.
+* You have a sigstore-supported public key infrastructure (PKI) key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or provide a link:https://docs.sigstore.dev/cosign/signing/overview/[Cosign public and private key pair] for signing operations.
 * You have a signing process in place to sign your images.
 * You have access to a registry that supports Cosign signatures, if you are using Cosign signatures.
+* If you are using a BYOPKI certificate as the root of trust, you enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`:
++
+[source,terminal]
+----
+$ oc edit featuregate cluster
+----
++
+.Example `FeatureGate` CR
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: TechPreviewNoUpgrade <1>
+----
+<1> Enables the required `SigstoreImageVerification` feature.
++
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
+====
 
 .Procedure
 
@@ -51,7 +74,7 @@ spec:
 <3> Defines a list of repositories or images assigned to this policy.
 <4> Specifies the parameters that define how the images are verified.
 <5> Defines a root of trust for the policy.
-<6> Specifies the policy types that define the root of trust, either a public key or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. Here, a public key with Rekor verification.
+<6> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. Here, a public key with Rekor verification.
 <7> For a public key policy, specifies a base64-encoded public key in the PEM format. The maximum length is 8192 characters.
 <8> Optional: Specifies a base64-encoded Rekor public key in the PEM format. The maximum length is 8192 characters.
 <9> Optional: Specifies one of the following processes to verify the identity in the signature and the actual image identity:
@@ -60,6 +83,44 @@ spec:
 * `ExactRepository`. The `exactRepository` parameter must be specified.
 * `RemapIdentity`. The `prefix` and `signedPrefix` parameters must be specified.
 --
++
+--
+.Example image policy object for a BYOPKI policy and the `MatchRepository` match policy
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1alpha1
+kind: ImagePolicy <1>
+metadata:
+  name: pki-policy
+  namespace: mynamespace <2>
+spec:
+  scopes:
+  - example.io <3>
+  policy: <4>
+    rootOfTrust: <5>
+      policyType: PKI <6>
+      pki: <7>
+        caRootsData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk....RVJUSUZJQ0FURS0tLS0t
+        caIntermediatesData: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURkVENDQ....0QT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
+        pkiCertificateSubject: <8>
+          email: email@example.com
+          hostname: myhost.example.com
+    signedIdentity:
+      matchPolicy: MatchRepository <9>
+----
+<1> Creates an `ImagePolicy` object.
+<2> Specifies the namespace where the image policy is applied.
+<3> Defines a list of repositories or images assigned to this policy.
+<4> Specifies the parameters that define how the images are verified.
+<5> Defines a root of trust for the policy.
+<6> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. Here, a BYOPKI certificate.
+<7> For a BYOPKI certificate, specify `caRootsData`. This parameter specifies a base64-encoded CA root certificate in the PEM format. The maximum length is 8192 characters. Optionally with `caIntermediatesData`, specifies a base64-encoded intermediate CA root certificate in the PEM format. The maximum length is 8192 characters.
+<8> Specifies a subject alternative name (SAN) to authenticate the user’s identity by using a hostname and an email address:
+* `email`. Specifies the email address specified when the certificate was generated.
+* `hostname`. Specifies the hostname specified when the certificate was generated.
+<9> For a BYOPKI certificate, specify `MatchRepository` to verify the identity in the signature and the actual image identity. The default signed identity is `matchRepoDigestOrExact`, which requires digest specification. The signature in this case was not created for digested image.
+--
+// <9> is from the test case: https://polarion.engineering.redhat.com/polarion/#/project/OSE/workitem?id=OCP-83752
 +
 --
 .Example image policy object with a Fulcio certificate policy and the `ExactRepository` match policy
@@ -92,7 +153,7 @@ spec:
 <3> Defines a list of repositories or images assigned to this policy.
 <4> Specifies the parameters that define how the images are verified.
 <5> Defines a root of trust for the policy.
-<6> Specifies the policy types that define the root of trust, either a public key or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. Here, a Fulcio certificate with required Rekor verification.
+<6> Specifies the policy types that define the root of trust, either a public key, a BYOPKI certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate]. Here, a Fulcio certificate with required Rekor verification.
 <7> For a Fulcio certificate policy, the following parameters are required:
 * `fulcioCAData`: Specifies a base64-encoded Fulcio certificate in the PEM format. The maximum length is 8192 characters.
 * `fulcioSubject`: Specifies the OIDC issuer and the email of the Fulcio authentication configuration.
@@ -156,6 +217,29 @@ sh-5.1# cat /etc/crio/policies/<namespace>.json
       "dockerRepository": "example.org/crio/signed"
      }
 # ...
+----
++
+.Example output for the image policy object for a BYOPKI certificate showing the new image policy
+[source,json]
+----
+# ...
+ "transports": {
+# ...
+    "docker": {
+      "docker.io": [
+        {
+          "type": "sigstoreSigned",
+          "pki": {
+            "caRootsData": "LS0t...LS0t",
+            "caIntermediatesData": "LS0t...LS0t"
+            "subjectEmail": "email@example.com",
+            "subjectHostname": "myhost.example.com"
+          },
+          "signedIdentity": {
+            "type": "matchRepository"
+          }
+        }
+      ],
 ----
 +
 .Example output for the image policy object with a Fulcio certificate showing the new image policy

--- a/modules/nodes-sigstore-configure.adoc
+++ b/modules/nodes-sigstore-configure.adoc
@@ -65,8 +65,14 @@ If multiple scopes match a single scope in the same a cluster or image policy, t
 If a scoped image or repository in an image policy is nested under one of the scoped images or repositories in a cluster image policy, only the policy from cluster image policy is applied. However, the image policy object is created. For example, if an image policy specifies `example.com/global/image`, and the cluster image policy specifies `example.com/global`, the namespace inherits the policy from the cluster image policy.
 
 `policy`:: Contains configuration to allow images from the sources listed in `scopes` to be verified, and defines how images not matching the verification policy are treated. You must configure a `rootOfTrust` and optionally, a `signedIdentity`.
-* `rootOfTrust`: Specifies the root of trust for the policy. Configure either a public key or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate].
+* `rootOfTrust`: Specifies the root of trust for the policy. Configure either a public key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate].
 ** `publicKey`: Indicates that the policy relies on a sigstore public key. You must specify a base64-encoded PEM format public key. You can optionally include link:https://docs.sigstore.dev/logging/overview/[Rekor verification].
+** `PKI` Indicates that the policy relies on a certificate from your own public key infrastructure (PKI) that is compatible with Cosign Bring Your Own Public Key Infrastructure (BYOPKI) verification. You must specify a base64-encoded PEM format public key. BYOPKI enables you to validate container images using an existing X.509 certificate while aligning with Cosign's bring-your-own PKI signing workflow.
++
+--
+:FeatureName: sigstore BYOPKI support
+include::snippets/technology-preview.adoc[]
+--
 ** `FulcioCAWithRekor`: Indicates that the policy is based on a Fulcio certificate. You must specify the following parameters:
 *** A base64-encoded PEM-format Fulcio CA
 *** An OpenID Connect (OIDC) issuer


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15866

Link to docs preview:
[Creating a cluster image policy CR](https://97651--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#nodes-sigstore-configure-cluster-policy_nodes-sigstore-using) -- Various updates.
[Creating an image policy CR](https://97651--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#nodes-sigstore-configure-image-policy_nodes-sigstore-using) -- Various updates.
[About cluster and image policy parameters](https://97651--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#nodes-sigstore-configure-parameters_nodes-sigstore-using) -- Updated _policy_ -> _rootOfTrust_ section.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
