### PR TITLE
OSDOCS-15754: adds concept module RHDE config

### DIFF
--- a/microshift_configuring/microshift-using-config-yaml.adoc
+++ b/microshift_configuring/microshift-using-config-yaml.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 A YAML file customizes {microshift-short} instances with your preferences, settings, and parameters.
 
+include::modules/microshift-config-rhde-con.adoc[leveloffset=+1]
+
 include::snippets/microshift-greenboot-status-snip.adoc[leveloffset=+2]
 
 include::modules/microshift-config-yaml.adoc[leveloffset=+1]
@@ -24,8 +26,8 @@ include::modules/microshift-nw-advertise-address.adoc[leveloffset=+2]
 
 include::modules/microshift-config-nodeport-limits.adoc[leveloffset=+2]
 
-[id="additional-resources_microshift-using-config-yaml_{context}"]
 [role="_additional-resources"]
+[id="additional-resources_microshift-using-config-yaml_{context}"]
 == Additional resources
 
 * xref:../../microshift-greenboot-checking-status.adoc#microshift-greenboot-checking-status[Checking Greenboot status]

--- a/modules/microshift-config-rhde-con.adoc
+++ b/modules/microshift-config-rhde-con.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * microshift_configuring/microshift-config-rhde-con.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-config-rhde-con_{context}"]
+= Configuring {op-system-bundle}
+
+{microshift-short} and {op-system-base-full} work together to bring a lighter-weight, single-node Kubernetes to the edge. This combination means that there is a single node that is both control-plane and worker. It also means that the operating system handles many functions. You add features by installing optional RPMs or Operators. In many cases, you must configure the operating system or other resources in addition to the {microshift-short} service.
+
+Bringing many of these pieces together is the {microshift-short} configuration file, `config.yaml`. The {microshift-short} configuration file customizes your application platform and can enable many advanced functions. For example:
+
+* Ingress is available by default, but you can add advanced functions such as TLS and route admission specifications by using parameters in the {microshift-short} configuration file.
+* If you do not need storage, you can disable the built-in storage provider by using the {microshift-short} configuration file. If you do want to use the built-in storage provider, you must make your adjustments in the `lvmd.config` file. The role of the {microshift-short} configuration file in this case is to set whether you use the default storage provider.
+* Advanced networking functions, such as using multiple networks. The Multus package is an installable RPM, but you set up access by using the {microshift-short} configuration file to set parameters. In addition, you must configure network settings on your networks through the host.
+
+For your convenience, a `config.yaml.default` file is automatically installed. You can copy and rename this file `config.yaml` and use it as a starting point for your own custom configuration.
+
+[NOTE]
+====
+You can also add features that operate without configurations to the {microshift-short} `config.yaml` file. For example, you can install and configure GitOps for application management without configuring {microshift-short}.
+====

--- a/modules/microshift-config-yaml.adoc
+++ b/modules/microshift-config-yaml.adoc
@@ -6,6 +6,8 @@
 [id="microshift-config-yaml_{context}"]
 = The {microshift-short} YAML configuration file
 
-At start up, {microshift-short} checks the system-wide `/etc/microshift/` directory for a configuration file named `config.yaml`. If the configuration file does not exist in the directory, built-in default values are used to start the service.
+At startup, {microshift-short} checks the system-wide `/etc/microshift/` directory for a configuration file named `config.yaml`. If the configuration file does not exist in the directory, built-in default values are used to start the service.
 
-The {microshift-short} configuration file must be used in combination with host and, sometimes, application and service settings. Ensure that each item is configured in tandem when you customize your {microshift-short} cluster.
+You must use the {microshift-short} configuration file must be used in combination with host and, sometimes, application and service settings. Ensure that you configure each function in tandem, as needed, when you adjust settings for your {microshift-short} cluster.
+
+For your convenience, a `config.yaml.default` file ready for your inputs is automatically installed.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-15754](https://issues.redhat.com/browse/OSDOCS-15754)

Link to docs preview:
[Configuring Red Hat Device Edge>](https://98256--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-config-rhde-con_microshift-configuring)

Reviews:
- [x] QE approved this change.
- [x] SME approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
