### PR TITLE
[enterprise-4.16] OADP-6539: Document Netapp ontap s3 as fully supported

### DIFF
--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -26,8 +26,7 @@ The following AWS S3 compatible object storage providers are fully supported by 
 * Ceph RADOS Gateway (Ceph Object Gateway)
 * Red Hat Container Storage
 * {odf-full}
-* {gcp-first}
-* {azure-first}
+* NetApp ONTAP S3 Object Storage
 
 [NOTE]
 ====


### PR DESCRIPTION
### Cherry pick OCP 4.16

* Cherry Picked from 551ad0a5e09c4c36356ca2598b9f18a3b2aa3349 xref: https://github.com/openshift/openshift-docs/pull/97629

### JIRA

* [OADP-6539](https://issues.redhat.com/browse/OADP-6539)

### Version(s):

* OCP 4.16 → branch/enterprise-4.16

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
