### PR TITLE
CMA: Unable to inject kerberos keytab volume for Kafka scaler via KedaController

### DIFF
--- a/modules/nodes-cma-autoscaling-keda-controller-edit.adoc
+++ b/modules/nodes-cma-autoscaling-keda-controller-edit.adoc
@@ -33,9 +33,16 @@ spec:
     caConfigMaps: <4>
     - thanos-cert
     - kafka-cert
+    volumeMounts: <5>
+    - mountPath: /<path_to_directory>
+      name: <name>
+    volumes: <6>
+    - name: <volume_name>
+      emptyDir:
+        medium: Memory
   metricsServer:
-    logLevel: '0' <5>
-    auditConfig: <6>
+    logLevel: '0' <7>
+    auditConfig: <8>
       logFormat: "json"
       logOutputVolumeClaim: "persistentVolumeClaimName"
       policy:
@@ -53,7 +60,9 @@ spec:
 <2> Specifies the level of verbosity for the Custom Metrics Autoscaler Operator log messages. The allowed values are `debug`, `info`, `error`. The default is `info`.
 <3> Specifies the logging format for the Custom Metrics Autoscaler Operator log messages. The allowed values are `console` or `json`. The default is `console`.
 <4> Optional: Specifies one or more config maps with CA certificates, which the Custom Metrics Autoscaler Operator can use to connect securely to TLS-enabled metrics sources.
-<5> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` for `debug`. The default is `0`.
-<6> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section.
+<5> Optional: Add the container mount path.
+<6> Optional: Add a `volumes` block to list each projected volume source. 
+<7> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` for `debug`. The default is `0`.
+<8> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section.
 
 . Click *Save* to save the changes.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-13608

https://github.com/kedacore/keda-olm-operator/pull/253

Link to docs preview:
[Editing the Keda Controller CR](https://98630--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-install.html#nodes-cma-autoscaling-keda-controller-edit_nodes-cma-autoscaling-custom-install) -- Added volumeMounts: <5> and volumes: <6> to the code block and associated call outs below. Moved the current <5> and <6> call outs to <7> and <8> with no changes to the text. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

