### PR TITLE
OBSDOCS-2325: Logging Z-Stream Release Notes - 6.0.10

### DIFF
--- a/modules/logging-release-notes-6-0-10.adoc
+++ b/modules/logging-release-notes-6-0-10.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-10_{context}"]
+= Logging 6.0.10 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:15564[RHBA-2025:15564].
+
+[id="logging-release-notes-6-0-10-bug-fixes_{context}"]
+== Bug Fixes
+
+* Before this update, a bug in the authorization workflow for user rules and alerts allowed users to view alerts from other users. With this update, the bug fix restores the correct authorization behavior, and users can only see their own rules and alerts. (link:https://issues.redhat.com/browse/LOG-7315[LOG-7315])
+
+* Before this update, creating an `AlertingRule` for `kernel` errors failed in the `openshift-logging` namespace because the infrastructure or audit tenant was not supported. As a consequence, users could not create `AlertingRules` for `kernel` messages without specifying a namespace label. With this update, `AlertingRule` validation allows the infrastructure or audit tenant in the `openshift-logging` namespace without a namespace label, enabling users to create `AlertingRules` for `kernel` errors successfully. (link:https://issues.redhat.com/browse/LOG-7319[LOG-7319])
+
+* Before this update, the loki-gateway did not enforce fine-grained authorization on the `/series` endpoint for the `application` tenant. As a consequence, users could get unauthorized access to the stream metadata information for different log streams. With this update, the `/series` endpoint uses the `match` parameter instead of the `query` parameter to filter the series metadata that is returned for a request. As a result, the loki-gateway correctly enforces fine-grained authorization for the `/series` endpoint for the `application` tenant. (link:https://issues.redhat.com/browse/LOG-7321[LOG-7321])
+
+* Before this update, Loki ingesters that got into an unhealthy state due to networking issues stayed in that state even after the network recovered. With this update, you can configure the {loki-op} to perform service discovery more often so that unhealthy ingesters can rejoin the group. (link:https://issues.redhat.com/browse/LOG-7323[LOG-7323])
+
+* Before this update, the `vector_buffer_byte_size` and `vector_buffer_events` metrics incorrectly reported negative values under certain system load and timing conditions. This led to unreliable monitoring, potentially masking buffer issues. With this update, a concurrent, centralized state tracker ensures that these metrics are always reported as non-negative values. This ensures that the metrics correctly report buffer sizes helping with accurate monitoring. (link:https://issues.redhat.com/browse/LOG-7595[LOG-7595])
+
+* Before this update, a log record with a malformed timestamp could cause the Vector agent to panic when attempting to forward logs to Loki. With this update, error handling for out-of-range timestamp values has been improved resolving the issue. (link:https://issues.redhat.com/browse/LOG-7601[LOG-7601])

--- a/release_notes/logging-release-notes-6-0.adoc
+++ b/release_notes/logging-release-notes-6-0.adoc
@@ -2,9 +2,12 @@
 include::_attributes/common-attributes.adoc[]
 [id="logging-release-notes-6-0"]
 = Release notes
+
 :context: logging-release-notes-6-0
 
 toc::[]
+
+include::modules/logging-release-notes-6-0-10.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-0-9.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 6.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:  https://issues.redhat.com/browse/OBSDOCS-2325
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://98301--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6-0.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
