### PR TITLE
OADP-4005: Add CloudStorage API support

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -29,16 +29,6 @@ If the underlying storage or the backup bucket are part of the same cluster, the
 
 For more information about CSI volume snapshots, see xref:../../../storage/container_storage_interface/persistent-storage-csi-snapshots.adoc#persistent-storage-csi-snapshots[CSI volume snapshots].
 
-:FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
-include::snippets/technology-preview.adoc[]
-
-[NOTE]
-====
-The `CloudStorage` API is a Technology Preview feature when you use a `CloudStorage` object and want OADP to use the `CloudStorage` API to automatically create an S3 bucket for use as a `BackupStorageLocation`.
-
-The `CloudStorage` API supports manually creating a `BackupStorageLocation` object by specifying an existing S3 bucket. The `CloudStorage` API that creates an S3 bucket automatically is currently only enabled for AWS S3 storage.
-====
-
 * If your cloud provider does not support snapshots or if your applications are on NFS data volumes, you can create backups by using Kopia or Restic. See xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc#oadp-backing-up-applications-restic-doc[Backing up applications with File System Backup: Kopia or Restic].
 
 include::snippets/pod-volume-restore-snapshot-read-only.adoc[]

--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -24,16 +24,6 @@ You can configure multiple backup storage locations within the same namespace fo
 
 include::snippets/snip-noobaa-and-mcg.adoc[]
 
-:FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
-include::snippets/technology-preview.adoc[]
-
-[NOTE]
-====
-The `CloudStorage` API is a Technology Preview feature when you use a `CloudStorage` object and want OADP to use the `CloudStorage` API to automatically create an S3 bucket for use as a `BackupStorageLocation`.
-
-The `CloudStorage` API supports manually creating a `BackupStorageLocation` object by specifying an existing S3 bucket. The `CloudStorage` API that creates an S3 bucket automatically is currently only enabled for AWS S3 storage.
-====
-
 You can back up persistent volumes (PVs) by using snapshots or a File System Backup (FSB).
 
 To back up PVs with snapshots, you must have a cloud provider that supports either a native snapshot API or Container Storage Interface (CSI) snapshots, such as one of the following cloud providers:

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc
@@ -16,9 +16,6 @@ You can install the {oadp-first} with MCG by installing the OADP Operator. The O
 
 include::snippets/oadp-mtc-operator.adoc[]
 
-:FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
-include::snippets/technology-preview.adoc[]
-
 You can create a `Secret` CR for the backup location and install the Data Protection Application. For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
 
 To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. For details, see xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].

--- a/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
@@ -16,9 +16,6 @@ include::snippets/oadp-mtc-operator.adoc[]
 
 You can configure xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway] or any AWS S3-compatible object storage as a backup location.
 
-:FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
-include::snippets/technology-preview.adoc[]
-
 You can create a `Secret` CR for the backup location and install the Data Protection Application. For more details, see xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator.adoc#oadp-installing-operator-doc[Installing the OADP Operator].
 
 To install the OADP Operator in a restricted network environment, you must first disable the default OperatorHub sources and mirror the Operator catalog. For details, see xref:../../../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments].

--- a/backup_and_restore/index.adoc
+++ b/backup_and_restore/index.adoc
@@ -57,9 +57,6 @@ OADP has the following requirements:
 
 include::snippets/oadp-ocp-compat.adoc[]
 
-:FeatureName: The `CloudStorage` API for S3 storage
-include::snippets/technology-preview.adoc[]
-
 * To back up PVs with snapshots, you must have cloud storage that has a native snapshot API or supports Container Storage Interface (CSI) snapshots, such as the following providers:
 
 ** Amazon Web Services


### PR DESCRIPTION
Version(s):
OCP 4.19-4.20

Issue:
[OADP-4005](https://issues.redhat.com/browse/OADP-4005)

Link to docs preview:
Technology Preview admonitions for CloudStorage API removed from the following chapters:
- [Backing up applications](https://98366--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html)
- [About installing OADP](https://98366--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html)
- [OADP requirements](https://98366--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/index.html#oadp-requirements)
- [Configuring the OpenShift API for Data Protection with Multicloud Object Gateway](https://98366--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html)
- [Configuring the OpenShift API for Data Protection with OpenShift Data Foundation](https://98366--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html)

Reviews:
- [x] QE has approved this change.
- [ ] Vale validation with AsciiDocDITA package done - not applicable.
