### PR TITLE
RHDEVDOCS-6567: Correct the formatting for 'Work with Builds' section

### DIFF
--- a/modules/ob-creating-a-buildpacks-build.adoc
+++ b/modules/ob-creating-a-buildpacks-build.adoc
@@ -154,8 +154,9 @@ $ oc get builds.shipwright.io buildpack-nodejs-build
 ----
 $ shp build list
 ----
+
 . Create a `BuildRun` resource and apply it to the {ocp-product-title} cluster:
-.. .. Using `oc` CLI:
+.. Using `oc` CLI:
 +
 [source,terminal]
 ----
@@ -173,7 +174,6 @@ EOF
 <1> Reference to the `buildpack-nodejs-build` resource that will be executed.
 .. Using `shp` CLI:
 +
-...
 [source,terminal]
 ----
 $ shp build run buildpack-nodejs-buildrun --follow
@@ -183,6 +183,7 @@ $ shp build run buildpack-nodejs-buildrun --follow
 ====
 The `shp` CLI version 0.16.0 cannot automatically generate a name for the `BuildRun` resource.
 You must create the name manually:
+
 
 . Create a `BuildRun` resource with a unique name
 +
@@ -199,6 +200,7 @@ $ shp buildrun create buildpack-nodejs-<buildrun_resource_name>  --buildref-name
 $ shp buildrun logs buildpack-nodej-<buildrun_resource_name> --follow
 ----
 ====
+
 . Check if the `BuildRun` resource was created:
 .. Using `oc` CLI:
 +
@@ -212,6 +214,7 @@ $ oc get buildrun buildpack-nodejs-buildrun
 ----
 $ shp buildrun list
 ----
+
 [NOTE]
 ====
 The `BuildRun` resource creates a `TaskRun` resource, which then creates the pods to execute build strategy steps.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): build-docs-1.5, build-docs-1.6
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/RHDEVDOCS-6567
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://98793--ocpdocs-pr.netlify.app/openshift-builds/latest/work_with_builds/using-builds.html#ob-creating-a-buildpacks-build_using-builds
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
