### PR TITLE
[enterprise-4.14] OCPBUGS-54741: Removed balance-tlb references from Agent Installer docs

### DIFF
--- a/modules/agent-install-sample-config-bond-sriov.adoc
+++ b/modules/agent-install-sample-config-bond-sriov.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="agent-install-sample-config-bond-sriov_{context}"]
-= Example: Bonds and SR-IOV dual-nic node network configuration
+= Example: Bonds and SR-IOV dual-NIC node network configuration
 
 :FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-The following `agent-config.yaml` file is an example of a manifest for dual port NIC with a bond and SR-IOV interfaces:
+The following `agent-config.yaml` file is an example of a manifest for dual port network interface controller (NIC) with a bond and SR-IOV interfaces:
 
 [source,yaml]
 ----
@@ -101,7 +101,7 @@ hosts:
                 next-hop-interface: bond0 <14>
                 table-id: 254
 ----
-<1> The `networkConfig` field contains information about the network configuration of the host, with subfields including `interfaces`,`dns-resolver`, and `routes`.
+<1> The `networkConfig` field includes information about the network configuration of the host, with subfields including `interfaces`,`dns-resolver`, and `routes`.
 <2> The `interfaces` field is an array of network interfaces defined for the host.
 <3> The name of the interface.
 <4> The type of interface. This example creates an ethernet interface.
@@ -113,7 +113,7 @@ hosts:
     * This value must be less than or equal to the maximum transmission rate.
     * Intel NICs do not support the `min-tx-rate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[*BZ#1772847*].
 <10> Sets a maximum transmission rate, in Mbps, for the VF. This sample value sets a rate of 200 Mbps.
-<11> Sets the desired bond mode.
-<12> Sets the preferred port of the bonding interface. The primary device is the first of the bonding interfaces to be used and is not abandoned unless it fails. This setting is particularly useful when one NIC in the bonding interface is faster and, therefore, able to handle a bigger load. This setting is only valid when the bonding interface is in `active-backup` mode (mode 1) and `balance-tlb` (mode 5).
+<11> Sets the needed bond mode.
+<12> Sets the preferred port of the bonding interface. The primary device is the first of the bonding interfaces to be used and is not abandoned unless it fails. This setting is particularly useful when one NIC in the bonding interface is faster and, therefore, able to handle a bigger load. This setting is only valid when the bonding interface is in `active-backup` mode (mode 1).
 <13> Sets a static IP address for the bond interface. This is the node IP address.
 <14> Sets `bond0` as the gateway for the default route.

--- a/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-host-dual-network-interfaces-in-the-install-config-yaml-file_{context}"]
-= Optional: Configuring host network interfaces for dual port NIC
+= Configuring host network interfaces for dual-port NIC
 
-Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces by using NMState to support dual port NIC.
+Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces by using NMState to support dual-port network interface controller (NIC).
 
 :FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
 include::snippets/technology-preview.adoc[leveloffset=+1]
@@ -134,8 +134,8 @@ Errors in the YAML syntax might result in a failure to apply the network configu
     * This value must be less than or equal to the maximum transmission rate.
     * Intel NICs do not support the `min-tx-rate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[*BZ#1772847*].
 <10> Sets a maximum transmission rate, in Mbps, for the VF. This sample value sets a rate of 200 Mbps.
-<11> Sets the desired bond mode.
-<12> Sets the preferred port of the bonding interface. The bond uses the primary device as the first device of the bonding interfaces. The bond does not abandon the primary device interface unless it fails. This setting is particularly useful when one NIC in the bonding interface is faster and, therefore, able to handle a bigger load. This setting is only valid when the bonding interface is in active-backup mode (mode 1) and balance-tlb (mode 5).
+<11> Sets the needed bond mode.
+<12> Sets the preferred port of the bonding interface. The bond uses the primary device as the first device of the bonding interfaces. The bond does not abandon the primary device interface unless it fails. This setting is particularly useful when one NIC in the bonding interface is faster and, therefore, able to handle a bigger load. This setting is only valid when the bonding interface is in active-backup mode (mode 1).
 <13> Sets a static IP address for the bond interface. This is the node IP address.
 <14> Sets `bond0` as the gateway for the default route.
 +


### PR DESCRIPTION
Cherry pick of #97672 with commit 868c0eade08b8a389ee6fd2cc441c8bb26f5985d

Version(s):
4.14

Issue:
[OCPBUGS-54741](https://issues.redhat.com/browse/OCPBUGS-54741)

Link to docs preview:
