### PR TITLE
OSDOCS-15879: fixes conditionals Storage MicroShift

### DIFF
--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -109,7 +109,6 @@ Direct matches are always attempted first. The volume's modes must match or cont
 
 All volumes with the same modes are grouped, and then sorted by size, smallest to largest. The binder gets the group with matching modes and iterates over each, in size order, until one size matches.
 
-ifndef::microshift[]
 [IMPORTANT]
 ====
 Volume access modes describe volume capabilities. They are not enforced constraints. The storage provider is responsible for runtime errors resulting from invalid use of the resource. Errors in the provider show up at runtime as mount errors.
@@ -120,7 +119,6 @@ For example, NFS offers `ReadWriteOnce` access mode. If you want to use the volu
 iSCSI and Fibre Channel volumes do not currently have any fencing mechanisms. You must ensure the volumes are only used by one node at a time. In certain situations, such as draining a node, the volumes can be used simultaneously by two nodes. Before draining the node, delete the pods that use the volumes.
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 ====
-endif::microshift[]
 
 The following table lists the access modes:
 
@@ -151,35 +149,34 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 and {rh-storage-first}. For third-party drivers, contact your storage vendor.
 --
 
-ifndef::microshift[]
 .Supported access modes for persistent volumes
 [cols=",^v,^v,^v,^v", width="100%",options="header"]
 |===
 |Volume plugin  |ReadWriteOnce ^[1]^ | ReadWriteOncePod |ReadOnlyMany|ReadWriteMany
-|AWS EBS ^[2]^ | ✅ | ✅ |  |  
+|AWS EBS ^[2]^ | ✅ | ✅ |  |
 |AWS EFS | ✅ | ✅ | ✅ | ✅
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |Azure File | ✅ |✅ | ✅ | ✅
-|Azure Disk | ✅ | ✅ |   |  
-//|Ceph RBD  | ✅ | ✅ |✅ |   
+|Azure Disk | ✅ | ✅ |   |
+//|Ceph RBD  | ✅ | ✅ |✅ |
 //|CephFS  | ✅ | ✅ | ✅ |  ✅
 |CIFS/SMB | ✅ | ✅ | ✅ | ✅
-|Cinder  | ✅ | ✅ | |  
+|Cinder  | ✅ | ✅ | |
 |Fibre Channel  | ✅ | ✅ |✅ |  ✅ ^[3]^
 endif::[]
 ifndef::openshift-rosa,openshift-rosa-hcp[]
-|GCP Persistent Disk  | ✅ |✅ |   |   
+|GCP Persistent Disk  | ✅ |✅ |   |
 |GCP Filestore | ✅ | ✅ |✅ | ✅
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 //|GlusterFS  | ✅ |✅ | ✅ | ✅
-|HostPath  | ✅ |✅ |   |   
+|HostPath  | ✅ |✅ |   |
 |{ibm-power-server-title}  Disk | ✅ |✅  | ✅ |  ✅
-|{ibm-cloud-name} VPC Disk | ✅ |✅ |  |  
+|{ibm-cloud-name} VPC Disk | ✅ |✅ |  |
 |iSCSI  | ✅ | ✅ |✅ |  ✅ ^[3]^
-|Local volume | ✅ |✅ |  |  
+|Local volume | ✅ |✅ |  |
 endif::[]
-|LVM Storage | ✅ | ✅ |   |  
+|LVM Storage | ✅ | ✅ |   |
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |NFS  | ✅ | ✅ |✅ | ✅
 |OpenStack Manila  |  |✅ |  | ✅
@@ -204,6 +201,7 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 endif::microshift[]
 
 ifdef::microshift[]
+[id="supported-access-modes_{context}"]
 == Supported access modes
 LVMS is the only CSI plugin {product-title} supports. The hostPath and LVs built in to {OCP} also support RWO.
 endif::microshift[]
@@ -352,6 +350,6 @@ allowVolumeExpansion: true
 
 [NOTE]
 ====
-`mountOptions` are not validated. Incorrect values will cause the mount to fail and an event to be logged to the PVC.
+The `mountOptions` parameter values are not validated. Incorrect values cause the mount to fail and an event to be logged to the PVC.
 ====
 endif::microshift[]


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-15879](https://issues.redhat.com/browse/OSDOCS-15879)

Link to docs preview:
https://97678--ocpdocs-pr.netlify.app/microshift/latest/microshift_storage/understanding-persistent-storage-microshift.html
https://97678--ocpdocs-pr.netlify.app/openshift-dedicated/latest/storage/understanding-persistent-storage.html
https://97678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html
https://97678--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/storage/understanding-persistent-storage.html
https://97678--ocpdocs-pr.netlify.app/openshift-rosa/latest/storage/understanding-persistent-storage.html

QE review:
- N/A fixes docs render; no technical changes

Additional info:
Fixes [this](https://github.com/openshift/openshift-docs/blame/enterprise-4.19/modules/storage-persistent-storage-pv.adoc#L100-L112) which came from [this](https://github.com/openshift/openshift-docs/commit/82f57f8433109046c785b40865b1fe1ed8aee353); and might be causing half of the Storage title content to be missing from the MicroShift 4.19 docs

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
