### PR TITLE
OSDOCS-15470-hardware: Removed code blocks from Hardware networks doc

### DIFF
--- a/modules/cnf-creating-an-additional-sriov-network-with-vrf-plug-in.adoc
+++ b/modules/cnf-creating-an-additional-sriov-network-with-vrf-plug-in.adoc
@@ -13,7 +13,7 @@ The SR-IOV Network Operator manages additional network definitions. When you spe
 Do not edit `NetworkAttachmentDefinition` custom resources that the SR-IOV Network Operator manages. Doing so might disrupt network traffic on your additional network.
 ====
 
-To create an additional SR-IOV network attachment with the CNI VRF plugin, perform the following procedure.
+To create an additional SR-IOV network attachment with the CNI virtual routing and forwarding (VRF) plugin, perform the following procedure.
 
 .Prerequisites
 
@@ -52,8 +52,8 @@ spec:
       "vrfname": "example-vrf-name" <2>
     }
 ----
-<1> `type` must be set to `vrf`.
-<2> `vrfname` is the name of the VRF that the interface is assigned to. If it does not exist in the pod, it is created.
+<1> Set the `type` parameter to `vrf`.
+<2> Specify a name for the VRF in the `vrfname` parameter. An interface gets assigned to the VRF. If you do not specify a name for the VRF in a pod, the SR-IOV Network Operator automatically generates a name for the VRF.
 
 . Create the `SriovNetwork` resource:
 +
@@ -82,8 +82,10 @@ There might be a delay before the SR-IOV Network Operator creates the CR.
 To verify that the VRF CNI is correctly configured and that the additional SR-IOV network attachment is attached, do the following:
 
 . Create an SR-IOV network that uses the VRF CNI.
+
 . Assign the network to a pod.
-. Verify that the pod network attachment is connected to the SR-IOV additional network. Remote shell into the pod and run the following command. The expected output shows the name of the VRF interface and its unique ID in the routing table.
+
+. Verify that the pod network attachment connects to the SR-IOV additional network. Ensure that you remote shell login into the pod and run the following command. The expected output shows the name of the VRF interface and its unique ID in the routing table.
 +
 [source,terminal]
 ----
@@ -97,10 +99,5 @@ $ ip vrf show
 $ ip link
 ----
 +
-.Example output
-[source,terminal]
-----
-...
-5: net1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master red state UP mode
-...
-----
+Example output: `5: net1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master red state UP mode`
+

--- a/modules/nw-enable-all-multicast-mode-sriov-network.adoc
+++ b/modules/nw-enable-all-multicast-mode-sriov-network.adoc
@@ -133,7 +133,7 @@ $ oc get network-attachment-definitions -n <namespace> <1>
 There might be a delay before the SR-IOV Network Operator creates the CR.
 ====
 
-. Display information about the SR-IOV network resources by running the following command:
+* Display information about the SR-IOV network resources by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-multus-add-pod.adoc
+++ b/modules/nw-multus-add-pod.adoc
@@ -58,7 +58,7 @@ endif::sriov[]
 .Procedure
 
 . Add an annotation to the `Pod` object. Only one of the following annotation formats can be used:
-
++
 .. To attach a secondary network without any customization, add an annotation with the following format. Replace `<network>` with the name of the secondary network to associate with the pod:
 +
 [source,yaml]
@@ -67,11 +67,8 @@ metadata:
   annotations:
     k8s.v1.cni.cncf.io/networks: <network>[,<network>,...] <1>
 ----
-<1> To specify more than one secondary network, separate each network
-with a comma. Do not include whitespace between the comma. If you specify
-the same secondary network multiple times, that pod will have multiple network
-interfaces attached to that network.
-
+<1> To specify more than one secondary network, separate each network with a comma. Do not include whitespace between the comma. If you specify the same secondary network multiple times, that pod will have multiple network interfaces attached to that network.
++
 .. To attach a secondary network with customizations, add an annotation with the following format:
 +
 [source,yaml]
@@ -83,7 +80,7 @@ metadata:
         {
           "name": "<network>", <1>
           "namespace": "<namespace>", <2>
-          "default-route": ["<default-route>"] <3>
+          "default-route": ["<default_route>"] <3>
         }
       ]
 ----

--- a/modules/nw-multus-advanced-annotations.adoc
+++ b/modules/nw-multus-advanced-annotations.adoc
@@ -38,12 +38,17 @@ $ oc edit pod <name>
 ----
 metadata:
   annotations:
-    k8s.v1.cni.cncf.io/networks: '[<network>[,<network>,...]]' <1>
+    k8s.v1.cni.cncf.io/networks: '[<network>[,<network>,...]]'
+# ...
 ----
