### PR TITLE
OBSDOCS-2403: Logging Z-Stream Release Notes - 6.2.5

### DIFF
--- a/modules/logging-release-notes-6-2-4.adoc
+++ b/modules/logging-release-notes-6-2-4.adoc
@@ -22,6 +22,8 @@ This release includes link:https://access.redhat.com/errata/RHSA-2025:13241[RHSA
 
 * Before this update, the `ClusterLogForwarder` API did not validate the URL scheme for Kafka outputs, which could lead to configuration errors. With this update, the `ClusterLogForwarder` API validates the URL scheme for Kafka outputs, and the API documentation reflects the valid URL scheme. (https://issues.redhat.com/browse/LOG-7387[LOG-7387])
 
+* Before this update, a log record with a malformed timestamp could cause the Vector agent to panic when attempting to forward logs to Loki. With this update, error handling for out-of-range timestamp values has been improved resolving the issue. (link:https://issues.redhat.com/browse/LOG-7599[LOG-7599])
+
 [id="logging-release-notes-6-2-4-cves_{context}"]
 == CVEs
 

--- a/modules/logging-release-notes-6-2-5.adoc
+++ b/modules/logging-release-notes-6-2-5.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.2.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-2-5_{context}"]
+= Logging 6.2.5 Release Notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:16075[RHBA-2025:16075].
+
+[id="logging-release-notes-6-2-5-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the `vector_buffer_byte_size` and `vector_buffer_events` metrics incorrectly reported negative values under certain system load and timing conditions. This led to unreliable monitoring, potentially masking buffer issues. With this update, a concurrent, centralized state tracker ensures that these metrics are always reported as non-negative values. This ensures that the metrics correctly report buffer sizes helping with accurate monitoring. (link:https://issues.redhat.com/browse/LOG-7593[LOG-7593])
+
+*  Before this update, a change to the container image format caused issues when mirroring the images to image registries that do not support the new format. With this update, the container images are published using the older format again resolving the issue.  (link:https://issues.redhat.com/browse/LOG-7700[LOG-7700])
+
+////
+[id="logging-release-notes-6-2-5-cves_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2025-22871[CVE-2025-22871]
+////

--- a/release_notes/logging-release-notes-6.2.adoc
+++ b/release_notes/logging-release-notes-6.2.adoc
@@ -6,8 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/logging-release-notes-6-2-5.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-2-4.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-2-3.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-2-2.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-2-1.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-2-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 6.2
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2403
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://98983--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6.2.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
