### PR TITLE
CNV - 45694: Added documentation for kubevirt_vmi_vcpu_delay_seconds_total

### DIFF
--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-//
+ //
 // * virt/support/virt-prometheus-queries.adoc
 
 :_mod-docs-content-type: REFERENCE
@@ -11,7 +11,7 @@ For a complete list of virtualization metrics, see link:https://github.com/kubev
 
 [NOTE]
 ====
-The following examples use `topk` queries that specify a time period. If virtual machines are deleted during that time period, they can still appear in the query output.
+The following examples use `topk` queries that specify a time period. If virtual machines (VMs) are deleted during that time period, they can still appear in the query output.
 ====
 
 // Hiding in ROSA/OSD as user cannot edit MCO
@@ -30,6 +30,18 @@ A value above '0' means that the vCPU wants to run, but the host scheduler canno
 ====
 To query the vCPU metric, the `schedstats=enable` kernel argument must first be applied to the `MachineConfig` object. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler.
 ====
+
+`kubevirt_vmi_vcpu_delay_seconds_total`::
+Returns the cumulative time, in seconds, that a vCPU was enqueued by the host scheduler but could not run immediately.  
+This delay appears to the virtual machine as _steal time_, which is CPU time lost when the host runs other workloads. Steal time can impact performance and often indicates CPU overcommitment or contention on the host. 
+Type: Counter.
+
+*Example vCPU delay query*
+[source,promql]
+----
+irate(kubevirt_vmi_vcpu_delay_seconds_total[5m]) > 0.05 <1>
+----
+<1> This query returns the average per-second delay over a 5-minute period. A high value may indicate CPU overcommitment or contention on the node.
 
 *Example vCPU wait time query*
 [source,promql]


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/CNV-45694

Link to docs preview:
https://98861--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries.html#virt-promql-vcpu-metrics_virt-prometheus-queries

QE review:
- [x] QE has approved this change.

Additional information:
The original PR has already been reviewed and approved by QE, and it has also undergone peer review. 
https://github.com/openshift/openshift-docs/pull/96063