### PR TITLE
OSDOCS#15784: oc-mirror verification RN

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -536,6 +536,11 @@ For more information, see xref:../networking/advanced_networking/route_advertise
 [id="ocp-release-notable-technical-changes_{context}"]
 == Notable technical changes
 
+[id="ocp-4-20-oc-mirror-v2-verify-creds_{context}"]
+=== oc-mirror plugin v2 verifies credentials and certificates before mirroring operations
+
+With this update, the oc-mirror plugin v2 now verifies information such as registry credentials, DNS name, and SSL certificates before populating the cache and beginning mirroring operations.
+This prevents users from discovering certain problems only after the cache is populated and mirroring has begun.
 
 [id="ocp-release-deprecated-removed-features_{context}"]
 == Deprecated and removed features


### PR DESCRIPTION
[OSDOCS-15784](https://issues.redhat.com/browse/OSDOCS-15784)

Version(s): 4.20 only

This PR adds a release note describing new behavior for the oc-mirror plugin regarding its process for verifying certain information.

QE review:
- [x] QE has approved this change.

Preview: [Release Note](https://98471--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-oc-mirror-v2-verify-creds_release-notes)