### PR TITLE
OCPBUGS-60006: Updating CRs to match telco-reference eng repo changes

### DIFF
--- a/scalability_and_performance/telco-hub-rds.adoc
+++ b/scalability_and_performance/telco-hub-rds.adoc
@@ -231,6 +231,13 @@ The following is the complete YAML reference of all the custom resources (CRs) f
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/acm/acmAgentServiceConfig.yaml[]
 ----
 
+[id="telco-hub-acmMCE-yaml_{context}"]
+.acmMCE.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/acm/acmMCE.yaml[]
+----
+
 [id="telco-hub-acmMCH-yaml_{context}"]
 .acmMCH.yaml
 [source,yaml]
@@ -308,6 +315,13 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/acm/observabilitySecret.yaml[]
 ----
 
+[id="telco-hub-clusters-pull-secret-copy-yaml_{context}"]
+.pull-secret-copy.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/acm/pull-secret-copy.yaml[]
+----
+
 [id="telco-hub-thanosSecret-yaml_{context}"]
 .thanosSecret.yaml
 [source,yaml]
@@ -321,6 +335,49 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 ----
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/talm/talmSubscription.yaml[]
 ----
+
+////
+Awaiting QE approval of these resources
+
+[id="telco-hub-backup-ref-crs_{context}"]
+=== Backup and recovery reference YAML
+
+[id="telco-hub-clusters-backupSchedule-yaml_{context}"]
+.backupSchedule.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/backup-recovery/backupSchedule.yaml[]
+----
+
+[id="telco-hub-clusters-dataProtectionApplication-yaml_{context}"]
+.dataProtectionApplication.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/backup-recovery/dataProtectionApplication.yaml[]
+----
+
+[id="telco-hub-clusters-objectBucketClaim-yaml_{context}"]
+.objectBucketClaim.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/backup-recovery/objectBucketClaim.yaml[]
+----
+
+
+[id="telco-hub-clusters-policy-backup-yaml_{context}"]
+.policy-backup.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/backup-recovery/policy-backup.yaml[]
+----
+
+[id="telco-hub-clusters-restore-yaml_{context}"]
+.restore.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/backup-recovery/restore.yaml[]
+----
+////
 
 [id="telco-hub-storage-ref-crs_{context}"]
 === Storage reference YAML
@@ -339,8 +396,8 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/lso/lsoNS.yaml[]
 ----
 
-[id="telco-hub-lsoOperatorgroup-yaml_{context}"]
-.lsoOperatorgroup.yaml
+[id="telco-hub-lsoOperatorGroup-yaml_{context}"]
+.lsoOperatorGroup.yaml
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/lso/lsoOperatorGroup.yaml[]
@@ -367,6 +424,13 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/odf-internal/odfOperatorGroup.yaml[]
 ----
 
+[id="telco-hub-odfReady-yaml_{context}"]
+.odfReady.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/odf-internal/odfReady.yaml[]
+----
+
 [id="telco-hub-odfSubscription-yaml_{context}"]
 .odfSubscription.yaml
 [source,yaml]
@@ -384,11 +448,53 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 [id="telco-hub-gitopsztp-ref-crs_{context}"]
 === GitOps Operator and {ztp} reference YAML
 
+[id="telco-hub-addPluginsPolicy-yaml"]
+.addPluginsPolicy.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/addPluginsPolicy.yaml[]
+----
+
+[id="telco-hub-clusters-app-project-yaml_{context}"]
+.app-project.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/app-project.yaml[]
+----
+
+[id="telco-hub-argocd-application-yaml"]
+.argocd-application.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/argocd-application.yaml[]
+----
+
+[id="telco-hub-argocd-tls-certs-cm-yaml"]
+.argocd-tls-certs-cm.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/argocd-tls-certs-cm.yaml[]
+----
+
 [id="telco-hub-argocd-ssh-known-hosts-cm-yaml"]
 .argocd-ssh-known-hosts-cm.yaml
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/argocd-ssh-known-hosts-cm.yaml[]
+----
+
+[id="telco-hub-clusterrole-yaml"]
+.clusterrole.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/clusterrole.yaml[]
+----
+
+[id="telco-hub-clusterrolebinding-yaml"]
+.clusterrolebinding.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/clusterrolebinding.yaml[]
 ----
 
 [id="telco-hub-gitopsNS-yaml_{context}"]
