### PR TITLE
OSDOCS-14500: Prune "Tutorials"

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -109,31 +109,27 @@ Distros: openshift-rosa
 Topics:
 - Name: Tutorials overview
   File: index
-#- Name: ROSA prerequisites
+#- Name: ROSA classic architecture prerequisites
 #  File: rosa-mobb-prerequisites-tutorial
-- Name: ROSA with HCP activation and account linking
-  File: cloud-experts-rosa-hcp-activation-and-account-linking-tutorial
-- Name: ROSA with HCP private offer acceptance and sharing
-  File: cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing
-- Name: Verifying Permissions for a ROSA STS Deployment
+- Name: Verifying Permissions for a ROSA classic architecture STS Deployment
   File: rosa-mobb-verify-permissions-sts-deployment
-- Name: Deploying ROSA with a Custom DNS Resolver
+- Name: Deploying ROSA classic architecture with a Custom DNS Resolver
   File: cloud-experts-custom-dns-resolver
-- Name: Using AWS WAF and Amazon CloudFront to protect ROSA workloads
+- Name: Using AWS WAF and Amazon CloudFront to protect ROSA classic architecture workloads
   File: cloud-experts-using-cloudfront-and-waf
-- Name: Using AWS WAF and AWS ALBs to protect ROSA workloads
+- Name: Using AWS WAF and AWS ALBs to protect ROSA classic architecture workloads
   File: cloud-experts-using-alb-and-waf
-- Name: Deploying OpenShift API for Data Protection on a ROSA cluster
+- Name: Deploying OpenShift API for Data Protection on a ROSA classic architecture cluster
   File: cloud-experts-deploy-api-data-protection
-- Name: AWS Load Balancer Operator on ROSA
+- Name: AWS Load Balancer Operator on ROSA classic architecture
   File: cloud-experts-aws-load-balancer-operator
 - Name: Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
   File: cloud-experts-entra-id-idp
-- Name: Using AWS Secrets Manager CSI on ROSA with STS
+- Name: Using AWS Secrets Manager CSI on ROSA classic architecture with STS
   File: cloud-experts-aws-secret-manager
-- Name: Using AWS Controllers for Kubernetes on ROSA
+- Name: Using AWS Controllers for Kubernetes on ROSA classic architecture
   File: cloud-experts-using-aws-ack
-- Name: Deploying the External DNS Operator on ROSA
+- Name: Deploying the External DNS Operator on ROSA classic architecture
   File: cloud-experts-external-dns
 - Name: Dynamically issuing certificates using the cert-manager Operator on ROSA
   File: cloud-experts-dynamic-certificate-custom-domain
@@ -141,13 +137,13 @@ Topics:
   File: cloud-experts-consistent-egress-ip
 - Name: Updating component routes with custom domains and TLS certificates
   File: cloud-experts-update-component-routes
-- Name: Getting started with ROSA
+- Name: Getting started with ROSA classic architecture
   Dir: cloud-experts-getting-started
   Distros: openshift-rosa
   Topics:
-  - Name: What is ROSA
+  - Name: What is ROSA classic architecture
     File: cloud-experts-getting-started-what-is-rosa
-  - Name: ROSA with AWS STS explained
+  - Name: ROSA classic architecture with AWS STS explained
     File: cloud-experts-rosa-sts-explained
   - Name: OpenShift concepts
     File: cloud-experts-getting-started-openshift-concepts
@@ -164,8 +160,6 @@ Topics:
       File: cloud-experts-getting-started-simple-ui-guide
     - Name: Detailed UI guide
       File: cloud-experts-getting-started-detailed-ui
-    - Name: HCP deployment guide
-      File: cloud-experts-getting-started-hcp
   - Name: Creating an admin user
     File: cloud-experts-getting-started-admin
   - Name: Setting up an identity provider

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -36,9 +36,9 @@ Topics:
   File: index
 - Name: Legal notice
   File: legal-notice
-- Name: ROSA with HCP overview
+- Name: ROSA overview
   File: about-hcp
-- Name: AWS STS and ROSA with HCP explained
+- Name: AWS STS and ROSA explained
   File: cloud-experts-rosa-hcp-sts-explained
 - Name: Architecture models
   File: rosa-architecture-models
@@ -50,11 +50,11 @@ Topics:
     File: rosa-policy-understand-availability
   - Name: Overview of responsibilities for ROSA
     File: rosa-policy-responsibility-matrix
-  - Name: ROSA with HCP service definition
+  - Name: ROSA service definition
     File: rosa-hcp-service-definition
-  - Name: ROSA with HCP instance types
+  - Name: ROSA instance types
     File: rosa-hcp-instance-types
-  - Name: ROSA with HCP update life cycle
+  - Name: ROSA update life cycle
     File: rosa-hcp-life-cycle
   - Name: SRE and service account access
     File: rosa-sre-access
@@ -121,9 +121,9 @@ Distros: openshift-rosa-hcp
 Topics:
 - Name: Tutorials overview
   File: index
-- Name: ROSA with HCP activation and account linking
+- Name: ROSA activation and account linking
   File: cloud-experts-rosa-hcp-activation-and-account-linking-tutorial
-- Name: ROSA with HCP private offer acceptance and sharing
+- Name: ROSA private offer acceptance and sharing
   File: cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing
 - Name: Deploying ROSA with a Custom DNS Resolver
   File: cloud-experts-custom-dns-resolver
@@ -141,8 +141,8 @@ Topics:
   File: cloud-experts-aws-secret-manager
 - Name: Using AWS Controllers for Kubernetes on ROSA
   File: cloud-experts-using-aws-ack
-- Name: Dynamically issuing certificates using the cert-manager Operator on ROSA
-  File: cloud-experts-dynamic-certificate-custom-domain
+#- Name: Dynamically issuing certificates using the cert-manager Operator on ROSA
+#  File: cloud-experts-dynamic-certificate-custom-domain
 - Name: Assigning consistent egress IP for external traffic
   File: cloud-experts-consistent-egress-ip
 # ---
@@ -161,14 +161,14 @@ Name: Prepare your environment
 Dir: rosa_planning
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Prerequisites checklist for deploying ROSA with HCP
+- Name: Prerequisites checklist for deploying ROSA
   File: rosa-cloud-expert-prereq-checklist
-- Name: Detailed requirements for deploying ROSA with HCP
+- Name: Detailed requirements for deploying ROSA
   File: rosa-sts-aws-prereqs
 - Name: Required IAM roles and resources
   File: rosa-hcp-prepare-iam-roles-resources
 ##### NOTE: THE BELOW IS REMOVED AS PART OF OSDOCS-13310
-#- Name: ROSA with HCP limits and scalability
+#- Name: ROSA limits and scalability
 #  File: rosa-hcp-limits-scalability
 ##### NOTE: THE ABOVE IS REMOVED AS PART OF OSDOCS-13310
 - Name: Required AWS service quotas
@@ -178,13 +178,13 @@ Topics:
 - Name: Planning resource usage in your cluster
   File: rosa-planning-environment
 ---
-Name: Install ROSA with HCP clusters
+Name: Install ROSA clusters
 Dir: rosa_hcp
 Distros: openshift-rosa-hcp
 Topics:
-- Name: ROSA with HCP quick start guide
+- Name: ROSA quick start guide
   File: rosa-hcp-quickstart-guide
-- Name: Creating ROSA with HCP clusters using the default options
+- Name: Creating ROSA clusters using the default options
   File: rosa-hcp-sts-creating-a-cluster-quickly
 - Name: Creating a ROSA cluster using Terraform
   Dir: terraform
@@ -192,19 +192,19 @@ Topics:
   Topics:
   - Name: Creating a default ROSA cluster using Terraform
     File: rosa-hcp-creating-a-cluster-quickly-terraform
-- Name: Creating ROSA with HCP clusters using a custom AWS KMS encryption key
+- Name: Creating ROSA clusters using a custom AWS KMS encryption key
   File: rosa-hcp-creating-cluster-with-aws-kms-key
-- Name: Configuring a shared virtual private cloud for ROSA with HCP clusters
+- Name: Configuring a shared virtual private cloud for ROSA clusters
   File: rosa-hcp-shared-vpc-config
-- Name: Creating a private cluster on ROSA with HCP
+- Name: Creating a private cluster on ROSA
   File: rosa-hcp-aws-private-creating-cluster
-- Name: Creating ROSA with HCP clusters with egress zero
+- Name: Creating ROSA clusters with egress zero
   File: rosa-hcp-egress-zero-install
-- Name: Creating a ROSA with HCP cluster that uses direct authentication with an external OIDC identity provider
+- Name: Creating a ROSA cluster that uses direct authentication with an external OIDC identity provider
   File: rosa-hcp-sts-creating-a-cluster-ext-auth
-- Name: Creating ROSA with HCP clusters without a CNI plugin
+- Name: Creating ROSA clusters without a CNI plugin
   File: rosa-hcp-cluster-no-cni
-- Name: Deleting a ROSA with HCP cluster
+- Name: Deleting a ROSA cluster
   File: rosa-hcp-deleting-cluster
 ---
 Name: Web console
@@ -569,7 +569,7 @@ Name: Upgrading
 Dir: upgrading
 Distros: openshift-rosa-hcp
 Topics:
