### PR TITLE
Cluster MTU docs changes

### DIFF
--- a/modules/nw-cluster-mtu-change-about.adoc
+++ b/modules/nw-cluster-mtu-change-about.adoc
@@ -7,14 +7,14 @@
 [id="nw-cluster-mtu-change-about_{context}"]
 = About the cluster MTU
 
-During installation the maximum transmission unit (MTU) for the cluster network is detected automatically based on the MTU of the primary network interface of nodes in the cluster. You do not usually need to override the detected MTU.
+During installation, the cluster network MTU is set automatically based on the primary network interface MTU of cluster nodes. You do not usually need to override the detected MTU.
 
-You might want to change the MTU of the cluster network for several reasons:
+You might want to change the MTU of the cluster network for one of the following reasons:
 
 * The MTU detected during cluster installation is not correct for your infrastructure.
 * Your cluster infrastructure now requires a different MTU, such as from the addition of nodes that need a different MTU for optimal performance.
 
-Only the OVN-Kubernetes cluster network plugin supports changing the MTU value.
+Only the OVN-Kubernetes network plugin supports changing the MTU value.
 
 [id="service-interruption-considerations_{context}"]
 == Service interruption considerations
@@ -61,15 +61,15 @@ Set the following values in the Cluster Network Operator configuration:
 |
 *Cluster Network Operator (CNO)*: Confirms that each field is set to a valid value.
 
-- The `mtu.machine.to` must be set to either the new hardware MTU or to the current hardware MTU if the MTU for the hardware is not changing. This value is transient and is used as part of the migration process. Separately, if you specify a hardware MTU that is different from your existing hardware MTU value, you must manually configure the MTU to persist by other means, such as with a machine config, DHCP setting, or a Linux kernel command line.
+- The `mtu.machine.to` must be set to either the new hardware MTU or to the current hardware MTU if the MTU for the hardware is not changing. This value is transient and is used as part of the migration process. If you set a hardware MTU different from the current value, you must manually configure it to persist. Use methods such as a machine config, DHCP setting, or kernel command line.
 - The `mtu.network.from` field must equal the `network.status.clusterNetworkMTU` field, which is the current MTU of the cluster network.
-- The `mtu.network.to` field must be set to the target cluster network MTU and must be lower than the hardware MTU to allow for the overlay overhead of the network plugin. For OVN-Kubernetes, the overhead is `100` bytes.
+- The `mtu.network.to` field must be set to the target cluster network MTU. It must be lower than the hardware MTU to allow for the overlay overhead of the network plugin. For OVN-Kubernetes, the overhead is `100` bytes.
 
 If the values provided are valid, the CNO writes out a new temporary configuration with the MTU for the cluster network set to the value of the `mtu.network.to` field.
 
 *Machine Config Operator (MCO)*: Performs a rolling reboot of each node in the cluster.
 
-|Reconfigure the MTU of the primary network interface for the nodes on the cluster. You can use a variety of methods to accomplish this, including:
+|Reconfigure the MTU of the primary network interface for the nodes on the cluster. You can use one of the following methods to accomplish this:
 
 - Deploying a new NetworkManager connection profile with the MTU change
 - Changing the MTU through a DHCP server setting

--- a/networking/advanced_networking/changing-cluster-network-mtu.adoc
+++ b/networking/advanced_networking/changing-cluster-network-mtu.adoc
@@ -21,9 +21,9 @@ include::modules/nw-cluster-mtu-applying-mtu-value.adoc[leveloffset=+2]
 include::modules/nw-cluster-mtu-finalizing-migration.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-[id="{context}-additional-resources"]
+[id="additional-resources-mtu-cluster-network"]
 == Additional resources
 
 * xref:../../installing/installing_bare_metal/upi/installing-bare-metal.adoc#installation-user-infra-machines-advanced_network_installing-bare-metal[Using advanced networking options for PXE and ISO installations]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#proc_manually-creating-a-networkmanager-profile-in-keyfile-format_assembly_networkmanager-connection-profiles-in-keyfile-format[Manually creating NetworkManager profiles in key file format]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#configuring-a-dynamic-ethernet-connection-using-nmcli_configuring-an-ethernet-connection[Configuring a dynamic Ethernet connection using nmcli]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/configuring_and_managing_networking/index#proc_manually-creating-a-networkmanager-profile-in-keyfile-format_assembly_networkmanager-connection-profiles-in-keyfile-format[Manually creating NetworkManager profiles in key file format]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/configuring_and_managing_networking/index#configuring-a-dynamic-ethernet-connection-using-nmcli_configuring-an-ethernet-connection[Configuring a dynamic Ethernet connection using nmcli]


### PR DESCRIPTION
Small changes as a result of the CQA template. Most changes were done in https://issues.redhat.com/browse/OSDOCS-16268, where I modularized the procedure. 

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-15235

Link to docs preview:
https://98469--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks.html
https://98469--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/changing-cluster-network-mtu.html

QE review:
QE is aware of these changes as per https://issues.redhat.com/browse/OSDOCS-16268. These are just basic style edits. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
