### PR TITLE
OCPBUGS-61216: Removed SLB doc from DAY 2 BM book

### DIFF
--- a/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+++ b/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
@@ -34,9 +34,6 @@ include::modules/creating-manifest-file-customized-br-ex-bridge.adoc[leveloffset
 
 * xref:../../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#bare-metal-expanding-the-cluster[Expanding the cluster]
 
-// Enabling OVS balance-slb mode for your cluster
-include::modules/enabling-OVS-balance-slb-mode.adoc[leveloffset=+1]
-
 // Services for a user-managed load balancer
 include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
 

--- a/modules/enabling-OVS-balance-slb-mode.adoc
+++ b/modules/enabling-OVS-balance-slb-mode.adoc
@@ -2,7 +2,6 @@
 //
 // IPI
 // * installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
-// * installing/installing_bare_metal/ipi/bare-metal-postinstallation-configuration.adoc
 // UPI
 // * installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OCPBUGS-61216](https://issues.redhat.com/browse/OCPBUGS-61216)

Link to docs preview:

* [BM DAY-2 book minus the SLB doc](https://98487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html)
* [Setting up the environment for an OpenShift installation](https://98487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#enabling-OVS-balance-slb-mode_ipi-install-installation-workflow)
* [Installing a user-provisioned cluster on bare metal](https://98487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html#enabling-OVS-balance-slb-mode_installing-bare-metal)
* [Installing a user-provisioned bare metal cluster with network customizations](https://98487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html#enabling-OVS-balance-slb-mode_installing-bare-metal-network-customizations)
* [Installing a user-provisioned bare metal cluster on a disconnected environment](https://98487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html)

- [x] SME has approved this change.
- [x] QE has approved this change.

