### PR TITLE
4.20-rn-clean

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -50,66 +50,11 @@ This release adds improvements related to the following components and concepts:
 [id="ocp-release-notes-auth_{context}"]
 === Authentication and authorization
 
-[id="ocp-release-notes-auth-direct_{context}"]
-==== Enabling direct authentication with an external OIDC identity provider (Technology Preview)
-
-With this release, you can enable direct integration with an external OpenID Connect (OIDC) identity provider to issue tokens for authentication. This bypasses the built-in OAuth server and uses the external identity provider directly.
-
-By integrating directly with an external OIDC provider, you can leverage the advanced capabilities of your preferred OIDC provider instead of being limited by the capabilities of the built-in OAuth server. Your organization can manage users and groups from a single interface, while also streamlining authentication across multiple clusters and in hybrid environments. You can also integrate with existing tools and solutions.
-
-Direct authentication is available as a Technology Preview feature.
-
-For more information, see xref:../authentication/external-auth.adoc#external-auth[Enabling direct authentication with an external OIDC identity provider].
-
-[id="ocp-4-20-auth-ServiceAccountTokenNodeBinding_{context}"]
-==== Enable ServiceAccountTokenNodeBinding Kubernetes feature by default
-
-In {product-title} {product-version}, the `ServiceAccountTokenNodeBinding` feature is now enabled by default, aligning with upstream Kubernetes behavior. This feature allows service account tokens to be bound directly to node objects in addition to the existing binding options. Benefits of this change include enhanced security through automatic token invalidation when bound nodes are deleted and better protection against token replay attacks across different nodes.
-
 [id="ocp-release-notes-documentation_{context}"]
 === Documentation
 
-[id="ocp-release-notes-documentation-etcd_{context}"]
-==== Consolidated etcd documentation
-
-This release includes an _etcd_ section, which consolidates all of the existing documentation about etcd for {product-title}. For more information, see xref:../etcd/etcd-overview.adoc#etc-overview[Overview of etcd].
-
-[id="ocp-release-notes-documentation-tutorials_{context}"]
-==== Tutorials guide
-
-{product-title} 4.20 now includes a _Tutorials_ guide, which takes the place of the _Getting started_ guide in previous releases. The existing tutorials were refreshed and the guide now focuses solely on hands-on tutorial content. It also provides a jumping off point to other recommended hands-on learning resources for {product-title} across Red{nbsp}Hat.
-
-For more information, see xref:../tutorials/index.adoc#tutorials-overview[Tutorials].
-
 [id="ocp-release-notes-edge-computing_{context}"]
 === Edge computing
-
-[id="ocp-release-edge-computing_pg-ztp-rhacm_{context}"]
-==== Using {rh-rhacm} PolicyGenerator resources to manage {ztp} cluster policies (General Availability)
-
-You can now use `PolicyGenerator` resources and {rh-rhacm-first} to deploy polices for managed clusters with {ztp}.
-The `PolicyGenerator` API is part of the link:https://open-cluster-management.io/[Open Cluster Management] standard and provides a generic way of patching resources, which is not possible with the `PolicyGenTemplate` API.
-Using `PolicyGenTemplate` resources to manage and deploy polices will be deprecated in an upcoming {product-title} release.
-
-For more information, see xref:../edge_computing/policygenerator_for_ztp/ztp-configuring-managed-clusters-policygenerator.adoc#ztp-configuring-managed-clusters-policygenerator[Configuring managed cluster policies by using PolicyGenerator resources].
-
-[id="ocp-release-edge-computing-arbiter-node_{context}"]
-==== Configuring a local arbiter node
-
-You can configure an {product-title} cluster with two control plane nodes and one local arbiter node so to retain high availability (HA) while reducing infrastructure costs for your cluster. This configuration is only supported for bare-metal installations.
-
-A local arbiter node is a lower-cost, co-located machine that participates in control plane quorum decisions. Unlike a standard control plane node, the arbiter node does not run the full set of control plane services. You can use this configuration to maintain HA in your cluster with only two fully provisioned control plane nodes instead of three.
-
-To enable this feature, you must define the arbiter machine pool in the `install-config.yaml` file and enable the `TechPreviewNoUpgrade` feature set. For more information, see xref:../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#ipi-install-config-local-arbiter-node_ipi-install-installation-workflow[Configuring a local arbiter node].
-
-[id="ocp-release-edge-computing-coordinating-reboots_{context}"]
-==== Coordinating reboots for configuration changes
-
-This release adds reboot policies to ZTP reference that can be applied by {cgu-operator-full} (TALM) to coordinate reboots across a fleet of spoke clusters when configuration changes require a reboot, such as deferred tuning changes. {cgu-operator} reboots all nodes in the targeted `MachineConfigPool` object on the selected clusters when the reboot policy is applied.
-
-Instead of rebooting nodes after each individual change, you can apply all configuration updates through policies and then trigger a single, coordinated reboot.
-
-For more information, see xref:../edge_computing/policygenerator_for_ztp/ztp-configuring-managed-clusters-policygenerator.adoc#ztp-coordinating-reboots-for-config-changes_ztp-configuring-managed-clusters-policygenerator[Coordinating reboots for configuration changes].
 
 [id="ocp-release-edge-computing-networkpolicy-support-for-lvms_{context}"]
 ==== NetworkPolicy support for the {lvms} Operator
