### PR TITLE
PR for SRVKE-1692: Add authorization and eventpolicy subsection in the Eventing section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -351,6 +351,8 @@ Topics:
     File: serverless-ha
 - Name: Configuring TLS encryption in Eventing
   File: serverless-config-tls-encryption-eventing
+- Name: Authorization and EventPolicy in Knative Eventing
+  File: serverless-event-authorization-eventpolicy
 - Name: Configuring kube-rbac-proxy resources for Eventing
   File: kube-rbac-proxy-eventing
 - Name: Using ContainerSource with OpenShift Service Mesh

--- a/eventing/serverless-event-authorization-eventpolicy.adoc
+++ b/eventing/serverless-event-authorization-eventpolicy.adoc
@@ -1,0 +1,30 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-event-authorization-eventpolicy"]
+= Authorization and EventPolicy in Knative Eventing
+include::_attributes/common-attributes.adoc[]
+:context: serverless-event-authorization-eventpolicy
+
+toc::[]
+
+Knative Eventing provides a mechanism to secure event delivery to prevent unauthorized access. Event-driven systems often rely on multiple producers and consumers of events, and without proper authorization controls, malicious or unintended event flows could compromise the system.
+
+To achieve fine-grained access control, Knative Eventing introduces the EventPolicy custom resource. This resource allows administrators and developers to define which entities are authorized to send events to specific consumers within a namespace. By applying EventPolicies, you can ensure that only trusted event sources or service accounts are able to send data to selected event consumers and this improves the overall security posture of their event-driven architecture.
+
+[NOTE]
+====
+You must enable the `transport-encryption` feature flag along with `authentication-oidc` to ensure secure and authenticated event delivery.
+====
+
+include::modules/serverless-event-default-authorization-mode.adoc[leveloffset=+1]
+
+include::modules/serverless-eventpolicy-resource-overview.adoc[leveloffset=+1]
+
+include::modules/serverless-event-auth-defining-targets.adoc[leveloffset=+1]
+
+include::modules/serverless-event-auth-defining-senders.adoc[leveloffset=+1]
+
+include::modules/serverless-event-auth-advanced-cloudevent-filtering-criteria.adoc[leveloffset=+1]
+
+include::modules/serverless-event-auth-eventpolicy-status-application.adoc[leveloffset=+1]
+
+include::modules/serverless-event-auth-applying-eventpolicy.adoc[leveloffset=+1]

--- a/modules/serverless-event-auth-advanced-cloudevent-filtering-criteria.adoc
+++ b/modules/serverless-event-auth-advanced-cloudevent-filtering-criteria.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-event-authorization-eventpolicy.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-event-auth-advanced-cloudevent-filtering-criteria_{context}"]
+= Advanced CloudEvent filtering criteria
+
+The `.spec.filters` method is optional but provides advanced criteria for event delivery. These filters allow you to restrict which events are permitted based not only on the source but also on the properties of the CloudEvent itself.
+
+For example, you can specify filters that only allow events of type `com.github.push`, or events that match a CloudEvents SQL (CESQL) expression for particular event types such as `order.created`, `order.updated`, or `order.canceled`.
+
+.Example of `spec.filters` method
+[source,yaml]
+----
+filters:
+  - cesql: "type IN ('order.created', 'order.updated', 'order.canceled')"
+  - exact:
+      type: com.github.push
+----
+
+[NOTE]
+====
+Filters are applied in addition to the `.spec.from` method. This means that an event must satisfy both the sender authorization and the filter criteria before it is delivered.
+====

