### PR TITLE
ROX-28812: Correct port exposure values

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -733,12 +733,11 @@ AND, OR
 | Port Exposure Method
 | One of: +
 
-UNSET +
-EXTERNAL +
-NODE +
-HOST +
-INTERNAL +
-ROUTE +
+Route +
+LoadBalancer +
+NodePort +
+HostPort +
+Exposure type is not set +
 | NOT, +
 AND, OR
 | *Deploy*, +


### PR DESCRIPTION
Version(s):
4.6+

[Issue:
](https://issues.redhat.com/browse/ROX-28812)

Link to docs preview:

https://97789--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/about-security-policies.html#policy-criteria_about-security-policies (Search for "port exposure")

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
