### PR TITLE
TRACING-5478: define OTLP exporter name

### DIFF
--- a/modules/distr-tracing-tempo-config-spanmetrics.adoc
+++ b/modules/distr-tracing-tempo-config-spanmetrics.adoc
@@ -46,7 +46,7 @@ spec:
         resource_to_telemetry_conversion:
           enabled: true # <5>
 
-      otlp:
+      otlp/traces:
         auth:
           authenticator: bearertokenauth
         endpoint: tempo-redmetrics-gateway.mynamespace.svc.cluster.local:8090
@@ -66,7 +66,7 @@ spec:
       pipelines:
         traces:
           receivers: [otlp]
-          exporters: [otlp, spanmetrics] # <6>
+          exporters: [otlp/traces, spanmetrics] # <6>
         metrics:
           receivers: [spanmetrics] # <7>
           exporters: [prometheus]

--- a/modules/otel-forwarding-logs-to-tempostack.adoc
+++ b/modules/otel-forwarding-logs-to-tempostack.adoc
@@ -115,7 +115,7 @@ spec:
             statements:
               - set(attributes["level"], ConvertCase(severity_text, "lower"))
     exporters:
-      otlphttp:
+      otlphttp/logs:
         endpoint: https://logging-loki-gateway-http.openshift-logging.svc.cluster.local:8080/api/logs/v1/application/otlp
         encoding: json
         tls:
@@ -130,7 +130,7 @@ spec:
         logs:
           receivers: [otlp]
           processors: [k8sattributes, transform, resource]
-          exporters: [otlphttp] # <3>
+          exporters: [otlphttp/logs] # <3>
         logs/test:
           receivers: [otlp]
           processors: []

--- a/modules/otel-forwarding-traces.adoc
+++ b/modules/otel-forwarding-traces.adoc
@@ -106,7 +106,7 @@ spec:
       resourcedetection:
         detectors: [openshift]
     exporters:
-      otlp:
+      otlp/traces:
         endpoint: "tempo-simplest-distributor:4317" # <1>
         tls:
           insecure: true
@@ -115,7 +115,7 @@ spec:
         traces:
           receivers: [jaeger, opencensus, otlp, zipkin] # <2>
           processors: [memory_limiter, k8sattributes, resourcedetection, batch]
-          exporters: [otlp]
+          exporters: [otlp/traces]
 ----
 <1> The Collector exporter is configured to export OTLP and points to the Tempo distributor endpoint, `"tempo-simplest-distributor:4317"` in this example, which is already created.
 <2> The Collector is configured with a receiver for Jaeger traces, OpenCensus traces over the OpenCensus protocol, Zipkin traces over the Zipkin protocol, and OTLP traces over the gRPC protocol.

--- a/modules/otel-migrating-from-jaeger-with-sidecars.adoc
+++ b/modules/otel-migrating-from-jaeger-with-sidecars.adoc
@@ -44,7 +44,7 @@ spec:
         detectors: [openshift]
         timeout: 2s
     exporters:
-      otlp:
+      otlp/traces:
         endpoint: "tempo-<example>-gateway:8090" # <1>
         tls:
           insecure: true
@@ -53,7 +53,7 @@ spec:
         traces:
           receivers: [jaeger]
           processors: [memory_limiter, resourcedetection, batch]
-          exporters: [otlp]
+          exporters: [otlp/traces]
 ----
 <1> This endpoint points to the Gateway of a TempoStack instance deployed by using the `<example>` {TempoOperator}.
 

--- a/modules/otel-migrating-from-jaeger-without-sidecars.adoc
+++ b/modules/otel-migrating-from-jaeger-without-sidecars.adoc
@@ -109,7 +109,7 @@ spec:
       resourcedetection:
         detectors: [openshift]
     exporters:
-      otlp:
+      otlp/traces:
         endpoint: "tempo-example-gateway:8090"
         tls:
           insecure: true
@@ -118,7 +118,7 @@ spec:
         traces:
           receivers: [jaeger]
           processors: [memory_limiter, k8sattributes, resourcedetection, batch]
-          exporters: [otlp]
+          exporters: [otlp/traces]
 ----
 
 . Point your tracing endpoint to the OpenTelemetry Operator.

--- a/modules/otel-send-traces-and-metrics-to-otel-collector-with-sidecar.adoc
+++ b/modules/otel-send-traces-and-metrics-to-otel-collector-with-sidecar.adoc
@@ -101,7 +101,7 @@ spec:
         detectors: [openshift]
         timeout: 2s
     exporters:
-      otlp:
+      otlp/traces:
         endpoint: "tempo-<example>-gateway:8090" # <1>
         tls:
           insecure: true
@@ -110,7 +110,7 @@ spec:
         traces:
           receivers: [otlp]
           processors: [memory_limiter, resourcedetection, batch]
-          exporters: [otlp]
+          exporters: [otlp/traces]
 ----
 <1> This points to the Gateway of the TempoStack instance deployed by using the `<example>` {TempoOperator}.
 

