### PR TITLE
OSDOCS-15868: Updated the lead-in paragraph in IPsec encryption for e…

### DIFF
--- a/modules/nw-ovn-ipsec-external.adoc
+++ b/modules/nw-ovn-ipsec-external.adoc
@@ -6,7 +6,7 @@
 [id="nw-ovn-ipsec-external_{context}"]
 = IPsec encryption for external traffic
 
-{product-title} supports IPsec encryption for traffic to external hosts with TLS certificates that you must supply.
+{product-title} supports the use of IPsec to encrypt traffic destined for external hosts, ensuring confidentiality and integrity of data in transit. This feature relies on X.509 certificates that you must supply.
 
 [id="supported-platforms_{context}"]
 == Supported platforms
@@ -20,7 +20,7 @@ This feature is supported on the following platforms:
 
 [IMPORTANT]
 ====
-If you have {op-system-base-full} worker nodes, these do not support IPsec encryption for external traffic.
+If you have {op-system-base-full} compute nodes, these do not support IPsec encryption for external traffic.
 ====
 
 If your cluster uses {hcp} for Red Hat {product-title}, configuring IPsec for encrypting traffic to external hosts is not supported.


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-15868](https://issues.redhat.com/browse/OSDOCS-15868)

Link to docs preview:
* [IPsec encryption for external traffic](https://99002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/configuring-ipsec-ovn.html#nw-ovn-ipsec-external_configuring-ipsec-ovn)

- [x] SME has approved this change (Francois Duthilleul). 
- [x] QE has approved this change (Anurag Saxena).