@@ -129,33 +74,10 @@ The default namespace for the {lvms} Operator is now `openshift-lvm-storage`. Yo
 [id="ocp-release-notes-extensions_{context}"]
 === Extensions ({olmv1})
 
-[id="ocp-release-notes-olmv1-preflight-permissions-check_{context}"]
-==== Preflight permissions check for cluster extensions (Technology Preview)
-
-With this release, the Operator Controller performs a dry run of the installation process when you try to install an extension. This dry run verifies that the specified service account has the required role-based access control (RBAC) rules for the roles and bindings defined by the bundle.
-
-If the service account is missing any required RBAC rules, the preflight check fails before the actual installation proceeds and generates a report.
-
-For more information, see xref:../extensions/ce/managing-ce.adoc#olmv1-troubleshooting-rbac-errors-with-preflight-check_managing-ce[Preflight permissions check for cluster extensions (Technology Preview)]
-
-[id="ocp-release-notes-olmv1-deploying-a-cluster-extension-to-a-specific-namespace_{context}"]
-==== Deploying a cluster extension in a specific namespace (Technology Preview)
-
-With this release, you can deploy an extension in a specific namespace by using the `OwnNamespace` or `SingleNamespace` install modes as a Technology Preview feature for `registry+v1` Operator bundles.
-
-For more information, see xref:../extensions/ce/managing-ce.adoc#olmv1-deploying-a-ce-in-a-specific-namespace_managing-ce[Deploying a cluster extension in a specific namespace (Technology Preview)]
-
 [id="ocp-release-notes-hcp_{context}"]
 === Hosted control planes
 
 Because {hcp} releases asynchronously from {product-title}, it has its own release notes. For more information, see xref:../hosted_control_planes/hosted-control-planes-release-notes.adoc#hosted-control-planes-release-notes[{hcp-capital} release notes].
-
-[id="ocp-release-notes-hcp-openstack-tp_{context}"]
-==== Hosted control planes on {rh-openstack-first} 17.1 (Technology Preview)
-
-{hcp-capital} on {rh-openstack} 17.1 are now supported as a Technology Preview.
-
-For more information, see xref:../hosted_control_planes/hcp-deploy/hcp-deploy-openstack.adoc#hosted-clusters-openstack-prerequisites_hcp-deploy-openstack[Deploying hosted control planes on OpenStack].
 
 [id="ocp-release-notes-ibm-power_{context}"]
 === {ibm-power-title}
@@ -164,17 +86,12 @@ The {ibm-power-name} release on {product-title} {product-version} adds improveme
 
 This release introduces support for the following features on {ibm-power-title}:
 
-* Expand Compliance Operator support with profiles for Defense Information Systems Agency Security Technical Implementation Guide (DISA STIG)
-
 [id="ocp-release-notes-ibm-z_{context}"]
 === {ibm-z-title} and {ibm-linuxone-title}
 
 The {ibm-z-name} and {ibm-linuxone-name} release on {product-title} {product-version} adds improvements and new capabilities to {product-title} components.
 
 This release introduces support for the following features on {ibm-z-name} and {ibm-linuxone-name}:
-
-* Support for {ibm-name} z17 and {ibm-linuxone-name} 5
-* Boot volume Linux Unified Key Setup (LUKS) encryption via {ibm-name} Crypto Express (CEX)
 
 [discrete]
 [id="ocp-release-notes-ibm-z-power-support-matrix_{context}"]
@@ -515,396 +432,51 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-release-notes-insights-operator-enhancements_{context}"]
 === Insights Operator
 
-
-[id="ocp-release-notes-insights-operator-runtime-extractor_{context}"]
-==== Insights Runtime Extractor is generally available
-
-
-
 [id="ocp-release-notes-installation-and-update_{context}"]
 === Installation and update
