### PR TITLE
OCPBUGS-60882: Add s360x architecture to pci-dss table as all pci-dss profiles are supported on IBM Z

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -345,6 +345,7 @@ Applying automatic remedations to any profile, such as `rhcos4-stig`, that uses 
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
  `ppc64le`
+ `s390x`
 |
 
 |ocp4-pci-dss-3-2 ^[3]^
@@ -362,6 +363,7 @@ Applying automatic remedations to any profile, such as `rhcos4-stig`, that uses 
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
  `ppc64le`
+ `s390x`
 |
 
 |ocp4-pci-dss-node ^[1]^
@@ -370,6 +372,7 @@ Applying automatic remedations to any profile, such as `rhcos4-stig`, that uses 
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library] 
 |`x86_64`
  `ppc64le`
+ `s390x`
 |{product-rosa} with {hcp} (ROSA HCP)
 
 |ocp4-pci-dss-node-3-2 ^[3]^
@@ -387,6 +390,7 @@ Applying automatic remedations to any profile, such as `rhcos4-stig`, that uses 
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
  `ppc64le`
+ `s390x`
 |{product-rosa} with {hcp} (ROSA HCP)
 |===
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-60882

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
