### PR TITLE
OSDOCS-16037 added metrics and log level assemblies and modules

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1260,6 +1260,10 @@ Topics:
     File: external-secrets-operator-config-net-policy
   - Name: Configuring the egress proxy
     File: external-secrets-operator-proxy
+  - Name: Monitoring the External Secrets Operator for Red Hat OpenShift
+    File: external-secrets-monitoring
+  - Name: Customizing the External Secrets Operator for Red Hat OpenShift
+    File: external-secrets-log-levels
   - Name: Uninstalling the External Secrets Operator
     File: external-secrets-operator-uninstall
   - Name: External Secrets Operator APIs

--- a/modules/external-secrets-bit-warden-config.adoc
+++ b/modules/external-secrets-bit-warden-config.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-bit-warden-config_{context}"]
+= Configuring the bitwardenSecretManagerProvider plugin
+
+You can enable the `bitwardenSecretManagerProvider` to use the Bitwarden Secrets Manager provider as a source for your secrets.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` custom resource by running the following command:
++
+[source,terminal]
+----
+$  oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Edit the `spec.plugins.bitwardenSecretManagerProvider` section as follows to enable the Bitwarden Secrets Manager:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  plugins:
+    bitwardenSecretManagerProvider:
+      mode: Enabled
+      secretRef:
+        name: <secret_object_name>
+----
++
+where:
+
+name:: The name of the secret containing the certificate key pair for the plugin. The key name in the secret for the certificate must be `tls.crt`. The key name for the private key must be `tls.key`. The key name for the Certificate Authority (CA) certificate key name must be `ca.crt`. Configuring the secret is optional when the cert-manager certificate provider is configured.
+
+. Save your changes and exit the editor.
+
+. If you disable the plugin the following resources must be deleted manually by running the following commands:
+
+[source,terminal]
+----
+$ oc delete deployments.apps bitwarden-sdk-server -n external-secrets
+----
+
+[source,terminal]
+----
+$ oc delete certificates.cert-manager.io bitwarden-tls-certs -n external-secrets
+----
+
+[source,terminal]
+----
+$ oc delete service bitwarden-sdk-server -n external-secrets
+----
+
+[source,terminal]
+----
+$ oc delete serviceaccounts bitwarden-sdk-server -n external-secrets
+----
+

--- a/modules/external-secrets-cert-manager-config.adoc
+++ b/modules/external-secrets-cert-manager-config.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-cert-manager-config_{context}"]
+= Configuring cert-manager for the external-secrets certificate requirements
+
+The `external-secrets` webhook and plugins can be assigned to `cert-manager` for certificate management. This configuration is optional.
+
+When `cert-manager` is not used, `external-secrets` defaults to its own certificate management. In this mode, it automatically generates the required certificates for the webhook, while you are responsible for manually configuring certificates for the plugins.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource.
+* You have installed the {cert-manager-operator}. For more information, see "Installing the {cert-manager-operator}"
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` custom resource by running the following command:
++
+[source,terminal]
+----
+$  oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Configure `cert-manager` by editing the `spec.controllerConfig.certProvider.certManager` section as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  controllerConfig:
+    certProvider:
+      certManager:
+        injectAnnotations: "true"
+        issuerRef:
+          name: <issuer_name>
+          kind: <issuer_kind>
+          group: <issuer_group>
+        mode: Enabled
+----
++
+where:
+
+injectAnnotation:: Must be set to `true` when enabled.
+name:: Name of the issuer object referenced in `ExternalSecretsConfig`.
+kind:: API issuer. Can be set to either `Issuer` or `ClusterIssuer`.
+group:: API issuer group. The group name must be `cert-manager.io`.
+mode:: Must be set to `Enabled`. This is an immutable field and cannot be modified once it is configured.
+
+. Save your changes.
+
+. After you update the `cert-manager` configurations in the `externalsecretsconfig.operator.openshift.io` object, you must manually delete `external-secrets-cert-controller` deployment by running the following command. This prevents performance degradation of the `external-secrets` application.
++
+[source,terminal]
+----
+$ oc delete deployments.apps external-secrets-cert-controller -n external-secrets
+----
+
+. Optionally, you can delete other resources created for the `cert-controller` by running the following commands:
++
+[source,terminal]
+----
+$ oc delete clusterrolebindings.rbac.authorization.k8s.io external-secrets-cert-controller
+----
++
+[source,terminal]
+----
+$ oc delete clusterroles.rbac.authorization.k8s.io external-secrets-cert-controller
+----
++
+[source,terminal]
+----
+$ oc delete serviceaccounts external-secrets-cert-controller -n external-secrets
+----
++
+[source,terminal]
+----
+$ oc delete secrets external-secrets-webhook -n external-secrets
+----
+
+

