### PR TITLE
OCPBUGS#13160: clarifying ABI IP support options

### DIFF
--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -103,7 +103,7 @@ For bare-metal platforms, host settings made in the platform section of the `ins
 +
 [NOTE]
 ====
-If you set the platform to `vSphere` or `baremetal`, you can configure IP address endpoints for cluster nodes in three ways:
+If you set the platform to `vSphere`, `baremetal`, or `none`, you can configure IP address endpoints for cluster nodes in three ways:
 
 * IPv4
 * IPv6


### PR DESCRIPTION
[OCPBUGS-13160](https://issues.redhat.com/browse/OCPBUGS-13160)

Version(s): 4.12+

This PR adds platform `none` to a note that clarifies IP stack options for the Agent-based Installer

QE review:
- [x] QE has approved this change.

Preview: [Note](https://98853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-inputs_installing-with-agent-based-installer:~:text=SSH%20public%20key.-,If%20you,-set%20the%20platform)