### PR TITLE
OSDOCS-15375 Cluster autoscaling parameters updates

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -610,9 +610,6 @@ Topics:
     File: dedicated-aws-dc
 - Name: Cluster autoscaling
   File: rosa-cluster-autoscaling
-- Name: Cluster autoscaling for ROSA HCP
-  File: rosa-cluster-autoscaling-hcp
-  # Remove cluster autoscaling for ROSA HCP once the HCP docs are published
 - Name: Managing compute nodes using machine pools
   Dir: rosa_nodes
   Distros: openshift-rosa

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -466,7 +466,7 @@ Topics:
   - Name: Configuring AWS Direct Connect
     File: dedicated-aws-dc
 - Name: Cluster autoscaling
-  File: rosa-cluster-autoscaling
+  File: rosa-cluster-autoscaling-hcp
 - Name: Managing compute nodes using machine pools
   Dir: rosa_nodes
   Topics:

--- a/rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
+++ b/rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
@@ -75,46 +75,9 @@ Pods with priority lower than the cutoff value do not cause the cluster to scale
 ////
 Default priority cutoff is 0. It can be changed using `--expendable-pods-priority-cutoff` flag, but we discourage it. cluster autoscaler also doesn't trigger scale-up if an unschedulable Pod is already waiting for a lower priority Pod preemption.
 ////
+include::modules/rosa-cluster-autoscaler-cli-interactive-during.adoc[leveloffset=+1]
 
-//::modules/rosa-cluster-autoscaler-cli-edit.adoc[leveloffset=+1]
-[id="rosa-edit-cluster-autoscale-cli_{context}"]
-== Edit autoscaling after cluster creation with the ROSA CLI
-
-You can edit any specific parameters of the cluster autoscaler after creating the autoscaler.
-
-.Procedure
-
-. To edit the cluster autoscaler, run the following command:
-+
-.Example
-[source,terminal]
-----
-$ rosa edit autoscaler --cluster=<mycluster>
-----
-+
-.. To edit a specific parameter, run the following command:
-+
-.Example
-[source,terminal]
-----
-$ rosa edit autoscaler --cluster=<mycluster> <parameter>
-----
-
-//::modules/rosa-cluster-autoscaler-cli-describe.adoc[leveloffset=+1]
-[id="rosa-cluster-autoscaler-cli-describe_{context}"]
-== View autoscaler configurations with the ROSA CLI
-
-You can view your cluster autoscaler configurations using the `rosa describe autoscaler` command.
-
-.Procedure
-
-* To view cluster autoscaler configurations, run the following command:
-+
-.Example
-[source,terminal]
-----
-$ rosa describe autoscaler -h --cluster=<mycluster>
-----
+include::modules/rosa-cluster-autoscaler-cli-during.adoc[leveloffset=+1]
 
 //include::modules/rosa-cluster-autoscaler-cli-settings.adoc[leveloffset=+1]
 [id="rosa-cluster-cli-autoscale-parameters_{context}"]
@@ -156,4 +119,44 @@ You can add the following parameters to the cluster creation command to configur
 |`--autoscaler-max-nodes-total 180`
 
 |===
+
+//::modules/rosa-cluster-autoscaler-cli-edit.adoc[leveloffset=+1]
+[id="rosa-edit-cluster-autoscale-cli_{context}"]
+== Edit autoscaling after cluster creation with the ROSA CLI
+
+You can edit any specific parameters of the cluster autoscaler after creating the autoscaler.
+
+.Procedure
+
+* To edit the cluster autoscaler, run the following command:
++
+.Example
+[source,terminal]
+----
+$ rosa edit autoscaler --cluster=<mycluster>
+----
++
+** To edit a specific parameter, run the following command:
++
+.Example
+[source,terminal]
+----
+$ rosa edit autoscaler --cluster=<mycluster> <parameter>
+----
+
+//::modules/rosa-cluster-autoscaler-cli-describe.adoc[leveloffset=+1]
+[id="rosa-cluster-autoscaler-cli-describe_{context}"]
+== View autoscaler configurations with the ROSA CLI
+
+You can view your cluster autoscaler configurations using the `rosa describe autoscaler` command.
+
+.Procedure
+
+* To view cluster autoscaler configurations, run the following command:
++
+.Example
+[source,terminal]
+----
+$ rosa describe autoscaler -h --cluster=<mycluster>
+----
 

--- a/rosa_cluster_admin/rosa-cluster-autoscaling.adoc
+++ b/rosa_cluster_admin/rosa-cluster-autoscaling.adoc
@@ -42,6 +42,8 @@ include::modules/rosa-cluster-autoscaler-cli-interactive-after.adoc[leveloffset=
 
 include::modules/rosa-cluster-autoscaler-cli-during.adoc[leveloffset=+1]
 
+include::modules/rosa-cluster-autoscaler-cli-settings.adoc[leveloffset=+1]
+
 include::modules/rosa-cluster-autoscaler-cli-after.adoc[leveloffset=+1]
 endif::openshift-rosa[]
 
@@ -53,4 +55,4 @@ ifdef::openshift-rosa[]
 include::modules/rosa-cluster-autoscaler-cli-delete.adoc[leveloffset=+1]
 endif::openshift-rosa[]
 
-include::modules/rosa-cluster-autoscaler-cli-settings.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-15375

Link to docs preview:

https://97923--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa-cluster-autoscaling-hcp.html
https://97923--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-cluster-autoscaling.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
