### PR TITLE
OSDOCS-15822: removes TP from bootc backup docs

### DIFF
--- a/microshift_backup_and_restore/microshift-backup-and-restore.adoc
+++ b/microshift_backup_and_restore/microshift-backup-and-restore.adoc
@@ -6,33 +6,12 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-You can manually back up and restore the {microshift-short} database on all supported systems. Greenboot health checks must be completed and you must stop the {microshift-short} service prior to any backups.
+You can manually back up and restore the {microshift-short} database on all supported systems. For application data, you must create custom procedures.
 
-[NOTE]
-====
-Only {microshift-short} data is backed up with the following procedures. Application data is not included.
-====
-
-* On `rpm-ostree` systems, {microshift-short} automatically creates a backup on every start. These automatic backups are deleted and replaced with the latest backup each time the system restarts.
-* If you are using an `rpm-ostree` system, the data is automatically restored after Greenboot rolls the system back. This data restoration ensures that the database matches the software running on the host after the rollback is completed.
-* On other system types, you must back up and restore data manually.
+include::modules/microshift-about-data-backups.adoc[leveloffset=+1]
 
 include::modules/microshift-service-stopping.adoc[leveloffset=+1]
 
 include::modules/microshift-backing-up-manually.adoc[leveloffset=+1]
 
-//additional resources for backing-up module
-[role="_additional-resources"]
-.Additional resources
-* xref:../microshift_install_rpm/microshift-install-rpm.adoc#microshift-service-stopping_microshift-install-rpm[Stopping the MicroShift service]
-* xref:../microshift_install_rpm/microshift-install-rpm.adoc#microshift-service-starting_microshift-install-rpm[Starting the MicroShift service]
-
 include::modules/microshift-restoring-data-backups.adoc[leveloffset=+1]
-
-//include::modules/microshift-service-starting.adoc[leveloffset=+1]
-
-//additional resources for restoring-data module
-[role="_additional-resources"]
-.Additional resources
-* xref:../microshift_install_rpm/microshift-install-rpm.adoc#microshift-service-stopping_microshift-install-rpm[Stopping the MicroShift service]
-* xref:../microshift_install_rpm/microshift-install-rpm.adoc#microshift-service-starting_microshift-install-rpm[Starting the MicroShift service]

--- a/modules/microshift-about-data-backups.adoc
+++ b/modules/microshift-about-data-backups.adoc
@@ -1,0 +1,21 @@
+//Module included in the following assemblies:
+//
+// * microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-about-data-backups_{context}"]
+= About backing up and restoring {microshift-short} data
+
+Before you can create a manual backup, greenboot health checks must finish running and you must stop the {microshift-short} service.
+
+* On `rpm-ostree` systems, {microshift-short} automatically creates a backup on every start. These automatic backups are deleted and replaced with the latest backup each time the system restarts.
+* Data is also automatically restored on an `rpm-ostree` system after a greenboot system rollback. This data restoration ensures that the database matches the software running on the host after the rollback is completed.
+* On other system types, you must back up and restore data manually.
+
+Automated backups are in the `/var/lib/microshift-backups` directory by default. You can use this directory for manually backing up and restoring data by specifying it in each command. When you restore a backup, you must use the entire file path.
+
+[NOTE]
+====
+The following procedures only backup and restore {microshift-short} data. Application data is not included.
+====
+

--- a/modules/microshift-auto-recovery-example-bootc-systems.adoc
+++ b/modules/microshift-auto-recovery-example-bootc-systems.adoc
@@ -6,10 +6,6 @@
 [id="microshift-auto-recovery-example-bootc-systems_{context}"]
 = Using automatic recovery in image mode for {op-system-base} systems
 
-:FeatureName: Image mode for {op-system-base}
-
-include::snippets/technology-preview.adoc[]
-
 As a use case, consider the following example situation in which you want to automate the `auto-recovery` process for image mode for {op-system-base-full} systems that use the systemd service.
 
 [IMPORTANT]

--- a/modules/microshift-backing-up-manually.adoc
+++ b/modules/microshift-backing-up-manually.adoc
@@ -1,12 +1,13 @@
 //Module included in the following assemblies:
 //
 // * microshift_updating/microshift-update-options.adoc
+// * microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-backing-up-manually_{context}"]
 = Backing up {microshift-short} data manually
 
-You can back up {microshift-short} data manually at any time. Back up your data before system updates to preserve it for use if an update fails or for other system trouble. Automated backups are created in the `/var/lib/microshift-backups` directory. You can use this directory for manually backing up and restoring data by specifying it in each command. When you create a backup, you must use the entire file path for the output file.
+You can back up {microshift-short} data manually at any time. Back up your data before system updates to preserve it for use if an update fails or for other system trouble. You can use the `/var/lib/microshift-backups` for manually backing up and restoring data by specifying it in each command. When you create a backup, you must use the entire file path for the output file.
 
 .Prerequisites
 
@@ -15,16 +16,15 @@ You can back up {microshift-short} data manually at any time. Back up your data 
 
 .Procedure
 
-. Manually create a backup by using the parent directory and specifying a name, such as `/var/lib/microshift-backups/<my_manual_backup>`, by running the following command:
+. Manually create a backup by using the parent directory and specifying a name, such as `/var/lib/microshift-backups/_<manual_backup>_`, by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo microshift backup /var/lib/microshift-backups/<my_manual_backup>
+$ sudo microshift backup /var/lib/microshift-backups/_<manual_backup>_ <1>
 ----
