### PR TITLE
OSDOCS-14512: Prune "Web Console"

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -167,7 +167,7 @@ Topics:
 - Name: Planning resource usage in your cluster
   File: rosa-planning-environment
 ---
-Name: Install  clusters
+Name: Install clusters
 Dir: rosa_hcp
 Distros: openshift-rosa-hcp
 Topics:

--- a/modules/about-developer_web-console.adoc
+++ b/modules/about-developer_web-console.adoc
@@ -22,17 +22,7 @@ endif::openshift-rosa-hcp[]
 
 Developers have access to workflows specific to their use cases, such as the ability to:
 
-* Create and deploy applications on 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[]
-by importing existing codebases, images, and container files.
+* Create and deploy applications on {product-title} by importing existing codebases, images, and container files.
 * Visually interact with applications, components, and services associated with them within a project and monitor their deployment and build status.
 * Group components within an application and connect the components within and across applications.
 * Integrate serverless capabilities (Technology Preview).
@@ -40,5 +30,7 @@ by importing existing codebases, images, and container files.
 
 You can use the *Topology* view to display applications, components, and workloads of your project. If you have no workloads in the project, the *Topology* view will show some links to create or import them. You can also use the *Quick Search* to import components directly.
 
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 .Additional resources
 See link:https://docs.openshift.com/container-platform/latest/applications/odc-viewing-application-composition-using-topology-view.html[Viewing application composition using the Topology] view for more information on using the *Topology* view in *Developer* perspective.
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/modules/adding-tab-pods-page.adoc
+++ b/modules/adding-tab-pods-page.adoc
@@ -10,17 +10,7 @@ There are different customizations you can make to the {product-title} web conso
 
 [NOTE]
 ====
-The 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[] 
-web console runs in a container connected to the cluster you have logged into. See "Dynamic plugin development" for information to test the plugin before creating your own.
+The {product-title} web console runs in a container connected to the cluster you have logged into. See "Dynamic plugin development" for information to test the plugin before creating your own.
 ====
 
 .Procedure

--- a/modules/dynamic-plug-in-development.adoc
+++ b/modules/dynamic-plug-in-development.adoc
@@ -19,12 +19,9 @@ Red{nbsp}Hat does not support custom plugin code. Only link:https://access.redha
 ifndef::openshift-rosa-hcp,openshift-rosa[]
 an {product-title} 
 endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-a {rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-a {rosa-classic-short} 
-endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp,openshift-rosa[]
+a {product-title} 
+endif::openshift-rosa-hcp,openshift-rosa[]
 cluster running.
 * You must have the {oc-first} installed.
 * You must have link:https://yarnpkg.com/[`yarn`] installed.
@@ -50,34 +47,14 @@ $ yarn install
 $ yarn run start
 ----
 
-. In another terminal window, login to the 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[]
-through the CLI.
+. In another terminal window, login to the {product-title} web console through the CLI.
 +
 [source,terminal]
 ----
 $ oc login
 ----
 
-. Run the
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[]
-web console in a container connected to the cluster you have logged in to by running the following command:
+. Run the {product-title} web console in a container connected to the cluster you have logged in to by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/dynamic-plugin-api.adoc
+++ b/modules/dynamic-plugin-api.adoc
@@ -1143,7 +1143,7 @@ A basic lazy loaded Code editor with hover help and completion.
 [discrete]
 == `ResourceYAMLEditor`
 
-A lazy loaded YAML editor for Kubernetes resources with hover help and completion. The component use the YAMLEditor and add on top of it more functionality likeresource update handling, alerts, save, cancel and reload buttons, accessibility and more. Unless `onSave` callback is provided, the resource update is automatically handled.It should be wrapped in a `React.Suspense` component.
+A lazy loaded YAML editor for Kubernetes resources with hover help and completion. The component use the YAMLEditor and add on top of it more functionality like resource update handling, alerts, save, cancel and reload buttons, accessibility and more. Unless `onSave` callback is provided, the resource update is automatically handled. It should be wrapped in a `React.Suspense` component.
 
 .Example
 [source,text]

--- a/modules/dynamic-plugin-proxy-service.adoc
+++ b/modules/dynamic-plugin-proxy-service.adoc
@@ -39,17 +39,7 @@ spec:
 +
 [NOTE]
 ====
-If the service proxy request does not contain the logged-in user's 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[]
-access token, set the authorization field to `None`.
+If the service proxy request does not contain the logged-in user's {product-title} access token, set the authorization field to `None`.
 ====
 <3> If the service uses a custom service CA, the `caCertificate` field must contain the certificate bundle.
 <4> Endpoint of the proxy.

--- a/modules/odc-setting-user-preferences.adoc
+++ b/modules/odc-setting-user-preferences.adoc
@@ -18,13 +18,13 @@ You can set the default user preferences for your cluster.
 .. In the *Create/Edit resource method* field, you can set a preference for creating or editing a resource. If both the form and YAML options are available, the console defaults to your selection.
 . In the *Language* section, select *Default browser language* to use the default browser language settings. Otherwise, select the language that you want to use for the console.
 . In the *Notifications* section, you can toggle display notifications created by users for specific projects on the *Overview* page or notification drawer.
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . In the *Applications* section:
 .. You can view the default *Resource type*. For example, if the {ServerlessOperatorName} is installed, the default resource type is *Serverless Deployment*. Otherwise, the default resource type is *Deployment*.
 .. You can select another resource type to be the default resource type from the *Resource Type* field.
-endif::openshift-rosa,openshift-dedicated[]
-ifdef::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . In the *Applications* section:
 .. You can view the default *Resource type*. The default resource type is *Deployment*.
 .. You can select another resource type to be the default resource type from the *Resource Type* field.
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/modules/optional-capabilities-operators.adoc
+++ b/modules/optional-capabilities-operators.adoc
@@ -4,14 +4,6 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="optional-capabilities-operators_{context}"]
-ifndef::openshift-rosa-hcp,openshift-rosa[]
 =  Enhancing the {product-title} web console with Operators
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-=  Enhancing the {rosa-short} web console with Operators
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-=  Enhancing the {rosa-classic-short} web console with Operators
-endif::openshift-rosa[]
 
 Cluster administrators can install Operators on clusters in the {product-title} web console by using the OperatorHub to provide customization outside of layered products for developers. For example, the Web Terminal Operator allows you to start a web terminal in your browser with common CLI tools for interacting with the cluster.

