### PR TITLE
OSDOCS-15860-17: Documented the Bare Metal Event Relay Operator removal

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1259,8 +1259,8 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.15 |4.16 |4.17
 
 |Bare Metal Event Relay Operator
-|Deprecated
-|Deprecated
+|Removed
+|Removed
 |Removed
 |====
 
@@ -1616,11 +1616,6 @@ In {product-title} 4.16, Patternfly 4 and React Router 5 were deprecated. The de
 
 [id="ocp-4-17-removed-features_{context}"]
 === Removed features
-
-[id="ocp-4-17-bare-metal-operator_{context}"]
-==== Bare Metal Event Relay Operator (BMER)
-
-BMER was deprecated in {product-title} version 4.15 and 4.16. With this release, BMER is no longer supported and the related BMER content is removed from the documentation.
 
 [id="ocp-4-17-sdn-plugin_{context}"]
 ==== OpenShift SDN network plugin (Removed)


### PR DESCRIPTION
[CM sent on the 28 August](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r-7264097611963963037).

Version(s):
4.17

Issue:
[OSDOCS-15860](https://issues.redhat.com/browse/OSDOCS-15860)

Link to docs preview:
* [Bare metal event relay Operator](https://98167--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bm-event-relay-operator-removed_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.

