### PR TITLE
OSDOCS-15860-15: Documented the Bare Metal Event Relay Operator removal

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1450,15 +1450,15 @@ In the following tables, features are marked with the following statuses:
 [discrete]
 === Bare metal monitoring
 
-.Bare Metal Event Relay Operator tracker
+.{redfish-operator} Operator tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.13 |4.14 |4.15
 
-|Bare Metal Event Relay Operator
-|Technology Preview
-|Technology Preview
-|Deprecated
+|{redfish-operator} Operator
+|Removed
+|Removed
+|Removed
 
 |====
 
@@ -1505,6 +1505,11 @@ To view information about the integrated {product-registry}, run `oc get imagest
 
 [id="ocp-4-15-removed-features"]
 === Removed features
+
+[id="ocp-4-15-bm-event-relay-operator-removed_{context}"]
+==== {redfish-operator} Operator removed
+
+The {redfish-operator} Operator was previously a Technology Preview feature and is now removed from {product-title}. For complete lifecycle information for the {redfish-operator} Operator, see link:https://access.redhat.com/product-life-cycles?product=Bare%20Metal%20Event%20Relay[Product Life Cycles: {redfish-operator}].
 
 [id="ocp-4-15-openshift-default-registry"]
 ==== Removal of the OPENSHIFT_DEFAULT_REGISTRY


### PR DESCRIPTION
[CM sent on the 28 August](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r-7264097611963963037).

Version(s):
4.15

Issue:
[OSDOCS-15860](https://issues.redhat.com/browse/OSDOCS-15860)

Link to docs preview:
* [Bare metal event relay Operator](https://98167--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bm-event-relay-operator-removed_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.

