### PR TITLE
OSSM-10535 Check and remove ":context:" and check mod-docs type format from modules

### DIFF
--- a/about/ossm-about-concepts.adoc
+++ b/about/ossm-about-concepts.adoc
@@ -11,7 +11,7 @@ toc::[]
 * {SMProductName} resources
 * Kiali provided by Red Hat
 
-Kali provided by Red Hat is composed of three parts:
+Kiali provided by Red Hat is composed of three parts:
 
 * {KialiProduct}
 * Kiali Server

--- a/install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
+++ b/install/ossm-deploying-multiple-service-meshes-on-single-cluster.adoc
@@ -44,4 +44,4 @@ include::modules/ossm-deploy-application-workloads-in-each-mesh.adoc[leveloffset
 [id="additional-resources-ossm-deploying-multiple-service-meshes-on-single-cluster"]
 == Additional resources
 
-* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-about-discoveryselectors_ossm-scoping-service-mesh-with-discoveryselectors[Discovery selectors]
+* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-installing-openshift-service-mesh[Scoping Service Mesh with discoverySelectors]

--- a/install/ossm-installing-openshift-service-mesh.adoc
+++ b/install/ossm-installing-openshift-service-mesh.adoc
@@ -32,7 +32,8 @@ include::modules/ossm-about-discoveryselectors.adoc[leveloffset=+2]
 include::modules/ossm-using-discoveryselectors-scope-service-mesh.adoc[leveloffset=+2]
 [role="_next-steps"]
 .Next steps
-* xref:../install/ossm-installing-openshift-service-mesh.adoc#deploying-book-info_ossm-about-bookinfo-application[Deploying the Bookinfo application]
+
+* xref:../install/ossm-installing-openshift-service-mesh.adoc#deploying-book-info_ossm-installing-openshift-service-mesh[Deploying the Bookinfo application]
 
 include::modules/ossm-about-bookinfo-application.adoc[leveloffset=+1]
 include::modules/ossm-deploying-bookinfo-application.adoc[leveloffset=+2]

--- a/install/ossm-istio-ambient-mode.adoc
+++ b/install/ossm-istio-ambient-mode.adoc
@@ -22,14 +22,14 @@ include::modules/ossm-about-discovery-selectors-istio-ambient-mode.adoc[leveloff
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-creating-istiocni-resource[Scoping the Service Mesh with discovery selectors]
+* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-installing-openshift-service-mesh[Scoping the mesh with discovery selectors]
 
 include::modules/ossm-scoping-sm-discovery-selectors-istio-ambient-mode.adoc[leveloffset=+2]
 include::modules/ossm-deploying-bookinfo-application-istio-ambient-mode.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-about-bookinfo-application_ossm-discoveryselectors-scope-service-mesh[About the Bookinfo application]
+* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-about-bookinfo-application_ossm-installing-openshift-service-mesh[About the Bookinfo application]
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]

--- a/install/ossm-sidecar-injection.adoc
+++ b/install/ossm-sidecar-injection.adoc
@@ -19,6 +19,6 @@ include::modules/ossm-enabling-sidecar-injection-istio-revision-tag-resource.ado
 == Additional resources
 * link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/[About admission controllers] (Kubernetes documentation)
 * link:https://istio.io/latest/docs/ops/common-problems/injection/[Istio sidecar injection problems] (Istio documentation)
-* xref:../install/ossm-installing-openshift-service-mesh.adoc#deploying-book-info_ossm-about-bookinfo-application[Deploying the Bookinfo application]
-* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-creating-istiocni-resource[Scoping the Service Mesh with discovery selectors]
+* xref:../install/ossm-installing-openshift-service-mesh.adoc#deploying-book-info_ossm-installing-openshift-service-mesh[Deploying the Bookinfo application]
+* xref:../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-installing-openshift-service-mesh[Scoping the mesh with discovery selectors]
 * xref:../about/ossm-about-concepts.adoc#istiorevisiontag-resource_ossm-about-concepts[IstioRevisionTag resource]

--- a/migrating/checklists/ossm-migrating-read-me.adoc
+++ b/migrating/checklists/ossm-migrating-read-me.adoc
@@ -15,7 +15,7 @@ include::modules/ossm-migrating-read-me-observability-integrations.adoc[leveloff
 include::modules/ossm-migrating-read-me-scoping-discovery-selectors.adoc[leveloffset=+1]
 
 .Next steps
-* xref:../../install/ossm-installing-openshift-service-mesh.adoc#ossm-about-discoveryselectors_ossm-scoping-service-mesh-with-discoveryselectors[Scoping Service Mesh with discoverySelectors]
+* xref:../../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-installing-openshift-service-mesh[Scoping Service Mesh with discoverySelectors]
 
 include::modules/ossm-migrating-read-me-sidecar-injection-considerations.adoc[leveloffset=+1]
 include::modules/ossm-migrating-read-me-support-for-multiple-control-planes.adoc[leveloffset=+1]

--- a/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
+++ b/migrating/cluster-wide/ossm-migrating-cluster-wide.adoc
@@ -27,7 +27,7 @@ include::modules/ossm-control-plane-configuration-migration-requirements.adoc[le
 
 * xref:../../migrating/checklists/ossm-migrating-network-policies.adoc#ossm-migrating-network-policies-setup-during-migration_ossm-migrating-network-policies[Set up network policies to use during migration]
 
-* xref:../../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-creating-istiocni-resource[Scoping the mesh with discoverySelectors]
+* xref:../../install/ossm-installing-openshift-service-mesh.adoc#ossm-scoping-service-mesh-with-discoveryselectors_ossm-installing-openshift-service-mesh[Scoping the mesh with discoverySelectors]
 
 include::modules/ossm-cluster-wide-migration-methods.adoc[leveloffset=+1]
 

--- a/modules/ossm-about-accessing-bookinfo-application-using-gateway.adoc
+++ b/modules/ossm-about-accessing-bookinfo-application-using-gateway.adoc
@@ -4,7 +4,6 @@
 :_mod-docs-content-type: CONCEPT
 [id="ossm-about-accessing-bookinfo-application-using-gateway_{context}"]
 = About accessing the Bookinfo application using a gateway
-:context: ossm-about-accessing-bookinfo-application-using-gateway
 
 The {SMProductName} Operator does not deploy gateways. Gateways are not part of the control plane. As a security best-practice, Ingress and Egress gateways should be deployed in a different namespace than the namespace that contains the control plane.
 

--- a/modules/ossm-about-bookinfo-application.adoc
+++ b/modules/ossm-about-bookinfo-application.adoc
@@ -4,7 +4,6 @@
 :_mod-docs-content-type: CONCEPT
 [id="ossm-about-bookinfo-application_{context}"]
 = About the Bookinfo application
-:context: ossm-about-bookinfo-application
 
 Installing the `bookinfo` example application consists of two main tasks: deploying the application and creating a gateway so the application is accessible outside the cluster.
 

--- a/modules/ossm-about-configuring-a-gateway-to-accept-ingress-traffic.adoc
+++ b/modules/ossm-about-configuring-a-gateway-to-accept-ingress-traffic.adoc
@@ -2,10 +2,9 @@
 
 // gateways/ossm-about-gateways.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ossm-about-configuring-a-gateway-to-accept-ingress-traffic_{context}"]
 = About configuring a gateway installed using gateway injection to accept ingress traffic
-:context: ossm-about-configuring-a-gateway-to-accept-ingress-traffic
 
 When you install a gateway using gateway injection you can configure it to receive ingress traffic using the {istio} `Gateway` and `VirtualService` resources in combination. The {istio} `Gateway` resource describes a load balancer operating at the edge of the mesh that receives incoming or outgoing HTTP/TCP connections. The `Gateway` specification describes a set of ports that should be exposed, the type of protocol to use, and the Server Name Indication (SNI) configuration for the load balancer. `VirtualServices` define routing rules to apply to an {istio} `Gateway`, similar to how you can use `VirtualServices` to define routing rules for internal mesh traffic.
 

--- a/modules/ossm-about-deploying-istio-using-service-mesh-operator.adoc
+++ b/modules/ossm-about-deploying-istio-using-service-mesh-operator.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ossm-about-deploying-istio-using-service-mesh-operator_{context}"]
 = About deploying Istio using the {SMProductName} Operator
-:context: ossm-about-deploying-istio-using-service-mesh-operator
 
 To deploy {istio} using the {SMProductName} Operator, you must create an `{istio}` resource. Then, the Operator creates an `IstioRevision` resource, which represents one revision of the {istio} control plane. Based on the `IstioRevision` resource, the Operator deploys the {istio} control plane, which includes the `istiod` `Deployment` resource and other resources.
 

--- a/modules/ossm-about-discoveryselectors.adoc
+++ b/modules/ossm-about-discoveryselectors.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ossm-about-discoveryselectors_{context}"]
 = About discovery selectors
-:context: ossm-about-discoveryselectors
 
 With discovery selectors, the mesh administrator can control which namespaces the control plane can access. By using a {k8s} label selector, the administrator sets the criteria for the namespaces visible to the control plane, excluding any namespaces that do not match the specified criteria.
 

--- a/modules/ossm-about-exposing-services-to-traffic-outside-a-cluster.adoc
+++ b/modules/ossm-about-exposing-services-to-traffic-outside-a-cluster.adoc
@@ -2,10 +2,9 @@
 
 // gateways/ossm-about-gateways.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ossm-about-exposing-services-to-traffic-outside-a-cluster_{context}"]
 = About exposing services to traffic outside a cluster
-:context: ossm-about-exposing-services-to-traffic-outside-a-cluster
 
 To enable traffic from outside an {ocp-short-name} cluster to access services in a mesh, you must expose a gateway proxy by either setting its `Service` type to `LoadBalancer` or by using the {ocp-short-name} Router.
 

--- a/modules/ossm-about-gateway-injection.adoc
+++ b/modules/ossm-about-gateway-injection.adoc
@@ -2,10 +2,9 @@
 
 // gateways/ossm-about-gateways.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ossm-about-gateway-injection_{context}"]
 = About gateway injection
-:context: ossm-about-gateway-injection
 
 Gateway injection relies upon the same mechanism as sidecar injection to inject the Envoy proxy into gateway pods. To install a gateway using gateway injection, you create a Kubernetes `Deployment` object and an associated Kubernetes `Service` object in a namespace that is visible to the {istio} control plane. When creating the `Deployment` object you label and annotate it so that the {istio} control plane injects a proxy, and the proxy is configured as a gateway. After installing the gateway, you configure it to control ingress and egress traffic using the {istio} `Gateway` and `VirtualService` resources.
 

--- a/modules/ossm-about-inplace-strategy.adoc
+++ b/modules/ossm-about-inplace-strategy.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // update/ossm-updating-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="about-inplace-strategy_{context}"]
 = About InPlace strategy
 

--- a/modules/ossm-about-istio-deployment.adoc
+++ b/modules/ossm-about-istio-deployment.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="about-istio-deployment_{context}"]
 = About Istio deployment
-:context: ossm-about-istio-deployment
 
 To deploy {istio}, you must create two resources: `Istio` and `IstioCNI`. The `Istio` resource deploys and configures the {istio} Control Plane. The `IstioCNI` resource deploys and configures the {istio} Container Network Interface (CNI) plugin. You should create these resources in separate projects; therefore, you must create two projects as part of the {istio} deployment process.
 

--- a/modules/ossm-about-mtls.adoc
+++ b/modules/ossm-about-mtls.adoc
@@ -6,20 +6,15 @@
 [id="ossm-about-mtls_{context}"]
 = About mutual Transport Layer Security (mTLS)
 
-
 In {SMProduct} 3, you use the `Istio` resource instead of the `ServiceMeshControlPlane` resource to configure mTLS settings. 
-
 
 In {SMProduct} 3, you configure `STRICT` mTLS mode by using the `PeerAuthentication` and `DestinationRule` resources. You set TLS protocol versions through Istio Workload Minimum TLS Version Configuration.
 
 Review the following `Istio` resources and concepts to configure mTLS settings properly:
 
-
 `PeerAuthentication`:: defines the type of mTLS traffic a sidecar accepts. In `PERMISSIVE` mode, both plaintext and mTLS traffic are accepted. In `STRICT` mode, only mTLS traffic is allowed.
 
-
 `DestinationRule`:: configures the type of TLS traffic a sidecar sends. In `DISABLE` mode, the sidecar sends plaintext. In `SIMPLE`, `MUTUAL`, and `ISTIO_MUTUAL` modes, the sidecar establishes a TLS connection.
-
 
 `Auto mTLS`:: ensures that all inter-mesh traffic is encrypted with mTLS by default, regardless of the `PeerAuthentication` mode configuration. `Auto mTLS` is controlled by the global mesh configuration field `enableAutoMtls`, which is enabled by default in {SMProduct} 2 and 3. The mTLS setting operates entirely between sidecar proxies, requiring no changes to application or service code.
 

--- a/modules/ossm-about-operator-update-process.adoc
+++ b/modules/ossm-about-operator-update-process.adoc
@@ -2,7 +2,7 @@
 //
 // update/ossm-updating-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ossm-about-operator-update-process_{context}"]
 = About Operator update process
 

--- a/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
+++ b/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="ossm-accessing-bookinfo-application-using-gateway-api"]
 = Accessing the Bookinfo application by using Gateway API
 

--- a/modules/ossm-creating-istio-cni-project-using-console.adoc
+++ b/modules/ossm-creating-istio-cni-project-using-console.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="ossm-creating-istio-cni-project_{context}"]
 = Creating the IstioCNI project using the web console
