### PR TITLE
Telcodocs 2274 D/S Docs: Support creating SriovNetworks in application namespace

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1596,6 +1596,8 @@ Topics:
     File: configuring-sriov-net-attach
   - Name: Configuring an SR-IOV InfiniBand network attachment
     File: configuring-sriov-ib-attach
+  - Name: Configuring SriovNetwork in application namespaces
+    File: configuring-namespaced-sriov-resources
   - Name: Configuring an RDMA subsystem for SR-IOV
     File: configuring-sriov-rdma-cni
   - Name: Configuring interface-level network sysctl settings and all-multicast mode for SR-IOV networks

--- a/modules/nw-configuring-sriov-in-app-namespace.adoc
+++ b/modules/nw-configuring-sriov-in-app-namespace.adoc
@@ -1,0 +1,157 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-device.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-configuring-sriov-in-app-namespace_{context}"]
+= Configuring SriovNetwork in application namespaces
+
+When an SriovNetwork custom resource (CR) is deployed in an application namespace, do not define or populate the `spec.networkNamespace` field. In this scenario, the NetworkAttachmentDefinition will be created in the same namespace as the SriovNetwork CR.
+
+The SR-IOV Network Operator webhook rejects the creation of an `SriovNetwork` resource in an application namespace if the `spec.networkNamespace` field is defined.
+
+Follow this procedure to create an `SriovNetwork` resource in an application namespace and attach a pod to the additional network.
+
+.Prerequisites
+
+The following steps must be completed by a cluster administrator before an application owner can configure a namespaced SriovNetwork resource: 
+
+* The SR-IOV Network Operator is installed in the `openshift-sriov-network-operator` namespace.
+* Nodes with SR-IOV hardware are labeled for the operator to identify the nodes.
+
+As an application owner you need to have administrator privileges on the application namespace.
+
+.Procedure
+
+. Specify the SR-IOV network device configuration for a node by creating an SR-IOV network node policy. The `SriovNetworkNodePolicy` object is created in the `openshift-sriov-network-operator` namespace to define the SR-IOV network device configuration for nodes. Example configuration for Intel DPK is as follows: 
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: intel-dpdk-node-policy
+  namespace: openshift-sriov-network-operator
+spec:
+  resourceName: intelnics
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  priority: 10
+  numVfs: 4
+  nicSelector:
+    vendor: "8086"
+    deviceID: "158b"
+    pfNames: [""]
+  deviceType: netdevice
+----
+
+. Create an application namespace. For example, create a namespace named `sriov-app` by running the following command:
++
+[source,terminal]
+----
+$ cat <<EOF | oc create -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: sriov-app
+EOF
+----
+
+. Create a YAML file, for example, `sriovnetwork.yaml`, to define the `SriovNetwork` object in the application namespace. 
++ 
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: test-network
+  namespace: sriov-app 
+spec:
+  resourceName: intelnics
+  ipam:
+    type: host-local
+    subnet: "10.0.0.0/24"
+    routes:
+      - dst: "0.0.0.0/0"
+        gw: "10.0.0.1"
+  vlan: 10
+----
+* `namespace`: The value must match the name of the application namespace, for example, `sriov-app`.
+* `resourceName`: This value must match the `spec.resourceName` defined in the `SriovNetworkNodePolicy` created by the cluster administrator, which in the example is `intelnics`.
+
+. Apply the YAML file to create the `SriovNetwork` object in the application namespace.
++
+[source,terminal]
+----
+$ oc create -f sriovnetwork.yaml
+----
++
+After an application owner has created the SriovNetwork resource, they can create a pod that uses the newly defined network. You attach a pod to the additional network by adding a specific annotation to the pod's YAML manifest.
+
+. Create a YAML file, for example, `test-pod.yaml`, to define a pod that uses the new network attachment:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: sriov-app 
+  annotations:
+    k8s.v1.cni.cncf.io/networks: test-network
+spec:
+  containers:
+  - name: test-pod-container
+    image: centos/tools
+    command: ["/bin/bash", "-c", "sleep 3600"]
+----
++
+* `namespace`: The namespace where the pod is created. This must be the same namespace where the `SriovNetwork` object is created.
+* `annotations`: `k8s.v1.cni.cncf.io/networks` specifies the additional network that the pod connects to. The value must match the `metadata.name` of the `SriovNetwork` object.  
+
+. Apply the YAML file to create the pod in the application namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create -f test-pod.yaml
+----        
+
+.Verification
+
+. Verify that the NetworkAttachmentDefinition has been created in the same namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get net-attach-def -n sriov-app
+----
++
+Where `sriov-app` is the application namespace where the `SriovNetwork` object is created.
++
+.Example output
++
+[source,terminal]
+----
+NAME           AGE
+test-network   2m
+----
+
+. Verify the pod is running and get its network status by describing the pod with the following command:
++
+[source,terminal]
+----
+$ oc describe pod test-pod -n sriov-app
+----
++
+Where `sriov-app` is the application namespace where the pod is created.
++
+In the output, look for the `k8s.v1.cni.cncf.io/network-status` annotation. This shows the name of the network and the IP assigned to the pod on that interface.
+
+. Check that the pod has the additional network interface by running the following command:
++
+[source,terminal]
+----
+$ oc exec -it test-pod -n sriov-app -- ip a
+----
++
+Look for a secondary network interface, for example `net1` or `eth1`, in addition to the default eth0 interface. The `net1` interface should have an IP address from the subnet you defined in the SriovNetwork object, for example `10.0.0.0/24`. This confirms the pod is using the new network attachment definition.
+

