### PR TITLE
CNV#51222: Restoring doc Deploying a vm template to a custom ns

### DIFF
--- a/modules/virt-adding-templates-to-custom-namespace.adoc
+++ b/modules/virt-adding-templates-to-custom-namespace.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_templates/virt-deploying-vm-template-to-custom-namespace.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-adding-templates-to-custom-namespace_{context}"]
+= Adding templates to a custom namespace
+
+[role="_abstract"]
+The Scheduling, Scale, and Performance (SSP) Operator deploys virtual machine templates to the `openshift` namespace by default. To also publish these templates in a custom namespace, set the `commonTemplatesNamespace` field in the `HyperConverged` custom resource (CR). After the templates sync to the custom namespace, you can modify or delete them there.
+
+[NOTE]
+====
+Do not edit templates in the `openshift` namespace. The SSP Operator reconciles that namespace and overwrites changes.
+====
+
+.Prerequisites
+* Install the {oc-first}.
+* Log in as a user with cluster-admin privileges.
+
+.Procedure
+
+. Optional: Create the custom namespace if it does not already exist:
++
+[source,terminal]
+----
+$ oc create namespace <custom_namespace>
+----
+
+. Optional: View the list of templates in the `openshift` namespace:
++
+[source,terminal]
+----
+$ oc get templates -n openshift
+----
+
+. Open the `HyperConverged` CR in your default editor by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc edit hco -n {CNVNamespace} kubevirt-hyperconverged
+----
+
+. Add the `commonTemplatesNamespace` field and set your target namespace. For example:
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  commonTemplatesNamespace: <custom_namespace>
+----
+
+. Save and exit. The SSP Operator creates or updates the templates in the custom namespace.
+
+. Verify the templates in the custom namespace:
++
+[source,terminal]
+----
+$ oc get templates -n <custom_namespace>
+----

--- a/modules/virt-deleting-templates-from-custom-namespace.adoc
+++ b/modules/virt-deleting-templates-from-custom-namespace.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_templates/virt-deploying-vm-template-to-custom-namespace.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="virt-deleting-templates-from-custom-namespace_{context}"]
+= Deleting templates from a custom namespace
+
+To delete virtual machine templates from a custom namespace, remove the `commonTemplateNamespace` attribute from the `HyperConverged` custom resource (CR) and delete each template from that custom namespace.
+
+.Procedure
+
+. Edit the `HyperConverged` CR in your default editor by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc edit hco -n {CNVNamespace} kubevirt-hyperconverged
+----
++
+. Remove the `commonTemplateNamespace` attribute:
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  commonTemplatesNamespace: <custom_namespace>
+----
++
+. Delete a specific template from the custom namespace that you removed from the `HyperConverged` CR:
++
+[source,terminal]
+----
+$ oc delete templates -n <custom_namespace> <template_name>
+----
+
+.Verification
+
+* Verify that the template was deleted from the custom namespace:
++
+[source,terminal]
+----
+$ oc get templates -n <custom_namespace>
+----

--- a/virt/creating_vm/virt-creating-vms-from-templates.adoc
+++ b/virt/creating_vm/virt-creating-vms-from-templates.adoc
@@ -32,6 +32,10 @@ Due to differences in storage behavior, some templates are incompatible with {sn
 
 include::modules/virt-creating-vm-from-template.adoc[leveloffset=+1]
 
-include::modules/virt-customizing-vm-template-web.adoc[leveloffset=+2]
+include::modules/virt-customizing-vm-template-web.adoc[leveloffset=+1]
 
-include::modules/virt-creating-template.adoc[leveloffset=+2]
+include::modules/virt-creating-template.adoc[leveloffset=+1]
+
+include::modules/virt-adding-templates-to-custom-namespace.adoc[leveloffset=+1]
+
+include::modules/virt-deleting-templates-from-custom-namespace.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/CNV-51222

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not Needed

Additional information:
This is for restoring the "Deploying a virtual machine template to a custom namespace" that was removed in 4.14+