--- a/modules/serverless-event-auth-applying-eventpolicy.adoc
+++ b/modules/serverless-event-auth-applying-eventpolicy.adoc
@@ -1,0 +1,192 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-event-authorization-eventpolicy.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-event-auth-applying-eventpolicy_{context}"]
+= Applying an EventPolicy
+
+This section describes the end-to-end steps for applying an EventPolicy to secure event delivery. In the following reference example, a Broker in `namespace-1` is configured to only accept events from a `PingSource` running in a different namespace `namespace-2`.
+
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Eventing are installed on your {ocp-product-title} cluster. 
+* You have enabled the `authentication-oidc` feature.
+
+.Procedure
+
+. Create two namespaces, deploy a Broker in `namespace-1`, and configure one `PingSource` in each namespace as per shown in the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-2
+---
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: broker
+  namespace: namespace-1
+---
+# PingSource in namespace-1
+apiVersion: sources.knative.dev/v1
+kind: PingSource
+metadata:
+  name: pingsource-1
+  namespace: namespace-1
+spec:
+  data: '{"message": "Hi from pingsource-1 from namespace-1"}'
+  schedule: '*/1 * * * *'
+  sink:
+    ref:
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: broker
+      namespace: namespace-1
+---
+# PingSource in namespace-2
+apiVersion: sources.knative.dev/v1
+kind: PingSource
+metadata:
+  name: pingsource-2
+  namespace: namespace-2
+spec:
+  data: '{"message": "Hi from pingsource-2 from namespace-2"}'
+  schedule: '*/1 * * * *'
+  sink:
+    ref:
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: broker
+      namespace: namespace-1
+----
+
+. Create an event-display service to show incoming events and add a Trigger to connect it to the Broker as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: event-display
+  namespace: namespace-1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: event-display
+  template:
+    metadata:
+      labels:
+        app: event-display
+    spec:
+      containers:
+        - name: event-display
+          image: gcr.io/knative-releases/knative.dev/eventing/cmd/event_display
+          ports:
+          - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: event-display
+  namespace: namespace-1
+spec:
+  selector:
+    app: event-display
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: trigger
+  namespace: namespace-1
+spec:
+  broker: broker
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: event-display
+----
++
+At this stage, because OIDC is disabled and no EventPolicy is applied, the event-display service shows events from both PingSources.
+
+. Enable OIDC in Knative Eventing and create an EventPolicy by executing the following example command:
++
+[source,terminal]
+----
+$ oc -n knative-eventing patch KnativeEventing knative-eventing \
+  --type merge \
+  -p '{"spec":{"config":{"features":{"authentication-oidc":"enabled"}}}}'
+----
+
+. Once OIDC is enabled, create an EventPolicy that authorizes only the PingSource from `namespace-2` as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1alpha1
+kind: EventPolicy
+metadata:
+  name: event-policy
+  namespace: namespace-1
+spec:
+  to:
+    - ref:
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+        name: broker
+  from:
+    - ref:
+        apiVersion: sources.knative.dev/v1
+        kind: PingSource
+        name: pingsource-2
+        namespace: namespace-2
+----
+
+.Verification
+
+. Verify the EventPolicy to check the Broker status by executing the following command:
++
+[source,terminal]
+----
+$ oc -n namespace-1 get broker broker -o yaml
+----
+
+. View logs from the event-display service to confirm only `pingsource-2` events arrive by executing the following command:
++
+[source,terminal]
+----
+$ oc -n namespace-1 logs -f -l app=event-display
+----
+
+. Delete the EventPolicy by executing the following command:
++
+[source,terminal]
+----
+$ oc -n namespace-1 delete eventpolicy event-policy
+----
+
+. Check the Broker status to confirm it has returned to the default `allow-same-namespace` mode by executing the following command:
++
+[source,terminal]
+----
+$ oc -n namespace-1 get broker broker -o yaml
+----
+
+. View the event-display service logs to confirm that only `pingsource-1` events from the same namespace appear by executing the following command:
++
+[source,terminal]
+----
+$ oc -n namespace-1 logs -f -l app=event-display
+----

--- a/modules/serverless-event-auth-defining-senders.adoc
+++ b/modules/serverless-event-auth-defining-senders.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-event-authorization-eventpolicy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-event-auth-defining-senders_{context}"]
+= Defining authorized senders in an EventPolicy
+
+The `.spec.from` section specifies the entities allowed to send events to the resources listed in `.spec.to.` This section can reference specific event sources or subjects service accounts, and it supports wildcard matching for broader coverage. There are two main ways to define senders.
+
+[id="serverless-event-auth-event-source-by-name_{context}"]
+== Event source by name
+
+The `from.ref` method directly references an event source resource. For example, referencing a `PingSource` in a different namespace ensures that only that specific source can deliver events to the defined targets.
+
+.Example of `from.ref` method
+[source,yaml]
+----
+from:
+  - ref:
+      apiVersion: sources.knative.dev/v1
+      kind: PingSource
+      name: my-source
+      namespace: another-namespace
+----
+
+[id="serverless-event-auth-subject-based-authorization_{context}"]
+== Subject based authorization
+
+The `from.sub` method specifies subjects, such as service accounts, that are allowed to send events. Wildcard patterns with `*` are used to authorize multiple accounts matching a pattern. For example, an EventPolicy may authorize a single trusted service account and also allow all accounts beginning with `other-` in the same namespace.
+
+.Example of `from.sub` method
+[source,yaml]
+----
+from:
+  - sub: system:serviceaccount:default:trusted-app
+  - sub: "system:serviceaccount:default:other-*"
+----

--- a/modules/serverless-event-auth-defining-targets.adoc
+++ b/modules/serverless-event-auth-defining-targets.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-event-authorization-eventpolicy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-event-auth-defining-targets_{context}"]
+= Defining targets in an EventPolicy
+
+The `.spec.to` section determines the consumers to which an EventPolicy applies. If the field is omitted, the EventPolicy applies to all resources within the namespace. You can specify multiple targets in this section to broaden the scope of the policy. There are two main ways to define targets.
+
+[id="serverless-event-auth-specific-resource-reference_{context}"]
+== Specific resource reference
+
+The `to.ref` method directly references a specific resource by name. For example, referencing a Broker named `my-broker` applies the EventPolicy only to that specific Broker. This method is most appropriate when you want to protect or restrict access to a well-defined, individual resource.
+
+.Example of `to.ref` method
+[source,yaml]
+----
+to:
+  - ref:
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: my-broker
+----
+
+[id="serverless-event-auth-label-based-resource-selection_{context}"]
+== Label-based resource selection
+
+The `to.selector` method uses label selectors to match multiple resources of a specific type. For example, specifying a label selector with `app: special-app` applies the EventPolicy to all Brokers that share that label. This method is suitable when you want the same authorization rules applied across a group of similar resources.
+
+.Example of `to.selector` method
+[source,yaml]
+----
+to:
+  - selector:
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      matchLabels:
+        app: special-app
+----

