### PR TITLE
OSDOCS-15950 [NETOBSERV] Aditi tool results: network-observability-netobserv-cli-install.adoc

### DIFF
--- a/modules/network-observability-netobserv-cli-install.adoc
+++ b/modules/network-observability-netobserv-cli-install.adoc
@@ -5,15 +5,17 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-cli-install_{context}"]
 = Installing the Network Observability CLI
-Installing the Network Observability CLI (`oc netobserv`) is a separate procedure from the Network Observability Operator installation. This means that, even if you have the Operator installed from OperatorHub, you need to install the CLI separately. 
+
+[role="_abstract"]
+Installing the Network Observability CLI (`oc netobserv`) is a separate procedure from the Network Observability Operator installation. This means that, even if you have the Operator installed from OperatorHub, you need to install the CLI separately.
 
 [NOTE]
 ====
-You can optionally use Krew to install the `netobserv` CLI plugin. For more information, see "Installing a CLI plugin with Krew". 
+You can optionally use Krew to install the `netobserv` CLI plugin. For more information, see "Installing a CLI plugin with Krew".
 ====
 
 .Prerequisites
-* You must install the {oc-first}. 
+* You must install the {oc-first}.
 * You must have a macOS or Linux operating system.
 
 .Procedure
@@ -46,7 +48,6 @@ $ sudo mv ./oc-netobserv-amd64 /usr/local/bin/oc-netobserv
 $ oc netobserv version
 ----
 +
-.Example output
 [source,terminal]
 ----
 Netobserv CLI version <version>


### PR DESCRIPTION
[OSDOCS-15950](https://issues.redhat.com//browse/OSDOCS-15950) [NETOBSERV] Aditi tool results: network-observability-netobserv-cli-install.adoc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15950

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE is not required for this PR. This PR addresses style and format issues as found by the Aditi tool.

Additional information:

- Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures.
- This will likely apply to release notes since it is 1 assembly file and not all content in release notes is applicable to all OCP branches.
- For each cherry-pick failure, I will manually verify the content, and create manual cherry-picks accordingly.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
