### PR TITLE
PR for SRVKE-1740: Document "IntegrationSource" section in OpenShift Serverless Eventing docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -258,6 +258,8 @@ Topics:
     File: serverless-custom-event-sources
   - Name: Connecting an event source to an event sink
     File: serverless-sink-source-odc
+  - Name: Getting started with IntegrationSource
+    File: serverless-getting-started-integrationsource
 - Name: Event sinks
   Dir: event-sinks
   Topics:

--- a/eventing/event-sources/serverless-getting-started-integrationsource.adoc
+++ b/eventing/event-sources/serverless-getting-started-integrationsource.adoc
@@ -1,0 +1,39 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-getting-started-integrationsource"]
+= Getting started with IntegrationSource
+include::_attributes/common-attributes.adoc[]
+:context: serverless-integrationsource
+
+toc::[]
+
+:FeatureName: {ServerlessProductName} IntegrationSource feature
+include::snippets/technology-preview.adoc[]
+
+The `IntegrationSource` API is a Knative Eventing custom resource (CR) that enables you to connect to external systems by leveraging selected Kamelets from the Apache Camel project.
+
+Kamelets act as reusable connectors that can function either as sources or sinks. By using an `IntegrationSource` API, you can consume data from external systems and forward the data as CloudEvents into Knative Eventing.
+
+{ServerlessProductName} supports the following Kamelet sources:
+
+* AWS DynamoDB Streams
+* AWS S3
+* AWS SQS
+* Timer Source
+
+include::modules/serverless-integrationsource-creating-aws-credentials.adoc[leveloffset=+1]
+
+include::modules/serverless-integrationsource-aws-dynamodb-streams.adoc[leveloffset=+1]
+
+include::modules/serverless-creating-integrationsource-for-dynamodbstreams.adoc[leveloffset=+2]
+
+include::modules/serverless-integrationsource-aws-simple-storage-service.adoc[leveloffset=+1]
+
+include::modules/serverless-creating-integrationsource-for-aws-sss.adoc[leveloffset=+2]
+
+include::modules/serverless-integrationsource-aws-simple-queue-service.adoc[leveloffset=+1]
+
+include::modules/serverless-creating-integrationsource-for-aws-sqs.adoc[leveloffset=+2]
+
+include::modules/serverless-integrationsource-aws-timer-source.adoc[leveloffset=+1]
+
+include::modules/serverless-creating-integrationsource-for-timer.adoc[leveloffset=+2]

--- a/modules/serverless-creating-integrationsource-for-aws-sqs.adoc
+++ b/modules/serverless-creating-integrationsource-for-aws-sqs.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-integrationsource.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-creating-integrationsource-for-aws-sqs_{context}"]
+= Creating an IntegrationSource for SQS
+
+To create an `IntegrationSource` API that receives messages from an Amazon SQS queue, apply a YAML manifest.
+
+.Prerequisites
+
+* You have created your AWS credentials and stored them in a Kubernetes Secret in the same namespace as the `IntegrationSource` resource.
+* You have the OpenShift CLI (oc) installed and are logged in to the target cluster.
+* You know the namespace where the `IntegrationSource` resource will be created.
+* A Knative broker or another event sink exists to receive the SQS events.
+
+.Procedure
+
+. Save the following YAML manifest as `integration-source-aws-sqs.yaml`:
++
+[source,yaml]
+----
+apiVersion: sources.knative.dev/v1alpha1
+kind: IntegrationSource
+metadata:
+  name: integration-source-aws-sqs
+  namespace: knative-samples
+spec:
+  aws:
+    sqs:
+      arn: "arn:aws:sqs:eu-north-1:123456789012:my-queue"
+      region: "eu-north-1"
+    auth:
+      secret:
+        ref:
+          name: "my-secret"
+  sink:
+    ref:
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: default
+----
++
+[NOTE]
+====
+Ensure that the ARN accurately reflects the SQS queue region, account number, and queue name. For example,
+`arn:aws:sqs:<region>:<account-id>:<queue-name>`
+====
+
+. Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f integration-source-aws-sqs.yaml
+----
++
+This manifest configures the `IntegrationSource` API to monitor an Amazon SQS queue identified by its ARN in the `eu-north-1` region. The `auth.secret.ref.name` field references the Kubernetes Secret (`my-secret`) that stores your AWS credentials. The events are delivered to the `default` Knative broker defined in the sink section.