-<1> Replace `<network>` with a JSON object as shown in the following examples. The single quotes are required.
++
+--
+where:
 
-. In the following example the annotation specifies which network attachment will have the default route,
-using the `default-route` parameter.
+`<network>`:: Replace with a JSON object as shown in the following examples. The single quotes are required.
+--
++
+In the following example the annotation specifies which network attachment will have the default route, using the `default-route` parameter.
 +
 [source,yaml]
 ----
@@ -66,33 +71,36 @@ spec:
     command: ["/bin/bash", "-c", "sleep 2000000000000"]
     image: centos/tools
 ----
-<1> The `name` key is the name of the secondary network to associate
++
+--
+where:
+
+`name`:: The `name` key is the name of the secondary network to associate
 with the pod.
-<2> The `default-route` key specifies a value of a gateway for traffic to be routed over if no other
-routing entry is present in the routing table. If more than one `default-route` key is specified,
-this will cause the pod to fail to become active.
-
+`default-route`:: The `default-route` key specifies a value of a gateway for traffic to be routed over if no other routing entry is present in the routing table. If more than one `default-route` key is specified, this will cause the pod to fail to become active.
+--
++
 The default route will cause any traffic that is not specified in other routes to be routed to the gateway.
-
++
 [IMPORTANT]
 ====
 Setting the default route to an interface other than the default network interface for {product-title}
 may cause traffic that is anticipated for pod-to-pod traffic to be routed over another interface.
 ====
-
++
 To verify the routing properties of a pod, the `oc` command may be used to execute the `ip` command within a pod.
-
++
 [source,terminal]
 ----
 $ oc exec -it <pod_name> -- ip route
 ----
-
++
 [NOTE]
 ====
 You may also reference the pod's `k8s.v1.cni.cncf.io/network-status` to see which secondary network has been
 assigned the default route, by the presence of the `default-route` key in the JSON-formatted list of objects.
 ====
-
++
 To set a static IP address or MAC address for a pod you can use the JSON formatted annotations. This requires you create networks that specifically allow for this functionality. This can be specified in a rawCNIConfig for the CNO.
 
 . Edit the CNO CR by running the following command:
@@ -101,9 +109,9 @@ To set a static IP address or MAC address for a pod you can use the JSON formatt
 ----
 $ oc edit networks.operator.openshift.io cluster
 ----
-
++
 The following YAML describes the configuration parameters for the CNO:
-
++
 .Cluster Network Operator YAML configuration
 [source,terminal,subs="attributes+"]
 ----
@@ -114,15 +122,17 @@ rawCNIConfig: '{ <3>
 }'
 type: Raw
 ----
-<1> Specify a name for the secondary network attachment that you are
-creating. The name must be unique within the specified `namespace`.
-<2> Specify the namespace to create the network attachment in. If
-you do not specify a value, then the `default` namespace is used.
-<3> Specify the CNI plugin configuration in JSON format, which
-is based on the following template.
++
+--
+where:
 
+`name`:: Specify a name for the secondary network attachment that you are creating. The name must be unique within the specified `namespace`.
+`namespace`:: Specify the namespace to create the network attachment in. If you do not specify a value, then the `default` namespace is used.
+`rawCNIConfig`:: Specify the CNI plugin configuration in JSON format, which is based on the following template.
+--
++
 The following object describes the configuration parameters for utilizing static MAC address and IP address using the macvlan CNI plugin:
-
++
 .macvlan CNI plugin JSON configuration object using static IP and MAC address
 [source,json]
 ----
@@ -143,28 +153,28 @@ The following object describes the configuration parameters for utilizing static
     }]
 }
 ----
++
+--
+where:
 
-<1> Specifies the name for the secondary network attachment to create. The name must be unique within the specified `namespace`.
-
-<2> Specifies an array of CNI plugin configurations. The first object specifies a macvlan plugin configuration and the second object specifies a tuning plugin configuration.
-
-<3> Specifies that a request is made to enable the static IP address functionality of the CNI plugin runtime configuration capabilities.
-
-<4> Specifies the interface that the macvlan plugin uses.
-
-<5> Specifies that a request is made to enable the static MAC address functionality of a CNI plugin.
-
+`name`:: Specifies the name for the secondary network attachment to create. The name must be unique within the specified `namespace`.
+`plugins`:: Specifies an array of CNI plugin configurations. The first object specifies a macvlan plugin configuration and the second object specifies a tuning plugin configuration.
+`ips`:: Specifies that a request is made to enable the static IP address functionality of the CNI plugin runtime configuration capabilities.
+`master`:: Specifies the interface that the macvlan plugin uses.
+`mac`:: Specifies that a request is made to enable the static MAC address functionality of a CNI plugin.
+--
++
 The above network attachment can be referenced in a JSON formatted annotation, along with keys to specify which static IP and MAC address will be assigned to a given pod.
