### PR TITLE
Fixed a misspelled ID in the No CNI HCP docs

### DIFF
--- a/rosa_hcp/rosa-hcp-cluster-no-cni.adoc
+++ b/rosa_hcp/rosa-hcp-cluster-no-cni.adoc
@@ -1,5 +1,5 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="rosa-hcp-cluster-no-cli"]
+[id="rosa-hcp-cluster-no-cni"]
 = {product-title} clusters without a CNI plugin
 include::_attributes/attributes-openshift-dedicated.adoc[]
 include::_attributes/common-attributes.adoc[]


### PR DESCRIPTION
This PR tries to fix this page's 404 error: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-cluster-no-cli

No CNI: 