-- Name: Upgrading ROSA with HCP
+- Name: Upgrading ROSA
   File: rosa-hcp-upgrading
 ---
 Name: CI/CD

--- a/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-load-balancer-operator.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-aws-load-balancer-operator"]
-= Tutorial: AWS Load Balancer Operator on ROSA
+= Tutorial: AWS Load Balancer Operator on {product-title}
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-aws-load-balancer-operator
 
@@ -33,7 +33,7 @@ Load Balancers created by the AWS Load Balancer Operator cannot be used for link
 ====
 endif::openshift-rosa-hcp[]
 
-The link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/[AWS Load Balancer Controller] manages AWS Elastic Load Balancers for a {product-title} (ROSA) cluster. The controller provisions link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html[AWS Application Load Balancers (ALB)] when you create Kubernetes Ingress resources and link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html[AWS Network Load Balancers (NLB)] when implementing Kubernetes Service resources with a type of LoadBalancer.
+The link:https://kubernetes-sigs.github.io/aws-load-balancer-controller/[AWS Load Balancer Controller] manages AWS Elastic Load Balancers for a {product-title} cluster. The controller provisions link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html[AWS Application Load Balancers (ALB)] when you create Kubernetes Ingress resources and link:https://docs.aws.amazon.com/elasticloadbalancing/latest/network/introduction.html[AWS Network Load Balancers (NLB)] when implementing Kubernetes Service resources with a type of LoadBalancer.
 
 Compared with the default AWS in-tree load balancer provider, this controller is developed with advanced annotations for both ALBs and NLBs. Some advanced use cases are:
 
@@ -42,7 +42,7 @@ Compared with the default AWS in-tree load balancer provider, this controller is
 * Specify custom NLB source IP ranges
 * Specify custom NLB internal IP addresses
 
-The link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator] is used to used to install, manage and configure an instance of `aws-load-balancer-controller` in a ROSA cluster.
+The link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator] is used to used to install, manage and configure an instance of `aws-load-balancer-controller` in a {product-title} cluster.
 
 [id="prerequisites_{context}"]
 == Prerequisites
@@ -53,11 +53,10 @@ AWS ALBs require a multi-AZ cluster, as well as three public subnets split acros
 ====
 
 ifndef::openshift-rosa-hcp[]
-* xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[A multi-AZ ROSA classic cluster]
+* xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[A multi-AZ {product-title} cluster]
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa-hcp[]
-* link:https://docs.openshift.com/rosa-hcp/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html[A multi-AZ ROSA cluster]
-endif::openshift-rosa-hcp[]
+* xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[A multi-AZ {product-title} cluster]
 * BYO VPC cluster
 * AWS CLI
 * OC CLI
@@ -87,7 +86,7 @@ $ echo "Cluster: ${ROSA_CLUSTER_NAME}, Region: ${REGION}, OIDC Endpoint: ${OIDC_
 This section only applies to clusters that were deployed into existing VPCs. If you did not deploy your cluster into an existing VPC, skip this section and proceed to the installation section below.
 ====
 
-. Set the below variables to the proper values for your ROSA deployment:
+. Set the below variables to the proper values for your cluster deployment:
 +
 [source,terminal]
 ----
@@ -131,7 +130,7 @@ $ aws ec2 create-tags \
 +
 [NOTE]
 ====
-The policy is sourced from link:https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.4/docs/install/iam_policy.json[the upstream AWS Load Balancer Controller policy] plus permission to create tags on subnets. This is required by the operator to function.
+The policy is sourced from link:https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.4/docs/install/iam_policy.json[the upstream AWS Load Balancer Controller policy] plus permission to create tags on subnets. This is required by the Operator to function.
 ====
 +
 [source,terminal]
@@ -235,7 +234,7 @@ spec:
 EOF
 ----
 +
-. Deploy an instance of the AWS Load Balancer Controller using the operator:
+. Deploy an instance of the AWS Load Balancer Controller using the Operator:
 +
 [NOTE]
 ====
@@ -255,7 +254,7 @@ spec:
 EOF
 ----
 +
-. Check the that the operator and controller pods are both running:
+. Check the that the Operator and controller pods are both running:
 +
 [source,terminal]
 ----

--- a/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-aws-secret-manager"]
-= Tutorial: Using AWS Secrets Manager CSI on ROSA with STS
+= Tutorial: Using AWS Secrets Manager CSI on {product-title} with STS
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-aws-secret-manager
 
@@ -17,14 +17,14 @@ toc::[]
 //   - Chris Kang
 // ---
 
-The AWS Secrets and Configuration Provider (ASCP) provides a way to expose AWS Secrets as Kubernetes storage volumes. With the ASCP, you can store and manage your secrets in Secrets Manager and then retrieve them through your workloads running on {product-title} (ROSA).
+The AWS Secrets and Configuration Provider (ASCP) provides a way to expose AWS Secrets as Kubernetes storage volumes. With the ASCP, you can store and manage your secrets in Secrets Manager and then retrieve them through your workloads running on {product-title}.
 
 [id="cloud-experts-aws-secret-manager-prerequisites"]
 == Prerequisites
 
 Ensure that you have the following resources and tools before starting this process:
 
-* A ROSA cluster deployed with STS
+* A {product-title} cluster deployed with STS
 * Helm 3
 * `aws` CLI
 * `oc` CLI
@@ -34,7 +34,7 @@ Ensure that you have the following resources and tools before starting this proc
 [id="cloud-experts-aws-secret-manager-preparing-environment"]
 === Additional environment requirements
 
-. Log in to your ROSA cluster by running the following command:
+. Log in to your {product-title} cluster by running the following command:
 +
 [source,terminal]
 ----
@@ -58,12 +58,13 @@ $ oc get authentication.config.openshift.io cluster -o json \
 "https://xxxxx.cloudfront.net/xxxxx"
 ----
 +
-If your output is different, do not proceed. 
+If your output is different, do not proceed.
+See 
 ifndef::openshift-rosa-hcp[]
-See xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Red{nbsp}Hat documentation on creating an STS cluster] before continuing this process.
+xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Red{nbsp}Hat documentation on creating an STS cluster] before continuing this process.
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa-hcp[]
-See link:https://docs.openshift.com/rosa-hcp/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html[Creating ROSA with HCP clusters using the default options] before continuing this process.
+xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Red{nbsp}Hat documentation on creating an STS cluster] before continuing this process.
 endif::openshift-rosa-hcp[]
 
 . Set the `SecurityContextConstraints` permission to allow the CSI driver to run by running the following command:

--- a/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
+++ b/cloud_experts_tutorials/cloud-experts-consistent-egress-ip.adoc
@@ -19,7 +19,7 @@ toc::[]
 
 You can assign a consistent IP address for traffic that leaves your cluster such as security groups which require an IP-based configuration to meet security standards.
 
-By default, {product-title} (ROSA) uses the OVN-Kubernetes container network interface (CNI) to assign random IP addresses from a pool. This can make configuring security lockdowns unpredictable or open.
+By default, {product-title} uses the OVN-Kubernetes container network interface (CNI) to assign random IP addresses from a pool. This can make configuring security lockdowns unpredictable or open.
 
 ifndef::openshift-rosa-hcp[]
 See xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address] for more information.
@@ -34,15 +34,9 @@ endif::openshift-rosa-hcp[]
 
 .Prerequisites
 
-* A ROSA cluster deployed with OVN-Kubernetes
-ifndef::openshift-rosa-hcp[]
+* A {product-title} cluster deployed with OVN-Kubernetes
 * The xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI] (`oc`)
 * The xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[ROSA CLI] (`rosa`)
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa-hcp[]
-* The link:https://docs.openshift.com/rosa/cli_reference/openshift_cli/getting-started-cli.html[OpenShift CLI] (`oc`)
-* The link:https://docs.openshift.com/rosa/cli_reference/rosa_cli/rosa-get-started-cli.html[ROSA CLI] (`rosa`)
-endif::openshift-rosa-hcp[]
 * link:https://stedolan.github.io/jq/[`jq`]
 
 

--- a/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.adoc
+++ b/cloud_experts_tutorials/cloud-experts-custom-dns-resolver.adoc
@@ -1,18 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-custom-dns-resolver"]
-= Tutorial: Deploying ROSA with a Custom DNS Resolver
+= Tutorial: Deploying {product-title} with a Custom DNS Resolver
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-custom-dns-resolver
 
 toc::[]
 
-A link:https://docs.aws.amazon.com/vpc/latest/userguide/DHCPOptionSet.html[custom DHCP option set] enables you to customize your VPC with your own DNS server, domain name, and more. {product-title} (ROSA) clusters support using custom DHCP option sets. By default, ROSA clusters require setting the "domain name servers" option to `AmazonProvidedDNS` to ensure successful cluster creation and operation. Customers who want to use custom DNS servers for DNS resolution must do additional configuration to ensure successful ROSA cluster creation and operation. 
+A link:https://docs.aws.amazon.com/vpc/latest/userguide/DHCPOptionSet.html[custom DHCP option set] enables you to customize your VPC with your own DNS server, domain name, and more. {product-title} clusters support using custom DHCP option sets. By default, {product-title} clusters require setting the "domain name servers" option to `AmazonProvidedDNS` to ensure successful cluster creation and operation. Customers who want to use custom DNS servers for DNS resolution must do additional configuration to ensure successful {product-title} cluster creation and operation. 
 
 In this tutorial, we will configure our DNS server to forward DNS lookups for specific DNS zones (further detailed below) to an link:https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver.html[Amazon Route 53 Inbound Resolver]. 
 
 [NOTE]
 ====
