### PR TITLE
Add ROSA IAM service account CLI documentation with product title attributes

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -1094,3 +1094,95 @@ a|How to perform the operation. Valid options are:
 |===
 
 For more information about the user role created with the `rosa create user-role` command, see _Understanding AWS account association_.
+
+[id="rosa-create-iamserviceaccount_{context}"]
+== create iamserviceaccount
+
+Create an AWS Identity and Access Management (IAM) role that can be assumed by a {product-title} service account using OpenID Connect (OIDC) identity federation.
+
+.Syntax
+[source,terminal]
+----
+$ rosa create iamserviceaccount --cluster=<cluster_name> | <cluster_id> --name=<service_account_name> [arguments]
+----
+
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
+
+a|--cluster <cluster_name>\|<cluster_id>
+|Required. The name or ID of the cluster for which to create the IAM service account role.
+
+|--name <service_account_name>
+|Required. The name of the {product-title} service account. This flag can be used multiple times to create a role for multiple service accounts.
+
+|--namespace <namespace_name>
+|The {product-title} namespace for the service account. Default: `default`
+
+|--role-name <role_name>
+|The name of the IAM role to create. If not specified, a name will be auto-generated using the pattern `{cluster-name}-{namespace}-{service-account-name}-role`.
+
+|--attach-policy-arn <policy_arn>
+|The ARN of an IAM policy to attach to the role. This flag can be used multiple times to attach multiple policies.
+
+|--inline-policy <policy_document>
+|An inline policy document in JSON format or a file path prefixed with `file://` (for example, `file://policy.json`).
+
+|--permissions-boundary <boundary_arn>
+|The ARN of an IAM policy to use as a permissions boundary for the role.
+
+|--path <iam_path>
+|The IAM path for the role. Default: `/`
+
+a|-m, --mode string
+a|How to perform the operation. Valid options are:
+
+`auto`:: Resource changes will be automatically applied using the current AWS account.
+`manual`:: Commands necessary to modify AWS resources will be output to be run manually.
+
+|===
+
+.Optional arguments inherited from parent commands
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--help
+|Shows help for this command.
+
+|--debug
+|Enables debug mode.
+
+|--interactive
+|Enables interactive mode.
+
+|--profile string
+|Specifies an AWS profile from your credentials file.
+
+|--yes
+|Automatically answers `yes` to confirm the operation.
+
+|===
+
+.Examples
+Create an IAM role for a service account named `my-app` in the `default` namespace with S3 read-only access.
+
+[source,terminal]
+----
+$ rosa create iamserviceaccount --cluster=mycluster --name=my-app --attach-policy-arn=arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+----
+
+Create an IAM role with a custom name and multiple policies.
+
+[source,terminal]
+----
+$ rosa create iamserviceaccount --cluster=mycluster --name=my-app --namespace=production --role-name=my-custom-role --attach-policy-arn=arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess --attach-policy-arn=arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess
+----
+
+Create an IAM role with an inline policy from a file.
+
+[source,terminal]
+----
+$ rosa create iamserviceaccount --cluster=mycluster --name=my-app --inline-policy=file://my-policy.json
+----

--- a/modules/rosa-delete-objects.adoc
+++ b/modules/rosa-delete-objects.adoc
@@ -207,6 +207,79 @@ Delete an identity provider named `github` from a cluster named `mycluster`.
 $ rosa delete idp github --cluster=mycluster
 ----
 
+[id="rosa-delete-iamserviceaccount_{context}"]
+== delete iamserviceaccount
+
+Deletes an AWS Identity and Access Management (IAM) role that was created for a {product-title} service account.
+
+.Syntax
+[source,terminal]
+----
+$ rosa delete iamserviceaccount --cluster=<cluster_name> | <cluster_id> [arguments]
+----
+
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
+
+a|--cluster <cluster_name>\|<cluster_id>
+|Required. The name or ID of the cluster from which to delete the IAM service account role.
+
+|--name <service_account_name>
+|The name of the {product-title} service account. Required when `--role-name` is not specified.
+
+|--namespace <namespace_name>
+|The {product-title} namespace for the service account. Default: `default`
+
+|--role-name <role_name>
+|The name of the IAM role to delete. If not specified, the role name will be auto-detected using the service account details.
+
+a|-m, --mode string
+a|How to perform the operation. Valid options are:
+
+`auto`:: Resource changes will be automatically applied using the current AWS account.
+`manual`:: Commands necessary to modify AWS resources will be output to be run manually.
+
+|===
+
+.Optional arguments inherited from parent commands
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--help
+|Shows help for this command.
+
+|--debug
+|Enables debug mode.
+
+|--interactive
+|Enables interactive mode.
+
+|--profile
+|Specifies an AWS profile from your credentials file.
+
+|--yes
+|Automatically answers `yes` to confirm the operation.
+
+|===
+
+.Examples
+Delete an IAM role for a service account named `my-app` in the `default` namespace.
+
+[source,terminal]
+----
+$ rosa delete iamserviceaccount --cluster=mycluster --name=my-app
+----
+
+Delete an IAM role by specifying the role name directly.
+
+[source,terminal]
+----
+$ rosa delete iamserviceaccount --cluster=mycluster --role-name=my-custom-role --yes
+----
+
 [id="rosa-delete-ingress_{context}"]
 == delete ingress
 