-:context: ossm-creating-istio-cni-project-using-console
 
 The {SMProductShortName} Operator deploys the {istio} CNI plugin to a project that you create. In this example, `istio-cni` is the name of the project.
 

--- a/modules/ossm-creating-istio-project-using-console.adoc
+++ b/modules/ossm-creating-istio-project-using-console.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="ossm-creating-istio-project_{context}"]
 = Creating the Istio project using the web console
-:context: ossm-creating-istio-project-using-console
   
 The {SMProductShortName} Operator deploys the {istio} control plane to a project that you create. In this example, `istio-system` is the name of the project.
 

--- a/modules/ossm-creating-istio-resource-using-console.adoc
+++ b/modules/ossm-creating-istio-resource-using-console.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="ossm-creating-istio-resource_{context}"]
 = Creating the Istio resource using the web console
-:context: ossm-creating-istio-resource-using-console
 
 Create the {istio} resource that will contain the YAML configuration file for your {istio} deployment. The {SMProductName} Operator uses information in the YAML file to create an instance of the {istio} control plane.
 

--- a/modules/ossm-creating-istiocni-resource-using-console.adoc
+++ b/modules/ossm-creating-istiocni-resource-using-console.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="ossm-creating-istiocni-resource_{context}"]
 = Creating the IstioCNI resource using the web console
