### PR TITLE
MULTIARCH-5409 migrating machine sets to/from x86/arm on GCP

### DIFF
--- a/modules/multiarch-migrating-cp-infra-gcp.adoc
+++ b/modules/multiarch-migrating-cp-infra-gcp.adoc
@@ -1,0 +1,105 @@
+// Module included in the following assemblies:
+//
+// * updating/updating_a_cluster/migrating-to-multi-payload.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="multiarch-migrating-cp-infra-gcp_{context}"]
+= Migrating control plane or infra machine sets between architectures on {gcp-full}
+
+You can migrate the control plane or infra machine sets in your {gcp-short} cluster between `x86` and `arm64` architectures.
+
+.Prerequisites
+
+* You have installed the {oc-first}.
+* You logged in to `oc` as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Check the architecture of the control plane or infra nodes by running the following command:
++
+[source,terminal]
+----
+$ oc get nodes -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          STATUS   ROLES                  AGE    VERSION   INTERNAL-IP EXTERNAL-IP   OS-IMAGE                                         KERNEL-VERSION                 CONTAINER-RUNTIME
+worker-001.example.com        Ready    infra                 100d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+master-001.example.com        Ready    control-plane,master   120d   v1.30.7   10.x.x.x    <none>        Red Hat Enterprise Linux CoreOS 4xx.xx.xxxxx-0   5.x.x-xxx.x.x.el9_xx.x86_64    cri-o://1.30.x
+----
++
+The `KERNEL-VERSION` field in the output indicates the architecture of the nodes.
+
+. Check that your cluster uses the multi payload by running the following command:
++
+[source,terminal]
+----
+$ oc adm release info -o jsonpath="{ .metadata.metadata}"
+----
++
+If you see the following output, the cluster is multi-architecture compatible.
++
+[source,terminal]
+----
+{
+ "release.openshift.io/architecture": "multi",
+ "url": "https://access.redhat.com/errata/<errata_version>"
+}
+----
++
+If the cluster is not using the multi payload, migrate the cluster to a multi-architecture cluster. For more information, see "Migrating to a cluster with multi-architecture compute machines".
+
+. If you use any custom image streams, update them from single-architecture to multi-architecture by running the following command for each image stream:
++
+--
+include::snippets/update-image-stream-to-multi-arch.adoc[]
+--
+
+. Select an instance type that matches the target architecture from link:https://cloud.google.com/compute/docs/general-purpose-machines[General-purpose machine family for Compute engine] (Google documentation). Check the link:https://cloud.google.com/compute/docs/regions-zones#available[Available regions and zones] table (Google documentation) to verify that the instance type is supported in your zone.
+
+. Select a supported disk type for the instance type that you selected from the "Supported disk types" section of link:https://cloud.google.com/compute/docs/general-purpose-machines[General-purpose machine family for Compute engine] (Google documentation).
+
+. Determine the {gcp-short} image that the machine set uses after migration by running the following command:
++
+[source,terminal]
+----
+$ oc get configmap/coreos-bootimages \
+  -n openshift-machine-config-operator \
+  -o jsonpath='{.data.stream}' | jq \
+  -r '.architectures.aarch64.images.gcp'
+----
++
+.Example output
+[source,terminal]
+----
+"gcp": {
+    "release": "415.92.202309142014-0",
+    "project": "rhcos-cloud",
+    "name": "rhcos-415-92-202309142014-0-gcp-aarch64"
+  }
+----
+Use the `project` and `name` parameters from the output to form the `image` parameter in the following format: `projects/<project>/global/images/<name>`.
+
+. To migrate the control plane to another architecture, run the following command:
++
+[source,terminal]
+----
+$ oc edit controlplanemachineset.machine.openshift.io cluster -n openshift-machine-api
+----
++
+.. Replace the `disks.type` parameter with the disk type that you selected.
+.. Replace the `disks.image` parameter with the `image` parameter that you formed previously.
+.. Replace the `machineType` parameter with the instance type that you selected.
+
+. To migrate an infra machine set to another architecture, run the following command using the ID of an infra machine set:
++
+[source,terminal]
+----
+$ oc edit machineset <infra-machine-set_id> -n openshift-machine-api
+----
++
+.. Replace the `disks.type` parameter with the disk type that you selected.
+.. Replace the `disks.image` parameter with the `image` parameter that you formed previously.
+.. Replace the `machineType` parameter with the instance type that you selected.

--- a/updating/updating_a_cluster/migrating-to-multi-payload.adoc
+++ b/updating/updating_a_cluster/migrating-to-multi-payload.adoc
@@ -41,11 +41,16 @@ include::modules/migrating-to-multi-arch-cli.adoc[leveloffset=+1]
 //  Migrating the x86 control plane to the arm64 architecture on AWS
 include::modules/migrating-from-x86-to-arm-cp.adoc[leveloffset=+1]
 
+// Migrating CP or infra between x86 and arm on GCP
+include::modules/multiarch-migrating-cp-infra-gcp.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc#cpmso-config-options-aws[Control plane configuration options for {aws-full}]
 
 * xref:../../installing/installing_aws/upi/upi-aws-installation-reqs.adoc#installation-aws-arm-tested-machine-types_upi-aws-installation-reqs[Tested instance types for AWS on 64-bit ARM infrastructures]
+
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-tested-machine-types-arm_installing-gcp-customizations[Tested instance types for GCP on 64-bit ARM infrastructures]
 
 * xref:../../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-to-multi-arch-cli_updating-clusters-overview[Migrating to a cluster with multi-architecture compute machines using the CLI]


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/MULTIARCH-5409

Link to docs preview:
https://98970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/migrating-to-multi-payload.html#multiarch-migrating-cp-infra-gcp_updating-clusters-overview

QE review:
- [x] QE has approved this change.