--- a/modules/rosa-list-objects.adoc
+++ b/modules/rosa-list-objects.adoc
@@ -208,6 +208,135 @@ List all identity providers (IDPs) for a cluster named `mycluster`.
 $ rosa list idps --cluster=mycluster
 ----
 
+[id="rosa-list-iamserviceaccounts_{context}"]
+== list iamserviceaccounts
+
+List IAM roles that were created for OpenShift service accounts.
+
+.Syntax
+[source,terminal]
+----
+$ rosa list iamserviceaccounts [arguments]
+----
+
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--cluster <cluster_name>\|<cluster_id>
+|The name or ID of the cluster to filter service account roles by.
+
+|--namespace <namespace_name>
+|The OpenShift namespace to filter service account roles by.
+
+|===
+
+.Optional arguments inherited from parent commands
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--help
+|Shows help for this command.
+
+|--debug
+|Enables debug mode.
+
+|--output
+|The output format. Allowed formats are `json` or `yaml`.
+
+|--profile
+|Specifies an AWS profile from your credentials file.
+
+|===
+
+.Examples
+List all IAM service account roles.
+
+[source,terminal]
+----
+$ rosa list iamserviceaccounts
+----
+
+List IAM service account roles for a specific cluster.
+
+[source,terminal]
+----
+$ rosa list iamserviceaccounts --cluster=mycluster
+----
+
+List IAM service account roles for a specific namespace in a cluster.
+
+[source,terminal]
+----
+$ rosa list iamserviceaccounts --cluster=mycluster --namespace=production
+----
+
+[id="rosa-describe-iamserviceaccount_{context}"]
+== describe iamserviceaccount
+
+Show detailed information about an IAM role created for an OpenShift service account.
+
+.Syntax
+[source,terminal]
+----
+$ rosa describe iamserviceaccount --cluster=<cluster_name> | <cluster_id> [arguments]
+----
+
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
+
+a|--cluster <cluster_name>\|<cluster_id>
+|Required. The name or ID of the cluster.
+
+|--name <service_account_name>
+|The name of the OpenShift service account. Required when `--role-name` is not specified.
+
+|--namespace <namespace_name>
+|The OpenShift namespace for the service account. Default: `default`
+
+|--role-name <role_name>
+|The name of the IAM role to describe. If not specified, the role name will be auto-detected using the service account details.
+
+|===
+
+.Optional arguments inherited from parent commands
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--help
+|Shows help for this command.
+
+|--debug
+|Enables debug mode.
+
+|--output
+|The output format. Allowed formats are `json` or `yaml`.
+
+|--profile
+|Specifies an AWS profile from your credentials file.
+
+|===
+
+.Examples
+Describe an IAM role for a service account named `my-app` in the `default` namespace.
+
+[source,terminal]
+----
+$ rosa describe iamserviceaccount --cluster=mycluster --name=my-app
+----
+
+Describe an IAM role by specifying the role name directly.
+
+[source,terminal]
+----
+$ rosa describe iamserviceaccount --cluster=mycluster --role-name=my-custom-role
+----
+
 [id="rosa-list-ingresses_{context}"]
 == list ingresses
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
Minor edits original PR: https://github.com/openshift/openshift-docs/pull/97931

Link to docs preview:
Create: https://98174--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-create-iamserviceaccount_rosa-managing-objects-cli
Delete: https://98174--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-delete-iamserviceaccount_rosa-managing-objects-cli

Classic create: https://98174--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-create-iamserviceaccount_rosa-managing-objects-cli
Classic delete: https://98174--ocpdocs-pr.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli.html#rosa-delete-iamserviceaccount_rosa-managing-objects-cli

QE review:
NA

Additional information:
Technical reviews completed in the original PR: https://github.com/openshift/rosa/pull/2949. 
