### PR TITLE
[enterprise-4.16] OSDOCS-15972 [NETOBSERV] Module Aditi tool results: AuthorLine

### DIFF
--- a/modules/network-observability-SRIOV-configuration.adoc
+++ b/modules/network-observability-SRIOV-configuration.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-SR-IOV-config_{context}"]
 = Configuring monitoring for SR-IOV interface traffic
+
 In order to collect traffic from a cluster with a Single Root I/O Virtualization (SR-IOV) device, you must set the `FlowCollector` `spec.agent.ebpf.privileged` field to `true`. Then, the eBPF agent monitors other network namespaces in addition to the host network namespaces, which are monitored by default. When a pod with a virtual functions (VF) interface is created, a new network namespace is created. With `SRIOVNetwork` policy `IPAM` configurations specified, the VF interface is migrated from the host network namespace to the pod network namespace.
 
 .Prerequisites

--- a/modules/network-observability-cli-capturing-metrics.adoc
+++ b/modules/network-observability-cli-capturing-metrics.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-cli-capturing-metrics_{context}"]
 = Capturing metrics
+
 You can generate on-demand dashboards in Prometheus by using a service monitor for network observability.
 
 .Prerequisites

--- a/modules/network-observability-cli-capturing-packets.adoc
+++ b/modules/network-observability-cli-capturing-packets.adoc
@@ -5,7 +5,8 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-cli-capturing-packets_{context}"]
 = Capturing packets
-You can capture packets using the Network Observability CLI. 
+
+You can capture packets using the Network Observability CLI.
 
 .Prerequisites
 * Install the {oc-first}.
@@ -19,7 +20,7 @@ You can capture packets using the Network Observability CLI.
 $ oc netobserv packets --action=Accept --cidr=0.0.0.0/0 --protocol=TCP --port=49051
 ----
 . Add filters to the `live table filter` prompt in the terminal to refine the incoming packets. An example filter is as follows:
-+ 
++
 [source,terminal]
 ----
 live table filter: [SrcK8S_Zone:us-west-1b] press enter to match multiple regular expressions at once
@@ -27,4 +28,4 @@ live table filter: [SrcK8S_Zone:us-west-1b] press enter to match multiple regula
 . Use the *PageUp* and *PageDown* keys to toggle between *None*, *Resource*, *Zone*, *Host*, *Owner* and *all of the above*.
 . To stop capturing, press kbd:[Ctrl+C].
 . View the captured data, which is written to a single file in an `./output/pcap` directory located in the same path that was used to install the CLI:
-.. The `./output/pcap/<capture_date_time>.pcap` file can be opened with Wireshark. 
+.. The `./output/pcap/<capture_date_time>.pcap` file can be opened with Wireshark.

--- a/modules/network-observability-lokistack-ingestion-query.adoc
+++ b/modules/network-observability-lokistack-ingestion-query.adoc
@@ -3,8 +3,8 @@
 // * networking/network_observability/installing-operators.adoc
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-lokistack-configuring-ingestion_{context}"]
-
 = LokiStack ingestion limits and health alerts
+
 The LokiStack instance comes with default settings according to the configured size. It is possible to override some of these settings, such as the ingestion and query limits. An automatic alert in the web console notifies you when these limits are reached.
 
 [NOTE]

--- a/modules/network-observability-netobserv-cli-install.adoc
+++ b/modules/network-observability-netobserv-cli-install.adoc
@@ -5,15 +5,16 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-cli-install_{context}"]
 = Installing the Network Observability CLI
-Installing the Network Observability CLI (`oc netobserv`) is a separate procedure from the Network Observability Operator installation. This means that, even if you have the Operator installed from OperatorHub, you need to install the CLI separately. 
+
+Installing the Network Observability CLI (`oc netobserv`) is a separate procedure from the Network Observability Operator installation. This means that, even if you have the Operator installed from OperatorHub, you need to install the CLI separately.
 
 [NOTE]
 ====
-You can optionally use Krew to install the `netobserv` CLI plugin. For more information, see "Installing a CLI plugin with Krew". 
+You can optionally use Krew to install the `netobserv` CLI plugin. For more information, see "Installing a CLI plugin with Krew".
 ====
 
 .Prerequisites
-* You must install the {oc-first}. 
+* You must install the {oc-first}.
 * You must have a macOS or Linux operating system.
 
 .Procedure

--- a/modules/network-observability-roles-create.adoc
+++ b/modules/network-observability-roles-create.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-roles-create_{context}"]
 = Create roles for authentication and authorization
