### PR TITLE
NO ISSUE: Fix catalog content resolution docs on d.r.c

### DIFF
--- a/extensions/catalogs/catalog-content-resolution.adoc
+++ b/extensions/catalogs/catalog-content-resolution.adoc
@@ -18,12 +18,12 @@ If you do not specify any catalog selection criteria, {olmv1-first} selects an e
 
 During resolution, bundles that are not deprecated are preferred over deprecated bundles by default.
 
-include::modules/olmv1-catalog-selection-by-name.adoc[leveloffset=1]
+include::modules/olmv1-catalog-selection-by-name.adoc[leveloffset=+1]
 
-include::modules/olmv1-catalog-selection-by-labels-or-expressions.adoc[leveloffset=1]
+include::modules/olmv1-catalog-selection-by-labels-or-expressions.adoc[leveloffset=+1]
 
-include::modules/olmv1-catalog-exclusion-by-labels-or-expressions.adoc[leveloffset=1]
+include::modules/olmv1-catalog-exclusion-by-labels-or-expressions.adoc[leveloffset=+1]
 
-include::modules/olmv1-catalog-selection-by-priority.adoc[leveloffset=1]
+include::modules/olmv1-catalog-selection-by-priority.adoc[leveloffset=+1]
 
-include::modules/olmv1-troubleshooting-catalog-selection-errors.adoc[leveloffset=1]
+include::modules/olmv1-troubleshooting-catalog-selection-errors.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: NA
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
~- [ ] QE has approved this change.~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Fixes a typo that causes rendering errors in d.r.c
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
