### PR TITLE
OSDOCS-15970 [NETOBSERV] Module Aditi tools results: Example Block

### DIFF
--- a/modules/network-observability-configuring-custom-metrics-examples.adoc
+++ b/modules/network-observability-configuring-custom-metrics-examples.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// network_observability/metrics-alerts-dashboards.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-configuring-custom-metrics-examples_{context}"]
+= Configuring custom metrics by using FlowMetric API examples
+
+[role="_abstract"]
+Examples of custom metrics using the `FlowMetric` API. You can add multiple `FlowMetric` resources to a project to see multiple dashboard views.
+
+[id="example-ingress-bytes-received-from-cluster-external-resources_{context}"]
+== Example to generate a metric that tracks ingress bytes received from cluster external sources
+
+You can configure the `FlowMetric` resource to generate a metric that tracks ingress bytes received from cluster external sources, similar to the following sample configuration:
+
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flowmetric-cluster-external-ingress-traffic
+  namespace: netobserv
+spec:
+  metricName: cluster_external_ingress_bytes_total
+  type: Counter
+  valueField: Bytes
+  direction: Ingress
+  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType]
+  filters:
+  - field: SrcSubnetLabel
+    matchType: Absence
+----
+* `metadata.namespace` must match the namespace defined in the `FlowCollector` `spec.namespace` object. This is `netobserv` by default.
+* `spec.metricName` defines the name of the Prometheus metric, which in the web console appears with the prefix `netobserv-<metricName>`.
+* `spec.type` field specifies the metric type. A `Counter` is useful for counting bytes or packets.
+* `spec.direction` defines the direction of traffic to capture. If not specified, both ingress and egress are captured, which can lead to duplicated counts.
+* `spec.labels` defines what the metrics look like and their relationship to different entities. They also define the metric's cardinality. For example, `SrcK8S_Name` is a high-cardinality metric.
+* `spec.filters` refines results based on the listed criteria. In this example,  selecting only the cluster external traffic is done by matching only flows where `SrcSubnetLabel` is absent. This assumes the subnet labels feature is enabled (via `spec.processor.subnetLabels`), which is done by default.
+
+[id="example-for-rounnd-trip-time_{context}"]
+== Example for Round-trip time
+
+You can configure the `FlowMetric` resource to show the Round-trip time (RTT) latency for cluster external ingress traffic, similar to the following sample configuration:
+
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowMetric
+metadata:
+  name: flowmetric-cluster-external-ingress-rtt
+  namespace: netobserv
+spec:
+  metricName: cluster_external_ingress_rtt_seconds
+  type: Histogram
+  valueField: TimeFlowRttNs
+  direction: Ingress
+  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType]
+  filters:
+  - field: SrcSubnetLabel
+    matchType: Absence
+  - field: TimeFlowRttNs
+    matchType: Presence
+  divider: "1000000000"
+  buckets: [".001", ".005", ".01", ".02", ".03", ".04", ".05", ".075", ".1", ".25", "1"]
+----
+* `metadata.namespace` must match the namespace defined in the `FlowCollector` `spec.namespace` object. This is `netobserv` by default.
+* `spec.type` specifies the type of metric. A `Histogram` is useful for a latency value (`TimeFlowRttNs`).
+* `divider` converts nanoseconds into seconds. RTT is provided in nanoseconds (`TimeFlowRttNs`) in flow logs. Use a divider of `1000000000` to convert the value into seconds, which is the standard Prometheus guideline.
+* The custom buckets specify precision on RTT, with optimal precision ranging between 5ms and 250ms.

--- a/modules/network-observability-configuring-custom-metrics.adoc
+++ b/modules/network-observability-configuring-custom-metrics.adoc
@@ -15,7 +15,7 @@ Configure the `FlowMetric` API to create custom Prometheus metrics by mapping fl
 . In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
 . In the *Project:*  dropdown list, select the project of the Network Observability Operator instance.
 . Click *Create FlowMetric*.
