### PR TITLE
CMP-3405: Update seccompprofile and seclinuxprofile related commands as both CRD scope…

### DIFF
--- a/modules/spo-applying-profiles.adoc
+++ b/modules/spo-applying-profiles.adoc
@@ -40,7 +40,7 @@ spec:
     runAsNonRoot: true
     seccompProfile:
       type: Localhost
-      localhostProfile: operator/my-namespace/profile1.json
+      localhostProfile: operator/profile1.json
   containers:
     - name: test-container
       image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21
@@ -54,14 +54,14 @@ spec:
 +
 [source,terminal]
 ----
-$ oc -n my-namespace get seccompprofile profile1 --output wide
+$ oc get seccompprofile profile1 --output wide
 ----
 +
 .Example output
 [source,terminal]
 ----
 NAME       STATUS     AGE   SECCOMPPROFILE.LOCALHOSTPROFILE
-profile1   Installed  14s   operator/my-namespace/profile1.json
+profile1   Installed  14s   operator/profile1.json
 ----
 
 . View the path to the localhost profile by running the following command:
@@ -74,7 +74,7 @@ $ oc get sp profile1 --output=jsonpath='{.status.localhostProfile}'
 .Example output
 [source,terminal]
 ----
-operator/my-namespace/profile1.json
+operator/profile1.json
 ----
 
 . Apply the `localhostProfile` output to the patch file:
@@ -87,7 +87,7 @@ spec:
       securityContext:
         seccompProfile:
           type: Localhost
-          localhostProfile: operator/my-namespace/profile1.json
+          localhostProfile: operator/profile1.json
 ----
 
 . Apply the profile to any other workload, such as a `Deployment` object, by running the following command:
@@ -117,7 +117,7 @@ $ oc -n my-namespace get deployment myapp --output=jsonpath='{.spec.template.spe
 ----
 {
   "seccompProfile": {
-    "localhostProfile": "operator/my-namespace/profile1.json",
+    "localhostProfile": "operator/profile1.json",
     "type": "localhost"
   }
 }
@@ -143,13 +143,13 @@ $ oc label ns nginx-deploy --overwrite=true pod-security.kubernetes.io/enforce=p
 +
 [source,terminal]
 ----
-$ oc get selinuxprofile.security-profiles-operator.x-k8s.io/nginx-secure -n nginx-deploy -ojsonpath='{.status.usage}'
+$ oc get selinuxprofile.security-profiles-operator.x-k8s.io/nginx-secure -ojsonpath='{.status.usage}'
 ----
 +
 .Example output
 [source,terminal]
 ----
-nginx-secure_nginx-deploy.process
+nginx-secure_.process
 ----
 
 . Apply the output string in the workload manifest in the `.spec.containers[].securityContext.seLinuxOptions` attribute:
@@ -175,7 +175,7 @@ spec:
           drop: [ALL]
         seLinuxOptions:
           # NOTE: This uses an appropriate SELinux type
-          type: nginx-secure_nginx-deploy.process
+          type: nginx-secure_.process
 ----
 +
 [IMPORTANT]

