### PR TITLE
OCPBUGS-60164: Added internal network cluster resource deletion to in…

### DIFF
--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -127,6 +127,7 @@ include::modules/installation-deployment-manager-bootstrap.adoc[leveloffset=+2]
 include::modules/installation-creating-gcp-control-plane.adoc[leveloffset=+1]
 include::modules/installation-deployment-manager-control-plane.adoc[leveloffset=+2]
 
+// Removing bootstrap resources in GCP
 include::modules/installation-gcp-user-infra-wait-for-bootstrap.adoc[leveloffset=+1]
 
 include::modules/installation-creating-gcp-worker.adoc[leveloffset=+1]

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -124,6 +124,7 @@ include::modules/installation-deployment-manager-bootstrap.adoc[leveloffset=+2]
 include::modules/installation-creating-gcp-control-plane.adoc[leveloffset=+1]
 include::modules/installation-deployment-manager-control-plane.adoc[leveloffset=+2]
 
+// Removing bootstrap resources in GCP
 include::modules/installation-gcp-user-infra-wait-for-bootstrap.adoc[leveloffset=+1]
 
 include::modules/installation-creating-gcp-worker.adoc[leveloffset=+1]

--- a/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
+++ b/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
@@ -5,12 +5,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-gcp-user-infra-wait-for-bootstrap_{context}"]
-= Wait for bootstrap completion and remove bootstrap resources in GCP
+= Removing bootstrap resources in GCP
 
-After you create all of the required infrastructure in Google Cloud Platform
-(GCP), wait for the bootstrap process to complete on the machines that you
-provisioned by using the Ignition config files that you generated with the
-installation program.
+After you create all of the required infrastructure in {gcp-first}, wait for the bootstrap process to complete on the machines that you provisioned by using the Ignition config files. The installation program created the Ignition config files.
 
 .Prerequisites
 
@@ -20,23 +17,19 @@ installation program.
 
 .Procedure
 
-. Change to the directory that contains the installation program and run the
-following command:
+. Change to the directory that includes the installation program and run the following command:
 +
 [source,terminal]
 ----
 $ ./openshift-install wait-for bootstrap-complete --dir <installation_directory> \ <1>
     --log-level info <2>
 ----
-<1> For `<installation_directory>`, specify the path to the directory that you
-stored the installation files in.
-<2> To view different installation details, specify `warn`, `debug`, or
-`error` instead of `info`.
+<1> For `<installation_directory>`, specify the path to the directory where you stored the installation files.
+<2> To view different installation details, specify `warn`, `debug`, or `error` instead of `info`.
 +
-If the command exits without a `FATAL` warning, your production control plane
-has initialized.
+If the command exits without a `FATAL` warning, your production control plane has initialized.
 
-. Delete the bootstrap resources:
+. To remove the bootstrap instance group from the backend services' backends, run the following commands:
 +
 [source,terminal]
 ----
@@ -45,8 +38,24 @@ $ gcloud compute backend-services remove-backend ${INFRA_ID}-api-internal --regi
 +
 [source,terminal]
 ----
-$ gsutil rm gs://${INFRA_ID}-bootstrap-ignition/bootstrap.ign
+$ ingress_backendservice=$(gcloud compute backend-services list --filter="backends.group~${INFRA_ID}" --format='value(name)' | grep -v "${INFRA_ID}")
 ----
++
+.. If `ingress_backendservice` is not empty, run the following `describe` command for the bootstrap group:
++
+[source,terminal]
+----
+$ gcloud compute backend-services describe ${ingress_backendservice} --region=${REGION}
+----
++
+.. If the `describe` command displays that the bootstrap group is one of its backends, run the following `remove-backend` command to remove the bootstrap group from the backends:
++
+[source,terminal]
+----
+$ gcloud compute backend-services remove-backend ${ingress_backendservice} --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-ig --instance-group-zone=${ZONE_0}
+----
+
+.. To remove the bucket and the deployment, run the following commands:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.12+ 

Issue:
[OCPBUGS-60164](https://issues.redhat.com/browse/OCPBUGS-60164)

Link to docs preview:
[Removing bootstrap resources in GCP](https://97971--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-gcp-user-infra-wait-for-bootstrap_installing-gcp-user-infra)


- [x] SME has approved this change (Yiyong He).
- [x] QE has approved this change (Jianli Wei).
