### PR TITLE
OSDOCS-16105#adding customer managed DNS to AWS

### DIFF
--- a/installing/installing_aws/ipi/installing-aws-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-customizations.adoc
@@ -7,11 +7,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on {aws-first} by using installer-provisioned infrastructure with customizations, including network configuration options. In each, you modify parameters in the `install-config.yaml` file before you install the cluster.
-
-By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing MTU and VXLAN configurations.
-
-You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a cluster on {aws-first} by using installer-provisioned infrastructure with customizations, including network configuration options. In each, you modify parameters in the `install-config.yaml` file before you install the cluster. By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing MTU and VXLAN configurations. You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
 [NOTE]
 ====
@@ -51,6 +48,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
+
+include::modules/installing-aws-managing-dns-solution.adoc[leveloffset=+2]
 
 include::modules/installation-aws-config-yaml-customizations.adoc[leveloffset=+2]
 
@@ -121,6 +120,8 @@ For more information about using Linux and Windows nodes in the same cluster, se
 ====
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/installation-aws-provisioning-dns-records.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/ipi/installing-aws-private.adoc
+++ b/installing/installing_aws/ipi/installing-aws-private.adoc
@@ -6,8 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a private cluster into an existing VPC on Amazon Web Services (AWS). The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify
-parameters in the `install-config.yaml` file before you install the cluster.
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a private cluster into an existing Virtual Private Cloud (VPC) on {aws-first}. The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
 == Prerequisites
 
@@ -45,6 +45,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
+
+include::modules/installing-aws-managing-dns-solution.adoc[leveloffset=+2]
 
 include::modules/installation-aws-config-yaml-customizations.adoc[leveloffset=+2]
 
@@ -98,6 +100,8 @@ include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/installation-aws-provisioning-dns-records.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/ipi/installing-aws-vpc.adoc
+++ b/installing/installing_aws/ipi/installing-aws-vpc.adoc
@@ -6,8 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster into an existing Amazon Virtual Private Cloud (VPC) on Amazon Web Services (AWS). The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify
-parameters in the `install-config.yaml` file before you install the cluster.
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a cluster into an existing {aws-short} Virtual Private Cloud (VPC) on Amazon Web Services (AWS). The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
 == Prerequisites
 
@@ -44,6 +44,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
+
+include::modules/installing-aws-managing-dns-solution.adoc[leveloffset=+2]
 
 include::modules/installation-aws-config-yaml-customizations.adoc[leveloffset=+2]
 
@@ -97,6 +99,8 @@ include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/installation-aws-provisioning-dns-records.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on Amazon Web Services (AWS) in a restricted network by creating an internal mirror of the installation release content on an existing Amazon Virtual Private Cloud (VPC).
+[role="_abstract"]
+You can install a cluster on {aws-first} in a restricted network by creating an internal mirror of the installation release content on an existing {aws-short} Virtual Private Cloud (VPC). By using this configuration, you can deploy a cluster in an environment with limited internet connectivity to help ensure compliance with security policies.
 
 [id="prerequisites_installing-restricted-networks-aws-installer-provisioned"]
 == Prerequisites
@@ -52,6 +53,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 .Additional resources
 
 * xref:../../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
+include::modules/installing-aws-managing-dns-solution.adoc[leveloffset=+2]
 
 include::modules/installation-aws-config-yaml-customizations.adoc[leveloffset=+2]
 
@@ -103,6 +106,8 @@ include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/installation-aws-provisioning-dns-records.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 

--- a/modules/installation-aws-provisioning-dns-records.adoc
+++ b/modules/installation-aws-provisioning-dns-records.adoc
@@ -1,0 +1,57 @@
+:_mod-docs-content-type: PROCEDURE
+[id="installation-aws-provisioning-own-dns-records_{context}"]
+= Provisioning your own DNS records
+
+[role="_abstract"]
+Use your cluster name and base cluster domain to configure a CNAME record for the API service `api.<cluster_name>.<base_domain>.` with the API load balancer DNS name. Similarly, use the load balancer DNS name of the Ingress service to provision a CNAME record for the `*.apps.<cluster_name>.<base_domain>.` hostname by using your cluster name and base cluster domain.
+
+:FeatureName: User-provisioned DNS
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+.Prerequisites
+* You have installed the {aws-short} CLI.
+
+.Procedure
+
+. Add the `userProvisionedDNS` parameter to the `install-config.yaml` file and enable the parameter. For more information, see "Enabling a user-managed DNS".
+
+. Install your cluster.
+
+. If you are installing a private cluster, set the `api_lb_name` variable by running the following command:
++
+[source,terminal]
+----
+$ api_lb_name="${INFRA_ID}-int"
+----
+
+. If you are installing a public cluster, set the `api_lb_name` variable by running the following command:
++
+[source,terminal]
+----
+$ api_lb_name="${INFRA_ID}-ext"
+----
+
+. To retrieve the DNS name of the API service, run the following command:
++
+[source,terminal]
+----
+$ aws --region ${REGION} elbv2 describe-load-balancers --names ${api_lb_name} --query 'LoadBalancers[*].DNSName' --output text
+----
+
+. Use the DNS name and your cluster name and base cluster domain to configure your own DNS record with the `api.<cluster_name>.<base_domain>.` hostname.
+
+. To retrieve the DNS name of the Ingress service, run the following command:
++
+[source,terminal]
+----
+$ ingress_lb_name=$(aws --region ${REGION} resourcegroupstaggingapi get-resources --resource-type-filters elasticloadbalancing:loadbalancer --tag-filters Key=kubernetes.io/cluster/${INFRA_ID},Values=owned Key=kubernetes.io/service-name,Values=openshift-ingress/router-default --query 'ResourceTagMappingList[*].ResourceARN | [0]' --output text | awk -F'/' '{print $2}')
+----
+
+. Run the following command, which uses the variable `ingress_lb_name` generated from the previous command:
++
+[source,terminal]
+----
+$ aws --region ${REGION} elb describe-load-balancers --load-balancer-names ${ingress_lb_name} --query 'LoadBalancerDescriptions[].DNSName' --output text
+----
+
+. Use the DNS name and your cluster name and base cluster domain to configure your own DNS record with the `*.apps.<cluster_name>.<base_domain>.` hostname.

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1110,6 +1110,13 @@ Optional AWS configuration parameters are described in the following table:
 
 |platform:
   aws:
