### PR TITLE
OSDOCS-14897:Add GDP feature to release notes

### DIFF
--- a/microshift_release_notes/microshift-4-20-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-20-release-notes.adoc
@@ -35,8 +35,10 @@ This release adds improvements related to the following components and concepts.
 //placeholder for delta updates
 
 //4.20 is an EUS release, so two minor version updates are supported
+
 [id="microshift-4-20-updating_{context}"]
 === Updating
+
 Updating two minor EUS versions in a single step is supported in {product-version}. Updates for both single-version minor releases and patch releases are also supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
 
 //TODO add new features and enhancements as needed, follow doc TOC titles as L3s, then add L4 headings for each feature
@@ -54,7 +56,6 @@ With this release, you can configure custom error code pages and logging paramet
 
 //[id="microshift-4-20-new-feature_{context}"]
 //==== placeholder RAs feature
-
 
 //[id="microshift-4-20-support_{context}"]
 //=== Support
@@ -77,12 +78,17 @@ With this release, you can configure custom error code pages and logging paramet
 //[id="microshift-4-20-palceholder-ntc_{context}"]
 //=== placeholder
 
-//[id="microshift-4-20-tech-preview_{context}"]
-//== Technology Preview features
+[id="microshift-4-20-tech-preview_{context}"]
+== Technology Preview features
 
-//Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
 
-//link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+[id="microshift-4-20-Generic-Device-Plugin_{context}"]
+=== Generic Device Plugin feature
+
+* The Generic Device Plugin (GDP) is a Kubernetes device plugin that enables applications running in pods to access host devices such as serial ports, cameras, and sound cards securely. This Technology Preview capability is especially important for edge and IoT environments where direct hardware interaction is a common requirement. The GDP integrates with the kubelet to advertise available devices to the cluster and facilitate their allocation to pods without requiring elevated privileges within the container itself.
 
 //[id="microshift-4-20-ai_{context}"]
 //=== Red{nbsp}Hat OpenShift AI with {microshift-short}
@@ -100,7 +106,6 @@ With this release, you can configure custom error code pages and logging paramet
 //[id="microshift-4-20-x-deprecated_{context}"]
 //=== placeholder
 
-
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
 //[id="microshift-4-20-bug-fixes_{context}"]
 //== Bug fixes
@@ -116,13 +121,6 @@ With this release, you can configure custom error code pages and logging paramet
 == Additional release notes
 Release notes for related components and products are available in the following documentation:
 
-[NOTE]
-====
-The following release notes are for downstream Red{nbsp}Hat products only; upstream or community release notes for related products are not included.
-====
-
-//TODO check the latest gitops release version
-[id="microshift-4-20-additional-release-notes-gitops_{context}"]
 === GitOps release notes
 See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/latest/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the following Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package: link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-14897

Link to docs preview:
https://98728--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-20-release-notes.html

QE review:
- [x] QE has approved this change.