### PR TITLE
OSDOCS-12324: Added passthrough mode to config in installing-gcp-clus…

### DIFF
--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -65,6 +65,9 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installing-gcp-user-defined-labels-and-tags.adoc[leveloffset=+1]
 
+// Criteria for user-defined labels and tags
+include::modules/installing-gcp-cluster-label-tag-reference.adoc[leveloffset=+2]
+
 //Configuring user-defined labels and tags for GCP
 include::modules/installing-gcp-cluster-creation.adoc[leveloffset=+2]
 

--- a/modules/installing-gcp-cluster-creation.adoc
+++ b/modules/installing-gcp-cluster-creation.adoc
@@ -5,17 +5,19 @@
 [id="installing-gcp-cluster-creation_{context}"]
 = Configuring user-defined labels and tags for GCP
 
+Configuring user-defined labels and tags for {gcp-full} means that you can apply key-value pairs to your cloud resources for the purposes of organizing, managing, and automating your infrastructure.
+
 .Prerequisites
 
 * The installation program requires that a service account includes a `TagUser` role, so that the program can create the {product-title} cluster with defined tags at both organization and project levels.
 
 .Procedure
 
-* Update the `install-config.yaml` file to define the list of desired labels and tags.
+* Update the `install-config.yaml` file to define the list of required labels and tags.
 +
 [NOTE]
 ====
-Labels and tags are defined during the `install-config.yaml` creation phase, and cannot be modified or updated with new labels and tags after cluster creation.
+If you set labels and tags during creation of the `install-config.yaml` configuration file, you cannot create new or update existing labels and tags after creation of the cluster.
 ====
 +
 .Sample `install-config.yaml` file
@@ -23,39 +25,21 @@ Labels and tags are defined during the `install-config.yaml` creation phase, and
 [source,yaml]
 ----
 apiVersion: v1
+credentialsMode: Passthrough <1>
 platform:
  gcp:
-   userLabels: <1>
-   - key: <label_key><2>
-     value: <label_value><3>
-   userTags: <4>
-   - parentID: <OrganizationID/ProjectID><5>
+   userLabels: <2>
+   - key: <label_key><3>
+     value: <label_value><4>
+   userTags: <5>
+   - parentID: <OrganizationID/ProjectID><6>
      key: <tag_key_short_name>
      value: <tag_value_short_name>
+# ...
 ----
-<1> Adds keys and values as labels to the resources created on GCP.
-<2> Defines the label name.
-<3> Defines the label content.
-<4> Adds keys and values as tags to the resources created on GCP.
-<5> The ID of the hierarchical resource where the tags are defined, at the organization or the project level.
-
-The following are the requirements for user-defined labels:
-
-* A label key and value must have a minimum of 1 character and can have a maximum of 63 characters.
-* A label key and value must contain only lowercase letters, numeric characters, underscore (`_`), and dash (`-`).
-* A label key must start with a lowercase letter.
-* You can configure a maximum of 32 labels per resource. Each resource can have a maximum of 64 labels, and 32 labels are reserved for internal use by {product-title}.
-
-The following are the requirements for user-defined tags:
-
-* Tag key and tag value must already exist. {product-title} does not create the key and the value.
-* A tag `parentID` can be either `OrganizationID` or `ProjectID`:
-** `OrganizationID` must consist of decimal numbers without leading zeros.
-** `ProjectID` must be 6 to 30 characters in length, that includes only lowercase letters, numbers, and hyphens.
-** `ProjectID` must start with a letter, and cannot end with a hyphen.
-* A tag key must contain only uppercase and lowercase alphanumeric characters, hyphen (`-`), underscore (`_`), and period (`.`).
-* A tag value must contain only uppercase and lowercase alphanumeric characters, hyphen (`-`), underscore (`_`), period (`.`), at sign (`@`), percent sign (`%`), equals sign (`=`), plus (`+`), colon (`:`), comma (`,`), asterisk (`*`), pound sign (`$`), ampersand (`&`), parentheses (`()`), square braces (`[]`), curly braces (`{}`), and space.
-* A tag key and value must begin and end with an alphanumeric character.
-* Tag value must be one of the pre-defined values for the key.
-* You can configure a maximum of 50 tags.
-* There should be no tag key defined with the same value as any of the existing tag keys that will be inherited from the parent resource.
+<1> In passthrough mode, the Cloud Credential Operator (CCO) passes the provided cloud credential to the components that request cloud credentials. 
+<2> Adds keys and values as labels to the resources created on {gcp-short}.
+<3> Defines the label name.
+<4> Defines the label content.
+<5> Adds keys and values as tags to the resources created on {gcp-short}.
+<6> The ID of the hierarchical resource where you defined the tags at the organization or the project level.

--- a/modules/installing-gcp-cluster-label-tag-reference.adoc
+++ b/modules/installing-gcp-cluster-label-tag-reference.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="installing-gcp-cluster-label-tag-reference_{context}"]
+= Criteria for user-defined labels and tags
+
+Before configuring user-defined labels and tags for {gcp-full}, consider the importance of meeting the requirements for these tag and labels to ensure proper resource governance.
+
+The following list details the requirements for user-defined labels:
+
+* A label key and value must have a minimum of 1 character and can have a maximum of 63 characters.
+* A label key and value must contain only lowercase letters, numeric characters, an underscore (`_`), and a dash (`-`).
+* A label key must start with a lowercase letter.
+* You can configure a maximum of 32 labels per resource. 
+** Each resource has a maximum of 64 labels, where {product-title} reserves 32 labels for internal use.
+
+The following list details the requirements for user-defined tags:
+
+* Tag key and tag value must already exist. {product-title} does not create the key and the value.
+* A tag `parentID` can be either `OrganizationID` or `ProjectID`:
+** `OrganizationID` must consist of decimal numbers without leading zeros.
+** `ProjectID` must be 6 to 30 characters in length, that includes only lowercase letters, numbers, and hyphens.
+** `ProjectID` must start with a letter, and cannot end with a hyphen.
+* A tag key must contain only uppercase and lowercase alphanumeric characters, a hyphen (`-`), an underscore (`_`), and a period (`.`).
+* A tag value must contain only uppercase and lowercase alphanumeric characters and any of the following characters:
+** A colon (`:`)
+** A comma (`,`)
+** A curly braces (`{}`)
+** A hyphen (`-`)
+** A parentheses (`()`)
+** A percent sign (`%`)
+** A plus (`+`)
+** A pound sign (`$`)
+** A space.
+** A square braces (`[]`)
+** An ampersand (`&`)
+** An asterisk (`*`)
+** An at sign (`@`)
+** An equals sign (`=`)
+** An underscore (`_`)
+** A period (`.`)
+* A tag key and value must begin and end with an alphanumeric character.
+* Tag value must be one of the predefined values for the key.
+* You can configure a maximum of 50 tags.
+* Do not define a tag key with the same value as any of the existing tag keys that get inherited from the parent resource.


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-12324](https://issues.redhat.com/browse/OSDOCS-12324)

Link to docs preview:
* [Configuring user-defined labels and tags for GCP](https://98338--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installing-gcp-cluster-creation_installing-gcp-customizations)

- [x] SME has approved this change (Bharath B).
- [x] QE has approved this change (Jianli Wei).

* https://github.com/openshift/openshift-docs/pull/63253