--- a/modules/spo-base-syscalls.adoc
+++ b/modules/spo-base-syscalls.adoc
@@ -17,7 +17,6 @@ You can use the `baseProfileName` attribute to establish the minimum required `s
 apiVersion: security-profiles-operator.x-k8s.io/v1beta1
 kind: SeccompProfile
 metadata:
-  namespace: my-namespace
   name: example-name
 spec:
   defaultAction: SCMP_ACT_ERRNO

--- a/modules/spo-binding-workloads.adoc
+++ b/modules/spo-binding-workloads.adoc
@@ -92,7 +92,7 @@ $ oc get pod test-pod -o jsonpath='{.spec.containers[*].securityContext.seccompP
 .Example output
 [source,terminal]
 ----
-{"localhostProfile":"operator/my-namespace/profile.json","type":"Localhost"}
+{"localhostProfile":"operator/profile.json","type":"Localhost"}
 ----
 endif::[]
 ifdef::selinux[]
@@ -106,7 +106,7 @@ $ oc get pod test-pod -o jsonpath='{.spec.containers[*].securityContext.seLinuxO
 .Example output
 [source,terminal]
 ----
-profile_nginx-binding.process
+profile_.process
 ----
 endif::[]
 

--- a/modules/spo-container-profile-instances.adoc
+++ b/modules/spo-container-profile-instances.adoc
@@ -104,8 +104,8 @@ ifdef::selinux[]
 .Example output for {object}
 [source,terminal]
 ----
-NAME                          USAGE                                              STATE
-test-recording-nginx-record   test-recording-nginx-record_my-namespace.process   Installed
+NAME                          USAGE                                  STATE
+test-recording-nginx-record   test-recording-nginx-record_.process   Installed
 ----
 endif::[]
 ifdef::seccomp[]

--- a/modules/spo-creating-profiles.adoc
+++ b/modules/spo-creating-profiles.adoc
@@ -40,7 +40,6 @@ $ oc new-project my-namespace
 apiVersion: security-profiles-operator.x-k8s.io/v1beta1
 kind: {kind}
 metadata:
-  namespace: my-namespace
   name: profile1
 spec:
   defaultAction: SCMP_ACT_LOG
@@ -76,7 +75,6 @@ apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: {kind}
 metadata:
   name: nginx-secure
-  namespace: nginx-deploy
 spec:
   allow:
     '@self':
@@ -97,7 +95,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc wait --for=condition=ready -n nginx-deploy selinuxprofile nginx-secure
+$ oc wait --for=condition=ready selinuxprofile nginx-secure
 ----
 +
 .Example output
@@ -121,15 +119,15 @@ $ oc -n openshift-security-profiles rsh -c selinuxd ds/spod
 +
 [source,terminal]
 ----
-$ cat /etc/selinux.d/nginx-secure_nginx-deploy.cil
+$ cat /etc/selinux.d/nginx-secure_.cil
 ----
 +
 .Example output
 [source,terminal]
 ----
-(block nginx-secure_nginx-deploy
+(block nginx-secure_
 (blockinherit container)
-(allow process nginx-secure_nginx-deploy.process ( tcp_socket ( listen )))
+(allow process nginx-secure_.process ( tcp_socket ( listen )))
 (allow process http_cache_port_t ( tcp_socket ( name_bind )))
 (allow process node_t ( tcp_socket ( node_bind )))
 )
@@ -145,7 +143,7 @@ $ semodule -l | grep nginx-secure
 .Example output
 [source,terminal]
 ----
-nginx-secure_nginx-deploy
+nginx-secure_
 ----
 endif::[]
 

--- a/modules/spo-log-enricher-app-trace.adoc
+++ b/modules/spo-log-enricher-app-trace.adoc
@@ -18,7 +18,6 @@ apiVersion: security-profiles-operator.x-k8s.io/v1beta1
 kind: SeccompProfile
 metadata:
   name: log
-  namespace: default
 spec:
   defaultAction: SCMP_ACT_LOG
 ----
@@ -31,12 +30,13 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: log-pod
+  namespace: default
 spec:
   securityContext:
     runAsNonRoot: true
     seccompProfile:
       type: Localhost
-      localhostProfile: operator/default/log.json
+      localhostProfile: operator/log.json
   containers:
   - name: log-container
     image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21

--- a/modules/spo-recording-profiles.adoc
+++ b/modules/spo-recording-profiles.adoc
@@ -142,7 +142,7 @@ endif::[]
 +
 [source,terminal]
 ----
-$ oc -n my-namepace delete pod my-pod
+$ oc -n my-namespace delete pod my-pod
 ----
 
 . Confirm the Security Profiles Operator reconciles the two {type} profiles:
@@ -151,7 +151,7 @@ ifdef::seccomp[]
 +
 [source,terminal]
 ----
-$ oc get seccompprofiles -lspo.x-k8s.io/recording-id=test-recording -n my-namespace
+$ oc get seccompprofiles -lspo.x-k8s.io/recording-id=test-recording
 ----
 +
 .Example output for seccompprofile
@@ -167,15 +167,15 @@ ifdef::selinux[]
 +
 [source,terminal]
 ----
-$ oc get selinuxprofiles -lspo.x-k8s.io/recording-id=test-recording -n my-namespace
+$ oc get selinuxprofiles -lspo.x-k8s.io/recording-id=test-recording
 ----
 +
 .Example output for selinuxprofile
 [source,terminal]
 ----
 NAME                   USAGE                                       STATE
-test-recording-nginx   test-recording-nginx_my-namespace.process   Installed
-test-recording-redis   test-recording-redis_my-namespace.process   Installed
+test-recording-nginx   test-recording-nginx_.process   Installed
+test-recording-redis   test-recording-redis_.process   Installed
 ----
 endif::[]
 

--- a/modules/spo-replicating-controllers.adoc
+++ b/modules/spo-replicating-controllers.adoc
@@ -93,7 +93,7 @@ spec:
       serviceAccountName: spo-deploy-test
       securityContext:
         seLinuxOptions:
-          type: nginx-secure_nginx-secure.process <1>
+          type: nginx-secure_.process <1>
       containers:
       - name: nginx-unpriv
         image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21

--- a/modules/spo-selinux-permissive.adoc
+++ b/modules/spo-selinux-permissive.adoc
@@ -23,7 +23,6 @@ apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
 kind: SelinuxProfile
 metadata:
   name: nginx-secure
-  namespace: nginx-deploy
 spec:
   permissive: true
 ----


### PR DESCRIPTION
… are cluster wide now

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
SPOv0.9.0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
In PR https://github.com/kubernetes-sigs/security-profiles-operator/pull/2735, the security profiles CRDs scope has been updated to cluster wide. In this PR, the security profiles related commands are updated accordingly.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
