### PR TITLE
CNV-51253: Add docs for ControllerRevisions

### DIFF
--- a/modules/best-practices-rhacm-managed-vm.adoc
+++ b/modules/best-practices-rhacm-managed-vm.adoc
@@ -15,3 +15,27 @@ Use a PVC and populator to define storage for the VM:: Because data volumes crea
 Use the import method when choosing a population source for your VM disk:: Select a {op-system-base} image from the software catalog to use the import method. Red{nbsp}Hat recommends using a specific version of the image rather than a floating tag for consistent results. The KubeVirt community maintains container disks for other operating systems in a Quay repository.
 
 Use `pullMethod: node`:: Use the pod `pullMethod: node` when creating a data volume from a registry source to take advantage of the {product-title} pull secret, which is required to pull container images from the Red{nbsp}Hat registry.
+
+Include a reference to the `ControllerRevision` object in the VM spec:: `ControllerRevision` objects store copies of `VirtualMachineInstancetype` objects and `VirtualMachinePreference` objects at the time when a VM is created, which is crucial for maintaining consistent VM behavior across restarts and during snapshot restores or cloning.
++
+Reference the `ControllerRevision` by including its `revisionName` value in the `instancetype` spec or `preference` spec in the `VirtualMachine` object, as shown in the following example. If you want to move to a newer version of an instance type or preference for a VM, you can stop the VM and clear the `revisionName` value in its spec, which creates a new `ControllerRevision` object after a restart.
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: example-vm-with-revision
+  namespace: example-namespace
+spec:
+  instancetype:
+    kind: VirtualMachineInstancetype
+    name: example-instancetype-name
+    revisionName: example-instancetype-revision-name # <1>
+  preference:
+    kind: VirtualMachinePreference
+    name: example-preference-name
+    revisionName: example-preference-revision-name # <2>
+----
+<1> The `revisionName` spec explicitly links to a specific `ControllerRevision` resource for the instance type.
+<2> The `revisionName` spec explicitly links to a specific `ControllerRevision` resource for the preference.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com//browse/CNV-51253

Link to docs preview:
https://98464--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-disaster-recovery.html#best-practices-rhacm-managed-vm_virt-disaster-recovery

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
