### PR TITLE
OSDOCS-16149:Update the z-stream RNs for 4.16.48

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3376,6 +3376,50 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.48
+[id="ocp-4-16-48_{context}"]
+=== RHSA-2025:15680 - {product-title} {product-version}.48 bug fix and security update
+
+Issued: 17 September 2025
+
+{product-title} release {product-version}.48 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:15680[RHSA-2025:15680] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.48 --pullspecs
+----
+
+[id="ocp-4-16-48-enhancements_{context}"]
+==== Enhancements
+
+* Before this update, the `cluster-policy-controller` container exposed the `10357` port for all networks and the bind address was set to `0.0.0.0`. The port was exposed outside the host network for the node because the `kube-controller-manager` (KCM) pod manifest set the `hostNetwork` parameter to `true`. This port is used only for the container probe. With this enhancement, the bind address is updated to listen on the localhost only. As result, the node security is improved because the port is not exposed outside of the node network. (link:https://issues.redhat.com/browse/OCPBUGS-60834[OCPBUGS-60834])
+
+[id="ocp-4-16-48-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, an outdated version of the {azure-short} API prevented specifying a Capacity Reservation Group for a `MachineSet`, if that group resided in a different subscription than the one originating the server creation. With this release, the most recent version of the {azure-short} API is used, which allows a Capacity Reservation Group for a `MachineSet` to be specified, even when that group is located in a separate subscription from the server creation point. (link:https://issues.redhat.com/browse/OCPBUGS-56169[OCPBUGS-56169])
+
+* Before this update, when a Cluster Operator took a long time to upgrade, the Cluster Version Operator (CVO) did not report anything because it could not determine if the upgrade was still progressing or already stuck. With this release, a new unknown status is added for the failing condition in the status of the cluster version reported by the CVO to remind the cluster administrators to check the cluster. As a result, the administrators do not need to wait on a blocked Cluster Operator upgrade. (link:https://issues.redhat.com/browse/OCPBUGS-58452[OCPBUGS-58452])
+
+* Before this update, when you changed the order of selectors in the `ClusterRole` parameter for the `OperatorGroup` in Operator Lifecycle Management (OLM), unnecessary etcd writes and auth cache invalidation degraded performance. With this release, an update to OLM prevents unnecessary etcd writes and auth cache invalidation when you change the selector order in the `ClusterRole` parameter. (link:https://issues.redhat.com/browse/OCPBUGS-58881[OCPBUGS-58881])
+
+* Before this update, when a `Machine Set` was scaled down and had reached its minimum size, the Cluster Autoscaler could leave the last remaining node with a `NoSchedule` taint that prevented use of a node. This issue was caused by a counting error in the Cluster Autoscaler. With this release, the counting error has been fixed so that the Cluster Autoscaler works as expected when a `Machine Set` is scaled down and has reached its minimum size. (link:https://issues.redhat.com/browse/OCPBUGS-59267[OCPBUGS-59267])
+
+* Before this update, the resources containing the configuration for the vSphere connection would break because of a mismatch between the user interface and the API. With this release, the resources do not break because the user interface uses the updated API definition. (link:https://issues.redhat.com/browse/OCPBUGS-60175[OCPBUGS-60175])
+
+* Before this update, the image registry would, in some cases, panic when attempting to purge failed uploads from s3-compatible storage providers. This issue was caused by the s3 driver for the image registry mishandling empty directory paths. With this release, the image registry properly handles empty directory paths, which fixes the panic. (link:https://issues.redhat.com/browse/OCPBUGS-60183[OCPBUGS-60183])
+
+* Before this update, insufficient obfuscation of new network data types in hosted control planes exposed user data. As a consequence, sensitive information was not protected. With this release, obfuscation for new network data types is implemented. As a result, obfuscated network data in hosted control planes improves data privacy. (link:https://issues.redhat.com/browse/OCPBUGS-60520[OCPBUGS-60520])
+
+* Before this update, when you used multiple recommenders for the Vertical Pod Autoscaler (VPA), the default VPA recommender would erroneously garbage collect `VPACheckpoint` objects that belonged to a VPA that was associated with a non-default recommender. With this release, the default recommender is prevented from garbage collecting the `VPACheckpoint` objects for non-default recommenders. (link:https://issues.redhat.com/browse/OCPBUGS-60609[OCPBUGS-60609])
+
+[id="ocp-4-16-48-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.47
 [id="ocp-4-16-47_{context}"]
 === RHSA-2025:14859 - {product-title} {product-version}.47 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-16149

Link to docs preview:
https://99025--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-48_release-notes