### PR TITLE
[enterprise-4.12] OSDOCS-15808 [NETOBSERV] Aditi tool results: RelatedLinks

### DIFF
--- a/modules/network-observability-quickfilter.adoc
+++ b/modules/network-observability-quickfilter.adoc
@@ -6,7 +6,9 @@
 [id="network-observability-quickfilter_{context}"]
 = Filtering the network traffic
 
-By default, the Network Traffic page displays the traffic flow data in the cluster based on the default filters configured in the `FlowCollector` instance. You can use the filter options to observe the required data by changing the preset filter.
+By default, the *Network Traffic* page displays the traffic flow data in the cluster based on the default filters configured in the `FlowCollector` instance. You can use the filter options to observe the required data by changing the preset filter.
+
+Alternatively, you can access the traffic flow data in the *Network Traffic* tab of the *Namespaces*, *Services*, *Routes*, *Nodes*, and *Workloads* pages which provide the filtered data of the corresponding aggregations.
 
 Query Options::
 You can use *Query Options* to optimize the search results, as listed below:

--- a/observability/network_observability/configuring-operator.adoc
+++ b/observability/network_observability/configuring-operator.adoc
@@ -23,7 +23,7 @@ include::modules/network-observability-enriched-flows.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/network_observability/json-flows-format-reference.adoc#network-observability-flows-format_json_reference[Network flows format reference].
+* xref:../../observability/network_observability/json-flows-format-reference.adoc#network-observability-flows-format_json_reference[Network flows format reference]
 
 include::modules/network-observability-configuring-FLP-sampling.adoc[leveloffset=+1]
 

--- a/observability/network_observability/installing-operators.adoc
+++ b/observability/network_observability/installing-operators.adoc
@@ -20,11 +20,12 @@ include::modules/network-observability-without-loki.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-enriched-flows_network_observability[Export enriched network flow data].
+* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-enriched-flows_network_observability[Export enriched network flow data]
 
 include::modules/network-observability-loki-install.adoc[leveloffset=+1]
 
 include::modules/network-observability-loki-secret.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../observability/network_observability/installing-operators.adoc#network-observability-lokistack-create_network_observability[Creating a LokiStack custom resource]
