### PR TITLE
CNV#64706: [DOC] Add IOMMU verification step to OpenShift Virtualization documentation. | Version 4.18

### DIFF
--- a/modules/virt-adding-kernel-arguments-enable-iommu.adoc
+++ b/modules/virt-adding-kernel-arguments-enable-iommu.adoc
@@ -27,19 +27,23 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker <1>
-  name: 100-worker-iommu <2>
+    machineconfiguration.openshift.io/role: worker
+  name: 100-worker-iommu
 spec:
   config:
     ignition:
       version: 3.2.0
   kernelArguments:
-      - intel_iommu=on <3>
+      - intel_iommu=on
 # ...
 ----
-<1> Applies the new kernel argument only to worker nodes.
-<2> The `name` indicates the ranking of this kernel argument (100) among the machine configs and its purpose. If you have an AMD CPU, specify the kernel argument as `amd_iommu=on`.
-<3> Identifies the kernel argument as `intel_iommu` for an Intel CPU.
+where:
+
+<apiversion>:: Applies the new kernel argument only to worker nodes.
+
+<name>:: Indicates the ranking of this kernel argument (100) among the machine configs and its purpose. If you have an AMD CPU, specify the kernel argument as `amd_iommu=on`.
+
+<intel_iommu=o>:: Identifies the kernel argument as `intel_iommu` for an Intel CPU.
 
 . Create the new `MachineConfig` object:
 +
@@ -50,9 +54,40 @@ $ oc create -f 100-worker-kernel-arg-iommu.yaml
 
 .Verification
 
-* Verify that the new `MachineConfig` object was added.
+.  Verify that the new `MachineConfig` object was added by entering the following command and observing the output:
 +
 [source,terminal]
 ----
 $ oc get MachineConfig
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                       IGNITIONVERSION                    AGE
+00-master                                   3.5.0                             164m
+00-worker                                   3.5.0                             164m
+01-master-container-runtime                 3.5.0                             164m
+01-master-kubelet                           3.5.0                             164m
+01-worker-container-runtime                 3.5.0                             164m
+01-worker-kubelet                           3.5.0                             164m
+100-master-chrony-configuration             3.5.0                             169m
+100-master-set-core-user-password           3.5.0                             169m
+100-worker-chrony-configuration             3.5.0                             169m
+100-worker-iommu                            3.5.0                             14s
+----
+
+. Verify that IOMMU is enabled at the operating system (OS) level by entering the following command:
++
+[source,terminal]
+----
+$ dmesg | grep -i iommu
+----
+* If IOMMU is enabled, output is displayed as shown in the following example:
++
+.Example output
+[source,terminal]
+----
+Intel: [ 0.000000] DMAR: Intel(R) IOMMU Driver
+AMD: [ 0.000000] AMD-Vi: IOMMU Initialized
 ----


### PR DESCRIPTION
Version(s): 4.18+

Issue: [CNV-64706](https://issues.redhat.com/browse/CNV-64706)

Link to docs preview: https://98467--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-configuring-virtual-gpus.html#virt-adding-kernel-arguments-enable-IOMMU_virt-configuring-virtual-gpus

QE review:
- [x] QE has approved this change.

