### PR TITLE
OCPBUGS#60854 Adding icr.io to firewall allowlist for IBM CloudPak

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -81,6 +81,14 @@ If your environment has a dedicated load balancer in front of your {product-titl
 |`sso.redhat.com`
 |443
 |The `https://console.redhat.com` site uses authentication from `sso.redhat.com`
+
+|`icr.io`
+|443
+|Provides IBM Cloud Pak container images. This domain is only required if you use IBM Cloud Paks.
+
+|`cp.icr.io`
+|443
+|Provides IBM Cloud Pak container images. This domain is only required if you use IBM Cloud Paks.
 |===
 +
 * You can use the wildcard `*.quay.io` instead of `cdn.quay.io` and `cdn0[1-6].quay.io` in your allowlist.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-60854](https://issues.redhat.com/browse/OCPBUGS-60854)

Link to docs preview:
https://97988--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#configuring-firewall_configuring-firewall

QE review:
- [x] QE has approved this change.