-
-[id="ocp-release-installation-and-update-remove-terraform-ibm-cloud_{context}"]
-==== Cluster API replaces Terraform on {ibm-cloud-title} installations
-
-
-
-[id="ocp-release-installation-and-update-aws-malaysia-thailand_{context}"]
-==== Installing a cluster on {aws-short} in the Malaysia and Thailand regions
-
-
-
-
-
-[id="ocp-release-installation-and-update-remove-terraform-azure-stack-hub_{context}"]
-==== Cluster API replaces Terraform on {azure-first} Stack Hub installations
-
-
-
-[id="ocp-release-installation-and-update-support-azure-instance-types_{context}"]
-==== Support added for additional {azure-first} instance types
-
-
-
-[id="ocp-release-installation-and-update-azure-outbound-access-vms_{context}"]
-==== Outbound access for VMs in {azure-first} will be retired
-
-
-
-[id="ocp-release-installation-and-update-gcp-confidential-computing-expansion_{context}"]
-==== Additional Confidential Computing platforms for {gcp-short}
-
-
-
-
-[id="ocp-release-GCP-custom-dns_{context}"]
-==== Installing a cluster on {gcp-first} with a user-provisioned DNS (Technology Preview)
-
-
-
-[id="ocp-release-installation-and-update-vsphere-multidisk_{context}"]
-==== Installing a cluster on {vmw-first} with multiple disks (Technology Preview)
-
-
-
-
-[id="ocp-release-installation-and-update-azure-boot-diagnostics_{context}"]
-==== Enabling boot diagnostics collection during installation on {azure-first}
-
-
-
-
-
-[id="ocp-release-admin-ack-updating_{context}"]
-==== Required administrator acknowledgment when updating from {product-title} 4.19 to 4.20
-
-
-
-[id="ocp-release-vsphere-host-groups_{context}"]
-==== OpenShift zones support for vSphere host groups (Technology Preview)
-
-
-
-
-
-[id="ocp-release-notes-agent-nutanix_{context}"]
-==== Nutanix support for the Agent-based Installer
-
-
-
 
 [id="ocp-release-notes-machine-config-operator_{context}"]
 === Machine Config Operator
 
-[id="ocp-release-notes-machine-config-operator-naming_{context}"]
-==== New naming for features
-
-
-
-[id="ocp-release-notes-machine-config-operator-ocl-ga_{context}"]
-==== Image mode for OpenShift is now generally available
-
-
-
-[id="ocp-release-notes-machine-config-operator-boot-image_{context}"]
-==== Boot image management is now default for {gcp-first} and {aws-first}
-
-
-
-[id="ocp-release-notes-machine-config-operator-cert-changes_{context}"]
-==== Changes to the Machine Config Operator certificates
-
-
 [id="ocp-release-notes-machine-management_{context}"]
 === Machine management
-
-
-[id="ocp-release-capi-mapi-migration_{context}"]
-==== Migrating resources between the Cluster API and the Machine API (Technology Preview)
-
-
-
-
-
-[id="ocp-release-cpms-prefix_{context}"]
-==== Custom prefixes for control plane machine names
-
-
-
-[id="ocp-release-aws-capacity-reservations_{context}"]
-==== Configuring Capacity Reservations on {aws-full} clusters
-
-
-
-[id="ocp-release-vmw-multi-disk_{context}"]
-==== Support for multiple {vmw-full} data disks (Technology Preview)
-
-
 
 [id="ocp-release-notes-monitoring_{context}"]
 === Monitoring
 
-
-
-[id="ocp-release-monitoring-updates-to-monitoring-stack-components-and-dependencies"]
-==== Updates to monitoring stack components and dependencies
-
-
-
-[id="ocp-release-monitoring-changes-to-alerting-rules"]
-==== Changes to alerting rules
-
-
-
-[id="ocp-release-monitoring-prometheus-v3-upgrade"]
-==== Prometheus v3 upgrade
-
-
-
-
-
-[id="ocp-release-monitoring-metrics-collection-profiles-ga"]
-==== Metrics collection profiles is generally available
-
-
-
-[id="ocp-release-monitoring-added-cluster-proxy-support-for-external-alertmanager-instances"]
-==== Added cluster proxy support for external Alertmanager instances
-
-
-
-[id="ocp-release-monitoring-strict-validation-for-cmo-is-improved"]
-==== Strict validation for the {cmo-full} is improved
-
-
-
 [id="ocp-release-notes-networking_{context}"]
 === Networking
