### PR TITLE
OSDOCS-15449: CQA updates disconnected install mirroring index

### DIFF
--- a/disconnected/mirroring/index.adoc
+++ b/disconnected/mirroring/index.adoc
@@ -6,17 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use a mirror registry to ensure that your clusters only use container images that satisfy your organizational controls on external content. Before you install a cluster on infrastructure that you provision in a restricted network, you must mirror the required container images into that environment. To mirror container images, you must have a registry for mirroring.
+As a cluster administrator, you can use a mirror registry to ensure that your clusters only use container images that satisfy your organizational controls on external content.
 
-[id="creating-mirror-registry"]
-== Creating a mirror registry
-
-If you already have a container image registry, such as {quay}, you can use it as your mirror registry. If you do not already have a registry, you can xref:../../disconnected/mirroring/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[create a mirror registry using the _mirror registry for Red{nbsp}Hat OpenShift_].
-
-[id="mirroring-images-disconnected-install"]
-== Mirroring images for a disconnected installation
-
-You can use one of the following procedures to mirror your {product-title} image repository to your mirror registry:
-
-* xref:../../disconnected/mirroring/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation by using the oc adm command]
-* xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2]
+include::modules/installing-mirroring-disconnected-con.adoc[leveloffset=+1]

--- a/modules/installing-mirroring-disconnected-con.adoc
+++ b/modules/installing-mirroring-disconnected-con.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * disconnected/mirroring/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-mirroring-disconnected-con_{context}"]
+= Mirror registries for installing clusters in disconnected environments
+
+You must mirror required container images into a disconnected environment before you can install and provision a cluster there. To mirror those container images, you must have a mirror registry. Consider the following options for creating and using a mirror registry:
+
+* If you already have a container image registry, such as {quay}, you can use it as your mirror registry. If you do not already have a registry, you must create one.
+
+* After you establish your registry, you need mirroring tools. To mirror your {product-title} image repository to the mirror registry in your disconnected environment, you can use the oc-mirror {oc-first} plugin. The oc-mirror plugin is a single tool that mirrors all required {product-title} content and other images to your mirror registry. The oc-mirror plugin is the preferred method for mirroring.
+
+* Alternately, you can use the `oc adm` command to mirror just release and catalog images for {product-title}.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-15449](https://issues.redhat.com/browse/OSDOCS-15449)

Link to docs preview:
[disconnected/mirroring/index](https://98095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/index.html)

QE review:
- N/A docs migration work

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
