### PR TITLE
OSDOCS-16019: updates ingress log file name

### DIFF
--- a/modules/microshift-ingress-controller-config.adoc
+++ b/modules/microshift-ingress-controller-config.adoc
@@ -125,7 +125,7 @@ ingress:
 |`accessLogging.destination.type`
 |The type of destination for logs. Valid values are `Container` or `Syslog`.
 
-* Setting this value to `Container` specifies that logs should go to a sidecar container. When the destination type is set to `Container`, a container called `access-logs` is automatically created. Using container logs means that logs might be dropped if the rate of logs exceeds the container runtime capacity or the custom logging solution capacity. You must have a custom logging solution that reads logs from this sidecar.
+* Setting this value to `Container` specifies that logs should go to a sidecar container. When the destination type is set to `Container`, a container called `logs` is automatically created. Using container logs means that logs might be dropped if the rate of logs exceeds the container runtime capacity or the custom logging solution capacity. You must have a custom logging solution that reads logs from this sidecar.
 
 * Setting this value to `Syslog` specifies that logs are sent to a Syslog endpoint. You must configure a custom Syslog instance and specify an endpoint that can receive Syslog messages. You must have a custom Syslog instance. For example, link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/getting-started-with-kernel-logging_managing-monitoring-and-updating-the-kernel[Getting started with kernel logging].
 
@@ -209,7 +209,7 @@ log message. The ingress controller might impose a separate bound on the total l
 
 * When you configure either `ingress.accessLogging.httpCaptureHeaders` or
 `ingress.accessLogging.httpCaptureCookies`, you must set `ingress.accessLogging.status` to `Enabled`.
-* When you set the `ingress.status` field to `Enabled`, the `accessLogging.destination.type` is automatically set to `Container` and the router logs all requests in the `access-logs` container.
+* When you set the `ingress.status` field to `Enabled`, the `accessLogging.destination.type` is automatically set to `Container` and the router logs all requests in the `logs` container.
 * If you set this value to `Disabled`, the router does not log any requests in the access log.
 
 |`certificateSecret`


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-16019](https://issues.redhat.com/browse/OSDOCS-16019)

Link to docs preview:
[microshift-ingress-control-config-check table entries for `accessLogging.destination.type` and `status`, the second bullet](https://98164--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-ingress-controller.html#microshift-ingress-control-config_microshift-ingress-controller)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
