### PR TITLE
OLS-2045: Inform user about expected prompt output on OLS when using…

### DIFF
--- a/modules/ols-thinking-model-generates-delineator-prompt.adoc
+++ b/modules/ols-thinking-model-generates-delineator-prompt.adoc
@@ -1,0 +1,13 @@
+// This module is used in the following assemblies:
+// troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ols-thinking-model-generates-delineator-prompt_{context}"]
+= Thinking model generates delineator prompt
+
+In some cases, thinking or reasoning models produce output that has delineators, such as `THOUGHT` or `reasoning`, to separate the thinking process from the model output that the {ols-long} Service uses to answer your question. 
+
+The {ols-long} Service does not configure the delineator behavior or produce the delineators in the output. The delineator feature is a model configuration setting. Typically, you can disable the feature using one of the following methods:
+
+* Append your question prompt with the specific keyword that the model requires to disable the delineator feature, for example, `/nothink`. For more information, see the documentation for the model you are using.
+* Modify the inference server configuration settings to disable the delineator feature. For more information, see the documentation for the inference server or for the model you are using.

--- a/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+++ b/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
@@ -10,3 +10,4 @@ The following topics provide information to help troubleshoot {ols-long}.
 
 include::modules/ols-502-bad-gateway-errors.adoc[leveloffset=+1]
 include::modules/ols-operator-missing-from-operatorhub-list.adoc[leveloffset=+1]
+include::modules/ols-thinking-model-generates-delineator-prompt.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-2046
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://98222--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/troubleshoot/ols-troubleshooting-openshift-lightspeed.html#ols-thinking-model-generates-delineator-prompt_ols-troubleshooting-openshift-lightspeed

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
