### PR TITLE
OCPBUGS-36269: Mark "ConfigChange" trigger for BuildConfig feature complete.

### DIFF
--- a/modules/builds-configuration-change-triggers.adoc
+++ b/modules/builds-configuration-change-triggers.adoc
@@ -16,5 +16,5 @@ The following is an example trigger definition YAML within the `BuildConfig`:
 
 [NOTE]
 ====
-Configuration change triggers currently only work when creating a new `BuildConfig`. In a future release, configuration change triggers will also be able to launch a build whenever a `BuildConfig` is updated.
+Configuration change triggers currently only work when creating a new `BuildConfig`.
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): enterprise-4.12, 4.13, 4.14, 4.15, 4.16, 4.17, 4.18, 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-36269
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: Changed note in [Change configuration triggers](https://98797--ocpdocs-pr.netlify.app/openshift-dedicated/latest/cicd/builds/triggering-builds-build-hooks.html#builds-configuration-change-triggers_triggering-builds-build-hooks)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review: @adambkaplan 
QE review: Builds doesnt have QE
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
