### PR TITLE
OSDOCS-16104: mirror-to-disk and disk-to-mirror 

### DIFF
--- a/modules/oc-mirror-about-cache-and-workspace-dirs.adoc
+++ b/modules/oc-mirror-about-cache-and-workspace-dirs.adoc
@@ -8,7 +8,7 @@
 
 You can use the `--cache-dir` flag to specify a directory where the oc-mirror plugin stores a persistent cache of image blobs and manifests for use during mirroring operations.
 
-The oc-mirror plugin uses the cache in the `disk-to-mirror` and `mirror-to-disk` workflows but does not use the cache in the `mirror-to-mirror` workflow. The plugin uses the cache to perform incremental mirroring and avoids remirroring unchanged images, which saves time and reduces network bandwidth usage.
+The oc-mirror plugin uses the cache in the `mirror-to-disk` and `disk-to-mirror` workflows but does not use the cache in the `mirror-to-mirror` workflow. The plugin uses the cache to perform incremental mirroring and avoids remirroring unchanged images, which saves time and reduces network bandwidth usage.
 
 The cache directory only contains data up to the last successful mirroring operation. If you delete or corrupt the cache directory, the oc-mirror plugin pulls the image blobs and manifests again, which can force a full remirror and increase network usage.
 


### PR DESCRIPTION
It should be `mirror-to-disk` and `disk-to-mirror` 

Currently:
The oc-mirror plugin uses the cache in the disk-to-mirror and mirror-to-disk workflows but does not use the cache in the mirror-to-mirror workflow.

Expected:
The oc-mirror plugin uses the cache in the mirror-to-disk and disk-to-mirror workflows but does not use the cache in the mirror-to-mirror workflow.

Correct work flow is mirror-to-disk then disk-to-mirror. Not  disk-to-mirror and mirror-to-disk currently it's written in reverse. 

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-16104

Link to docs preview:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/disconnected_environments/mirroring-in-disconnected-environments#oc-mirror-about-cache-and-workspace-dirs_about-installing-oc-mirror-v2
 