--- a/modules/rhdh-install-web-console.adoc
+++ b/modules/rhdh-install-web-console.adoc
@@ -4,15 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="rhdh-install-web-console_{context}"]
-ifndef::openshift-rosa-hcp,openshift-rosa[]
 =  Installing the {rh-dev-hub} using the {product-title} web console
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-=  Installing the {rh-dev-hub} using the {rosa-short} web console
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-=  Installing the {rh-dev-hub} using the {rosa-classic-short} web console
-endif::openshift-rosa[]
 
 The web console provides a quick start with instructions on how to install the {rh-dev-hub} Operator.
 

--- a/modules/rhdh-web-console.adoc
+++ b/modules/rhdh-web-console.adoc
@@ -4,14 +4,6 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="rhdh-web-console_{context}"]
-ifndef::openshift-rosa-hcp,openshift-rosa[]
 = {rh-dev-hub} in the {product-title} web console
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-= {rh-dev-hub} in the {rosa-short} web console
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-= {rh-dev-hub} in the {rosa-classic-short} web console
-endif::openshift-rosa[]
 
 The {rh-dev-hub} is a platform you can use to experience a streamlined development environment. {rh-dev-hub} is driven by a centralized software catalog, providing efficiency to your microservices and infrastructure. It enables your product team to deliver quality code without any compromises. A quick start is available for you to learn more about how to install the developer hub.

--- a/modules/serverless-web-console.adoc
+++ b/modules/serverless-web-console.adoc
@@ -6,14 +6,4 @@
 [id="using-serverless-with-openshift_{context}"]
 = Red Hat {serverlessproductname} in the web console
 
-Red Hat {serverlessproductname} enables developers to create and deploy serverless, event-driven applications on {product-title}. You can use the 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[]
-web console OperatorHub to install the {serverlessproductname} Operator.
+Red Hat {serverlessproductname} enables developers to create and deploy serverless, event-driven applications on {product-title}. You can use the {product-title} web console OperatorHub to install the {serverlessproductname} Operator.

--- a/modules/virt-about-the-overview-dashboard.adoc
+++ b/modules/virt-about-the-overview-dashboard.adoc
@@ -4,54 +4,14 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="virt-about-the-overview-dashboard_{context}"]
-ifndef::openshift-rosa-hcp,openshift-rosa[]
 = About the {product-title} dashboards page
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-= About the {rosa-short} dashboards page 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-= About the {rosa-classic-short} dashboards page
-endif::openshift-rosa[]
 
 Access the {product-title} dashboard, which captures high-level information
-about the cluster, by navigating to *Home* -> *Overview* from
-the 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[]
-web console.
+about the cluster, by navigating to *Home* -> *Overview* from the {product-title} web console.
 
-The 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[]
-dashboard provides various cluster information, captured in
-individual dashboard cards.
+The {product-title} dashboard provides various cluster information, captured in individual dashboard cards.
 
-The 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[]
-dashboard consists of the following cards:
+The {product-title} dashboard consists of the following cards:
 
 * *Details* provides a brief overview of informational cluster details.
 +

