### PR TITLE
OSDOCS-14097: Restriction on installing clusters into installer-created VPC

### DIFF
--- a/modules/ccs-aws-provisioned.adoc
+++ b/modules/ccs-aws-provisioned.adoc
@@ -63,13 +63,15 @@ Two buckets are required with a typical size of 2 TB each.
 == VPC
 Customers should expect to see one VPC per cluster. Additionally, the VPC needs the following configurations:
 
+include::snippets/install-cluster-in-vpc.adoc[]
+
 * *Subnets*: Two subnets for a cluster with a single availability zone, or six subnets for a cluster with multiple availability zones.
 +
 [NOTE]
 ====
 A *public subnet* connects directly to the internet through an internet gateway. A *private subnet* connects to the internet through a network address translation (NAT) gateway.
 ====
-+ 
++
 * *Route tables*: One route table per private subnet, and one additional table per cluster.
 
 * *Internet gateways*: One Internet Gateway per cluster.

--- a/modules/ccs-gcp-provisioned.adoc
+++ b/modules/ccs-gcp-provisioned.adoc
@@ -36,6 +36,8 @@ GCP compute instances are required to deploy the control plane and data plane fu
 [id="gcp-policy-vpc_{context}"]
 == VPC
 
+include::snippets/install-cluster-in-vpc.adoc[]
+
 * **Subnets:** One master subnet for the control plane workloads and one worker subnet for all others.
 * **Router tables:** One global route table per VPC.
 * **Internet gateways:** One internet gateway per cluster.

--- a/modules/create-wif-cluster-ocm.adoc
+++ b/modules/create-wif-cluster-ocm.adoc
@@ -145,6 +145,9 @@ For more information about custom application ingress settings, click on the inf
 
 . Optional: To install the cluster into a GCP Shared VPC, follow these steps.
 +
+--
+include::snippets/install-cluster-in-vpc.adoc[]
+
 [IMPORTANT]
 ====
 The VPC owner of the host project must enable a project as a host project in their Google Cloud console and add the *Computer Network Administrator*, *Compute Security Administrator*, and *DNS Administrator* roles to the following service accounts prior to cluster installation:
@@ -157,7 +160,7 @@ Failure to do so will cause the cluster go into the "Installation Waiting" state
 The VPC owner of the host project has 30 days to grant the listed permissions before the cluster creation fails.
 For more information, see link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#set-up-shared-vpc[Enable a host project] and link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#migs-service-accounts[Provision Shared VPC].
 ====
-+
+
 .. Select *Install into GCP Shared VPC*.
 .. Specify the *Host project ID*. If the specified host project ID is incorrect, cluster creation fails.
 
@@ -169,7 +172,7 @@ You must have created the Cloud network address translation (NAT) and a Cloud ro
 ====
 If you are installing a cluster into a Shared VPC, the VPC name and subnets are shared from the host project.
 ====
-+
+--
 . Click *Next*.
 . If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
 +

--- a/modules/osd-create-cluster-ccs-aws.adoc
+++ b/modules/osd-create-cluster-ccs-aws.adoc
@@ -134,6 +134,10 @@ If you are using private API endpoints, you cannot access your cluster until you
 ====
 +
 . Optional: To install the cluster in an existing AWS Virtual Private Cloud (VPC):
++
+--
+include::snippets/install-cluster-in-vpc.adoc[]
+
 .. Select *Install into an existing VPC*.
 .. If you are installing into an existing VPC and opted to use private API endpoints, you can select *Use a PrivateLink*. This option enables connections to the cluster by Red Hat Site Reliability Engineering (SRE) using only AWS PrivateLink endpoints.
 +
@@ -143,6 +147,7 @@ The *Use a PrivateLink* option cannot be changed after a cluster is created.
 ====
 +
 .. If you are installing into an existing VPC and you want to enable an HTTP or HTTPS proxy for your cluster, select *Configure a cluster-wide proxy*.
+--
 . If you opted to install the cluster in an existing AWS VPC, provide your *Virtual Private Cloud (VPC) subnet settings* and select *Next*.
 You must have created the Cloud network address translation (NAT) and a Cloud router. See the "Additional resources" section for information about Cloud NATs and Google VPCs.
 +

--- a/modules/osd-create-cluster-ccs-gcp.adoc
+++ b/modules/osd-create-cluster-ccs-gcp.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * osd_install_access_delete_cluster/creating-a-gcp-cluster.adoc
+// * I do not believe this is in use, confirm with Mark Letalien.
 
 
 
@@ -157,11 +158,12 @@ Private Service Connect is supported only with *Install into an existing VPC*.
 +
 .. If you are installing into an existing VPC and you want to enable an HTTP or HTTPS proxy for your cluster, select *Configure a cluster-wide proxy*.
 +
+
 [IMPORTANT]
 ====
 In order to configure a cluster-wide proxy for your cluster, you must first create the Cloud network address translation (NAT) and a Cloud router. See the _Additional resources_ section for more information.
 ====
-+
+
 . Accept the default application ingress settings, or to create your own custom settings, select *Custom Settings*.
 
 .. Optional: Provide route selector.
@@ -171,7 +173,6 @@ In order to configure a cluster-wide proxy for your cluster, you must first crea
 +
 For more information about custom application ingress settings, click on the information icon provided for each setting.
 
-+
 . Click *Next*.
 
 . Optional: To install the cluster into a GCP Shared VPC:

--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -153,6 +153,10 @@ If you are using private API endpoints, you cannot access your cluster until you
 +
 
 . Optional: To install the cluster in an existing GCP Virtual Private Cloud (VPC):
