### PR TITLE
[enterprise-4.19] OSDOCS#16129: Warning of Kubernetes API deprecation in a future release

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -142,7 +142,7 @@ For more information, see xref:../extensions/ce/managing-ce.adoc#olmv1-deploying
 [id="ocp-4-19-dynamic-accelerator-slicer-operator-tp_{context}"]
 ==== Dynamic Accelerator Slicer Operator (Technology Preview)
 
-With this release, you can use the Dynamic Accelerator Slicer (DAS) Operator to dynamically slice GPU accelerators in {product-title}, instead of relying on statically sliced GPUs defined when the node is booted. This allows you to dynamically slice GPUs based on specific workload demands, ensuring efficient resource utilization. 
+With this release, you can use the Dynamic Accelerator Slicer (DAS) Operator to dynamically slice GPU accelerators in {product-title}, instead of relying on statically sliced GPUs defined when the node is booted. This allows you to dynamically slice GPUs based on specific workload demands, ensuring efficient resource utilization.
 
 For more information, see xref:../hardware_accelerators/das-about-dynamic-accelerator-slicer-operator.adoc#das-about-dynamic-accelerator-slicer-operator_das-about-dynamic-accelerator-slicer-operator[Dynamic Accelerator Slicer (DAS) Operator].
 
@@ -1414,6 +1414,13 @@ With this release, support for the `useModal` hook in dynamic plugins are deprec
 Starting with this release, use the `useOverlay` API hook to launch modals
 
 //For more information about `useOverlay`, see [Doc link to dynamic plugin api docs TBD.]
+
+[id="ocp-4-19-kubernetes-api-deprecation_{context}"]
+==== Kubernetes API deprecation
+
+{product-title} 4.17 inadvertently reintroduced a removed Kubernetes API, `admissionregistration.k8s.io/v1beta1`. This API is deprecated and is planned for removal in a future {product-title} release. Migrate any instances of this API to `admissionregistration.k8s.io/v1`.
+
+For information about how to check your cluster for Kubernetes APIs that are planned for removal, see link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API deprecations and removals].
 
 [id="ocp-4-19-removed-features_{context}"]
 === Removed features


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-16129

Link to docs preview:
https://98825--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-kubernetes-api-deprecation_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**Requires change management due to updating RNs retroactively, and a change in support (deprecation)**