### PR TITLE
OSDOCS-16079-RN Release note for GCP XPN DNS zone

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -435,6 +435,13 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-release-notes-installation-and-update_{context}"]
 === Installation and update
 
+[id="ocp-release-notes-installation-gcp-xpn-dns-zones_{context}"]
+==== Installing a cluster on {gcp-full} into a shared VPC specifying a DNS private zone in a third project
+
+With this release, you can specify the location of a DNS private zone when installing a cluster on {gcp-short} into a shared VPC. The private zone can be located in a service project that is distinct from the host project or main service project.
+
+For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-short} configuration parameters].
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 === Machine Config Operator
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-16079

Link to docs preview:
https://98569--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-installation-gcp-xpn-dns-zones_release-notes

QE review:
- [x] QE has approved this change.