++
+--
+include::snippets/install-cluster-in-vpc.adoc[]
+
 .. Select *Install into an existing VPC*.
 +
 [IMPORTANT]
@@ -166,7 +170,7 @@ Private Service Connect is supported only with *Install into an existing VPC*.
 ====
 In order to configure a cluster-wide proxy for your cluster, you must first create the Cloud network address translation (NAT) and a Cloud router. See the _Additional resources_ section for more information.
 ====
-+
+--
 . Accept the default application ingress settings, or to create your own custom settings, select *Custom Settings*.
 
 .. Optional: Provide route selector.
@@ -264,7 +268,6 @@ By default, clusters are created with the delete protection feature disabled.
 ====
 If you delete a cluster that was installed into a GCP Shared VPC, inform the VPC owner of the host project to remove the IAM policy roles granted to the service account that was referenced during cluster creation.
 ====
-
 
 .Verification
 

--- a/modules/osd-create-cluster-gcp-account.adoc
+++ b/modules/osd-create-cluster-gcp-account.adoc
@@ -124,6 +124,7 @@ Red Hat recommends using Private Service Connect when deploying a private {produ
 //Once PSC docs are live add link from note above.
 +
 . Optional: To install the cluster in an existing GCP Virtual Private Cloud (VPC):
+
 .. Select *Install into an existing VPC*.
 +
 [IMPORTANT]

--- a/modules/osd-create-cluster-rhm-gcp-account.adoc
+++ b/modules/osd-create-cluster-rhm-gcp-account.adoc
@@ -124,6 +124,7 @@ Red Hat recommends using Private Service Connect when deploying a private {produ
 //Once PSC docs are live add link from note above.
 +
 . Optional: To install the cluster in an existing GCP Virtual Private Cloud (VPC):
+
 .. Select *Install into an existing VPC*.
 +
 [IMPORTANT]

--- a/rosa_hcp/rosa-hcp-shared-vpc-config.adoc
+++ b/rosa_hcp/rosa-hcp-shared-vpc-config.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 You can create {hcp-title-first} clusters in shared, centrally-managed AWS virtual private clouds (VPCs).
 
+include::snippets/install-cluster-in-vpc.adoc[]
+
 [NOTE]
 ====
 * This process requires *two separate* AWS accounts that belong to the same AWS organization. One account functions as the VPC-owning AWS account (*VPC Owner*), while the other account creates the cluster in the cluster-creating AWS account (*Cluster Creator*).

--- a/rosa_install_access_delete_clusters/rosa-shared-vpc-config.adoc
+++ b/rosa_install_access_delete_clusters/rosa-shared-vpc-config.adoc
@@ -11,6 +11,8 @@ ifdef::openshift-rosa[]
 endif::openshift-rosa[]
 clusters in shared, centrally-managed AWS virtual private clouds (VPCs).
 
+include::snippets/install-cluster-in-vpc.adoc[]
+
 [NOTE]
 ====
 This process requires *two separate* AWS accounts that belong to the same AWS organization. One account functions as the VPC-owning AWS account (*VPC Owner*), while the other account creates the cluster in the cluster-creating AWS account (*Cluster Creator*).

--- a/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
+++ b/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
@@ -180,6 +180,8 @@ ifdef::openshift-rosa[]
 
 If you choose to deploy a PrivateLink cluster, then be sure to deploy the cluster in the pre-existing BYO VPC:
 
+include::snippets/install-cluster-in-vpc.adoc[]
+
 * Create a public and private subnet for each AZ that your cluster uses.
 ** Alternatively, implement transit gateway for internet and egress with appropriate routes.
 * The VPC's CIDR block must contain the `Networking.MachineCIDR` range, which is the IP address for cluster machines.
@@ -207,6 +209,8 @@ ifdef::openshift-rosa-hcp[]
 === Create VPC before cluster deployment
 
 {product-title} clusters must be deployed into an existing AWS Virtual Private Cloud (VPC).
+
+include::snippets/install-cluster-in-vpc.adoc[]
 
 include::snippets/rosa-existing-vpc-requirements.adoc[leveloffset=+0]
 

--- a/snippets/install-cluster-in-vpc.adoc
+++ b/snippets/install-cluster-in-vpc.adoc
@@ -1,0 +1,23 @@
+// Text snippet included in the following modules:
+// * OSD files
+// * modules/create-wif-cluster-ocm.adoc
+// * modules/osd-create-cluster-ccs-gcp.adoc
+// * modules/osd-create-cluster-ccs-aws.adoc
+// * modules/ccs-gcp-provisioned.adoc
+// * modules/ccs-aws-provisioned.adoc
+
+// * ROSA files
+// * modules/rosa-shared-vpc-config.adoc - installing clusters
+// * modules/rosa-cloud-expert-prereq-checklist.adoc - line 181 prep your enviro
+
+
+// * HCP files
+// * modules/rosa-hcp-shared-vpc-config.adoc
+// * modules/rosa-cloud-expert-prereq-checklist.adoc - line 211 for HCP
+
+
+:_mod-docs-content-type: SNIPPET
+[NOTE]
+====
+Installing a new {product-title} cluster into a VPC that was automatically created by the installer for a different cluster is not supported.
+====


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-15791

Link to docs preview:

- https://98360--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_aws_clusters/creating-an-aws-cluster.html
- https://98360--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-sa.html
- https://98360--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.html
- https://98360--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs.html
- https://98360--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html
- https://98360--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-shared-vpc-config.html
- https://98360--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-cloud-expert-prereq-checklist.html
- https://98360--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-shared-vpc-config.html
- https://98360--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-cloud-expert-prereq-checklist.html

QE review:
not needed for this note created by PM