@@ -45,6 +46,7 @@ include::modules/network-observability-lokistack-ingestion-query.adoc[leveloffse
 include::modules/network-observability-operator-install.adoc[leveloffset=+1]
 
 include::modules/network-observability-multitenancy.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_configuring-flow-collector-considerations"]
 == Important Flow Collector configuration considerations
@@ -58,8 +60,6 @@ Once you create the `FlowCollector` instance, you can reconfigure it, but the po
 
 [role="_additional-resources"]
 .Additional resources
-For more general information about Flow Collector specifications and the Network Observability Operator architecture and resource use, see the following resources:
-
 * xref:../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-resources-table_network_observability[Resource considerations]
@@ -67,13 +67,15 @@ For more general information about Flow Collector specifications and the Network
 * xref:../../observability/network_observability/understanding-network-observability-operator.adoc#network-observability-architecture_nw-network-observability-operator[Network observability architecture]
 
 include::modules/network-observability-updating-migrating.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../operators/operator-reference.adoc#cluster-kube-storage-version-migrator-operator_operator-reference[Kubernetes Storage Version Migrator Operator]
 
 include::modules/network-observability-kafka-option.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
-xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-kafka-config_network_observability[Configuring the FlowCollector resource with Kafka].
+* xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-kafka-config_network_observability[Configuring the FlowCollector resource with Kafka]
 
 include::modules/network-observability-operator-uninstall.adoc[leveloffset=+1]

--- a/observability/network_observability/metrics-alerts-dashboards.adoc
+++ b/observability/network_observability/metrics-alerts-dashboards.adoc
@@ -23,6 +23,7 @@ include::modules/network-observability-configuring-custom-metrics.adoc[leveloffs
 ====
 High cardinality can affect the memory usage of Prometheus. You can check whether specific labels have high cardinality in the xref:../../observability/network_observability/json-flows-format-reference.adoc#network-observability-flows-format_json_reference[Network Flows format reference].
 ====
+
 include::modules/network-observability-flowmetrics-charts.adoc[leveloffset=+1]
 
 include::modules/network-observability-tcp-flag-syn-flood.adoc[leveloffset=+1]
@@ -30,5 +31,5 @@ include::modules/network-observability-tcp-flag-syn-flood.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-filtering-ebpf-rule_nw-observe-network-traffic[Filtering eBPF flow data using a global rule]
-* xref:../../observability/monitoring/managing-alerts.adoc#creating-alerting-rules-for-user-defined-projects_managing-alerts[Creating alerting rules for user-defined projects].
+* xref:../../observability/monitoring/managing-alerts.adoc#creating-alerting-rules-for-user-defined-projects_managing-alerts[Creating alerting rules for user-defined projects]
 * xref:../../support/troubleshooting/investigating-monitoring-issues.adoc#determining-why-prometheus-is-consuming-disk-space_investigating-monitoring-issues[Troubleshooting high cardinality metrics- Determining why Prometheus is consuming a lot of disk space]

--- a/observability/network_observability/network-observability-network-policy.adoc
+++ b/observability/network_observability/network-observability-network-policy.adoc
@@ -13,6 +13,6 @@ include::modules/network-observability-deploy-network-policy.adoc[leveloffset=+1
 
 include::modules/network-observability-create-network-policy.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
+[role="_addition-resources"]
 .Additional resources
-xref:../../networking/network_policy/creating-network-policy.adoc#nw-networkpolicy-object_creating-network-policy[Creating a network policy using the CLI]
+* xref:../../networking/network_policy/creating-network-policy.adoc#nw-networkpolicy-create-cli_creating-network-policy[Creating a network policy using the CLI]

--- a/observability/network_observability/network-observability-operator-monitoring.adoc
+++ b/observability/network_observability/network-observability-operator-monitoring.adoc
@@ -18,3 +18,7 @@ include::modules/network-observability-viewing-alerts.adoc[leveloffset=+1]
 include::modules/network-observability-disabling-health-alerts.adoc[leveloffset=+2]
 
 include::modules/network-observability-ebpf-agent-alert.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/monitoring/managing-alerts.adoc#creating-alerting-rules-for-user-defined-projects_managing-alerts[Creating alerting rules for user-defined projects]

--- a/observability/network_observability/network-observability-scheduling-resources.adoc
+++ b/observability/network_observability/network-observability-scheduling-resources.adoc
@@ -16,5 +16,5 @@ include::modules/network-observability-nodes-taints-tolerations.adoc[leveloffset
 [role="_additional-resources"]
 .Additional resources
 * xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
-* link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[Assign Pods to Nodes] (Kubernetes documentation)
-* link:https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass[Pod Priority and Preemption] (Kubernetes documentation)
+* link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[Assign Pods to Nodes (Kubernetes documentation)]
+* link:https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass[Pod Priority and Preemption (Kubernetes documentation)]

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -23,14 +23,14 @@ include::modules/network-observability-configuring-options-overview.adoc[levelof
 
 include::modules/network-observability-dns-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources-dns-overview"]
+[role="_additional-resources"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-dns-tracking_nw-observe-network-traffic[Working with DNS tracking]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
 
 include::modules/network-observability-RTT-overview.adoc[leveloffset=+2]
 
-[role="_additional-resources-rtt-overview"]
+[role="_additional-resources"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-RTT_nw-observe-network-traffic[Working with RTT tracing]
 
@@ -38,7 +38,7 @@ include::modules/network-observability-ebpf-rule-flow-filter.adoc[leveloffset=+2
 
 include::modules/network-observability-flow-filter-parameters.adoc[leveloffset=+3]
 
-[role="_additional-resources-flow-filter-parameters"]
+[role="_additional-resources"]
 .Additional resources
 * xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-filtering-ebpf-rule_nw-observe-network-traffic[Filtering eBPF flow data with rules]
 * xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network Observability metrics]
@@ -79,9 +79,7 @@ include::modules/network-observability-configuring-options-topology.adoc[levelof
 //Quick filters
 include::modules/network-observability-quickfilter.adoc[leveloffset=+1]
 
-Alternatively, you can access the traffic flow data in the *Network Traffic* tab of the *Namespaces*, *Services*, *Routes*, *Nodes*, and *Workloads* pages which provide the filtered data of the corresponding aggregations.
-
-[role="_additional-resources-quickfilter"]
+[role="_additional-resources"]
 .Additional resources
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters]
 * xref:../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]


### PR DESCRIPTION
Cherry-pick: ca266f8688698f3dc7a328faded8f9f1090aaf9d

Original PR: https://github.com/openshift/openshift-docs/pull/97916/

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12

QE review:
QE is not required for this PR.

Additional information:
* network-observability-operator-release-notes.adoc is not included as the updates to the file applied to content that is not available on 4.12.
* CP is for [OSDOCS-15808](https://issues.redhat.com//browse/OSDOCS-15808), not [OSDOCS-15970](https://issues.redhat.com//browse/OSDOCS-15970). [OSDOCS-15970](https://issues.redhat.com//browse/OSDOCS-15970) in the branch name is user error.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
