### PR TITLE
MIG-1767: Storage live migration is GA so remove tech preview

### DIFF
--- a/migration_toolkit_for_containers/mtc-migrating-vms.adoc
+++ b/migration_toolkit_for_containers/mtc-migrating-vms.adoc
@@ -13,9 +13,6 @@ For KubeVirt VMs, the primary use case for VM storage migration is if you want t
 * You are rebalancing between different storage providers.
 * New storage is available that is better suited to the workload running inside the VM.
 
-:FeatureName: Virtual machine storage migration
-include::snippets/technology-preview.adoc[]
-
 include::modules/mtc-vm-storage-migration-process-works.adoc[leveloffset=+1]
 
 [id="mtc-supported-persistent-volumes-actions-vms_{context}"]


### PR DESCRIPTION
### JIRA

* [MIG-1767](https://issues.redhat.com/browse/MIG-1767)

removing `tech preview snippet`. see [Slack](https://redhat-internal.slack.com/archives/C068X44C8VB/p1757015461399969?thread_ts=1757013036.070929&cid=C068X44C8VB) for details

### Version(s):

* OCP 4.19 → branch/enterprise-4.19
* OCP 4.20 → branch/enterprise-4.20
* OCP 4.21 → branch/enterprise-4.21

### Link to docs preview:

* [Migrating virtual machine storage](https://98621--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-migrating-vms.html)

### Dev & QE review:

- [X] [Dev has approved this change](https://github.com/openshift/openshift-docs/pull/98621#issuecomment-3259661035).
- [X] [QE has approved this change](https://github.com/openshift/openshift-docs/pull/98621#pullrequestreview-3195884533).
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
