### PR TITLE
[enterprise-4.18] OSDOCS#16129: Warning of Kubernetes API deprecation in a future release

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1659,10 +1659,16 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |====
 
-////
 [id="ocp-4-18-deprecated-features_{context}"]
 === Deprecated features
-////
+
+[id="ocp-4-18-kubernetes-api-deprecation_{context}"]
+==== Kubernetes API deprecation
+
+{product-title} 4.17 inadvertently reintroduced a removed Kubernetes API, `admissionregistration.k8s.io/v1beta1`. This API is deprecated and is planned for removal in a future {product-title} release. Migrate any instances of this API to `admissionregistration.k8s.io/v1`.
+
+For information about how to check your cluster for Kubernetes APIs that are planned for removal, see link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API deprecations and removals].
+
 
 [id="ocp-4-18-removed-features_{context}"]
 === Removed features
@@ -3075,7 +3081,7 @@ $ oc adm release info 4.18.23 --pullspecs
 
 * Before this update, OCP updates that shipped a change to `coredns` templates would restart the static pod and pre-reboot the node. This issue occurred before the image pull for the base operation system image update. As a consequence, a race occurred where the `rpm-ostree`, the operating system (OS) update manager, failed the image pull because of network errors and stall. With this release, a retry in the Machine Config Operator (MCO) OS update operation is added to work around the race condition due to the restarts of the `coredns` pod. (link:https://issues.redhat.com/browse/OCPBUGS-60034[OCPBUGS-60034])
 
-* Before this update, when you used multiple recommenders for the Vertical Pod Autoscaler (VPA), the default VPA recommender would erroneously garbage collect `VPACheckpoint` objects that belonged to a VPA object which was associated with a non-default recommender. With this release, the default recommender does not garbage collect the checkpoints owned by the other recommenders. (link:https://issues.redhat.com/browse/OCPBUGS-60235[OCPBUGS-60235]) 
+* Before this update, when you used multiple recommenders for the Vertical Pod Autoscaler (VPA), the default VPA recommender would erroneously garbage collect `VPACheckpoint` objects that belonged to a VPA object which was associated with a non-default recommender. With this release, the default recommender does not garbage collect the checkpoints owned by the other recommenders. (link:https://issues.redhat.com/browse/OCPBUGS-60235[OCPBUGS-60235])
 
 * Before this update, the *Events* page incorrectly displayed `{error}` instead of an error message. With this release, the error message is displayed. (link:https://issues.redhat.com/browse/OCPBUGS-60278[OCPBUGS-60278])
 
@@ -3114,7 +3120,7 @@ $ oc adm release info 4.18.22 --pullspecs
 +
 --
 ** You are upgrading from 4.17 to 4.18 during an update of the OVN-Kubernetes image.
-** During the upgrade, if a pod on another system that was selected by an egress IP was deleted when the `ovnkube-node` pod was not running. 
+** During the upgrade, if a pod on another system that was selected by an egress IP was deleted when the `ovnkube-node` pod was not running.
 --
 +
 (link:https://issues.redhat.com/browse/OCPBUGS-59531[OCPBUGS-59531])


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-16129

Link to docs preview:
https://98826--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-kubernetes-api-deprecation_release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**Requires change management due to updating RNs retroactively, and a change in support (deprecation)**