### PR TITLE
MULTIARCH-5425 Adding ns-scope podplacementconfig object

### DIFF
--- a/modules/multi-arch-creating-namespace-podplacement-config.adoc
+++ b/modules/multi-arch-creating-namespace-podplacement-config.adoc
@@ -1,0 +1,62 @@
+//Module included in the following assemblies
+//
+//post_installation_configuration/multiarch-tuning-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="multi-arch-creating-namespace-podplacement-config_{context}"]
+= Creating the namespace-scoped PodPlacementConfig object
+
+[role="_abstract"]
+After creating the `ClusterPodPlacementConfig` object, you can configure pod placement at the namespace level by creating namespace-scoped `PodPlacementConfig` objects.
+
+`PodPlacementConfig` objects modify the pod placement controller's behavior at the namespace level, and take precedence over the `ClusterPodPlacementConfig` object.
+
+.Prerequisites
+
+* You have created a `ClusterPodPlacementConfig` object.
+
+.Procedure
+
+. Using a text editor, create a YAML file based on the following example and modify the example with your namespace values:
++
+.Example `PodPlacementConfig` object configuration
+[source,yaml]
+----
+apiVersion: multiarch.openshift.io/v1beta1
+kind: PodPlacementConfig
+metadata:
+  name: my-namespace-config
+  namespace: my-namespace
+spec:
+  labelSelector:
+      matchExpressions:
+        - key: app
+          operator: In
+          values:
+            - my-label-for-apps-performing-better-on-arm64
+  priority: 100
+  plugins:
+    nodeAffinityScoring:
+      enabled: true
+      platforms:
+        - architecture: amd64
+          weight: 25
+        - architecture: arm64
+          weight: 75
+----
++
+where:
++
+`metadata`:: Specifies the object name, and namespace name. This parameter is required.
+`spec.labelSelector`:: Optionally specifies a label so that the `PodPlacementConfig` only applies to a subset of pods in the namespace. If you do not specify this parameter, the `PodPlacementConfig` applies to all pods in the namespace.
+`spec.priority`:: Optionally specifies a priority in case multiple `PodPlacementConfig` objects exist in one namespace. Higher priorities take precedence. Valid values are 0-255, and the default value is 0. If you specify multiple `PodPlacementConfig` objects in one namespace, they must have different priority values.
+`spec.plugins.nodeAffinityScoring`:: Specifies architecture preferences for pod placement. The controller prioritizes nodes based on the architecture scores, with higher weights taking precedence. If you enable this plugin by setting `spec.plugins.nodeAffinityScoring.enabled` to `true`, you must specify at least one platform with an architecture and weight value.
+`spec.plugins.nodeAffinityScoring.platforms[]`:: Specifies one or more platform configurations, each with a required architecture and weight pair. This parameter is required if `spec.plugins.nodeAffinityScoring` is present. Valid architecture values are `arm64`, `amd64`, `ppc64le`, and `s390x`. Valid weight values are 0-100. Each architecture can only be specified once.
++
+. Apply the configuration file by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <filename>
+----
+Replace `<filename>` with the name of the `PodPlacementConfig` configuration file.

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc
@@ -60,6 +60,9 @@ include::modules/multi-arch-creating-podplacment-config-using-cli.adoc[leveloffs
 
 include::modules/multi-arch-creating-podplacment-config-using-web-console.adoc[leveloffset=+2]
 
+//Creating namespace-scoped pod placement config
+include::modules/multi-arch-creating-namespace-podplacement-config.adoc[leveloffset=+1]
+
 //Deleting the pod placement config object
 
 include::modules/multi-arch-deleting-podplacment-config-using-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/MULTIARCH-5425

Link to docs preview:
https://98695--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.html#multi-arch-creating-namespace-podplacement-config_multiarch-tuning-operator

QE review:
- [x] QE has approved this change.

To be merged on April 6