### PR TITLE
CNV-62389: Remove TP feature note (Set the interface link state)

### DIFF
--- a/virt/vm_networking/virt-setting-interface-link-state.adoc
+++ b/virt/vm_networking/virt-setting-interface-link-state.adoc
@@ -1,10 +1,10 @@
-:_mod-docs-content-type: ASSEMBLY                              
-[id="virt-setting-interface-link-state"]                                    
-= Managing the link state of a virtual machine interface                                               
-include::_attributes/common-attributes.adoc[]                  
-:context: virt-setting-interface-link-state                                   
-                                                               
-toc::[]                                                         
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-setting-interface-link-state"]
+= Managing the link state of a virtual machine interface
+include::_attributes/common-attributes.adoc[]
+:context: virt-setting-interface-link-state
+
+toc::[]
 
 You can manage the link state of a primary or secondary virtual machine (VM) interface by using the {product-title} web console or the CLI. By specifying the link state, you can logically connect or disconnect the virtual network interface controller (vNIC) from a network.
 
@@ -15,10 +15,6 @@ You can manage the link state of a primary or secondary virtual machine (VM) int
 
 You can specify the desired link state when you first create a VM, by editing the configuration of an existing VM that is stopped or running, or when you hot plug a new network interface to a running VM. If you edit a running VM, you do not need to restart or migrate the VM for the changes to be applied. The current link state of a VM interface is reported in the `status.interfaces.linkState` field of the `VirtualMachineInstance` manifest.
 
-:FeatureName: Setting the VM interface link state
-include::snippets/technology-preview.adoc[]
-
 include::modules/virt-configuring-interface-link-state-web.adoc[leveloffset=+1]
 
 include::modules/virt-configuring-interface-link-state.adoc[leveloffset=+1]
-


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/CNV-62389

Link to docs preview:
https://98397--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-setting-interface-link-state.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
