### PR TITLE
OSDOCS-15860-20: Documented the Bare Metal Event Relay Operator removal

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -483,21 +483,6 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 == Deprecated and removed features
 
 [discrete]
-[id="ocp-release-note-bare-metal-dep-rem_{context}"]
-=== Bare metal monitoring deprecated and removed features
-
-.Bare Metal Event Relay Operator tracker
-[cols="4,1,1,1",options="header"]
-|====
-|Feature |4.18 |4.19 |4.20
-
-|Bare Metal Event Relay Operator
-|Removed
-|Removed
-|Removed
-|====
-
-[discrete]
 [id="ocp-release-note-images-dep-rem_{context}"]
 === Images deprecated and removed features
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-15860](https://issues.redhat.com/browse/OSDOCS-15860)

Link to docs preview:
* [Bare metal event relay Operator](https://98167--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-bm-event-relay-operator-removed_release-notes)

- [x] SME has approved this change (Eric Rich).
- [x] QE has approved this change (Jack Ding).