--- a/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
+++ b/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
@@ -54,17 +54,13 @@ conster Header: React.FC ++= () => {++
 When creating your plugin, follow these guidelines for using PatternFly:
 
 * Use link:https://www.patternfly.org/components/all-components/[PatternFly] components and PatternFly CSS variables. Core PatternFly components are available through the SDK. Using PatternFly components and variables help your plugin look consistent in future console versions.
-ifndef::openshift-rosa-hcp,openshift-rosa[]
+ifndef::openshift-rosa-hcp[]
 ** Use Patternfly 4.x if you are using {product-title} versions 4.14 and earlier.
 ** Use Patternfly 5.x if you are using {product-title} 4.15 or later.
-endif::openshift-rosa-hcp,openshift-rosa[]
+endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa-hcp[]
 ** Use Patternfly 5.x.
 endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-** Use Patternfly 4.x if you are using {rosa-classic-short} versions 4.14 and earlier.
-** Use Patternfly 5.x if you are using {rosa-classic-short} 4.15 or later.
-endif::openshift-rosa[]
 * Make your plugin accessible by following link:https://www.patternfly.org/accessibility/accessibility-fundamentals/[PatternFly's accessibility fundamentals].
 * Avoid using other CSS libraries such as Bootstrap or Tailwind. They might conflict with PatternFly and not match the rest of the console. Plugins should only include styles that are specific to their user interfaces to be evaluated on top of base PatternFly styles. Avoid importing styles such as `@patternfly/react-styles/**/*.css` or any styles from the `@patternfly/patternfly` package in your plugin.
 * The console application is responsible for loading base styles for all supported PatternFly version(s).

--- a/web_console/using-dashboard-to-get-cluster-information.adoc
+++ b/web_console/using-dashboard-to-get-cluster-information.adoc
@@ -1,27 +1,9 @@
-ifndef::openshift-rosa-hcp,openshift-rosa[]
 :_mod-docs-content-type: ASSEMBLY
 [id="using-dashboard-to-get-cluster-info"]
 = Using the {product-title} dashboard to get cluster information
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: using-dashboard-to-get-cluster-info
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-:_mod-docs-content-type: ASSEMBLY
-[id="using-dashboard-to-get-cluster-info"]
-= Using the {rosa-short} dashboard to get cluster information
-include::_attributes/common-attributes.adoc[]
-include::_attributes/attributes-openshift-dedicated.adoc[]
-:context: using-dashboard-to-get-cluster-info
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-:_mod-docs-content-type: ASSEMBLY
-[id="using-dashboard-to-get-cluster-info"]
-= Using the {rosa-classic-short} dashboard to get cluster information
-include::_attributes/common-attributes.adoc[]
-include::_attributes/attributes-openshift-dedicated.adoc[]
-:context: using-dashboard-to-get-cluster-info
-endif::openshift-rosa[]
 
 toc::[]
 

--- a/web_console/web-console-overview.adoc
+++ b/web_console/web-console-overview.adoc
@@ -13,17 +13,7 @@ ifndef::openshift-rosa-hcp[]
 include::snippets/unified-perspective-web-console.adoc[]
 endif::openshift-rosa-hcp[]
 
-You can create quick start tutorials for 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[]
-that provide guided steps within the web console with user tasks. They are helpful for getting oriented with an application, Operator, or other product offering.
+You can create quick start tutorials for {product-title} that provide guided steps within the web console with user tasks. They are helpful for getting oriented with an application, Operator, or other product offering.
 
 include::modules/about-administrator_web-console.adoc[leveloffset=+1]
 include::modules/about-developer_web-console.adoc[leveloffset=+1]
@@ -34,8 +24,8 @@ include::modules/enabling-developer-perspective_web-console.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../welcome/learn_more_about_openshift.adoc#cluster-administrator[Learn more about Cluster Administrator]
-* xref:../applications/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[Viewing the applications in your project, verifying their deployment status, and interacting with them in the *Topology* view]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+* xref:../applications/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[Viewing the applications in your project, verifying their deployment status, and interacting with them in the *Topology* view]
 * xref:../web_console/using-dashboard-to-get-cluster-information.adoc#using-dashboard-to-get-cluster-info[Viewing cluster information]
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../web_console/configuring-web-console.adoc#configuring-web-console[Configuring the web console]

--- a/web_console/web_terminal/installing-web-terminal.adoc
+++ b/web_console/web_terminal/installing-web-terminal.adoc
@@ -13,17 +13,7 @@ You can install the web terminal by using the {web-terminal-op} listed in the {p
 [id="prerequisites_installing-web-terminal"]
 == Prerequisites
 
-* You are logged into the 
-ifndef::openshift-rosa-hcp,openshift-rosa[]
-{product-title} 
-endif::openshift-rosa-hcp,openshift-rosa[]
-ifdef::openshift-rosa-hcp[]
-{rosa-short} 
-endif::openshift-rosa-hcp[]
-ifdef::openshift-rosa[]
-{rosa-classic-short} 
-endif::openshift-rosa[]
-web console.
+* You are logged into the {product-title} web console.
 * You have cluster administrator permissions.
 
 [discrete]


### PR DESCRIPTION
[OSDOCS-14512](https://issues.redhat.com//browse/OSDOCS-14512): Prune "Web Console"

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-14512

Link to docs preview:
HCP: https://98558--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/web_console/web-console-overview
Classic: https://98558--ocpdocs-pr.netlify.app/openshift-rosa/latest/web_console/web-console-overview

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