-. Configure the `FlowMetric` resource, similar to the following sample configurations:
+. Configure the `FlowMetric` resource to generate a metric that tracks ingress bytes received from cluster external sources, similar to the following sample configuration:
 +
 .Generate a metric that tracks ingress bytes received from cluster external sources
 
@@ -36,11 +36,11 @@ spec:
   - field: SrcSubnetLabel
     matchType: Absence
 ----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+<1> The `FlowMetric` resources must be created in the namespace defined in the `FlowCollector` `spec.namespace` object. This is `netobserv` by default.
 <2> The name of the Prometheus metric, which in the web console appears with the prefix `netobserv-<metricName>`.
-<3> The `type` specifies the type of metric. The `Counter` `type` is useful for counting bytes or packets.
+<3> The `type` field specifies the metric type. A `Counter` is useful for counting bytes or packets.
 <4> The direction of traffic to capture. If not specified, both ingress and egress are captured, which can lead to duplicated counts.
-<5> Labels define what the metrics look like and the relationship between the different entities and also define the metrics cardinality. For example, `SrcK8S_Name` is a high cardinality metric.
+<5> Labels define what the metrics look like and their relationship to different entities. They also define the metric's cardinality. For example, `SrcK8S_Name` is a high-cardinality metric.
 <6> Refines results based on the listed criteria. In this example,  selecting only the cluster external traffic is done by matching only flows where `SrcSubnetLabel` is absent. This assumes the subnet labels feature is enabled (via `spec.processor.subnetLabels`), which is done by default.
 
 .Verification
@@ -72,7 +72,7 @@ spec:
 ----
 <1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
 <2> The `type` specifies the type of metric. The `Histogram` `type` is useful for a latency value (`TimeFlowRttNs`).
-<3> Since the Round-trip time (RTT) is provided as nanos in flows, use a divider of 1 billion to convert into seconds, which is standard in Prometheus guidelines.
+<3> Since the RTT is provided as nanos in flows, use a divider of 1 billion to convert into seconds, which is standard in Prometheus guidelines.
 <4> The custom buckets specify precision on RTT, with optimal precision ranging between 5ms and 250ms.
 
 .Verification

--- a/modules/network-observability-configuring-custom-metrics.adoc
+++ b/modules/network-observability-configuring-custom-metrics.adoc
@@ -7,7 +7,7 @@
 = Configuring custom metrics by using FlowMetric API
 
 [role="_abstract"]
-Configure the `FlowMetric` API to create custom Prometheus metrics by mapping flow log fields as labels to meet specific monitoring needs.
+You can configure the `FlowMetric` API to create custom metrics by using flowlogs data fields as Prometheus labels. You can add multiple `FlowMetric` resources to a project to see multiple dashboard views.
 
 .Procedure
 
@@ -15,69 +15,8 @@ Configure the `FlowMetric` API to create custom Prometheus metrics by mapping fl
 . In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
 . In the *Project:*  dropdown list, select the project of the Network Observability Operator instance.
 . Click *Create FlowMetric*.
