### PR TITLE
[OSDOCS-16128]: Removing TP boilerplate about dual-stack

### DIFF
--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc.adoc
@@ -16,6 +16,3 @@ In the context of {hcp}, a disconnected environment is an {product-title} deploy
 Depending on where the pods are running, they are affected by the `ImageDigestMirrorSet` (IDMS) or `ImageContentSourcePolicy` (ICSP) that is created in the management cluster or by the `ImageContentSource` that is set in the `spec` field of the manifest for the hosted cluster. The `spec` field is translated into an IDMS object on the hosted cluster.
 
 You can deploy {hcp} in a disconnected environment on IPv4, IPv6, and dual-stack networks. IPv4 is one of the simplest network configurations to deploy {hcp} in a disconnected environment. IPv4 ranges require fewer external components than IPv6 or dual-stack setups. For {hcp} on {VirtProductName} in a disconnected environment, use either an IPv4 or a dual-stack network.
-
-:FeatureName: {hcp-capital} in a disconnected environment on a dual-stack network
-include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-16128
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://98827--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-disconnected/hcp-deploy-dc.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
