### PR TITLE
[enterprise-4.20] OSDOCS-16135: Add Kueue to addtl RN page

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -409,3 +409,5 @@ endif::openshift-origin[]
 // Formerly out-of-cluster layering
 :image-mode-os-out-caps: Out-of-cluster image mode
 :image-mode-os-out-lower: out-of-cluster image mode
+// kueue
+:kueue: Red Hat build of Kueue

--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -20,6 +20,8 @@ xref:../networking/networking_operators/aws_load_balancer_operator/aws-load-bala
 
 B::
 link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1/html/about_builds/ob-release-notes#ob-release-notes[{builds-v2title}]
++
+link:https://https://docs.redhat.com/en/documentation/red_hat_build_of_kueue/1.1/html/release_notes/index[{kueue}]
 
 C::
 xref:../security/cert_manager_operator/cert-manager-operator-release-notes.adoc#cert-manager-operator-release-notes[{cert-manager-operator}]


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-16135

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not required, just adding a docs link

Additional information:
This PR can be merged once Kueue 1.1 is released, plan is for Oct 1, 2025
