### PR TITLE
OSDOCS-16181 [NETOBSERV] Release notes 1.10

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3265,10 +3265,12 @@ Topics:
   Dir: network_observability
   Distros: openshift-enterprise,openshift-origin
   Topics:
-  - Name: Network observability release notes 1.9.3
-    File: network-observability-release-notes-1-9-3
-  - Name: Network observability release notes 1.9.2
-    File: network-observability-release-notes-1-9-2
+  - Name: Network Observability Operator release notes 1.10
+    File: network-observability-operator-release-notes-1-10
+  #- Name: Network observability release notes 1.9.3
+  #  File: network-observability-release-notes-1-9-3
+  #- Name: Network observability release notes 1.9.2
+  #  File: network-observability-release-notes-1-9-2
   - Name: Network observability release notes
     File: network-observability-operator-release-notes
   - Name: Network observability overview

--- a/modules/network-observability-operator-release-notes-1-10-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-10-advisory.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes-1-10.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-10-advisory_{context}"]
+= Network Observability Operator 1.10 advisory
+
+[role="_abstract"]
+Review the advisory that is available for the Network Observability Operator 1.10:
+
+//* link:https://access.redhat.com/errata/<number>[<number> Network Observability Operator 1.10]
+// Likely to be updated just after release in separate PR.

--- a/modules/network-observability-operator-release-notes-1-10-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-10-fixed-issues.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes-1-10.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-10-fixed-issues_{context}"]
+= Network Observability Operator 1.10 fixed issues
+
+[role="_abstract"]
+The Network Observability Operator 1.10 release contains several fixed issues that improve performance and the user experience.
+
+[id="metricname-and-remap-fields-are-validated-flowmetrics_{context}"]
+== MetricName and Remap fields are validated
+
+Before this update, users could create a `FlowMetric` custom resource (CR) with an invalid metric name. Although the `FlowMetric` CR was successfully created, the underlying metric would fail silently without providing any error feedback to the user.
+
+With this release, the `FlowMetric`, `metricName`, and `remap` fields are now validated before creation, so users are immediately notified if they enter an invalid name.
+
+link:https://issues.redhat.com/browse/NETOBSERV-2348[NETOBSERV-2348]
+
+[id="export-overview-topology-freeze_{context}"]
+== Improved html-to-image export performance
+
+Before this update, performance issues in the underlying library caused the `html-to-image` export function to take a long time, leading to browser freezing.
+
+With this release, the performance of the `html-to-image` library has been improved, reducing export wait times and eliminating browser freezing during image generation.
+
+link:https://issues.redhat.com/browse/NETOBSERV-2314[NETOBSERV-2314]
+
+[id="improved-warning-messages-on-missing-privileged-mode-for-ebpf-features_{context}"]
+== Improved warnings for eBPF privileged mode
+
+Before this update, when users selected `eBPF` features that require `privileged` mode, the features would often fail without clearly informing the user that `privileged` mode was missing or needed to be enabled.
+
+With this release, a validation hook immediately warns the user if the configuration is inconsistent. This improves user understanding and prevents misconfiguration.
+
+link:https://issues.redhat.com/browse/NETOBSERV-2268[NETOBSERV-2268]
+
+[id="source-destination-subnet-labels-in-open-telemetry-exporter_{context}"]
+== Subnet labels added to OpenTelemetry exporter
+
+Before this update, the `OpenTelemetry` metrics exporter was missing the network flow labels `SrcSubnetLabel` and `DstSubnetLabel`, causing them to show as empty.
+
+With this release, these labels are now correctly provided by the exporter. They have also been renamed to `source.subnet.label` and `destination.subnet.label` for improved clarity and consistency with `OpenTelemetry` standards.
+
+link:https://issues.redhat.com/browse/NETOBSERV-2405[NETOBSERV-2405]
+
+[id="reduced-default-tolerations-for-network-observability-components_{context}"]
+== Reduced default tolerations for network observability components
+Before this update, a default toleration was set on all network observability components to allow them to be scheduled on any node, including those tainted with `NoSchedule`. This could potentially block cluster upgrades.
+
+With this release, the default toleration is now only maintained for the `eBPF` agents and the `Flowlogs-Pipeline` when configured in `Direct` mode. The toleration has been removed from the {product-title} web console plugin and the `Flowlogs-Pipeline` when configured in `Kafka` mode.
+
+Additionally, while tolerations were always configurable in the `FlowCollector` custom resource (CR), it was previously impossible to replace the tolerations with an empty list. It is now possible to replace the tolerations with an empty list.
+
+link:https://issues.redhat.com/browse/NETOBSERV-2434[NETOBSERV-2434]

