### PR TITLE
CNV-43321: change support for oracle cloud infra from TP to GA

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -67,10 +67,10 @@ endif::[]
 * link:https://docs.aws.amazon.com/rosa/latest/userguide/what-is-rosa.html[What is {product-rosa}?] in the {aws-short} documentation
 
 | {oci-first-no-rt}
-| Technology Preview
+| GA
 | {oci} native storage
 | * link:https://access.redhat.com/articles/7118050[{VirtProductName} and Oracle Cloud Infrastructure known issues and limitations] in the Red{nbsp}Hat Knowledgebase
-* link:https://github.com/oracle-quickstart/oci-openshift/blob/main/custom_manifests/oci-ccm-csi-drivers/v1.30.0-RWX-LA/openshift-virtualization.md[Installing {VirtProductName} on OCI] in the `oracle-quickstart/oci-openshift` GitHub repository
+* link:https://github.com/oracle-quickstart/oci-openshift/blob/main/docs/openshift-virtualization.md[Installing {VirtProductName} on OCI] in the `oracle-quickstart/oci-openshift` GitHub repository
 
 | Azure Red{nbsp}Hat OpenShift (ARO)
 | Technology Preview


### PR DESCRIPTION
Version(s):
Main, 4.20

Issue: [CNV-43321](https://issues.redhat.com/browse/CNV-43321)

[Link to docs preview](https://98033--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html)

QE review:
- [x] QE has approved this change.