### PR TITLE
OSDOCS-14723: adds 4.15.57 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -557,3 +557,12 @@ For the latest images included with {microshift-short}, view the contents of the
 ==== Bug fix
 
 With this release, {microshift-short} networking is now updated to the OpenVSwitch 3.3 package. This update keeps the networking switch platform supported and helps to ensure timely bug fix delivery in the future.
+
+[id="microshift-4-15-57-dp_{context}"]
+=== RHBA-2025:14465 - {microshift-short} 4.15.57 bug fix advisory
+
+Issued: 27 August 2025
+
+{product-title} release 4.15.57 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:14465[RHBA-2025:14465] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:14397[RHSA-2025:14397] advisory.
+
+For the latest images included with {microshift-short}, view the contents of the `microshift-release-info` RPM. See xref:../microshift_install/microshift-embed-in-rpm-ostree-offline-use.adoc#microshift-embed-microshift-image-offline-deployment_microshift-embed-rpm-ostree-offline-use[Embedding {microshift-short} containers for offline deployments].


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-14723](https://issues.redhat.com/browse/OSDOCS-14723)

Link to docs preview:
[microshift-4-15-57-dp_release-notes](https://97980--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-15-release-notes.html#microshift-4-15-57-dp_release-notes)

QE review:
- N/A stock release note, no technical updates

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
