### PR TITLE
OCPBUGS-58134: Added datastore to table 2.4 in vSphere docs

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -16,7 +16,7 @@ endif::[]
 = vCenter requirements
 
 ifndef::upi[]
-Before you install an {product-title} cluster on your vCenter that uses infrastructure that the installer provisions, you must prepare your environment.
+Before you install an {product-title} cluster on your vCenter that uses infrastructure that the installation program provisions, you must prepare your environment.
 endif::upi[]
 
 ifdef::upi[]
@@ -30,9 +30,9 @@ endif::upi[]
 ifndef::upi[]
 To install an {product-title} cluster in a vCenter, the installation program requires access to an account with privileges to read and create the required resources. Using an account that has global administrative privileges is the simplest way to access all of the necessary permissions.
 
-If you cannot use an account with global administrative privileges, you must create roles to grant the privileges necessary for {product-title} cluster installation. While most of the privileges are always required, some are required only if you plan for the installation program to provision a folder to contain the {product-title} cluster on your vCenter instance, which is the default behavior. You must create or amend vSphere roles for the specified objects to grant the required privileges.
+If you cannot use an account with global administrative privileges, you must create roles to grant the privileges necessary for {product-title} cluster installation. Most of the privileges are always required. Some privileges are required only if you plan for the installation program to provision a folder to contain the {product-title} cluster on your vCenter instance, which is the default behavior. You must create or change vSphere roles for the specified objects to grant the required privileges.
 
-An additional role is required if the installation program is to create a vSphere virtual machine folder.
+The installation program requires an additional role to create a vSphere virtual machine folder.
 endif::upi[]
 
 ifdef::upi[]
@@ -66,7 +66,7 @@ endif::upi[]
 `StorageProfile.View`
 
 |vSphere vCenter Cluster
-|If VMs will be created in the cluster root
+|If VMs need creation in the cluster root
 |
 [%hardbreaks]
 `Host.Config.Storage`
@@ -76,7 +76,7 @@ endif::upi[]
 `VirtualMachine.Config.AddNewDisk`
 
 |vSphere vCenter Resource Pool
-|If an existing resource pool is provided
+|For a provided existing resource pool 
 |
 [%hardbreaks]
 `Resource.AssignVMToPool`
@@ -84,7 +84,7 @@ endif::upi[]
 `VApp.Import`
 `VirtualMachine.Config.AddNewDisk`
 
-|vSphere datastore
+|vSphere Datastore
 |Always
 |
 [%hardbreaks]
@@ -201,7 +201,7 @@ endif::upi[]
 `"Profile-driven storage"."Profile-driven storage view"`
 
 |vSphere vCenter Cluster
-|If VMs will be created in the cluster root
+|For VMs creation in the cluster root
 |
 [%hardbreaks]
 `Host.Configuration."Storage partition configuration"`
@@ -211,7 +211,7 @@ endif::upi[]
 `"Virtual machine"."Change Configuration"."Add new disk"`
 
 |vSphere vCenter Resource Pool
-|If an existing resource pool is provided
+|If providing an existing resource pool
 |
 [%hardbreaks]
 `Host.Configuration."Storage partition configuration"`
@@ -220,7 +220,7 @@ endif::upi[]
 `VApp.Import`
 `"Virtual machine"."Change Configuration"."Add new disk"`
 
-|vSphere datastore
+|vSphere Datastore
 |Always
 |
 [%hardbreaks]
@@ -355,7 +355,7 @@ endif::ipi[]
 |True
 |Listed required privileges
 
-|vSphere vCenter datastore
+|vSphere vCenter Datastore
 |Always
 |False
 |Listed required privileges
@@ -388,9 +388,9 @@ For more information about creating an account with only the required privileges
 [id="installation-vsphere-installer-infra-minimum-requirements_{context}"]
 == Minimum required vCenter account privileges
 
-After you create a custom role and assign privileges to it, you can create permissions by selecting specific vSphere objects and then assigning the custom role to a user or group for each object.
+After you create a custom role and assign privileges to the role, you can create permissions by selecting specific vSphere objects. You can then assign the custom role to a user or group for each object.
 
-Before you create permissions or request for the creation of permissions for a vSphere object, determine what minimum permissions apply to the vSphere object. By doing this task, you can ensure a basic interaction exists between a vSphere object and {product-title} architecture.
+Before you create permissions or request for the creation of permissions for a vSphere object, decide what minimum permissions apply to the vSphere object. By doing this task, you can ensure a basic interaction exists between a vSphere object and {product-title} architecture.
 
 [IMPORTANT]
 ====
@@ -401,7 +401,7 @@ Consider creating a custom role when an account with global administrative privi
 
 [IMPORTANT]
 ====