-This tutorial uses the open-source BIND DNS server (`named`) to demonstrate the configuration necessary to forward DNS lookups to an Amazon Route 53 Inbound Resolver located in the VPC you plan to deploy a ROSA cluster into. Refer to the documentation of your preferred DNS server for how to configure zone forwarding.
+This tutorial uses the open-source BIND DNS server (`named`) to demonstrate the configuration necessary to forward DNS lookups to an Amazon Route 53 Inbound Resolver located in the VPC you plan to deploy a {product-title} cluster into. Refer to the documentation of your preferred DNS server for how to configure zone forwarding.
 ====
 
 [id="cloud-experts-custom-dns-resolver-prerequisites"]
@@ -124,9 +124,9 @@ $ aws route53resolver list-resolver-endpoint-ip-addresses \
 
 Use the following procedure to configure your DNS server to forward the necessary private hosted zones to your Amazon Route 53 Inbound Resolver. 
 
-//ifdef::openshift-rosa-hcp[]
-=== ROSA with HCP
-ROSA with HCP clusters require you to configure DNS forwarding for two private hosted zones:
+ifdef::openshift-rosa-hcp[]
+=== {product-title}
+{product-title} clusters require you to configure DNS forwarding for two private hosted zones:
 
 * `<cluster-name>.hypershift.local`
 * `rosa.<domain-prefix>.<unique-ID>.p3.openshiftapps.com`
@@ -148,10 +148,10 @@ zone "<cluster-name>.hypershift.local" { <1>
   };
 };
 ----
-<1> Replace `<cluster-name>` with your ROSA HCP cluster name.
+<1> Replace `<cluster-name>` with your {product-title} cluster name.
 <2> Replace with the IP addresses of your inbound resolver endpoints collected above, ensuring that following each IP address there is a `;`.
 +
-. link:https://docs.openshift.com/rosa/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html[Create your cluster].
+. xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Create your cluster].
 +
 . Once your cluster has begun the creation process, locate the newly created private hosted zone:
 +
