### PR TITLE
ROX-29160: Document new default policy that verifies Red Hat images are signed

### DIFF
--- a/modules/high-sev-security-policies.adoc
+++ b/modules/high-sev-security-policies.adoc
@@ -22,6 +22,16 @@ The following table lists the default security policies in {product-title} that 
 |Build or Deploy |Fixable Severity at least Important |Alerts when deployments with fixable vulnerabilities have a severity rating of at least Important. |Enabled
 |Build or Deploy |Rapid Reset: Denial of Service Vulnerability in HTTP/2 Protocol |Alerts on deployments with images containing components that are susceptible to a Denial of Service (DoS) vulnerability for HTTP/2 servers. This addresses a flaw in the handling of multiplexed streams in HTTP/2. A client can rapidly create a request and immediately reset them, which creates extra work for the server while avoiding hitting any server-side limits, resulting in a denial of service attack. To use this policy, consider cloning the policy and adding the `Fixable` policy criteria before enabling it. |Disabled
 |Build or Deploy |Secure Shell (ssh) Port Exposed in Image |Alerts when deployments expose port 22, which is commonly reserved for SSH access. |Enabled
+|Build or Deploy 
+|Red{nbsp}Hat Images must be signed by the Red{nbsp}Hat Release Key 
+a|Alerts when a Red{nbsp}Hat image is not signed by the official link:https://access.redhat.com/security/team/key[Red{nbsp}Hat product signing key, "Release Key 3"]. These alerts apply to images from the following registries and remotes:
+
+* `registry.redhat.io`
+* `registry.access.redhat.com`
+* `quay.io/openshift-release-dev/ocp-release`
+* `quay.io/openshift-release-dev/ocp-v4.0-art-dev` 
+
+|Disabled
 |Deploy |Emergency Deployment Annotation |Alerts when deployments use the emergency annotation, such as "admission.stackrox.io/break-glass":"ticket-1234" to circumvent StackRox Admission controller checks. |Enabled
 |Deploy |Environment Variable Contains Secret |Alerts when deployments have environment variables that contain 'SECRET'. |Enabled
 |Deploy |Fixable CVSS >= 6 and Privileged |Alerts when deployments run in privileged mode with fixable vulnerabilities that have a CVSS of at least 6. However, Red{nbsp}Hat recommends that you create policies using CVE severity instead of CVSS score. |Disabled by default in version 3.72.0 and later


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.9+

Issue:
[ROX-29160](https://issues.redhat.com/browse/ROX-29160)

Link to docs preview: https://97894--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/default-security-policies.html

QE review: ACS has no QE
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

