### PR TITLE
OSDOCS-14172: Adding docs for supported Kueue environments and arch

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -116,3 +116,4 @@
 //Kueue
 :platform: Red Hat OpenShift Container Platform
 :kueue-op: Red Hat Build of Kueue Operator
+:ms: Red{nbsp}Hat build of MicroShift (MicroShift)

--- a/disconnected/install-disconnected.adoc
+++ b/disconnected/install-disconnected.adoc
@@ -16,6 +16,8 @@ After enabling OLM in a disconnected environment, you can continue to use your u
 
 For full documentation on completing these steps, see the {platform} documentation on link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/disconnected_environments/olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].
 
+include::modules/compatible-environments.adoc[leveloffset=+1]
+
 include::modules/install-kueue-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/install/install-kueue.adoc
+++ b/install/install-kueue.adoc
@@ -8,10 +8,13 @@ toc::[]
 
 You can install {product-title} by using the {kueue-op} in OperatorHub.
 
+include::modules/compatible-environments.adoc[leveloffset=+1]
+
 include::modules/install-kueue-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift#installing-the-cert-manager-operator-for-red-hat-openshift[Installing the {cert-manager-operator}]
 
 include::modules/create-kueue-cr.adoc[leveloffset=+1]

--- a/modules/compatible-environments.adoc
+++ b/modules/compatible-environments.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * install/install-kueue.adoc
+// * disconnected/install-disconnected.adoc
+// * release_notes/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="compatible-environments_{context}"]
+= Compatible environments
+
+Before you install {product-title}, review this section to ensure that your cluster meets the requirements.
+
+[id="compatible-environments-arch_{context}"]
+== Supported architectures
+
+{product-title} is supported on the following architectures:
+
+* ARM64
+* 64-bit x86
+* ppc64le ({ibm-power-name})
+* s390x ({ibm-z-name})
+
+[id="compatible-environments-platforms_{context}"]
+== Supported platforms
+
+{product-title} is supported on the following platforms:
+
+* {platform}
+* {hcp-capital} for {platform}
+
+[IMPORTANT]
+====
+Currently, {product-title} is not supported on {ms}.
+====

--- a/release_notes/release-notes.adoc
+++ b/release_notes/release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 {product-title} is released as an Operator that is supported on {platform}.
 
+include::modules/compatible-environments.adoc[leveloffset=+1]
+
 include::modules/release-notes-1.0.1.adoc[leveloffset=+1]
 
 include::modules/release-notes-1.0.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- `kueue-docs`
- `kueue-docs-1.1`

Issue:

Fixes the following issues
- https://issues.redhat.com/browse/OSDOCS-14172
- https://issues.redhat.com/browse/OSDOCS-14052

Link to docs preview:
- https://98007--ocpdocs-pr.netlify.app/openshift-kueue/latest/install/install-kueue.html
- https://98007--ocpdocs-pr.netlify.app/openshift-kueue/latest/disconnected/install-disconnected
- https://98007--ocpdocs-pr.netlify.app/openshift-kueue/latest/release_notes/release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