--- a/modules/serverless-creating-integrationsource-for-aws-sss.adoc
+++ b/modules/serverless-creating-integrationsource-for-aws-sss.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-integrationsource.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-creating-integrationsource-for-aws-sss_{context}"]
+= Creating an IntegrationSource for AWS S3
+
+To create an `IntegrationSource` API that receives data from an Amazon S3 bucket, apply a YAML manifest.
+
+.Prerequisites
+
+* You have created your AWS credentials and stored them in a Kubernetes Secret in the same namespace as the `IntegrationSource` resource.
+* You have the OpenShift CLI (oc) installed and are logged in to the target cluster.
+* You know the namespace where the `IntegrationSource` resource will be created.
+* A Knative broker or another event sink exists to receive S3 events.
+
+.Procedure
+
+. Save the following YAML manifest as `integration-source-aws-s3.yaml`:
++
+[source,yaml]
+----
+apiVersion: sources.knative.dev/v1alpha1
+kind: IntegrationSource
+metadata:
+  name: integration-source-aws-s3
+  namespace: knative-samples
+spec:
+  aws:
+    s3:
+      arn: "arn:aws:s3:::my-bucket"
+      region: "eu-north-1"
+    auth:
+      secret:
+        ref:
+          name: "my-secret"
+  sink:
+    ref:
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: default
+----
+
+. Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f integration-source-aws-s3.yaml
+----
++
+This manifest configures the `IntegrationSource` API to monitor an Amazon S3 bucket identified by its Amazon Resource Name (ARN)`arn:aws:s3:::my-bucket` in the `eu-north-1 region`. The `auth.secret.ref.name` field references the Kubernetes Secret (`my-secret`) that stores your AWS credentials. Events are delivered to the `default` Knative broker defined in the sink section.

--- a/modules/serverless-creating-integrationsource-for-dynamodbstreams.adoc
+++ b/modules/serverless-creating-integrationsource-for-dynamodbstreams.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-integrationsource.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-creating-integrationsource-for-dynamodbstreams_{context}"]
+= Creating an IntegrationSource for DynamoDB Streams
+
+To create an `IntegrationSource` API that receives events from Amazon DynamoDB Streams, apply a YAML manifest.
+
+.Prerequisites
+
+* You have created a Kubernetes Secret containing valid Amazon Web Services (AWS) credentials with access to Amazon DynamoDB Streams.
+* You have the OpenShift CLI (oc) installed and are logged in to the target cluster.
+* You know the namespace where the `IntegrationSource` resource will be created.
+* A Knative broker or another valid event sink already exists in the same namespace to receive the events.
+
+.Procedure
+
+. Save the following YAML manifest as `integration-source-aws-ddb.yaml`:
++
+[source,yaml]
+----
+apiVersion: sources.knative.dev/v1alpha1
+kind: IntegrationSource
+metadata:
+  name: integration-source-aws-ddb
+  namespace: knative-samples
+spec:
+  aws:
+    ddbStreams:
+      table: "my-table"
+      region: "eu-north-1"
+    auth:
+      secret:
+        ref:
+          name: "my-secret"
+  sink:
+    ref:
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: default
+----
+
+. Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f integration-source-aws-ddb.yaml
+----
++
+This manifest configures the `IntegrationSource` API to read change events from the DynamoDB table `my-table` in the `eu-north-1` region. The `auth.secret.ref.name` field references the Kubernetes Secret (`my-secret`) that stores your AWS credentials. The events are sent to the `default` Knative broker defined in the sink section.

--- a/modules/serverless-creating-integrationsource-for-timer.adoc
+++ b/modules/serverless-creating-integrationsource-for-timer.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-integrationsource.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-creating-integrationsource-for-timer_{context}"]
+= Creating an IntegrationSource for timer
+
+To create an `IntegrationSource` API that produces periodic messages with a custom payload, apply a YAML manifest.
+
+.Prerequisites
+
+* You have the OpenShift CLI (oc) installed and are logged in to the target cluster.
+* You know the namespace where the `IntegrationSource` resource will be created.
+* A Knative broker or another event sink exists to receive the SQS events.
+
+.Procedure
+
+. Save the following YAML manifest as `integration-source-timer.yaml`:
++
+[source,yaml]
+----
+apiVersion: sources.knative.dev/v1alpha1
+kind: IntegrationSource
+metadata:
+  name: integration-source-timer
+  namespace: knative-samples
+spec:
+  timer:
+    period: 2000
+    message: "Hello from Timer source"
+  sink:
+    ref:
+      apiVersion: eventing.knative.dev/v1
+      kind: Broker
+      name: default
+----
+
+. Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f integration-source-timer.yaml
+----
++
+This manifest configures the `IntegrationSource` to emit a message `"Hello from Timer source"` every 2000 milliseconds (2 seconds). The generated messages are sent to the `default` Knative broker defined in the sink section.

