### PR TITLE
[Osdocs 16058]Update ROSA CLI attribute

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -61,4 +61,5 @@
 :egress-zero: egress zero
 :egress-zero-title: {product-title} clusters with {egress-zero}
 :classic-short: {rosa-classic-short}
-:rosa-cli-first: pass:quotes[Red Hat OpenShift Service on AWS CLI (`rosa`)]
+:rosa-cli-first: pass:quotes[ROSA command-line interface (CLI) (`rosa`)]
+:rosa-cli: ROSA CLI

--- a/modules/setting-higher-pid-limit-on-existing-cluster.adoc
+++ b/modules/setting-higher-pid-limit-on-existing-cluster.adoc
@@ -16,7 +16,7 @@ Changing the `podPidsLimit` on an existing cluster will trigger non-control plan
 .Prerequisites
 
 * You have a {product-title} cluster.
-* You have installed the ROSA CLI (`rosa`).
+* You have installed the {rosa-cli-first}.
 * You have installed the OpenShift CLI (`oc`).
 * You have logged in to your Red{nbsp}Hat account by using the ROSA CLI.
 
@@ -24,7 +24,7 @@ Changing the `podPidsLimit` on an existing cluster will trigger non-control plan
 . Create or edit the `KubeletConfig` object to change the PID limit.
 +
 --
-** If this is the first time you are changing the default PID limit, create the `KubeletConfig` object and set the `--pod-pids-limit` value by running the following command: 
+** If this is the first time you are changing the default PID limit, create the `KubeletConfig` object and set the `--pod-pids-limit` value by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.19+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-16058
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://98375--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-configuring-pid-limits#setting-higher-pid-limit-on-existing-cluster_rosa-configuring-pid-limits
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
