### PR TITLE
RHDEVDOCS-6675: Adding an admonition in a few sections

### DIFF
--- a/modules/gitops-managing-secrets-using-sscsid-with-gitops-overview.adoc
+++ b/modules/gitops-managing-secrets-using-sscsid-with-gitops-overview.adoc
@@ -10,8 +10,14 @@ Some applications need sensitive information, such as passwords and usernames wh
 
 [IMPORTANT]
 ====
-Anyone who is authorized to create a pod in a namespace can use that RBAC to read any secret in that namespace. With the SSCSI Driver Operator, you can use an external secrets store to store and provide sensitive information to pods securely. 
+Anyone who is authorized to create a pod in a namespace can use that RBAC to read any secret in that namespace. With the SSCSI Driver Operator, you can use an external secrets store to store and provide sensitive information to pods securely.
 ====
+
+[WARNING]
+====
+Avoid modifying the `argocd-secret` secret that {gitops-shortname} creates, using external secret management solutions such as the External Secrets Operator or Vault plugins. The `openshift-gitops-operator` manages this secret as part of its core functionality. If you modify this secret externally, it can cause reconciliation conflicts, unpredictable behavior, or disruption of Argo CD instances and {gitops-shortname} workflows. To maintain consistency and reliability, allow the {gitops-shortname} Operator to exclusively manage the `argocd-secret` secret.
+====
+
 
 [id="benefits_{context}"]
 == Benefits

--- a/modules/logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account.adoc
+++ b/modules/logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account.adoc
@@ -35,3 +35,8 @@ To be a user of the `cluster-admins` group, use the `oc adm groups new cluster-a
 ====
 You cannot create two Argo CD CRs in the same namespace.
 ====
+
+[WARNING]
+====
+Avoid modifying the `argocd-secret` secret that {gitops-shortname} creates, using external secret management solutions such as the External Secrets Operator or Vault plugins. The `openshift-gitops-operator` manages this secret as part of its core functionality. If you modify this secret externally, it can cause reconciliation conflicts, unpredictable behavior, or disruption of Argo CD instances and {gitops-shortname} workflows. To maintain consistency and reliability, allow the {gitops-shortname} Operator to exclusively manage the `argocd-secret` secret.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.18

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6675

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

A warning admonition is added at the end of the procedure in the [Logging in to the Argo CD instance by using the Argo CD admin account](https://98719--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/installing-openshift-gitops.html#logging-in-to-the-argo-cd-instance-by-using-the-argo-cd-admin-account_installing-openshift-gitops) section.

A warning admonition is added after the Important note in the [Overview of managing secrets using Secrets Store CSI driver](https://98719--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops.html#gitops-managing-secrets-using-sscsid-with-gitops-overview_managing-secrets-securely-using-sscsid-with-gitops) section.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @svghadi
QE review: @varshab1210 
Peer review: @shivanisathe25

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