-
++
 Edit the pod with:
-
++
 [source,terminal]
 ----
 $ oc edit pod <name>
 ----
-
++
 .macvlan CNI plugin JSON configuration object using static IP and MAC address
-
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -180,20 +190,17 @@ metadata:
       }
     ]'
 ----
-
 <1> Use the `<name>` as provided when creating the `rawCNIConfig` above.
-
 <2> Provide an IP address including the subnet mask.
-
 <3> Provide the MAC address.
-
++
 [NOTE]
 ====
 Static IP addresses and MAC addresses do not have to be used at the same time, you may use them individually, or together.
 ====
-
-To verify the IP address and MAC properties of a pod with secondary networks, use the `oc` command to execute the ip command within a pod.
-
++
+. To verify the IP address and MAC properties of a pod with secondary networks, use the `oc` command to execute the ip command within a pod.
++
 [source,terminal]
 ----
 $ oc exec -it <pod_name> -- ip a

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -13,7 +13,7 @@
 [id="nw-multus-ipam-object_{context}"]
 = Configuration of IP address assignment for a network attachment
 
-For secondary networks, IP addresses can be assigned using an IP Address Management (IPAM) CNI plugin, which supports various assignment methods, including Dynamic Host Configuration Protocol (DHCP) and static assignment.
+For secondary networks, you can assign IP addresses by using an IP Address Management (IPAM) CNI plugin, which supports various assignment methods, including Dynamic Host Configuration Protocol (DHCP) and static assignment.
 
 The DHCP IPAM CNI plugin responsible for dynamic assignment of IP addresses operates with two distinct components:
 
@@ -22,17 +22,18 @@ The DHCP IPAM CNI plugin responsible for dynamic assignment of IP addresses oper
 
 For networks requiring `type: dhcp` in their IPAM configuration, ensure the following:
 
-* A DHCP server is available and running in the environment. The DHCP server is external to the cluster and is expected to be part of the customer's existing network infrastructure.
+* A DHCP server is available and running in the environment. 
+* The DHCP server is external to the cluster and you expect the server to form part of the existing network infrastructure for the customer.
 * The DHCP server is appropriately configured to serve IP addresses to the nodes.
 
-In cases where a DHCP server is unavailable in the environment, it is recommended to use the Whereabouts IPAM CNI plugin instead. The Whereabouts CNI provides similar IP address management capabilities without the need for an external DHCP server.
+In cases where a DHCP server is unavailable in the environment, consider using the Whereabouts IPAM CNI plugin instead. The Whereabouts CNI provides similar IP address management capabilities without the need for an external DHCP server.
 
 [NOTE]
 ====
-Use the Whereabouts CNI plugin when there is no external DHCP server or where static IP address management is preferred. The Whereabouts plugin includes a reconciler daemon to manage stale IP address allocations.
+Use the Whereabouts CNI plugin when no external DHCP server exists or where static IP address management is preferred. The Whereabouts plugin includes a reconciler daemon to manage stale IP address allocations.
 ====
 
-A DHCP lease must be periodically renewed throughout the container's lifetime, so a separate daemon, the DHCP IPAM CNI Daemon, is required. To deploy the DHCP IPAM CNI daemon, modify the Cluster Network Operator (CNO) configuration to trigger the deployment of this daemon as part of the secondary network setup.
+Ensure the periodic renewal of a DHCP lease throughout the lifetime of a container by including a separate daemon, the DHCP IPAM CNI Daemon. To deploy the DHCP IPAM CNI daemon, change the Cluster Network Operator (CNO) configuration to trigger the deployment of this daemon as part of the secondary network setup.
 
 ////
 IMPORTANT: If you set the `type` parameter to the `DHCP` value, you cannot set any other parameters.
@@ -75,7 +76,7 @@ The `addresses` array requires objects with the following fields:
 
 |`address`
 |`string`
-|An IP address and network prefix that you specify. For example, if you specify `10.10.21.10/24`, then the secondary network is assigned an IP address of `10.10.21.10` and the netmask is `255.255.255.0`.
+|An IP address and network prefix that you specify. For example, if you specify `10.10.21.10/24`, the secondary network gets assigned an IP address of `10.10.21.10` and the netmask of `255.255.255.0`.
 
 |`gateway`
 |`string`
@@ -94,7 +95,7 @@ The `addresses` array requires objects with the following fields:
 
 |`gw`
 |`string`