--- a/modules/nw-introduction-namespaced-sriov.adoc
+++ b/modules/nw-introduction-namespaced-sriov.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-namespaced-sriov-resources.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="introduction-to-namespaced-sriovnetwork-resources_{context}"]
+= An introduction to namespaced SriovNetwork resources
+
+SR-IOV networks can be created and managed directly within application namespaces. This capability provides application owners with fine-grained control over network configurations, simplifying their workflow.
+
+This approach offers several key advantages that enhance the user experience:
+
+* Increased Autonomy and Control: Application owners gain direct control over their network configurations, eliminating the need for a cluster administrator to create `SriovNetwork` objects on their behalf.
+* Enhanced Security: By allowing users to manage resources within their own namespaces, the feature improves security and provides better separation between applications. This also helps avoid the unintentional misconfiguration of other applications' NetworkAttachmentDefinition objects.
+* Simplified Permissions: Managing `SriovNetwork` resources directly in their own namespaces simplifies user permissions. This streamlines the workflow and reduces the operational overhead for developers. 

--- a/modules/nw-sriov-network-object.adoc
+++ b/modules/nw-sriov-network-object.adoc
@@ -49,9 +49,9 @@ ifdef::ocp-sriov-net[]
 endif::ocp-sriov-net[]
 ----
 <1> A name for the object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with same name.
-<2> The namespace where the SR-IOV Network Operator is installed.
+<2> The namespace where the SR-IOV Network Operator is installed. You can also install the SR-IOV Network Operator in any namespace.
 <3> The value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
-<4> The target namespace for the `SriovNetwork` object. Only {object} in the target namespace can attach to the additional network.
+<4> The target namespace for the SriovNetwork object. Only pods in the target namespace can attach to the additional network. When installing the SR-IOV Network Operator in a namespace other than `openshift-sriov-network-operator`, you must not configure this field..
 <5> Optional: A Virtual LAN (VLAN) ID for the additional network. The integer value must be from `0` to `4095`. The default value is `0`.
 <6> Optional: The spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
 +

--- a/networking/hardware_networks/configuring-namespaced-sriov-resources.adoc
+++ b/networking/hardware_networks/configuring-namespaced-sriov-resources.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-namespaced-sriov-resources"]
+= Configuring namespaced SR-IOV resources
+include::_attributes/common-attributes.adoc[]
+:context: configuring-namespaced-sriov-resources
+
+toc::[]
+
+[role="_abstract"]
+Namespaced SriovNetwork Resources allow application owners to create and manage their own SriovNetwork resources directly within their namespaces, rather than relying on a cluster administrator to do it in a shared operator namespace. This method simplifies permissions, improves security, and provides better separation between applications. 
+
+// An introduction to namespaced SriovNetwork resources
+include::modules/nw-introduction-namespaced-sriov.adoc[leveloffset=+1]
+
+// Configuring SriovNetwork in application namespaces
+include::modules/nw-configuring-sriov-in-app-namespace.adoc[leveloffset=+2]
+

--- a/networking/hardware_networks/configuring-sriov-net-attach.adoc
+++ b/networking/hardware_networks/configuring-sriov-net-attach.adoc
@@ -13,6 +13,10 @@ Before you perform any tasks in the following documentation, ensure that you xre
 // Ethernet device configuration object
 include::modules/nw-sriov-network-object.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+xref:../../networking/hardware_networks/configuring-namespaced-sriov-resources.adoc#introduction-to-namespaced-sriovnetwork-resources_configuring-namespaced-sriov-resources[Configuring namespaced SR-IOV resources]
+
 // Creating a configuration for assignment of dual-stack IP addresses dynamically
 include::modules/nw-multus-configure-dualstack-ip-address.adoc[leveloffset=+2]
 


### PR DESCRIPTION
[TELCODOCS-2274]: D/S Docs: Support creating SriovNetworks in application namespace

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2274
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://99000--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-namespaced-sriov-resources.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
