### PR TITLE
CNV#63767_maintreleaseupdate 

### DIFF
--- a/virt/release_notes/virt-4-19-release-notes.adoc
+++ b/virt/release_notes/virt-4-19-release-notes.adoc
@@ -101,9 +101,6 @@ As a cluster administrator, you can prevent users from enabling VM delete protec
 //CNV-55497 Doc: PVC source support for DataImportCron
 * You can now use a PVC as the source of a custom `DataImportCron` in the `dataImportCronTemplates` section of the `HyperConverged` custom resource (CR). See xref:../../virt/storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates] for more information.
 
-//CNV-58547 UI - Bulk Storage Class Migration within a single cluster
-* By using the {product-title} web console, you can now xref:../../virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.adoc#virt-migrating-bulk-vms-different-storage-class-web_virt-migrating-vms-in-single-cluster-to-different-storage-class[migrate VMs in bulk from one storage class to another storage class].
-
 [id="virt-4-19-web_{context}"]
 === Web console
 
@@ -312,8 +309,18 @@ You can also disable free page reporting of memory ballooning for all new VMs. T
 
 Release notes for asynchronous releases of Red Hat {VirtProductName}.
 
+[id="virt-4.19.4_{context}"]
+=== Version 4.19.4
+
+.New and changed features
+
+//CNV-63767 Release note: TP to GA (formerly CNV-58547 as TP UI - Bulk Storage Class Migration within a single cluster)
+* By using the {product-title} web console, you can now xref:../../virt/managing_vms/virt-migrating-vms-in-single-cluster-to-different-storage-class.adoc#virt-migrating-bulk-vms-different-storage-class-web_virt-migrating-vms-in-single-cluster-to-different-storage-class[migrate VMs in bulk from one storage class to another storage class].
++
+This feature requires both {VirtProductName} 4.19.4 or greater and {mtc-first} 1.8.9 or greater.
+
 [id="virt-4.19.3_{context}"]
-=== 4.19.3
+=== Version 4.19.3
 
 .New and changed features
 
@@ -321,7 +328,7 @@ Release notes for asynchronous releases of Red Hat {VirtProductName}.
 * Support for s390x architecture is now generally available. You can use {VirtProductName} on an {product-title} cluster that has been deployed in one or more logical partitions (LPARs) on {ibm-z-name} and {ibm-linuxone-name} (s390x architecture) systems. For more information, see xref:../../virt/install/preparing-cluster-for-virt.adoc#ibm-z-linuxone-compatibility_preparing-cluster-for-virt[{ibm-z-title} and {ibm-linuxone-title} compatibility].
 
 [id="virt-4.19.1_{context}"]
-=== 4.19.1
+=== Version 4.19.1
 
 .New and changed features
 


### PR DESCRIPTION
Version(s): 4.19
This update moves a RN from the Storage section to the Maintenance releases section so that it is now clear that the new functionality is generally available only as of CNV 4.19.4 and MTC 1.8.9. 

Issue: [CNV-63767](https://issues.redhat.com/browse/CNV-63767)

Link to docs preview: https://98220--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-19-release-notes.html#virt-4.19.4_virt-4-19-release-notes

QE review: Approved by Adam.


