### PR TITLE
MIG-1763: MTC 1.8.10 release notes and attributes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -77,7 +77,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
-:mtc-version-z: 1.8.8
+:mtc-version-z: 1.8.10
 :mtc-legacy-image: 1.7
 :mtv-first: Migration Toolkit for Virtualization (MTV)
 :mtv-short: MTV

--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,6 +15,8 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-10.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-9.adoc[leveloffset=+1]
 
 include::modules/migration-mtc-release-notes-1-8-8.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-10.adoc
+++ b/modules/migration-mtc-release-notes-1-8-10.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-10_{context}"]
+= {mtc-full} 1.8.10 release notes
+
+[id="resolved-issues-1-8-10_{context}"]
+== Resolved issues
+
+{mtc-first} 1.8.10 has the following major resolved issues:
+
+.`migmigration` failed to clean up stale virt-handler pods for stopped VMs
+
+With this release, `migmigration` object no longer fails to clean up stale `virt-handler` pods for stopped virtual machines (VMs) in an Azure Red Hat OpenShift (ARO) cluster with {mtc-short} Operator and {odf-first} storage cluster-CEPH RBD virtualization. This resolution addresses an issue where migration failure occurred due to an attempt to clean up non-existent `virt-handler` pods during live migration when the VM was stopped and no VMI existed. As a result, stopped VMs no longer prevent successful migration. link:https://issues.redhat.com/browse/MIG-1762[(MIG-1762)]

--- a/modules/migration-mtc-release-notes-1-8-2.adoc
+++ b/modules/migration-mtc-release-notes-1-8-2.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * migration_toolkit_for_containers/release_notes/mtc-release-notes-1-8.adoc
+// * migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
 :_mod-docs-content-type: REFERENCE
 [id="migration-mtc-release-notes-1-8-2_{context}"]
 = {mtc-full} 1.8.2 release notes

--- a/modules/migration-mtc-release-notes-1-8-3.adoc
+++ b/modules/migration-mtc-release-notes-1-8-3.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * migration_toolkit_for_containers/release_notes/mtc-release-notes-1-8.adoc
+// * migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
 :_mod-docs-content-type: REFERENCE
 [id="migration-mtc-release-notes-1-8-3_{context}"]
 = {mtc-full} 1.8.3 release notes

--- a/modules/migration-mtc-release-notes-1-8-7.adoc
+++ b/modules/migration-mtc-release-notes-1-8-7.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * migration_toolkit_for_containers/mtc-release-notes-1-7.adoc
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="migration-mtc-release-notes-1-8-7_{context}"]

--- a/modules/migration-mtc-release-notes-1-8-8.adoc
+++ b/modules/migration-mtc-release-notes-1-8-8.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * migration_toolkit_for_containers/mtc-release-notes-1-7.adoc
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="migration-mtc-release-notes-1-8-8_{context}"]

--- a/modules/migration-mtc-release-notes-1-8-9.adoc
+++ b/modules/migration-mtc-release-notes-1-8-9.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * migration_toolkit_for_containers/mtc-release-notes-1-7.adoc
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="migration-mtc-release-notes-1-8-9_{context}"]


### PR DESCRIPTION
### JIRA

* [MIG-1763](https://issues.redhat.com/browse/MIG-1763)

### Version(s):

* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19
* OCP 4.20 → branch/enterprise-4.20
* OCP 4.21 → branch/enterprise-4.21

### Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

### Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

* [Migration Toolkit for Containers 1.8.10 release notes](https://98072--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes#migration-mtc-release-notes-1-8-10_mtc-release-notes)

### QE review:
- [X] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/98072#pullrequestreview-3212595905).
-  [X] [Rel Eng has approved this change](https://github.com/openshift/openshift-docs/pull/98072#pullrequestreview-3212224739)




<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
