### PR TITLE
OSDOCS-16076-RN adding release note for Azure Intel TDX Confidential VMs

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -442,6 +442,18 @@ With this release, you can specify the location of a DNS private zone when insta
 
 For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-short} configuration parameters].
 
+[id="ocp-release-notes-installation-azure-confidential-vms_{context}"]
+==== Installing a cluster on {azure-full} using Intel TDX Confidential VMs
+
+With this release, you can install a cluster on {azure-short} using Intel-based Confidential VMs. The following machine sizes are now supported:
+
+* DCesv5-series
+* DCedsv5-series
+* ECesv5-series
+* ECedsv5-series
+
+For more information, see xref:../installing/installing_azure/ipi/installing-azure-customizations.adoc#installation-azure-confidential-vms_installing-azure-customizations[Enabling confidential VMs].
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 === Machine Config Operator
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-16076

Link to docs preview:
https://98556--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-installation-azure-confidential-vms_release-notes

QE review:
- [x] QE has approved this change.
