### PR TITLE
OCPBUGS-59924: Added disk wipe note to Removing a cluster that uses i…

### DIFF
--- a/installing/installing_openstack/uninstalling-cluster-openstack.adoc
+++ b/installing/installing_openstack/uninstalling-cluster-openstack.adoc
@@ -8,4 +8,5 @@ toc::[]
 
 You can remove a cluster that you deployed to {rh-openstack-first}.
 
+// Removing a cluster that uses installer-provisioned infrastructure
 include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]

--- a/modules/installation-uninstall-clouds.adoc
+++ b/modules/installation-uninstall-clouds.adoc
@@ -23,12 +23,15 @@ endif::[]
 ifeval::["{context}" == "uninstalling-cluster-ibm-power-vs"]
 :ibm-power-vs:
 endif::[]
+ifeval::["{context}" == "uninstalling-cluster-openstack"]
+:osp:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-uninstall-clouds_{context}"]
 = Removing a cluster that uses installer-provisioned infrastructure
 
-You can remove a cluster that uses installer-provisioned infrastructure from your cloud.
+You can remove a cluster that uses installer-provisioned infrastructure that you provisioned from your cloud platform.
 
 ifdef::aws[]
 [NOTE]
@@ -39,7 +42,7 @@ endif::aws[]
 
 [NOTE]
 ====
-After uninstallation, check your cloud provider for any resources not removed properly, especially with User Provisioned Infrastructure (UPI) clusters. There might be resources that the installer did not create or that the installer is unable to access.
+After uninstallation, check your cloud provider for any resources that were not removed properly, especially with user-provisioned infrastructure clusters. Some resources might exist because either the installation program did not create the resource or could not access the resource.
 ifdef::gcp[]
 For example, some Google Cloud resources require link:https://cloud.google.com/iam/docs/overview#concepts_related_to_access_management[IAM permissions] in shared VPC host projects, or there might be unused link:https://cloud.google.com/sdk/gcloud/reference/compute/health-checks/delete[health checks that must be deleted].
 endif::gcp[]
@@ -50,6 +53,9 @@ endif::gcp[]
 * You have a copy of the installation program that you used to deploy the cluster.
 * You have the files that the installation program generated when you created your
 cluster.
+ifdef::osp[]
+* You installed the `core-installer` tool by entering the `sudo dnf install coreos-installer` command in your CLI.
+endif::osp[]
 ifdef::ibm-cloud,ibm-power-vs[]
 * You have configured the `ccoctl` binary.
 * You have installed the {ibm-cloud-name} CLI and installed or updated the VPC infrastructure service plugin. For more information see "Prerequisites" in the link:https://cloud.ibm.com/docs/vpc?topic=vpc-infrastructure-cli-plugin-vpc-reference&interface=ui#cli-ref-prereqs[{ibm-cloud-name} CLI documentation].
@@ -60,11 +66,11 @@ ifdef::ibm-cloud,ibm-power-vs[]
 . If the following conditions are met, this step is required:
 ** The installer created a resource group as part of the installation process.
 ** You or one of your applications created persistent volume claims (PVCs) after the cluster was deployed.
-
 +
 In which case, the PVCs are not removed when uninstalling the cluster, which might prevent the resource group from being successfully removed. To prevent a failure:
-
++
 .. Log in to the {ibm-cloud-name} using the CLI.
++
 .. To list the PVCs, run the following command:
 +
 [source,terminal]
@@ -73,7 +79,7 @@ $ ibmcloud is volumes --resource-group-name <infrastructure_id>
 ----
 +
 For more information about listing volumes, see the link:https://cloud.ibm.com/docs/vpc?topic=vpc-infrastructure-cli-plugin-vpc-reference&interface=ui#volume-cli[{ibm-cloud-name} CLI documentation].
-
++
 .. To delete the PVCs, run the following command:
 +
 [source,terminal]
@@ -107,7 +113,8 @@ ifdef::ibm-cloud,ibm-power-vs[]
 You must set the variable name exactly as specified. The installation program expects the variable name to be present to remove the service IDs that were created when the cluster was installed.
 ====
 endif::ibm-cloud,ibm-power-vs[]
-. From the directory that contains the installation program on the computer that you used to install the cluster, run the following command:
+
+. From the directory that has the installation program on the computer that you used to install the cluster, run the following command:
 +
 [source,terminal]
 ----
@@ -121,18 +128,14 @@ ifndef::ibm-power-vs[]
 +
 [NOTE]
 ====
-You must specify the directory that contains the cluster definition files for
-your cluster. The installation program requires the `metadata.json` file in this
-directory to delete the cluster.
+You must specify the directory that includes the cluster definition files for your cluster. The installation program requires the `metadata.json` file in this directory to delete the cluster.
 ====
 endif::ibm-power-vs[]
 ifdef::ibm-power-vs[]
 +
 [NOTE]
 ====
-* You must specify the directory that contains the cluster definition files for
-your cluster. The installation program requires the `metadata.json` file in this
-directory to delete the cluster.
+* You must specify the directory that has the cluster definition files for your cluster. The installation program requires the `metadata.json` file in this directory to delete the cluster.
 
 * You might have to run the `openshift-install destroy` command up to three times to ensure a proper cleanup.
 ====
@@ -156,9 +159,11 @@ If your cluster uses Technology Preview features that are enabled by the `TechPr
 --
 endif::ibm-cloud,ibm-power-vs[]
 
-. Optional: Delete the `<installation_directory>` directory and the
-{product-title} installation program.
+ifdef::osp[]
+. Optional: Use the `coreos-installer` tool to add the `coreos.inst.wipe=yes` flag to the Preboot Execution Environment (PXE) boot configuration. This operation wipes the disk on your system so that if you create a new cluster, you have a clean installation environment. For more detailed instructions, see link:https://access.redhat.com/solutions/7128657[How to wipe OpenStack disks in {product-title} 4 reinstallation] (Knowledgebase article).
+endif::osp[]
 
+. Optional: Delete the `<installation_directory>` directory and the {product-title} installation program.
 
 ifeval::["{context}" == "uninstalling-cluster-aws"]
 :!aws:
@@ -171,6 +176,9 @@ ifeval::["{context}" == "uninstalling-cluster-ibm-cloud"]
 endif::[]
 ifeval::["{context}" == "uninstalling-cluster-ibm-power-vs"]
 :!ibm-power-vs:
+endif::[]
+ifeval::["{context}" == "uninstalling-cluster-openstack"]
+:!osp:
 endif::[]
 
 // The above CCO credential removal for {ibm-cloud-title} is only necessary for manual mode. Future releases that support other credential methods will not require this step.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OCPBUGS-59924](https://issues.redhat.com/browse/OCPBUGS-59924)

Link to docs preview:
* [OpenStack](https://97897--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/uninstalling-cluster-openstack.html)
* [IBM Power Virtual Server ](https://97897--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/uninstalling-cluster-ibm-power-vs.html)


- [x] SME has approved this change ( David Hernandez Fernandez- Approval on the Jira) .
- [x] QE has approved this change (Itzik Brown).