@@ -198,11 +198,11 @@ zone "rosa.<domain-prefix>.<unique-ID>.p3.openshiftapps.com" { <1>
 ----
 <1> Replace `<domain-prefix>` with your cluster domain prefix and `<unique-ID>` with your unique ID collected above.
 <2> Replace with the IP addresses of your inbound resolver endpoints collected above, ensuring that following each IP address there is a `;`.
-//endif::openshift-rosa-hcp[]
+endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa[]
-=== ROSA Classic
-ROSA Classic clusters require you to configure DNS forwarding for one private hosted zones:
+=== {product-title}
+{product-title} clusters require you to configure DNS forwarding for one private hosted zones:
 
 * `<domain-prefix>.<unique-ID>.p1.openshiftapps.com`
 

--- a/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploy-api-data-protection.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-deploy-api-data-protection"]
-= Tutorial: Deploying OpenShift API for Data Protection on a ROSA cluster
+= Tutorial: Deploying OpenShift API for Data Protection on a {product-title} cluster
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploy-api-data-protection
 
@@ -22,10 +22,10 @@ include::snippets/mobb-support-statement.adoc[leveloffset=+1]
 .Prerequisites
 
 ifndef::openshift-rosa-hcp[]
-* A xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[ROSA classic cluster]
+* A xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[{product-title} cluster]
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa-hcp[]
-* A link:https://docs.openshift.com/rosa-hcp/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html[ROSA cluster]
+* A xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[{product-title} cluster]
 endif::openshift-rosa-hcp[]
 
 .Environment
@@ -34,7 +34,7 @@ endif::openshift-rosa-hcp[]
 +
 [NOTE]
 ====
-Change the cluster name to match your ROSA cluster and ensure you are logged into the cluster as an Administrator.
+Change the cluster name to match your {product-title} cluster and ensure you are logged into the cluster as an Administrator.
 Ensure all fields are outputted correctly before moving on.
 ====
 +
@@ -363,9 +363,9 @@ EOF
 
 [NOTE]
 ====
-* In OADP 1.1.x ROSA STS environments, the container image backup and restore (`spec.backupImages`) value must be set to `false` as it is not supported.
-* The Restic feature (`restic.enable=false`) is disabled and not supported in ROSA STS environments.
-* The DataMover feature (`dataMover.enable=false`) is disabled and not supported in ROSA STS environments.
+* In OADP 1.1.x {product-title} STS environments, the container image backup and restore (`spec.backupImages`) value must be set to `false` as it is not supported.
+* The Restic feature (`restic.enable=false`) is disabled and not supported in {product-title} STS environments.
+* The DataMover feature (`dataMover.enable=false`) is disabled and not supported in {product-title} STS environments.
 ====
 
 [id="perform-a-backup_{context}"]

--- a/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain.adoc
+++ b/cloud_experts_tutorials/cloud-experts-dynamic-certificate-custom-domain.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-dynamic-certificate-custom-domain"]
-= Tutorial: Dynamically issuing certificates using the cert-manager Operator on ROSA
+= Tutorial: Dynamically issuing certificates using the cert-manager Operator on {product-title}
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-dynamic-certificate-custom-domain
 
@@ -24,7 +24,7 @@ Learn how to use the link:https://docs.openshift.com/container-platform/latest/s
 [id="cloud-experts-dynamic-certificate-custom-domain-prerequisites"]
 == Prerequisites
 
-* A ROSA cluster (HCP or Classic)
+* A {product-title} cluster
 * A user account with `cluster-admin` privileges
 * The OpenShift CLI (`oc`)
 * The Amazon Web Services (AWS) CLI (`aws`)
@@ -71,9 +71,9 @@ $ export CLUSTER=my-custom-value
 [id="cloud-experts-dynamic-certificate-prep-aws"]
 == Preparing your AWS account
 
-When cert-manager requests a certificate from Let’s Encrypt (or another ACME certificate issuer), Let's Encrypt servers validate that you control the domain name in that certificate using _challenges_. For this tutorial, you are using a link:https://letsencrypt.org/docs/challenge-types/#dns-01-challenge[DNS-01 challenge] that proves that you control the DNS for your domain name by putting a specific value in a TXT record under that domain name. This is all done automatically by cert-manager. To allow cert-manager permission to modify the Amazon Route 53 public hosted zone for your domain, you need to create an Identity Access Management (IAM) role with specific policy permissions and a trust relationship to allow access to the pod.
+When cert-manager requests a certificate from Let's Encrypt (or another ACME certificate issuer), Let's Encrypt servers validate that you control the domain name in that certificate using _challenges_. For this tutorial, you are using a link:https://letsencrypt.org/docs/challenge-types/#dns-01-challenge[DNS-01 challenge] that proves that you control the DNS for your domain name by putting a specific value in a TXT record under that domain name. This is all done automatically by cert-manager. To allow cert-manager permission to modify the Amazon Route 53 public hosted zone for your domain, you need to create an Identity Access Management (IAM) role with specific policy permissions and a trust relationship to allow access to the pod.
 
-The public hosted zone that is used in this tutorial is in the same AWS account as the ROSA cluster. If your public hosted zone is in a different account, a few additional steps for link:https://cert-manager.io/docs/configuration/acme/dns01/route53/#cross-account-access[Cross Account Access] are required.
+The public hosted zone that is used in this tutorial is in the same AWS account as the {product-title} cluster. If your public hosted zone is in a different account, a few additional steps for link:https://cert-manager.io/docs/configuration/acme/dns01/route53/#cross-account-access[Cross Account Access] are required.
 
 . Retrieve the Amazon Route 53 public hosted zone ID:
 +

--- a/cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc
+++ b/cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc
@@ -19,7 +19,7 @@ toc::[]
 //   - Thatcher Hubbard
 // ---
 
-You can configure Microsoft Entra ID (formerly Azure Active Directory) as the cluster identity provider in {product-title} (ROSA).
+You can configure Microsoft Entra ID (formerly Azure Active Directory) as the cluster identity provider in {product-title}.
 
 This tutorial guides you to complete the following tasks:
 
@@ -132,7 +132,7 @@ image:azure-portal_edit-group-claims-page.png[Azure Portal - Edit Groups Claim P
 
 You must configure {product-title} to use Entra ID as its identity provider.
 
-Although ROSA offers the ability to configure identity providers by using {cluster-manager}, use the ROSA CLI to configure the cluster's OAuth provider to use Entra ID as its identity provider. Before configuring the identity provider, set the necessary variables for the identity provider configuration.
+Although {product-title} offers the ability to configure identity providers by using {cluster-manager}, use the ROSA CLI to configure the cluster's OAuth provider to use Entra ID as its identity provider. Before configuring the identity provider, set the necessary variables for the identity provider configuration.
 
 .Procedure
 
@@ -148,7 +148,7 @@ $ TENANT_ID=zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz <5>
 ----
 +
 --
-<1> Replace this with the name of your ROSA cluster.
+<1> Replace this with the name of your cluster.
 <2> Replace this value with the name you used in the OAuth callback URL that you generated earlier in this process.
 <3> Replace this with the Application (client) ID.
 <4> Replace this with the Client Secret.

--- a/cloud_experts_tutorials/cloud-experts-external-dns.adoc
+++ b/cloud_experts_tutorials/cloud-experts-external-dns.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-external-dns"]
-= Tutorial: Deploying the External DNS Operator on ROSA
+= Tutorial: Deploying the External DNS Operator on {product-title}
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-external-dns
 
@@ -18,7 +18,7 @@ toc::[]
 //  - Dustin Scott
 //---
 
-The External DNS Operator deploys and manages `ExternalDNS` to provide the name resolution for services and routes from the external DNS provider, like Amazon Route 53, to {product-title} (ROSA) clusters. In this tutorial, we will deploy and configure the External DNS Operator with a secondary ingress controller to manage DNS records in Amazon Route 53. 
+The External DNS Operator deploys and manages `ExternalDNS` to provide the name resolution for services and routes from the external DNS provider, like Amazon Route 53, to {product-title} clusters. In this tutorial, we will deploy and configure the External DNS Operator with a secondary ingress controller to manage DNS records in Amazon Route 53. 
 
 [IMPORTANT]
 ====
@@ -28,11 +28,12 @@ The `External DNS` Operator does not support STS using IAM Roles for Service Acc
 [id="cloud-experts-external-dns-prerequisites"]
 == Prerequisites
 
-* A ROSA Classic cluster
+//I have not substituted ROSA in the instance below because this is a specific mention of HCP in a Classic only Tutorial.
+* A {product-title} cluster
 +
 [NOTE]
 ====
-ROSA with HCP is not supported at this time.
+{rosa-title} is not supported at this time.
 ====
 +
 * A user account with `cluster-admin` privileges

--- a/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-hcp-activation-and-account-linking-tutorial.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id=“cloud-experts-rosa-hcp-activation-and-account-linking-tutorial”]
-= Tutorial: {hcp-title} activation and account linking
+= Tutorial: {product-title} activation and account linking
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-rosa-hcp-activation-and-account-linking-tutorial
 
@@ -15,7 +15,7 @@ toc::[]
 //  - Jiri Fiala
 //---
 
-This tutorial describes the process for activating {hcp-title-first} and linking to an AWS account, before deploying the first cluster.
+This tutorial describes the process for activating {product-title} and linking to an AWS account, before deploying the first cluster.
 
 [IMPORTANT]
 ====
@@ -24,30 +24,30 @@ If you have received a private offer for the product, make sure to proceed accor
 
 == Prerequisites
 
-* Log in to the Red{nbsp}Hat account that you want to associate with the AWS account that will activate the {hcp-title} product subscription.
-* The AWS account used for service billing can only be associated with a single Red{nbsp}Hat account. Typically an AWS payer account is the one that is used to subscribe to ROSA and used for account linking and billing.
-* All team members belonging to the same Red{nbsp}Hat organization can use the linked AWS account for service billing while creating {hcp-title} clusters.
+* Log in to the Red{nbsp}Hat account that you want to associate with the AWS account that will activate the {product-title} product subscription.
+* The AWS account used for service billing can only be associated with a single Red{nbsp}Hat account. Typically an AWS payer account is the one that is used to subscribe to {product-title} and used for account linking and billing.
+* All team members belonging to the same Red{nbsp}Hat organization can use the linked AWS account for service billing while creating {product-title} clusters.
 
 == Subscription enablement and AWS account setup
 
-. Activate the {hcp-title} product at the link:https://console.aws.amazon.com/rosa/home[AWS console page] by clicking the *Get started* button:
+. Activate the {product-title} product at the link:https://console.aws.amazon.com/rosa/home[AWS console page] by clicking the *Get started* button:
 +
 .Get started 
 +
 image::rosa-get-started.png[]
 +
-If you have activated ROSA before but did not complete the process, you can click the button and complete the account linking as described in the following steps.
+If you have activated {product-title} before but did not complete the process, you can click the button and complete the account linking as described in the following steps.
 
 . Confirm that you want your contact information to be shared with Red{nbsp}Hat and enable the service:
 +
-.Enable ROSA
+.Enable {product-title}
 image::rosa-enable-2.png[]
 +
 * You will not be charged by enabling the service in this step. The connection is made for billing and metering that will take place only after you deploy your first cluster. This could take a few minutes.
 +
 . After the process is completed, you will see a confirmation:
 +
-.ROSA enablement confirmation
+.{product-title} enablement confirmation
 +
 image::rosa-prereq-enable-3.png[]
 +
@@ -61,7 +61,7 @@ image::rosa-service-quota-4.png[]
 
 . If all the prerequisites are met, the page will look like this:
 +
-.Verify ROSA prerequisites 
+.Verify {product-title} prerequisites 
 +
 image::rosa-prereq-5.png[]
 +
@@ -87,9 +87,9 @@ Your AWS account must be linked to a single Red{nbsp}Hat organization.
 image::rosa-login-rh-account-7.png[]
 +
 * You can also register for a new Red{nbsp}Hat account or reset your password on this page.
-* Log in to the Red{nbsp}Hat account that you want to associate with the AWS account that has activated the {hcp-title} product subscription.
-* The AWS account used for service billing can only be associated with a single Red{nbsp}Hat account. Typically an AWS payer account is the one that is used to subscribe to ROSA and used for account linking and billing.
-* All team members belonging to the same Red{nbsp}Hat organization can use the linked AWS account for service billing while creating {hcp-title} clusters.
+* Log in to the Red{nbsp}Hat account that you want to associate with the AWS account that has activated the {product-title} product subscription.
+* The AWS account used for service billing can only be associated with a single Red{nbsp}Hat account. Typically an AWS payer account is the one that is used to subscribe to {product-title} and used for account linking and billing.
+* All team members belonging to the same Red{nbsp}Hat organization can use the linked AWS account for service billing while creating {product-title} clusters.
 
 . Complete the Red{nbsp}Hat account linking after reviewing the terms and conditions:
 +
@@ -110,7 +110,7 @@ Both the Red{nbsp}Hat and AWS account numbers are shown on this screen.
 
 . Click the *Connect accounts* button if you agree with the service terms.
 +
-If this is the first time you are using the {hybrid-console}, you will be asked to agree with the general managed services terms and conditions before being able to create the first ROSA cluster:
+If this is the first time you are using the {hybrid-console}, you will be asked to agree with the general managed services terms and conditions before being able to create the first cluster:
 +
 .Terms and conditions
 +
@@ -126,7 +126,7 @@ Submit your agreement once you have reviewed any additional terms when prompted 
 
 . The {hybrid-console-second} provides a confirmation that AWS account setup was completed and lists the prerequisites for cluster deployment:
 +
-.Complete ROSA prerequisites
+.Complete {product-title} prerequisites
 +
 image::rosa-cluster-create-10.png[]
 +
@@ -136,17 +136,11 @@ The last section of this page shows cluster deployment options, either using the
 +
 image::rosa-cli-ui-12.png[]
 
-== Selecting the AWS billing account for {hcp-title} during cluster deployment using the CLI
+== Selecting the AWS billing account for {product-title} during cluster deployment using the CLI
 
 [IMPORTANT]
 ====
-Make sure that you have the most recent ROSA command-line interface (CLI) and AWS CLI installed and have completed the ROSA prerequisites covered in the previous section. See 
-ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/cli_reference/rosa_cli/rosa-get-started-cli.html#rosa-get-started-cli[Help with ROSA CLI setup] and link:https://aws.amazon.com/cli/[Instructions to install the AWS CLI] for more information.
-endif::openshift-rosa-hcp[]
-ifndef::openshift-rosa-hcp[]
-xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[Help with ROSA CLI setup] and link:https://aws.amazon.com/cli/[Instructions to install the AWS CLI] for more information.
-endif::openshift-rosa-hcp[]
+Make sure that you have the most recent ROSA command-line interface (CLI) and AWS CLI installed and have completed the {product-title} prerequisites covered in the previous section. See xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[Help with ROSA CLI setup] and link:https://aws.amazon.com/cli/[Instructions to install the AWS CLI] for more information.
 ====
 
 . Initiate the cluster deployment using the `rosa create cluster` command. You can click the *copy* button on the link:https://console.redhat.com/openshift/create/rosa/getstarted[Set up Red{nbsp}Hat OpenShift Service on AWS (ROSA) console page] and paste the command in your terminal. This launches the cluster creation process in interactive mode:
@@ -157,25 +151,25 @@ image::rosa-cli-15.png[]
 
 . To use a custom AWS profile, one of the non-default profiles specified in your `~/.aws/credentials`, you can add the `–profile <profile_name>` selector to the rosa create cluster command so that the command looks like rosa create cluster `–profile stage`. If no AWS CLI profile is specified using this option, the default AWS CLI profile will determine the AWS infrastructure profile into which the cluster is deployed. The billing AWS profile is selected in one of the following steps.
 
-. When deploying a {hcp-title} cluster, the billing AWS account needs to be specified:
+. When deploying a {product-title} cluster, the billing AWS account needs to be specified:
 +
 .Specify the Billing Account
 +
 image::rosa-create-cli-billing-17.png[]
 +
 * Only AWS accounts that are linked to the user's logged in Red{nbsp}Hat account are shown.
-* The specified AWS account is charged for using the ROSA service.
-* An indicator shows if the ROSA contract is enabled or not enabled for a given AWS billing account.
+* The specified AWS account is charged for using the {product-title} service.
+* An indicator shows if the {product-title} contract is enabled or not enabled for a given AWS billing account.
 ** If you select an AWS billing account that shows the _Contract enabled_ label, on-demand consumption rates are charged only after the capacity of your pre-paid contract is consumed.
 ** AWS accounts without the _Contract enabled_ label are charged the applicable on-demand consumption rates.
 
 .Additional resources 
 
-* The detailed cluster deployment steps are beyond the scope of this tutorial. See xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Creating {hcp-title} clusters using the default options] for more details about how to complete the {hcp-title} cluster deployment using the CLI.
+* The detailed cluster deployment steps are beyond the scope of this tutorial. See xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Creating {product-title} clusters using the default options] for more details about how to complete the {product-title} cluster deployment using the CLI.
 