-:context: ossm-creating-istiocni-resource
 
 Create an {istio} Container Network Interface (CNI) resource, which contains the configuration file for the Istio CNI plugin. The {SMProductShortName} Operator uses the configuration specified by this resource to deploy the CNI pod.
 

--- a/modules/ossm-customizing-istio-configuration.adoc
+++ b/modules/ossm-customizing-istio-configuration.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="ossm-customizing-istio_{context}"]
 = Customizing Istio configuration
-:context: ossm-customizing-istio-configuration
 
 The `values` field of the `Istio` custom resource definition, which was created when the control plane was deployed, can be used to customize Istio configuration using Istio's `Helm` configuration values. When you create this resource using the OpenShift Container Platform web console, it is pre-populated with configuration settings to enable Istio to run on OpenShift.
 

--- a/modules/ossm-deploying-istio.adoc
+++ b/modules/ossm-deploying-istio.adoc
@@ -1,7 +1,6 @@
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="ossm-deploying-istio"]
 = Deploying Istio
-:context: ossm-deploying-istio
 
 .Procedure
 

--- a/modules/ossm-exposing-a-gateway-to-traffic-outside-the-cluster-using-openshift-routes.adoc
+++ b/modules/ossm-exposing-a-gateway-to-traffic-outside-the-cluster-using-openshift-routes.adoc
@@ -4,7 +4,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-exposing-a-gateway-to-traffic-outside-the-cluster-using-openshift-routes_{context}"]
 = Exposing a gateway to traffic outside the cluster by using OpenShift Routes
