### PR TITLE
OSDOCS-16088: adds warning about images power loss

### DIFF
--- a/modules/microshift-embed-microshift-image-offline-deploy.adoc
+++ b/modules/microshift-embed-microshift-image-offline-deploy.adoc
@@ -9,6 +9,8 @@
 
 You can use image builder to create {op-system-ostree} images with embedded {microshift-short} container images. To embed container images, you must add the image references to your image builder blueprint file.
 
+include::snippets/microshift-power-loss-embed-images.adoc[leveloffset=1]
+
 .Prerequisites
 
 * You have root-user access to your build host.

--- a/modules/microshift-preparing-for-image-building-bootc.adoc
+++ b/modules/microshift-preparing-for-image-building-bootc.adoc
@@ -13,3 +13,5 @@ Use the following {op-system-base} documentation to understand the full details 
 * Follow the instructions at the following link:
 
 ** link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/index[Using image mode for RHEL to build, deploy, and manage operating systems]
+
+include::snippets/microshift-power-loss-embed-images.adoc[leveloffset=1]

--- a/snippets/microshift-power-loss-embed-images.adoc
+++ b/snippets/microshift-power-loss-embed-images.adoc
@@ -1,0 +1,11 @@
+// Text snippet included in the following modules:
+//
+// * modules/
+// * modules/
+
+:_mod-docs-content-type: SNIPPET
+
+[WARNING]
+====
+For offline or disconnected configurations, embed all container image dependencies as part of the system image. When container images are downloaded without being embedded into the system image, CRI-O wipes them off during unclean shutdowns, such as when a power loss occurs. In this case, you can only restore those container images when the system is online.
+====


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OSDOCS-16088](https://issues.redhat.com/browse/OSDOCS-16088)

Link to docs preview:
https://99003--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-about-rhel-image-mode.html#microshift-preparing-for-image-building_microshift-about-rhel-image-mode
https://99003--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_rpm_ostree/microshift-embed-in-rpm-ostree-offline-use.html

QE review:
- N/A this is just an admonition

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
