### PR TITLE
enable rule in root config

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -17,6 +17,9 @@ RedHat.ReleaseNotes = NO
 Vale.Terms = YES
 Vale.Avoid = YES
 
+# Enable specifc DITA rules on assemblies
+AsciiDocDITA.AdmonitionTitle = error
+
 # Disable module specific rules
 OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO
 OpenShiftAsciiDoc.NoNestingInModules = NO


### PR DESCRIPTION
Enables singular DITA rule in root config, for linting on assemblies
