### PR TITLE
[RHACS] Correct values for 4.8 and 4.7 Scanner V4

### DIFF
--- a/modules/default-requirements-central-services.adoc
+++ b/modules/default-requirements-central-services.adoc
@@ -126,11 +126,11 @@ The requirements in this table are based on the default of 3 replicas.
 | Scanner V4 Indexer | CPU | Memory
 
 | *Request*
-| 4.5 cores
-| 1536 MiB
+| 3 cores
+| 4500 MiB
 
 | *Limit*
-| 12 cores
+| 6 cores
 | 9 GiB
 |===
 
@@ -142,12 +142,12 @@ The requirements in this table are based on the default of 2 replicas.
 | Scanner V4 Matcher | CPU | Memory
 
 | *Request*
-| 1 core
-| 3 GiB
+| 2 cores
+| 1000 MiB
 
 | *Limit*
-| 2 cores
-| 6 GiB
+| 4 cores
+| 4 GiB
 |===
 
 *Scanner V4 DB*
@@ -158,12 +158,12 @@ Scanner V4 requires Scanner V4 DB (PostgreSQL 15) to store data. For Scanner V4 
 | Scanner V4 DB | CPU | Memory | Storage
 
 | *Request*
-| 1 core
-| 4 GiB
+| 0.2 cores
+| 3 GiB
 | 50 GiB
 
 | *Limit*
-| 4 cores
-| 8 GiB
+| 2 cores
+| 4 GiB
 | 50 GiB
 |===


### PR DESCRIPTION
Changes/additional work after #98791 

Versions: 4.7 and 4.8

Issue: none

Link to docs preview:

QE review: **ACS has no QE, approved by SME**
(approved)

Additional information:

Corrects values for 4.7 and 4.8