### PR TITLE
OSDOCS-15524: update contrib guide to ban discrete headings

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -277,7 +277,7 @@ Do not use backticks or other markup in assembly or module headings.
 
 Do not use special characters or symbols in titles. Symbols and special characters in titles can cause rendering errors in the HTML output.
 
-Use only one link:https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/#section-level-syntax[Level 0] (`=`) heading in any file. 
+Use only one link:https://docs.asciidoctor.org/asciidoc/latest/sections/titles-and-levels/#section-level-syntax[Level 0] (`=`) heading in any file.
 Level 0 headings map to an H1 or `<h1>` in HTML.
 
 Do not use Level 2 (H3) headings (`===`) or lower in any files.
@@ -380,26 +380,12 @@ For anchor IDs of "Prerequisites", "Additional resources", and "Next steps" titl
 
 === Discrete headings
 
-If you have a section heading that you do not want to appear in the TOC (for example, if you think that some section is not worth showing up or if there are already too many nested levels), you can use a discrete (or floating) heading:
+Do not use discrete headings. If you have several short subjects to talk about that you want headings on, you can use list formatting. You could also consider bulleted lists, or revising your overall document structure to highlight the topics with headings.
 
-https://docs.asciidoctor.org/asciidoc/latest/blocks/discrete-headings/
-
-A discrete heading also will not get a section number in the Customer Portal build of the doc. Previously, we would use plain bold mark-up around a heading like this, but discrete headings also allow you to ignore section nesting rules (like jumping from a `==` section level to a `====` level if you wanted for some style reason).
-
-To use a discrete heading, add `[discrete]` to the line before your unique ID:
-
-.Example in a module
+.Example list formatting in a module or assembly
 ----
-[discrete]
-[id="managing-authorization-policies_{context}"]
-== Managing authorization policies
-----
-
-.Example in an assembly
-----
-[discrete]
-[id="olm-restricted-networks-mirroring-catalog"]
-== Mirroring a catalog
+OVN node switch::
+A virtual switch named `<node-name>`.
 ----
 
 == Writing assemblies


### PR DESCRIPTION
Version(s):
main

Issue:
[OSDOCS-15524](https://issues.redhat.com/browse/OSDOCS-15524)

Link to docs preview:
N/A

QE review:
N/A

Additional information:
Updates contrib guide for migration implementation item: discrete headings

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