+
 Specify authentication and authorization configurations by defining `ClusterRole` and `ClusterRoleBinding`. You can create a YAML file to define these roles.
 
 .Procedure

--- a/modules/network-observability-virtualization-configuration.adoc
+++ b/modules/network-observability-virtualization-configuration.adoc
@@ -5,10 +5,11 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-virtualization-config_{context}"]
 = Configuring virtual machine (VM) secondary network interfaces for Network Observability
+
 You can observe network traffic on an OpenShift Virtualization setup by identifying eBPF-enriched network flows coming from VMs that are connected to secondary networks, such as through OVN-Kubernetes. Network flows coming from VMs that are connected to the default internal pod network are automatically captured by Network Observability.
 
 .Procedure
-. Get information about the virtual machine launcher pod by running the following command. This information is used in Step 5: 
+. Get information about the virtual machine launcher pod by running the following command. This information is used in Step 5:
 +
 [source,terminal]
 ----
@@ -21,7 +22,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    k8s.v1.cni.cncf.io/network-status: |- 
+    k8s.v1.cni.cncf.io/network-status: |-
       [{
         "name": "ovn-kubernetes",
         "interface": "eth0",
@@ -37,7 +38,7 @@ metadata:
         "interface": "podc0f69e19ba2", <2>
         "ips": [                       <3>
           "10.10.10.15"
-        ], 
+        ],
         "mac": "02:fb:f8:00:00:12",    <4>
         "dns": {}
       }]
@@ -56,7 +57,7 @@ status:
 . In the web console, navigate to *Operators* -> *Installed Operators*.
 . Under the *Provided APIs* heading for the *NetObserv Operator*, select *Flow Collector*.
 . Select *cluster* and then select the *YAML* tab.
-. Configure `FlowCollector` based on the information you found from the additional network investigation: 
+. Configure `FlowCollector` based on the information you found from the additional network investigation:
 +
 [source,yaml]
 ----
@@ -71,15 +72,15 @@ spec:
   processor:
     advanced:
       secondaryNetworks:
-      - index:                    <2>
-        - MAC                     <3>
-        name: my-vms/l2-network   <4> 
+      - index:  <2>
+        - MAC   <3>
+        name: my-vms/l2-network  <4>
 # ...
 ----
-<.> Ensure that the eBPF agent is in `privileged` mode so that flows are collected for secondary interfaces.
-<.> Define the fields to use for indexing the virtual machine launcher pods. It is recommended to use the `MAC` address as the indexing field to get network flows enrichment for secondary interfaces. If you have overlapping MAC address between pods, then additional indexing fields, such as `IP` and `Interface`, could be added to have accurate enrichment.
-<.> If your additional network information has a MAC address, add `MAC` to the field list.
-<.> Specify the name of the network found in the `k8s.v1.cni.cncf.io/network-status` annotation. Usually <namespace>/<network_attachement_definition_name>. 
+<1> Ensure that the eBPF agent is in `privileged` mode so that flows are collected for secondary interfaces.
+<2> Define the fields to use for indexing the virtual machine launcher pods. It is recommended to use the `MAC` address as the indexing field to get network flows enrichment for secondary interfaces. If you have overlapping MAC address between pods, then additional indexing fields, such as `IP` and `Interface`, could be added to have accurate enrichment.
+<3> If your additional network information has a MAC address, add `MAC` to the field list.
+<4> Specify the name of the network found in the `k8s.v1.cni.cncf.io/network-status` annotation. Usually <namespace>/<network_attachement_definition_name>.
 
 . Observe VM traffic:
 .. Navigate to the *Network Traffic* page.

--- a/observability/network_observability/network-observability-release-notes-1-9-2.adoc
+++ b/observability/network_observability/network-observability-release-notes-1-9-2.adoc
@@ -2,6 +2,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-operator-release-notes-1-9-2"]
 = Network Observability Operator release notes 1.9.2
+
 :context: network-observability-operator-release-notes-v1-9-2
 include::_attributes/common-attributes.adoc[]
 


### PR DESCRIPTION
Cherry-pick: cc17ba824579139bf6d1665e14a8a0f048bae27c

Original PR: https://github.com/openshift/openshift-docs/pull/98206


Version(s):
4.16

QE review:
QE is not required for this PR.

Additional information:
- network-events-overview and viewing-network-events do not apply to 4.16, so there are only 8 files instead of 10.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
