### PR TITLE
OBSDOCS-2326 Logging Z-Stream Release Notes - 6.1.8

### DIFF
--- a/modules/logging-release-notes-6-1-8.adoc
+++ b/modules/logging-release-notes-6-1-8.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * about/logging-release-notes-6.1.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-8_{context}"]
+= Logging 6.1.8 Release Notes
+
+This release includes <link to the advisory>.
+// The above line needs rephrasing once the advisory link is ready.
+
+[id="logging-release-notes-6-1-8-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, Loki ingesters that got into an unhealthy state due to networking issues stayed in that state even after the network recovered. With this update, you can configure the Loki Operator to perform service discovery more often so that unhealthy ingesters can rejoin the group. (link:https://issues.redhat.com/browse/LOG-7322[LOG-7322])
+
+* Before this update, the loki-gateway did not enforce fine-grained authorization on the `/series` endpoint for the `application` tenant. As a consequence, users could get unauthorized access to the stream metadata information from different log streams. With this update, the `/series` endpoint uses the `match` parameter instead of the `query` parameter to filter the series metadata that is returned for a request. As a result, the loki-gateway correctly enforces fine-grained authorization for the `/series` endpoint for the `application` tenant. (link:https://issues.redhat.com/browse/LOG-7320[LOG-7320])
+
+* Before this update, creating an `AlertingRule` for `kernel` errors failed in the `openshift-logging` namespace because the infrastructure or audit tenant was not supported. As a consequence, users could not create `AlertingRules` for `kernel` messages without specifying a namespace label. With this update, `AlertingRule` validation allows the infrastructure or audit tenant in the `openshift-logging` namespace without a namespace label, enabling users to create `AlertingRules` for `kernel` errors successfully. (link:https://issues.redhat.com/browse/LOG-7318[LOG-7318])
+
+* Before this update, a bug in the authorization workflow for user rules and alerts allowed users to view alerts from other users. With this update, the bug fix restores the correct authorization behavior, and users can only see their own rules and alerts. (link:https://issues.redhat.com/browse/LOG-7314[LOG-7314])
+
+//[id="logging-release-notes-6-1-8-cves_{context}"]
+//== CVEs
+
+// Need to check the list of CVEs for 6.1.8
+
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].

--- a/release_notes/logging-release-notes-6.1.adoc
+++ b/release_notes/logging-release-notes-6.1.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/logging-release-notes-6-1-8.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-1-6.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-1-5.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 6.1.8

Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-2326

Fix Version: 6.1

Doc Preview: https://97978--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6.1.html#logging-release-notes-6-1-8_logging-release-notes-6-1

QE Review:
Peer Review: