### PR TITLE
OSDOCS-15860-16: Documented the Bare Metal Event Relay Operator removal

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -1796,15 +1796,15 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-16-bare-metal-dep-rem_{context}"]
 === Bare metal monitoring deprecated and removed features
 
-.Bare Metal Event Relay Operator tracker
+.{redfish-operator} Operator tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.14 |4.15 |4.16
 
-|Bare Metal Event Relay Operator
-|Technology Preview
-|Deprecated
-|Deprecated
+|{redfish-operator} Operator
+|Removed
+|Removed
+|Removed
 
 |====
 
@@ -1874,6 +1874,11 @@ For more information, see xref:../edge_computing/policygenerator_for_ztp/ztp-adv
 //|`podTopologySpread`
 
 //|===
+
+[id="ocp-4-16-bm-event-relay-operator-removed_{context}"]
+==== {redfish-operator} Operator removed
+
+The {redfish-operator} Operator was previously a Technology Preview feature and is now removed from {product-title}. For complete lifecycle information for the {redfish-operator} Operator, see link:https://access.redhat.com/product-life-cycles?product=Bare%20Metal%20Event%20Relay[Product Life Cycles: {redfish-operator}].
 
 [id="ocp-4-16-dell-idrac-removed_{context}"]
 ==== Dell iDRAC driver for BMC addressing removed


### PR DESCRIPTION
[CM sent on the 28 August](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r-7264097611963963037).

Version(s):
4.16

Issue:
[OSDOCS-15860](https://issues.redhat.com/browse/OSDOCS-15860)

Link to docs preview:
* [Bare metal event relay Operator](https://98167--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bm-event-relay-operator-removed_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.