-
-[id="ocp-release-networking-support-load-secrets_{context}"]
-==== Creating a route with externally managed certificate (General Availability)
-
-
-
-[id="ocp-release-networking-gateway-api-controller_{context}"]
-==== Support for using Gateway API to configure cluster ingress traffic (General Availability)
-
-
-
-[id="ocp-release-networking-gateway-api-crd-lifecycle_{context}"]
-==== Support for managing Gateway API custom resource definition (CRD) lifecycle
-
-
-[id="ocp-release-networking-gateway-api-ossm-version-bump_{context}"]
-==== Updates to Gateway API custom resource definitions (CRDs)
-
-
-
-[id="ocp-release-networking-balance-slb-mode_{context}"]
-==== Enable OVS balance-slb mode for your cluster (General Availability)
-
-
-
-[id="ocp-release-networking-allocate-load-balancers-to-specific-subnets_{context}"]
-==== Allocate API and ingress load balancers to specific subnets
-
-
-
-
-[id="ocp-release-networking-ptp-dual-oc_{context}"]
-==== Dual-port NICs for improved redundancy in PTP ordinary clocks (Technology Preview)
-
-
-
-[id="ocp-release-networking-conditional-webhook_{context}"]
-==== Support for conditional webhook matching in the SR-IOV Network Operator
-
-
-
-[id="ocp-release-dpu-device-management-with-dpu-operator_{context}"]
-==== Enabling DPU device management with the DPU Operator
-W
-
-[id="ocp-release-cluster-user-defined-networks-localnet_{context}"]
-==== Localnet topology for user-defined networks (Generally Available)
-
-
-
-
-[id="ocp-release-port-isolation-linux-bridge_{context}"]
-==== Enable port isolation for a Linux bridge NAD (Generally Available)
-
-
-
-[id="ocp-release-whereabouts-ipam_{context}"]
-==== Fast IPAM configuration for the Whereabouts IPAM CNI plugin (Technology Preview)
-
-
-
-[id="ocp-release-metallb-unnumbered-bgp-peering_{context}"]
-
-
-
-[id="ocp-release-unnumbered-bgp-peering_{context}"]
-==== Unnumbered BGP peering (Technology Preview)
-
-
-
-[id="ocp-release-custom-dns-host-name-disconnected_{context}"]
-==== Create a custom DNS host name to resolve DNS connectivity issues
-
-
-
-[id="ocp-release-ptp-fast-events-rest-api-v2_{context}"]
-==== Removal of PTP events REST API v1 and events consumer application sidecar
-
-
-[id="ocp-release-sr-iov-arm_{context}"]
-==== Deploying the SR-IOV Network Operator on a cluster that runs on ARM architecture
-
-
-
-[id="ocp-release-route-external-cert-feature-gate_{context}"]
-==== Re-add a previously deleted secret with `RouteExternalCertificate` feature gate enabled
-
-
 
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 
-[id="ocp-release-notes-machine-config-operator-cgroup-v1_{context}"]
-==== cgroup v1 has been removed
-
-c
-
 [id="ocp-release-notes-openshift-cli_{context}"]
 === OpenShift CLI (oc)
-
-
-
-[id="ocp-release-notes-openshift-cli-sign-mirroring_{context}"]
-==== Mirroring and verifying image signatures in oc-mirror plugin v2
-
-
 
 [id="ocp-release-notes-osdk_{context}"]
 === Operator development
 
-[id="ocp-release-notes-osdk-base-images_{context}"]
-==== Supported Operator base images
-
-
-// NOTE: The KCS article link will be published on the GA date. It is a draft right now.
-
 [id="ocp-release-notes-postinstallation-configuration_{context}"]
 === Postinstallation configuration
-
-
-[id=ocp-release-notes-postinstallation-configuration-using-bmaas_{context}]
-==== Using bare metal as a service (Technology Preview)
-
-
 
 [id="ocp-release-notes-rhcos_{context}"]
 === {op-system-first}
 
-[id="ocp-release-rhcos-rhel-9-6_{context}"]
-==== {op-system} uses {op-system-base} 9.6
-
-
 [id="ocp-release-notes-scalability-and-performance_{context}"]
 === Scalability and performance
-
-[id="ocp-release-notes-scalability-and-performance_kernelpagesize_{context}"]
-==== Performance profile kernel page size configuration
-
-
-
-[id="ocp-release-notes-scalability-and-performance-cluster-compare-enhancements_{context}"]
-==== Updates to the cluster-compare plugin
-
-
-[id="ocp-release-notes-tuning-hcp-performance-profile_{context}"]
-==== Tuning {hcp} using a performance profile
-
-
 
 [id="ocp-release-notes-security_{context}"]
 === Security
 
-[id="ocp-release-notes-tls-modern-profile-control-plane_{context}"]
-==== Control plane now supports TLS 1.3 and the Modern TLS security profile
-
-
 [id="ocp-release-notes-storage_{context}"]
 === Storage
