### PR TITLE
OCPBUGS-60660-15: Added proxy attribute to the Insights Operator configu

### DIFF
--- a/modules/insights-operator-configuring.adoc
+++ b/modules/insights-operator-configuring.adoc
@@ -19,22 +19,100 @@ The `ConfigMap` object does not exist by default, so an {product-title} cluster 
 //====
 
 .ConfigMap object configuration structure
-This example of an *insights-config* `ConfigMap` object (`config.yaml` configuration) shows configuration options using standard YAML formatting.
+This example of an *insights-config* `ConfigMap` object (`config.yaml` configuration) shows configuration options by using standard YAML formatting.
 
 image::insights-operator-configmap-example.png[Example of Insights Operator ConfigMap object]
 
 .Configurable attributes and default values
-The table below describes the available configuration attributes:
+The following table describes the available configuration attributes:
 
 [NOTE]
 ====
 The *insights-config* `ConfigMap` object follows standard YAML formatting, wherein child values are below the parent attribute and indented two spaces. For the *Obfuscation* attribute, enter values as bulleted children of the parent attribute.
 ====
 
+
 .Insights Operator configurable attributes
 [options="header"]
+[cols=".^2l,.^3a,.^1a,.^1a",options="header"]
 |====
 |Attribute name|Description|Value type|Default value
+
+|enableGlobalObfuscation
+|Enables the global obfuscation of IP addresses and the cluster domain name.
+|Boolean
+|`false`
+
+|endpoint
+|Sets the upload endpoint.
+|URL
+|https://console.redhat.com/api/ingress/v1/upload
+
+|clusterTransferEndpoint
+|The endpoint for checking and downloading cluster transfer data.
+|URL
+|https://api.openshift.com/api/accounts_mgmt/v1/cluster_transfers/
+
+|clusterTransferInterval
+|Sets the frequency for checking available cluster transfers.
+|Time interval
+|`24h`
+
+|conditionalGathererEndpoint
+|Sets the endpoint for providing conditional gathering rule definitions.
+|URL
+|https://console.redhat.com/api/gathering/gathering_rules
+
+|httpProxy, httpsProxy, noProxy
+|Set custom proxy for Insights Operator.
+|URL
+|No default
+
+|interval 
+|Sets the data gathering and upload frequency.
+|Time interval
+|`2h`
+
+|reportEndpoint 
+|Specifies the endpoint for downloading the latest Insights analysis. For the specified default value, ensure that you replace `<cluster_id>` with the unique identified, cluster ID, of your cluster.
+|URL
+|https://console.redhat.com/api/insights-results-aggregator/v2/cluster/<cluster_id>/reports
+
+|reportPullingDelay
+|Sets the delay between data upload and data download.
+|Time interval
+|`60s`
+
+|reportPullingTimeout 
+|Sets the timeout value for the Insights download request.
+|Time interval
+|?
+
+|reportMinRetryTime 
+|Sets the time for when to retry a request.
+|Time interval
+|`30s`
+
+|scaEndpoint 
+|Specifies the endpoint for downloading the simple content access (SCA) entitlements.
+|URL
+|https://api.openshift.com/api/accounts_mgmt/v1/entitlement_certificates
+
+|scaInterval
+|Specifies the frequency of the simple content access entitlements download.
+|Time interval
+|`8h`
+
+|scaPullDisabled
+|Disables the simple content access entitlements download.
+|Boolean
+|`false`
+|====
+
+
+
+
+
 |`Obfuscation: - networking`|Enables the global obfuscation of IP addresses and the cluster domain name.|Boolean|`false`
 |`Obfuscation: - workload_names`|Obfuscate data coming from the Deployment Validation Operator if it is installed.|Boolean|`false`
 |`sca: interval`|Specifies the frequency of the simple content access entitlements download.|Time interval|`8h`


### PR DESCRIPTION
Version(s):
4.15 and 4.14.

Issue:
[OCPBUGS-59206](https://issues.redhat.com/browse/OCPBUGS-59206)

Link to docs preview:
* [Configuring Insights Operator](https://97878--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator.html#insights-operator-configuring_using-insights-operator)

- [] SME has approved this change (Harshada Patil/Ondrej Pokorny ).
- [] QE has approved this change (baiyang zhou) > Waiting on version support info.


