### PR TITLE
OSDOCS-14502: Prune "Backup & Restore"

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1145,7 +1145,7 @@ Topics:
   - Name: OADP use cases
     Dir: oadp-use-cases
     Topics:
-    - Name: Backing up an application using OADP with ROSA STS
+    - Name: Backing up an application using OADP with ROSA (classic architecture)
       File: oadp-rosa-backup-restore
 # ODF not supported on ROSA Classic
 #    - Name: Backing up an application using OADP and ODF

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -902,7 +902,7 @@ Topics:
   - Name: OADP use cases
     Dir: oadp-use-cases
     Topics:
-    - Name: Backing up an application using OADP with ROSA STS
+    - Name: Backing up an application using OADP with ROSA
       File: oadp-rosa-backup-restore
     - Name: Backing up an application using OADP and ODF
       File: oadp-usecase-backup-using-odf

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -70,13 +70,12 @@ ifndef::openshift-rosa,openshift-rosa-hcp[]
 For more information, see xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting/restic-issues.adoc#oadp-restic-restore-failing-psa-policy_restic-issues[Restic restore partially failing on OCP 4.15 due to changed PSA policy].
 endif::openshift-rosa,openshift-rosa-hcp[]
 
-// TODO: Add xrefs to ROSA HCP when Operators book is added.
-ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
+ifndef::openshift-rosa-hcp[]
 * xref:../../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[Installing Operators on clusters for administrators]
-// This xref is not included in the ROSA docs.
-ifndef::openshift-rosa[]
-* xref:../../../operators/user/olm-installing-operators-in-namespace.adoc#olm-installing-operators-in-namespace[Installing Operators in namespaces for non-administrators]
-endif::openshift-rosa[]
 endif::openshift-rosa-hcp[]
+// This xref is not included in the ROSA classic docs.
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+* xref:../../../operators/user/olm-installing-operators-in-namespace.adoc#olm-installing-operators-in-namespace[Installing Operators in namespaces for non-administrators]
+endif::openshift-rosa,openshift-rosa-hcp[]

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc
@@ -19,10 +19,7 @@ include::modules/oadp-creating-restore-hooks.adoc[leveloffset=+1]
 include::snippets/oadp-image-stream-tag-trigger.adoc[leveloffset=+1]
 ====
 
-//TODO: Add this xref to ROSA HCP when Images book is added.
-ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../../openshift_images/triggering-updates-on-imagestream-changes.adoc#triggering-updates-on-imagestream-changes[Triggering updates on image stream changes]
-endif::openshift-rosa-hcp[]

--- a/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-rosa/oadp-rosa-backing-up-applications.adoc
@@ -12,9 +12,13 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can use {oadp-first} with {product-rosa} (ROSA) clusters to back up and restore application data.
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+You can use {oadp-first} with {product-title} clusters to back up and restore application data.
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 ifndef::openshift-rosa,openshift-rosa-hcp[]
+You can use {oadp-first} with {product-rosa} (ROSA) clusters to back up and restore application data.
+
 ROSA is a fully-managed, turnkey application platform that allows you to deliver value to your customers by building and deploying applications.
 
 ROSA provides seamless integration with a wide range of {aws-first} compute, database, analytics, machine learning, networking, mobile, and other services to speed up the building and delivery of differentiating experiences to your customers.

--- a/backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-rosa-backup-restore.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-use-cases/oadp-rosa-backup-restore.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="oadp-rosa-backing-up-and-cleaning-example"]
-= Backing up workloads on OADP with ROSA STS
+= Backing up workloads on OADP with {product-title}
 include::_attributes/common-attributes.adoc[]
 :context: oadp-rosa-backing-up-and-cleaning-example
 

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -28,12 +28,9 @@ include::modules/oadp-1-4-0-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+3]
 include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+3]
 
-// TODO: Include this xref when the Operators book is added to the ROSA HCP docs.
-ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
-endif::openshift-rosa-hcp[]
 
 [id="oadp-converting-dpa-to-new-version-1-4-0_{context}"]
 === Converting DPA to the new version

--- a/modules/avoiding-the-velero-plugin-panic-error.adoc
+++ b/modules/avoiding-the-velero-plugin-panic-error.adoc
@@ -41,7 +41,6 @@ $ oc label backupstoragelocations.velero.io <bsl_name> app.kubernetes.io/compone
 You can force the reconciliation by making any minor change to the DPA itself.
 ====
 
-
 .Verification
 
 * After the DPA is reconciled, confirm that the parameter has been created and that the correct registry data has been populated into it by entering the following command:

--- a/modules/installing-oadp-rosa-sts.adoc
+++ b/modules/installing-oadp-rosa-sts.adoc
@@ -7,7 +7,7 @@
 = Installing the OADP Operator and providing the IAM role
 
 [role="_abstract"]
-AWS Security Token Service (AWS STS) is a global web service that provides short-term credentials for IAM or federated users. {product-title} (ROSA) with {sts-short} is the recommended credential mode for ROSA clusters. This document describes how to install {oadp-first} on ROSA with {aws-short} {sts-short}.
+AWS Security Token Service (AWS STS) is a global web service that provides short-term credentials for IAM or federated users. {product-title} with {sts-short} is the recommended credential mode. This document describes how to install {oadp-first} on clusters with {aws-short} {sts-short}.
 
 
 [IMPORTANT]
@@ -32,12 +32,24 @@ The Data Mover feature is not currently supported in ROSA clusters. You can use 
 
 .Prerequisites
 
-* An {product-title} ROSA cluster with the required access and tokens. For instructions, see the previous procedure _Preparing AWS credentials for OADP_. If you plan to use two different clusters for backing up and restoring, you must prepare {aws-short} credentials, including `ROLE_ARN`, for each cluster.
-
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+* An {product-title} 
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+* A {product-title} 
+endif::openshift-rosa,openshift-rosa-hcp[]
+cluster with the required access and tokens. For instructions, see the previous procedure _Preparing AWS credentials for OADP_. If you plan to use two different clusters for backing up and restoring, you must prepare {aws-short} credentials, including `ROLE_ARN`, for each cluster.
 
 .Procedure
 
-. Create an {product-title} secret from your {aws-short} token file by entering the following commands:
+. Create 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+an {product-title} 
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+a {product-title} 
+endif::openshift-rosa,openshift-rosa-hcp[]
+secret from your {aws-short} token file by entering the following commands:
 
 .. Create the credentials file:
 +
@@ -117,7 +129,6 @@ applog   Bound    pvc-351791ae-b6ab-4e8b-88a4-30f73caf5ef8   1Gi        RWO     
 mysql    Bound    pvc-16b8e009-a20a-4379-accc-bc81fedd0621   1Gi        RWO            gp3-csi        4d19h
 ----
 
-
 . Get the storage class by running the following command:
 +
 [source,terminal]
@@ -188,10 +199,15 @@ $ cat << EOF | oc create -f -
         uploaderType: kopia # <3>
 EOF
 ----
-<1> ROSA supports internal image backup. Set this field to `false` if you do not want to use image backup.
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+<1> ROSA supports internal image backup. Set this field to false if you do not want to use image backup.
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+<1> {product-title} supports internal image backup. Set this field to false if you do not want to use image backup.
+endif::openshift-rosa,openshift-rosa-hcp[]
 <2> See the important note regarding the `nodeAgent` attribute.
 <3> The type of uploader. The possible values are `restic` or `kopia`. The built-in Data Mover uses Kopia as the default uploader mechanism regardless of the value of the `uploaderType` field.
-
++
 // . Create the `DataProtectionApplication` resource, which is used to configure the connection to the storage where the backups and volume snapshots are stored:
 
 .. If you are using CSI or non-CSI volumes, deploy a Data Protection Application by entering the following command:
@@ -235,7 +251,12 @@ $ cat << EOF | oc create -f -
           provider: aws
 EOF
 ----
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 <1> ROSA supports internal image backup. Set this field to false if you do not want to use image backup.
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+<1> {product-title} supports internal image backup. Set this field to false if you do not want to use image backup.
+endif::openshift-rosa,openshift-rosa-hcp[]
 <2> See the important note regarding the `nodeAgent` attribute.
 <3> The `credentialsFile` field is the mounted location of the bucket credential on the pod.
 <4> The `enableSharedConfig` field allows the `snapshotLocations` to share or reuse the credential defined for the bucket.
@@ -246,7 +267,14 @@ You are now ready to back up and restore {product-title} applications, as descri
 
 [IMPORTANT]
 ====
-The `enable` parameter of `restic` is set to `false` in this configuration, because OADP does not support Restic in ROSA environments.
+The `enable` parameter of `restic` is set to `false` in this configuration, because OADP does not support Restic in 
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+ROSA 
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+{product-title} 
+endif::openshift-rosa,openshift-rosa-hcp[]
+environments.
 
 If you use OADP 1.2, replace this configuration:
 

