### PR TITLE
Update ocp-4-19-release-notes.adoc

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -518,11 +518,10 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 
 
 [id="ocp-release-notes-insights-operator-runtime-extractor_{context}"]
-==== Insights Runtime Extractor is generally available
+==== Insights Runtime Extractor (Technology Preview)
 
-In {product-title} 4.18, the Insights Operator introduced the _Insights Runtime Extractor_ workload data collection feature as a Technology Preview feature to help Red{nbsp}Hat better understand the workload of your containers.
-Now, in version 4.19, the feature is generally available.
-The Insights Runtime Extractor feature gathers runtime workload data and sends it to Red{nbsp}Hat.
+In this release, the Insights Operator introduces the workload data collection _Insights Runtime Extractor_ feature. Available as a Technology Preview, the Insights Runtime Extractor feature gathers runtime workload data and sends it to Red{nbsp}Hat. Red{nbsp}Hat uses the collected runtime workload data to gain insights that you can then use to make investment decisions that helps improve how you use your {product-title} containers. For more information, see xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates].
+
 
 [id="ocp-release-notes-installation-and-update_{context}"]
 === Installation and update

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -513,16 +513,6 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 2. Persistent non-shared storage must be provisioned by using local storage, such as iSCSI, FC, or by using LSO with DASD, FCP, or EDEV/FBA.
 --
 
-[id="ocp-release-notes-insights-operator-enhancements_{context}"]
-=== Insights Operator
-
-
-[id="ocp-release-notes-insights-operator-runtime-extractor_{context}"]
-==== Insights Runtime Extractor (Technology Preview)
-
-In this release, the Insights Operator introduces the workload data collection _Insights Runtime Extractor_ feature. Available as a Technology Preview, the Insights Runtime Extractor feature gathers runtime workload data and sends it to Red{nbsp}Hat. Red{nbsp}Hat uses the collected runtime workload data to gain insights that you can then use to make investment decisions that helps improve how you use your {product-title} containers. For more information, see xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates].
-
-
 [id="ocp-release-notes-installation-and-update_{context}"]
 === Installation and update
 


### PR DESCRIPTION
CM sent on the 16 Sep. Will merge PR on the 17 or 18 Sep.


Version(s):
4.19

Issue:
[OSDOCS-16108](https://issues.redhat.com/browse/OSDOCS-16108)

Link to docs preview:
[Insights Runtime Extractor (Technology Preview)](https://98716--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-insights-operator-runtime-extractor_release-notes)

QE review:
- [x] QE has approved this change.