--- a/modules/external-secrets-enable-metrics.adoc
+++ b/modules/external-secrets-enable-metrics.adoc
@@ -1,0 +1,128 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/exteernal-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-metrics_{context}"]
+= Configuring metrics collection for {external-secrets-operator} operands by using a ServiceMonitor
+
+[role="_abstract"]
+The {external-secrets-operator} operands exposes metrics by default on port `8080` at the `/metrics` service endpoint for all three components (`external-secrets`, `external-secrets-cert-controll`, and `external-secrets-webhook`). You can configure metrics collection for the external-secrets operands by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics. For more information, see "Configuring user workload monitoring".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled the user workload monitoring.
+
+.Procedure
+
+. Create the `ClusterRoleBinding` resource required for granting permissions to access metrics:
+
+.. Create the `clusterrolebinding-external-secrets.yaml` YAML file:
++
+The following example shows a `cluserrolebinding-external-secrets.yaml` file.
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: external-secrets
+  name: external-secrets-allow-metrics-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-operator-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets
+  - kind: ServiceAccount
+    name: external-secrets-cert-controller
+    namespace: external-secrets
+  - kind: ServiceAccount
+    name: external-secrets-webhook
+    namespace: external-secrets
+----
+
+.. Create the `ClusterRoldeBinding` custom resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f clusterrolebinding-external-secrets.yaml
+----
+
+. Create the `ServiceMonitor` CR:
+
+.. Create the `servicemonitor-external-secrets.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets
+  name: external-secrets-metrics-monitor
+  namespace: external-secrets
+spec:
+  endpoints:
+    - interval: 60s
+      path: /metrics
+      port: metrics
+      scheme: http
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+      - external-secrets
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - external-secrets
+          - external-secrets-cert-controller
+          - external-secrets-webhook
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+          - external-secrets
+      - key: app.kubernetes.io/managed-by
+        operator: In
+        values:
+          - external-secrets-operator
+----
+
+.. Create the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets.yaml
+----
++
+After the `ServiceMonitor` CR is created, the user workload Prometheus instance begins metrics collection from the {external-secrets-operator} operands. The collected metrics are labeled with `job="external-secrets"`,`job="external-secrets-cainjector"`, and `job="external-secrets-webhook"`.
+
+.Verification
+
+. In the {product-title} web console, navigate to *Observe* -> *Targets*.
+
+. In the Label filter field, enter the following labels to filter the metrics targets for each operand:
++
+[source,terminal]
+----
+$ service=external-secrets
+----
++
+[source,terminal]
+----
+$ service=external-secrets-cert-controller-metrics
+----
++
+[source,terminal]
+----
+$ service=external-secrets-webhook
+----
+
+. Confirm that the *Status* column shows `Up` for the `external-secrets`, `external-secrets-cert-controller` and `external-secrets-webhook`.

--- a/modules/external-secrets-enable-operand-log-level.adoc
+++ b/modules/external-secrets-enable-operand-log-level.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operand-log-level_{context}"]
+= Setting a log level for the {external-secrets-operator} operand
+
+You can set a log level for the {external-secrets-operator} to determine the verbosity of log messages.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the log level value by editing the `spec.appConfig.logLevel` section:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  appConfig:
+    logLevel: <log_level> <1>
+----
++
+<1> Supports the value range of 1-5. The log level gets mapped to the following operand support levels:
+ * 1 - warnings
+ * 2 - error logs
+ * 3 - info logs
+ * 4 and 5 - debug logs
+
+. Save your changes and exit the editor.
+

--- a/modules/external-secrets-enable-operator-log-level.adoc
+++ b/modules/external-secrets-enable-operator-log-level.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-log-levels.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-log-level_{context}"]
+= Setting a log level for the {external-secrets-operator}
+
+You can set a log level for the {external-secrets-operator} to determine the verbosity of the operator log messages.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have created the `ExternalSecretsConfig` custom resource.
+
+.Procedure
+
+* Update the subscription object for {external-secrets-operator} to provide the verbosity level for the operator logs by running the following command:
++
+[source,terminal]
+----
+$ oc -n <external_secrets_operator_namespace> patch subscription openshift-external-secrets-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"OPERATOR_LOG_LEVEL","value":"<log_level>"}]}}}'
+----
++
+where:
+
+external_secrets_operator_namespace:: Namespace where the operator is installed.
+
+log_level:: Supports the value range of 1-5. The default is 2.
+
+.Verification
+
+. The External Secrets Operator pod is redeployed. Verify that the log level of the {external-secrets-operator} is updated by running the following command:
++
+[source,terminal]
+----
+$ oc set env deploy/external-secrets-operator-controller-manager -n external-secrets-operator --list | grep -e OPERATOR_LOG_LEVEL -e container
+----
++
+.Example output
+[source,terminal]
+----
+# deployments/external-secrets-operator-controller-manager, container manager
+OPERATOR_LOG_LEVEL=2
+----
+
+. Verify that the log level of the {external-secrets-operator} is updated by running the `oc logs` command:
++
+[source,terminal]
+----
+$ oc logs -n external-secrets-operator -f deployments/external-secrets-operator-controller-manager -c manager
+----

--- a/modules/external-secrets-enable-operator-metrics.adoc
+++ b/modules/external-secrets-enable-operator-metrics.adoc
@@ -1,0 +1,202 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/exteernal-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-operator-metrics_{context}"]
+= Configuring metrics collection for {external-secrets-operator} by using a ServiceMonitor
+
+[role="_abstract"]
+The {external-secrets-operator} exposes metrics by default on port `8443` at the `/metrics` service endpoint. You can configure metrics collection for the Operator by creating a `ServiceMonitor` custom resource (CR) that enables the Prometheus Operator to collect custom metrics. For more information, see "Configuring user workload monitoring".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled the user workload monitoring.
+
+.Procedure
+
+. Configure the Operator to use `HTTP` for the metrics server. `HTTPS` is enabled by default.
+
+.. Update the subscription object for {external-secrets-operator} to configure the `HTTP` protocol by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-secrets-operator patch subscription openshift-external-secrets-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"METRICS_BIND_ADDRESS","value":":8080"}, {"name": "METRICS_SECURE", "value": "false"}]}}}'
+----
+
+.. To verify that the {external-secrets-operator-short} pod is redeployed and that the configured values for `METRICS_BIND_ADDRESS` and `METRICS_SECURE` are updated, run the following command:
++
+[source,terminal]
+----
+$ oc set env --list deployment/external-secrets-operator-controller-manager -n external-secrets-operator | grep -e METRICS_BIND_ADDRESS -e METRICS_SECURE -e container
+----
++
+The following example shows that the `METRICS_BIND_ADDRESS` and `METRICS_SECURE` have been updated:
++
+[source,terminal]
+----
+# deployments/external-secrets-operator-controller-manager, container manager
+METRICS_BIND_ADDRESS=:8080
+METRICS_SECURE=false
+----
+
+. Create the `Secret` resource with the `kubernetes.io/service-account.name` annotation to inject the token required for authenticating with the metrics server.
+
+.. Create the `secret-external-secrets-operator.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-auth
+  namespace: external-secrets-operator
+  annotations:
+    kubernetes.io/service-account.name: external-secrets-operator-controller-manager
+type: kubernetes.io/service-account-token
+----
+
+.. Create the `Secret` resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f secret-external-secrets-operator.yaml
+----
+
+. Create the `ClusterRoleBinding` resource required for granting permissions to access metrics:
+
+.. Create the `clusterrolebinding-external-secrets.yaml` YAML file:
++
+The following example shows a `cluserrolebinding-external-secrets.yaml` file.
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-allow-metrics-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-operator-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets-operator-controller-manager
+    namespace: external-secrets-operator
+----
+
+.. Create the `ClusterRoldeBinding` custom resource by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f clusterrolebinding-external-secrets.yaml
+----
+
+. Create the `ServiceMonitor` CR if using the default `HTTPS`:
+
+.. Create the `servicemonitor-external-secrets-operator-https.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-monitor
+  namespace: external-secrets-operator
+spec:
+  endpoints:
+    - authorization:
+        credentials:
+          name: external-secrets-operator-metrics-auth
+          key: token
+        type: Bearer
+      interval: 60s
+      path: /metrics
+      port: metrics-https
+      scheme: https
+      scrapeTimeout: 30s
+      tlsConfig:
+        ca:
+          configMap:
+            name: openshift-service-ca.crt
+            key: service-ca.crt
+        serverName: external-secrets-operator-controller-manager-metrics-service.external-secrets-operator.svc.cluster.local
+  namespaceSelector:
+    matchNames:
+      - external-secrets-operator
+  selector:
+    matchLabels:
+      app: external-secrets-operator
+      svc: external-secrets-operator-controller-manager-metrics-service
+----
+
+.. Create the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets-operator-https.yaml
+----
+
+. Create the `ServiceMonitor` CR if configured to use `HTTP`:
+
+.. Create the `servicemonitor-external-secrets-operator-http.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: external-secrets-operator
+  name: external-secrets-operator-metrics-monitor
+  namespace: external-secrets-operator
+spec:
+  endpoints:
+    - authorization:
+        credentials:
+          name: external-secrets-operator-metrics-auth
+          key: token
+        type: Bearer
+      interval: 60s
+      path: /metrics
+      port: metrics-http
+      scheme: http
+      scrapeTimeout: 30s
+  namespaceSelector:
+    matchNames:
+      - external-secrets-operator
+  selector:
+    matchLabels:
+      app: external-secrets-operator
+      svc: external-secrets-operator-controller-manager-metrics-service
+----
+
+.. Create the `ServiceMonitor` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f servicemonitor-external-secrets-operator-http.yaml
+----
++
+After the `ServiceMonitor` CR is created, the user workload Prometheus instance begins metrics collection from the Operator. The collected metrics are labeled with `job="external-secrets-operator-controller-manager-metrics-service"`.
+
+.Verification
+
+. In the {product-title} web console, navigate to *Observe* -> *Targets*.
+
+. In the Label filter field, enter the following labels to filter the metrics targets for each operand:
++
+[source,terminal]
+----
+$ service=external-secrets-operator-controller-manager-metrics-service
+----
+
+. Confirm that the *Status* column shows `Up` for the `external-secrets-operator`.

