### PR TITLE
OSDOCS-14899:Adding GDP configs to defaults table

### DIFF
--- a/microshift_configuring/microshift-using-config-yaml.adoc
+++ b/microshift_configuring/microshift-using-config-yaml.adoc
@@ -4,6 +4,10 @@ include::_attributes/attributes-microshift.adoc[]
 = Using the {microshift-short} configuration file
 :context: microshift-configuring
 
+:FeatureName: The Generic Device Plugin for {microshift-short}
+
+include::snippets/technology-preview.adoc[]
+
 toc::[]
 
 A YAML file customizes {microshift-short} instances with your preferences, settings, and parameters.

--- a/modules/microshift-config-parameters-table.adoc
+++ b/modules/microshift-config-parameters-table.adoc
@@ -77,6 +77,82 @@ The following table explains {microshift-short} configuration YAML parameters an
 |`number`
 |By default, `etcd` uses as much memory as needed to handle the load on the system. However, in memory constrained systems, it might be preferred or necessary to limit the amount of memory `etcd` can to use at a given time.
 
+|`generic.Device.Plugin.devices`
+|`groups`
+|Lists the device definitions to be exposed by the plugin. Each Device entry contains a 'name' and a list of groups.
+
+|`generic.Device.Plugin.devices.groups`
+|`count`, `paths`, 'usbs'
+|Lists device groups. Devices within a group comprise a pool of devices under a common name. When you request a device from that pool, you can receive a device from different defined paths.
+
+|`generic.Device.Plugin.devices.groups.count`
+|`number`
+|Specifies how many times this group of devices can be mounted concurrently. If unspecified, Count defaults to 1. Setting a high count, for example, `1000` for `/dev/fuse`, is possible because there are no inherent limits, but performance might be affected depending on the host capabilities and the nature of the device.
+
+|`generic.Device.Plugin.devices.groups.paths`
+|`string`
+|Lists the host device file paths. Paths can be glob patterns. For example, `/dev/ttyUSB`, in which case each matched device is schedulable Count times. This field is exclusive with usbs. You cannot define both parameters in the same device group.
+
+|`generic.Device.Plugin.devices.groups.paths.limit`
+|`number`
+|Specifies up to how many times this device can be used in the group concurrently when other devices in the group yield more matches. For example, if one path in the group matches 5 devices and another matches 1 device, but has a limit of 10, then the group provides 5 pairs of devices. When unspecified, the limit defaults to `1`.
+
+|`generic.Device.Plugin.devices.groups.paths.mountPath`
+|`string`
+|The file path at which the host device should be mounted within the container. When unspecified, mountPath defaults to `path`.
+
+|`generic.Device.Plugin.devices.groups.paths.path`
+|`string`
+|The file path of a device on the host. For example, `/dev/video0`, `/dev/ttyUSB*`.
+
+|`generic.Device.Plugin.devices.groups.paths.permissions`
+|`r`, `w`, `m`
+|The file-system permissions given to the mounted device. Applies only to mounts of type `Device`. Can be one or more of:
+
+* `r` allows the container to read from the specified device.
+
+* `w` allows the container to write to the specified device.
+
+* `m` allows the container to create device files that do not yet exist.
+
+When unspecified, the value defaults to `mrw`.
+
+|`generic.Device.Plugin.devices.groups.paths.readOnly`
+|`true`, `false`
+|Specifies whether the path should be mounted read-only. Applies only to mounts of type `Mount`.
+
+|`generic.Device.Plugin.devices.groups.paths.type`
+|`Device`, `Mount`
+|Describes what type of file-system node this `path` represents and thus how it should be mounted. When unspecified, `type` defaults to `Device`.
+
+|`generic.Device.Plugin.devices.groups.usbs`
+|`string`
+|Lists the USB specifications that this device group consists of. The vendor and product IDs must always match. The serial ID must match if provided, or skipped if the ID is empty. The `usbs` field is exclusive with `paths`.
+
+|`generic.Device.Plugin.devices.groups.usbs.product`
+|`string`
+|The USB Product ID of the device to match on. For example, `0x7523`.
+
+|`generic.Device.Plugin.devices.groups.usbs.serial`
+|`string`
+|The serial number of the device to match on. A USB device must match exactly on all the given attributes to pass.
+
+|`generic.Device.Plugin.devices.groups.usbs.vendor`
+|`string`
+|The USB Vendor ID of the device to match on. For example, `0x1a86`.
+
+|`generic.Device.Plugin.devices.name`
+|`string`
+|A unique string representing the kind of device this specification describes. For example, `serial`, `video`, or `fuse`. This name is used in pod resource requests. For example, `device.microshift.io/serial`.
+
+|`generic.Device.Plugin.domain`
+|`string`
+|Specifies the domain prefix with which devices are advertised and present in the cluster. For example, `device.microshift.io/serial`. The default value is `device.microshift.io`.
+
+|`generic.Device.Plugin.status`
+|`Enabled`, `Disabled`
+|Specifies the default GDP status.
+
 |`ingress.certificateSecret`
 |`string`
 |A reference to a secret that contains the default certificate that is served by the ingress controller. When routes do not specify their own certificate, `certificateSecret` is used.

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -6,6 +6,10 @@
 [id="microshift-yaml-default_{context}"]
 = Default settings
 
+:FeatureName: The Generic Device Plugin for {microshift-short}
+
+include::snippets/technology-preview.adoc[]
+
 If you do not create a `config.yaml` file or use a configuration snippet YAML file, default values are used. The following example shows the default configuration settings.
 
 *  To see the default values, run the following command:
@@ -40,6 +44,24 @@ dns:
   baseDomain: microshift.example.com
 etcd:
   memoryLimitMB: 0
+genericDevicePlugin:
+    devices:
+        - groups:
+            - count: 1
+              paths:
+                - limit: 1
+                  mountPath: /dev/ttyACM0
+                  path: /dev/ttyACM0
+                  permissions: mrw
+                  readOnly: false
+                  type: Device
+              usbs:
+                - product: ""
+                  serial: ""
+                  vendor: ""
+          name: serial
+    domain: device.microshift.io
+    status: Disabled
 ingress:
   accessLogging:
     destination:
@@ -51,7 +73,7 @@ ingress:
         facility: ""
         maxLength: 1024
         port: 0
-      type: ""
+        type: ""
     httpCaptureCookies:
       - matchType: ""
         maxLength: 0


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-14899

Link to docs preview:
https://98475--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html

QE review:
- [x] QE has approved this change.