### PR TITLE
add template from main

### DIFF
--- a/.vale/templates/bot-comment-output.tmpl
+++ b/.vale/templates/bot-comment-output.tmpl
@@ -1,0 +1,48 @@
+{{- /* Modify Vale's output https://docs.errata.ai/vale/cli#--output */ -}}
+
+{{- /* Keep track of our various counts */ -}}
+
+{{- $e := 0 -}}
+{{- $w := 0 -}}
+{{- $s := 0 -}}
+
+{{- /* Range over the linted files */ -}}
+[
+{{- range $jdx, $file := .Files -}}
+    {{- $path := .Path -}}
+    {{- /* Range over the file's alerts */ -}}
+    {{- if $jdx -}},{{- end -}}
+    {{- range $idx, $a := .Alerts -}}
+
+        {{- $error := "" -}}
+        {{- if eq .Severity "error" -}}
+            {{- $error = "error" -}}
+            {{- $e = add1 $e  -}}
+        {{- else if eq .Severity "warning" -}}
+            {{- $error = "warning" -}}
+            {{- $w = add1 $w -}}
+        {{- else -}}
+            {{- $error = "suggestion" -}}
+            {{- $s = add1 $s -}}
+        {{- end}}
+
+        {{- /* Variables setup */ -}}
+        {{- $loc := printf "%d" .Line -}}
+        {{- $check := printf "%s" .Check -}}
+        {{- $message := printf "%s" .Message -}}
+        {{- /* Only add a link for RedHat rule errors */ -}}
+        {{- $link := "" -}}
+        {{- if contains "RedHat." .Check -}}
+            {{- $link = printf "For more information, see [%s](https://redhat-documentation.github.io/vale-at-red-hat/docs/main/reference-guide/%s)." .Check (lower (trimPrefix "RedHat." .Check)) -}}
+        {{- end -}}
+        {{- if $idx -}},{{- end -}}
+
+        {{- /* Output */ -}}
+        {
+            "body": "🤖 **[{{ $error }}] {{$check}}**: {{ $message }} {{ $link }}",
+            "path": "{{ $path }}",
+            "line": {{ $loc }}
+        }
+    {{end -}}
+{{end -}}
+]


### PR DESCRIPTION

Version(s): 4.12

Additional information: adds vale prow test [commenting template](https://github.com/openshift/openshift-docs/blob/main/.vale/templates/bot-comment-output.tmpl) to this enterprise branch
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