-:context: ossm-exposing-a-gateway-to-traffic-outside-the-cluster-using-openshift-routes
 
 You can expose a gateway to traffic outside the cluster by using {ocp-short-name} Routes. This approach provides an alternative to using Kubernetes load balancer service when you have to expose gateways to traffic outside the cluster.
 

--- a/modules/ossm-exposing-service-using-istio-gateway-and-virtualservice.adoc
+++ b/modules/ossm-exposing-service-using-istio-gateway-and-virtualservice.adoc
@@ -4,7 +4,6 @@
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-exposing-service-using-istio-gateway-and-virtualservice_{context}"]
 = Exposing a service by using the {istio} Gateway and VirtualService resources
-:context: ossm-exposing-service-using-istio-gateway-and-virtualservice
 
 This procedure uses the {istio} `Gateway` and `VirtualService` resources to configure a gateway that was deployed by using gateway injection. The resources configure the gateway to expose a service in the mesh to traffic outside the mesh. Then, you expose the gateway to traffic outside the cluster by setting the `Service` for the gateway to type `LoadBalancer`.
 

--- a/modules/ossm-installing-gateway-using-gateway-injection.adoc
+++ b/modules/ossm-installing-gateway-using-gateway-injection.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: PROCEDURE
-[id="ossm-about-gateway-injection_{context}"]
+[id="ossm-installing-gateway-using-gateway-injection_{context}"]
 = Installing a gateway by using gateway injection
