### PR TITLE
ROX-11689: Add info about key value pairs and roles

### DIFF
--- a/modules/assign-role-to-user-or-group.adoc
+++ b/modules/assign-role-to-user-or-group.adoc
@@ -12,9 +12,9 @@ You can use the {product-title-short} portal to assign roles to a user or a grou
 . From the list of authentication providers, select the authentication provider.
 . Click *Edit minimum role and rules*.
 . Under the *Rules* section, click *Add new rule*.
-. For *Key*, select one of the values from `userid`, `name`, `email` or `group`.
-. For *Value*, enter the value of the user ID, name, email address or group based on the key you selected.
-. Click the *Role* drop-down menu and select the role you want to assign.
+. For *Key*, select one of the values from `userid`, `name`, `email`, or `groups`. The available choices depend on the authentication provider.
+. For *Value*, enter the value of the user ID, name, email address, or group based on the key you selected. For example, to assign the `Analyst` role to a user by email, after selecting `email` for the *Key* field, enter the email address of the user.
+. Click the *Role* drop-down menu and select the role you want to assign. For example, to assign the `Analyst` role to a user whose email you have entered, select `Analyst`.
 . Click *Save*.
 
-You can repeat these instructions for each user or group and assign different roles.
+You can repeat these instructions for each user or group and assign different roles. For role aggregation, you can use the same key/value pair with multiple roles. For example, you can create a rule that assigns the `Analyst` role to the user `jsmith@example.com`, and then add another rule to assign the `Vulnerability Report Creator` role to the same user. For more information about roles, see "System roles". 


### PR DESCRIPTION
Version(s):
4.6+

[Issue
](https://issues.redhat.com/browse/ROX-11689)

[Link to docs preview
](https://97791--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-user-access/manage-role-based-access-control-3630.html#assign-role-to-user-or-group_manage-role-based-access-control)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