--- a/modules/external-secrets-enable-user-workload-monitor.adoc
+++ b/modules/external-secrets-enable-user-workload-monitor.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-enable-user-workload-monitor_{context}"]
+= Enabling user workload monitoring
+
+You can enable monitoring for user-defined projects by configuring user workload monitoring in the cluster. For more information, see "Setting up metrics collection for user-defined projects".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Create the `cluster-monitoring-config.yaml` YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+----
+
+. Apply the `ConfigMap` by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f cluster-monitoring-config.yaml
+----
+
+.Verification
+
+* Verify that the monitoring components for user workloads are running in the `openshift-user-workload-monitoring` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring get pod
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                   READY   STATUS    RESTARTS   AGE
+prometheus-operator-5f79cff9c9-67pjb   2/2     Running   0          25h
+prometheus-user-workload-0             6/6     Running   0          25h
+thanos-ruler-user-workload-0           4/4     Running   0          25h
+----
++
+The status of the pods such as `prometheus-operator`, `prometheus-user-workload`, and `thanos-ruler-user-workload` must be `Running`.

--- a/modules/external-secrets-query-metrics.adoc
+++ b/modules/external-secrets-query-metrics.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-query-metrics_{context}"]
+= Querying metrics for the external-secrets operand
+
+As a cluster administrator, or as a user with view access to all namespaces, you can query `external-secrets` operand metrics by using the {product-title} web console or the command-line interface (CLI). For more information, see "Accessing metrics".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled monitoring and metrics collection by creating a `ServiceMonitor` object.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Observe* -> *Metrics*.
+
+. In the query field, enter the following PromQL expressions to query the {external-secrets-operator} operands metric for each operand:
++
+[source,promql]
+----
+{job="external-secrets"}
+----
++
+[source,promql]
+----
+{job="external-secrets-webhook"}
+----
++
+[source,promql]
+----
+{job="external-secrets-cert-controller-metrics"}
+----

