### PR TITLE
OBSDOCS-2326: Logging Z-Stream Release Notes - 6.1.8

### DIFF
--- a/modules/logging-release-notes-6-1-7.adoc
+++ b/modules/logging-release-notes-6-1-7.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * release-notes/logging-release-notes-6.1.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-7_{context}"]
+= Logging 6.1.7 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:8143[RHBA-2025:8143].
+
+[id="logging-release-notes-6-1-7-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, merging data from the `message` field into the root of a Syslog log event caused the log event to be inconsistent with the ViaQ data model. The inconsistency could lead to overwritten system information, data duplication, or event corruption. This update revises Syslog parsing and merging for the Syslog output to align with other output types, resolving this inconsistency. (link:https://issues.redhat.com/browse/LOG-7184[LOG-7184])
+
+
+* Before this update, log forwarding failed if you configured a cluster-wide proxy with a URL containing a username with an encoded "@" symbol; for example "user%40name". This update resolves the issue by adding correct support for URL-encoded values in proxy configurations. (link:https://issues.redhat.com/browse/LOG-7187[LOG-7187])
+
+[id="logging-release-notes-6-1-7-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2022-49043[CVE-2022-49043]
+* link:https://access.redhat.com/security/cve/CVE-2024-12087[CVE-2024-12087]
+* link:https://access.redhat.com/security/cve/CVE-2024-12088[CVE-2024-12088]
+* link:https://access.redhat.com/security/cve/CVE-2024-12133[CVE-2024-12133]
+* link:https://access.redhat.com/security/cve/CVE-2024-12243[CVE-2024-12243]
+* link:https://access.redhat.com/security/cve/CVE-2024-12747[CVE-2024-12747]
+* link:https://access.redhat.com/security/cve/CVE-2024-56171[CVE-2024-56171]
+* link:https://access.redhat.com/security/cve/CVE-2025-0395[CVE-2025-0395]
+* link:https://access.redhat.com/security/cve/CVE-2025-24928[CVE-2025-24928]
+
+[NOTE]
+====
+For detailed information on Red{nbsp}Hat security ratings, review link:https://access.redhat.com/security/updates/classification/#important[Severity ratings].
+====

--- a/modules/logging-release-notes-6-1-8.adoc
+++ b/modules/logging-release-notes-6-1-8.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * release-notes/logging-release-notes-6.1.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-1-8_{context}"]
+= Logging 6.1.8 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:15565[RHBA-2025:15565].
+
+[id="logging-release-notes-6-1-8-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, a bug in the authorization workflow for user rules and alerts allowed users to view alerts from other users. With this update, the bug fix restores the correct authorization behavior, and users can only see their own rules and alerts. (link:https://issues.redhat.com/browse/LOG-7314[LOG-7314])
+
+* Before this update, creating an `AlertingRule` for `kernel` errors failed in the `openshift-logging` namespace because the infrastructure or audit tenant was not supported. As a consequence, users could not create `AlertingRules` for `kernel` messages without specifying a namespace label. With this update, `AlertingRule` validation allows the infrastructure or audit tenant in the `openshift-logging` namespace without a namespace label, enabling users to create `AlertingRules` for `kernel` errors successfully. (link:https://issues.redhat.com/browse/LOG-7318[LOG-7318])
+
+* Before this update, the loki-gateway did not enforce fine-grained authorization on the `/series` endpoint for the `application` tenant. As a consequence, users could get unauthorized access to the stream metadata information from different log streams. With this update, the `/series` endpoint uses the `match` parameter instead of the `query` parameter to filter the series metadata that is returned for a request. As a result, the loki-gateway correctly enforces fine-grained authorization for the `/series` endpoint for the `application` tenant. (link:https://issues.redhat.com/browse/LOG-7320[LOG-7320])
+
+* Before this update, Loki ingesters that got into an unhealthy state due to networking issues stayed in that state even after the network recovered. With this update, you can configure the {loki-op} to perform service discovery more often so that unhealthy ingesters can rejoin the group. (link:https://issues.redhat.com/browse/LOG-7322[LOG-7322])
+
+* Before this update, the `vector_buffer_byte_size` and `vector_buffer_events` metrics incorrectly reported negative values under certain system load and timing conditions. This led to unreliable monitoring, potentially masking buffer issues. With this update, a concurrent, centralized state tracker ensures that these metrics are always reported as non-negative values. This ensures that the metrics correctly report buffer sizes helping with accurate monitoring. (link:https://issues.redhat.com/browse/LOG-7594[LOG-7594])
+
+* Before this update, a log record with a malformed timestamp could cause the Vector agent to panic when attempting to forward logs to Loki. With this update, error handling for out-of-range timestamp values has been improved resolving the issue. (link:https://issues.redhat.com/browse/LOG-7600[LOG-7600])

--- a/release_notes/logging-release-notes-6.1.adoc
+++ b/release_notes/logging-release-notes-6.1.adoc
@@ -2,9 +2,14 @@
 include::_attributes/common-attributes.adoc[]
 [id="logging-release-notes-6-1"]
 = Logging 6.1 Release Notes
+
 :context: logging-release-notes-6-1
 
 toc::[]
+
+include::modules/logging-release-notes-6-1-8.adoc[leveloffset=+1]
+
+include::modules/logging-release-notes-6-1-7.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-1-6.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 6.1
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2326
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://98302--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6.1.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Note that this PR includes 6.17 release notes because they were missing. The contents of the 6.17 release notes had been reviewed here: https://github.com/openshift/openshift-docs/pull/94862/
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
