### PR TITLE
OSDOCS#16031: Update the z-stream RNs for 4.14.56

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3420,6 +3420,33 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.56
+[id="ocp-4-14-56_{context}"]
+=== RHSA-2025:14855 - {product-title} 4.14.56 bug fix and security update
+
+Issued: 04 September 2025
+
+{product-title} release 4.14.56, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:14855[RHSA-2025:14855] advisory. There is no RPM package for this update.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.56 --pullspecs
+----
+
+[id="ocp-4-14-56-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, the sidecar of the `openshift-ptp` pod crashed when it stopped during a restart. As a consequence, the clock class metrics were unavailable. With this release, the sidecar for the `openshift-ptp` pod does not stop during a restart. As a result, the clock class metrics are available. (link:https://issues.redhat.com/browse/OCPBUGS-59233[OCPBUGS-59233])
+
+[id="ocp-4-14-56-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.55
 [id="ocp-4-14-55_{context}"]
 === RHSA-2025:13289 - {product-title} 4.14.55 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-16031](https://issues.redhat.com//browse/OSDOCS-16031)

Link to docs preview:
[4.14.56](https://98554--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-56_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
The errata URLs will return 404 until the go-live date of 9/4/25.