-== Selecting the AWS billing account for {hcp-title} during cluster deployment using the web console
+== Selecting the AWS billing account for {product-title} during cluster deployment using the web console
 
-. A cluster can be created using the web console by selecting the second option in the bottom section of the introductory *Set up ROSA* page:
+. A cluster can be created using the web console by selecting the second option in the bottom section of the introductory *Set up {product-title}* page:
 +
 .Deploy with web interface
 +
@@ -185,22 +179,22 @@ image::rosa-deploy-ui-19.png[]
 ====
 Complete the prerequisites before starting the web console deployment process. 
 
-The `rosa` CLI is required for certain tasks, such as creating the account roles. If you are deploying ROSA for the first time, follow this the CLI steps until running the `rosa whoami` command, before starting the web console deployment steps.
+The `rosa` CLI is required for certain tasks, such as creating the account roles. If you are deploying {product-title} for the first time, follow this the CLI steps until running the `rosa whoami` command, before starting the web console deployment steps.
 ====
 
-. The first step when creating a ROSA cluster using the web console is the control plane selection. Make sure the *Hosted* option is selected before clicking the *Next* button:
+. The first step when creating a {product-title} cluster using the web console is the control plane selection. Make sure the *Hosted* option is selected before clicking the *Next* button:
 +
 .Select hosted option
 +
 image::rosa-deploy-ui-hcp-20.png[]
 
-. The next step *Accounts and roles* allows you specifying the infrastructure AWS account, into which the ROSA cluster is deployed and where the resources are consumed and managed:
+. The next step *Accounts and roles* allows you specifying the infrastructure AWS account, into which the {product-title} cluster is deployed and where the resources are consumed and managed:
 +
 .AWS infrastructure account
 +
 image::rosa-ui-account-21.png[]
 +
-* Click the *How to associate a new AWS account*, if you don not see the account into which you want to deploy the ROSA cluster for detailed information on how to create or link account roles for this association.
+* Click the *How to associate a new AWS account*, if you don not see the account into which you want to deploy the {product-title} cluster for detailed information on how to create or link account roles for this association.
 * The `rosa` CLI is used for this.
 * If you are using multiple AWS accounts and have their profiles configured for the AWS CLI, you can use the `--profile` selector to specify the AWS profile when working with the `rosa` CLI commands.
 
@@ -211,8 +205,8 @@ image::rosa-ui-account-21.png[]
 image::rosa-ui-billing-22.png[]
 +
 * Only AWS accounts that are linked to the user's logged in Red{nbsp}Hat account are shown.
-* The specified AWS account is charged for using the ROSA service.
-* An indicator shows if the ROSA contract is enabled or not enabled for a given AWS billing account.
+* The specified AWS account is charged for using the {product-title} service.
+* An indicator shows if the {product-title} contract is enabled or not enabled for a given AWS billing account.
 ** If you select an AWS billing account that shows the _Contract enabled_ label, on-demand consumption rates are charged only after the capacity of your pre-paid contract is consumed.
 ** AWS accounts without the _Contract enabled_ label are charged the applicable on-demand consumption rates.
 
@@ -220,5 +214,5 @@ The following steps past the billing AWS account selection are beyond the scope 
 
 .Additional resources
 
-* For information on using the CLI to create a cluster, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-sts-creating-a-cluster-quickly[Creating a {hcp-title} cluster using the CLI].
-* See link:https://cloud.redhat.com/learning/learn:getting-started-red-hat-openshift-service-aws-rosa/resource/resources:how-deploy-cluster-red-hat-openshift-service-aws-using-console-ui[this learning path] for more details on how to complete ROSA cluster deployment using the web console.
+* For information on using the CLI to create a cluster, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-sts-creating-a-cluster-quickly[Creating a {product-title} cluster using the CLI].
+* See link:https://cloud.redhat.com/learning/learn:getting-started-red-hat-openshift-service-aws-rosa/resource/resources:how-deploy-cluster-red-hat-openshift-service-aws-using-console-ui[this learning path] for more details on how to complete cluster deployment using the web console.

--- a/cloud_experts_tutorials/cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing.adoc
@@ -1,33 +1,33 @@
 :_mod-docs-content-type: ASSEMBLY
 [id=“cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing”]
-= Tutorial: ROSA with HCP private offer acceptance and sharing
+= Tutorial: {product-title} private offer acceptance and sharing
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-rosa-with-hcp-private-offer-acceptance-and-sharing
 
 toc::[]
 
-This guide describes how to accept a private offer for {hcp-title-first} and how to ensure that all team members can use the private offer for the clusters they provision.
+This guide describes how to accept a private offer for {product-title} and how to ensure that all team members can use the private offer for the clusters they provision.
 
-{hcp-title} costs are composed of the AWS infrastructure costs and the {hcp-title} service costs. AWS infrastructure costs, such as the EC2 instances that are running the needed workloads, are charged to the AWS account where the infrastructure is deployed. ROSA service costs are charged to the AWS account specified as the "AWS billing account" when deploying a cluster.
+{product-title} costs are composed of the AWS infrastructure costs and the {product-title} service costs. AWS infrastructure costs, such as the EC2 instances that are running the needed workloads, are charged to the AWS account where the infrastructure is deployed. {product-title} service costs are charged to the AWS account specified as the "AWS billing account" when deploying a cluster.
 
-The cost components can be billed to different AWS accounts. Detailed description of how the ROSA service cost and AWS infrastructure costs are calculated can be found on the link:https://aws.amazon.com/rosa/pricing/[{product-title} Pricing page].
+The cost components can be billed to different AWS accounts. Detailed description of how the {product-title} service cost and AWS infrastructure costs are calculated can be found on the link:https://aws.amazon.com/rosa/pricing/[{product-title} Pricing page].
 
 == Accepting a private offer
 
-. When you get a private offer for {hcp-title}, you are provided with a unique URL that is accessible only by a specific AWS account ID that was specified by the seller.
+. When you get a private offer for {product-title}, you are provided with a unique URL that is accessible only by a specific AWS account ID that was specified by the seller.
 +
 [NOTE]
 ====
 Verify that you are logged in using the AWS account that was specified as the buyer. Attempting to access the offer using another AWS account produces a "page not found" error message as shown in Figure 11 in the troubleshooting section below.
 ====
 +
-.. You can see the offer selection drop down menu with a regular private offer pre-selected in Figure 1. This type of offer can be accepted only if the {hcp-title} was not activated before using the public offer or another private offer.
+.. You can see the offer selection drop down menu with a regular private offer pre-selected in Figure 1. This type of offer can be accepted only if the {product-title} was not activated before using the public offer or another private offer.
 +
 .Regular private offer
 +
 image::rosa-regular-private-offer.png[]
 +
-.. You can see a private offer that was created for an AWS account that previously activated {hcp-title} using the public offer, showing the product name and the selected private offer labeled as "Upgrade", that replaces the currently running contract for {hcp-title} in Figure 2.
+.. You can see a private offer that was created for an AWS account that previously activated {product-title} using the public offer, showing the product name and the selected private offer labeled as "Upgrade", that replaces the currently running contract for {product-title} in Figure 2.
 +
 .Private offer selection selection screen
 +
@@ -57,14 +57,14 @@ image::rosa-private-offer-details.png[]
 Private offers have several available configurations. 
 
 * It is possible that the private offer you are accepting is set up with a fixed future start date. 
-* If you do not have another active {hcp-title} subscription at the time of accepting the private offer, a public offer or an older private offer entitlement, accept the private offer itself and continue with the account linking and cluster deployment steps after the specified service start date. 
+* If you do not have another active {product-title} subscription at the time of accepting the private offer, a public offer or an older private offer entitlement, accept the private offer itself and continue with the account linking and cluster deployment steps after the specified service start date. 
 
-You must have an active {hcp-title} entitlement to complete these steps. Service start dates are always reported in the UTC time zone
+You must have an active {product-title} entitlement to complete these steps. Service start dates are always reported in the UTC time zone
 ====
 
 . Create or upgrade your contract. 
 +
-.. For private offers accepted by an AWS account that does not have {hcp-title} activated yet and is creating the first contract for this service, click the *Create contract button*.
+.. For private offers accepted by an AWS account that does not have {product-title} activated yet and is creating the first contract for this service, click the *Create contract button*.
 +
 .Create contract button
 +
