### PR TITLE
(CLOSED) [OBSDOCS-1401] Include notice about req log store versions

### DIFF
--- a/installing/installing-logging.adoc
+++ b/installing/installing-logging.adoc
@@ -20,6 +20,7 @@ You can use either the {ocp-product-title} web console or the {ocp-product-title
 [IMPORTANT]
 ====
 You must configure the {clo} after the {loki-op}.
+You must install the {clo} and the {loki-op} with the same major and minor version.
 ====
 
 

--- a/upgrading/upgrading-to-logging-60.adoc
+++ b/upgrading/upgrading-to-logging-60.adoc
@@ -28,6 +28,11 @@ The only managed log storage solution available in this release is a Lokistack, 
 
 [IMPORTANT]
 ====
+You must install the {clo} and the {loki-op} with the same major and minor version.
+====
+
+[IMPORTANT]
+====
 To continue using an existing Red Hat managed Elasticsearch or Kibana deployment provided by the *elasticsearch-operator*, remove the owner references from the `Elasticsearch` resource named `elasticsearch`, and  the `Kibana` resource named `kibana` in the `openshift-logging` namespace before removing the `ClusterLogging` resource named `instance` in the same namespace.
 ====
 


### PR DESCRIPTION
Version(s):
- standalone-logging-docs-6.0 +

Issue:
- https://issues.redhat.com/browse/OBSDOCS-1401

Link to docs preview:
- [Installing](https://98982--ocpdocs-pr.netlify.app/openshift-logging/latest/installing/installing-logging.html)
- [Upgrading](https://98982--ocpdocs-pr.netlify.app/openshift-logging/latest/upgrading/upgrading-to-logging-60.html#log-storage)

QE review:
- [ ] QE has approved this change.