-. Configure the `FlowMetric` resource to generate a metric that tracks ingress bytes received from cluster external sources, similar to the following sample configuration:
-+
-.Generate a metric that tracks ingress bytes received from cluster external sources
-
-[source,yaml]
-----
-apiVersion: flows.netobserv.io/v1alpha1
-kind: FlowMetric
-metadata:
-  name: flowmetric-cluster-external-ingress-traffic
-  namespace: netobserv                              <1>
-spec:
-  metricName: cluster_external_ingress_bytes_total  <2>
-  type: Counter                                     <3>
-  valueField: Bytes
-  direction: Ingress                                <4>
-  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType] <5>
-  filters:                                          <6>
-  - field: SrcSubnetLabel
-    matchType: Absence
-----
-<1> The `FlowMetric` resources must be created in the namespace defined in the `FlowCollector` `spec.namespace` object. This is `netobserv` by default.
-<2> The name of the Prometheus metric, which in the web console appears with the prefix `netobserv-<metricName>`.
-<3> The `type` field specifies the metric type. A `Counter` is useful for counting bytes or packets.
-<4> The direction of traffic to capture. If not specified, both ingress and egress are captured, which can lead to duplicated counts.
-<5> Labels define what the metrics look like and their relationship to different entities. They also define the metric's cardinality. For example, `SrcK8S_Name` is a high-cardinality metric.
-<6> Refines results based on the listed criteria. In this example,  selecting only the cluster external traffic is done by matching only flows where `SrcSubnetLabel` is absent. This assumes the subnet labels feature is enabled (via `spec.processor.subnetLabels`), which is done by default.
-
-.Verification
-. Once the pods refresh, navigate to *Observe* -> *Metrics*.
-. In the *Expression* field, type the metric name to view the corresponding result. You can also enter an expression, such as `topk(5, sum(rate(netobserv_cluster_external_ingress_bytes_total{DstK8S_Namespace="my-namespace"}[2m])) by (DstK8S_HostName, DstK8S_OwnerName, DstK8S_OwnerType))`
-+
-.Show RTT latency for cluster external ingress traffic
-
-[source,yaml]
-----
-apiVersion: flows.netobserv.io/v1alpha1
-kind: FlowMetric
-metadata:
-  name: flowmetric-cluster-external-ingress-rtt
-  namespace: netobserv    <1>
-spec:
-  metricName: cluster_external_ingress_rtt_seconds
-  type: Histogram                 <2>
-  valueField: TimeFlowRttNs
-  direction: Ingress
-  labels: [DstK8S_HostName,DstK8S_Namespace,DstK8S_OwnerName,DstK8S_OwnerType]
-  filters:
-  - field: SrcSubnetLabel
-    matchType: Absence
-  - field: TimeFlowRttNs
-    matchType: Presence
-  divider: "1000000000"      <3>
-  buckets: [".001", ".005", ".01", ".02", ".03", ".04", ".05", ".075", ".1", ".25", "1"]  <4>
-----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
-<2> The `type` specifies the type of metric. The `Histogram` `type` is useful for a latency value (`TimeFlowRttNs`).
-<3> Since the RTT is provided as nanos in flows, use a divider of 1 billion to convert into seconds, which is standard in Prometheus guidelines.
-<4> The custom buckets specify precision on RTT, with optimal precision ranging between 5ms and 250ms.
+. Configure the `FlowMetric` resource for your custom metrics. For examples, see "Configuring custom metrics by using FlowMetric API examples".
 
 .Verification
 . Once the pods refresh, navigate to *Observe* -> *Metrics*.
 . In the *Expression* field, you can type the metric name to view the corresponding result.
-
-
-

--- a/observability/network_observability/metrics-alerts-dashboards.adoc
+++ b/observability/network_observability/metrics-alerts-dashboards.adoc
@@ -21,6 +21,8 @@ include::modules/network-observability-custom-metrics.adoc[leveloffset=+1]
 
 include::modules/network-observability-configuring-custom-metrics.adoc[leveloffset=+1]
 
+include::modules/network-observability-configuring-custom-metrics-examples.adoc[leveloffset=+2]
+
 include::modules/network-observability-creating-metrics-network-events.adoc[leveloffset=+1]
 
 [IMPORTANT]


### PR DESCRIPTION
[OSDOCS-15970](https://issues.redhat.com//browse/OSDOCS-15970) [NETOBSERV] Module Aditi tools results: Example Block

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15970

Link to docs preview:

* Configuring custom metrics by using FlowMetric API: https://98045--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards.html#network-observability-configuring-custom-metrics_metrics-dashboards-alerts
* Configuring custom metrics by using FlowMetric API examples: https://98045--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards.html#network-observability-configuring-custom-metrics-examples_metrics-dashboards-alerts
* 

QE review:
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- To adhere to Aditi tool results, some restructuring of content was required. As a result, requested Dev/QE review to verify info is still correct.
- Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures.
- This will likely apply to release notes since it is 1 assembly file and not all content in release notes is applicable to all OCP branches.
- If there are cherry-pick failures, I will manually verify the content, and create manual cherry-picks accordingly.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
