### PR TITLE
OLS-2078: Create release notes for OLS 1.0.5

### DIFF
--- a/modules/ols-1-0-5-fixed-issues.adoc
+++ b/modules/ols-1-0-5-fixed-issues.adoc
@@ -1,0 +1,11 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-5-fixed-issues_{context}"]
+= Fixed issues
+
+{ols-official} 1.0.5 fixes the following issues:
+
+Before this update, {ols-official} failed to use the GPT-5 model, and {openai} generated an `Error code: 400` error message. With this release, {ols-official} supports the GPT-5 model. https://issues.redhat.com/browse/OLS-2041[OLS-2041]

--- a/modules/ols-1-0-5-release-notes.adoc
+++ b/modules/ols-1-0-5-release-notes.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-5-release-notes_{context}"]
+= {ols-long} version 1.0.5
+
+{ols-official} 1.0.5 is now available on {ocp-product-title} 4.16 and later.
+
+[id="ols-1-0-5-enhancements_{context}"]
+== Enhancements
+
+{ols-official} 1.0.5 provides the following enhancements:
+
+* This release makes {ols-official} 1.0.5 generally available, and is supported on {ocp-product-title} 4.16 and later.
+
+* With this release, you can attach `cron job` logs to the question you submit to {ols-official}, enabling the Service to provide more context-aware troubleshooting, diagnostics, and analysis of automated job outcomes, errors, or irregular behaviors.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -13,12 +13,14 @@ The release notes highlight what is new and what has changed with each {ols-offi
 {ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
 ====
 
+include::modules/ols-1-0-5-release-notes.adoc[leveloffset=+1]
+include::modules/ols-1-0-5-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-4-release-notes.adoc[leveloffset=+1]
-include::modules/ols-1-0-4-fixed-issues.adoc[leveloffset=2]
+include::modules/ols-1-0-4-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-3-release-notes.adoc[leveloffset=+1]
-include::modules/ols-1-0-3-fixed-issues.adoc[leveloffset=2]
+include::modules/ols-1-0-3-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-2-release-notes.adoc[leveloffset=+1]
-include::modules/ols-1-0-2-fixed-issues.adoc[leveloffset=2]
+include::modules/ols-1-0-2-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-1-release-notes.adoc[leveloffset=+1]
 include::modules/ols-1-0-1-known-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2078
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://98888--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-1-0-5-release-notes_ols-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
