### PR TITLE
CNV#51222: Restoring Enabling dedicated resources for VMs in web

### DIFF
--- a/modules/virt-dedicated-resources-vm-template.adoc
+++ b/modules/virt-dedicated-resources-vm-template.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * virt/creating_vm/virt-creating-vms-from-templates.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-dedicated-resources-vm-template_{context}"]
+= Enabling dedicated resources for a virtual machine template
+
+[role="_abstract"]
+You can enable dedicated resources for a virtual machine (VM) template in the {product-title} web console.
+VMs that are created from this template will be scheduled with dedicated resources.
+
+.Procedure
+
+. In the {product-title} web console, click *Virtualization* -> *Templates* in the side menu.
+. Select the template that you want to edit to open the *Template details* page.
+. On the *Scheduling* tab, click the edit icon beside *Dedicated Resources*.
+. Select *Schedule this workload with dedicated resources (guaranteed policy)*.
+. Click *Save*.

--- a/virt/creating_vm/virt-creating-vms-from-templates.adoc
+++ b/virt/creating_vm/virt-creating-vms-from-templates.adoc
@@ -34,8 +34,6 @@ include::modules/virt-creating-vm-from-template.adoc[leveloffset=+1]
 
 include::modules/virt-customizing-vm-template-web.adoc[leveloffset=+1]
 
-include::modules/virt-creating-template.adoc[leveloffset=+1]
+include::modules/virt-creating-template.adoc[leveloffset=+2]
 
-include::modules/virt-adding-templates-to-custom-namespace.adoc[leveloffset=+1]
-
-include::modules/virt-deleting-templates-from-custom-namespace.adoc[leveloffset=+1]
+include::modules/virt-dedicated-resources-vm-template.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/CNV-51222

Link to docs preview:
https://98180--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vm/virt-creating-vms-from-templates.html#virt-enabling-dedicated-resources-vm-template_virt-creating-vms-from-templates

QE review:
Not Needed

Additional information:
This is for restoring the "Enabling dedicated resources for virtual machine templates in the web console" that was removed in 4.14+
