### PR TITLE
f_OSDOCS-1511#CQA analysis

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
@@ -20,7 +20,7 @@ endif::machinemgmt[]
 ifdef::vpa[]
 The Vertical Pod Autoscaler Operator (VPA) and each component has its own pod in the VPA namespace on the control plane nodes. You can move the VPA Operator and component pods to infrastructure or worker nodes by adding a node selector to the VPA subscription and the `VerticalPodAutoscalerController` CR.
 
-You can create and use infrastructure nodes to host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see _Creating infrastructure machine sets_.
+You can create and use infrastructure nodes to host only infrastructure components. For example, the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see _Creating infrastructure machine sets_.
 
 You can move the components to the same node or separate nodes as appropriate for your organization.
 endif::vpa[]
@@ -34,7 +34,7 @@ NAME                                                READY   STATUS    RESTARTS  
 vertical-pod-autoscaler-operator-6c75fcc9cd-5pb6z   1/1     Running   0          7m59s   10.128.2.24   c416-tfsbj-master-1   <none>           <none>
 vpa-admission-plugin-default-6cb78d6f8b-rpcrj       1/1     Running   0          5m37s   10.129.2.22   c416-tfsbj-master-1   <none>           <none>
 vpa-recommender-default-66846bd94c-dsmpp            1/1     Running   0          5m37s   10.129.2.20   c416-tfsbj-master-0   <none>           <none>
-vpa-updater-default-db8b58df-2nkvf                  1/1     Running   0          5m37s   10.129.2.21   c416-tfsbj-master-1   <none>           <none> 
+vpa-updater-default-db8b58df-2nkvf                  1/1     Running   0          5m37s   10.129.2.21   c416-tfsbj-master-1   <none>           <none>
 ----
 
 .Procedure
@@ -340,7 +340,7 @@ endif::vpa[]
 $ oc get pods -n openshift-vertical-pod-autoscaler -o wide
 ----
 +
-The pods are no longer deployed to the control plane nodes. In the example output below, the node is now an infra node, not a control plane node.
+The pods are no longer deployed to the control plane nodes. In the following example output, the node is now an infra node, not a control plane node.
 +
 .Example output
 [source,terminal]
@@ -349,7 +349,7 @@ NAME                                                READY   STATUS    RESTARTS  
 vertical-pod-autoscaler-operator-6c75fcc9cd-5pb6z   1/1     Running   0          7m59s   10.128.2.24   c416-tfsbj-infra-eastus3-2bndt   <none>           <none>
 vpa-admission-plugin-default-6cb78d6f8b-rpcrj       1/1     Running   0          5m37s   10.129.2.22   c416-tfsbj-infra-eastus1-lrgj8   <none>           <none>
 vpa-recommender-default-66846bd94c-dsmpp            1/1     Running   0          5m37s   10.129.2.20   c416-tfsbj-infra-eastus1-lrgj8   <none>           <none>
-vpa-updater-default-db8b58df-2nkvf                  1/1     Running   0          5m37s   10.129.2.21   c416-tfsbj-infra-eastus1-lrgj8   <none>           <none> 
+vpa-updater-default-db8b58df-2nkvf                  1/1     Running   0          5m37s   10.129.2.21   c416-tfsbj-infra-eastus1-lrgj8   <none>           <none>
 ----
 
 ifeval::["{context}" == "nodes-pods-vertical-autoscaler"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16001

Link to docs preview:
One module updated in two locations: 
- [Moving the Vertical Pod Autoscaler Operator components](https://98082--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-vpa_creating-infrastructure-machinesets)
- [Moving the Vertical Pod Autoscaler Operator components](https://98082--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-vpa_creating-infrastructure-machinesets)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
