### PR TITLE
[enterprise-4.19] OSDOCS#15507: Removing discrete headings from core files specific to …

### DIFF
--- a/networking/network_security/network-policy-apis.adoc
+++ b/networking/network_security/network-policy-apis.adoc
@@ -8,7 +8,6 @@ toc::[]
 
 Network policy is defined using both cluster-scoped and namespace-scoped network policy APIs. By defining network policy across these different levels, you can create sophisticated network security configurations for your clusters, including full multi-tenant isolation.
 
-[discrete]
 == Network policies and their scope
 
 Cluster-scoped network policy:: Cluster and network administrators can use the AdminNetworkPolicy to define network policy at the cluster level. The AdminNetworkPolicy feature consists of two APIs: the `AdminNetworkPolicy` API and `BaselineAdminNetworkPolicy` API. These APIs are used to set rules that can be applied to the entire cluster, or delegated to the namespace-scoped `NetworkPolicy`.
@@ -17,9 +16,8 @@ Policies defined using the `AdminNetworkPolicy` API take precedence over all oth
 +
 Policies defined using the `BaselineAdminNetworkPolicy` API apply only when no other network policy overrides them. When you use the `AdminNetworkPolicy` API to delegate an aspect of network policy to the namespace-scoped `NetworkPolicy`, you should also define a sensible minimum restriction in the `BaselineAdminNetworkPolicy`. This ensures a baseline level of network security at the cluster level in case the `NetworkPolicy` for a namespace does not provide sufficient protection.
 
-Namespace-scoped network policy:: Application developers and namespace tenants can use the `NetworkPolicy` API to define network policy rules for a specific namespace. Rules in the `NetworkPolicy` for a namespace take precedence over cluster-wide rules configured using the BaselineAdminNetworkPolicy API, or for a cluster-wide rule that that has been delegated or "passed" from the cluster-wide `AdminNetworkPolicy` API. 
+Namespace-scoped network policy:: Application developers and namespace tenants can use the `NetworkPolicy` API to define network policy rules for a specific namespace. Rules in the `NetworkPolicy` for a namespace take precedence over cluster-wide rules configured using the BaselineAdminNetworkPolicy API, or for a cluster-wide rule that that has been delegated or "passed" from the cluster-wide `AdminNetworkPolicy` API.
 
-[discrete]
 == How network policy is evaluated and applied
 
 When a network connection is established, the network provider (default: OVN-Kubernetes) checks the connection details against network policy rules to determine how to handle the connection.

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -142,7 +142,7 @@ For more information, see xref:../extensions/ce/managing-ce.adoc#olmv1-deploying
 [id="ocp-4-19-dynamic-accelerator-slicer-operator-tp_{context}"]
 ==== Dynamic Accelerator Slicer Operator (Technology Preview)
 
-With this release, you can use the Dynamic Accelerator Slicer (DAS) Operator to dynamically slice GPU accelerators in {product-title}, instead of relying on statically sliced GPUs defined when the node is booted. This allows you to dynamically slice GPUs based on specific workload demands, ensuring efficient resource utilization. 
+With this release, you can use the Dynamic Accelerator Slicer (DAS) Operator to dynamically slice GPU accelerators in {product-title}, instead of relying on statically sliced GPUs defined when the node is booted. This allows you to dynamically slice GPUs based on specific workload demands, ensuring efficient resource utilization.
 
 For more information, see xref:../hardware_accelerators/das-about-dynamic-accelerator-slicer-operator.adoc#das-about-dynamic-accelerator-slicer-operator[Dynamic Accelerator Slicer (DAS) Operator].
 
