### PR TITLE
CNV- 65115: How to migrate a VM to a specific destination node

### DIFF
--- a/modules/virt-migrate-vm-to-labeled-node.adoc
+++ b/modules/virt-migrate-vm-to-labeled-node.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// virt/live_migration/virt-configuring-live-migration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-migrate-vm-to-labeled-node_{context}"]
+= Migrating a VM to a specific node
+
+You can migrate a running virtual machine (VM) to a specific subset of nodes by using the `addedNodeSelector` field on the `VirtualMachineInstanceMigration` object. This field lets you apply additional node selection rules for a *one-time* migration attempt, without affecting the VM configuration or future migrations.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* The VM you want to migrate is running.
+* You have identified the labels of the target nodes. Multiple labels can be specified and are combined with logical `AND`.
+* The `oc` CLI tool is installed.
+
+.Procedure
+
+. Create a migration manifest YAML file. For example:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstanceMigration
+metadata:
+  name: migration-job
+spec:
+  vmiName: vmi-fedora
+  addedNodeSelector:
+    accelerator: gpu-enabled23
+    kubernetes.io/hostname: "ip-172-28-114-199.example"
+----
++
+
+where:
+
+`vmiName`:: Specifies the name of the running VM (for example, `vmi-fedora`).
+`addedNodeSelector`:: Specifies additional constraints for selecting the target node.
+
+. Apply the manifest to the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <file_name>.yaml
+----
++
+If no nodes satisfy the constraints, the migration is declared a failure after a timeout. The VM remains unaffected.

--- a/virt/live_migration/virt-configuring-live-migration.adoc
+++ b/virt/live_migration/virt-configuring-live-migration.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="virt-configuring-live-migration"]
 = Configuring live migration
+
 include::_attributes/common-attributes.adoc[]
+
 :context: virt-configuring-live-migration
 
 toc::[]
@@ -30,6 +32,8 @@ You can create live migration policies by using the {product-title} web console.
 ====
 
 include::modules/virt-configuring-a-live-migration-policy.adoc[leveloffset=+2]
+
+include::modules/virt-migrate-vm-to-labeled-node.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_virt-configuring-live-migration"]


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/CNV-65115

Link to docs preview:
https://98489--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-configuring-live-migration.html#virt-migrate-vm-to-labeled-node_virt-configuring-live-migration

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
