### PR TITLE
[OCPBUGS-60700]: Adding steps to proc to restore etcd for a hosted cluster

### DIFF
--- a/modules/hosted-cluster-etcd-backup-restore-on-premise.adoc
+++ b/modules/hosted-cluster-etcd-backup-restore-on-premise.adoc
@@ -259,3 +259,38 @@ $ oc get -n ${CONTROL_PLANE_NAMESPACE} pods -l app=etcd -w
 $ oc patch -n ${HOSTED_CLUSTER_NAMESPACE} hostedclusters/${CLUSTER_NAME} \
   -p '{"spec":{"pausedUntil":"null"}}' --type=merge
 ----
+
+. Manually roll out the hosted cluster by entering the following command:
++
+[source,terminal]
+----
+$ oc annotate hostedcluster -n \
+  <hosted_cluster_namespace> <hosted_cluster_name> \
+  hypershift.openshift.io/restart-date=$(date --iso-8601=seconds)
+----
++
+The Multus admission controller and network node identity pods do not start yet.
+
+. Delete the pods for the second and third members of etcd and their PVCs by entering the following commands:
++
+[source,terminal]
+----
+$ oc delete -n ${CONTROL_PLANE_NAMESPACE} pvc/data-etcd-1 pod/etcd-1 --wait=false
+----
++
+[source,terminal]
+----
+$ oc delete -n ${CONTROL_PLANE_NAMESPACE} pvc/data-etcd-2 pod/etcd-2 --wait=false
+----
+
+. Manually roll out the hosted cluster again by entering the following command:
++
+[source,terminal]
+----
+$ oc annotate hostedcluster -n \
+  <hosted_cluster_namespace> <hosted_cluster_name> \
+  hypershift.openshift.io/restart-date=$(date --iso-8601=seconds) \
+  --overwrite
+----
++
+After a few minutes, the control plane pods start running.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-60700
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://97991--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp_high_availability/hcp-backup-restore-on-premise.html#hosted-cluster-etcd-backup-restore-on-premise_hcp-backup-restore-on-premise
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
