### PR TITLE
CNV-66307-b: fixed obsolete prereq

### DIFF
--- a/modules/virt-creating-linux-bridge-nad-cli.adoc
+++ b/modules/virt-creating-linux-bridge-nad-cli.adoc
@@ -17,7 +17,7 @@ Configuring IP address management (IPAM) in a network attachment definition for 
 
 .Prerequisites
 
-* The node must support nftables and the `nft` binary must be deployed to enable MAC spoof check.
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.17, 4.16

Issue: 
[CNV-66307](https://issues.redhat.com/browse/CNV-66307)

Link to docs preview

QE review:
- [x] QE has approved this change.
