### PR TITLE
[enterprise-4.18] TELCODOCS-2127: Adding kernalpagesize API to PP

### DIFF
--- a/modules/cnf-memory-optimization.adoc
+++ b/modules/cnf-memory-optimization.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cnf-configuring-kernal-page-size_{context}"]
+= Configuring memory page sizes
+
+By configuring memory page sizes, system administrators can implement more efficient memory management on a specific node to suit workload requirements. The Node Tuning Operator provides a method for configuring huge pages and kernel page sizes by using a performance profile.

--- a/modules/configuring-kernal-page-size.adoc
+++ b/modules/configuring-kernal-page-size.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="cnf-page-size-optimization_{context}"]
+= Configuring kernel page sizes
+
+Use the `kernelPageSize` specification in a performance profile to configure the kernel page size on a specific node. Specify larger kernel page sizes for memory-intensive, high-performance workloads. 
+
+[NOTE]
+====
+For nodes with an x86_64 or AMD64 architecture, you can only specify `4k` for the `kernelPageSize` specification. For nodes with an AArch64 architecture, you can specify `4k` or `64k` for the `kernelPageSize` specification. The default value is `4k`.
+====
+
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+
+* Install the {oc-first}.
+
+.Procedure
+
+. Create a performance profile to target nodes where you want to configure the kernel page size by creating a YAML file that defines the `PerformanceProfile` resource:
++
+.Example `pp-kernel-pages.yaml` file
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v1
+kind: PerformanceProfile
+metadata:
+    name: example-performance-profile
+#...
+spec:
+    kernelPageSize: "64k" <1>
+    nodeSelector:
+        node-role.kubernetes.io/worker: "" <2>
+----
+<1> This example specifies a kernel page size of `64k`. You can only specify `64k` for nodes with an AArch64 architecture. The default value is `4k`.
+<2> This example targets nodes with the `worker` role.
+
+. Apply the performance profile to the cluster:
++
+[source,bash]
+----
+$ oc create -f pp-kernel-pages.yaml
+----
++
+.Example output
+----
+performanceprofile.performance.openshift.io/example-performance-profile created
+----
+
+.Verification
+
+. Start a debug session on the node where you applied the performance profile by running the following command:
++
+[source,bash]
+----
+$ oc debug node/<node_name> <1>
+----
+<1> Replace `<node_name>` with the name of the node with the performance profile applied.
+
+. Verify that the kernel page size is set to the value you specified in the performance profile by running the following command:
++
+[source,bash]
+----
+$ getconf PAGESIZE
+----
++
+.Example output
+----
+65536
+----

--- a/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+++ b/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
@@ -89,7 +89,11 @@ include::modules/cnf-about-irq-affinity-setting.adoc[leveloffset=+2]
 
 include::modules/cnf-configure_for_irq_dynamic_load_balancing.adoc[leveloffset=+2]
 
-include::modules/cnf-configuring-huge-pages.adoc[leveloffset=+1]
+include::modules/cnf-memory-optimization.adoc[leveloffset=+1]
+
+include::modules/configuring-kernal-page-size.adoc[leveloffset=+2]
+
+include::modules/cnf-configuring-huge-pages.adoc[leveloffset=+2]
 
 include::modules/cnf-allocating-multiple-huge-page-sizes.adoc[leveloffset=+2]
 


### PR DESCRIPTION
CP of #87727

Version(s):
4.18

Doc preview:

https://97737--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.html#cnf-configuring-kernal-page-size_cnf-low-latency-perf-profile