--- a/modules/otel-send-traces-and-metrics-to-otel-collector-without-sidecar.adoc
+++ b/modules/otel-send-traces-and-metrics-to-otel-collector-without-sidecar.adoc
@@ -106,7 +106,7 @@ spec:
       resourcedetection:
         detectors: [openshift]
     exporters:
-      otlp:
+      otlp/traces:
         endpoint: "tempo-<example>-distributor:4317" # <1>
         tls:
           insecure: true
@@ -115,7 +115,7 @@ spec:
         traces:
           receivers: [jaeger, opencensus, otlp, zipkin]
           processors: [memory_limiter, k8sattributes, resourcedetection, batch]
-          exporters: [otlp]
+          exporters: [otlp/traces]
 ----
 <1> This points to the Gateway of the TempoStack instance deployed by using the `<example>` {TempoOperator}.
 

--- a/observability/otel/otel-collector/otel-collector-connectors.adoc
+++ b/observability/otel/otel-collector/otel-collector-connectors.adoc
@@ -179,7 +179,7 @@ include::snippets/technology-preview.adoc[]
     processors:
       batch:
     exporters:
-      otlp:
+      otlp/traces:
         endpoint: tempo-simplest-distributor:4317
         tls:
           insecure: true
@@ -198,7 +198,7 @@ include::snippets/technology-preview.adoc[]
         traces:
           receivers: [forward]
           processors: [batch]
-          exporters: [otlp]
+          exporters: [otlp/traces]
 # ...
 ----
 

--- a/observability/otel/otel-collector/otel-collector-exporters.adoc
+++ b/observability/otel/otel-collector/otel-collector-exporters.adoc
@@ -33,7 +33,7 @@ The OTLP gRPC Exporter exports traces and metrics by using the OpenTelemetry pro
 # ...
   config:
     exporters:
-      otlp:
+      otlp/traces:
         endpoint: tempo-ingester:4317 # <1>
         tls: # <2>
           ca_file: ca.pem
@@ -48,9 +48,7 @@ The OTLP gRPC Exporter exports traces and metrics by using the OpenTelemetry pro
     service:
       pipelines:
         traces:
-          exporters: [otlp]
-        metrics:
-          exporters: [otlp]
+          exporters: [otlp/traces]
 # ...
 ----
 <1> The OTLP gRPC endpoint. If the `+https://+` scheme is used, then client transport security is enabled and overrides the `insecure` setting in the `tls`.
@@ -72,7 +70,7 @@ The OTLP HTTP Exporter exports traces and metrics by using the OpenTelemetry pro
 # ...
   config:
     exporters:
-      otlphttp:
+      otlphttp/traces:
         endpoint: http://tempo-ingester:4318 # <1>
         tls: # <2>
         headers: # <3>
@@ -82,9 +80,7 @@ The OTLP HTTP Exporter exports traces and metrics by using the OpenTelemetry pro
     service:
       pipelines:
         traces:
-          exporters: [otlphttp]
-        metrics:
-          exporters: [otlphttp]
+          exporters: [otlphttp/traces]
 # ...
 ----
 <1> The OTLP HTTP endpoint. If the `+https://+` scheme is used, then client transport security is enabled and overrides the `insecure` setting in the `tls`.

--- a/observability/otel/otel-config-multicluster.adoc
+++ b/observability/otel/otel-config-multicluster.adoc
@@ -203,7 +203,7 @@ spec:
         traces:
           receivers: [jaeger, opencensus, otlp, zipkin]
           processors: [memory_limiter, k8sattributes, resourcedetection, batch]
-          exporters: [otlp]
+          exporters: [otlphttp]
   volumes:
     - name: otel-certs
       secret:
@@ -240,7 +240,7 @@ spec:
               key_file: /certs/server.key
               client_ca_file: /certs/ca.crt
     exporters:
-      otlp:
+      otlp/traces:
         endpoint: "tempo-<simplest>-distributor:4317" # <2>
         tls:
           insecure: true
@@ -249,7 +249,7 @@ spec:
         traces:
           receivers: [otlp]
           processors: []
-          exporters: [otlp]
+          exporters: [otlp/traces]
   volumes:
     - name: otel-certs
       secret:


### PR DESCRIPTION
At the moment, most examples contain an exporter named `otlp` which is configured to send OTLP telemetry data to Tempo. However, Tempo can only ingest traces, and not any other signal (metrics, logs, profiles).

Therefore, let's be explicit in the examples and rename this exporter to `otlp/traces`, to make it clear that this exporter only supports traces.

Version(s):
all supported OCP versions

Issue:
https://issues.redhat.com/browse/TRACING-5478

Link to docs preview:
https://97924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr-tracing-tempo-configuring.html
https://97924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-connectors.html
https://97924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-exporters.html
https://97924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-config-multicluster.html
https://97924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-forwarding-telemetry-data.html
https://97924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-migrating.html
https://97924--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-sending-traces-logs-and-metrics-to-otel-collector.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

cc @max-cx @IshwarKanse @pavolloffay 