### PR TITLE
OADP-6644: S3 support statement

### DIFF
--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -7,12 +7,17 @@
 [id="oadp-s3-compatible-backup-storage-providers_{context}"]
 = AWS S3 compatible backup storage providers
 
-OADP is compatible with many object storage providers for use with different backup and snapshot operations. Several object storage providers are fully supported, several are unsupported but known to work, and some have known  limitations.
+{oadp-short} works with many S3-compatible object storage providers. Several object storage providers are certified and tested with every release of {oadp-short}. Various S3 providers are known to work with {oadp-short} but are not specifically tested and certified. These providers will be supported on a best-effort basis. Additionally, there are a few S3 object storage providers with known issues and limitations that are listed in this documentation.
 
-[id="oadp-s3-compatible-backup-storage-providers-supported"]
-== Supported backup storage providers
+[NOTE]
+====
+Red Hat will provide support for {oadp-short} on any S3-compatible storage, but support will stop if the S3 endpoint is determined to be the root cause of an issue.
+====
 
-The following AWS S3 compatible object storage providers are fully supported by OADP through the AWS plugin for use as backup storage locations:
+[id="oadp-certified-backup-storage-providers_{context}"]
+== Certified backup storage providers
+
+The following AWS S3 compatible object storage providers are fully supported by {oadp-short} through the AWS plugin for use as backup storage locations:
 
 * MinIO
 * Multicloud Object Gateway (MCG)


### PR DESCRIPTION
### JIRA

* [OADP-6644](https://issues.redhat.com/browse/OADP-6644)

    Changing title from the heading **Supported backup storage providers** to **Certified backup storage providers**
    Adding a `NOTE` admonition to the support statement. I have added this at the top as there is another admonition and i do not want to detract from that.

### Version(s):

* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19
* OCP 4.20 → branch/enterprise-4.20

### Link to docs preview:

* [AWS S3 compatible backup storage providers](https://98387--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#oadp-s3-compatible-backup-storage-providers_about-installing-oadp)

### QE review:

* [x] - QE has review

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