@@ -425,14 +531,6 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 ----
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/app-project.yaml[]
 ----
-
-// [id="telco-hub-argocd-openshift-gitops-patch-yaml_{context}"]
-// .argocd-openshift-gitops-patch.json
-// [source,json]
-// ----
-// include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/argocd-openshift-gitops-patch.json[]
-// ----
-// Removing as this file no longer exists in the telco-hub repository.
 
 [id="telco-hub-clusters-app-yaml_{context}"]
 .clusters-app.yaml
@@ -476,8 +574,81 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/gitops/ztp-installation/policies-app.yaml[]
 ----
 
+[id="telco-hub-registry-ref-crs_{context}"]
+=== Registry reference YAML
+
+[id="telco-hub-catalog-source-yaml"]
+.catalog-source.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/registry/catalog-source.yaml[]
+----
+
+[id="telco-hub-idms-operator-yaml"]
+.idms-operator.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/registry/idms-operator.yaml[]
+----
+
+[id="telco-hub-idms-release-yaml"]
+.idms-release.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/registry/idms-release.yaml[]
+----
+
+[id="telco-hub-clusters-image-config-yaml_{context}"]
+.image-config.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/registry/image-config.yaml[]
+----
+
+[id="telco-hub-itms-generic-yaml"]
+.itms-generic.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/registry/itms-generic.yaml[]
+----
+
+[id="telco-hub-itms-release-yaml"]
+.itms-release.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/registry/itms-release.yaml[]
+----
+
+[id="telco-hub-kustomization-registry-yaml_context"]
+.kustomization.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/registry/kustomization.yaml[]
+----
+
+[id="telco-hub-operator-hub-yaml"]
+.operator-hub.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/registry/operator-hub.yaml[]
+----
+
+[id="telco-hub-clusters-registry-ca-yaml_{context}"]
+.registry-ca.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/required/registry/registry-ca.yaml[]
+----
+
 [id="telco-hub-logging-ref-crs_{context}"]
 === Logging reference YAML
+
+[id="telco-hub-clusterLogForwarder-yaml"]
+.clusterLogForwarder.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/logging/clusterLogForwarder.yaml[]
+----
 
 [id="telco-hub-clusterLogNS-yaml"]
 .clusterLogNS.yaml
@@ -491,6 +662,27 @@ include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/logging/clusterLogOperGroup.yaml[]
+----
+
+[id="telco-hub-clusterLogServiceAccount-yaml_{context}"]
+.clusterLogServiceAccount.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/logging/clusterLogServiceAccount.yaml[]
+----
+
+[id="telco-hub-clusterLogServiceAccountAuditBinding-yaml_{context}"]
+.clusterLogServiceAccountAuditBinding.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/logging/clusterLogServiceAccountAuditBinding.yaml[]
+----
+
+[id="telco-hub-clusterLogServiceAccountInfrastructureBinding-yaml_{context}"]
+.clusterLogServiceAccountInfrastructureBinding.yaml
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift-kni/telco-reference/release-4.19/telco-hub/configuration/reference-crs/optional/logging/clusterLogServiceAccountInfrastructureBinding.yaml[]
 ----
 
 [id="telco-hub-clusterLogSubscription-yaml_{context}"]


### PR DESCRIPTION
OCPBUGS-60006: Updating CRs to match telco-reference eng repo changes

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OCPBUGS-60006

Link to docs preview:
https://97766--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html#telco-yaml-reference_telco-hub

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
