### PR TITLE
CP415-OSDOCS-15449: manual backport CQA

### DIFF
--- a/installing/disconnected_install/index.adoc
+++ b/installing/disconnected_install/index.adoc
@@ -6,23 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use a mirror registry to ensure that your clusters only use container images that satisfy your organizational controls on external content. Before you install a cluster on infrastructure that you provision in a restricted network, you must mirror the required container images into that environment. To mirror container images, you must have a registry for mirroring.
+As a cluster administrator, you can use a mirror registry to ensure that your clusters only use container images that satisfy your organizational controls on external content.
 
-[id="creating-mirror-registry"]
-== Creating a mirror registry
-
-If you already have a container image registry, such as {quay}, you can use it as your mirror registry. If you do not already have a registry, you can xref:../../installing/disconnected_install/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[create a mirror registry using the _mirror registry for Red{nbsp}Hat OpenShift_].
-
-[id="mirroring-images-disconnected-install"]
-== Mirroring images for a disconnected installation
-
-You can use one of the following procedures to mirror your {product-title} image repository to your mirror registry:
-
-* xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
-* xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
+include::modules/installing-mirroring-disconnected-con.adoc[leveloffset=+1]
 
 [id="next-steps_{context}"]
 [role="_additional-resources"]
 == Next steps
 
+* xref:../../installing/disconnected_install/installing-mirroring-creating-registry.adoc#installing-mirroring-creating-registry[Creating a mirror registry using the _mirror registry for Red{nbsp}Hat OpenShift_]
+* xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Mirroring images for a disconnected installation]
+* xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
 * xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]

--- a/modules/installing-mirroring-disconnected-con.adoc
+++ b/modules/installing-mirroring-disconnected-con.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * disconnected_install/index.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installing-mirroring-disconnected-con_{context}"]
+= Mirror registries for installing clusters in disconnected environments
+
+You must mirror required container images into a disconnected environment before you can install and provision a cluster there. To mirror those container images, you must have a mirror registry. Consider the following options for creating and using a mirror registry:
+
+* If you already have a container image registry, such as {quay}, you can use it as your mirror registry. If you do not already have a registry, you must create one.
+* After you establish your registry, you need mirroring tools. To mirror your {product-title} image repository to the mirror registry in your disconnected environment, you can use the oc-mirror {oc-first} plugin. The oc-mirror plugin is a single tool that mirrors all required {product-title} content and other images to your mirror registry. The oc-mirror plugin is the preferred method for mirroring.
+* Alternately, you can use the `oc adm` command to mirror just release and catalog images for {product-title}.


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-15449](https://issues.redhat.com/browse/OSDOCS-15449)

Link to docs preview:
https://98352--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/disconnected_install/index.html

Additional information:
Manual CP https://github.com/openshift/openshift-docs/pull/98095

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