--- a/modules/oadp-1-4-0-release-notes.adoc
+++ b/modules/oadp-1-4-0-release-notes.adoc
@@ -28,7 +28,6 @@ link:https://issues.redhat.com/browse/OADP-3922[OADP-3922]
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12438505[OADP 1.4.0 resolved issues] in Jira.
 
-
 [id="known-issues-1-4-0_{context}"]
 == Known issues
 
@@ -39,7 +38,6 @@ The empty value is only added for BSLs that are created using Data Protection Ap
 link:https://issues.redhat.com/browse/OADP-4274[OADP-4274]
 
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12438506[OADP 1.4.0 known issues] in Jira.
-
 
 [id="upgrade-notes-1-4-0_{context}"]
 == Upgrade notes

--- a/modules/oadp-1-4-1-release-notes.adoc
+++ b/modules/oadp-1-4-1-release-notes.adoc
@@ -14,7 +14,7 @@ The {oadp-first} 1.4.1 release notes lists new features, resolved issues and bug
 
 .New DPA fields to update client qps and burst
 
-You can now change Velero Server Kubernetes API queries per second and burst values by using the new Data Protection Application (DPA) fields. The new DPA fields are `spec.configuration.velero.client-qps` and `spec.configuration.velero.client-burst`, which both default to 100.
+You can now change Velero Server Kubernetes API queries per second and burst values by using the new Data Protection Application (DPA) fields. The new DPA fields are `spec.configuration.velero.client-qps` and `spec.configuration.velero.client-burst`, which both default to 100.
 link:https://issues.redhat.com/browse/OADP-4076[OADP-4076]
 
 .Enabling non-default algorithms with Kopia
@@ -103,7 +103,6 @@ link:https://issues.redhat.com/browse/OADP-4344[OADP-4344]
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12442016[OADP 1.4.1 resolved issues] in Jira.
 
-
 [id="known-issues-1-4-1_{context}"]
 == Known issues
 
@@ -117,10 +116,8 @@ link:https://issues.redhat.com/browse/OADP-4407[OADP-4407]
 During a File System Backup (FSB) restore operation, a `Deployment` resource referencing an `ImageStream` is not restored properly. The restored pod that runs the FSB, and the `postHook` is terminated prematurely.
 
 During the restore operation, the {ocp} controller updates the `spec.template.spec.containers[0].image` field in the `Deployment` resource with an updated `ImageStreamTag` hash. The update triggers the rollout of a new pod, terminating the pod on which `velero` runs the FSB along with the post-hook. 
-// TODO: Include this xref when the Images book is added to ROSA HCP.
-ifndef::openshift-rosa-hcp[]
+
 For more information about image stream trigger, see xref:../../../openshift_images/triggering-updates-on-imagestream-changes.adoc#triggering-updates-on-imagestream-changes[Triggering updates on image stream changes].
-endif::openshift-rosa-hcp[]
 
 The workaround for this behavior is a two-step restore process:
 

--- a/modules/oadp-configuring-velero-plugins.adoc
+++ b/modules/oadp-configuring-velero-plugins.adoc
@@ -19,10 +19,10 @@ Both types of plugin are optional, but most users configure at least one cloud p
 You can install any of the following default Velero cloud provider plugins when you configure the `oadp_v1alpha1_dpa.yaml` file during deployment:
 
 * `aws` (Amazon Web Services)
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 * `gcp` (Google Cloud Platform)
 * `azure` (Microsoft Azure)
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 * `openshift` (OpenShift Velero plugin)
 * `csi` (Container Storage Interface)
 * `kubevirt` (KubeVirt)

--- a/modules/oadp-features.adoc
+++ b/modules/oadp-features.adoc
@@ -20,7 +20,6 @@ OADP backs up Kubernetes objects and internal images by saving them as an archiv
 You must exclude Operators from the backup of an application for backup and restore to succeed.
 ====
 
-
 Restore::
 You can restore resources and PVs from a backup. You can restore all objects in a backup or filter the objects by namespace, PV, or label.
 

--- a/modules/oadp-usecase-include-ca-cert-backup.adoc
+++ b/modules/oadp-usecase-include-ca-cert-backup.adoc
@@ -16,7 +16,6 @@ To prevent a `certificate signed by unknown authority` error, you must include a
 * Include a self-signed CA certificate in the `DataProtectionApplication` CR.
 * Back up an application.
 
-
 .Prerequisites
 
 * You installed the {oadp-short} Operator.

