### PR TITLE
remove old content from search results for OKD, same as was already done for OpenShift

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -12,6 +12,8 @@
   <%= (distro_key == "openshift-webscale") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
   <%= (distro_key == "openshift-dpu") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
   <%= ((["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7"].include?(version)) && distro_key == "openshift-enterprise") ? '<meta name="googlebot" content="noindex">' : '' %>
+  <%= ((["3.6", "3.7", "3.9", "3.10", "3.11", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"].include?(version)) && distro_key == "openshift-origin") ? '<meta name="googlebot" content="noindex">' : '' %>
+
   <title><%= [topic_title, subgroup_title].compact.join(' - ') %> | <%= group_title %> | <%= distro %> <%= version %></title>
   <link href="https://assets.openshift.net/content/subdomain.css" rel="stylesheet" type="text/css"/>
   <link href="https://docs.okd.io/latest/_stylesheets/search.css" rel="stylesheet" media="screen"/>


### PR DESCRIPTION
Version(s):
main only

Issue:
n/a OKD build

Link to docs preview:
n/a
QE review:
n/a

Additional information:
This should have been implemented to OKD at the time it was done for docs.openshift 