### PR TITLE
CNV-66307: removed obsolete prereq

### DIFF
--- a/modules/virt-creating-linux-bridge-nad-cli.adoc
+++ b/modules/virt-creating-linux-bridge-nad-cli.adoc
@@ -17,7 +17,6 @@ Configuring IP address management (IPAM) in a network attachment definition for 
 
 .Prerequisites
 
-* The node must support nftables and the `nft` binary must be deployed to enable MAC spoof check.
 * You have installed the {oc-first}.
 
 .Procedure


### PR DESCRIPTION
Version(s):
Main, 4.18-4.20

Issue:
[CNV-66307](https://issues.redhat.com/browse/CNV-66307)

[Link to docs preview](https://98699--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-linux-bridge.html)

QE review:
- [x] QE has approved this change.


Changes to 4.16, 4.17 are here: https://github.com/openshift/openshift-docs/pull/98726