### PR TITLE
OSDOCS-16067:Removed incorrect init command sections from ROSA CLI doc.

### DIFF
--- a/cli_reference/rosa_cli/rosa-get-started-cli.adoc
+++ b/cli_reference/rosa_cli/rosa-get-started-cli.adoc
@@ -16,8 +16,8 @@ include::modules/rosa-configure.adoc[leveloffset=+1]
 
 * xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[Getting started with the OpenShift CLI]
 
-ifdef::openshift-rosa[]
+ifndef::openshift-rosa-hcp[]
 include::modules/rosa-initialize.adoc[leveloffset=+1]
-endif::openshift-rosa[]
 include::modules/rosa-using-bash-script.adoc[leveloffset=+1]
+endif::openshift-rosa-hcp[]
 include::modules/rosa-updating-rosa-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-16067

ROSA (HCP) is STS only. This PR removes the following sections documenting the init command (used in non-STS clusters only) from the ROSA CLI getting started docs: 

- [1.4](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/rosa_cli/rosa-get-started-cli#rosa-initialize_rosa-getting-started-cli)
- [1.5](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/rosa_cli/rosa-get-started-cli#rosa-using-bash-script_rosa-getting-started-cli)

<img width="401" height="502" alt="image" src="https://github.com/user-attachments/assets/99756ac7-7db1-4c07-8d43-67298c2e8680" />

Link to docs preview:
[Getting started with the ROSA CLI](https://98794--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/rosa_cli/rosa-get-started-cli.html)

Peer review:
- [ ] Peer reviewer has approved this change.

QE review:
- QE approval is not required for this PR

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
