### PR TITLE
OCPBUGS 60766 replace confusing sentence in cgroup docs

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -44,7 +44,7 @@ include::snippets/deprecated-feature.adoc[]
 
 .Procedure
 
-. Enable cgroup v1 on nodes:
+. Configure the wanted cgroup version on your nodes:
 
 .. Edit the `node.config` object:
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-60766

Minor editorial change. No QE needed.

Nodes -> [Configuring Linux cgroup](https://97972--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2) -- Edited Step 1
Post-install -> [Configuring Linux cgroup](https://97972--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#nodes-clusters-cgroups-2_post-install-cluster-tasks) -- Edited Step 1