### PR TITLE
ROX-30546: Correct number of connections default value

### DIFF
--- a/modules/central-configuration-options-operator.adoc
+++ b/modules/central-configuration-options-operator.adoc
@@ -130,7 +130,7 @@ If no PVC with the given name exists, it is created. The default value is `centr
 a| Use this parameter to override the default maximum connection pool size between Central and Central DB. The default value is 90.
 Ensure that this value does not exceed the maximum number of connections supported by the Central DB:
 
-* An Operator-managed Central DB supports a maximum of 200 connections by default.
+* An Operator-managed Central DB supports a maximum of 100 connections by default.
 * For external PostgreSQL databases, check the database settings or consult your cloud provider for managed databases.
 
 |`central.db.resources.limits`


### PR DESCRIPTION
Version(s):
4.6+

[Issue](https://issues.redhat.com/browse/ROX-30546)

[Link to docs preview
](https://97677--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-config-options-ocp.html)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
