### PR TITLE
OSDOCS-11537:Migrate Architecture book to HCP.

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -40,8 +40,6 @@ Topics:
   File: about-hcp
 - Name: AWS STS and ROSA explained
   File: cloud-experts-rosa-hcp-sts-explained
-- Name: Architecture models
-  File: rosa-architecture-models
 - Name: Policies and service definition
   Dir: rosa_policy_service_definition
   Distros: openshift-rosa-hcp
@@ -145,6 +143,25 @@ Topics:
 #  File: cloud-experts-dynamic-certificate-custom-domain
 - Name: Assigning consistent egress IP for external traffic
   File: cloud-experts-consistent-egress-ip
+---
+Name: Architecture
+Dir: architecture
+Distros: openshift-rosa-hcp
+Topics:
+- Name: Architecture overview
+  File: index
+- Name: Product architecture
+  File: architecture
+- Name: Architecture models
+  File: rosa-architecture-models
+- Name: Control plane architecture
+  File: control-plane
+- Name: NVIDIA GPU architecture overview
+  File: nvidia-gpu-architecture-overview
+- Name: Understanding OpenShift development
+  File: understanding-development
+- Name: Admission plugins
+  File: admission-plug-ins
 ---
 Name: Prepare your environment
 Dir: rosa_planning

--- a/architecture/admission-plug-ins.adoc
+++ b/architecture/admission-plug-ins.adoc
@@ -27,10 +27,10 @@ endif::openshift-rosa,openshift-dedicated[]
 [id="admission-plug-ins-additional-resources"]
 == Additional resources
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc#configuring-sriov-operator_configuring-sriov-operator[Configuring the SR-IOV Network Operator]
 
 * xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations_dedicating_nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 * xref:../nodes/pods/nodes-pods-priority.adoc#admin-guide-priority-preemption-names_nodes-pods-priority[Pod priority names]

--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -8,37 +8,36 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 The _control plane_, which is composed of control plane machines, manages the {product-title} cluster.
+ifdef::openshift-rosa-hcp[]
+In {product-title}, the control plane is hosted and managed in a Red{nbsp}Hat owned AWS account. Control planes are dedicated and isolated per cluster and are always highly available.
+endif::openshift-rosa-hcp[]
 The control plane machines manage workloads on the compute machines, which are also known as worker machines.
 The cluster itself manages all upgrades to the machines by the actions of the Cluster Version Operator (CVO),
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 the Machine Config Operator,
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 and a set of individual Operators.
 
-ifdef::openshift-rosa[]
-:FeatureName: This control plane architecture
-include::snippets/rosa-classic-support.adoc[]
-endif::openshift-rosa[]
-
 // This module does not apply to OSD/ROSA
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/architecture-machine-config-pools.adoc[leveloffset=+1]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../machine_configuration/index.adoc#machine-config-drift-detection_machine-config-overview[Understanding configuration drift detection]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/architecture-machine-roles.adoc[leveloffset=+1]
 
 // This additional resource does not apply to OSD/ROSA
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../hosted_control_planes/index.adoc#hcp-overview[{hcp-capital} overview]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+
 
 include::modules/operators-overview.adoc[leveloffset=+1]
 
@@ -49,9 +48,9 @@ include::modules/arch-cluster-operators.adoc[leveloffset=+2]
 .Additional resources
 * xref:../operators/operator-reference.adoc#operator-reference[Cluster Operators reference]
 endif::[]
-
+ifndef::openshift-rosa-hcp[]
 include::modules/arch-olm-operators.adoc[leveloffset=+2]
-
+endif::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager (OLM) concepts and resources]
@@ -66,9 +65,9 @@ include::modules/cpmso-control-plane-recovery.adoc[leveloffset=+1]
 endif::openshift-dedicated,openshift-rosa[]
 
 // These xrefs do not apply to OSD/ROSA
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../etcd/etcd-practices.adoc#recommended-etcd-practices[Recommended etcd practices]
 * xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd[Backing up etcd]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/architecture/index.adoc
+++ b/architecture/index.adoc
@@ -2,9 +2,9 @@
 [id="architecture-overview"]
 = Architecture overview
 include::_attributes/common-attributes.adoc[]
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 :context: architecture-overview
 
 toc::[]

--- a/architecture/index.adoc
+++ b/architecture/index.adoc
@@ -19,22 +19,22 @@ include::modules/openshift-architecture-common-terms.adoc[leveloffset=+1]
 .Additional resources
 
 // Topic not included in the OSD/ROSA docs
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * For more information on networking, see xref:../networking/networking_overview/understanding-networking.adoc#understanding-networking[{product-title} networking].
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * For more information on storage, see xref:../storage/index.adoc#index[{product-title} storage].
 * For more information on authentication, see xref:../authentication/index.adoc#index[{product-title} authentication].
 * For more information on Operator Lifecycle Manager (OLM), see xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[OLM].
 // Topic not included in the OSD/ROSA docs
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * For more information on over-the-air (OTA) updates, see xref:../updating/understanding_updates/intro-to-updates.adoc#understanding-openshift-updates[Introduction to OpenShift updates].
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 include::modules/sd-vs-ocp.adoc[leveloffset=+1]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [id="about-installation-and-updates"]
 == About installation and updates
 
