### PR TITLE
OSDOCS#15938: Update the z-stream RNs for 4.15.57

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2797,6 +2797,36 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.57
+[id="ocp-4-15-57_{context}"]
+=== RHSA-2025:14397 - {product-title} 4.15.57 bug fix and security update
+
+Issued: 27 August 2025
+
+{product-title} release 4.15.57 is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:14397[RHSA-2025:14397] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:14395[RHBA-2025:14395] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.57 --pullspecs
+----
+
+[id="ocp-4-15-57-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, a Machine Config Operator (MCO) deployed `MoneyChainNet` (MCN) custom resource definitions (CRD) in default clusters, which caused upgrade conflicts due to an {product-title} 4.15 feature. As a consequence, upgrade failures in {product-title} 4.15 caused cluster update instability. With this release, the MCN CRD deployment in default clusters is removed to avoid upgrade conflicts. As a result, the upgrade process does not fail. (link:https://issues.redhat.com/browse/OCPBUGS-59737[OCPBUGS-59737])
+
+* Before this update, navigating between tabs on the *Storage class* page with a multipath URL resulted in an error. As a consequence, blank pages appeared when switching tabs after loading the plugin on a *Storage class* page. With this release, there are no blank tabs on the *Storage class* page after switching from another tab because the invalid `href` is correct. (link:https://issues.redhat.com/browse/OCPBUGS-60029[OCPBUGS-60029])
+
+  * Before this update, when a cluster was created with an internal Image Registry Operator on {azure-first}, and used a reused storage account with a private endpoint, the cluster was not completely verified. This issue caused mount permission issues during the pod creation and with persistent volume claims (PVC) with the `azurefile-csi` storage class. As a consequence, users encountered pod failures and mount permission issues with private storage accounts. With this release, the `azurefile-csi` storage class supports private endpoints, and resolves mount permission issues with pre-existing private storage accounts. As a result, pods run successfully using the predefined storage class. (link:https://issues.redhat.com/browse/OCPBUGS-60544[OCPBUGS-60544])
+
+[id="ocp-4-15-57-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.15.56
 [id="ocp-4-15-56_{context}"]
 === RHSA-2025:12370 - {product-title} 4.15.56 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-15938](https://issues.redhat.com//browse/OSDOCS-15938)

Link to docs preview:
[4.15.57](https://98071--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-57_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 8/27/25.