+    userProvisionedDNS:
+|Enables user-provisioned DNS instead of the default cluster-provisioned DNS solution. If you use this feature, you must provide your own DNS solution that includes records for `api.<cluster_name>.<base_domain>.` and `*.apps.<cluster_name>.<base_domain>.`. `userProvisionedDNS` is a Technology Preview feature.
+
+*Value:* `Enabled` or `Disabled`. The default value is `Disabled`.
+
+|platform:
+  aws:
     region:
 |The AWS region that the installation program creates all cluster resources in.
 

--- a/modules/installing-aws-managing-dns-solution.adoc
+++ b/modules/installing-aws-managing-dns-solution.adoc
@@ -1,0 +1,39 @@
+
+:_mod-docs-content-type: PROCEDURE
+[id="installation-aws-enabling-user-managed-DNS_{context}"]
+= Enabling a user-managed DNS
+
+[role="_abstract"]
+You can install a cluster with a domain name server (DNS) solution that you manage instead of the default cluster-provisioned DNS solution that uses the Route 53 service for {aws-first}.
+
+For example, your organization's security policies might not allow the use of public DNS services such as {aws-full} DNS. In such scenarios, you can use your own DNS service to bypass the public DNS service and manage your own DNS for the IP addresses of the API and Ingress services.
+
+If you enable user-managed DNS during installation, the installation program provisions DNS records for the API and Ingress services only within the cluster. To ensure access from outside the cluster, you must provision the DNS records in an external DNS service of your choice for the API and Ingress services after installation.
+
+:FeatureName: User-provisioned DNS
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+.Procedure
+* Before you deploy your cluster, use a text editor to open the `install-config.yaml` file  and add the following stanza:
+** To enable user-managed DNS:
++
+[source,yaml]
+----
+featureSet: CustomNoUpgrade
+featureGates: ["AWSClusterHostedDNSInstall=true"]
+
+# ...
+
+platform:
+  aws:
+    userProvisionedDNS: Enabled
+----
++
+where:
++
+--
+`userProvisionedDNS`:: Enables user-provisioned DNS management.
+--
+
+.Next steps
+For information about provisioning your DNS records for the API server and the Ingress services, see "Provisioning your own DNS records".


### PR DESCRIPTION
Versions:
4.21+

Issue:
https://issues.redhat.com/browse/OSDOCS-17856

Link to docs preview:

- [Optional AWS configuration parameters](https://98724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-optional-aws_installation-config-parameters-aws)

**Installing a cluster on AWS with customizations**

- [Enabling a user-managed DNS](https://98724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations#installation-aws-enabling-user-managed-DNS_installing-aws-customizations)
- [Provisioning your own DNS records](https://98724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations#installation-aws-provisioning-own-dns-records_installing-aws-customizations)

**Installing a cluster on AWS in a disconnected environment**

- [Enabling a user-managed DNS](https://98724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned#installation-aws-enabling-user-managed-DNS_installing-restricted-networks-aws-installer-provisioned)
- [Provisioning your own DNS records](https://98724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-restricted-networks-aws-installer-provisioned#installation-aws-provisioning-own-dns-records_installing-restricted-networks-aws-installer-provisioned)

**Installing a cluster on AWS into an existing VPC**

- [Enabling a user-managed DNS](https://98724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-vpc#installation-aws-enabling-user-managed-DNS_installing-aws-vpc)
- [Provisioning your own DNS records](https://98724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-vpc#installation-aws-provisioning-own-dns-records_installing-aws-vpc)

**Installing a private cluster on AWS**
- [Enabling a user-managed DNS](https://98724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-private#installation-aws-enabling-user-managed-DNS_installing-aws-private)
- [Provisioning your own DNS records](https://98724--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-private#installation-aws-provisioning-own-dns-records_installing-aws-private)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