-|The gateway where network traffic is routed.
+|The gateway that routes network traffic.
 
 |====
 
@@ -105,7 +106,7 @@ The `addresses` array requires objects with the following fields:
 
 |`nameservers`
 |`array`
-|An array of one or more IP addresses for to send DNS queries to.
+|An array of one or more IP addresses where DNS queries get sent.
 
 |`domain`
 |`array`
@@ -165,33 +166,10 @@ spec:
         "cniVersion": "0.3.1",
         "type": "bridge",
         "ipam": {
-          "type": "dhcp"
+          "type": "dhcp" <1>
         }
       }
   # ...
 ----
+<1> Specifies dynamic IP address (DHCP) assignment for the cluster.
 
-The following table describes the configuration parameters for dynamic IP address address assignment with DHCP.
-
-.`ipam` DHCP configuration object
-[cols=".^2,.^2,.^6",options="header"]
-|====
-|Field|Type|Description
-
-|`type`
-|`string`
-|The IPAM address type. The value `dhcp` is required.
-
-|====
-
-The following JSON example describes the configuration p for dynamic IP address address assignment with DHCP.
-
-.Dynamic IP address (DHCP) assignment configuration example
-[source,json]
-----
-{
-  "ipam": {
-    "type": "dhcp"
-  }
-}
-----

--- a/modules/nw-multus-whereabouts.adoc
+++ b/modules/nw-multus-whereabouts.adoc
@@ -10,7 +10,7 @@
 
 The Whereabouts CNI plugin helps the dynamic assignment of an IP address to a secondary network without the use of a DHCP server.
 
-The Whereabouts CNI plugin also supports overlapping IP address ranges and configuration of the same CIDR range multiple times within separate `NetworkAttachmentDefinition` CRDs. This provides greater flexibility and management capabilities in multi-tenant environments.
+The Whereabouts CNI plugin also supports overlapping IP address ranges and configuration of the same CIDR range multiple times within separate `NetworkAttachmentDefinition` CRDs. This provides greater flexibility and management capabilities in multitenant environments.
 
 [id="dynamic-ip-address-assignment-objects_{context}"]
 == Dynamic IP address configuration parameters
@@ -63,7 +63,7 @@ The following example shows a dynamic address assignment configuration in a NAD 
 [id="dynamic-ip-address-assignment-whereabouts-overlapping-ip-ranges_{context}"]
 == Dynamic IP address assignment that uses Whereabouts with overlapping IP address ranges
 
-The following example shows a dynamic IP address assignment that uses overlapping IP address ranges for multi-tenant networks. 
+The following example shows a dynamic IP address assignment that uses overlapping IP address ranges for multitenant networks. 
 
 .NetworkAttachmentDefinition 1
 [source,json]

--- a/modules/nw-sriov-configure-exclude-topology-manager.adoc
+++ b/modules/nw-sriov-configure-exclude-topology-manager.adoc
@@ -40,14 +40,14 @@ spec:
   excludeTopology: true <3>
 ----
 <1> The resource name of the SR-IOV network device plugin. This YAML uses a sample `resourceName` value.
-<2> Identify the device for the Operator to configure by using the NIC selector.
+<2> Identify the device for the Operator to configure by using the network interface controller (NIC selector).
 <3> To exclude advertising the NUMA node for the SR-IOV network resource to the Topology Manager, set the value to `true`. The default value is `false`.
 +
 [NOTE]
 ====
-If multiple `SriovNetworkNodePolicy` resources target the same SR-IOV network resource, the `SriovNetworkNodePolicy` resources must have the same value as the `excludeTopology` specification. Otherwise, the conflicting policy is rejected.
+If many `SriovNetworkNodePolicy` resources target the same SR-IOV network resource, the `SriovNetworkNodePolicy` resources must have the same value as the `excludeTopology` specification. Otherwise, the conflicting policy is rejected.
 ====
-
++
 .. Create the `SriovNetworkNodePolicy` resource by running the following command. Successful output lists the name of the `SriovNetworkNodePolicy` resource and the `created` status.
 +
 [source,terminal]
@@ -56,7 +56,7 @@ $ oc create -f sriov-network-node-policy.yaml
 ----
 
 . Create the `SriovNetwork` CR:
-
++
 .. Save the following YAML in the `sriov-network.yaml` file, replacing values in the YAML to match your environment:
 +
 [source,yaml]
@@ -78,7 +78,7 @@ spec:
 <2> Specify the resource name for the `SriovNetworkNodePolicy` CR from the previous step. This YAML uses a sample `resourceName` value.
 <3> Enter the namespace for your SR-IOV network resource.
 <4> Enter the IP address management configuration for the SR-IOV network.