@@ -101,16 +101,16 @@ These are always in UTC time zone.
 
 . Clicking the *Set up your account* button in the previous step takes you to the AWS and Red{nbsp}Hat account linking step. At this time, you are already logged in with the AWS account that accepted the offer. If you are not logged in with a Red{nbsp}Hat account, you will be prompted to do so.
 +
-{hcp-title} entitlement is shared with other team members through your Red{nbsp}Hat organization account. All existing users in the same Red{nbsp}Hat organization are able to select the billing AWS account that accepted the private offer by following the above described steps. You can link:https://www.redhat.com/wapps/ugc/protected/usermgt/userList.html[manage users in your Red{nbsp}Hat organization], when logged in as the Red{nbsp}Hat organization administrator, and invite or create new users.
+{product-title} entitlement is shared with other team members through your Red{nbsp}Hat organization account. All existing users in the same Red{nbsp}Hat organization are able to select the billing AWS account that accepted the private offer by following the above described steps. You can link:https://www.redhat.com/wapps/ugc/protected/usermgt/userList.html[manage users in your Red{nbsp}Hat organization], when logged in as the Red{nbsp}Hat organization administrator, and invite or create new users.
 +
 [NOTE]
 ====
-{hcp-title} private offer cannot be shared with AWS linked accounts through the AWS License Manager.
+{product-title} private offer cannot be shared with AWS linked accounts through the AWS License Manager.
 ====
 
-. Add any users that you want to deploy ROSA clusters. Check link:https://access.redhat.com/customer-service-users[this user management FAQ] for more details about Red{nbsp}Hat account user management tasks. 
+. Add any users that you want to deploy {product-title} clusters. Check link:https://access.redhat.com/customer-service-users[this user management FAQ] for more details about Red{nbsp}Hat account user management tasks. 
 
-. Verify that the already logged in Red{nbsp}Hat account includes all users that are meant to be ROSA cluster deployers benefiting from the accepted private offer.
+. Verify that the already logged in Red{nbsp}Hat account includes all users that are meant to be {product-title} cluster deployers benefiting from the accepted private offer.
 
 . Verify that the Red{nbsp}Hat account number and the AWS account ID are the desired accounts that are to be linked. This linking is unique and a Red{nbsp}Hat account can be connected only with a single AWS (billing) account.
 +
@@ -126,13 +126,13 @@ An AWS account can be connected with a single Red{nbsp}Hat account only. Once Re
 
 == AWS billing account selection
 
-* When deploying {hcp-title} clusters, verify that end users select the AWS billing account that accepted the private offer. 
+* When deploying {product-title} clusters, verify that end users select the AWS billing account that accepted the private offer. 
 
-* When using the web interface for deploying {hcp-title}, the Associated AWS infrastructure account" is typically set to the AWS account ID used by the administrator of the cluster that is being created. 
+* When using the web interface for deploying {product-title}, the Associated AWS infrastructure account" is typically set to the AWS account ID used by the administrator of the cluster that is being created. 
 ** This can be the same AWS account as the billing AWS account. 
 ** AWS resources are deployed into this account and all the billing associated with those resources are processed accordingly.
 +
-.Infrastructure and billing AWS account selection during {hcp-title} cluster deployment
+.Infrastructure and billing AWS account selection during {product-title} cluster deployment
 +
 image::rosa-infrastructure-and-billing-aws-account-selection-during-rosa-with-hcp-cluster-deployment.png[]
 +
@@ -143,15 +143,15 @@ image::rosa-infrastructure-and-billing-aws-account-selection-during-rosa-with-hc
 
 == Example scenario
 
-* John is developer who briefly tested {hcp-title} by activating the service using their AWS account 123412341234, then deleted the cluster after the trial was completed.
+* John is developer who briefly tested {product-title} by activating the service using their AWS account 123412341234, then deleted the cluster after the trial was completed.
 * John is responsible for the company's main AWS account 111111111111 and manages their AWS organization with several linked AWS accounts.
-* John accepts a private offer for {hcp-title} as described in "Accepting a private offer".
+* John accepts a private offer for {product-title} as described in "Accepting a private offer".
 * John connects the AWS account 111111111111, that was used for accepting the private offer, with their Red{nbsp}Hat account right after accepting the private offer as described in "Connecting AWS and Red{nbsp}Hat accounts".
-* Anne wants to deploy a new ROSA cluster. Normally, they use their AWS account 123412341234 which is linked to the master AWS account 111111111111 for all cloud infrastructure needs.
+* Anne wants to deploy a new {product-title} cluster. Normally, they use their AWS account 123412341234 which is linked to the master AWS account 111111111111 for all cloud infrastructure needs.
 * John makes sure that Anne Red{nbsp}Hat user is in the same Red{nbsp}Hat organization as John’s Red{nbsp}Hat user. John is the Red{nbsp}Hat organization administrator and can do that here.
 * Anne visits the {hybrid-console} and starts a new cluster deployment.
 * During the initial steps, Anne makes sure to select 111111111111 as the AWS billing account, while using their own AWS account 123412341234 as the AWS infrastructure account.
-* Note that Anne is also able to select their own AWS account 123412341234 as the billing account when creating a cluster because they previously activated the ROSA with HCP public offer. However, that would result in custom private offer pricing not being applied to this cluster. Therefore it is important for John to communicate the information about which AWS billing account is to be used by employees when creating a new cluster in order to benefit from a private offer that was accepted before.
+* Note that Anne is also able to select their own AWS account 123412341234 as the billing account when creating a cluster because they previously activated the {product-title} public offer. However, that would result in custom private offer pricing not being applied to this cluster. Therefore it is important for John to communicate the information about which AWS billing account is to be used by employees when creating a new cluster in order to benefit from a private offer that was accepted before.
 ////
 
 == Troubleshooting
@@ -170,7 +170,7 @@ image::rosa-http-404-error-when-using-the-private-offer-url.png[]
 
 === The private offer cannot be accepted because of active subscription
 
-* If you try accessing a private offer that was created for the first time {hcp-title} activation, while you already have {hcp-title} activated using another public or private offer, and see the following notice, then contact the seller who provided you with the offer. 
+* If you try accessing a private offer that was created for the first time {product-title} activation, while you already have {product-title} activated using another public or private offer, and see the following notice, then contact the seller who provided you with the offer. 
 +
 The seller can provide you with a new offer that will seamlessly replace your current agreement, without a need to cancel your previous subscription.
 +
@@ -190,7 +190,7 @@ image::rosa-aws-account-is-already-linked-to-a-different-red-hat-account.png[]
 
 ** However, since this guide pertains to private offers, the assumption is that you are logged in with the AWS account that was specified as the buyer and already accepted the private offer so it is intended to be used as the billing account. Logging in as another AWS account is not expected after a private offer was accepted.
 
-* You can still log in with another Red{nbsp}Hat user which is already connected to the AWS account that accepted the private offer. Other Red{nbsp}Hat users belonging to the same Red{nbsp}Hat organization are able to use the linked AWS account as the ROSA with HCP AWS billing account when creating clusters as seen in Figure 10.
+* You can still log in with another Red{nbsp}Hat user which is already connected to the AWS account that accepted the private offer. Other Red{nbsp}Hat users belonging to the same Red{nbsp}Hat organization are able to use the linked AWS account as the {product-title} AWS billing account when creating clusters as seen in Figure 10.
 
 * If you believe that the existing account linking might not be correct, see the "My team members belong to different Red{nbsp}Hat organizations" question below for tips on how you can proceed.
 

--- a/cloud_experts_tutorials/cloud-experts-template-tutorial.adoc
+++ b/cloud_experts_tutorials/cloud-experts-template-tutorial.adoc
@@ -58,8 +58,8 @@ Check out the syntax guide below for examples of what you can add here.
 //TODO: If no other resources are likely to be needed, just delete this block.
 [id='cloud-experts-<topic>-tutorial-additional-resources']
 == Additional resources
-* link:https://cloud.redhat.com/experts/rosa/verify-permissions[Verify required permissions for a ROSA STS deployment]
-* link:https://cloud.redhat.com/experts/rosa/ecr[Configure a ROSA cluster to pull images from AWS Elastic Container Registry]
+* link:https://cloud.redhat.com/experts/rosa/verify-permissions[Verify required permissions for {product-title} STS deployment]
+* link:https://cloud.redhat.com/experts/rosa/ecr[Configure a {product-title} cluster to pull images from AWS Elastic Container Registry]
 
 //TODO: When you are finished writing your tutorial, delete everything below this line.
 // These are just some basic syntax examples so you can copy and paste easily.

