### PR TITLE
OCPBUGS-54739: Clarify MTU default for localnet NAD

### DIFF
--- a/modules/configuration-ovnk-multi-network-policy.adoc
+++ b/modules/configuration-ovnk-multi-network-policy.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-additional-network.adoc
+// * networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="compatibility-with-multi-network-policy_{context}"]

--- a/modules/configuration-ovnk-network-plugin-json-object.adoc
+++ b/modules/configuration-ovnk-network-plugin-json-object.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-additional-network.adoc
+// * networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="configuration-ovnk-network-plugin-json-object_{context}"]
@@ -46,8 +46,13 @@ When omitted, the logical switch implementing the network only provides layer 2 
 
 |`mtu`
 |`string`
-|
-The maximum transmission unit (MTU). If you do not set a value, the Cluster Network Operator (CNO) sets a default MTU value by calculating the difference among the underlay MTU of the primary network interface, the overlay MTU of the pod network, such as the Geneve (Generic Network Virtualization Encapsulation), and byte capacity of any enabled features, such as IPsec. 
+a|
+The maximum transmission unit (MTU). If you do not set a value, the Cluster Network Operator (CNO) sets a default MTU value by calculating the difference among the underlay MTU of the primary network interface, the overlay MTU of the pod network, such as the Geneve (Generic Network Virtualization Encapsulation), and byte capacity of any enabled features, such as IPsec.
+
+[IMPORTANT]
+====
+If the `topology` field is set to `localnet`, the MTU value must match the MTU value of the underlying network. If left unset, the default value is the MTU of the overlay network, not the underlay network.
+====
 
 |`netAttachDefName`
 |`string`

--- a/modules/configuring-layer-two-switched-topology.adoc
+++ b/modules/configuring-layer-two-switched-topology.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-additional-network.adoc
+// * networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="configuration-layer-two-switched-topology_{context}"]

--- a/modules/configuring-localnet-switched-topology.adoc
+++ b/modules/configuring-localnet-switched-topology.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/ovn_kubernetes_network_provider/configuring-secondary-networks.adoc
+// * networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="configuration-localnet-switched-topology_{context}"]
@@ -47,9 +47,10 @@ spec:
 <3> The name for the secondary network from which traffic is forwarded to the OVS bridge. This secondary network must match the name of the `spec.config.name` field of the `NetworkAttachmentDefinition` CRD that defines the OVN-Kubernetes secondary network.
 <4> The name of the OVS bridge on the node. This value is required only if you specify `state: present`.
 <5> The state for the mapping. Must be either `present` to add the bridge or `absent` to remove the bridge. The default value is `present`.
-+
+
 The following JSON example configures a localnet secondary network that is named `localnet1`. Note that the value for the `mtu` parameter must match the MTU value that was set for the secondary network interface that is mapped to the `br-ex` bridge interface.
-+
+
+.Example `localnet` configuration JSON
 [source,json]
 ----
 {
@@ -107,9 +108,10 @@ spec:
 <6> Specifies the name of the secondary network that forwards traffic to the OVS bridge. This name must match the value of the `spec.config.name` field in the `NetworkAttachmentDefinition` CRD that defines the OVN-Kubernetes secondary network.
 <7> Specifies the name of the OVS bridge on the node. The value is required only when `state: present` is set.
 <8> Specifies the state of the mapping. Valid values are `present` to add the bridge or `absent` to remove the bridge. The default value is `present`.
-+
+
 The following JSON example configures a localnet secondary network that is named `localnet2`. Note that the value for the `mtu` parameter must match the MTU value that was set for the `eth1` secondary network interface.
-+
+
+.Example `localnet` configuration JSON
 [source,json]
 ----
 {

--- a/modules/configuring-ovnk-additional-networks.adoc
+++ b/modules/configuring-ovnk-additional-networks.adoc
@@ -1,25 +1,25 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-additional-network.adoc
+// *networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="configuration-ovnk-additional-networks_{context}"]
 = Configuration for an OVN-Kubernetes secondary network
 
-The {openshift-networking} OVN-Kubernetes network plugin allows the configuration of secondary network interfaces for pods. To configure secondary network interfaces, you must define the configurations in the `NetworkAttachmentDefinition` custom resource definition (CRD).
+The {openshift-networking} OVN-Kubernetes network plugin allows the configuration of secondary network interfaces for pods. To configure secondary network interfaces, you must define the configurations in the `NetworkAttachmentDefinition` custom resource (CR).
 
 [NOTE]
 ====
-Pod and multi-network policy creation might remain in a pending state until the OVN-Kubernetes control plane agent in the nodes processes the associated `network-attachment-definition` CRD.
+Pod and multi-network policy creation might remain in a pending state until the OVN-Kubernetes control plane agent in the nodes processes the associated `network-attachment-definition` CR.
 ====
 
-You can configure an OVN-Kubernetes secondary network in layer 2, layer 3, or localnet topologies. For more information about features supported on these topologies, see "UserDefinedNetwork and NetworkAttachmentDefinition support matrix". 
+You can configure an OVN-Kubernetes secondary network in layer 2, layer 3, or localnet topologies. For more information about features supported on these topologies, see "UserDefinedNetwork and NetworkAttachmentDefinition support matrix".
 
 The following sections provide example configurations for each of the topologies that OVN-Kubernetes currently allows for secondary networks.
 
 [NOTE]
 ====
-Networks names must be unique. For example, creating multiple `NetworkAttachmentDefinition` CRDs with different configurations that reference the same network is unsupported.
+Networks names must be unique. For example, creating multiple `NetworkAttachmentDefinition` CRs with different configurations that reference the same network is unsupported.
 ====
 
 [id="configuration-additional-network-types-supported-platforms_{context}"]

--- a/modules/configuring-pods-secondary-network.adoc
+++ b/modules/configuring-pods-secondary-network.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-additional-network.adoc
+// * networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="configuring-pods-secondary-network_{context}"]

--- a/modules/configuring-pods-static-ip.adoc
+++ b/modules/configuring-pods-static-ip.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/multiple_networks/configuring-additional-network.adoc
+// * networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="configuring-pods-static-ip_{context}"]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OCPBUGS-54739

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

4.17 is the first version w/ the new navigation. Would need different PR for earlier versions.