### PR TITLE
OSDOCS-16028-1:Update the z-stream RNs for 4.18.23

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3028,6 +3028,63 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.23
+[id="ocp-4-18-23_{context}"]
+=== RHSA-2025:14820 - {product-title} {product-version}.23 bug fix and security update
+
+Issued: 03 September 2025
+
+{product-title} release {product-version}.23 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:14820[RHSA-2025:14820] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:14816[RHBA-2025:14816] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.23 --pullspecs
+----
+
+[id="ocp-4-18-23-enhancements_{context}"]
+==== Enhancements
+
+* Before this update, deleting an `istag` resource with the `--dry-run=server` option unintentionally caused actual deletion of the image from the server. This unexpected deletion occurred due to the dry-run option being implemented incorrectly in the `oc delete istag` command. With this release, the `dry-run` option is wired to the 'oc delete istag' command. As a result, the accidental deletion of image objects is prevented and the `istag` object remains intact when using the `--dry-run=server` option. (link:https://issues.redhat.com/browse/OCPBUGS-58461[OCPBUGS-58461])
+
+* Before this update, the `cluster-policy-controller` container was exposing the `10357` port for all networks (the bind address was set to `0.0.0.0`). The port was exposed outside the host network for the node because the KCM pod manifest set `hostNetwork` to `true`. This port is used solely for the probe of the container. With this enhancement, the bind address was updated to listen on the `localhost` only. As result, the node security is improved because the port is not exposed outside the node network. (link:https://issues.redhat.com/browse/OCPBUGS-60131[OCPBUGS-60131])
+
+[id="ocp-4-18-23-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, a bug on `oc adm inspect --all-namespaces` command construction meant that must-gather was not correctly gathering information about leases, `csistoragecapacities`, and the assisted-installer namespace. With this release, the issue is fixed and must-gather will gather the information correctly. (link:https://issues.redhat.com/browse/OCPBUGS-46437[OCPBUGS-46437])
+
+* Before this update, certain traffic patterns with large packets running between {product-title} nodes and pods triggered an {product-title} host to send Internet Control Message Protocol (ICMP) needs frag to another {product-title} host. This situation lowered the viable maximum transmission unit (MTU) in the cluster. As a consequence, executing the `ip route show cache` command displayed a cached route with a lower MTU than the physical link. Packets were dropped and {product-title} components were degrading because the host did not send pod-to-pod traffic with the large packets. With this release, NF Tables rules prevent the {product-title} nodes from lowering their MTU in response to these traffic patterns. (link:https://issues.redhat.com/browse/OCPBUGS-58288[OCPBUGS-58288])
+
+* Before this update, when a Cluster Operator takes a long time to upgrade, Cluster Version Operator does not report anything as it cannot determine if the upgrade is still progressing or already stuck. With this release, a new unknown status is added for the failing condition in status of the Cluster Version reported by Cluster Version Operator to remind the cluster administrators to check the cluster and avoid waiting on a blocked Cluster Operator upgrade. (link:https://issues.redhat.com/browse/OCPBUGS-58450[OCPBUGS-58450])
+
+* Before this update, intermittent egress IP handling due to inconsistent state updates caused packet drops in user traffic. With this release, egress IP handling consistency has been improved. (link:https://issues.redhat.com/browse/OCPBUGS-59371[OCPBUGS-59371])
+
+* Before this update, SELinux status check were not performed before running SELinux related commands. As a consequence, if the target RHEL machine did not have SELinux enabled, the related steps failed. With this release, the SELinux status check is added to ensure that the steps are successfully executed. (link:https://issues.redhat.com/browse/OCPBUGS-59844[OCPBUGS-59844])
+
+* Before this update, downloads on control plane nodes were inconsistently scheduled because of a mismatch between the node selector for downloads and the console pods. As a consequence, downloads were scheduled on random nodes, which caused potential resource contention and sub-optimal performance. With this release, downloaded workloads consistently schedule on control plane nodes, which improves resource allocation. (link:https://issues.redhat.com/browse/OCPBUGS-59897[OCPBUGS-59897])
+
+* Before this update, the delete workflow erroneously displayed `workflow mode: diskToMirror / delete`, leading to user confusion regarding the correct workflow mode. With this release, `workflow mode: delete` displays during delete operations. (link:https://issues.redhat.com/browse/OCPBUGS-59966[OCPBUGS-59966])
+
+* Before this update, the `netavark` package did not install because it did not contain the 4.18 RHEL8 repositories. With this release, the `netavark` package is succesfully installed from the `container-tools` module. (link:https://issues.redhat.com/browse/OCPBUGS-59973[OCPBUGS-59973])
+
+* Before this update, there was a period when the event data was not yet available when the `cloud-event-proxy` container or pod rebooted. This caused the `getCurrenState` function to incorrectly return a `clockclass` of `0`. With this release, the `getCurrentState` function no longer returns an incorrect `clockclass` and instead returns an HTTP `400 Bad Request` or `404 Not Found Error`. (link:https://issues.redhat.com/browse/OCPBUGS-59984[OCPBUGS-59984])
+
+* Before this update, OCP updates that shipped a change to `coredns` templates would restart the static pod and pre-reboot the node. This issue occurred before the image pull for the base operation system image update. As a consequence, a race occurred where the `rpm-ostree`, the operating system (OS) update manager, failed the image pull because of network errors and stall. With this release, a retry in the Machine Config Operator (MCO) OS update operation is added to work around the race condition due to the restarts of the `coredns` pod. (link:https://issues.redhat.com/browse/OCPBUGS-60034[OCPBUGS-60034])
+
+* Before this update, when you used multiple recommenders for the Vertical Pod Autoscaler (VPA), the default VPA recommender would erroneously garbage collect `VPACheckpoint` objects that belonged to a VPA object which was associated with a non-default recommender. With this release, the default recommender does not garbage collect the checkpoints owned by the other recommenders. (link:https://issues.redhat.com/browse/OCPBUGS-60235[OCPBUGS-60235]) 
+
+* Before this update, the *Events* page incorrectly displayed `{error}` instead of an error message. With this release, the error message is displayed. (link:https://issues.redhat.com/browse/OCPBUGS-60278[OCPBUGS-60278])
+
+* Before this update , on dual-stack clusters with IPv6 as the primary networking stack, the bare-metal Installer-Provisioned Infrastructure (IP) would incorrectly provide an IPv4 URL for the virtual media ISO image. This caused installation failures on Baseboard Management Controllers (BMCs) that were configured exclusively for IPv6 networking, as they could not reach the IPv4 address. With this release, the installer logic was updated to always provide an IPv6 URL when a BMC is using IPv6 addressing and the installation process now completes successfully. (link:https://issues.redhat.com/browse/OCPBUGS-60592[OCPBUGS-60592])
+
+[id="ocp-4-18-23-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.22
 [id="ocp-4-18-22_{context}"]
 === RHSA-2025:13325 - {product-title} {product-version}.22 bug fix and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-16028

Link to docs preview:
https://98396--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-23_release-notes