--- a/cloud_experts_tutorials/cloud-experts-update-component-routes.adoc
+++ b/cloud_experts_tutorials/cloud-experts-update-component-routes.adoc
@@ -6,11 +6,11 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-:fn-supported-versions: footnote:[Modifying these routes on {product-title} ROSA versions prior to 4.14 is not typically supported. However, if you have a cluster using version 4.13, you can request for Red Hat Support to enable support for this feature on your version 4.13 cluster by link:https://access.redhat.com/support/cases/new[opening a support case].]
-:fn-term-component-routes: footnote:[We use the term "component routes" to refer to the OAuth, Console, and Downloads routes that are provided when ROSA are first installed.]
+:fn-supported-versions: footnote:[Modifying these routes on {product-title} versions prior to 4.14 is not typically supported. However, if you have a cluster using version 4.13, you can request for Red Hat Support to enable support for this feature on your version 4.13 cluster by link:https://access.redhat.com/support/cases/new[opening a support case].]
+:fn-term-component-routes: footnote:[We use the term "component routes" to refer to the OAuth, Console, and Downloads routes that are provided when {product-title} is first installed.]
 
 //Article text
-This guide demonstrates how to modify the hostname and TLS certificate of the Web console, OAuth server, and Downloads component routes in {product-title} (ROSA) version 4.14 and above.{fn-supported-versions}
+This guide demonstrates how to modify the hostname and TLS certificate of the Web console, OAuth server, and Downloads component routes in {product-title} version 4.14 and above.{fn-supported-versions}
 
 The changes that we make to the component routes{fn-term-component-routes} in this guide are described in greater detail in the customizing the link:https://docs.openshift.com/container-platform/latest/authentication/configuring-internal-oauth.html#customizing-the-oauth-server-url_configuring-internal-oauth[internal OAuth server URL], link:https://docs.openshift.com/container-platform/latest/web_console/customizing-the-web-console.html#customizing-the-console-route_customizing-web-console[console route], and link:https://docs.openshift.com/container-platform/latest/web_console/customizing-the-web-console.html#customizing-the-download-route_customizing-web-console[download route] OpenShift Container Platform documentation. 
 
@@ -18,11 +18,11 @@ The changes that we make to the component routes{fn-term-component-routes} in th
 == Prerequisites
 * ROSA CLI (`rosa`) version 1.2.37 or higher
 * AWS CLI (`aws`)
-* A ROSA Classic cluster version 4.14 or higher
+* A {product-title} cluster version 4.14 or higher
 +
 [NOTE]
 ====
-ROSA with HCP is not supported at this time.
+{rosa-title} is not supported at this time.
 ====
 +
 * OpenShift CLI (`oc`)

--- a/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-alb-and-waf.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-using-alb-and-waf"]
-= Tutorial: Using AWS WAF and AWS ALBs to protect ROSA workloads
+= Tutorial: Using AWS WAF and AWS ALBs to protect {product-title} workloads
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-using-alb-and-waf
 
@@ -19,7 +19,7 @@ toc::[]
 
 AWS WAF is a web application firewall that lets you monitor the HTTP and HTTPS requests that are forwarded to your protected web application resources.
 
-You can use an AWS Application Load Balancer (ALB) to add a Web Application Firewall (WAF) to your {product-title} (ROSA) workloads. Using an external solution protects ROSA resources from experiencing denial of service due to handling the WAF.
+You can use an AWS Application Load Balancer (ALB) to add a Web Application Firewall (WAF) to your {product-title} workloads. Using an external solution protects {product-title} resources from experiencing denial of service due to handling the WAF.
 
 [IMPORTANT]
 ====
@@ -29,11 +29,11 @@ It is recommended that you use the more flexible xref:../cloud_experts_tutorials
 [id="prerequisites_{context}"]
 == Prerequisites
 
-* Multiple availability zone (AZ) ROSA (HCP or Classic) cluster.
+* Multiple availability zone (AZ) {product-title} cluster.
 +
 [NOTE]
 ====
-AWS ALBs require at least two _public_ subnets across AZs, link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#availability-zones[per the AWS documentation]. For this reason, only multiple AZ ROSA clusters can be used with ALBs.
+AWS ALBs require at least two _public_ subnets across AZs, link:https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#availability-zones[per the AWS documentation]. For this reason, only multiple AZ {product-title} clusters can be used with ALBs.
 ====
 +
 * You have access to the OpenShift CLI (`oc`).
@@ -64,7 +64,7 @@ $ echo "Cluster: $(echo ${CLUSTER} | sed 's/-[a-z0-9]\{5\}$//'), Region: ${REGIO
 This section only applies to clusters that were deployed into existing VPCs. If you did not deploy your cluster into an existing VPC, skip this section and proceed to the installation section below.
 ====
 
-. Set the below variables to the proper values for your ROSA deployment:
+. Set the below variables to the proper values for your {product-title} deployment:
 +
 [source,terminal]
 ----
@@ -109,7 +109,7 @@ $ aws ec2 create-tags \
 [id="deploy-aws-load-balancer-operator_{context}"]
 == Deploy the AWS Load Balancer Operator
 
-The link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator] is used to used to install, manage and configure an instance of `aws-load-balancer-controller` in a ROSA cluster. To deploy ALBs in ROSA, we need to first deploy the AWS Load Balancer Operator.
+The link:https://github.com/openshift/aws-load-balancer-operator[AWS Load Balancer Operator] is used to used to install, manage and configure an instance of `aws-load-balancer-controller` in a {product-title} cluster. To deploy ALBs in {product-title}, we need to first deploy the AWS Load Balancer Operator.
 
 . Create a new project to deploy the AWS Load Balancer Operator into by running the following command:
 +
@@ -343,7 +343,7 @@ Hello OpenShift!
 [id="configure-aws-waf_{context}"]
 === Configure the AWS WAF
 
-The link:https://aws.amazon.com/waf/[AWS WAF] service is a web application firewall that lets you monitor, protect, and control the HTTP and HTTPS requests that are forwarded to your protected web application resources, like ROSA.
+The link:https://aws.amazon.com/waf/[AWS WAF] service is a web application firewall that lets you monitor, protect, and control the HTTP and HTTPS requests that are forwarded to your protected web application resources, like {product-title}.
 
 . Create a AWS WAF rules file to apply to our web ACL:
 +

--- a/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id=“cloud-experts-using-aws-ack]
-= Tutorial: Using AWS Controllers for Kubernetes on ROSA
+= Tutorial: Using AWS Controllers for Kubernetes on {product-title}
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-using-aws-ack
 
@@ -18,7 +18,7 @@ toc::[]
 //  - Connor Wooley
 //---
 
-link:https://aws-controllers-k8s.github.io/community/[AWS Controllers for Kubernetes] (ACK) lets you define and use AWS service resources directly from {product-title} (ROSA). With ACK, you can take advantage of AWS-managed services for your applications without needing to define resources outside of the cluster or run services that provide supporting capabilities such as databases or message queues within the cluster.
+link:https://aws-controllers-k8s.github.io/community/[AWS Controllers for Kubernetes] (ACK) lets you define and use AWS service resources directly from {product-title}. With ACK, you can take advantage of AWS-managed services for your applications without needing to define resources outside of the cluster or run services that provide supporting capabilities such as databases or message queues within the cluster.
 
 You can install various ACK Operators directly from OperatorHub. This makes it easy to get started and use the Operators with your applications. This controller is a component of the AWS Controller for Kubernetes project, which is currently in developer preview.
 
@@ -27,7 +27,7 @@ Use this tutorial to deploy the ACK S3 Operator. You can also adapt it for any o
 [id="cloud-experts-using-aws-ack-prerequisites"]
 == Prerequisites
 
-* A ROSA cluster
+* A {product-title} cluster
 * A user account with `cluster-admin` privileges
 * The OpenShift CLI (`oc`)
 * The Amazon Web Services (AWS) CLI (`aws`)

--- a/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-cloudfront-and-waf.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cloud-experts-using-cloudfront-and-waf"]
-= Tutorial: Using AWS WAF and Amazon CloudFront to protect ROSA workloads
+= Tutorial: Using AWS WAF and Amazon CloudFront to protect {product-title} workloads
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-using-cloudfront-and-waf
 
@@ -19,12 +19,12 @@ toc::[]
 
 AWS WAF is a web application firewall that lets you monitor the HTTP and HTTPS requests that are forwarded to your protected web application resources.
 
-You can use an Amazon CloudFront to add a Web Application Firewall (WAF) to your {product-title} (ROSA) workloads. Using an external solution protects ROSA resources from experiencing denial of service due to handling the WAF.
+You can use an Amazon CloudFront to add a Web Application Firewall (WAF) to your {product-title} workloads. Using an external solution protects {product-title} resources from experiencing denial of service due to handling the WAF.
 
 [id="prerequisites_{context}"]
 == Prerequisites
 
-* A ROSA (HCP or Classic) cluster.
+* A {product-title} cluster.
 * You have access to the OpenShift CLI (`oc`).
 * You have access to the AWS CLI (`aws`).
 
@@ -134,7 +134,7 @@ router-cloudfront-waf   LoadBalancer   172.30.16.141   a68a838a7f26440bf8647809b
 [id="configure-aws-waf_{context}"]
 === Configure the AWS WAF
 
-The link:https://aws.amazon.com/waf/[AWS WAF] service is a web application firewall that lets you monitor, protect, and control the HTTP and HTTPS requests that are forwarded to your protected web application resources, like ROSA.
+The link:https://aws.amazon.com/waf/[AWS WAF] service is a web application firewall that lets you monitor, protect, and control the HTTP and HTTPS requests that are forwarded to your protected web application resources, like {product-title}.
 
 . Create a AWS WAF rules file to apply to our web ACL:
 +