-Accounts that are not configured with the required privileges are unsupported. Installing an {product-title} cluster in a vCenter is tested against a full list of privileges as described in the "Required vCenter account privileges" section. By adhering to the full list of privileges, you can reduce the possibility of unexpected behaviors that might occur when creating a custom role with a restricted set of privileges.
+Red{nbsp}Hat does not support configuring an account without including the required privileges. Installing an {product-title} cluster in a vCenter is tested against a full list of privileges as described in the "Required vCenter account privileges" section. By adhering to the full list of privileges, you can reduce the possibility of unexpected behaviors that might occur when creating a custom role with a restricted set of privileges.
 ====
 
 The following tables specify how the required vCenter account privileges provided earlier in this document are relevant to different aspects of {product-title} architecture.
@@ -444,17 +444,23 @@ ifndef::upi[]
 `VirtualMachine.Config.AddNewDisk`
 
 |vSphere vCenter Resource Pool
-|If you provide an existing resource pool in the `install-config.yaml` file
+|If you included an existing resource pool in the `install-config.yaml` file
 |
 [%hardbreaks]
-`Datastore.Browse`
-`Datastore.FileManagement`
+
 `Host.Config.Storage`
-`InventoryService.Tagging.ObjectAttachable`
 `Resource.AssignVMToPool`
 `VApp.AssignResourcePool`
 `VApp.Import`minimum`
 
+|vSphere Datastore
+|If you referenced a datastore in the `install-config.yaml` file
+|
+[%hardbreaks]
+
+`Datastore.Browse`
+`Datastore.FileManagement`
+`InventoryService.Tagging.ObjectAttachable`
 
 |vSphere Port Group
 |Always
@@ -536,7 +542,7 @@ ifndef::upi[]
 endif::upi[]
 
 [id="post-installation-vsphere-minimum-permissions_{context}"]
-.Minimum permissions for post-installation management of components
+.Minimum permissions for postinstallation management of components
 [%collapsible]
 ====
 [cols="4a,4a,3a",options="header"]
@@ -569,12 +575,12 @@ endif::upi[]
 `Resource.AssignVMToPool`
 
 |vSphere vCenter Resource Pool
-|If you provide an existing resource pool in the `install-config.yaml` file
+|If you included an existing resource pool in the `install-config.yaml` file
 |
 [%hardbreaks]
 `Host.Config.Storage`
 
-|vSphere datastore
+|vSphere Datastore
 |Always
 |
 [%hardbreaks]
@@ -655,12 +661,12 @@ endif::upi[]
 `Host.Config.Storage`
 
 |vSphere vCenter Resource Pool
-|If you provide an existing resource pool in the `install-config.yaml` file
+|If you included an existing resource pool in the `install-config.yaml` file
 |
 [%hardbreaks]
 `Host.Config.Storage`
 
-|vSphere datastore
+|vSphere Datastore
 |Always
 |
 [%hardbreaks]
@@ -727,12 +733,12 @@ endif::upi[]
 `Resource.AssignVMToPool`
 
 |vSphere vCenter Resource Pool
-|If you provide an existing resource pool in the `install-config.yaml` file
+|If you included an existing resource pool in the `install-config.yaml` file
 |
 [%hardbreaks]
 `Read Only`
 
-|vSphere datastore
+|vSphere Datastore
 |Always
 |
 [%hardbreaks]
@@ -785,21 +791,22 @@ endif::upi[]
 
 If you intend on using vMotion in your vSphere environment, consider the following before installing an {product-title} cluster.
 
-* {product-title} generally supports compute-only vMotion, where _generally_ implies that you meet all VMware best practices for vMotion.
+* Using Storage vMotion can cause issues and is not supported.
+* Using VMware compute vMotion to migrate the workloads for both {product-title} compute machines and control plane machines is generally supported, where _generally_ implies that you meet all VMware best practices for vMotion.
 +
 --
 To help ensure the uptime of your compute and control plane nodes, ensure that you follow the VMware best practices for vMotion, and use VMware anti-affinity rules to improve the availability of {product-title} during maintenance or hardware issues.
 
 For more information about vMotion and anti-affinity rules, see the VMware vSphere documentation for  link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vcenterhost.doc/GUID-3B41119A-1276-404B-8BFB-A32409052449.html[vMotion networking requirements] and link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.resmgmt.doc/GUID-FBE46165-065C-48C2-B775-7ADA87FF9A20.html[VM anti-affinity rules].
 --
-* Using Storage vMotion can cause issues and is not supported. If you are using vSphere volumes in your pods, migrating a VM across datastores, either manually or through Storage vMotion, causes invalid references within {product-title} persistent volume (PV) objects that can result in data loss.
-* {product-title} does not support selective migration of VMDKs across datastores, using datastore clusters for VM provisioning or for dynamic or static provisioning of PVs, or using a datastore that is part of a datastore cluster for dynamic or static provisioning of PVs.
+* If you are using {vmw-full} volumes in your pods, migrating a VM across datastores, either manually or through Storage vMotion, causes invalid references within {product-title} persistent volume (PV) objects that can result in data loss.
+* {product-title} does not support selective migration of virtual machine disks (VMDKs) across datastores, using datastore clusters for VM provisioning or for dynamic or static provisioning of PVs, or using a datastore that is part of a datastore cluster for dynamic or static provisioning of PVs.
 +
 [IMPORTANT]
 ====
-You can specify the path of any datastore that exists in a datastore cluster. By default, Storage Distributed Resource Scheduler (SDRS), which uses Storage vMotion, is automatically enabled for a datastore cluster. Red Hat does not support Storage vMotion, so you must disable Storage DRS to avoid data loss issues for your {product-title} cluster.
+You can specify the path of any datastore that exists in a datastore cluster. By default, Storage Distributed Resource Scheduler (SDRS), which uses Storage vMotion, is automatically enabled for a datastore cluster. Red Hat does not support Storage vMotion, so you must disable SDRS to avoid data loss issues for your {product-title} cluster.
 
-If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
+If you must specify VMs across many datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
 ====
 
 [discrete]
@@ -825,7 +832,7 @@ endif::upi[]
 ** 3 control plane nodes
 ** 3 compute machines
 
-Although these resources use 856 GB of storage, the bootstrap node is destroyed during the cluster installation process. A minimum of 800 GB of storage is required to use a standard cluster.
+Although these resources use 856 GB of storage, the bootstrap node gets deleted during the cluster installation process. At a minimum , a standard cluster requires 800 GB of storage.
 
 If you deploy more compute machines, the {product-title} cluster will use more storage.
 
@@ -833,7 +840,7 @@ If you deploy more compute machines, the {product-title} cluster will use more s
 [id="installation-vsphere-installer-infra-requirements-limits_{context}"]
 == Cluster limits
 
-Available resources vary between clusters. The number of possible clusters within a vCenter is limited primarily by available storage space and any limitations on the number of required resources. Be sure to consider both limitations to the vCenter resources that the cluster creates and the resources that you require to deploy a cluster, such as IP addresses and networks.
+Available resources vary between clusters. A limit exists for the number of possible clusters within vCenter, primarily by available storage space and any limitations on the number of required resources. Be sure to consider both limitations to the vCenter resources that the cluster creates and the resources that you require to deploy a cluster, such as IP addresses and networks.
 
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-networking_{context}"]
@@ -862,13 +869,13 @@ Additionally, you must create the following networking resources before you inst
 ifndef::upi[]
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-_{context}"]
-=== Required IP Addresses
+=== Required IP addresses
 For a network that uses DHCP, an installer-provisioned vSphere installation requires two static IP addresses:
 
-* The **API** address is used to access the cluster API.
-* The **Ingress** address is used for cluster ingress traffic.
+* The **API** address for accessing the cluster API.
+* The **Ingress** address for cluster ingress traffic.
 
-You must provide these IP addresses to the installation program when you install the {product-title} cluster.
+You must give these IP addresses to the installation program when you install the {product-title} cluster.
 endif::upi[]
 
 [discrete]
@@ -886,16 +893,11 @@ You must create DNS records for two static IP addresses in the appropriate DNS s
 
 |API VIP
 |`api.<cluster_name>.<base_domain>.`
-|This DNS A/AAAA or CNAME (Canonical Name) record must point to the load balancer
-for the control plane machines. This record must be resolvable by both clients
-external to the cluster and from all the nodes within the cluster.
+|This DNS A/AAAA or CNAME (Canonical Name) record must point to the load balancer for the control plane machines. This record must be resolvable by both clients external to the cluster and from all the nodes within the cluster.
 
 |Ingress VIP
 |`*.apps.<cluster_name>.<base_domain>.`
-|A wildcard DNS A/AAAA or CNAME record that points to the load balancer that targets the
-machines that run the Ingress router pods, which are the worker nodes by
-default. This record must be resolvable by both clients external to the cluster
-and from all the nodes within the cluster.
+|A wildcard DNS A/AAAA or CNAME record that points to the load balancer that targets the machines that run the Ingress router pods, which are the worker nodes by default. This record must be resolvable by both clients external to the cluster and from all the nodes within the cluster.
 |===
 
 ifeval::["{context}" == "ipi-vsphere-installation-reqs"]


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OCPBUGS-58134](https://issues.redhat.com/browse/OCPBUGS-58134)

Link to docs preview:

* [vCentre requirements: Minimum permissions on installer-provisioned infrastructure table](https://98323--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html#installation-vsphere-installer-infra-requirements_ipi-vsphere-installation-reqs)

- [x] SME has approved this change (Yiyong He).
- [x] QE has approved this change (Wenxin Wei).
