### PR TITLE
CNV-51253: ControllerRevision label update

### DIFF
--- a/modules/best-practices-rhacm-discovered-vm.adoc
+++ b/modules/best-practices-rhacm-discovered-vm.adoc
@@ -12,7 +12,7 @@ You can take several actions to improve your experience and chance of success wh
 
 Protecting the VM when using MTV, the {product-title} web console, or a custom VM:: Because automatic labeling is not currently available, the application owner must manually label the components of the VM application when using MTV, the {product-title} web console, or a custom VM.
 +
-After creating the VM, apply a common label to the following resources associated with the VM: `VirtualMachine`, `DataVolume`, `PersistentVolumeClaim`, `Service`, `Route`, `Secret`, `ConfigMap`, `VirtualMachinePreference`, and `VirtualMachineInstancetype`. Do not label virtual machine instances (VMIs) or pods; {VirtProductName} creates and manages these automatically.
+After creating the VM, apply a common label to the following resources associated with the VM: `VirtualMachine`, `DataVolume`, `PersistentVolumeClaim`, `Service`, `Route`, `Secret` and `ConfigMap`. If the VM uses an instance type or preference, you must also label the `ControllerRevision` copy of these objects referenced by the spec or status of the VM. Do not label virtual machine instances (VMIs) or pods; {VirtProductName} creates and manages these automatically.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com//browse/CNV-51253

Link to docs preview:
https://98527--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-disaster-recovery.html#best-practices-rhacm-discovered-vm_virt-disaster-recovery

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