--- a/modules/external-secrets-query-operator-metrics.adoc
+++ b/modules/external-secrets-query-operator-metrics.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-monitoring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-query-operator-metrics_{context}"]
+= Querying metrics for the {external-secrets-operator}
+
+As a cluster administrator, or as a user with view access to all namespaces, you can query the Operator metrics by using the {product-title} web console or the command-line interface (CLI). For more information, see "Accessing metrics".
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the {external-secrets-operator}.
+* You have enabled monitoring and metrics collection by creating a `ServiceMonitor` object.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Observe* -> *Metrics*.
+
+. In the query field, enter the following PromQL expressions to query the {external-secrets-operator} metric:
++
+[source,promql]
+----
+{job="external-secrets-operator-controller-manager-metrics-service"}
+----
+

--- a/security/external_secrets_operator/external-secrets-log-levels.adoc
+++ b/security/external_secrets_operator/external-secrets-log-levels.adoc
@@ -1,0 +1,37 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-log-levels"]
+= Customizing the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-log-levels
+
+toc::[]
+
+After the {external-secrets-operator} is installed, you can customize its behavior by editing the `ExternalSecretsConfig` custom resource (CR). This lets you modify components like the external-secrets controller, the cert-controller, the webhook, and the `bitwardenSecretManagerProvider` plugin and also lets you set environment variables for the Operator pod.
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../external_secrets_operator/external-secrets-operator-api.adoc#external-secrets-operator-api[External Secrets Operator for Red hat OpenShift APIs]
+
+//include::modules/cert-manager-enable-operand-log-level.adoc[leveloffset=+1]
+
+include::modules/external-secrets-enable-operator-log-level.adoc[leveloffset=+1]
+
+// enable operand log level
+include::modules/external-secrets-enable-operand-log-level.adoc[leveloffset=+1]
+
+// configure cert-manager certificate requirements
+include::modules/external-secrets-cert-manager-config.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-secrets-log-levels_additional-resources"]
+.Additional resources
+
+* xref:../cert_manager_operator/index.adoc#cert-manager-operator-about[cert-manager Operator for Red Hat Openshift]
+* xref:../cert_manager_operator/cert-manager-operator-install#cert-manager-operator-install[Installing the cert-manager-Operator for Red Hat Openshift]
+
+// configuring bitwarden
+include::modules/external-secrets-bit-warden-config.adoc[leveloffset=+1]
+
+
+

