### PR TITLE
OSDOCS#15867: Update the z-stream RNs for 4.19.9

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2828,6 +2828,56 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.19.9
+[id="ocp-4-19-9_{context}"]
+=== RHSA-2025:13848 - {product-title} {product-version}.9 image release, bug fix, and security update advisory
+
+Issued: 19 August 2025
+
+{product-title} release {product-version}.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:13848[RHSA-2025:13848] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:13827[RHBA-2025:13827] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.9 --pullspecs
+----
+
+[id="ocp-4-19-9-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, boot images for 4.1 and 4.2 failed to work with {product-title} {product-version}, and caused degraded cluster operation. With this release, a static Grand Unified Bootloader (GRUB) configuration is installed for Extensible Firmware Interface (EFI) and firmware components, and the cluster operates normally during node scaling. (link:https://issues.redhat.com/browse/OCPBUGS-52485[OCPBUGS-52485])
+
+* Before this update, the {gcp-first} machine API was blocked by sequential reconciliation processing. As a consequence, users experienced slow scaling of nodes during GCP integration. With this release, the GCP machine API performance is improved by enabling parallel execution of many reconciliation processes. As a result, GCP node scaling performance improves. (link:https://issues.redhat.com/browse/OCPBUGS-59386[OCPBUGS-59386])
+
+* Before this update, users configured {product-title} Vertical Pod Autoscaler (VPA) custom recommenders using a version with an upstream issue in VPA. As a consequence, the issue caused instability in VPA updates. With this release, the custom VPA checkpoint garbage collector does not remove untracked checkpoints, and prevents instability in {product-title}. As a result, {product-title} VPA updates are stable and constant pod rescheduling does not occur. (link:https://issues.redhat.com/browse/OCPBUGS-59638[OCPBUGS-59638])
+
+* Before this update, the machine config daemon failed Domain Name System (DNS) lookups during the {product-title} 4.16 manifest application on {vmw-first} infrastructure. As a consequence, user DNS lookups failed during the {product-title} 4.16 upgrade, halting upgrades indefinitely. With this release, retries of remote operating system updates with backoff are implemented to avoid failing because of CoreDNS pod restarts during the upgrades. (link:https://issues.redhat.com/browse/OCPBUGS-59899[OCPBUGS-59899])
+
+* Before this update, cluster upgrade failures occurred because of an increased reconcile attempts limit. This failure caused Prometheus pod unavailability and resulted in service degradation. With this release, the Operator allows an additional reconcile attempt before reporting failures. As a result, the cluster upgrade test stability is improved, reducing failure rate, and enhancing upgrade reliability. (link:https://issues.redhat.com/browse/OCPBUGS-59932[OCPBUGS-59932])
+
+* Before this update, the sidecar of a {product-title} Precision Time Protocol (PTP) pod unexpectedly restarted after termination, and caused the clock class termination to fail with an `exit code 7` error. As a consequence, the metrics were unavailable. With this release, the sidecar restart does not cause the clock class termination error in a {product-title} PTP pod, and does not stop during the restart. (link:https://issues.redhat.com/browse/OCPBUGS-59970[OCPBUGS-59970])
+
+* Before this update, when a user upgraded to {product-title} {product-version}, the Machine Config Operator (MCO) rotated a Transport Layer Security (TLS) certificate. This caused an issue where nodes could not join the cluster during the scale-up process. With this release, the MCO provides a custom ARO resource that determines the necessary Subject Alternative Name (SAN) IP address, and adds it in the rotated TLS certificate. As a result, nodes can join the cluster during the scale-up process. (link:https://issues.redhat.com/browse/OCPBUGS-59978[OCPBUGS-59978])
+
+* Before this update, an interpolation error in the `ResourceEventStream` code format caused incorrect error messages when users connected to the event stream. With this release, the interpolation format for error messages in the event stream is correct. As a result, users see accurate error messages when they connect to the event stream. (link:https://issues.redhat.com/browse/OCPBUGS-60039[OCPBUGS-60039])
+
+* Before this update, the primary node port in the communication matrix project was unbound, and caused a missing communication flow and service unavailability on the primary node. With this release, the port on the controller manager is closed and is available only from the `localhost`. As a result, the service is bound to the correct port. (link:https://issues.redhat.com/browse/OCPBUGS-60132[OCPBUGS-60132])
+
+* Before this update, a `MachineSet` custom resource update failure occurred because of multiple arch annotation labels. As a consequence, the machine update failed. With this release, the update issue is corrected by allowing multiple labels in the `{{capacity.cluster-autoscaler.kubernetes.io/labels}}` annotation, and properly parses the architecture value. As a result, the Machine Config Operator does not fail during an update. (link:https://issues.redhat.com/browse/OCPBUGS-60224[OCPBUGS-60224])
+
+* Before this update, the `LeaderWorkerSet` Operator description was outdated. As a consequence, users experienced incorrect descriptions. With this release, the `LeaderWorkerSet` Operator description is updated and the description accurately describes the concept. (link:https://issues.redhat.com/browse/OCPBUGS-60225[OCPBUGS-60225])
+
+* Before this update, the `cloud-event-proxy` sidecar process terminated and caused the notification API to remain in a `clockClass=0` state even when the pod recovered. As a consequence, the notification API remained inactive after the sidecar process terminated. With this release, the `cloud-event-proxy` process recovery does not result in a `clockClass=0` state for the notification API. Now, the notification API correctly updates the `clockClass` variable when the `cloud-event-proxy` recovers. (link:https://issues.redhat.com/browse/OCPBUGS-60261[OCPBUGS-60261])
+
+* Before this update, insufficient obfuscation of new network data types in an OVN-K hosted cluster exposed sensitive data. As a consequence, user data was exposed. With this release, the anonymizer is updated to discover and obfuscate new network data types, and ensure secure communication. (link:https://issues.redhat.com/browse/OCPBUGS-60295[OCPBUGS-60295])
+
+[id="ocp-4-19-9-updating_{context}"]
+==== Updating
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.19.7
 [id="ocp-4-19-7_{context}"]
 === RHSA-2025:12341 - {product-title} {product-version}.7 image release, bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-15867](https://issues.redhat.com//browse/OSDOCS-15867)

Link to docs preview:
[4.19.9](https://97707--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-9_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
 - First OCP Konflux release.
 - The errata URLs will return 404 until the go-live date of 8/19/25.