--- a/modules/network-observability-operator-release-notes-1-10-known-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-10-known-issues.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes-1-10.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-10-known-issues_{context}"]
+= Network Observability Operator 1.10 known issues
+
+[role="_abstract"]
+Review the following known issues and their recommended workarounds (where available) that might affect your use of the Network Observability Operator 1.10 release.
+
+[id="eBPF-agent-compatibility-with-older-open-shift-versions_{context}"]
+== eBPF agent compatibility with older {product-title} versions
+The eBPF agent used in the Network Observability Command Line Interface (CLI) packet capture feature is incompatible with {product-title} versions 4.16 and older.
+
+This limitation prevents the eBPF-based Packet Capture Agent (PCA) from functioning correctly on those older clusters.
+
+To work around this problem, you must manually configure PCA to use an older, compatible eBPF agent container image. For more information, see the Red Hat Knowledgebase Solution link:https://access.redhat.com/solutions/7132671[eBPF agent compatibility with older Openshift versions in Network Observability CLI 1.10+].
+
+link:https://issues.redhat.com/browse/NETOBSERV-2358[NETOBSERV-2358]

--- a/modules/network-observability-operator-release-notes-1-10-new-features-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-10-new-features-enhancements.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes-1-10.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-10-new-features-enhancements_{context}"]
+= Network Observability Operator 1.10 new features and enhancements
+
+[role="_abstract"]
+The Network Observability Operator 1.10 release enhances security, improves performance, and introduces new CLI UI tools for better network flow management.
+
+[id="network-policy-updates_{context}"]
+== Network policy updates
+The Network Observability Operator now supports configuring both ingress and egress network policies to control pod traffic. This enhancement improves security.
+
+By default, the `spec.NetworkPolicy.enable` specification is now set to `true`. This means that if you use Loki or Kafka, it is recommended that you deploy the Loki Operator and Kafka instances into dedicated namespaces. This ensures that the network policies can be configured correctly to allow communication between all components.
+//check if deploying Loki and Kafka in dedicated namespaces is included in the updated network policy, "Configuring network policy". Might need to add an IMPORTANT admonition to that section.
+
+[id="network-observability-operator-cli-ui-updates_{context}"]
+== Network Observability Operator CLI UI updates
+This release brings the following new features and updates to the Network Observability Operator CLI (`oc netobserv`) user interface (UI):
+
+*Table view enhancements*
+
+* Customizable columns: Click *Manage Columns* to select which columns to display, and tailor the table to your needs.
+* Smart filtering: Live filters now include auto-suggestions, making it easier to select the right keys and values.
+* Packet preview: When capturing packets, click a row to inspect the `pcap` content directly.
+
+*Terminal-based line charts enhancements*
+
+* Metrics visualization: Real-time graphs are rendered directly in the CLI.
+* Panel selection: Choose from predefined views or customize views by using the *Manage Panels* pop-up menu to selectively view charts of specific metrics.
+
+[id="network-observability-console-improvements_{context}"]
+== Network observability console improvements
+The network observability console plugin includes a new view to configure the `FlowCollector` custom resource (CR). From this view, you can complete the following tasks:
+
+* Configure the `FlowCollector` CR.
+* Calculate your resource footprint.
+* Gain increased of issues such as configuration warnings or high metrics cardinality.
+
+[id="network-observability-operator-performance-improvements_{context}"]
+== Performance improvements
+Network Observability Operator 1.10 has improved the performance and memory footprint of the Operator, especially visible on large clusters.
+

--- a/modules/network-observability-operator-release-notes-1-10-removed-features.adoc
+++ b/modules/network-observability-operator-release-notes-1-10-removed-features.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes-1-10.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-10-removed-features_{context}"]
+== Network Observability Operator 1.10 removed features
+
+[role="_abstract"]
+Review the removed features that might affect your use of the Network Observability Operator 1.10 release.
+
+[id="flowcollector-api-v1beta1_{context}"]
+== FlowCollector API version v1beta1 has been removed
+The `FlowCollector` custom resource (CR) API version `v1beta1` has been removed and is no longer supported. Use the `v1beta2` version.

