### PR TITLE
RHDEVDOCS-6528: Content updates in the Sizing requirements for GitOps section

### DIFF
--- a/modules/sizing-requirements-for-gitops.adoc
+++ b/modules/sizing-requirements-for-gitops.adoc
@@ -13,13 +13,13 @@ Every time you install the {gitops-title} Operator, the resources on the namespa
 [cols="2,2,2,2,2",options="header"]
 |===
 |Workload |CPU requests |CPU limits |Memory requests |Memory limits
-|argocd-application-controller |250m |2 |1024Mi |2048Mi
+|openshift-gitops-application-controller |250m |2 |1024Mi |2048Mi
 |applicationset-controller |250m |2 |512Mi |1024Mi
-|argocd-server |125m |500m |128Mi |256Mi
-|argocd-repo-server |250m |1 |256Mi |1024Mi
-|argocd-redis |250m |500m |128Mi |256Mi
-|argocd-dex-server |250m |500m |128Mi |256Mi
-|argocd-redis-ha-haproxy |200m |500m |128Mi |256Mi
+|openshift-gitops-server |125m |500m |128Mi |256Mi
+|openshift-gitops-repo-server |250m |1 |256Mi |1024Mi
+|openshift-gitops-redis |250m |500m |128Mi |256Mi
+|openshift-gitops-dex-server |250m |500m |128Mi |256Mi
+|openshift-gitops-redis-ha-haproxy |250m |500m |128Mi |256Mi
 |===
 
 Optionally, you can also use the ArgoCD custom resource with the `oc` command to see the specifics and modify them:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.18, gitops-docs-1.17

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6528

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

In the table, under the [Sizing requirements for GitOps](https://98016--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/preparing-gitops-install.html#sizing-requirements-for-gitops_preparing-gitops-install ) section, updated the value of the CPU requests row in the `argocd-redis-ha-haproxy` column as well as the column names under the **Workload** column.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review:
QE review:
Peer review:

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
