### PR TITLE
[DRAFT] OSDOCS-15987 [NETOBSERV] Module Aditi tool results: TaskExample

### DIFF
--- a/modules/network-observability-flowmetrics-charts.adoc
+++ b/modules/network-observability-flowmetrics-charts.adoc
@@ -16,14 +16,9 @@ You can view custom charts as an administrator in the *Dashboard* menu.
 . In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
 . In the *Project:*  dropdown list, select the project of the Network Observability Operator instance.
 . Click *Create FlowMetric*.
-<<<<<<< HEAD
 . Configure the `FlowMetric` resource, similar to the following sample configurations:
 +
 .Chart for tracking ingress bytes received from cluster external sources
-=======
-. Configure the `FlowMetric` resource to create a chart for tracking ingress bytes receive from cluster external resources, similar to this sample configuration:
-+
->>>>>>> b1537d7153 (OSDOCS-15987 [NETOBSERV] Module Aditi tool results: TaskExample)
 [source,yaml]
 ----
 apiVersion: flows.netobserv.io/v1alpha1
@@ -52,7 +47,6 @@ metadata:
 ----
 <1> The `FlowMetric` resources must be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
 
-<<<<<<< HEAD
 .Verification
 . Once the pods refresh, navigate to *Observe* -> *Dashboards*.
 . Search for the *NetObserv / Main* dashboard. View two panels under the *NetObserv / Main* dashboard, or optionally a dashboard name that you create:
@@ -63,10 +57,6 @@ metadata:
 For more information about the query language, refer to the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus documentation].
 
 .Chart for RTT latency for cluster external ingress traffic
-=======
-. Configure the `FlowMetric` resource to create a chart for Round-trip time (RTT) latency for cluster external ingress traffic, similar to this sample configuration:
-+
->>>>>>> b1537d7153 (OSDOCS-15987 [NETOBSERV] Module Aditi tool results: TaskExample)
 [source,yaml]
 ----
 apiVersion: flows.netobserv.io/v1alpha1
@@ -117,9 +107,5 @@ promQL: "(sum(rate($METRIC_sum{DstK8S_Namespace!=\"\"}[2m])) by (DstK8S_Namespac
 . Once the pods refresh, navigate to *Observe* -> *Dashboards*.
 . Search for the *NetObserv / Main* dashboard. View the new panel under the *NetObserv / Main* dashboard, or optionally a dashboard name that you create.
 
-<<<<<<< HEAD
 For more information about the query language, refer to the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus documentation].
 
-=======
-For more information about the query language, refer to the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus documentation].
->>>>>>> b1537d7153 (OSDOCS-15987 [NETOBSERV] Module Aditi tool results: TaskExample)

--- a/modules/network-observability-flowmetrics-charts.adoc
+++ b/modules/network-observability-flowmetrics-charts.adoc
@@ -16,9 +16,14 @@ You can view custom charts as an administrator in the *Dashboard* menu.
 . In the *Provided APIs* heading for the *NetObserv Operator*, select *FlowMetric*.
 . In the *Project:*  dropdown list, select the project of the Network Observability Operator instance.
 . Click *Create FlowMetric*.
+<<<<<<< HEAD
 . Configure the `FlowMetric` resource, similar to the following sample configurations:
 +
 .Chart for tracking ingress bytes received from cluster external sources
+=======
+. Configure the `FlowMetric` resource to create a chart for tracking ingress bytes receive from cluster external resources, similar to this sample configuration:
++
+>>>>>>> b1537d7153 (OSDOCS-15987 [NETOBSERV] Module Aditi tool results: TaskExample)
 [source,yaml]
 ----
 apiVersion: flows.netobserv.io/v1alpha1
@@ -45,8 +50,9 @@ metadata:
       legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
 # ...
 ----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+<1> The `FlowMetric` resources must be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
 
+<<<<<<< HEAD
 .Verification
 . Once the pods refresh, navigate to *Observe* -> *Dashboards*.
 . Search for the *NetObserv / Main* dashboard. View two panels under the *NetObserv / Main* dashboard, or optionally a dashboard name that you create:
@@ -57,6 +63,10 @@ metadata:
 For more information about the query language, refer to the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus documentation].
 
 .Chart for RTT latency for cluster external ingress traffic
+=======
+. Configure the `FlowMetric` resource to create a chart for Round-trip time (RTT) latency for cluster external ingress traffic, similar to this sample configuration:
++
+>>>>>>> b1537d7153 (OSDOCS-15987 [NETOBSERV] Module Aditi tool results: TaskExample)
 [source,yaml]
 ----
 apiVersion: flows.netobserv.io/v1alpha1
@@ -91,13 +101,13 @@ metadata:
       legend: "{{DstK8S_Namespace}} / {{DstK8S_OwnerName}}"
 # ...
 ----
-<1> The `FlowMetric` resources need to be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
+<1> The `FlowMetric` resources must be created in the namespace defined in the `FlowCollector` `spec.namespace`, which is `netobserv` by default.
 <2> Using a different `dashboardName` creates a new dashboard that is prefixed with `Netobserv`. For example, *Netobserv / <dashboard_name>*.
-
++
 This example uses the `histogram_quantile` function to show `p50` and `p99`.
-
++
 You can show averages of histograms by dividing the metric, `$METRIC_sum`, by the metric, `$METRIC_count`, which are automatically generated when you create a histogram. With the preceding example, the Prometheus query to do this is as follows:
-
++
 [source,yaml]
 ----
 promQL: "(sum(rate($METRIC_sum{DstK8S_Namespace!=\"\"}[2m])) by (DstK8S_Namespace,DstK8S_OwnerName) / sum(rate($METRIC_count{DstK8S_Namespace!=\"\"}[2m])) by (DstK8S_Namespace,DstK8S_OwnerName))*1000"
@@ -107,5 +117,9 @@ promQL: "(sum(rate($METRIC_sum{DstK8S_Namespace!=\"\"}[2m])) by (DstK8S_Namespac
 . Once the pods refresh, navigate to *Observe* -> *Dashboards*.
 . Search for the *NetObserv / Main* dashboard. View the new panel under the *NetObserv / Main* dashboard, or optionally a dashboard name that you create.
 
+<<<<<<< HEAD
 For more information about the query language, refer to the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus documentation].
 
+=======
+For more information about the query language, refer to the link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Prometheus documentation].
+>>>>>>> b1537d7153 (OSDOCS-15987 [NETOBSERV] Module Aditi tool results: TaskExample)


### PR DESCRIPTION
[OSDOCS-15987](https://issues.redhat.com//browse/OSDOCS-15987) [NETOBSERV] Module Aditi tool results: TaskExample

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15987

Link to docs preview:
https://98275--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards.html#network-observability-custom-charts-flowmetrics_metrics-dashboards-alerts

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- To adhere to Aditi tool results, some restructuring of content was required. As a result, requested Dev/QE review to verify info is still correct.
- Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures.
- For each cherry-pick failure, I will manually verify the content, and create manual cherry-picks accordingly.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
