### PR TITLE
OSDOCS-16079 GCP XPN specifying DNS Zone

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2376,6 +2376,22 @@ Additional GCP configuration parameters are described in the following table:
 
 |platform:
   gcp:
+    dns:
+      privateZone:
+        name:
+|The name of the private DNS zone. This parameter is only used during shared VPC installations. You can use a private DNS zone in a service project that is distinct from the projects specified by the `projectID` or `networkProjectID` parameters.
+|String.
+
+|platform:
+  gcp:
+    dns:
+      privateZone:
+        projectID:
+|The ID of the project that contains the private zone from the `privateZone.name` parameter.
+|String.
+
+|platform:
+  gcp:
     userProvisionedDNS:
 |Enables user-provisioned DNS instead of the default cluster-provisioned DNS solution. If you use this feature, you must provide your own DNS solution that includes records for `api.<cluster_name>.<base_domain>.` and `*.apps.<cluster_name>.<base_domain>.`.
 |`Enabled` or `Disabled`. The default value is `Disabled`.

--- a/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
@@ -47,3 +47,18 @@ If you do not supply a service account for control plane nodes in the `install-c
 * `resourcemanager.projects.setIamPolicy`
 ====
 
+The following permissions are required when you select a separate project for the location of the DNS zone or zones. These permissions are also required when the DNS zone or zones are located in a third project.
+
+.Required minimal permissions for provisioning DNS resources in a separate project
+====
+* `dns.changes.create`
+* `dns.changes.get`
+* `dns.managedZones.create`
+* `dns.managedZones.delete`
+* `dns.managedZones.get`
+* `dns.managedZones.list`
+* `dns.managedZones.update`
+* `dns.resourceRecordSets.create`
+* `dns.resourceRecordSets.delete`
+* `dns.resourceRecordSets.list`
+====


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-16079

Link to docs preview:
[Permissions update](https://98565--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account#minimum-required-permissions-ipi-gcp-xpn_installing-gcp-account)
[Config parameter](https://98565--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp)


QE review:
- [x] QE has approved this change.

Based on brent's work in https://github.com/openshift/openshift-docs/pull/96700