### PR TITLE
OSDOCS-15860-14: Documented the Bare Metal Event Relay Operator removal

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1804,6 +1804,21 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
+[discrete]
+=== Bare metal monitoring deprecated and removed features
+
+.{redfish-operator} Operator tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.14 |4.15 |4.16
+
+|{redfish-operator} Operator
+|Removed
+|Removed
+|Removed
+
+|====
+
 [id="ocp-4-14-deprecated-features"]
 === Deprecated features
 
@@ -1862,6 +1877,11 @@ See xref:../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-csv-manual-ann
 
 [id="ocp-4-14-removed-features"]
 === Removed features
+
+[id="ocp-4-14-bm-event-relay-operator-removed_{context}"]
+==== {redfish-operator} Operator removed
+
+The {redfish-operator} Operator was previously a Technology Preview feature and is now removed from {product-title}. For complete lifecycle information for the {redfish-operator} Operator, see link:https://access.redhat.com/product-life-cycles?product=Bare%20Metal%20Event%20Relay[Product Life Cycles: {redfish-operator}].
 
 [id="ocp-4-14-removed-kube-1-27-apis"]
 ==== Beta APIs removed from Kubernetes 1.27


### PR DESCRIPTION
[CM sent on the 28 August](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r-7264097611963963037).

Version(s):
4.14

Issue:
[OSDOCS-15860](https://issues.redhat.com/browse/OSDOCS-15860)

Link to docs preview:
* [Bare metal event relay Operator](https://98167--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bm-event-relay-operator-removed_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.

