### PR TITLE
OCPBUGS-60660: Updated vSphere disconnected doc to swap clusterOSImag…

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -417,7 +417,9 @@ platform:
 ----
 endif::osp+restricted[]
 ifdef::vsphere+restricted[]
-. In the `install-config.yaml` file, set the value of `platform.vsphere.clusterOSImage` to the image location or name. For example:
+. Choose one of the following methods to speficy an {op-system} image for your cluster than runs in a {vmw-full} vCenter environment.
++
+.. The `clusterOSImage` parameter method: In the `install-config.yaml` file, set the value of `platform.vsphere.clusterOSImage` to the image location or name. For example:
 +
 [source,yaml]
 ----
@@ -425,6 +427,26 @@ platform:
   vsphere:
       clusterOSImage: http://mirror.example.com/images/rhcos-43.81.201912131630.0-vmware.x86_64.ova?sha256=ffebbd68e8a1f2a245ca19522c16c86f67f9ac8e4e0c1f0a812b068b16f7265d
 ----
++
+.. The `topology.template` parameter method:
++
+... Download the *{op-system-first} - vSphere* image in Open Virtual Appliance (OVA) format to your local system. For more information, see "Creating the RHCOS image for restricted network installations".
++
+... From the *Hosts and Clusters* tab on the {vmw-short} Client, right-click your cluster name and select *Deploy OVF Template*.
++
+... On the *Select an OVF* tab, specify the name of the {op-system} OVA file that you downloaded.
++
+... On the *Select a name and folder* tab, set a *Virtual machine name* for your template, such as `Template-{op-system}`.
++
+... Click the name of your vSphere cluster and select the folder you created in the previous step.
++
+... On the *Select a compute resource* tab, click the name of your vSphere cluster.
++
+... On the *Select storage* tab, configure the storage options for your VM.
++
+... When creating the OVF template, do not specify values on the *Customize template* tab or configure the template any further.
++
+... In the `install-config.yaml` file, set the value of `topology.template` to the path where you imported the image to your {vmw-short} vCenter instance.
 endif::vsphere+restricted[]
 ifdef::nutanix+restricted[]
 . In the `install-config.yaml` file, set the value of `platform.nutanix.clusterOSImage` to the image location or name. For example:

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -14,9 +14,14 @@ endif::[]
 [id="installation-installer-provisioned-vsphere-config-yaml_{context}"]
 = Sample install-config.yaml file for an installer-provisioned VMware vSphere cluster
 
-You can customize the `install-config.yaml` file to specify more details about
-your {product-title} cluster's platform or modify the values of the required
-parameters.
+You can customize the `install-config.yaml` file to specify more details about your {product-title} cluster's platform or change the values of the required parameters.
+
+ifdef::restricted[]
+[NOTE]
+====
+The sample `install-config.yaml` file shows the `clusterOSImage` parameter to specify the URL for the {op-system-first} image. As an alternative to this configuration, you can use the `topology.template` parameter to point to the path in your vCenter environment that includes an {op-system} image in Open Virtual Appliance (OVA) format.
+====
+endif::restricted[]
 
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OCPBUGS-60660](https://issues.redhat.com/browse/OCPBUGS-60660)

Link to docs preview:
* [Creating the installation configuration file](https://97816--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere#installation-initializing_installing-restricted-networks-installer-provisioned-vsphere)

- [x] SME has approved this change (Joe Callen).
- [x] QE has approved this change (Wenxin Wei).

[Slack thread.](https://redhat-internal.slack.com/archives/C68TNFWA2/p1755632335661849)