-
-[id="ocp-release-notes-sscsi-disconnected-environment-support_{context}"]
-==== Support for the Secrets Store CSI driver in disconnected environments
-
-
-[id="ocp-release-notes-storage-azure-file-cross-sub-support_{context}"]
-==== Azure File cross-subscription support is generally available
-
-
-[id="ocp-release-notes-storage-vol-attributes_{context}"]
-==== Volume Attributes Classes (Technology Preview)
-
-
-[id="ocp-release-notes-storage-cli-cmd-pvc-usage_{context}"]
-==== New CLI command to show PVC usage (Technology Preview)
-
-[id="ocp-release-notes-storage-cli-cmd-resize-recovery_{context}"]
-==== CSI volume resizing recovery is generally available
-
-
-
-[id="ocp-release-notes-storage-resize-migrated-vsphere-in-tree-vols_{context}"]
-==== Support for resizing vSphere in-tree migrated volumes is generally available
-
-
-[id="ocp-release-notes-storage-disable-vsphere_{context}"]
-==== Disabling and enabling storage on vSphere is generally available
-
-
-[id="ocp-release-notes-storage-increase-max-vols-per-node-vsphere"]
-==== Increasing the maximum number of volumes per node for vSphere (Technology Preview)
-
-
-[id="ocp-release-notes-storage-vsphere-migrating-cns-vols-between-datastores_{context}"]
-==== Migrating CNS volumes between datastores for vSphere is fully supported
-
-
-[id="ocp-release-notes-storage-nfs-export-options-filestore"]
-==== NFS export options for Filestore storage class is generally available.
-
 
 [id="ocp-release-notes-web-console_{context}"]
 === Web console
 
 
-[id="ocp-release-notes-patternfly-6-upgrade_{context}"]
-==== Patternfly 6 upgrade
-
-
-
 [id="ocp-release-notable-technical-changes_{context}"]
 == Notable technical changes
-
-[discrete]
-[id="ocp-release-notable-technical-changes-readonlyrootfilesystem_{context}"]
-=== Pods deploy with readOnlyRootFilesystem set to true
-
-
-
-[discrete]
-[id="ocp-release-notable-technical-changes-loopback-cert_{context}"]
-=== Extended loopback certificate validity to three years for kube-apiserver
-
-
-
-[id="ocp-release-notes-readiness-probes-etcd_{context}"]
-=== Readiness probes exclude etcd checks
 
 
 [id="ocp-release-deprecated-removed-features_{context}"]
@@ -1193,44 +765,20 @@ c
 [id="ocp-release-deprecated-features_{context}"]
 === Deprecated features
 
-[id="ocp-release-oc-adm-pod-network-removed_{context}"]
-==== `oc adm pod-network` command deprecated
-
-
-[id="ocp-release-useModal-dynamic-plugin-removed_{context}"]
-==== useModal hook for dynamic plugin SDK
-
-
 [id="ocp-release-removed-features_{context}"]
 === Removed features
-
-[id="ocp-release-rhel-worker-nodes-removed_{context}"]
-==== Package-based {op-system-base} compute machines
-
-
-[id="ocp-release-removed-kube-1-32-apis_{context}"]
-==== APIs removed from Kubernetes 1.32
-
 
 .APIs removed from Kubernetes 1.32
 [cols="2,2,2,1",options="header",]
 |===
 |Resource |Removed API |Migrate to |Notable changes
 
-|`FlowSchema`
-|`flowcontrol.apiserver.k8s.io/v1beta3`
-|`flowcontrol.apiserver.k8s.io/v1`
-|No
+|
+|
+|
+|
 
-|`PriorityLevelConfiguration`
-|`flowcontrol.apiserver.k8s.io/v1beta3`
-|`flowcontrol.apiserver.k8s.io/v1`
-|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#flowcontrol-resources-v132[Yes]
 |===
-
-[id="ocp-release-removed-osdk_{context}"]
-==== Operator SDK CLI and related scaffolding and testing tools
-
 
 [id="ocp-release-bug-fixes_{context}"]
 == Bug fixes
@@ -1259,14 +807,9 @@ c
 [id="ocp-release-note-api-auth-bug-fixes_{context}"]
 ==== API Server and Authentication
 
-
-
-
 [discrete]
 [id="ocp-release-note-bare-metal-hardware-bug-fixes_{context}"]
 ==== Bare Metal Hardware Provisioning
-
-
 
 
 


### PR DESCRIPTION
Remove [4.19 note references](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/index) from the 4.20 raw file. 

Version(s):
4.20

Issue:
N/A

Link to docs preview:
https://97854--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html