-
++
 .. Create the `SriovNetwork` resource by running the following command. Successful output lists the name of the `SriovNetwork` resource and the `created` status.
 +
 [source,terminal]
@@ -87,7 +87,7 @@ $ oc create -f sriov-network.yaml
 ----
 
 . Create a pod and assign the SR-IOV network resource from the previous step:
-
++
 .. Save the following YAML in the `sriov-network-pod.yaml` file, replacing values in the YAML to match your environment:
 +
 [source,yaml]
@@ -111,7 +111,7 @@ spec:
     command: ["sleep", "infinity"]
 ----
 <1> This is the name of the `SriovNetwork` resource that uses the `SriovNetworkNodePolicy` resource.
-
++
 .. Create the `Pod` resource by running the following command. The expected output shows the name of the `Pod` resource and the `created` status.
 +
 [source,terminal]
@@ -136,21 +136,21 @@ test-deployment-sriov-76cbbf4756-k9v72   1/1     Running   0          45h
 ----
 
 . Open a debug session with the target pod to verify that the SR-IOV network resources are deployed to a different node than the memory and CPU resources.
-
++
 .. Open a debug session with the pod by running the following command, replacing <pod_name> with the target pod name.
 +
 [source,terminal]
 ----
 $ oc debug pod/<pod_name>
 ----
-
++
 ..  Set `/host` as the root directory within the debug shell. The debug pod mounts the root file system from the host in `/host` within the pod. By changing the root directory to `/host`, you can run binaries from the host file system:
 +
 [source,terminal]
 ----
 $ chroot /host
 ----
-
++
 .. View information about the CPU allocation by running the following commands:
 +
 [source,terminal]
@@ -158,6 +158,7 @@ $ chroot /host
 $ lscpu | grep NUMA
 ----
 +
+
 .Example output
 [source,terminal]
 ----
@@ -174,24 +175,20 @@ $ cat /proc/self/status | grep Cpus
 .Example output
 [source,terminal]
 ----
-Cpus_allowed:	aa
+Cpus_allowed:	ffff
 Cpus_allowed_list:	1,3,5,7
 ----
++
+The expected output shows the CPUs (1, 3, 5, and 7) that get allocated to a `NUMA` node, such as `NUMA node1`. The SR-IOV network resource can use the NIC from another `NUMA` node, such as `NUMA node0`. Note that the `ffff` hexadecimal value represents the CPU cores that run a process.  
 +
 [source,terminal]
 ----
 $ cat  /sys/class/net/net1/device/numa_node
 ----
 +
-.Example output
-[source,terminal]
-----
-0
-----
+Expected output shows the number for the `NUMA` node, such as `0`.
 +
-In this example, CPUs 1,3,5, and 7 are allocated to `NUMA node1` but the SR-IOV network resource can use the NIC in `NUMA node0`.
-
 [NOTE]
 ====
-If the `excludeTopology` specification is set to `True`, it is possible that the required resources exist in the same NUMA node.
+If you set the `excludeTopology` specification to `True`, the required resources might exist in the same NUMA node.
 ====

--- a/modules/nw-sriov-configuring-multiple-nodes.adoc
+++ b/modules/nw-sriov-configuring-multiple-nodes.adoc
@@ -1,9 +1,12 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-net-attach.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="configure-sr-iov-operator-parallel-nodes_{context}"]
 = Configuring parallel node draining during SR-IOV network policy updates
 
-By default, the SR-IOV Network Operator drains workloads from a node before every policy change.
-The Operator performs this action, one node at a time, to ensure that no workloads are affected by the reconfiguration.
+By default, the SR-IOV Network Operator drains workloads from a node before every policy change. The Operator performs this action, one node at a time, to ensure that the reconfiguration does not impact workloads.
 
 In large clusters, draining nodes sequentially can be time-consuming, taking hours or even days. In time-sensitive environments, you can enable parallel node draining in an `SriovNetworkPoolConfig` custom resource (CR) for faster rollouts of SR-IOV network configurations. 
 
@@ -11,10 +14,12 @@ To configure parallel draining, use the `SriovNetworkPoolConfig` CR to create a 
 
 [NOTE]
 ====
-A node can only belong to one SR-IOV network pool configuration. If a node is not part of a pool, it is added to a virtual, default, pool that is configured to drain one node at a time only.
+A node can only belong to one SR-IOV network pool configuration. If a node is not part of a pool, the node gets added to a virtual, default, pool that with a configuration for draining one node at a time only.
 
 The node might restart during the draining process.
 ====
+
+The procedure requires that you create SR-IOV resources and then parallel drain the nodes.
 
 .Prerequisites
 
