### PR TITLE
OSDOCS#16075:  Update the z-stream RN for 4.19.11

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2847,6 +2847,53 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.19.11
+[id="ocp-4-19-11_{context}"]
+=== RHBA-2025:15293 - {product-title} {product-version}.11 image release, bug fix, and security update advisory
+
+Issued: 09 September 2025
+
+{product-title} release {product-version}.11, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:15293[RHBA-2025:15293] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:15291[RHSA-2025:15291] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.11 --pullspecs
+----
+
+[id="ocp-4-19-11-enhancements_{context}"]
+==== Enhancements
+
+* The machine config nodes custom resource, which you can use to monitor the progress of machine configuration updates to nodes, is now generally available. With the promotion to General Availability, you can view the status of updates to custom machine config pools, in addition to the control plane and worker pools. The functionality for the feature has not changed. However, some of the information in the command output and in the status fields in the `MachineConfigNode` object have been updated. The `must-gather` for the Machine Config Operator includes all `MachineConfigNodes` objects in the cluster. For more information, see xref:../machine_configuration/index.adoc#checking-mco-node-status_machine-config-overview[About checking machine config node status].
+
+* In clusters with slow, unreliable connections to an image registry, you can use a `PinnedImageSet` object to get the images in advance, before they are actually needed. You can associate those images with a machine config pool. This ensures that the images are available when needed. The `must-gather` for the Machine Config Operator now includes all `PinnedImageSet` objects in the cluster. For more information, see xref:../machine_configuration/machine-config-pin-preload-images-about.adoc#machine-config-pin-preload-images_machine-config-operator[Pinning images to nodes].
+
+* With this update, the Kubernetes API server distribution is optimized, ensuring a balanced load among all primary nodes after a quorum is reestablished. This addresses the issue of a single API server receiving the majority of live connections, and causing high CPU usage. Resource utilization is improved and CPU spikes are reduced during primary node or API server restarts. (link:https://issues.redhat.com/browse/OCPBUGS-60121[OCPBUGS-60121])
+
+[id="ocp-4-19-11-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, disabling the {product-registry} retained legacy pull secret finalizers and caused hung secret deletion during the registry removal. This issue blocked cluster deletion. With this release, secret finalizers do not block namespace deletion when the registry is disabled, and ensures cluster deletion. (link:https://issues.redhat.com/browse/OCPBUGS-56614[OCPBUGS-56614])
+
+* Before this update, the `oc mirror` command failed on RHEL 8 systems with a `noexec-mounted /tmp` directory because it could not start the temporary files or scripts. As a consequence, image mirroring was prevented. With this release, the `oc mirror` command includes an exception for the `noexec-mounted /tmp` drectory, and mirroring on RHEL 8 systems is successful. As a result, the `oc mirror` command lists output and mirror container images on RHEL 8 systems with a `noexec-mounted /tmp` directory. (link:https://issues.redhat.com/browse/OCPBUGS-59760[OCPBUGS-59760])
+
+* Before this update, temporary `apiserver` downtime caused the `cluster-etcd-operator` to incorrectly report that the `openshift-etcd` namespace did not exist. As a consequence, users saw incorrect messages about a missing namespace during the downtime. With this release, a fix is implemented to improve the error message for a missing etcd namespace. As a result, the error message is corrected, and ensures that the `cluster-etcd-operator` status accurately reflects the issue during temporary `apiserver` downtime. (link:https://issues.redhat.com/browse/OCPBUGS-59802[OCPBUGS-59802])
+
+* Before this update, duplicate link buttons on the *Quickstarts* page appeared only in the `/quickstart` path, and confused users. With this release, the *Quickstart* link buttons display correctly and duplicates are eliminated. (link:https://issues.redhat.com/browse/OCPBUGS-60420[OCPBUGS-60420])
+
+* Before this update, a {hcp-capital} cluster rejected certificates with multiple Storage Area Network (SAN) entries due to conflicting DNS names. As a consequence, users encountered certificate deployment errors with multi-SAN hostnames in {hcp-capital} clusters. With this release, certificate validation for multiple SAN entries is supported in {hcp-capital} clusters. As a result, certificates with multiple SAN entries are accepted, improving {hcp-capital} cluster deployments. (link:https://issues.redhat.com/browse/OCPBUGS-60483[OCPBUGS-60483])
+
+* Before this update, the last node retained the `ToBeDeletedByClusterAutoscaler` taint during the scale-down process because of incorrect machine deletion handling. As a consequence, the last node affected the cluster autoscaling efficiency. With this release, the `ToBeDeletedByClusterAutoscaler` taint is removed from the last node after scaling down. The last node does not retain the unwanted taint, and the cluster stability is improved. (link:https://issues.redhat.com/browse/OCPBUGS-60900[OCPBUGS-60900])
+
+* Before this release, the stale IP address entries in the `address_set` configuration element that corresponded to the DNS egress firewall rule were not removed. This resulted in an increasing `address_set`, and led to memory leak issues. With this release, the issue is fixed by removing the IP addresses from the `address_set` after a 5-second grace period that follows the Time to Live (TTL) expiration of the IP addresses. (link:https://issues.redhat.com/browse/OCPBUGS-60979[OCPBUGS-60979])
+
+[id="ocp-4-19-11-updating_{context}"]
+==== Updating
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.19.10
 [id="ocp-4-19-10_{context}"]
 === RHSA-2025:14823 - {product-title} {product-version}.10 image release, bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-16075](https://issues.redhat.com//browse/OSDOCS-16075)

Link to docs preview:
[4.19.11](https://98696--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-11_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 9/9/25. Also, [MCO-1720](https://issues.redhat.com//browse/MCO-1720) and [MCO-1766](https://issues.redhat.com//browse/MCO-1766) are included in the Enhancements section for M. Burke.


