### PR TITLE
[enterprise-4.18] OSDOCS 15252 MachineOSConfig name should match MachineConfigPool

### DIFF
--- a/modules/coreos-layering-configuring-on.adoc
+++ b/modules/coreos-layering-configuring-on.adoc
@@ -13,6 +13,8 @@ To apply a custom layered image to your cluster by using the on-cluster build pr
 * where the final image should be pushed and pulled from
 * the push and pull secrets to use
 
+You can create only one `MachineOSConfig` CR for each machine config pool.
+
 When you create the object, the Machine Config Operator (MCO) creates a `MachineOSBuild` object and a builder pod. The build process also creates transient objects, such as config maps, which are cleaned up after the build is complete. The `MachineOSBuild` object and the associated `builder-*` pod use the same naming scheme, `<MachineOSConfig_CR_name>-<hash>`, for example:
 
 .Example `MachineOSBuild` object
@@ -130,7 +132,7 @@ spec:
     name: builder-dockercfg-mtcl23
 ----
 <1> Specifies the `machineconfiguration.openshift.io/v1` API that is required for `MachineConfig` CRs.
-<2> Specifies a name for the `MachineOSConfig` object. This name is used with other on-cluster layering resources. The examples in this documentation use the name `layered`. 
+<2> Specifies a name for the `MachineOSConfig` object. The name must match the name of the associated machine config pool. This name is used with other on-cluster layering resources. The examples in this documentation use the name `layered`. 
 <3> Specifies the name of the machine config pool associated with the nodes where you want to deploy the custom layered image. The examples in this documentation use the `layered` machine config pool.
 <4> Specifies the Containerfile to configure the custom layered image.
 <5> Specifies the architecture this containerfile is to be built for: `ARM64`, `AMD64`, `PPC64LE`, `S390X`, or `NoArch`. The default is `NoArch`, which defines a Containerfile that can be applied to any architecture. 


### PR DESCRIPTION
**DO NOT MERGE UNTIL 4.18.24 IS RELEASED** Planned for 9/17/25

Manual cherrypick of https://github.com/openshift/openshift-docs/pull/96902
