### PR TITLE
Telcodocs 2269 1: Disable RPS - pods should "pay" for networking

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -563,6 +563,30 @@ In {product-title} {product-version}, the NUMA Resources Operator automatically 
 
 For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-managing-ha-nrop_numa-aware[Managing high availability (HA) for the NUMA-aware scheduler].
 
+[id="ocp-4-20-receive-packet-steering-disabled_{context}"]
+==== Receive Packet Steering (RPS) is now disabled by default
+
+With this release, Receive Packet Steering (RPS) is no longer configured when Performance Profile is applied. The RPS configuration affects containers that perform networking system calls, such as send, directly within latency-sensitive threads. To avoid latency impacts when RPS is not configured, move networking calls to helper threads or processes.
+
+The previous RPS configuration resolved latency issues at the expense of overall pod kernel networking performance. The current default configuration promotes transparency by requiring developers to address the underlying application design instead of obscuring performance impacts.
+
+To revert to the previous behavior, add the `performance.openshift.io/enable-rps` annotation to the PerformanceProfile manifest:
+
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: example-performanceprofile
+  annotations:
+    performance.openshift.io/enable-rps: "enable"
+----
+
+[NOTE]
+====
+This action restores the prior functionality at the cost of globally reducing networking performance for all pods.
+====
+
 [id="ocp-release-notes-security_{context}"]
 === Security
 


### PR DESCRIPTION
[TELCODOCS-2471]: RN: Disable RPS - pods should "pay" for networking

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2471
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://98796--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-receive-packet-steering-disabled_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