--- a/modules/performing-a-backup-oadp-rosa-sts.adoc
+++ b/modules/performing-a-backup-oadp-rosa-sts.adoc
@@ -4,10 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="performing-a-backup-oadp-rosa-sts_{context}"]
-= Performing a backup with OADP and ROSA STS
+= Performing a backup with OADP and {product-title}
 
 [role="_abstract"]
-The following example `hello-world` application has no persistent volumes (PVs) attached. Perform a backup by using {oadp-first} with {product-rosa} (ROSA) STS.
+The following example `hello-world` application has no persistent volumes (PVs) attached. Perform a backup by using {oadp-first} with {product-title}.
 
 Either Data Protection Application (DPA) configuration will work.
 
@@ -43,7 +43,6 @@ $ curl `oc get route/hello-openshift -n hello-world -o jsonpath='{.spec.host}'`
 Hello OpenShift!
 ----
 
-
 . Back up the workload by running the following command:
 +
 [source,terminal]
@@ -62,7 +61,7 @@ $ cat << EOF | oc create -f -
 EOF
 ----
 
-. Wait until the backup is completed and then run the following command:
+. Wait until the backup is complete, and then run the following command:
 +
 [source,terminal]
 ----

--- a/modules/preparing-aws-credentials-for-oadp.adoc
+++ b/modules/preparing-aws-credentials-for-oadp.adoc
@@ -15,7 +15,7 @@ An {aws-full} account must be prepared and configured to accept an {oadp-first} 
 +
 [IMPORTANT]
 ====
-Change the cluster name to match your ROSA cluster, and ensure you are logged into the cluster as an administrator. Ensure that all fields are outputted correctly before continuing.
+Change the cluster name to match your cluster, and ensure you are logged into the cluster as an administrator. Ensure that all fields are outputted correctly before continuing.
 ====
 +
 [source,terminal]
@@ -33,7 +33,7 @@ $ export CLUSTER_NAME=my-cluster <1>
   ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
 ----
 +
-<1> Replace `my-cluster` with your ROSA cluster name.
+<1> Replace `my-cluster` with your cluster name.
 
 . On the {aws-short} account, create an IAM policy to allow access to {aws-short} S3:
 
@@ -46,7 +46,7 @@ $ POLICY_ARN=$(aws iam list-policies --query "Policies[?PolicyName=='RosaOadpVer
 +
 <1> Replace `RosaOadp` with your policy name.
 
-..  Enter the following command to create the policy JSON file and then create the policy in ROSA:
+..  Enter the following command to create the policy JSON file and then create the policy:
 +
 [NOTE]
 ====

--- a/modules/updating-role-arn-oadp-rosa-sts.adoc
+++ b/modules/updating-role-arn-oadp-rosa-sts.adoc
@@ -7,7 +7,14 @@
 = Updating the IAM role ARN in the {oadp-short} Operator subscription
 
 [role="_abstract"]
-While installing the {oadp-short} Operator on a ROSA Security Token Service (STS) cluster, if you provide an incorrect IAM role Amazon Resource Name (ARN), the `openshift-adp-controller` pod gives an error. The credential requests that are generated contain the wrong IAM role ARN. To update the credential requests object with the correct IAM role ARN, you can edit the {oadp-short} Operator subscription and patch the IAM role ARN with the correct value. By editing the {oadp-short} Operator subscription, you do not have to uninstall and reinstall {oadp-short} to update the IAM role ARN.
+While installing the {oadp-short} Operator on a
+ifndef::openshift-rosa,openshift-rosa-hcp[]
+ROSA Security Token Service (STS) 
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+{product-title} 
+endif::openshift-rosa,openshift-rosa-hcp[]
+cluster, if you provide an incorrect IAM role Amazon Resource Name (ARN), the `openshift-adp-controller` pod gives an error. The credential requests that are generated contain the wrong IAM role ARN. To update the credential requests object with the correct IAM role ARN, you can edit the {oadp-short} Operator subscription and patch the IAM role ARN with the correct value. By editing the {oadp-short} Operator subscription, you do not have to uninstall and reinstall {oadp-short} to update the IAM role ARN.
 
 .Prerequisites
 


### PR DESCRIPTION
[OSDOCS-14502](https://issues.redhat.com//browse/OSDOCS-14502): Prune "Backup & Restore"

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-14502

Link to docs preview:
HCP: https://98788--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/backup_and_restore/application_backup_and_restore/oadp-intro
Classic: https://98788--ocpdocs-pr.netlify.app/openshift-rosa/latest/backup_and_restore/application_backup_and_restore/oadp-intro

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