@@ -42,7 +42,7 @@ As a cluster administrator, you can use the {product-title} xref:../architecture
 
 * Installer-provisioned infrastructure
 * User-provisioned infrastructure
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 [id="about-control-planes"]
 == About the control plane
@@ -51,7 +51,7 @@ The xref:../architecture/control-plane.adoc#control-plane[control plane] manages
 MCPs are groups of machines, such as control plane components or user workloads, that are based on the resources that they handle.
 {product-title} assigns different roles to hosts. These roles define the function of a machine in a cluster.
 The cluster contains definitions for the standard control plane and worker role types.
-
+ifndef::openshift-rosa-hcp[]
 You can use Operators to package, deploy, and manage services on the control plane.
 Operators are important components in {product-title} because they provide the following services:
 
@@ -59,13 +59,13 @@ Operators are important components in {product-title} because they provide the f
 * Provide ways to watch applications
 * Manage over-the-air updates
 * Ensure applications stay in the specified state
-
-ifndef::openshift-dedicated,openshift-rosa[]
+endif::openshift-rosa-hcp[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../hosted_control_planes/index.adoc#hcp-overview[{hcp-capital} overview]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 [id="about-containerized-applications-for-developers"]
 == About containerized applications for developers
@@ -81,7 +81,7 @@ Kubernetes works on basic units called pods. A pod is a single instance of a run
 You can create a service by grouping a set of pods and their access policies.
 Services provide permanent internal IP addresses and host names for other applications to use as pods are created and destroyed. Kubernetes defines workloads based on the type of your application.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [id="coreos-and-ignition"]
 == About {op-system-first} and Ignition
 
@@ -98,7 +98,7 @@ The {product-title} installation program creates the Ignition configuration file
 During the first boot, Ignition reads its configuration from the installation media or the location that you specify and applies the configuration to the machines.
 
 You can learn how xref:../architecture/architecture-rhcos.adoc#architecture-rhcos[Ignition works], the process for a {op-system-first} machine in an {product-title} cluster, view Ignition configuration files, and change Ignition configuration after an installation.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 [id="about-admission-plug-ins"]
 == About admission plugins

--- a/architecture/nvidia-gpu-architecture-overview.adoc
+++ b/architecture/nvidia-gpu-architecture-overview.adoc
@@ -99,6 +99,6 @@ include::modules/nvidia-gpu-features.adoc[leveloffset=+1]
 * link:https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/time-slicing-gpus-in-openshift.html[Time-slicing NVIDIA GPUs in OpenShift]
 * link:https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/mirror-gpu-ocp-disconnected.html[Deploy GPU Operators in a disconnected or airgapped environment]
 // Topic not available in OSD/ROSA
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../hardware_enablement/psap-node-feature-discovery-operator.html[Node Feature Discovery Operator]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/architecture/rosa-architecture-models.adoc
+++ b/architecture/rosa-architecture-models.adoc
@@ -23,14 +23,14 @@ endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa-hcp[]
 include::modules/rosa-hcp-architecture.adoc[leveloffset=+1]
 endif::openshift-rosa-hcp[]
-
 ifdef::openshift-rosa[]
 include::modules/rosa-architecture.adoc[leveloffset=+1]
 endif::openshift-rosa[]
 
 include::modules/osd-aws-privatelink-architecture.adoc[leveloffset=+2]
 include::modules/rosa-architecture-local-zones.adoc[leveloffset=+2]
-
+ifdef::openshift-rosa[]
 .Additional resources
 
 * xref:../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.html[Configuring machine pools in Local Zones]
+endif::openshift-rosa[]

--- a/hardware_accelerators/nvidia-gpu-architecture.adoc
+++ b/hardware_accelerators/nvidia-gpu-architecture.adoc
@@ -98,6 +98,6 @@ include::modules/nvidia-gpu-features.adoc[leveloffset=+1]
 * link:https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/time-slicing-gpus-in-openshift.html[Time-slicing NVIDIA GPUs in OpenShift]
 * link:https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/mirror-gpu-ocp-disconnected.html[Deploy GPU Operators in a disconnected or airgapped environment]
 // Topic not available in OSD/ROSA
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../hardware_enablement/psap-node-feature-discovery-operator.html[Node Feature Discovery Operator]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/arch-olm-operators.adoc
+++ b/modules/arch-olm-operators.adoc
@@ -17,20 +17,20 @@ endif::openshift-dedicated,openshift-rosa[]
 and authorized users can select Operators to install from catalogs of Operators. After installing an Operator from OperatorHub, it can be made available globally or in specific namespaces to run in user applications.
 
 Default catalog sources are available that include Red Hat Operators, certified Operators, and community Operators.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Cluster administrators
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Administrators with the `dedicated-admin` role
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 can also add their own custom catalog sources, which can contain a custom set of Operators.
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 All Operators listed in the Operator Hub marketplace should be available for installation. These Operators are considered customer workloads, and are not monitored by Red Hat Site Reliability Engineering (SRE).
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 [NOTE]
 ====

--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -7,14 +7,14 @@
 
 {product-title} assigns hosts different roles. These roles define the function of the machine within the cluster. The cluster contains definitions for the standard `master` and `worker` role types.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 The cluster also contains the definition for the `bootstrap` role. Because the bootstrap machine is used only during cluster installation, its function is explained in the cluster installation documentation.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 == Control plane and node host compatibility
 
 The {product-title} version must match between control plane host and node host. For example, in a {product-version} cluster, all control plane hosts must be {product-version} and all nodes must be {product-version}.
@@ -40,7 +40,7 @@ The `kubelet` service must not be newer than `kube-apiserver`, and can be up to 
 1. For example, {product-title} 4.11, 4.13.
 2. For example, {product-title} 4.10, 4.12.
 --
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 [id="defining-workers_{context}"]
 == Cluster workers
@@ -57,22 +57,23 @@ In a Kubernetes cluster, worker nodes run and manage the actual workloads reques
 For information about how to enable runC instead of the default crun, see the documentation for creating a `ContainerRuntimeConfig` CR.
 ====
 
-In {product-title}, compute machine sets control the compute machines, which are assigned the `worker` machine role. Machines with the `worker` role drive compute workloads that are governed by a specific machine pool that autoscales them. Because {product-title} has the capacity to support multiple machine types, the machines with the `worker` role are classed as _compute_ machines. In this release, the terms _worker machine_ and _compute machine_ are used interchangeably because the only default type of compute machine is the worker machine. In future versions of {product-title}, different types of compute machines, such as infrastructure machines, might be used by default.
-
+In {product-title}, compute machine sets control the compute machines, which are assigned the `worker` machine role. Machines with the `worker` role drive compute workloads that are governed by a specific machine pool that autoscales them. Because {product-title} has the capacity to support multiple machine types, the machines with the `worker` role are classed as _compute_ machines. In the current {product-title} release, the terms _worker machine_ and _compute machine_ are used interchangeably because the only default type of compute machine is the worker machine.
+In future versions of {product-title}, different types of compute machines, such as infrastructure machines, might be used by default.
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 Compute machine sets are groupings of compute machine resources under the `machine-api` namespace. Compute machine sets are configurations that are designed to start new compute machines on a specific cloud provider. Conversely, machine config pools (MCPs) are part of the Machine Config Operator (MCO) namespace. An MCP is used to group machines together so the MCO can manage their configurations and facilitate their upgrades.
 ====
-
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [id="defining-masters_{context}"]
 == Cluster control planes
 
 In a Kubernetes cluster, the _master_ nodes run services that are required to control the Kubernetes cluster. In {product-title}, the control plane is comprised of control plane machines that have a `master` machine role. They contain more than just the Kubernetes services for managing the {product-title} cluster.
 
 For most {product-title} clusters, control plane machines are defined by a series of standalone machine API resources.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 For supported cloud provider and {product-title} version combinations, control planes can be managed with control plane machine sets.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-dedicated,openshift-rosa[]
 Control planes are managed with control plane machine sets.
 endif::openshift-dedicated,openshift-rosa[]
@@ -80,9 +81,9 @@ Extra controls apply to control plane machines to prevent you from deleting all 
 
 [NOTE]
 ====
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Exactly three control plane nodes must be used for all production deployments. However, on bare metal platforms, clusters can be scaled up to five control plane nodes.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-dedicated,openshift-rosa[]
 Single availability zone clusters and multiple availability zone clusters require a minimum of three control plane nodes.
 endif::openshift-dedicated,openshift-rosa[]

--- a/modules/etcd-overview.adoc
+++ b/modules/etcd-overview.adoc
@@ -8,7 +8,9 @@
 = Overview of etcd
 
 etcd is a consistent, distributed key-value store that holds small amounts of data that can fit entirely in memory. Although etcd is a core component of many projects, it is the primary data store for Kubernetes, which is the standard system for container orchestration.
-
+ifdef::openshift-rosa-hcp[]
+In {product-title}, etcd is hosted on a Red{nbsp}Hat owned and managed OpenShuft cluster.
+endif::openshift-rosa-hcp[]
 [id="etcd-benefits_{context}"]
 == Benefits of using etcd
 
@@ -30,9 +32,9 @@ The etcd Operator observes, analyzes, and acts:
 . It fixes the differences through the etcd cluster management APIs, the Kubernetes API, or both.
 
 etcd holds the cluster state, which is constantly updated. This state is continuously persisted, which leads to a high number of small changes at high frequency.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a result, it is critical to back the etcd cluster member with fast, low-latency I/O. For more information about best practices for etcd, see "Recommended etcd practices".
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a result, Red Hat Site Reliability Engineering (SRE) backs the etcd cluster member with fast, low-latency I/O.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/operators-overview.adoc
+++ b/modules/operators-overview.adoc
@@ -32,7 +32,9 @@ While both follow similar Operator concepts and goals, Operators in {product-tit
 
 Cluster Operators:: Managed by the Cluster Version Operator (CVO) and installed by default to perform cluster functions.
 Optional add-on Operators:: Managed by Operator Lifecycle Manager (OLM) and can be made accessible for users to run in their applications. Also known as _OLM-based Operators_.
-
+ifdef::openshift-rosa-hcp[]
+OLM runs within the user's AWS account on the OpenShift worker nodes.
+endif::openshift-rosa-hcp[]
 ifeval::["{context}" == "operators-overview"]
 :!index:
 endif::[]

--- a/modules/sd-vs-ocp.adoc
+++ b/modules/sd-vs-ocp.adoc
@@ -32,15 +32,19 @@ endif::openshift-dedicated[]
 ifdef::openshift-rosa[]
 {product-title} is hosted and managed in a public cloud (Amazon Web Services) provided by the customer.
 endif::openshift-rosa[]
+ifdef::openshift-rosa-hcp[]
+The control plane components of {product-title} are hosted and managed by Red{nbsp}Hat in a separate account.
+The worker nodes and storage of {product-title} are hosted and managed in a public cloud (Amazon Web Services) provided by the customer.
+endif::openshift-rosa-hcp[]
 
 |Customers have top-level administrative access to the infrastructure.
 |
 ifdef::openshift-dedicated[]
 Customers have a built-in administrator group (`dedicated-admin`), though the top-level administration access is available when cloud accounts are provided by the customer.
 endif::openshift-dedicated[]
-ifdef::openshift-rosa[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 Customers have a built-in administrator group (`dedicated-admin`), though the top-level administration access is available.
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 |Customers can use all supported features and configuration settings available in {OCP}.
 |Some {OCP} features and configuration settings might not be available or changeable in {product-title}.

--- a/rosa_architecture/rosa-admission-plug-ins.adoc
+++ b/rosa_architecture/rosa-admission-plug-ins.adoc
@@ -28,9 +28,9 @@ endif::openshift-rosa,openshift-dedicated[]
 [id="admission-plug-ins-additional-resources"]
 == Additional resources
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref: /networking/hardware_networks/configuring-sriov-operator.adoc#configuring-sriov-operator[Configuring the SR-IOV Network Operator]
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 * xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations_dedicating_nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
 

--- a/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
+++ b/rosa_hcp/rosa-hcp-aws-private-creating-cluster.adoc
@@ -24,5 +24,5 @@ xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-ide
 
 * xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-hcp-firewall-prerequisites_rosa-sts-aws-prereqs[AWS PrivateLink firewall prerequisites]
 * xref:../rosa_hcp/rosa-hcp-deleting-cluster.adoc#rosa-hcp-deleting-cluster[Deleting a {product-title} cluster]
-* xref:../rosa_architecture/rosa-architecture-models.adoc#rosa-hcp-architecture_rosa-architecture-models[{product-title} architecture models]
+* xref:../architecture/rosa-architecture-models.adoc#rosa-architecture-models[{product-title} architecture models]
 * xref:../support/troubleshooting/rosa-troubleshooting-installations-hcp.adoc#rosa-troubleshooting-installations-hcp[Troubleshooting {product-title} cluster installations]

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -19,7 +19,7 @@ Since it is not possible to upgrade or convert existing {rosa-classic-title} clu
 ====
 
 .Further reading
-* For a comparison between {product-title} and {rosa-classic-title}, see the xref:../rosa_architecture/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
+* For a comparison between {product-title} and {rosa-classic-title}, see the xref:../architecture/rosa-architecture-models.adoc#rosa-hcp-classic-comparison_rosa-architecture-models[Comparing architecture models] documentation.
 * See the AWS documentation for information about link:https://docs.aws.amazon.com/rosa/latest/userguide/getting-started-hcp.html[Getting started with {product-title} using the ROSA CLI in auto mode].
 
 .Additional resources


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-11537

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
