### PR TITLE
OSSM-10649 Fix the module link after the module "About deploying Istio using OSSM"

### DIFF
--- a/install/ossm-installing-openshift-service-mesh.adoc
+++ b/install/ossm-installing-openshift-service-mesh.adoc
@@ -14,8 +14,7 @@ Before installing {SMProduct} 3, make sure you are not running {SMProduct} 3 and
 ====
 
 include::modules/ossm-about-deploying-istio-using-service-mesh-operator.adoc[leveloffset=+1]
-include::modules/ossm-about-istio-control-plane-update-strategies.adoc
-[leveloffset=+2]
+include::modules/ossm-about-istio-control-plane-update-strategies.adoc[leveloffset=+2]
 include::modules/ossm-installing-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources-multiple-meshes"]


### PR DESCRIPTION
Change type: Doc update; Fix the module link after the module "About deploying Istio using OSSM"

Doc JIRA: https://issues.redhat.com/browse/OSSM-10649

Fix Version:
[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)
[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: https://98049--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-installing-openshift-service-mesh.html#ossm-about-deploying-istio-using-service-mesh-operator_ossm-installing-openshift-service-mesh

SME/QE Review: @MaxBab @dgn 
Peer Review: @rh-tokeefe 