@@ -177,7 +177,7 @@ This release introduces support for the following features on {ibm-z-name} and {
 * Support for {ibm-name} z17 and {ibm-linuxone-name} 5
 * Boot volume Linux Unified Key Setup (LUKS) encryption via {ibm-name} Crypto Express (CEX)
 
-[discrete]
+
 [id="ocp-release-notes-ibm-z-power-support-matrix_{context}"]
 === {ibm-power-title}, {ibm-z-title}, and {ibm-linuxone-title} support matrix
 
@@ -1083,7 +1083,7 @@ The *Getting Started* pane in the web console provides resources such as, a tour
 
 The web console now uses Patternfly 6. Support for Patternfly 4 in the web console is no longer available.
 
-[discrete]
+
 This release also introduces the following updates to the web console. You can now do the following actions:
 
 * Specify distinct console logos for both light and dark themes using the `logos` field in the `.spec.customization.logos` configuration, allowing for more comprehensive branding.
@@ -1129,7 +1129,7 @@ In the following tables, features are marked with the following statuses:
 * _Deprecated_
 * _Removed_
 
-[discrete]
+
 [id="ocp-release-note-bare-metal-dep-rem_{context}"]
 === Bare metal monitoring deprecated and removed features
 
@@ -1144,7 +1144,7 @@ In the following tables, features are marked with the following statuses:
 |Removed
 |====
 
-[discrete]
+
 [id="ocp-release-note-images-dep-rem_{context}"]
 === Images deprecated and removed features
 
@@ -1159,7 +1159,7 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |====
 
-[discrete]
+
 [id="ocp-release-note-install-dep-rem_{context}"]
 === Installation deprecated and removed features
 
@@ -1210,7 +1210,7 @@ In the following tables, features are marked with the following statuses:
 |====
 
 // No deprecated or removed features for 3 consecutive releases
-// [discrete]
+//
 // [id="ocp-release-note-monitoring-dep-rem_{context}"]
 // === Monitoring deprecated and removed features
 
@@ -1220,7 +1220,7 @@ In the following tables, features are marked with the following statuses:
 // |Feature |4.17 |4.18 |4.19
 // |====
 
-[discrete]
+
 [id="ocp-release-note-networking-dep-rem_{context}"]
 === Networking deprecated and removed features
 
@@ -1236,7 +1236,7 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[discrete]
+
 [id="ocp-release-note-node-dep-rem_{context}"]
 === Node deprecated and removed features
 
@@ -1266,7 +1266,7 @@ In the following tables, features are marked with the following statuses:
 |Removed
 |====
 
-[discrete]
+
 [id="ocp-release-note-cli-dep-rem_{context}"]
 === OpenShift CLI (oc) deprecated and removed features
 
@@ -1281,7 +1281,7 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |====
 
-[discrete]
+
 [id="ocp-release-note-operators-dep-rem_{context}"]
 === Operator lifecycle and development deprecated and removed features
 
@@ -1329,7 +1329,7 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |====
 
-[discrete]
+
 === Storage deprecated and removed features
 
 .Storage deprecated and removed tracker
@@ -1353,7 +1353,7 @@ In the following tables, features are marked with the following statuses:
 |Removed
 |====
 
-[discrete]
+
 [id="ocp-clusters-dep-rem_{context}"]
 === Updating clusters deprecated and removed features
 
@@ -1363,7 +1363,7 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.17 |4.18 |4.19
 |====
 
-[discrete]
+
 [id="ocp-release-note-web-console-dep-rem_{context}"]
 === Web console deprecated and removed features
 
@@ -1384,7 +1384,7 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[discrete]
+
 [id="ocp-release-note-workloads-dep-rem_{context}"]
 === Workloads deprecated and removed features
 
@@ -1490,9 +1490,9 @@ For more information about the unsupported, community-maintained, version of the
 //Telco Edge / TALO
 //Telco Edge / ZTP
 
-[discrete]
+
 [id="ocp-release-note-api-auth-bug-fixes_{context}"]
-==== API Server and Authentication
+=== API Server and Authentication
 
 * Previously, contents of the `MachineConfig` and `ControllerConfig` resources from group `machineconfiguration.openshift.io` were not excluded from audit logs. With this release, they are excluded from audit logs because they might contain secrets. (link:https://issues.redhat.com/browse/OCPBUGS-55709[OCPBUGS-55709])
 
@@ -1514,9 +1514,9 @@ For more information about the unsupported, community-maintained, version of the
 
 * Previously, the openshift-apiserver could panic when both image and error fields were unset during CRD request handling, this led to runtime crashes and instability in the API server under certain conditions. With this release, a guard is added to ensure no panic occurs by safely handling the case when both fields are unset, resulting in a more robust and stable CRD request handling process without crashes. (link:https://issues.redhat.com/browse/OCPBUGS-45861[OCPBUGS-45861])
 
-[discrete]
+
 [id="ocp-release-note-bare-metal-hardware-bug-fixes_{context}"]
-==== Bare Metal Hardware Provisioning
+=== Bare Metal Hardware Provisioning
 
 * Previously, NetworkManager logs from the Ironic Python Agent (IPA) were not included in the ramdisk logs; instead only `dmesg` logs were included in the ramdisk logs. With this release, the ramdisk logs that exist in the `metal3-ramdisk-logs` container of a metal3 pod now contain the entire journal from the host instead of just `dmesg` logs and IPA. (link:https://issues.redhat.com/browse/OCPBUGS-56042[OCPBUGS-56042])
 
@@ -1530,9 +1530,9 @@ For more information about the unsupported, community-maintained, version of the
 
 * Previously, after deleting a `BaremetalHost` that has a related `DataImage`, the `DataImage` was still present. With this release, the `DataImage` is deleted if it exists after the `BaremetalHost` has been deleted. (link:https://issues.redhat.com/browse/OCPBUGS-51294[OCPBUGS-51294])
 
-[discrete]
+
 [id="ocp-release-note-cloud-compute-bug-fixes_{context}"]
-==== Cloud Compute
+=== Cloud Compute
 
 * When upgrading {gcp-short} clusters that use a boot disk that is not compatible with UEFI, you cannot enable Shielded VM support.
 Previously, this prevented the creation of new compute machines.
@@ -1662,15 +1662,15 @@ With this release, availability sets are no longer modified after creation, allo
 
 * Previously, the `openshift-cnv` namespace components did not feature the `openshift.io/required-scc` annotation. Workloads were not requesting their required security content constraints (SCCs). With this release, the `openshift.io/required-scc` annotation is added to the `openshift-cnv` namespace components so that workloads can request the required SCCs. (link:https://issues.redhat.com/browse/OCPBUGS-49657[OCPBUGS-49657])
 
-[discrete]
+
 [id="ocp-release-note-cloud-cred-operator-bug-fixes_{context}"]
-==== Cloud Credential Operator
+=== Cloud Credential Operator
 
 * Previously, the `aws-sdk-go-v2` software development kit (SDK) failed to authenticate an `AssumeRoleWithWebIdentity` API operation on an {aws-first} {sts-first} cluster. With this release, `pod-identity-webhook` now includes a default region so that this issue no longer persists. (link:https://issues.redhat.com/browse/OCPBUGS-41727[OCPBUGS-41727])
 
-[discrete]
+
 [id="ocp-release-note-cluster-autoscaler-bug-fixes_{context}"]
-==== Cluster Autoscaler
+=== Cluster Autoscaler
 
 * Previously, when a Machine Set was scaled down and had reached its minimum size, the Cluster Autoscaler could leave the last remaining node with a no schedule taint that prevented use of a node. This issues was caused by a counting error in the Cluster Autoscaler. With this release, the counting error has been fixed so that the Cluster Autoscaler works as expected when a Machine Set is scaled down and has reached its minimum size. (link:https://issues.redhat.com/browse/OCPBUGS-54231[OCPBUGS-54231])
 
@@ -1678,9 +1678,9 @@ With this release, availability sets are no longer modified after creation, allo
 
 * Previously the Cluster Autoscaler could stop scaling because of a failed machine in a machine set. This condition occurred because of inaccuracies in the way the Cluster Autoscaler counts machines in various non-running phases. With this release, the inaccuracies have been fixed, so that the Cluster Autoscaler accurately counts machines. (link:https://issues.redhat.com/browse/OCPBUGS-11115[OCPBUGS-11115])
 
-[discrete]
+
 [id="ocp-release-note-cluster-override-admin-operator-bug-fixes_{context}"]
-==== Cluster Resource Override Admission Operator
+=== Cluster Resource Override Admission Operator
 
 * Previously, the Cluster Resource Admission Override Operator failed to delete old secrets during upgrading from {product-title} 4.16 to {product-title} 4.17. This situation caused the Cluster Resource Override Admission Operator webhook to stop working and prevented pods from being created in namespaces that had the Cluster Resource Override Admission Operator enabled. With this release, old secrets are deleted, error handling by the Cluster Resource Override Admission Operator is improved, and the issue with creating pods in namespaces is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-54886[OCPBUGS-54886])
 
@@ -1688,9 +1688,9 @@ With this release, availability sets are no longer modified after creation, allo
 
 * Previously, if you specified a `forceSelinuxRelabel` parameter in a `ClusterResourceOverride` CR and then changed the parameter to another value, the changed value would not be reflected in the `clusterresourceoverride-configuration` Config Map. This Config Map is required for applying the selinux relabelling workaround feature to your cluster. With this release, this issue is fixed so that when the `forceSelinuxRelabel` parameter is changed, the `clusterresourceoverride-configuration` Config Map received the update. (link:https://issues.redhat.com/browse/OCPBUGS-44649[OCPBUGS-44649])
 
-[discrete]
+
 [id="ocp-release-note-cluster-version-operator-bug-fixes_{context}"]
-==== Cluster Version Operator
+=== Cluster Version Operator
 
 * Previously, the status of the `ClusterVersion` condition could  changed from `ImplicitlyEnabled` to `ImplicitlyEnabledCapabilities`. With this release, the `ClusterVersion` condition type has been fixed and changed from `ImplicitlyEnabled` to `ImplicitlyEnabledCapabilities`. (link:https://issues.redhat.com/browse/OCPBUGS-56771[OCPBUGS-56771])
 
@@ -1698,15 +1698,15 @@ With this release, availability sets are no longer modified after creation, allo
 
 * Previously, when a Cluster Operator takes a long time to upgrade, Cluster Version Operator does not report anything as it cannot determine if the upgrade is still progressing or already stuck. With this release, a new unknown status is added for the failing condition in status of the Cluster Version reported by Cluster Version Operator to remind the cluster administrators to check the cluster and avoid waiting on a blocked Cluster Operator upgrade. (link:https://issues.redhat.com/browse/OCPBUGS-23514[OCPBUGS-23514])
 
-[discrete]
+
 [id="ocp-release-note-image-streams-bug-fixes_{context}"]
-==== ImageStreams
+=== ImageStreams
 
 * Previously, image import blocked registries that would fail if those registries were configured with `NeverContactSource`, even when mirror registries were set up. With this update, image importing is no longer blocked when a registry has mirrors configured. This ensures that image imports succeed even if the original source was set to `NeverContactSource` in the `ImageDigestMirrorSet` or `ImageTagMirrorSet` resources. (link:https://issues.redhat.com/browse/OCPBUGS-44432[OCPBUGS-44432])
 
-[discrete]
+
 [id="ocp-release-note-installer-bug-fixes_{context}"]
-==== Installer
+=== Installer
 
 * Previously, if you attempted to install an {aws-first} cluster with minimum privileges and you did not specify an instance type in the `install-config.yaml` file, installation of the cluster failed. This issue happened because the installation program could not find supported instance types that the cluster could use in supported availability zones. For example, the `m6i.xlarge` default instance type was unavailable in `ap-southeast-4` and `eu-south-2` availability zones. With this release, the `openshift-install` program now requires the `ec2:DescribeInstanceTypeOfferings` {aws-short} permission to prevent the installation of the cluster from failing in situations where `m6i.xlarge` or another supported instance type is unavailable in a supported availability zone. (link:https://issues.redhat.com/browse/OCPBUGS-46596[OCPBUGS-46596])
 
@@ -1796,9 +1796,9 @@ With this release, availability sets are no longer modified after creation, allo
 
 * Previously, the temporary directory that was created when the `openshift-install agent create pxe-files` command was run was not removed after the command completed. With this release, the temporary directory is now removed properly after the command completes. (link:https://issues.redhat.com/browse/OCPBUGS-39583[OCPBUGS-39583])
 
-[discrete]
+
 [id="ocp-release-note-machine-config-operator-bug-fixes_{context}"]
-==== Machine Config Operator
+=== Machine Config Operator
 
 * Previously, the `ContainerRuntimeConfig` incorrectly set the `--root` path for the `runc` runtime. This caused containers to run with an incorrect root path and led to issues with the container operations. With this release, the `--root` path for container runtime is correct and matches the specified runtime, providing consistent operation. (link:https://issues.redhat.com/browse/OCPBUGS-47629[OCPBUGS-47629])
 
@@ -1808,9 +1808,9 @@ With this release, availability sets are no longer modified after creation, allo
 
 * Previously, after deleting a `MachineOSConfig` object, the associated `MachineOSBuild` object was not deleted as expected. This was because the ownership of the `MachineOSBuild` object was not set. With this release, all of the objects are created for the build and all associated objects are deleted when the `MachineOSConfig` object is deleted. (link:https://issues.redhat.com/browse/OCPBUGS-44602[OCPBUGS-44602])
 
-[discrete]
+
 [id="ocp-release-note-management-console-bug-fixes_{context}"]
-==== Management Console
+=== Management Console
 
 * Previously, the *Projects details* in the *Developer Perspective* erroneously did not include breadcrumbs. With this release, the breadcrumbs have been added. (link:https://issues.redhat.com/browse/OCPBUGS-52298[OCPBUGS-52298])
 
@@ -1862,15 +1862,15 @@ With this release, availability sets are no longer modified after creation, allo
 
 * Previously, `PackageManifest` by name only was selected on the *Operator installation* status page. In some cases, this caused the incorrect `PackageManifest` to be used for displaying the logo and provider since there can be name collisions. With this release, `PackageManifests` are selected by name and label selector to make sure the correct one is selected for the current installation. As a result, the correct logo and provider are always shown on the operator install status page. (link:https://issues.redhat.com/browse/OCPBUGS-21755[OCPBUGS-21755])
 
-[discrete]
+
 [id="ocp-release-note-monitoring-bug-fixes_{context}"]
-==== Monitoring
+=== Monitoring
 
 * Previously, if a scrape failed, Prometheus erroneously considered the samples from the very next scrape as duplicates and dropped them. This issue affected only the scrape immediately following a failure, while subsequent scrapes were processed correctly. With this release, the scrape following a failure is now correctly handled, ensuring that no valid samples are mistakenly dropped. (link:https://issues.redhat.com/browse/OCPBUGS-53025[OCPBUGS-53025])
 
-[discrete]
+
 [id="ocp-release-note-networking-bug-fixes_{context}"]
-==== Networking
+=== Networking
 
 * Previously, when a pod used the CNI plugin for DHCP address assignment, in conjunction with other CNI plugins, the network interface of the pod might have been unexpectedly deleted. As a consequence, when the DHCP lease expired for the pod, the DHCP proxy entered a loop when trying to re-create a new lease, leading to the node becoming unresponsive. With this release, the DHCP lease maintenance terminates if the network interface does not exist. As a result, interface deletions are handled gracefully, ensuring node stability. (link:https://issues.redhat.com/browse/OCPBUGS-45272[OCPBUGS-45272])
 
@@ -1933,9 +1933,9 @@ Warning ErrorAllocatingPod 4s (x7 over 79s)  ovnk-controlplane  failed to update
 +
 (link:https://issues.redhat.com/browse/OCPBUGS-54245[OCPBUGS-54245])
 
-[discrete]
+
 [id="ocp-release-note-node-bug-fixes_{context}"]
-==== Node
+=== Node
 
 * Previously, if your cluster used Zscaler and scanned all transfers, it could experience a timeout when pulling images. This problem was due to a hard-coded timeout value for image pulls. The pull progress timeout of CRI-O is now increased to 30 seconds. As a result, previously affected clusters should not experience timeouts. (link:https://issues.redhat.com/browse/OCPBUGS-54662[OCPBUGS-54662])
 
@@ -1949,15 +1949,15 @@ Warning ErrorAllocatingPod 4s (x7 over 79s)  ovnk-controlplane  failed to update
 
 * Previously, CPUs for the last guaranteed pod admitted to a node remained allocated after the pod was deleted. This behavior caused scheduling domain inconsistencies. With this release, CPUs that are allocated to guaranteed pods return to the pool of available CPU resources as expected, ensuring correct CPU scheduling for subsequent pods. (link:https://issues.redhat.com/browse/OCPBUGS-17792[OCPBUGS-17792])
 
-[discrete]
+
 [id="ocp-release-note-node-tuning-operator-bug-fixes_{context}"]
-==== Node Tuning Operator (NTO)
+=== Node Tuning Operator (NTO)
 
 * Previously, when applying a performance profile to a node, {product-title} selected the appropriate profile based on the vendor identifier of the CPU unit on the node. Because of this, if a CPU uses a different vendor identifier that is not recognized, {product-title} failed to include the proper profile. For example the identifier might include APM, rather than ARM. With this fix, for CPUs that use the ARM architecture, the Operator now selects a profile based only on the architecture, and not the vendor identifier. As a result, the correct profile is applied. (link:https://issues.redhat.com/browse/OCPBUGS-52352[OCPBUGS-52352])
 
-[discrete]
+
 [id="ocp-release-note-observability-bug-fixes_{context}"]
-==== Observability
+=== Observability
 
 * Previously, the *Silence details* page had an incorrect link URL that was missing the `namespace` parameter, which caused users to be unable to silence specific alerts in the dev console for certain versions. This resulted in poor alert management. With this release, the undefined link in `SilencedAlertsList` has been fixed using the active namespace. As a result, the 'No Alert found' error is now resolved, and the *Alert details* page in {product-title} Monitoring is navigated to correctly. (link:https://issues.redhat.com/browse/OCPBUGS-48142[OCPBUGS-48142])
 
@@ -1971,9 +1971,9 @@ Warning ErrorAllocatingPod 4s (x7 over 79s)  ovnk-controlplane  failed to update
 
 * Previously, bounds were based on the first bar in a bar chart. If a bar was larger in size than the first bar, the bar would extend beyond the bar chart boundary. With this release, the bound for a bar chart is based on the largest bar, so no bars extend outside the boundary of a bar chart. (link:https://issues.redhat.com/browse/OCPBUGS-45174[OCPBUGS-45174])
 
-[discrete]
+
 [id="ocp-release-note-oc-mirror-bug-fixes_{context}"]
-==== oc-mirror
+=== oc-mirror
 
 * Previously, oc-mirror plugin v2 did not display any progress output during the local cache population phase. For mirror configurations involving a large number of images, this could make the process appear unresponsive or stuck.
 With this update, a progress bar has been added to provide the cache population status, enabling the user to see the current progress of the cache population. (link:https://issues.redhat.com/browse/OCPBUGS-56563[OCPBUGS-56563])
@@ -2003,9 +2003,9 @@ With this update, oc-mirror plugin v2 supports Helm charts that reference images
 
 * Previously, when mirroring using an internal oc-mirror reserved keyword—such as `release-images`—in the destination or `--from` path flags, the operation could fail or behave unexpectedly. With this release, oc-mirror plugin v2 correctly handles reserved keywords used in destination or source paths. (link:https://issues.redhat.com/browse/OCPBUGS-42862[OCPBUGS-42862])
 
-[discrete]
+
 [id="ocp-release-note-oc-cli-bug-fixes_{context}"]
-==== OpenShift CLI (oc)
+=== OpenShift CLI (oc)
 
 * Previously, if you tried to add a node to a disconnected environment using the `oc adm node-image` command, private registry images were inaccessible to the command, causing node addition failure. This error only occurred if the cluster was initially installed with an installer binary downloaded from (link:https://mirror.openshift.com/pub/[mirror.openshift.com]). With this release, a fix has been implemented that enables successful image pull and node creation in disconnected environments. (link:https://issues.redhat.com/browse/OCPBUGS-53106[OCPBUGS-53106])
 
@@ -2015,9 +2015,9 @@ With this update, oc-mirror plugin v2 supports Helm charts that reference images
 
 * Previously, the `oc adm node-image create --pxe generated` command did not create only the Preboot Execution Environment (PXE) artifacts. Instead, the command created the PXE artifacts with other artifacts from a `node-joiner` pod and stored them all in the wrong subdirectory. Additionally, the PXE artifacts were incorrectly prefixed with `agent` instead of `node`. With this release, generated PXE artifacts are stored in the correct directory and receive the correct prefix. (link:https://issues.redhat.com/browse/OCPBUGS-45311[OCPBUGS-45311])
 
-[discrete]
+
 [id="ocp-release-note-olm-bug-fixes_{context}"]
-==== Operator Lifecycle Manager (OLM)
+=== Operator Lifecycle Manager (OLM)
 
 * Previously, if an Operator did not have the required `olm.managed=true` label, the Operator might fail and enter a `CrashLoopBackOff` state. When this happened, the logs did not report the status as an error. As a result, the failure was difficult to diagnose. With this update, this type of failure is reported as an error. (link:https://issues.redhat.com/browse/OCPBUGS-56034[OCPBUGS-56034])
 
@@ -2031,9 +2031,9 @@ With this update, oc-mirror plugin v2 supports Helm charts that reference images
 
 * Previously, {olmv1} did not apply all of the metadata provided by cluster extension authors in Operator bundles. As a result, {olmv1} did not apply properties, such as update constraints, that were specified in the `metadata/properties.yaml` file. This update fixes the issue. (link:https://issues.redhat.com/browse/OCPBUGS-44808[OCPBUGS-44808])
 
-[discrete]
+
 [id="ocp-release-note-operator-controller-manager-bug-fixes_{context}"]
-==== Operator Controller Manager
+=== Operator Controller Manager
 
 * Previously, the `HTTP_PROXY`, `http_proxy`, `HTTPS_PROXY`, `https_proxy`, `NO_PROXY`, and `no_proxy` variables were set on build containers regardless of default proxy settings. With this release, the variables are only added if they are defined in defaults and are not null. (link:https://issues.redhat.com/browse/OCPBUGS-55642[OCPBUGS-55642])
 
@@ -2047,9 +2047,9 @@ With this update, oc-mirror plugin v2 supports Helm charts that reference images
 
 * Previously, {olmv0} took a snapshot of the catalog source for every installed Operator when it reconciled a subscription. This behavior resulted in high CPU usage. With this update, {olmv0} caches catalog sources and limits calls to the gRPC Remote Procedure Calls (gRPC) server to resolve the issue. (link:https://issues.redhat.com/browse/OCPBUGS-48468[OCPBUGS-48468])
 
-[discrete]
+
 [id="ocp-release-note-pao-bug-fixes_{context}"]
-==== Performance Addon Operator
+=== Performance Addon Operator
 
 * Previously, if you specified a long string of isolated CPUs in a performance profile, such as `0,1,2,...,512`, the `tuned`, Machine Config Operator and `rpm-ostree` components failed to process the string as expected. As a consequence, after you applied the performance profile, the expected kernel arguments were missing. The system failed silently with no reported errors. With this release, the string for isolated CPUs in a performance profile is converted to sequential ranges, such as `0-512`. As a result, the kernel arguments are applied as expected in most scenarios. (link:https://issues.redhat.com/browse/OCPBUGS-45264[OCPBUGS-45264])
 +
@@ -2062,9 +2062,9 @@ The issue might still occur with some combinations of input for isolated CPUs in
 +
 With this release, PPC no longer fails to create the performance profile because PPC can now build a performance profile for a cluster that has compute nodes that each have different core ID numbering for their logical processors. The PPC now outputs a warning message that indicates to use the generated performance profile with caution, because different core ID numbering might impact system optimization and isolated management of tasks. (link:https://issues.redhat.com/browse/OCPBUGS-44372[OCPBUGS-44372])
 
-[discrete]
+
 [id="ocp-release-note-samples-operator-bug-fixes_{context}"]
-==== Samples Operator
+=== Samples Operator
 
 * Previously, the Samples Operator updated the `lastTransitionTime` spec in the `Progressing` condition even when the condition did not change. This made the Operator show as less stable than it was. With this release, the `lastTransitionTime` spec updates only when the `Progressing` condition changes. (link:https://issues.redhat.com/browse/OCPBUGS-54591[OCPBUGS-54591])
 
@@ -2072,9 +2072,9 @@ With this release, PPC no longer fails to create the performance profile because
 
 * Previously, the Samples Operator established a watch for all cluster Operators, which caused the sync loop of the Samples Operator to run when any Operator changed. With this release, the Samples Operator watches only the Operators that it needs to monitor. (link:https://issues.redhat.com/browse/OCPBUGS-54589[OCPBUGS-54589])
 
-[discrete]
+
 [id="ocp-release-note-storage-bug-fixes_{context}"]
-==== Storage
+=== Storage
 
 * Previously, using the `oc adm top pvc` command would not show usage statistics for persistent volume claims (PVCs) for clusters with restricted network configurations, such as clusters with a proxy or clusters in a disconnected environment. With this release, usage statistics can be acquired for clusters in these environments. (link:https://issues.redhat.com/browse/OCPBUGS-54168[OCPBUGS-54168])
 
@@ -2100,9 +2100,9 @@ With this release, PPC no longer fails to create the performance profile because
 
 * Previously, the VMWare vSphere CSI driver Operator would panic if the vCenter address was incorrect. With this release, the issue has been resolved. (link:https://issues.redhat.com/browse/OCPBUGS-43273[OCPBUGS-43273])
 
-[discrete]
+
 [id="ocp-release-note-rhcos-bug-fixes_{context}"]
-==== {op-system-first}
+=== {op-system-first}
 
 * Previously, the `GRUB` bootloader was not automatically updated on {op-system} nodes. As a result, when nodes were created on {op-system-base} 8 and were subsequently updated to {op-system-base}, `GRUB` could not load the kernel as it uses a format that is not supported by older `GRUB` versions. With this release, a `GRUB` bootloader update is forced on nodes during updates to {product-title} 4.18 so that the issue does not occur on {product-title} {product-version}. (link:https://issues.redhat.com/browse/OCPBUGS-55144[OCPBUGS-55144])
 
@@ -2122,7 +2122,7 @@ In the following tables, features are marked with the following statuses:
 * _Removed_
 
 
-[discrete]
+
 [id="ocp-release-notes-auth-tech-preview_{context}"]
 === Authentication and authorization Technology Preview features
 
@@ -2143,7 +2143,7 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[discrete]
+
 [id="ocp-release-notesedge-computing-tp-features_{context}"]
 === Edge computing Technology Preview features
 
@@ -2168,7 +2168,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |====
 
-[discrete]
+
 [id="ocp-release-notes-extensions-tech-preview_{context}"]
 === Extensions Technology Preview features
 
@@ -2200,7 +2200,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |====
 
-[discrete]
+
 [id="ocp-release-notes-installing-tech-preview_{context}"]
 === Installation Technology Preview features
 
@@ -2271,7 +2271,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |====
 
-[discrete]
+
 [id="ocp-release-notes-mco-tech-preview_{context}"]
 === Machine Config Operator Technology Preview features
 
@@ -2292,7 +2292,7 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[discrete]
+
 [id="ocp-release-notes-machine-management-tech-preview_{context}"]
 === Machine management Technology Preview features
 
@@ -2347,7 +2347,7 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |====
 
-[discrete]
+
 [id="ocp-release-notes-monitoring-tech-preview_{context}"]
 === Monitoring Technology Preview features
 
@@ -2363,7 +2363,7 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[discrete]
+
 [id="ocp-release-notes-multi-arch-tech-preview_{context}"]
 === Multi-Architecture Technology Preview features
 
@@ -2393,7 +2393,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |====
 
-[discrete]
+
 [id="ocp-release-notes-networking-tech-preview_{context}"]
 === Networking Technology Preview features
 
@@ -2508,7 +2508,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |====
 
-[discrete]
+
 [id="ocp-release-notes-nodes-tech-preview_{context}"]
 === Node Technology Preview features
 
@@ -2529,7 +2529,7 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
-[discrete]
+
 [id="ocp-release-notes-oc-cli-tech-preview_{context}"]
 === OpenShift CLI (oc) Technology Preview features
 
@@ -2554,7 +2554,7 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |====
 
-[discrete]
+
 [id="ocp-release-notes-operator-lifecycle-tech-preview_{context}"]
 === Operator lifecycle and development Technology Preview features
 
@@ -2581,7 +2581,7 @@ In the following tables, features are marked with the following statuses:
 |Removed
 |====
 
-[discrete]
+
 [id="ocp-release-notes-rhcos-tech-preview_{context}"]
 === {rh-openstack-first} Technology Preview features
 
@@ -2606,7 +2606,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |====
 
-[discrete]
+
 [id="ocp-release-notes-scalability-tech-preview_{context}"]
 === Scalability and performance Technology Preview features
 
@@ -2656,7 +2656,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |====
 
-[discrete]
+
 [id="ocp-release-notes-storage-tech-preview_{context}"]
 === Storage Technology Preview features
 
@@ -2751,7 +2751,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |====
 
-[discrete]
+
 [id="ocp-release-notes-web-console-tech-preview_{context}"]
 === Web console Technology Preview features
 


### PR DESCRIPTION
…enterprise-4.19

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-15507

Link to docs preview:
https://98913--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/network_security/network-policy-apis.html
https://98913--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/network-policy-apis.html
https://98913--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html
https://98913--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/network_security/network-policy-apis.html
https://98913--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/network_security/network-policy-apis.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
