### PR TITLE
[enterprise-4.13] HCIDOCS-218: Static dual-stack bootstrap network configuration

### DIFF
--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -3,19 +3,24 @@
 // ipi-install-configuration-files.adoc
 // installing-vsphere-installer-provisioned-network-customizations.adoc
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
-:vSphere:
-endif::[]
-
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
 :vsphere:
 endif::[]
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id='modifying-install-config-for-dual-stack-network_{context}']
-= Optional: Deploying with dual-stack networking
+= Deploying IP addressing with dual-stack networking
+
+When deploying IP addressing with dual-stack networking for the bootstrap virtual machine (VM), the bootstrap VM functions with a single IP version.
+
+[NOTE]
+====
+The following examples are for DHCP. DHCP-based dual stack clusters can deploy with one IPv4 and one IPv6 virtual IP address (VIP) each from Day 1.
+Deploying a cluster with static IP addresses involves configuring IP addresses for the bootstrap VM, API, and ingress VIPs. Configuring dual-stack with a static IP set in `install-config` requires one VIP each for API and ingress. Add secondary VIPs after deployment.
+====
 
 For dual-stack networking in {product-title} clusters, you can configure IPv4 and IPv6 address endpoints for cluster nodes. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. For a cluster with the IPv4 family as the primary address family, specify the IPv4 setting first. For a cluster with the IPv6 family as the primary address family, specify the IPv6 setting first.
 
+.Example NMState YAML configuration file that includes the IPv4 and IPv6 address endpoints for cluster nodes
 [source,yaml]
 ----
 machineNetwork:
@@ -30,12 +35,10 @@ serviceNetwork:
 - 172.30.0.0/16
 - fd03::/112
 ----
-
 ifndef::vsphere[]
 [IMPORTANT]
 ====
 On a bare-metal platform, if you specified an NMState configuration in the `networkConfig` section of your `install-config.yaml` file, add `interfaces.wait-ip: ipv4+ipv6` to the NMState YAML file to resolve an issue that prevents your cluster from deploying on a dual-stack network.
-
 .Example NMState YAML configuration file that includes the `wait-ip` parameter
 [source,yaml]
 ----
@@ -49,9 +52,7 @@ networkConfig:
 ----
 ====
 endif::vsphere[]
-
 To provide an interface to the cluster for applications that use IPv4 and IPv6 addresses, configure IPv4 and IPv6 virtual IP (VIP) address endpoints for the Ingress VIP and API VIP services. To configure IPv4 and IPv6 address endpoints, edit the `apiVIPs` and `ingressVIPs` configuration settings in the `install-config.yaml` file . The `apiVIPs` and `ingressVIPs` configuration settings use a list format. The order of the list indicates the primary and secondary VIP address for each service.
-
 ifdef::vsphere[]
 [source,yaml]
 ----
@@ -65,7 +66,6 @@ platform:
       - <wildcard_ipv6>
 ----
 endif::[]
-
 ifndef::vsphere[]
 [source,yaml]
 ----
@@ -80,19 +80,7 @@ platform:
 ----
 endif::[]
 
-ifdef::vSphere[]
-[IMPORTANT]
-====
-You can configure dual-stack networking on a single interface only.
-====
-
 [NOTE]
 ====
-* In a vSphere cluster configured for dual-stack networking, the node custom resource object has only the IP address from the primary network listed in `Status.addresses` field.
-* In the pod that uses the host networking with dual-stack connectivity, the `Status.podIP` and `Status.podIPs` fields contain only the IP address from the primary network.
+For a cluster with dual-stack networking configuration, you must assign both IPv4 and IPv6 addresses to the same interface.
 ====
-endif::vSphere[]
-
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
-:!vSphere:
-endif::[]


### PR DESCRIPTION
**Fixes:** [HCIDOCS-218](https://issues.redhat.com/browse/HCIDOCS-218)

**For:** OCP 4.13

Cherry Picked from 04b94c4f3ff7139d87a9f8a10e6a4806f4a6448f xref: https://github.com/openshift/openshift-docs/pull/93170