@@ -25,9 +30,7 @@ The node might restart during the draining process.
 
 .Procedure
 
-. Create a `SriovNetworkPoolConfig` resource:
-
-.. Create a YAML file that defines the `SriovNetworkPoolConfig` resource:
+. Create a YAML file that defines the `SriovNetworkPoolConfig` resource:
 +
 .Example `sriov-nw-pool.yaml` file
 [source,yaml]
@@ -48,7 +51,7 @@ spec:
 <3> Specify an integer number, or percentage value, for nodes that can be unavailable in the pool during an update. For example, if you have 10 nodes and you set the maximum unavailable to 2, then only 2 nodes can be drained in parallel at any time, leaving 8 nodes for handling workloads.
 <4> Specify the nodes to add the pool by using the node selector. This example adds all nodes with the `worker` role to the pool.
 
-.. Create the `SriovNetworkPoolConfig` resource by running the following command:
+. Create the `SriovNetworkPoolConfig` resource by running the following command:
 +
 [source,terminal]
 ----
@@ -62,9 +65,7 @@ $ oc create -f sriov-nw-pool.yaml
 $ oc create namespace sriov-test
 ----
 
-. Create a `SriovNetworkNodePolicy` resource:
-
-..  Create a YAML file that defines the `SriovNetworkNodePolicy` resource:
+. Create a YAML file that defines the `SriovNetworkNodePolicy` resource:
 +
 .Example `sriov-node-policy.yaml` file
 [source,yaml]
@@ -85,16 +86,14 @@ spec:
   resourceName: sriov_nic_1
 ----
 
-.. Create the `SriovNetworkNodePolicy` resource by running the following command:
+. Create the `SriovNetworkNodePolicy` resource by running the following command:
 +
 [source,terminal]
 ----
 $ oc create -f sriov-node-policy.yaml
 ----
 
-. Create a `SriovNetwork` resource:
-
-.. Create a YAML file that defines the `SriovNetwork` resource:
+. Create a YAML file that defines the `SriovNetwork` resource:
 +
 .Example `sriov-network.yaml` file
 [source,yaml]
@@ -112,31 +111,21 @@ spec:
   ipam: '{ "type": "static" }'
 ----
 
-.. Create the `SriovNetwork` resource by running the following command:
+. Create the `SriovNetwork` resource by running the following command:
 +
 [source,terminal]
 ----
 $ oc create -f sriov-network.yaml
 ----
 
-.Verification 
-
-* View the node pool you created by running the following command:
+. View the node pool you created by running the following command:
 +
 [source,terminal]
 ----
 $ oc get sriovNetworkpoolConfig -n openshift-sriov-network-operator
 ----
 +
-.Example output
-[source,terminal]
-----
-NAME     AGE
-pool-1   67s <1>
-----
-<1> In this example, `pool-1` contains all the nodes with the `worker` role.
-
-To demonstrate the node draining process using the example scenario from the above procedure, complete the following steps:
+Expected output shows the name of the node pool, such as `pool-1`, that includes all the node that have the `worker` role and the age of the node pool in seconds, such as `67s`. 
 
 . Update the number of virtual functions in the `SriovNetworkNodePolicy` resource to trigger workload draining in the cluster:
 +
@@ -145,7 +134,7 @@ To demonstrate the node draining process using the example scenario from the abo
 $ oc patch SriovNetworkNodePolicy sriov-nic-1 -n openshift-sriov-network-operator --type merge -p '{"spec": {"numVfs": 4}}'
 ----
 
-. Monitor the draining status on the target cluster by running the following command:
+. Check the draining status on the target cluster by running the following command:
 +
 [source,terminal]
 ----
@@ -160,4 +149,4 @@ openshift-sriov-network-operator   worker-0   InProgress    Drain_Required      
 openshift-sriov-network-operator   worker-1   InProgress    Drain_Required       DrainComplete        3d10h
 ----
 +
-When the draining process is complete, the `SYNC STATUS` changes to `Succeeded`, and the `DESIRED SYNC STATE` and `CURRENT SYNC STATE` values return to `IDLE`.
+When the draining process completes, the `SYNC STATUS` changes to `Succeeded`, and the `DESIRED SYNC STATE` and `CURRENT SYNC STATE` values return to `IDLE`.

--- a/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
+++ b/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
@@ -10,7 +10,7 @@ To enable hardware offloading, you now create a dedicated machine config pool an
 
 .Prerequisites
 
-. SR-IOV Network Operator installed and set into `systemd` mode.
+* SR-IOV Network Operator installed and set into `systemd` mode.
 
 .Procedure
 

