### PR TITLE
OLS-2084: Update YAML example for MCP server

### DIFF
--- a/modules/ols-enabling-custom-mcp-server.adoc
+++ b/modules/ols-enabling-custom-mcp-server.adoc
@@ -16,7 +16,7 @@ include::snippets/technology-preview.adoc[]
 
 * You have configured a large language model provider.
 
-* You have deployed the {ols-long} service.
+* You have configured the `OLSConfig` CR file, which automatically deploys the {ols-long} Service.
 
 .Procedure
 
@@ -27,7 +27,7 @@ include::snippets/technology-preview.adoc[]
 $ oc edit olsconfig cluster
 ----
 
-. Add `MCPServer` to the `spec.ols.featureGates` specification file and include the MCP server information.
+. Add `MCPServer` to the `spec.featureGates` specification file and include the MCP server information.
 +
 [source,yaml]
 ----
@@ -36,7 +36,7 @@ kind: OLSConfig
 metadata:
   name: cluster
 spec:
-  featureGate:
+  featureGates:
     - MCPServer <1>
   mcpServers:
     - name: mcp-server-1 <2>


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2084

Link to docs preview:
https://98934--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-enabling-mcp-server_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