--- a/modules/serverless-event-auth-eventpolicy-status-application.adoc
+++ b/modules/serverless-event-auth-eventpolicy-status-application.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-event-authorization-eventpolicy.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-event-auth-eventpolicy-status-application_{context}"]
+= EventPolicy status and application
+
+The status of an EventPolicy provides runtime information about which sources have been resolved and whether the policy is active and ready as shown in the following example:
+
+[source,yaml]
+----
+status:
+  from:
+    - system:serviceaccount:default:trusted-app
+    - "system:serviceaccount:default:other-*"
+  conditions:
+    - type: Ready
+      status: "True"
+    - type: SubjectsResolved
+      status: "True"
+----
+
+Event consumers, such as Brokers, reflect which EventPolicies apply to them in their status.
+
+[source,yaml]
+----
+status:
+  policies:
+    - name: my-event-policy
+      apiVersion: v1alpha1
+  conditions:
+    - type: Ready
+      status: "True"
+    - type: EventPoliciesReady
+      status: "True"
+----
+
+These conditions indicate whether EventPolicies are ready and have been successfully applied to the resource.
+
+If an incoming request fails to satisfy any applicable EventPolicy, it will be rejected with an HTTP 403 Forbidden status code. If multiple EventPolicies apply to a resource, an event is accepted as long as it matches at least one of them. This ensures that unauthorized event deliveries are blocked at the system level.
+
+When multiple EventPolicies apply to the same resource, the system evaluates them in parallel. An event is accepted if it matches at least one applicable EventPolicy. This approach allows flexibility, as valid events are not rejected even under strict authorization, so long as they satisfy the requirements of at least one policy.

--- a/modules/serverless-event-default-authorization-mode.adoc
+++ b/modules/serverless-event-default-authorization-mode.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-event-authorization-eventpolicy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-event-default-authorization-mode_{context}"]
+= Default authorization mode
+
+Knative Eventing authorization is governed by two key mechanisms. The `EventPolicy` custom resource defines explicit rules for event delivery, and the `default-authorization-mode` feature flag applies whenever no `EventPolicy` is associated with a resource.
+
+The supported authorization modes are as follows:
+
+[cols=2,options=header]
+|===
+
+|Authorization mode
+|Description
+
+|`allow-all`
+|All incoming event requests are permitted without restriction.
+
+|`deny-all`
+|All incoming event requests are denied. To enable event delivery, an EventPolicy must explicitly authorize the requests.
+
+|`allow-same-namespace`
+|(Default) Only requests from subjects within the same namespace are allowed.
+
+|===
+
+To configure the default authorization mode via the {ServerlessOperatorName}, you can edit the `KnativeEventing` custom resource as shown in the following example:
+
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  config:
+    features:
+      authentication-oidc: "enabled"
+      default-authorization-mode: "deny-all"
+----

--- a/modules/serverless-eventpolicy-resource-overview.adoc
+++ b/modules/serverless-eventpolicy-resource-overview.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * /serverless/Eventing/serverless-event-authorization-eventpolicy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-eventpolicy-resource-overview_{context}"]
+= EventPolicy resource overview
+
+The EventPolicy resource defines rules for event delivery. It specifies which entities like service accounts or event sources are allowed to send events, which consumers may receive events, and optionally, additional criteria that CloudEvents must match to be accepted.
+
+An EventPolicy is structured with three primary sections as follows:
+
+[cols=2,options]
+|===
+
+|`.spec.to`
+|Defines the resources such as Brokers or Channels that the EventPolicy applies to.
+
+|`.spec.from`
+|Defines which sources or subjects are authorized to send events to the targets.
+
+|`.spec.filters`
+|(Optional) Specifies advanced filtering conditions that must be satisfied by the CloudEvent itself before it is allowed.
+
+|===
+
+The example of an EventPolicy is as follows: 
+
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1alpha1
+kind: EventPolicy
+metadata:
+  name: my-event-policy
+  namespace: default
+spec:
+  to:
+    - ref:
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+        name: my-broker
+    - selector:
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+        matchLabels:
+          app: special-app
+  from:
+    - ref:
+        apiVersion: sources.knative.dev/v1
+        kind: PingSource
+        name: my-source
+        namespace: another-namespace
+    - sub: system:serviceaccount:default:trusted-app
+    - sub: "system:serviceaccount:default:other-*"
+  filters:
+    - cesql: "type IN ('order.created', 'order.updated', 'order.canceled')"
+    - exact:
+        type: com.github.push
+----


### PR DESCRIPTION
**Affected versions:** 

- `serverless-docs-1.37`
- `serverless-docs-1.36`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVKE-1692

**Doc preview:** [Authorization and EventPolicy in Knative Eventing](https://97655--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/serverless-event-authorization-eventpolicy.html)

**Reviews:**

- [x] QE has approved this change.
- [x] SME has approved this change.
- [x] Peer has approved this change.