### PR TITLE
OSDOCS-14643: adds 4.16.47 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -439,3 +439,12 @@ See the latest images included with {microshift-short} by xref:../microshift_upd
 ==== Bug fixes
 
 * Previously, the greenboot health check was marking a {op-system-ostree} healthy system as unhealthy due to a relatively low 300-second timeout. This timeout was not enough on systems with a slow network. With this release, the default greenboot wait timeout is now 600 seconds, meaning there is more time to download images. This results in an accurate system check.
+
+[id="microshift-4-16-47-dp_{context}"]
+=== RHBA-2025:14926 - {microshift-short} 4.16.47 bug fix advisory
+
+Issued: 3 September 2025
+
+{product-title} release 4.16.47 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:14926[RHBA-2025:14926] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:14859[RHSA-2025:14859] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-14643](https://issues.redhat.com/browse/OSDOCS-14643)

Link to docs preview:
[microshift-4-16-47-dp_release-notes](https://98349--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html#microshift-4-16-47-dp_release-notes)

QE review:
- N/A no technical info; stock text only

Additional info: Please review, but do not merge. If all is well, please place the "ok-to-merge" label on this and I will merge when the release goes live. TY!
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
