### PR TITLE
[enterprise-4.17]OSDOCS#13845: CP from v4.19 of Add information for encrypt etcd disk

### DIFF
--- a/microshift_install_get_ready/microshift-install-get-ready.adoc
+++ b/microshift_install_get_ready/microshift-install-get-ready.adoc
@@ -20,6 +20,12 @@ include::modules/microshift-install-rhel-tools-concepts.adoc[leveloffset=+1]
 
 include::modules/microshift-install-rhde-steps.adoc[leveloffset=+1]
 
+include::modules/microshift-encrypt-etcd-data.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_storage_devices/encrypting-block-devices-using-luks_managing-storage-devices#luks-disk-encryption_encrypting-block-devices-using-luks[LUKS disk encryption]
+
 [id="additional-resources_microshift-install-get-ready_{context}"]
 [role="_additional-resources"]
 == Additional resources

--- a/modules/microshift-encrypt-etcd-data.adoc
+++ b/modules/microshift-encrypt-etcd-data.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assembly:
+//
+// * microshift_install_get_ready/microshift-install-get-ready.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-encrypt-etcd-data_{context}"]
+= Encrypt etcd data
+
+Kubernetes objects are stored in an etcd database and might contain sensitive data. The etcd data is not encrypted by default. You can encrypt the disk that contains the etcd database by using the Linux Unified Key Setup-on-disk-format (LUKS) management tool for block device encryption.


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-13845](https://issues.redhat.com//browse/OSDOCS-13845)

Link to docs preview:
[Encrypt etcd data](https://98922--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready.html#microshift-encrypt-etcd-data_microshift-install-get-ready)

QE review:
- [ ] QE has approved this change.
N/A for CP to 4.17

Additional information:
Cherry Picked from a4ac0629d5a5da637d0659a586bb27b299e6c257  [Original PR](https://github.com/openshift/openshift-docs/pull/97979/commits)


