### PR TITLE
[SRVLOGIC-522] Move kn workflow run step to project directory

### DIFF
--- a/modules/serverless-logic-running-workflows.adoc
+++ b/modules/serverless-logic-running-workflows.adoc
@@ -17,6 +17,13 @@ You can use the `run` command with `kn workflow` to build and run your {Serverle
 
 .Procedure
 
+. From the directory where you created your {ServerlessLogicProductName} project, move to your project directory by running the following command:
++
+[source,terminal]
+----
+$ cd ./<your-project-name>
+----
+
 . Run the following command to build and run your {ServerlessLogicProductName} workflow project:
 +
 [source,terminal]
@@ -24,7 +31,7 @@ You can use the `run` command with `kn workflow` to build and run your {Serverle
 $ kn workflow run
 ----
 +
-When the project is ready, the Development UI automatically opens in your browser on `localhost:8080/q/dev-ui` and you will find the *Serverless Workflow Tools* tile available. Alternatively, you can access the tool directly using `http://localhost:8080/q/dev-ui/org.apache.kie.sonataflow.sonataflow-quarkus-devui/workflows`.
+When the project is ready, the Development UI automatically opens in your browser at `localhost:8080/q/dev-ui` and you will find the *Serverless Workflow Tools* tile available. Alternatively, you can access the tool directly using `http://localhost:8080/q/dev-ui/org.apache.kie.sonataflow.sonataflow-quarkus-devui/workflows`.
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
serverless-docs-1.35+

Issue:
- https://issues.redhat.com/browse/SRVLOGIC-522

Link to docs preview:
- [Running a workflow locally](https://98078--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-getting-started/serverless-logic-creating-managing-workflows.html#serverless-logic-running-workflows_serverless-logic-creating-managing-workflows)

QE review:
- [x] QE has approved this change.
