### PR TITLE
OSDOCS-15794: adds hardware recs to MicroShift sys reqs

### DIFF
--- a/modules/microshift-install-system-requirements.adoc
+++ b/modules/microshift-install-system-requirements.adoc
@@ -6,7 +6,7 @@
 [id="microshift-install-system-requirements_{context}"]
 = System requirements for installing {microshift-short}
 
-These requirements are the minimum system requirements for {microshift-short} and {op-system-base}. Add the system requirements for the workload you plan to run.
+These requirements are the minimum system requirements for {microshift-short} and {op-system-base-full}. Add the system requirements for the workload you plan to run.
 
 For example, if an IoT gateway solution requires 4 GB of RAM, your system needs to have at least 2 GB for {op-system-base} and {microshift-short}, plus 4 GB for the workloads. Thus, this example deployment requires 6 GB of RAM in total.
 
@@ -14,9 +14,17 @@ Allow for extra capacity for future needs if you are deploying physical devices 
 
 The following conditions must be met before installing {microshift-short}:
 
-* A compatible version of {op-system-base-full}. For more information, see the following link:
+* A compatible version of {op-system-base}. For more information, see the following link:
 
 ** link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/getting_ready_to_install_microshift/microshift-install-get-ready#get-ready-install-rhde-compatibility-table_microshift-install-get-ready[Compatibility table]
+
+* Hardware or hypervisors that are certified for your {op-system-base} version are strongly recommended. For more information, see the following links:
+
+** link:https://catalog.redhat.com/en/hardware[Red Hat certified hardware]
+** link:https://access.redhat.com/articles/certified-hypervisors[Certified hypervisors]
+** For information about the support policy for non-certified hardware or hypervisors, see the following link:
+
+*** link:https://access.redhat.com/articles/third-party-software-support[How does Red Hat support me when I use non-Red Hat components?]
 
 * AArch64 or x86_64 system architecture.
 * 2 CPU cores.


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-15794](https://issues.redhat.com/browse/OSDOCS-15794)

Link to docs preview:
[microshift-install-system-requirements_microshift-install-get-ready](https://97922--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready.html#microshift-install-system-requirements_microshift-install-get-ready)

QE review:
- N/A reference information added that is not verified by QE; requires PM verification only (see Jira)

Additional information:
Backporting is nice to have but not required. Any backport CPs that fail do not need manual CPs.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
