### PR TITLE
TELCODOCS#2140: Temporary comment out of DAS

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3580,8 +3580,8 @@ Topics:
   File: gaudi-ai-accelerator
 - Name: Remote Direct Memory Access (RDMA)
   File: rdma-remote-direct-memory-access
-- Name: Dynamic Accelerator Slicer (DAS) Operator
-  File: das-about-dynamic-accelerator-slicer-operator
+# - Name: Dynamic Accelerator Slicer (DAS) Operator
+#   File: das-about-dynamic-accelerator-slicer-operator
 ---
 Name: Backup and restore
 Dir: backup_and_restore


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2140

Link to docs preview:
https://98066--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_accelerators/about-hardware-accelerators

QE review:
NA

Additional information:
The changes made in #97359/#97850 need to be temporarily reverted due to devs running into blocking bugs at the last minute. Cleanest solution without reverting completely is to comment out the new content from the topic map. We will remove the comments when publishing time comes.