--- a/modules/network-observability-operator-release-notes-1-10-technology-preview-features.adoc
+++ b/modules/network-observability-operator-release-notes-1-10-technology-preview-features.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes-1-10.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-10-technology-preview-features_{context}"]
+= Network Observability Operator 1.10 Technology Preview features
+
+[id="network-observability-operator-custom-alerts-technology-preview_{context}"]
+== Network Observability Operator custom alerts (Technology Preview)
+This release introduces new alert functionality, and custom alert configuration. These capabilities are Technology Preview features, and must be explicitly enabled.
+
+To view the new alerts, in the {product-title} web console, click *Observe* → *Alerting* → *Alerting rules*.
+
+[id="network-observability-operator-network-health-dashboard-technology-preview_{context}"]
+== Network Observability Operator Network Health dashboard (Technology Preview)
+When you enable the Technology Preview alerts functionality in the Network Observability Operator, you can view a a new *Network Health* dashboard in the {product-title} web console by clicking *Observe*.
+
+The *Network Health* dashboard provides a summary of triggered alerts, distinguishing between critical, warning, and minor issues, and also shows pending alerts.

--- a/observability/network_observability/network-observability-operator-release-notes-1-10.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes-1-10.adoc
@@ -1,0 +1,27 @@
+//Network Observability Operator Release Notes
+:_mod-docs-content-type: ASSEMBLY
+[id="network-observability-operator-release-notes-1-10"]
+= Network Observability Operator release notes 1.10
+
+:context: network-observability-operator-release-notes-v1-10
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+With the Network Observability Operator, administrators can observe and analyze network traffic flows for {product-title} clusters.
+
+These release notes track the development of the Network Observability Operator in the {product-title}.
+
+For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-overview[About Network Observability Operator].
+
+include::modules/network-observability-operator-release-notes-1-10-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-new-features-enhancements.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-technology-preview-features.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-removed-features.adoc[leveloffest=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-known-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-fixed-issues.adoc[leveloffset=+1]

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -14,6 +14,12 @@ These release notes track the development of the Network Observability Operator 
 
 For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-overview[About network observability].
 
+include::modules/network-observability-operator-release-notes-1-9-3-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-9-2-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-release-notes-1-9-2-bug-fixes.adoc[leveloffset=+1]
+
 [id="network-observability-operator-release-notes-1-9-1_{context}"]
 == Network Observability Operator 1.9.1
 The following advisory is available for the Network Observability Operator 1.9.1:


### PR DESCRIPTION
[OSDOCS-16181](https://issues.redhat.com//browse/OSDOCS-16181) [NETOBSERV] Release notes 1.10

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the `no-1.10` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the <no-.10> content just before its GA.

Note to self for integration: applies to OCP 4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-16181

Link to docs preview:
* Network Observability Operator 1.10 release notes: https://99081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes-1-10.html
* Network Observability Operator 1.10 advisory: https://99081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes-1-10.html#network-observability-operator-release-notes-1-10-advisory_network-observability-operator-release-notes-v1-10
* Network Observability Operator 1.10 new features and enhancements: https://99081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes-1-10.html#network-observability-operator-release-notes-1-10-new-features-enhancements_network-observability-operator-release-notes-v1-10
* Network Observability Operator 1.10 Technology Preview features: https://99081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes-1-10.html#network-observability-operator-release-notes-1-10-technology-preview-features_network-observability-operator-release-notes-v1-10
* Network Observability Operator 1.10 removed features: https://99081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes-1-10.html#network-observability-operator-release-notes-1-10-removed-features_network-observability-operator-release-notes-v1-10
* Network Observability Operator 1.10 known issues: https://99081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes-1-10.html#network-observability-operator-release-notes-1-10-known-issues_network-observability-operator-release-notes-v1-10
* Network Observability Operator 1.10 fixed issues: https://99081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes-1-10.html#network-observability-operator-release-notes-1-10-fixed-issues_network-observability-operator-release-notes-v1-10

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* If the advisory is not available before doc merge freeze, it is being addressed by this Jira: https://issues.redhat.com/browse/OSDOCS-16508 
* Following the guidance here: https://redhat-documentation.github.io/supplementary-style-guide/#release-notes
* Following the order outlined here: https://redhat-documentation.github.io/supplementary-style-guide/#release-note-types 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