-Replace `<my_manual_backup>` with the backup name that you want to use.
+<1> Replace `_<manual_backup>_` with the backup name that you want to use.
 +
 .Example output
-+
 [source,terminal]
 ----
 ??? I1017 07:38:16.770506    5900 data_manager.go:92] "Copying data to backup directory" storage="/var/lib/microshift-backups" name="test" data="/var/lib/microshift"
@@ -35,11 +35,11 @@ Replace `<my_manual_backup>` with the backup name that you want to use.
 
 . Optional: Manually create a backup in a specific parent directory with a custom name by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo microshift backup /mnt/<other_backups_location>/<another_manual_backup>
+$ sudo microshift backup /mnt/_<other_backups_location>_/_<another_manual_backup>_
 ----
-Replace `<other_backups_location>` with the directory you want to use and `<my_manual_backup>` with the backup name you want to use.
+Replace `_<other_backups_location>_` with the directory you want to use and `_<my_manual_backup>_` with the backup name you want to use.
 
 .Verification
-* You can verify that the backup exists by viewing the data in the directory you chose. For example, `/var/lib/microshift-backups/<my_manual_backup>/` or `/mnt/<other_backups_location>/<another_manual_backup>`.
+* You can verify that the backup exists by viewing the data in the directory you chose. For example, `/var/lib/microshift-backups/_<manual_backup>_/` or `/mnt/_<other_backups_location>_/_<another_manual_backup>_`.

--- a/modules/microshift-restoring-data-backups.adoc
+++ b/modules/microshift-restoring-data-backups.adoc
@@ -1,36 +1,36 @@
 //Module included in the following assemblies:
 //
 // * microshift_updating/microshift-update-options.adoc
+// * microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="microshift-restoring-data-backups-manually_{context}"]
 = Restoring {microshift-short} data backups manually
 
-You can restore {microshift-short} data from a backup manually. Backups can be restored after updates, or after other system events that remove or damage required data. Automated backups are in the `/var/lib/microshift-backups` directory by default. You can use this directory for manually backing up and restoring data by specifying it in each command. When you restore a backup, you must use the entire file path.
+You can restore {microshift-short} data from a backup manually. Backups can be restored after updates, or after other system events that remove or damage required data. When you restore a backup, you must use the entire file path.
 
 [NOTE]
 ====
-On an `rpm-ostree` system, {microshift-short} backs up and restores data automatically.
+On an `rpm-ostree` system, {microshift-short} backs up and restores data automatically. Automated backups are in the `/var/lib/microshift-backups` directory by default.
 ====
 
 .Prerequisites
 
 * Root access to the host.
-* Full path of the data backup file.
+* You have the full path of the data backup file.
 * The {microshift-short} service is stopped.
 
 .Procedure
 
 . Manually restore {microshift-short} data by using the full file path of the backup you want to restore by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo microshift restore /var/lib/microshift-backups/<my_manual_backup>
+$ sudo microshift restore /var/lib/microshift-backups/_<manual_backup>_ <1>
 ----
-Replace `<my_manual_backup>` with the backup name that you used. Optional: You can also restore automatic `ostree` backups using the full file path.
+<1> Replace `_<manual_backup>_` with the backup name that you used. Optional: You can also restore automatic `ostree` backups using the full file path.
 +
 .Example output
-+
 [source,terminal]
 ----
 ??? I1017 07:39:52.055165    6007 data_manager.go:131] "Copying backup to data directory" storage="/var/lib/microshift-backups" name="test" data="/var/lib/microshift"
@@ -43,13 +43,18 @@ Replace `<my_manual_backup>` with the backup name that you used. Optional: You c
 
 . Optional. Manually restore data from a customized directory by using the full file path of the backup. Run the following command:
 +
-[source,terminal]
+[source,terminal,subs="+quotes"]
 ----
-$ sudo microshift restore /<mnt>/<other_backups_location>/<another_manual_backup>
+$ sudo microshift restore /mnt/_<other_backups_location>_/_<another_manual_backup>_ <1>
 ----
-Replace `<other_backups_location>` with the directory you used and `<my_manual_backup>` with the backup name you used when creating the backup you are restoring.
+<1> Replace `_<other_backups_location>_` with the directory you used and `_<my_manual_backup>_` with the backup name you used when creating the backup you are restoring.
 
 . Restart the host. Restarting the host enables all workloads and pods to restart.
 
 .Verification
+
 * Use the `oc get pods -A` command to verify that the cluster is running, then check the restored data.
++
+--
+include::snippets/microshift-healthy-pods-snip.adoc[leveloffset=+2]
+--

--- a/modules/microshift-service-stopping.adoc
+++ b/modules/microshift-service-stopping.adoc
@@ -2,6 +2,7 @@
 //
 // * microshift/microshift-install-rpm.adoc
 // * microshift/microshift-update-rpms-ostree.adoc
+// * microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="stopping-microshift-service_{context}"]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-15822](https://issues.redhat.com/browse/OSDOCS-15822)

Link to docs preview:
[microshift-about-data-backups_microshift-backup-and-restore](https://97657--ocpdocs-pr.netlify.app/microshift/latest/microshift_backup_and_restore/microshift-backup-and-restore.html#microshift-about-data-backups_microshift-backup-and-restore)

QE review:
- N/A

Additional information:
Also applied some DITA optimization to the structure of this content. No technical changes made.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
