### PR TITLE
OSDOCS-15940 removed first three limitations from Limitations of ESO

### DIFF
--- a/modules/external-secrets-operator-limitations.adoc
+++ b/modules/external-secrets-operator-limitations.adoc
@@ -8,7 +8,10 @@
 
 The following are the limitations of {external-secrets-operator} during the installation and uninstallation of the `external-secrets` application.
 
-* Uninstalling the {external-secrets-operator} does not delete the resources created for `external-secrets` application. you must clean up the resources manually.
+* Uninstalling the External Secrets Operator for Red Hat OpenShift does not delete the resources created for the `external-secrets` application. You must clean up the resources manually.
+
 * When you add `cert-manager` Operator configurations in `externalsecrets.operator.openshift.io` object after creation, delete the `external-secrets-cert-controller` deployment resource manually to prevent degradation of the `external-secrets` application.
-* Enable the `BitwardenSecretManagerProvider` field in `externalsecrets.operator.openshift.io` object only when installed on OpenShift Cluster running on x86_64 and arm64 architectures .
+
+* Enable the `BitwardenSecretManagerProvider` field in `externalsecrets.operator.openshift.io` object only when installed on an OpenShift Cluster running on x86_64 and arm64 architectures .
+
 * Ensure `cert-manager` Operator is installed and operational before deploying the {external-secrets-operator} for seamless functioning. If you install the `cert-manager` Operator later, manually restart the `external-secrets-operator` pod to apply cert-manager configurations in `externalsecrets.operator.openshift.io` object.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-15940

Link to docs preview:
https://98785--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-install.html


QE review:
- [ ] QE has approved this change.


Additional information:

