### PR TITLE
[OCPBUGS-35508] Add documentation for compressible system reserved feature

### DIFF
--- a/modules/nodes-nodes-resources-configuring-about.adoc
+++ b/modules/nodes-nodes-resources-configuring-about.adoc
@@ -57,6 +57,8 @@ Administrators should treat system daemons similar to pods that have a guarantee
 
 Enforcing `system-reserved` limits can prevent critical system services from receiving CPU and memory resources. As a result, a critical system service can be ended by the out-of-memory killer. The recommendation is to enforce `system-reserved` only if you have profiled the nodes exhaustively to determine precise estimates and you are confident that critical system services can recover if any process in that group is ended by the out-of-memory killer.
 
+Starting with {product-title} 4.19, you can use the `system-reserved-compressible` feature to correctly apply CPU resource allocation to system services. This feature addresses a long-standing issue where the standard `system-reserved` CPU allocation calculations resulted in incorrect CPU shares/weights being applied to the system cgroup slice, ensuring that system services receive the precise CPU allocation specified in your reservations.
+
 [id="allocate-eviction-thresholds_{context}"]
 == Understanding Eviction Thresholds
 

--- a/modules/nodes-nodes-resources-configuring-compressible.adoc
+++ b/modules/nodes-nodes-resources-configuring-compressible.adoc
@@ -1,0 +1,134 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-nodes-resources-configuring.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-nodes-resources-configuring-compressible_{context}"]
+= Configuring compressible resources for system components
+
+{product-title} supports correctly applying CPU resource allocation to system components through compressible resource reservation. This feature addresses a long standing issue where `system-reserved` CPU allocation calculations result in incorrect CPU shares/weights being applied to the system cgroup slice, particularly on systems with large numbers of CPUs.
+
+[IMPORTANT]
+====
+The `system-reserved-compressible` feature is not enabled by default in {product-title}. You must manually configure it using a `KubeletConfig` custom resource (CR). This feature is available starting from {product-title} 4.19.
+====
+
+== Understanding the system-reserved CPU allocation calculation issue
+
+When configuring `system-reserved` resources, the CPU allocation calculations for cgroup shares (cgroups v1) and weights (cgroups v2) do not correctly reflect the specified CPU reservation values. This results in system services not receiving the intended CPU allocation. The problem becomes more pronounced on systems with large numbers of CPUs.
+
+For example, on a node with 128 CPU cores, when specifying `system-reserved=cpu=4` (4 cores):
+
+**Without `system-reserved-compressible` (standard behavior):**
+
+* Kubepods cgroup weight: 4,844 (calculated in two steps for cgroups v2 from `128 - 4 = 124` cores available to kubepods:
+  - First: CPU shares = `(124000 milliCPU * 1024) / 1000 = 126,976`  
+  - Then: CPU weight = `1 + ((126976 - 2) * 9999) / 262142 = 4,844` 
+* System cgroup weight: 100 (default minimum weight)
+* User cgroup weight: 100 (default weight)
+* Total weight: 4,844 + 100 + 100 = 5,044
+* System slice proportion: 100 ÷ 5,044 = 0.01982
+* Effective CPU allocation for system: 0.01982 × 128 = 2.537668517 cores
+* **Result: System services receive only ~2.54 cores instead of the intended 4 cores**
+
+**With `system-reserved-compressible`:**
+
+* Kubepods cgroup weight: 4,844 (same as above)
+* System cgroup weight: 153 (calculated proportionally to reserved amount)
+* User cgroup weight: 100 (default weight)
+* Total weight: 4,844 + 153 + 100 = 5,097
+* System slice proportion: 153 ÷ 5,097 = 0.03002
+* Effective CPU allocation for system: 0.03002 × 128 = 3.842260153 cores
+* **Result: System services receive ~3.84 cores, much closer to the intended 4 cores**
+
+**Why this discrepancy occurs:**
+
+The issue stems from the default minimum cgroup weight of 100 assigned to the system cgroup in standard `system-reserved` configurations. This fixed weight doesn't scale with the actual CPU reservation amount, leading to disproportionate resource allocation, especially on high CPU count systems where the kubepods cgroup receives significantly higher weights.
+
+The `system-reserved-compressible` feature solves this by correctly setting the system cgroup weight proportional to the actual reserved CPU amount (changing from the fixed weight of 100 to 153 for 4 cores reserved), ensuring that the specified CPU reservations are more accurately reflected in the cgroup configuration.
+
+== When to use compressible resource reservation
+
+Consider using `system-reserved-compressible` when:
+
+* You have identified CPU allocation discrepancies when using standard `system-reserved` configurations, especially on nodes with high CPU counts
+* You want to ensure accurate CPU allocation for system services as specified in your resource reservations
+* You need to fix the CPU shares/weights calculation issue that affects the basic `system-reserved` CPU allocation
+* You want to apply only CPU limits without memory restrictions to avoid potential OOM issues with critical services
+* You need precise control over CPU resource allocation between system services and workload pods
+
+
+== Configuring system-reserved compressible resource reservation
+
+To enable the `system-reserved-compressible` feature, you must create a `KubeletConfig` CR that includes the appropriate cgroup settings and `enforceNodeAllocatable` configuration.
+
+.Prerequisites
+
+* Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure.
+
+.Procedure
+
+. Create a `KubeletConfig` CR that enables compressible resource allocation:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: system-reserved-compressible
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+  kubeletConfig:
+    systemReservedCgroup: "/system.slice" <1>
+    enforceNodeAllocatable:
+      - pods
+      - system-reserved-compressible <2>
+    systemReserved: <3>
+      cpu: "4"
+      memory: "8Gi"
+----
+<1> Specifies the cgroup path for system reserved resources.
+<2> Enables the compressible resource allocation feature for system services.
+<3> Defines the CPU and memory resources to reserve. Note that memory limits are still specified but only CPU limits are enforced on the system slice.
+
+. Apply the configuration:
++
+[source,terminal]
+----
+$ oc create -f <config-file-name>.yaml
+----
+
+. Verify the configuration is applied:
++
+[source,terminal]
+----
+$ oc get kubeletconfig
+----
+
+
+== Monitoring and troubleshooting
+
+After enabling `system-reserved-compressible`, monitor your system services:
+
+* Check CPU usage of system services: `systemctl status <service>`
+* Verify system cgroup CPU allocation: `cat /sys/fs/cgroup/cpu/system.slice/cpu.shares` (cgroups v1) or `cat /sys/fs/cgroup/system.slice/cpu.weight` (cgroups v2)
+* Monitor for CPU throttling events in system logs
+* Use `oc adm top nodes` to monitor node resource utilization
+
+If you experience issues:
+
+* Reduce the CPU reservation values if system services are being throttled too aggressively
+* Ensure your `systemReserved` values are appropriate for your workload
+* Monitor pod scheduling and ensure sufficient resources remain for workload pods
+* Consider disabling the feature if memory management becomes problematic
+* Verify that the specified cgroup paths exist and are correctly configured
+
+[role="_additional-resources"]
+== Additional resources
+
+* Creating a KubeletConfig CR to edit kubelet parameters
+* link:https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/[Reserving compute resources for system daemons] (Kubernetes documentation)
+* link:https://github.com/kubernetes/kubernetes/issues/72881[Kubernetes issue about system-reserved behavior]
+* link:https://github.com/kubernetes/kubernetes/pull/125982[Kubernetes pull request introducing compressible resource allocation]

--- a/nodes/nodes/nodes-nodes-resources-configuring.adoc
+++ b/nodes/nodes/nodes-nodes-resources-configuring.adoc
@@ -34,6 +34,8 @@ include::modules/nodes-nodes-resources-configuring-auto.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-resources-configuring-setting.adoc[leveloffset=+1]
 
+include::modules/nodes-nodes-resources-configuring-compressible.adoc[leveloffset=+1]
+
 ////
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
https://issues.redhat.com/browse/OCPBUGS-35508 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
 4.19+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://github.com/kubernetes/kubernetes/issues/72881
https://github.com/kubernetes/kubernetes/pull/125982

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Will be provided after PR is opened and preview build completes


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
 This PR documents the system-reserved-compressible feature that addresses a long standing CPU
  allocation calculation issue in Kubernetes (issue #72881). The feature was introduced in Kubernetes
  PR #125982 and is available in OpenShift 4.19.

  Key changes:
  - Added comprehensive documentation for the system-reserved-compressible feature
  - Included detailed CPU allocation calculations with actual Kubernetes source code references
  - Provided concrete examples showing the calculation discrepancy on high CPU count systems
  - Added configuration examples using KubeletConfig CR
  - Included monitoring and troubleshooting guidance

  The documentation explains how this feature fixes CPU shares/weights calculation issues that become
  pronounced on systems with large numbers of CPUs, using real data from a 128 core system example.

  Files modified:
  - nodes/nodes/nodes-nodes-resources-configuring.adoc (added module inclusion)
  - modules/nodes-nodes-resources-configuring-compressible.adoc (comprehensive feature documentation)
  - modules/nodes-nodes-resources-configuring-about.adoc (added feature reference)


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
