### PR TITLE
TELCODOCS-2270-RN topology-aware scheduler: HA - Adding RN and updating TP table

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -465,6 +465,13 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-release-notes-scalability-and-performance_{context}"]
 === Scalability and performance
 
+[id="ocp-release-notes-numa-resources-operator-replicas_{context}"]
+==== Configuring NUMA-aware scheduler replicas and high availability (Technology Preview)
+
+In {product-title} {product-version}, the NUMA Resources Operator automatically enables high availability (HA) mode by default. In this mode, the NUMA Resources Operator creates one scheduler replica for each control-plane node in the cluster to ensure redundancy. This default behavior occurs if the `spec.replicas` field is not specified in the `NUMAResourcesScheduler` Custom Resource (CR). Alternatively, you can explicitly set a specific number of scheduler replicas to override the default HA behavior or disable the scheduler entirely by setting the `spec.replicas` field to `0`.
+
+For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-managing-ha-nrop_numa-aware[Managing high availability (HA) for the NUMA-aware scheduler].
+
 [id="ocp-release-notes-security_{context}"]
 === Security
 
@@ -1514,6 +1521,11 @@ In the following tables, features are marked with the following statuses:
 |Pinned Image Sets
 |Technology Preview
 |Technology Preview
+|Technology Preview
+
+|Configuring NUMA-aware scheduler replicas and high availability
+|Not available
+|Not available
 |Technology Preview
 |====
 


### PR DESCRIPTION
[TELCODOCS-2270]: topology-aware scheduler: HA by default

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2270
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://97817--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-numa-resources-operator-replicas_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to](https://96669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/network) merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