-:context: ossm-installing-gateway-using-gateway-injection
 
 This procedure explains how to install a gateway by using gateway injection.
 

--- a/modules/ossm-scoping-service-mesh-with-discoveryselectors.adoc
+++ b/modules/ossm-scoping-service-mesh-with-discoveryselectors.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ossm-scoping-service-mesh-with-discoveryselectors_{context}"]
 = Scoping the Service Mesh with discovery selectors
-:context: ossm-scoping-service-mesh-with-discoveryselectors
 
 {SMProductShortName} includes workloads that meet the following criteria:
 

--- a/modules/ossm-selecting-inplace-strategy.adoc
+++ b/modules/ossm-selecting-inplace-strategy.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // update/ossm-updating-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="selecting-inplace-strategy_{context}"]
 = Selecting InPlace strategy
 

--- a/modules/ossm-selecting-revisionbased-strategy.adoc
+++ b/modules/ossm-selecting-revisionbased-strategy.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // update/ossm-updating-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="selecting-revision-based-strategy_{context}"]
 = Selecting RevisionBased strategy
 

--- a/modules/ossm-service-mesh-overview.adoc
+++ b/modules/ossm-service-mesh-overview.adoc
@@ -3,6 +3,7 @@ Module included in the following assemblies:
 * about/ossm-about-openshift-service-mesh.adoc
 ////
 
+:_mod-docs-content-type: CONCEPT
 [id="ossm-servicemesh-overview_{context}"]
 = Introduction to {SMProductName}
 

--- a/modules/ossm-understanding-operator-updates-and-channels.adoc
+++ b/modules/ossm-understanding-operator-updates-and-channels.adoc
@@ -2,7 +2,7 @@
 //
 // update/ossm-updating-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ossm-understanding-operator-updates-and-channels_{context}"]
 = Understanding Operator updates and channels
 

--- a/modules/ossm-understanding-sm-istio-versions.adoc
+++ b/modules/ossm-understanding-sm-istio-versions.adoc
@@ -2,7 +2,7 @@
 //
 // update/ossm-updating-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ossm-understanding-sm-istio-versions_{context}"]
 = Understanding Service Mesh and Istio versions
 

--- a/modules/ossm-understanding-versioning.adoc
+++ b/modules/ossm-understanding-versioning.adoc
@@ -2,7 +2,7 @@
 //
 // update/ossm-updating-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Concept
+:_mod-docs-content-type: CONCEPT
 [id="ossm-understanding-versioning_{context}"]
 = Understanding versioning
 

--- a/modules/ossm-using-discoveryselectors-scope-service-mesh.adoc
+++ b/modules/ossm-using-discoveryselectors-scope-service-mesh.adoc
@@ -1,10 +1,9 @@
 // Module included in the following assemblies:
 // install/ossm-installing-openshift-service-mesh.adoc
 
-:_mod-docs-content-type: Procedure
+:_mod-docs-content-type: PROCEDURE
 [id="ossm-discoveryselectors-scope-service-mesh_{context}"]
 = Scoping a Service Mesh by using discovery selectors
-:context: ossm-discoveryselectors-scope-service-mesh
 
 If you know which namespaces to include in the {SMProductShortName}, configure `discoverySelectors` during or after installation by adding the required selectors to the `meshConfig.discoverySelectors` section of the `{istio}` resource. For example, configure {istio} to discover only namespaces labeled `istio-discovery=enabled`.
 


### PR DESCRIPTION
Change type: Check and remove ":context:" and check mod-docs type format from modules

Doc JIRA: https://issues.redhat.com/browse/OSSM-10535

Fix Version: 
[service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)
[service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

NOTE: I will create manual cherrypicks for 3.0 and 3.1 branches to avoid potential merge conflicts.

This issue covers the following changes:

- Check and remove ":context:" from all module files.
- Check and Capitalise all docs type mentioned. for example instead of "Procedure" use "PROCEDURE".
- Fixed a major spelling mistake where "Kali" was used instead of "Kiali".
- Fix all failing xrefs after removal of ":context:"
- Changed duplicate ID used in two modules.

Doc Previews: N/A

Peer Review: @kaldesai 