### PR TITLE
TELCODOCS-2465: Adding dual-stacking networking to IBI and IBU

### DIFF
--- a/modules/cnf-image-based-upgrade-seed-image-config.adoc
+++ b/modules/cnf-image-based-upgrade-seed-image-config.adoc
@@ -26,7 +26,7 @@ endif::[]
 The following table lists the components, resources, and configurations that you must and must not include in your seed image:
 
 .Seed image configuration
-[cols=2*, width="80%", options="header"]
+[cols="2,1", options="header"]
 |====
 |Cluster configuration
 |Include in seed image
@@ -37,7 +37,7 @@ The following table lists the components, resources, and configurations that you
 |`MachineConfig` resources for the target cluster
 |Yes
 
-|IP version ^[1]^
+|IP version configuration, either IPv4, IPv6, or dual-stack networking
 |Yes
 
 |Set of Day 2 Operators, including the {lcao} and the {oadp-short} Operator
@@ -66,7 +66,6 @@ ifdef::ibu[]
 |No
 endif::[]
 |====
-. Dual-stack networking is not supported in this release.
 . If the seed cluster is installed in a disconnected environment, the target clusters must also be installed in a disconnected environment.
 . The proxy configuration must be either enabled or disabled in both the seed and target clusters. However, the proxy servers configured on the clusters does not have to match.
 

--- a/modules/cnf-image-based-upgrade-seed-image-guide.adoc
+++ b/modules/cnf-image-based-upgrade-seed-image-guide.adoc
@@ -11,13 +11,7 @@ This means that the seed cluster must match the configuration of the target clus
 ** Number of CPU cores
 ** Tuned performance configuration, such as number of reserved CPUs
 * `MachineConfig` resources for the target cluster
-* IP version
-+
-[NOTE]
-====
-Dual-stack networking is not supported in this release.
-====
-
+* IP version configuration, either IPv4, IPv6, or dual-stack networking
 * Set of Day 2 Operators, including the {lcao} and the {oadp-short} Operator
 * Disconnected registry
 * FIPS configuration

--- a/modules/ibi-create-config-iso.adoc
+++ b/modules/ibi-create-config-iso.adoc
@@ -200,7 +200,9 @@ spec:
   hostname: ibi-host <4>
   imageSetRef:
     name: ibi-img-version-arch <5>
-  machineNetwork: 10.0.0.0/24 <6>
+  machineNetworks: <6>
+  - cidr: 10.0.0.0/24
+  #- cidr: fd01::/64
   proxy: <7>
     httpProxy: "http://proxy.example.com:8080"
     #httpsProxy: "http://proxy.example.com:8080"
@@ -211,7 +213,7 @@ spec:
 <3> Specify the name of the `ClusterDeployment` resource that you want to use for the image-based installation of the target host.
 <4> Specify the hostname for the cluster.
 <5> Specify the name of the `ClusterImageSet` resource you used to define the container release images to use for deployment.
-<6> Specify the public CIDR (Classless Inter-Domain Routing) of the external network.
+<6> Specify the public Classless Inter-Domain Routing (CIDR) of the external network. For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format. Regardless of the list order, the IPv4 family becomes the primary address family.
 <7> Optional: Specify a proxy to use for the cluster deployment.
 +
 [IMPORTANT]

--- a/modules/ibi-create-standalone-config-iso.adoc
+++ b/modules/ibi-create-standalone-config-iso.adoc
@@ -57,8 +57,9 @@ controlPlane:
   name: master
   replicas: 1
 networking:
-  machineNetwork:
+  machineNetwork: <1>
   - cidr: 192.168.200.0/24
+  #- cidr: fd01::/64
 platform:
   none: {}
 fips: false
@@ -66,6 +67,7 @@ cpuPartitioningMode: "AllNodes"
 pullSecret: '{"auths":{"<your_pull_secret>"}}}'
 sshKey: 'ssh-rsa <your_ssh_pub_key>'
 ----
+<1> For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format. You must specify the IPv4 family as the primary address family by defining the IPv4 address as the first item in the list.
 
 [IMPORTANT]
 ====

--- a/modules/ibi-image-based-install-cluster-guide.adoc
+++ b/modules/ibi-image-based-install-cluster-guide.adoc
@@ -30,12 +30,7 @@ For a successful image-based installation and deployment, see the following guid
 *** Number of CPU cores
 *** Tuned performance configuration, such as number of reserved CPUs
 
-** IP version
-+
-[NOTE]
-====
-Dual-stack networking is not supported in this release.
-====
+** IP version configuration, either IPv4, IPv6, or dual-stack networking
 
 ** Disconnected registry
 +

--- a/modules/ibi-image-cluster-install-api-spec.adoc
+++ b/modules/ibi-image-cluster-install-api-spec.adoc
@@ -45,7 +45,7 @@ imageDigestSources:
 
 |`bareMetalHostRef`|`string`| Specify the `bareMetalHost` resource to use for the cluster deployment
 
-|`machineNetwork`|`string`| Specify the public CIDR (Classless Inter-Domain Routing) of the external network.
+|`machineNetwork`|`string`| Specify the public Classless Inter-Domain Routing (CIDR) of the external network. For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format. Regardless of the list order, the IPv4 family becomes the primary address family.
 
 |`proxy`|`string`|Specifies proxy settings for the cluster, for example:
 [source,yaml]


### PR DESCRIPTION
[TELCODOCS-2465](https://issues.redhat.com//browse/TELCODOCS-2465): Adding dual-stacking networking to IBI and IBU

Version(s):
4.20

Issue:
https://issues.redhat.com/browse/TELCODOCS-2465

Link to docs preview:

IBU updates
- https://98802--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/cnf-understanding-image-based-upgrade.html#cnf-image-based-upgrade-seed-image-guide_understanding-image-based-upgrade
- https://98802--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/preparing_for_image_based_upgrade/cnf-image-based-upgrade-generate-seed#cnf-image-based-upgrade-seed-image-config_generate-seed

IBI updates
- https://98802--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi-understanding-image-based-install#ibi-seed-cluster-guidelines_ibi-understanding-image-based-install
- https://98802--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi-preparing-for-image-based-install#cnf-image-based-upgrade-seed-image-config_ibi-preparing-image-based-install
- https://98802--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install#ibi-create-config-iso_ibi-edge-image-based-install
- https://98802--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_base_install/ibi_deploying_sno_clusters/ibi-edge-image-based-install#ibi-image-cluster-install-api-spec_ibi-edge-image-based-install


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

