### PR TITLE
OBSDOCS-2375 migrate links to incidents to standalone

### DIFF
--- a/about/cluster-observability-operator-overview.adoc
+++ b/about/cluster-observability-operator-overview.adoc
@@ -14,9 +14,11 @@ The {coo-short} deploys the following monitoring components:
 * **Prometheus** - A highly available Prometheus instance capable of sending metrics to an external endpoint by using remote write.
 * **Thanos Querier** (optional) - Enables querying of Prometheus instances from a central location.
 * **Alertmanager** (optional) - Provides alert configuration capabilities for different services.
-* **UI plugins** (optional) - Enhances the observability capabilities with plugins for monitoring, logging, distributed tracing and troubleshooting.
+* **xref:../ui_plugins/observability-ui-plugins-overview.adoc#observability-ui-plugins-overview[UI plugins]** (optional) - Enhances the observability capabilities with plugins for monitoring, logging, distributed tracing and troubleshooting.
 * **Korrel8r** (optional) - Provides observability signal correlation, powered by the open source Korrel8r project.
-* **Incident detection** (optional) - Groups related alerts into incidents, to help you identify the root causes of alert bursts.
+* **xref:../ui_plugins/monitoring-ui-plugin.adoc#coo-incident-detection-overview_monitoring-ui-plugin[Incident detection]** (optional) - Groups related alerts into incidents, to help you identify the root causes of alert bursts.
+
+
 
 include::modules/coo-versus-default-ocp-monitoring.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
main, CP to 1-latest

Issue:
[OBSDOCS-2375](https://issues.redhat.com//browse/OBSDOCS-2375)

Link to docs preview:


QE review:
n/a

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
