### PR TITLE
TELCODOCS-2259: Release note for ARM dual port OC for PTP

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -521,6 +521,16 @@ This feature provides a periodic summary of filtered logs, which is not availabl
 
 For more information, see xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#cnf-configuring-enhanced-log-reduction-for-linuxptp_configuring-ptp[Configuring enhanced PTP logging].
 
+[id="ocp-4-20-networking-arm-dual-oc_{context}"]
+==== PTP ordinary clocks with added redundancy on AArch64 nodes (Technology Preview)
+
+With this release, you can configure PTP ordinary clocks with added redundancy on AArch64 architecture nodes that use the following dual-port NICs only:
+
+* NVIDIA ConnectX-7 series
+* NVIDIA BlueField-3 series, in NIC mode
+
+This feature is available as a Technology Preview. For more information, see xref:../networking/advanced_networking/ptp/about-ptp.adoc#ptp-dual-ports-oc_about-ptp[Using dual-port NICs to improve redundancy for PTP ordinary clocks].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 


### PR DESCRIPTION
[TELCODOCS-2259](https://issues.redhat.com//browse/TELCODOCS-2259): Release note for ARM dual port OC for PTP

Version(s):
4.20

Issue:
https://issues.redhat.com/browse/TELCODOCS-2259

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