--- a/modules/nw-sriov-hwol-creating-network-attachment-definition.adoc
+++ b/modules/nw-sriov-hwol-creating-network-attachment-definition.adoc
@@ -42,16 +42,12 @@ $ oc create -f net-attach-def.yaml
 
 .Verification
 
-* Run the following command to see whether the new definition is present:
+* Run the following command to check that the new definition exists:
 +
 [source,terminal]
 ----
 $ oc get net-attach-def -A
 ----
 +
-.Example output
-[source,terminal]
-----
-NAMESPACE         NAME             AGE
-net-attach-def    net-attach-def   43h
-----
+The output shows the namespace, name, and age of the new definition.
+

--- a/modules/nw-sriov-nic-mlx-secure-boot.adoc
+++ b/modules/nw-sriov-nic-mlx-secure-boot.adoc
@@ -71,14 +71,11 @@ $ oc -n openshift-sriov-network-operator get sriovnetworknodestate.sriovnetwork.
 <1> The `totalvfs` value is the same number used in the `mstconfig` command earlier in the procedure. 
 
 . Enable secure boot to prevent unauthorized operating systems and malicious software from loading during the device's boot process. 
-
-.. Enable secure boot using the BIOS (Basic Input/Output System).
 +
-[source,terminal]
-----
-Secure Boot: Enabled
-Secure Boot Policy: Standard
-Secure Boot Mode: Mode Deployed
-----
-
+.. Enable secure boot by using the BIOS (Basic Input/Output System) to set values for the following parameters:
++
+** `Secure Boot: Enabled`
+** `Secure Boot Policy: Standard`
+** `Secure Boot Mode: Mode Deployed`
++
 .. Reboot the system.

--- a/modules/nw-sriov-nic-partitioning.adoc
+++ b/modules/nw-sriov-nic-partitioning.adoc
@@ -6,9 +6,7 @@
 [id="nw-sriov-nic-partitioning_{context}"]
 = Virtual function (VF) partitioning for SR-IOV devices
 
-In some cases, you might want to split virtual functions (VFs) from the same physical function (PF) into multiple resource pools.
-For example, you might want some of the VFs to load with the default driver and the remaining VFs load with the `vfio-pci` driver.
-In such a deployment, the `pfNames` selector in your SriovNetworkNodePolicy custom resource (CR) can be used to specify a range of VFs for a pool using the following format: `<pfname>#<first_vf>-<last_vf>`.
+In some cases, you might want to split virtual functions (VFs) from the same physical function (PF) into many resource pools. For example, you might want some of the VFs to load with the default driver and the remaining VFs load with the `vfio-pci` driver. 
 
 For example, the following YAML shows the selector for an interface named `netpf0` with VF `2` through `7`:
 
