### PR TITLE
OSSM-10604: Move location of installing Kiali multi-cluster task topi…

### DIFF
--- a/install/ossm-multi-cluster-topologies.adoc
+++ b/install/ossm-multi-cluster-topologies.adoc
@@ -15,6 +15,7 @@ include::modules/ossm-applying-certificates-to-a-multi-cluster-topology.adoc[lev
 include::modules/ossm-installing-multi-primary-multi-network-mesh.adoc[leveloffset=+1]
 include::modules/ossm-verifying-multi-cluster-topology.adoc[leveloffset=+2]
 include::modules/ossm-removing-multi-cluster-installation-from-development-environment.adoc[leveloffset=+2]
+include::modules/ossm-installing-primary-remote-multi-network-mesh.adoc[leveloffset=+1]
 include::modules/ossm-installing-kiali-multi-cluster-mesh.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -23,7 +24,6 @@ include::modules/ossm-installing-kiali-multi-cluster-mesh.adoc[leveloffset=+1]
 
 * xref:../observability/kiali/ossm-kiali.adoc#ossm-kiali[Using Kiali Operator provided by Red Hat]
 
-include::modules/ossm-installing-primary-remote-multi-network-mesh.adoc[leveloffset=+1]
 [role="_next-steps"]
 .Next steps
 * xref:../install/ossm-multi-cluster-topologies.adoc#ossm-verifying-multi-cluster-topology_ossm-multi-cluster-topologies[Verifying a multi-cluster topology]


### PR DESCRIPTION
Affects:

[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)
[service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

PR must be merged to service docs main and CP'd back to the 3.0 and 3.1 branches.

Version(s): 3.1

Issue:
https://issues.redhat.com/browse/OSSM-10604

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
