### PR TITLE
OSSM-10414 2.6.10 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -202,7 +202,7 @@ endif::[]
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.9
+:SMProductVersion: 2.6.10
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-6-10.adoc
+++ b/modules/ossm-release-2-6-10.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/servicemesh-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-6-10_{context}"]
+= {SMProductName} version 2.6.10
+
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.10, and includes the `ServiceMeshControlPlane` resource version updates for 2.6.10.
+
+This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
+You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
+
+[id="ossm-release-2-6-10-components_{context}"]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.7
+
+|Kiali Server
+|1.73
+|===

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 // The following include statements pull in the module files that comprise 2.x release notes.
 
+include::modules/ossm-release-2-6-10.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-9.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-5-12.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.10 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

Doc JIRA: https://issues.redhat.com/browse/OSSM-10414

Fix Version: 4.14+

Doc Previews: https://98647--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-release-2-6-10_ossm-release-notes

QE Review: @unsortedhashsets 
Peer Review: @rh-tokeefe 