@@ -16,22 +14,23 @@ For example, the following YAML shows the selector for an interface named `netpf
 ----
 pfNames: ["netpf0#2-7"]
 ----
+where:
 
-* `netpf0` is the PF interface name.
-* `2` is the first VF index (0-based) that is included in the range.
-* `7` is the last VF index (0-based) that is included in the range.
+`netpf0`:: The name of the PF interface name.
+`2`:: The first VF index (0-based) that gets included in the range.
+`7`:: The last VF index (0-based) that gets included in the range.
 
-You can select VFs from the same PF by using different policy CRs if the following requirements are met:
+You can select VFs from the same PF by using different policy CRs provided that you meet the following requirements:
 
-* The `numVfs` value must be identical for policies that select the same PF.
+* The `numVfs` value must be similar for policies that select the same PF.
 * The VF index must be in the range of `0` to `<numVfs>-1`. For example, if you have a policy with `numVfs` set to `8`, then the `<first_vf>` value must not be smaller than `0`, and the `<last_vf>` must not be larger than `7`.
 * The VFs ranges in different policies must not overlap.
 * The `<first_vf>` must not be larger than the `<last_vf>`.
 
 The following example illustrates NIC partitioning for an SR-IOV device.
 
-The policy `policy-net-1` defines a resource pool `net-1` that contains the VF `0` of PF `netpf0` with the default VF driver.
-The policy `policy-net-1-dpdk` defines a resource pool `net-1-dpdk` that contains the VF `8` to `15` of PF `netpf0` with the `vfio` VF driver.
+The policy `policy-net-1` defines a resource pool `net-1` that includes the VF `0` of PF `netpf0` with the default VF driver.
+The policy `policy-net-1-dpdk` defines a resource pool `net-1-dpdk` that includes the VF `8` to `15` of PF `netpf0` with the `vfio` VF driver.
 
 Policy `policy-net-1`:
 
@@ -72,15 +71,15 @@ spec:
 ----
 
 .Verifying that the interface is successfully partitioned
-Confirm that the interface partitioned to virtual functions (VFs) for the SR-IOV device by running the following command.
 
+* Confirm that the interface partitioned to virtual functions (VFs) for the SR-IOV device by running the following command.
++
 [source,terminal]
 ----
 $ ip link show <interface> <1>
 ----
-
 <1> Replace `<interface>` with the interface that you specified when partitioning to VFs for the SR-IOV device, for example, `ens3f1`.
-
++
 .Example output
 [source,terminal]
 ----

--- a/modules/nw-sriov-runtime-config-ethernet.adoc
+++ b/modules/nw-sriov-runtime-config-ethernet.adoc
@@ -10,23 +10,7 @@ When attaching a pod to an additional network, you can specify a runtime configu
 
 You specify the runtime configuration by setting an annotation in the pod specification. The annotation key is `k8s.v1.cni.cncf.io/networks`, and it accepts a JSON object that describes the runtime configuration.
 
-The following JSON describes the runtime configuration options for an Ethernet-based SR-IOV network attachment.
-
-[source,json]
-----
-[
-  {
-    "name": "<name>", <1>
-    "mac": "<mac_address>", <2>
-    "ips": ["<cidr_range>"] <3>
-  }
-]
-----
-<1> The name of the SR-IOV network attachment definition CR.
-<2> Optional: The MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you also must specify `{ "mac": true }` in the `SriovNetwork` object.
-<3> Optional: IP addresses for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you also must specify `{ "ips": true }` in the `SriovNetwork` object.
-
-.Example runtime configuration
+.Example runtime configuration for an Ethernet-based SR-IOV network attachment
 [source,yaml]
 ----
 apiVersion: v1
@@ -37,9 +21,9 @@ metadata:
     k8s.v1.cni.cncf.io/networks: |-
       [
         {
-          "name": "net1",
-          "mac": "20:04:0f:f1:88:01",
-          "ips": ["192.168.10.1/24", "2001::1/64"]
+          "name": "<network_attachment>", <1>
+          "mac": "<mac_address>", <2>
+          "ips": ["<cidr_range>"] <3>
         }
       ]
 spec:
@@ -49,3 +33,6 @@ spec:
     imagePullPolicy: IfNotPresent
     command: ["sleep", "infinity"]
 ----
+<1> The name of the SR-IOV network attachment definition CR. Example value is `ibl`.
+<2> Optional: The MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you also must specify `{ "mac": true }` in the `SriovNetwork` object. Example value is `c2:11:22:33:44:55:66:77`.
+<3> Optional: IP addresses for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you also must specify `{ "ips": true }` in the `SriovNetwork` object. Example value is `192.168.10.1/24", "2001::1/64`.

--- a/modules/nw-sriov-troubleshooting.adoc
+++ b/modules/nw-sriov-troubleshooting.adoc
@@ -2,28 +2,26 @@
 //
 // * networking/hardware_networks/configuring-sriov-device.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="nw-sriov-troubleshooting_{context}"]
 = Troubleshooting SR-IOV configuration
 
 After following the procedure to configure an SR-IOV network device, the following sections address some error conditions.
 
-To display the state of nodes, run the following command:
+.Procedure
+
+* To display the state of nodes, run the following command:
 
 [source,terminal]
 ----
 $ oc get sriovnetworknodestates -n openshift-sriov-network-operator <node_name>
 ----
 
-where: `<node_name>` specifies the name of a node with an SR-IOV network device.
+where:
 
-.Error output: Cannot allocate memory
-[source,terminal]
-----
-"lastSyncError": "write /sys/bus/pci/devices/0000:3b:00.1/sriov_numvfs: cannot allocate memory"
-----
+<node_name>:: Specifies the name of a node with an SR-IOV network device.
 
-When a node indicates that it cannot allocate memory, check the following items:
+If the output from the command indicates "cannot allocate memory", check the following items:
 
 * Confirm that global SR-IOV settings are enabled in the BIOS for the node.
-
 * Confirm that VT-d is enabled in the BIOS for the node.


### PR DESCRIPTION
This PR removes low-level code blocks from the Hardware networks documentation.

Version(s):
4.16+

Issue:
[OSDOCS-15470](https://issues.redhat.com/browse/OSDOCS-15470)

Link to docs preview:
* [Hardware networks](https://98460--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov)

Reviews: 
- [x] SME (Ben Bennett/Ben Nemec)
- [x] QE (Zhiqiang Fang (SR-IOV) / Weibin Liang (Multus))

Epic = https://issues.redhat.com/browse/OSDOCS-15186