--- a/security/external_secrets_operator/external-secrets-monitoring.adoc
+++ b/security/external_secrets_operator/external-secrets-monitoring.adoc
@@ -1,0 +1,49 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-monitoring"]
+= Monitoring the External Secrets Operator for Red Hat OpenShift
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-monitoring
+
+toc::[]
+
+By default, the {external-secrets-operator} exposes metrics for the Operator and the operands. You can configure OpenShift Monitoring to collect these metrics by using the Prometheus Operator format.
+
+// Enabling user workload monitoring for the external-secrets-operator operand
+include::modules/external-secrets-enable-user-workload-monitor.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/monitoring/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc#setting-up-metrics-collection-for-user-defined-projects_configuring-metrics-uwm[Setting up metrics collection for user-defined projects]
+
+// Metrics scraping for external-secrets-operator
+include::modules/external-secrets-enable-operator-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#configurable-monitoring-components_preparing-to-configure-the-monitoring-stack-uwm[Configurable monitoring components]
+
+// Querying metrics for the external-secrets operator
+include::modules/external-secrets-query-operator-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc#accessing-metrics[Accessing metrics]
+
+
+// Metrics scraping for external-secrets operands by using a ServiceMonitor
+include::modules/external-secrets-enable-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#configurable-monitoring-components_preparing-to-configure-the-monitoring-stack-uwm[Configuring user workload monitoring]
+
+// Querying metrics for the external-secrets operands
+include::modules/external-secrets-query-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc#accessing-metrics[Accessing metrics]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16037

Link to docs preview:
https://98474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-log-levels.html
https://98474--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-monitoring.html


QE review:
- [x] QE has approved this change.


Additional information:

