### PR TITLE
OSSM-10553 OSSM 3.1.1 (At ReleaseCandidate): [DOC] Release Notes, Known Issues and Bug Fixes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,14 +17,14 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.1.0
+:SMProductVersion: 3.1.1
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.7
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio
-:istio-latest: 1.26.2
+:istio-latest: 1.26.3
 //update istio-latest as necessary
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat

--- a/modules/ossm-release-notes-3-1-1.adoc
+++ b/modules/ossm-release-notes-3-1-1.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-1-1_{context}"]
+= {SMProductName} version 3.1.1
+
+This release of {SMProductName} is included with the {SMProductName} Operator 3.1.1 and is supported on {ocp-product-title} 4.16 and later. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.1.1, see "Service Mesh version support tables".
+
+[id="ossm-enhancements-3-1-1_{context}"]
+== Enhancements
+
+* This enhancement updates {istio} to version 1.26.3.
+
+* This enhancement updates Kiali operator to version 2.11.2.
+
+[id="ossm-bug-fixes-3-1-1_{context}"]
+== Fixed issues
+
+* Before this update, enabling `NetworkPolicy` field globally in the `{istio}` custom resource (CR) failed to create the corresponding `NetworkPolicy` resource due to incorrect resource handling. This issue prevented users from applying network policies when {istio} was enabled globally. With this update, `NetworkPolicy` resource creation is enabled upon `{istio}` CR update, allowing end users to consistently apply network policy rules in {istio}. (link:https://issues.redhat.com/browse/OSSM-10595[OSSM-10595])
+
+* Before this update, creating a `PodDisruptionBudget` for a single `istiod` pod with a `minAvailable` value of `1` caused an upgrade to fail, preventing node restart during upgrade. As a consequence, the upgrade was unsuccessful. With this update, the {istio} Operator disables the default `podDisruptionBudget` for the single `istiod` pod in the {istio} 1.24.3 configuration. As a result, the node can now restart during an upgrade without being prevented by the single `istiod` pod. (link:https://issues.redhat.com/browse/OSSM-9392[OSSM-9392])
+
+

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -6,6 +6,34 @@
 [id="ossm-release-notes-supported-versions_{context}"]
 = {SMProduct} supported versions
 
+See the following table for information about {SMProduct} 3.1.1 supported versions.
+
+== {SMProduct} 3.1.1 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.1.1
+
+|{SMProduct} `Istio` control plane resource
+|1.26.3
+
+|{ocp-product-title}
+|4.16 and later
+
+| Envoy proxy
+| 1.34.3
+
+| `IstioCNI` resource
+| 1.26.3
+
+|Kiali Operator
+|2.11.2
+
+|===
+
 See the following table for information about {SMProduct} 3.1.0 supported versions.
 
 == {SMProduct} 3.1.0 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -16,6 +16,7 @@ For additional information about the {SMProductName} life cycle and supported pl
 //03/25/2025:
 //Gwynne is rotating off Service Mesh. For next writer and CS: Continue to refine the IA for rel notes. The structure and IA will likely make more sense as there are more z-streams and versions released, making it easier to see how best to lay rel notes out in docs.redhat. Should anything be its own tile to make it easier to find for users?
 
+include::modules/ossm-release-notes-3-1-1.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-1-new-features-enhancements.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-1-technology-preview-features.adoc[leveloffset=+1]
 include::modules/ossm-release-notes-3-1-fixed-issues.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 3.1.1 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-10553

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

Doc Previews:

Release notes: https://98145--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes#ossm-release-3-1-1_ossm-release-notes

Version support table: https://98145--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-1-1-supported-versions

QE Review: @cam-garrison @pbajjuri20 
Peer Review: @rh-tokeefe 