### PR TITLE
OSDOC#43771 - Updates to NAD CLI configuration

### DIFF
--- a/modules/virt-creating-localnet-nad-cli.adoc
+++ b/modules/virt-creating-localnet-nad-cli.adoc
@@ -35,7 +35,7 @@ spec:
 ----
 <1> The name of the configuration object.
 <2> Specifies the nodes to which the node network configuration policy is to be applied. The recommended node selector value is `node-role.kubernetes.io/worker: ''`.
-<3> The name of the additional network from which traffic is forwarded to the OVS bridge. This attribute must match the value of the `spec.config.name` field of the `NetworkAttachmentDefinition` object that defines the OVN-Kubernetes additional network.
+<3> The name of the additional network from which traffic is forwarded to the OVS bridge. This attribute must match the value of the `spec.config.physicalNetworkName` field of the `NetworkAttachmentDefinition` object that defines the OVN-Kubernetes additional network.
 <4> The name of the OVS bridge on the node. This value is required if the `state` attribute is `present`.
 <5> The state of the mapping. Must be either `present` to add the mapping or `absent` to remove the mapping. The default value is `present`.
 +
@@ -57,21 +57,23 @@ spec:
   config: |-
     {
             "cniVersion": "0.3.1", <1>
-            "name": "localnet-network", <2>
+            "name": "localnet1", <2>
             "type": "ovn-k8s-cni-overlay", <3>
             "topology": "localnet", <4>
-            "mtu": 1500, <5>
-            "vlanID": 200, <6>
-            "netAttachDefName": "default/localnet-network" <7>
+            "physicalNetworkName": "localnet-network", <5>
+            "mtu": 1500, <6>
+            "vlanID": 200, <7>
+            "netAttachDefName": "default/localnet-network" <8>
     }
 ----
 <1> The CNI specification version. The required value is `0.3.1`.
-<2> The name of the network. This attribute must match the value of the `spec.desiredState.ovn.bridge-mappings.localnet` field of the `NodeNetworkConfigurationPolicy` object that defines the OVS bridge mapping.
+<2> The name of the network.
 <3> The name of the CNI plug-in to be configured. The required value is `ovn-k8s-cni-overlay`.
 <4> The topological configuration for the network. The required value is `localnet`.
-<5> Optional: The maximum transmission unit (MTU) value. If you do not set a value, the Cluster Network Operator (CNO) sets a default MTU value by calculating the difference among the underlay MTU of the primary network interface, the overlay MTU of the pod network, and byte capacity of any enabled features, such as IPsec.
-<6> Optionally, for more fine-grained network management, you can configure a virtual LAN (VLAN) ID for the NAD. VMs that use this NAD have an interface that can communicate only with devices that use the same VLAN ID (`200` in this example).
-<7> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
+<5> The name of the host's physical network interface, to which the pod's new network interface will be attached. This setting can be reused by multiple NADs. Note that `physicalNetworkName` must match the value of the `spec.desiredState.ovn.bridge-mappings.localnet` field of the `NodeNetworkConfigurationPolicy` object that defines the OVS bridge mapping.
+<6> Optional: The maximum transmission unit (MTU) value. If you do not set a value, the Cluster Network Operator (CNO) sets a default MTU value by calculating the difference between the underlay MTU of the primary network interface, the overlay MTU of the pod network, and the byte capacity of any enabled features, such as IPsec encryption.
+<7> Optional: The virtual LAN (VLAN) ID for the NAD. VMs that use this NAD have an interface that can communicate only with devices that use the same VLAN ID. In this example, the VLAN ID is `200`.
+<8> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
 
 . Apply the manifest:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15 - 4.18

Issue:
https://issues.redhat.com/browse/CNV-43771

Link to docs preview:
https://98488--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.html#virt-creating-localnet-nad-cli_virt-connecting-vm-to-ovn-secondary-network

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is a 4.18-based copy of https://github.com/openshift/openshift-docs/pull/97989

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
