### PR TITLE
OSDOCS-15903-17: Created a release note for removed support TLS custo…

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1617,6 +1617,33 @@ In {product-title} 4.16, Patternfly 4 and React Router 5 were deprecated. The de
 [id="ocp-4-17-removed-features_{context}"]
 === Removed features
 
+[id="ocp-4-17-tls-1-2-ciphers_{context}"]
+==== Removed support for TLS 1.2 custom profile ciphers
+
+{product-title} no longer supports the following Transport Layer Security (TLS) 1.2 cipher suites that formed part of the custom TLS profile. Including these cipher suites as a part of a custom TLS profile for TLS v1.2 does not give you the results that you expect.
+
+* `TLS_RSA_WITH_AES_128_GCM_SHA256`
+* `TLS_RSA_WITH_AES_256_GCM_SHA384`
+* `TLS_RSA_WITH_AES_128_CBC_SHA`
+* `TLS_RSA_WITH_AES_256_CBC_SHA`
+* `TLS_RSA_WITH_3DES_EDE_CBC_SHA`
+
+If you must use TLS v1.2, use only v1.2 cipher suites from the Intermediate TLS profile type to ensure that v1.2 is chosen correctly in the TLS handshake. `Intermediate` is the default TLS v1.2 profile and includes the following cipher suites:
+
+* `TLS_AES_128_GCM_SHA256`
+* `TLS_AES_256_GCM_SHA384`
+* `TLS_CHACHA20_POLY1305_SHA256`
+* `ECDHE-ECDSA-AES128-GCM-SHA256`
+* `ECDHE-RSA-AES128-GCM-SHA256`
+* `ECDHE-ECDSA-AES256-GCM-SHA384`
+* `ECDHE-RSA-AES256-GCM-SHA384`
+* `ECDHE-ECDSA-CHACHA20-POLY1305`
+* `ECDHE-RSA-CHACHA20-POLY1305`
+* `DHE-RSA-AES128-GCM-SHA256`
+* `DHE-RSA-AES256-GCM-SHA384`
+
+For a wider range of stronger ciphers in TLS v1.2, use the Intermediate TLS profile type rather than a Custom TLS profile type. If you do not require TLS v1.2, use the Modern profile type, which has the strongest ciphers.
+
 [id="ocp-4-17-sdn-plugin_{context}"]
 ==== OpenShift SDN network plugin (Removed)
 OpenShift SDN network plugin was deprecated in 4.15 and 4.16. With this release, the SDN network plugin is no longer supported and the content has been removed from the documentation.


### PR DESCRIPTION
[CM sent](https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-a:r5716787599964662975) on the 15th of October.

Version(s):
4.17

Issue:
[OSDOCS-15903](https://issues.redhat.com/browse/OSDOCS-15903)

Link to docs preview:
* [Removed support for TLS 1.2 custom profile ciphers](https://98317--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html)

- [x] SME has approved this change (Candace Holman).
- [x] QE has approved this change (Melvin Joseph).

[Service mesh](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/service_mesh/index#ossm-security-cipher_ossm-security) docs mention the now unsupported cipher suites. 