--- a/cloud_experts_tutorials/rosa-mobb-cli-quickstart.adoc
+++ b/cloud_experts_tutorials/rosa-mobb-cli-quickstart.adoc
@@ -150,7 +150,7 @@ $ aws configure
 3. Place the extracted `oc` executable in your OS path or local directory
 
 
-### Set up the ROSA CLI
+### Set up the {product-title} CLI
 
 1. Download the OS specific ROSA CLI from [Red Hat](https://www.openshift.com/products/amazon-openshift/download)
 
@@ -158,7 +158,7 @@ $ aws configure
 
 3. Place the extracted `rosa` and `kubectl` executables in your OS path or local directory
 
-4. Log in to ROSA
+4. Log in to {product-title}
 
   ```bash
   rosa login
@@ -170,9 +170,9 @@ $ aws configure
   Logged in as <email address> on 'https://api.openshift.com'
   ```
 
-### Verify ROSA privileges
+### Verify {product-title} privileges
 
-Verify that ROSA has the minimal permissions
+Verify that {product-title} has the minimal permissions
 
   ```bash
   rosa verify permissions
@@ -180,7 +180,7 @@ Verify that ROSA has the minimal permissions
 >Expected output: `AWS SCP policies ok`
 
 
-Verify that ROSA has the minimal quota
+Verify that {product-title} has the minimal quota
 
   ```bash
   rosa verify quota
@@ -188,7 +188,7 @@ Verify that ROSA has the minimal quota
 >Expected output: `AWS quota ok`
 
 
-### Initialize ROSA
+### Initialize {product-title}
 
 Initialize the ROSA CLI to complete the remaining validation checks and configurations
 
@@ -196,11 +196,11 @@ Initialize the ROSA CLI to complete the remaining validation checks and configur
   rosa init
   ```
 
-## Deploy Red Hat OpenShift on AWS (ROSA)
+## Deploy {product-title}
 
 ### Interactive Installation
 
-ROSA can be installed using command-line parameters or in interactive mode.  For an interactive installation run the following command
+{product-title} can be installed using command-line parameters or in interactive mode. For an interactive installation run the following command
 
   ```bash
   rosa create cluster --interactive --mode auto
@@ -226,7 +226,7 @@ ROSA can be installed using command-line parameters or in interactive mode.  For
   ```
   >Note: the installation process should take between 30 - 45 minutes
 
-### Get the web console link to the ROSA cluster
+### Get the web console link to the {product-title} cluster
 
 To get the web console link run the following command.
 
@@ -238,7 +238,7 @@ To get the web console link run the following command.
 
 ### Create cluster-admin user
 
-By default, only the OpenShift SRE team will have access to the ROSA cluster.  To add a local admin user, run the following command to create the `cluster-admin` account in your cluster.
+By default, only the OpenShift SRE team will have access to the {product-title} cluster. To add a local admin user, run the following command to create the `cluster-admin` account in your cluster.
 
 >Substitute your actual cluster name for `<cluster-name>`
 
@@ -247,9 +247,9 @@ By default, only the OpenShift SRE team will have access to the ROSA cluster.  T
   ```
 >Refresh your web browser and you should see the `cluster-admin` option to log in
 
-## Delete Red Hat OpenShift on AWS (ROSA)
+## Delete {product-title}
 
-Deleting a ROSA cluster consists of two parts
+Deleting a {product-title} cluster consists of two parts
 
 1. Delete the cluster instance, including the removal of AWS resources.
 

--- a/cloud_experts_tutorials/rosa-mobb-prerequisites-tutorial.adoc
+++ b/cloud_experts_tutorials/rosa-mobb-prerequisites-tutorial.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-mobb-prerequisites-tutorial"]
-= Tutorial: ROSA prerequisites
+= Tutorial: {product-title} prerequisites
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-mobb-prerequisites-tutorial
 
@@ -19,14 +19,14 @@ toc::[]
 //---
 //This file is not being built as of 2023-09-22 based on a conversation with Michael McNeill.
 
-This document contains a set of prerequisites that must be run once before you can create your first ROSA cluster.
+This document contains a set of prerequisites that must be run once before you can create your first {product-title} cluster.
 
 == AWS
 
-An AWS account with the link:https://console.aws.amazon.com/rosa/home?#/get-started[AWS ROSA prerequisites] met.
+An AWS account with the link:https://console.aws.amazon.com/rosa/home?#/get-started[AWS {product-title} prerequisites] met.
 
 
-image::rosa-aws-pre.png[AWS console ROSA prequisites]
+image::rosa-aws-pre.png[AWS console {product-title} prerequisites]
 
 == AWS CLI
 
@@ -163,7 +163,7 @@ $ aws iam create-service-linked-role --aws-service-name \
 . Download the operating system specific ROSA CLI from link:https://www.openshift.com/products/amazon-openshift/download[Red Hat].
 . Extract the downloaded file on your local machine.
 . Place the extracted `rosa` and `kubectl` executables in your operating system path or local directory.
-. Log in to ROSA:
+. Log in to {product-title}:
 +
 [source,terminal]
 ----
@@ -177,7 +177,7 @@ You will be prompted to enter in the *Red Hat Offline Access Token* you retrieve
 Logged in as <email address> on 'https://api.openshift.com'
 ----
 +
-. Verify that ROSA has the minimal quota:
+. Verify that {product-title} has the minimal quota:
 +
 [source,terminal]
 ----
@@ -193,9 +193,9 @@ AWS quota ok
 
 == Associate your AWS account with your Red Hat account
 
-To perform ROSA cluster provisioning tasks, you must create `ocm-role` and `user-role` IAM resources in your AWS account and link them to your Red Hat organization.
+To perform {product-title} cluster provisioning tasks, you must create `ocm-role` and `user-role` IAM resources in your AWS account and link them to your Red Hat organization.
 
-. Create the `ocm-role` which the OpenShift Cluster Manager will use to be able to administer and Create ROSA clusters. If this has already been done for your OpenShift Cluster Manager Organization, you can skip to creating the user-role:
+. Create the `ocm-role` which the OpenShift Cluster Manager will use to be able to administer and create {product-title} clusters. If this has already been done for your OpenShift Cluster Manager Organization, you can skip to creating the user-role:
 +
 [TIP]
 ====
@@ -219,7 +219,7 @@ If you have multiple AWS accounts that you want to associate with your Red Hat O
 $ rosa create user-role --mode auto --yes
 ----
 +
-. Create the ROSA Account Roles which give the ROSA installer and machines permissions to perform actions in your account:
+. Create the {product-title} Account Roles which give the {product-title} installer and machines permission to perform actions in your account:
 +
 [source,terminal]
 ----

--- a/cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.adoc
+++ b/cloud_experts_tutorials/rosa-mobb-verify-permissions-sts-deployment.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-mobb-verify-permissions-sts-deployment"]
-= Tutorial: Verifying permissions for a ROSA STS deployment
+= Tutorial: Verifying permissions for a {product-title} STS deployment
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-mobb-verify-permissions-sts-deployment
 
@@ -15,34 +15,23 @@ toc::[]
 // tags: ["AWS", "ROSA", "STS"]
 // ---
 
-To proceed with the deployment of a ROSA cluster, an account must support the required roles and permissions.
+To proceed with the deployment of a {product-title} cluster, an account must support the required roles and permissions.
 AWS Service Control Policies (SCPs) cannot block the API calls made by the installer or Operator roles.
 
-Details about the IAM resources required for an STS-enabled installation of ROSA can be found here: xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources]
-ifndef::openshift-rosa-hcp[]
-Details about the IAM resources required for an STS-enabled installation of ROSA can be found here: xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for ROSA clusters that use STS]
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa-hcp[]
-Details about the IAM resources required for an STS-enabled installation of ROSA can be found here: link:https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html[About IAM resources for ROSA clusters]
-endif::openshift-rosa-hcp[]
+Details about the IAM resources required for an STS-enabled installation of {product-title} can be found here: xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for {product-title} clusters that use STS].
 
-This guide is validated for ROSA v4.11.X.
+This guide is validated for {product-title} v4.11.X.
 
 == Prerequisites
 
 * link:https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html[AWS CLI]
-ifndef::openshift-rosa-hcp[]
 * xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-get-started-cli[ROSA CLI] v1.2.6
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa-hcp[]
-* link:https://docs.openshift.com/rosa/cli_reference/rosa_cli/rosa-get-started-cli.html[ROSA CLI] v1.2.6
-endif::openshift-rosa-hcp[]
 * link:https://stedolan.github.io/jq/[jq CLI]
 * link:https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html[AWS role with required permissions]
 
 [id="verify-ROSA-permissions_{context}"]
-== Verifying ROSA permissions
-To verify the permissions required for ROSA, we can run the script included in the following section without ever creating any AWS resources.
+== Verifying {product-title} permissions
+To verify the permissions required for {product-title}, we can run the script included in the following section without ever creating any AWS resources.
 
 The script uses the `rosa`, `aws`, and `jq` CLI commands to create files in the working directory that will be used to verify permissions in the account connected to the current AWS configuration.
 


### PR DESCRIPTION
[OSDOCS-14500](https://issues.redhat.com//browse/OSDOCS-14500): Prune "Tutorials"

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-14500

Link to docs preview:
ROSA HCP: https://98004--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cloud_experts_tutorials/
ROSA Classic: https://98004--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
