### PR TITLE
CNV-46504: Updated MTU value and minor vale updates

### DIFF
--- a/modules/virt-creating-layer2-nad-cli.adoc
+++ b/modules/virt-creating-layer2-nad-cli.adoc
@@ -4,13 +4,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-creating-layer2-nad-cli_{context}"]
-= Creating a NAD for layer 2 topology using the CLI
+= Creating a NAD for layer 2 topology by using the CLI
 
 You can create a network attachment definition (NAD) which describes how to attach a pod to the layer 2 overlay network.
 
 .Prerequisites
+
 * You have access to the cluster as a user with `cluster-admin` privileges.
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 
@@ -30,26 +31,25 @@ spec:
             "name": "my-namespace-l2-network", <2>
             "type": "ovn-k8s-cni-overlay", <3>
             "topology":"layer2", <4>
-            "mtu": 1300, <5>
+            "mtu": 1400, <5>
             "netAttachDefName": "my-namespace/l2-network" <6>
     }
 ----
-<1> The CNI specification version. The required value is `0.3.1`.
+<1> The Container Network Interface (CNI) specification version. The required value is `0.3.1`.
 <2> The name of the network. This attribute is not namespaced. For example, you can have a network named `l2-network` referenced from two different `NetworkAttachmentDefinition` objects that exist in two different namespaces. This feature is useful to connect VMs in different namespaces.
-<3> The name of the CNI plug-in to be configured. The required value is `ovn-k8s-cni-overlay`.
+<3> The name of the CNI plugin. The required value is `ovn-k8s-cni-overlay`.
 <4> The topological configuration for the network. The required value is `layer2`.
 <5> Optional: The maximum transmission unit (MTU) value. If you do not set a value, the Cluster Network Operator (CNO) sets a default MTU value by calculating the difference among the underlay MTU of the primary network interface, the overlay MTU of the pod network, such as the Geneve (Generic Network Virtualization Encapsulation), and byte capacity of any enabled features, such as IPsec.
 <6> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
 +
 [NOTE]
 ====
-The above example configures a cluster-wide overlay without a subnet defined. This means that the logical switch implementing the network only provides layer 2 communication. You must configure an IP address when you create the virtual machine by either setting a static IP address or by deploying a DHCP server on the network for a dynamic IP address.
+The previous example configures a cluster-wide overlay without a subnet defined. This means that the logical switch implementing the network only provides layer 2 communication. You must configure an IP address when you create the virtual machine by either setting a static IP address or by deploying a DHCP server on the network for a dynamic IP address.
 ====
 
-. Apply the manifest:
+. Apply the manifest by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f <filename>.yaml
 ----
-


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/CNV-46504

Link to docs preview:
- https://98221--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.html#virt-creating-layer2-nad-cli_virt-connecting-vm-to-ovn-secondary-network

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
One minor change for the Jira, but I also ran Vale against the file and made updates based on the corrections suggested.
