### PR TITLE
OLS-1852: Regenerate OLSConfig API reference doc

### DIFF
--- a/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
@@ -104,6 +104,7 @@ spec:
     providers:
       - credentialsSecretRef:
           name: credentials
+        apiVersion: <api_version_for_azure_model>
         deploymentName: <azure_ai_deployment_name>
         models:
           - name: <model_name>

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
@@ -104,6 +104,7 @@ spec:
     providers:
       - credentialsSecretRef:
           name: credentials
+        apiVersion: <api_version_for_azure_model>
         deploymentName: <azure_ai_deployment_name>
         models:
           - name: <model_name>

--- a/modules/ols-olsconfig-api-specifications.adoc
+++ b/modules/ols-olsconfig-api-specifications.adoc
@@ -3,13 +3,13 @@
 [id="openshift-lightspeed-olsconfig-api-specifications_{context}"]
 = OLSConfig API specifications
 
+
+
 Description::
 +
 --
-Red Hat {product-title} Lightspeed instance. `OLSConfig` is the Schema for the `olsconfigs` API
+Red Hat {product-title} Lightspeed instance. OLSConfig is the Schema for the olsconfigs API
 --
-
-
 
 Type::
   `object`
@@ -73,9 +73,18 @@ Required::
 |===
 | Property | Type | Description
 
+| `featureGates`
+| `array (string)`
+| Feature Gates holds list of features to be enabled explicitly, otherwise they are disabled by default.
+possible values: MCPServer
+
 | `llm`
 | `object`
 | LLMSpec defines the desired state of the large language model (LLM).
+
+| `mcpServers`
+| `array`
+| MCP Server settings
 
 | `ols`
 | `object`
@@ -242,7 +251,7 @@ Required::
 
 | `contextWindowSize`
 | `integer`
-| Defines the model's context window size. Default is specific to provider/model.
+| Defines the model's context window size, in tokens. The default is 128k tokens.
 
 | `name`
 | `string`
@@ -276,7 +285,7 @@ Type::
 
 | `maxTokensForResponse`
 | `integer`
-| Max tokens for response
+| Max tokens for response. The default is 2048 tokens.
 
 |===
 == .spec.llm.providers[].tlsSecurityProfile
@@ -452,6 +461,87 @@ Note that the Modern profile is currently not supported because it is not
 yet well adopted by common software libraries.
 
 |===
+== .spec.mcpServers
+Description::
++
+--
+MCP Server settings
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.mcpServers[]
+Description::
++
+--
+MCPServer defines the settings for a single MCP server.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name of the MCP server
+
+| `streamableHTTP`
+| `object`
+| Streamable HTTP Transport settings
+
+|===
+== .spec.mcpServers[].streamableHTTP
+Description::
++
+--
+Streamable HTTP Transport settings
+--
+
+Type::
+  `object`
+
+Required::
+  - `url`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `enableSSE`
+| `boolean`
+| Enable Server Sent Events
+
+| `headers`
+| `object (string)`
+| Headers to send to the MCP server
+
+| `sseReadTimeout`
+| `integer`
+| SSE Read Timeout, default is 10 seconds
+
+| `timeout`
+| `integer`
+| Timeout for the MCP server, default is 5 seconds
+
+| `url`
+| `string`
+| URL of the MCP server
+
+|===
 == .spec.ols
 Description::
 +
@@ -464,6 +554,7 @@ Type::
 
 Required::
   - `defaultModel`
+  - `defaultProvider`
 
 
 
@@ -474,6 +565,10 @@ Required::
 | `additionalCAConfigMapRef`
 | `object`
 | Additional CA certificates for TLS communication between OLS service and LLM Provider
+
+| `byokRAGOnly`
+| `boolean`
+| Only use BYOK RAG sources, ignore the {product-title} documentation RAG
 
 | `conversationCache`
 | `object`
@@ -499,9 +594,25 @@ Required::
 | `string`
 | Log level. Valid options are DEBUG, INFO, WARNING, ERROR and CRITICAL. Default: "INFO".
 
+| `proxyConfig`
+| `object`
+| Proxy settings for connecting to external servers, such as LLM providers.
+
 | `queryFilters`
 | `array`
 | Query filters
+
+| `quotaHandlersConfig`
+| `object`
+| LLM Token Quota Configuration
+
+| `rag`
+| `array`
+| RAG databases
+
+| `storage`
+| `object`
+| Persistent Storage Configuration
 
 | `tlsConfig`
 | `object`
@@ -634,6 +745,14 @@ Type::
 | `dataCollector`
 | `object`
 | Data Collector container settings.
+
+| `database`
+| `object`
+| Database container settings.
+
+| `mcpServer`
+| `object`
+| MCP server container settings.
 
 | `replicas`
 | `integer`
@@ -1127,6 +1246,355 @@ If empty, everything from the claim is made available, otherwise
 only the result of this request.
 
 |===
+== .spec.ols.deployment.database
+Description::
++
+--
+Database container settings.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `nodeSelector`
+| `object (string)`
+| 
+
+| `resources`
+| `object`
+| ResourceRequirements describes the compute resource requirements.
+
+| `tolerations`
+| `array`
+| 
+
+
+|===
+== .spec.ols.deployment.database.resources
+Description::
++
+--
+ResourceRequirements describes the compute resource requirements.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `claims`
+| `array`
+| Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+
+| `limits`
+| `integer-or-string`
+| Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+| `requests`
+| `integer-or-string`
+| Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+|===
+== .spec.ols.deployment.database.resources.claims
+Description::
++
+--
+Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.ols.deployment.database.resources.claims[]
+Description::
++
+--
+ResourceClaim references one entry in PodSpec.ResourceClaims.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.
+
+| `request`
+| `string`
+| Request is the name chosen for a request in the referenced claim.
+If empty, everything from the claim is made available, otherwise
+only the result of this request.
+
+|===
+== .spec.ols.deployment.database.tolerations
+Description::
++
+--
+
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.ols.deployment.database.tolerations[]
+Description::
++
+--
+The pod this Toleration is attached to tolerates any taint that matches
+the triple <key,value,effect> using the matching operator <operator>.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `effect`
+| `string`
+| Effect indicates the taint effect to match. Empty means match all taint effects.
+When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+
+| `key`
+| `string`
+| Key is the taint key that the toleration applies to. Empty means match all taint keys.
+If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+
+| `operator`
+| `string`
+| Operator represents a key's relationship to the value.
+Valid operators are Exists and Equal. Defaults to Equal.
+Exists is equivalent to wildcard for value, so that a pod can
+tolerate all taints of a particular category.
+
+| `tolerationSeconds`
+| `integer`
+| TolerationSeconds represents the period of time the toleration (which must be
+of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+it is not set, which means tolerate the taint forever (do not evict). Zero and
+negative values will be treated as 0 (evict immediately) by the system.
+
+| `value`
+| `string`
+| Value is the taint value the toleration matches to.
+If the operator is Exists, the value should be empty, otherwise just a regular string.
+
+|===
+== .spec.ols.deployment.mcpServer
+Description::
++
+--
+MCP server container settings.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `resources`
+| `object`
+| ResourceRequirements describes the compute resource requirements.
+
+|===
+== .spec.ols.deployment.mcpServer.resources
+Description::
++
+--
+ResourceRequirements describes the compute resource requirements.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `claims`
+| `array`
+| Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+
+| `limits`
+| `integer-or-string`
+| Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+| `requests`
+| `integer-or-string`
+| Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+
+|===
+== .spec.ols.deployment.mcpServer.resources.claims
+Description::
++
+--
+Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.ols.deployment.mcpServer.resources.claims[]
+Description::
++
+--
+ResourceClaim references one entry in PodSpec.ResourceClaims.
+--
+
+Type::
+  `object`
+
+Required::
+  - `name`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.
+
+| `request`
+| `string`
+| Request is the name chosen for a request in the referenced claim.
+If empty, everything from the claim is made available, otherwise
+only the result of this request.
+
+|===
+== .spec.ols.proxyConfig
+Description::
++
+--
+Proxy settings for connecting to external servers, such as LLM providers.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `proxyCACertificate`
+| `object`
+| The configmap holding proxy CA certificate
+
+| `proxyURL`
+| `string`
+| Proxy URL, e.g. https://proxy.example.com:8080
+If not specified, the cluster wide proxy will be used, though env var "https_proxy".
+
+|===
+== .spec.ols.proxyConfig.proxyCACertificate
+Description::
++
+--
+The configmap holding proxy CA certificate
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `name`
+| `string`
+| Name of the referent.
+This field is effectively required, but due to backwards compatibility is
+allowed to be empty. Instances of this type with an empty value here are
+almost certainly wrong.
+More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+
+|===
 == .spec.ols.queryFilters
 Description::
 +
@@ -1168,6 +1636,160 @@ Type::
 | `replaceWith`
 | `string`
 | Replacement for the matched pattern.
+
+|===
+== .spec.ols.quotaHandlersConfig
+Description::
++
+--
+LLM Token Quota Configuration
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `enableTokenHistory`
+| `boolean`
+| Enable token history
+
+| `limitersConfig`
+| `array`
+| Token quota limiters
+
+|===
+== .spec.ols.quotaHandlersConfig.limitersConfig
+Description::
++
+--
+Token quota limiters
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.ols.quotaHandlersConfig.limitersConfig[]
+Description::
++
+--
+LimiterConfig defines settings for a token quota limiter
+--
+
+Type::
+  `object`
+
+Required::
+  - `initialQuota`
+  - `name`
+  - `period`
+  - `quotaIncrease`
+  - `type`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `initialQuota`
+| `integer`
+| Initial value of the token quota
+
+| `name`
+| `string`
+| Name of the limiter
+
+| `period`
+| `string`
+| Period of time the token quota is for
+
+| `quotaIncrease`
+| `integer`
+| Token quota increase step
+
+| `type`
+| `string`
+| Type of the limiter
+
+|===
+== .spec.ols.rag
+Description::
++
+--
+RAG databases
+--
+
+Type::
+  `array`
+
+
+
+
+== .spec.ols.rag[]
+Description::
++
+--
+RAGSpec defines how to retrieve a RAG databases.
+--
+
+Type::
+  `object`
+
+Required::
+  - `image`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `image`
+| `string`
+| The URL of the container image to use as a RAG source
+
+| `indexID`
+| `string`
+| The Index ID of the RAG database
+
+| `indexPath`
+| `string`
+| The path to the RAG database inside of the container image
+
+|===
+== .spec.ols.storage
+Description::
++
+--
+Persistent Storage Configuration
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `class`
+| `string`
+| Storage class of the requested volume
+
+| `size`
+| `integer-or-string`
+| Size of the requested volume
 
 |===
 == .spec.ols.tlsConfig


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-1852
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://98886--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/olsconfigure-api.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