--- a/modules/serverless-integrationsource-aws-dynamodb-streams.adoc
+++ b/modules/serverless-integrationsource-aws-dynamodb-streams.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-integrationsource.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-integrationsource-aws-dynamodb-streams_{context}"]
+= AWS DynamoDB Streams with IntegrationSource
+
+The Amazon Web Services (AWS) DynamoDB Streams Kamelet allows you to consume changes from an Amazon DynamoDB table and forward them into Knative Eventing. This integration makes it easier to react to database changes and propagate events within your serverless applications.
+
+To configure an `IntegrationSource` for DynamoDB Streams, you must provide valid AWS credentials, specify the DynamoDB table and its region, and define the event sink, such as a Knative broker.

--- a/modules/serverless-integrationsource-aws-simple-queue-service.adoc
+++ b/modules/serverless-integrationsource-aws-simple-queue-service.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-integrationsource.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-integrationsource-aws-simple-queue-service_{context}"]
+= AWS SQS with IntegrationSource
+
+The Amazon Web Services (AWS) Simple Queue Service (SQS) Kamelet enables you to consume messages from an Amazon SQS queue and forward them into Knative Eventing. This integration allows {ServerlessProductName} applications to react to queued messages, supporting event-driven architectures that decouple producers and consumers.
+
+To configure an `IntegrationSource` for SQS, you must provide valid AWS credentials, specify the Amazon SQS queue Amazon Resource Name (ARN) and its region, and define the event sink, such as a Knative broker. The Amazon Resource Name (ARN) uniquely identifies the SQS queue across all AWS accounts and regions.

--- a/modules/serverless-integrationsource-aws-simple-storage-service.adoc
+++ b/modules/serverless-integrationsource-aws-simple-storage-service.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-integrationsource.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-integrationsource-aws-simple-storage-service_{context}"]
+= AWS S3 with IntegrationSource
+
+The Amazon Web Services (AWS) Simple Storage Service (S3) Kamelet allows you to consume object storage events such as file uploads or updates from an Amazon S3 bucket and forward them into Knative Eventing. This integration helps {ServerlessProductName} applications react to changes in object storage, such as new files or data updates, without the need for polling.
+
+To configure an `IntegrationSource` for S3, you must provide valid AWS credentials, specify the Amazon S3 bucket Amazon Resource Name (ARN) and its region, and define the event sink, such as a Knative broker.

--- a/modules/serverless-integrationsource-aws-timer-source.adoc
+++ b/modules/serverless-integrationsource-aws-timer-source.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-integrationsource.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-integrationsource-aws-timer-source_{context}"]
+= Timer source with IntegrationSource
+
+The Timer Kamelet produces periodic messages with a custom payload and forwards them into Knative Eventing. This is useful for testing event flows or generating scheduled events without relying on external systems.
+
+To configure an `IntegrationSource` for the Timer Kamelet, you specify the interval at which messages are generated and the message content, and then define the event sink, such as a Knative broker.

--- a/modules/serverless-integrationsource-creating-aws-credentials.adoc
+++ b/modules/serverless-integrationsource-creating-aws-credentials.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-integrationsource.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-integrationsource-creating-aws-credentials_{context}"]
+= Creating AWS credentials
+
+To connect to Amazon Web Services (AWS) resources, the `IntegrationSource` requires a Kubernetes Secret that contains valid AWS credentials. You must create this Secret in the same namespace as the `IntegrationSource` resource and must include both the AWS access key and secret key.
+
+.Prerequisites
+
+* You have an AWS account with an access key ID and secret access key that allow access to the Amazon DynamoDB Streams service.
+* You have the OpenShift CLI (oc) installed and are logged in to the cluster.
+* You have identified the namespace in which the `IntegrationSource` resource will be created.
+
+.Procedure
+
+* Create the Secret by running the following command:
++
+[source,terminal]
+----
+$ oc -n <namespace> create secret generic my-secret \
+  --from-literal=aws.accessKey=<accessKey> \
+  --from-literal=aws.secretKey=<secretKey>
+----
++
+Replace `<namespace>` with the namespace where the `IntegrationSource` resource resides, and substitute `<accessKey>` and `<secretKey>` with the corresponding AWS credentials.


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.37`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVKE-1740

**Doc preview:** [Understanding IntegrationSource](https://98792--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-integrationsource#serverless-integrationsource-creating-aws-credentials_serverless-integrationsource)

**Reviews:**

- [x] QE has approved this change.
- [x] SME has approved this change.
- [x] Peer has approved this change.