### PR TITLE
CNV-43322: Release note for OCI GA

### DIFF
--- a/virt/release_notes/virt-4-20-release-notes.adoc
+++ b/virt/release_notes/virt-4-20-release-notes.adoc
@@ -61,6 +61,9 @@ This release adds new features and enhancements related to the following compone
 [id="virt-4-20-installation-update_{context}"]
 === Installation and update
 
+//CNV-43322 Release notes:TP to GA OCI
+* Installing {VirtProductName} on {oci-first-no-rt} is now generally available. For more information, see link:https://access.redhat.com/articles/7118050[{VirtProductName} and Oracle Cloud Infrastructure known issues and limitations] in the Red{nbsp}Hat Knowledgebase, and link:https://github.com/oracle-quickstart/oci-openshift/blob/main/docs/openshift-virtualization.md[Installing {VirtProductName} on OCI] on GitHub.
+
 [id="virt-4-20-infrastructure_{context}"]
 === Infrastructure
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
[CNV-43322](https://issues.redhat.com/browse/CNV-43322)

[Link to docs preview](https://98327--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-20-release-notes.html#virt-4-20-installation-update_virt-4-20-release-notes)

QE review:
- [x] QE has approved this change.