### PR TITLE
OSDOCS-16038 created assemblies and modules for egress proxy info

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1243,6 +1243,8 @@ Topics:
     File: external-secrets-operator-release-notes
   - Name: Installing the External Secrets Operator
     File: external-secrets-operator-install
+  - Name: Configuring the egress proxy
+    File: external-secrets-operator-proxy
   - Name: Uninstalling the External Secrets Operator
     File: external-secrets-operator-uninstall
   - Name: External Secrets Operator APIs

--- a/modules/external-secrets-proxy-security-considerations.adoc
+++ b/modules/external-secrets-proxy-security-considerations.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-proxy.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-proxy-security-considerations_{context}"]
+= Security considerations
+
+When using the egress proxy for {external-secrets-operator}, there are some security concerns you should consider:
+
+* `external-secrets` operand fetches the secrets from the configured external providers and stores it in a Kubernetes native Secrets resource. This results in a secret zero problem. It is recommended to secure the secret objects using additional encryption. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.9/html/planning_your_deployment/security-considerations_rhodf#data-encryption-options_rhodf[Data encryption options]
+
+* When configuring `SecretStore` and `ClusterSecretStore`, consider using short-term credential-based authorization. This approach enhances security by limiting the window of opportunity for unauthorized access, even if credentials are compromised.
+
+* To enhance the security of the {external-secrets-operator}, it is crucial to implement Role-Based Access Controls (RBACs). These RBACs should define and limit access to the custom resources provided by the {external-secrets-operator-short}.
+

--- a/modules/external-secrets-proxy-support.adoc
+++ b/modules/external-secrets-proxy-support.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-proxy.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-proxy-support_{context}"]
+= Configuring the egress proxy for the {external-secrets-operator}
+
+The egress proxy can be configured in the `ExternalSecretsConfig` or the `ExternalSecretsManager` custom resource. The Operator and the operand make use of the {product-title} supported Certificate Authority (CA) bundle for the proxy validations.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+* To set the proxy in the `ExternalSecretsConfig` resource, perform the following steps:
+
+. Edit the `ExternalSecretsConfig` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Edit the `spec.appConfig.proxy` section to set the proxy values as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  appConfig:
+    proxy:
+      httpProxy: <http_proxy> <1>
+      httpsProxy: <https_proxy> <2>
+      noProxy: <no_proxy> <3>
+----
++
+<1> Proxy URL for the http requests.
+<2> Proxy URL for the https requests.
+<3> Comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used.
+
+* To set the proxy in the `ExternalSecretsManager` resource, perform the following steps.
+
+. Edit the `ExternalSecretsManager` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsmanagers.operator.openshift.io cluster
+----
+
+. Edit the `spec.globalConfig.proxy` section to set the proxy values as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsManager
+...
+spec:
+  globalConfig:
+    proxy:
+      httpProxy: <http_proxy> <1>
+      httpsProxy: <https_proxy> <2>
+      noProxy: <no_proxy> <3>
+----
++
+<1> Proxy URL for the http requests.
+<2> Proxy URL for the https requests.
+<3> Comma-separated list of hostnames and/or CIDRs and/or IPs for which the proxy should not be used.
+
+

--- a/security/external_secrets_operator/external-secrets-operator-install.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-install.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 The {external-secrets-operator} is not installed on the {product-title} by default. Install the {external-secrets-operator-short} by using either the web console or the command-line interface (CLI).
 
-:FeatureName: The {external-secrets-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 //Limitations of application installation and uninstallation
 include::modules/external-secrets-operator-limitations.adoc[leveloffset=+1]
 

--- a/security/external_secrets_operator/external-secrets-operator-proxy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-proxy.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-proxy"]
+= About the egress proxy for the {external-secrets-operator}
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-proxy
+
+If a cluster-wide egress proxy is configured in {product-title}, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. OLM automatically updates all of the Operator's deployments with the `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.
+
+// Configuring external secrets operator proxy
+include::modules/external-secrets-proxy-support.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-resources-operator-proxy_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]
+

--- a/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
@@ -10,9 +10,6 @@ The {external-secrets-operator} is a cluster-wide service that provides lifecycl
 
 These release notes track the development of {external-secrets-operator-short}.
 
-:FeatureName: The {external-secrets-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 For more information, see xref:../../security/external_secrets_operator/index.adoc#external-secrets-operator-about[{external-secrets-operator-short} overview].
 
 [id="external-secrets-operator-release-notes-0-1-0_{context}"]

--- a/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 You can remove the {external-secrets-operator} from {product-title} by uninstalling the Operator and removing its related resources.
 
-:FeatureName: The {external-secrets-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 // Uninstalling the {external-secrets-operator-short}
 include::modules/external-secrets-operator-uninstall-console.adoc[leveloffset=+1]
 

--- a/security/external_secrets_operator/index.adoc
+++ b/security/external_secrets_operator/index.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 The {external-secrets-operator} operates as a cluster-wide service to deploy and manage the `external-secrets` application. The `external-secrets` application integrates with external secrets management systems and performs secret fetching, refreshing, and provisioning within the cluster.
 
-:FeatureName: The {external-secrets-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 //About the {external-secrets-operator}
 include::modules/external-secrets-about.adoc[leveloffset=+1]
 
@@ -31,3 +28,13 @@ include::modules/external-secrets-fips-support.adoc[leveloffset=+1]
 * xref:../../security/container_security/security-compliance.adoc#security-compliance[Understanding compliance]
 * xref:../../installing/overview/installing-fips.adoc#installing-fips-mode_installing-fips[Installing a cluster in FIPS mode]
 * xref:../../installing/overview/installing-preparing.adoc#installing-preparing-security[Do you need extra security for your cluster?]
+
+// Product security considerations
+include::modules/external-secrets-proxy-security-considerations.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.19/html/planning_your_deployment/security-considerations_rhodf[Security considerations]
+
+* link:https://external-secrets.io/latest/guides/security-best-practices/[Security Best Practices]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16038

Link to docs preview:
https://98461--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-proxy.html


QE review:
- [x] QE has approved this change.


Additional information:

