### PR TITLE
OSDOCS#16030: Update the z-stream RNs for 4.16.47

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3376,6 +3376,43 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.47
+[id="ocp-4-16-47_{context}"]
+=== RHSA-2025:14859 - {product-title} {product-version}.47 bug fix and security update
+
+Issued: 03 September 2025
+
+{product-title} release {product-version}.47 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:14859[RHSA-2025:14859] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.47 --pullspecs
+----
+
+[id="ocp-4-16-47-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, the build controller used secrets that were linked for general use, not for the image pull secrets. With this release, the default image pull secrets search for builds that use the `ImagePullSecrets` Kubernetes Secret that is linked to the service account. (link:https://issues.redhat.com/browse/OCPBUGS-60233[OCPBUGS-60233])
+
+* Before this update, the *{azure-first} Files Container Storage Interface* (CSI) driver attempted to reuse existing storage accounts. With this release, the *{azure-short} Files CSI* driver creates storage accounts during dynamic provisioning. Persistent Volumes that were previously provisioned use the same storage account that was used before the cluster update. (link:https://issues.redhat.com/browse/OCPBUGS-60248[OCPBUGS-60248])
+
+* Before this update, in a {hcp-capital} cluster, the input/outout (I/O) archive contained the hostname when the network `obfuscation` attribute was enabled. With this release, this issue is resolved, and the I/O archives do not contain hostnames when they are obfuscated. (link:https://issues.redhat.com/browse/OCPBUGS-60448[OCPBUGS-60448])
+
+* Before this update, a high volume of snapshot resources caused controller timeouts during startup. As a consequence, snapshot operations were disrupted, impacting backup and restore functions. With this release, the Container Storage Interface (CSI) Snapshot Controller handles large snapshot volumes more efficiently, which reduces startup timeouts. As a result, the handling of large snapshot numbers is improved, and backup and restore functions complete as expected. (link:https://issues.redhat.com/browse/OCPBUGS-60448[OCPBUGS-60450])
+
+* Before this update, ending the sidecar of an `openshift-ptp` pod caused the clock class to stop with an `exit code 7` error after a restart. This error was due to improper handling of the sidecar termination process. As a consequence, the clock class metrics were unavailable. With this release, the sidecar restart does not cause a clock class metrics error, and the metrics are reported after a sidecar restart. (link:https://issues.redhat.com/browse/OCPBUGS-60570[OCPBUGS-60570])
+
+* Before this update, the Machine Config Daemon caused Domain Name Service (DNS) lookup failures during an {product-title} 4.16 upgrade on {vmw-first} infrastructure. This error was due to `rpm-ostree` failing to access the `quay.io` registry. As a consequence, upgrades were stopped due to DNS lookup failures. With this release, DNS lookup failures during the {product-title} 4.16 upgrade on {vmw-short} infrastructure are resolved. As a result, the upgrade to {product-title} 4.16 does not stop due to DNS lookup failures. (link:https://issues.redhat.com/browse/OCPBUGS-60621[OCPBUGS-60621])
+
+* Before this update, the upgrade to {product-title} 4.16 on {vmw-first} infrastructure caused Domain Name Service (DNS) lookup failures during the `rpm-ostree` system rebase due to `Skopeo` proxy errors. As a consequence, upgrades stopped. With this release, the issue that caused DNS lookup failures during {product-title} 4.16 upgrades on {vmw-short} is fixed by resolving Docker registry connection issues. As a result, the upgrade process does not stop, and the DNS lookups resume. (link:https://issues.redhat.com/browse/OCPBUGS-60794[OCPBUGS-60794])
+
+[id="ocp-4-16-47-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.46
 [id="ocp-4-16-46_{context}"]
 === RHSA-2025:13336 - {product-title} {product-version}.46 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-16030](https://issues.redhat.com//browse/OSDOCS-16030)

Link to docs preview:
[4.16.47](https://98405--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-47_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
The errata URLs will return 404 until the go-live date of 9/3/25.
