### PR TITLE
OSDOCS-16077 [NETOBSERV] 1.9.3 release notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3265,6 +3265,8 @@ Topics:
   Dir: network_observability
   Distros: openshift-enterprise,openshift-origin
   Topics:
+  - Name: Network observability release notes 1.9.3
+    File: network-observability-release-notes-1-9-3
   - Name: Network observability release notes 1.9.2
     File: network-observability-release-notes-1-9-2
   - Name: Network observability release notes

--- a/modules/network-observability-operator-release-notes-1-9-3-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-3-advisory.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes-1-9-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-3-advisory_{context}"]
+= Network Observability Operator 1.9.3 advisory
+
+The following advisory is available for the Network Observability Operator 1.9.3:
+
+* link:https://access.redhat.com/errata/RHEA-2025:15780[RHEA-2025:15780 Network Observability Operator 1.9.3]

--- a/observability/network_observability/network-observability-release-notes-1-9-3.adoc
+++ b/observability/network_observability/network-observability-release-notes-1-9-3.adoc
@@ -1,0 +1,17 @@
+//Network Observability Operator Release Notes
+:_mod-docs-content-type: ASSEMBLY
+[id="network-observability-release-notes-1-9-3"]
+= Network Observability Operator release notes 1.9.3
+
+:context: network-observability-operator-release-notes-v1-9-3
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+With the Network Observability Operator, administrators can observe and analyze network traffic flows for {product-title} clusters.
+
+These release notes track the development of the Network Observability Operator in the {product-title}.
+
+For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-operator_network-observability-overview[Network Observability Operator].
+
+include::modules/network-observability-operator-release-notes-1-9-3-advisory.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-16077](https://issues.redhat.com//browse/OSDOCS-16077) [NETOBSERV] 1.9.3 release notes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-16077

Link to docs preview:
- Network Observability Operator release notes 1.9.3 https://98549--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-release-notes-1-9-3.html
- Network Observability Operator 1.9.3 advisory: https://98549--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-release-notes-1-9-3.html#network-observability-operator-release-notes-1-9-3-advisory_network-observability-operator-release-notes-v1-9-3

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- A refactoring of release notes is being handled by a separate Jira.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
