### PR TITLE
OSSM-10596 Arrange the release notes assembly for 3.0

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3,11 +3,11 @@ Name: Release Notes
 Dir: ossm-release-notes
 Distros: openshift-service-mesh
 Topics:
-- Name: Service Mesh 3.x release notes
+- Name: Service Mesh 3.0 release notes
   File: ossm-release-notes
-- Name: Service Mesh 3.x version support tables
+- Name: Service Mesh 3.0 version support tables
   File: ossm-release-notes-version-support-tables
-- Name: Service Mesh 3.x feature support tables
+- Name: Service Mesh 3.0 feature support tables
   File: ossm-release-notes-feature-support-tables
 ---
 Name: Migrating from Service Mesh 2 to Service Mesh 3

--- a/modules/ossm-release-notes-3-0-1.adoc
+++ b/modules/ossm-release-notes-3-0-1.adoc
@@ -6,4 +6,4 @@
 [id="ossm-release-3-0-1_{context}"]
 = {SMProductName} version 3.0.1
 
-This release of {SMProductName} is included with the {SMProductName} Operator 3.0.1 and is supported on {ocp-product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {ocp-product-title} 4.14 and later. For supported component versions for 3.0.1, see "Service Mesh version support tables".
+This release of {SMProductName} is included with the {SMProductName} Operator 3.0.1 and is supported on {ocp-product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs). For supported component versions for 3.0.1, see "Service Mesh version support tables".

--- a/modules/ossm-release-notes-3-0-2.adoc
+++ b/modules/ossm-release-notes-3-0-2.adoc
@@ -6,4 +6,4 @@
 [id="ossm-release-3-0-2_{context}"]
 = {SMProductName} version 3.0.2
 
-This release of {SMProductName} is included with the {SMProductName} Operator 3.0.2 and is supported on {ocp-product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {ocp-product-title} 4.14 and later. For supported component versions for 3.0.2, see "Service Mesh version support tables".
+This release of {SMProductName} is included with the {SMProductName} Operator 3.0.2 and is supported on {ocp-product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs). For supported component versions for 3.0.2, see "Service Mesh version support tables".

--- a/modules/ossm-release-notes-3-0-3.adoc
+++ b/modules/ossm-release-notes-3-0-3.adoc
@@ -6,7 +6,7 @@
 [id="ossm-release-3-0-3_{context}"]
 = {SMProductName} version 3.0.3
 
-This release of {SMProductName} is included with the {SMProductName} Operator 3.0.3 and is supported on {ocp-product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {ocp-product-title} 4.14 and later. For supported component versions for 3.0.3, see "Service Mesh version support tables".
+This release of {SMProductName} is included with the {SMProductName} Operator 3.0.3 and is supported on {ocp-product-title} 4.14 and later. This release addresses Common Vulnerabilities and Exposures (CVEs). For supported component versions for 3.0.3, see "Service Mesh version support tables".
 
 [id="ossm-enhancements-3-0-3_{context}"]
 == Enhancements

--- a/modules/ossm-release-notes-observability-features.adoc
+++ b/modules/ossm-release-notes-observability-features.adoc
@@ -38,4 +38,4 @@ Module included in the following assemblies:
 | NA
 |===
 
-. While Grafana is not included as part of {SMProduct}, the preconfigured dashboards for Grafana maintained by the Istio community can be use with {SMProduct} under a Developer Preview scope. These are best used as a starting point for building your own dashboards.
+. While Grafana is not included as part of {SMProduct}, you can use the preconfigured dashboards for Grafana maintained by the {istio} community with {SMProduct} under a Developer Preview scope. 

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -166,5 +166,3 @@ See the following table for information about {SMProduct} 3 supported versions.
 | `IstioCNI` resource
 | 1.24.3 ^[1]^
 |===
-
-//note to self for post GA: might be worth having Envoy proxy and IstioCNI attributes.

--- a/ossm-release-notes/ossm-release-notes-feature-support-tables.adoc
+++ b/ossm-release-notes/ossm-release-notes-feature-support-tables.adoc
@@ -20,6 +20,7 @@ Developer Preview (DP) features are not supported by Red Hat in any way and are 
 Not available (NA) features might not be available with {SMProductName} 3.
 
 include::modules/ossm-release-notes-sail-operator-apis.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-istio-deployment-lifecycle.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -28,15 +29,17 @@ include::modules/ossm-release-notes-istio-deployment-lifecycle.adoc[leveloffset=
 * xref:../install/ossm-istioctl-tool.adoc#ossm-support-for-istioctl_ossm-istioctl-tool[Support for Istioctl]
 
 include::modules/ossm-release-notes-istio-traffic-management.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-kubernetes-gateway-api.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-security-features.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-observability-features.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-consoles-and-dashboards.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-extensibility-features.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-istio-ambient-mode.adoc[leveloffset=+1]
 
-// commented out in case it is needed for GA
-//[role="_additional-resources"]
-//[id="additional-resources_{context}"]
-//.Additional resources
 

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -6,36 +6,35 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{SMProductName} release notes contain information about new features and enhancements, deprecated features, technology preview features, bug fixes, and known issues. They contain a set of tables for supported component versions and Istio features, and are organized by {SMProduct} version.
+The {SMProductName} release notes provide details about new features and enhancements, deprecated features, technology preview features, fixed issues, and known issues. The release notes also include tables for supported component versions and {istio} features, organized by {SMProduct} version.
 
 [NOTE]
 ====
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[{ocp-short-name} Operator Life Cycles].
 ====
 
-//03/25/2025:
-//Gwynne is rotating off Service Mesh. For next writer and CS: Continue to refine the IA for rel notes. The structure and IA will likely make more sense as there are more z-streams and versions released, making it easier to see how best to lay rel notes out in docs.redhat. Should anything be its own tile to make it easier to find for users?
-
 include::modules/ossm-release-notes-3-0-5.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-4.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-3.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-2.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-1.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-new-features.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-known-issues.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-deprecated-removed-features.adoc[leveloffset=+1]
-
-//only GA release notes should appear since Service Mesh is versioned. Readdress in IA post GA.
-//include::snippets/technology-preview.adoc[]
-
-//include::modules/ossm-release-3-0-TP-1.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources-release-notes_{context}"]
 == Additional resources
 
-* xref:../ossm-release-notes/ossm-release-notes-version-support-tables.adoc#ossm-release-notes-version-support-tables[Service Mesh version support]
-* xref:../ossm-release-notes/ossm-release-notes-feature-support-tables.adoc#ossm-release-notes-feature-support-tables[Service Mesh 3.0 feature support tables]
+* xref:../ossm-release-notes/ossm-release-notes-version-support-tables.adoc#ossm-release-notes-version-support-tables[Service Mesh version support tables]
+* xref:../ossm-release-notes/ossm-release-notes-feature-support-tables.adoc#ossm-release-notes-feature-support-tables[Service Mesh feature support tables]
 * xref:../migrating/ossm-migrating-from-service-mesh-2-to-3.adoc#ossm-migrating-from-service-mesh-2-to-3[Migrating from {smproductshortname} 2 to {smproductshortname} 3]
 * xref:../migrating/checklists/ossm-migrating-read-me.adoc#ossm-migrating-read-me[Important information to know if you are migrating from {SMProduct} 2.6]
 * xref:../migrating/checklists/ossm-migrating-read-me.adoc#ossm-migrating-read-me-support-for-istioctl_ossm-migrating-read-me[Support for Istioctl]


### PR DESCRIPTION
Change type: Arrange the release notes assembly for 3.0

Doc JIRA: https://issues.redhat.com/browse/OSSM-10596

Fix Version:
[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Previews: https://99101--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes

Peer Review: @rh-tokeefe 