### PR TITLE
[enterprise-4.18]OCPBUGS-61722: Reverting PTP v1 content removed in error

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1732,6 +1732,10 @@ Topics:
       File: ptp-cloud-events-consumer-dev-reference-v2
     - Name: PTP events REST API v2 reference
       File: ptp-events-rest-api-reference-v2
+    - Name: Developing PTP events consumer applications with the REST API v1
+      File: ptp-cloud-events-consumer-dev-reference
+    - Name: PTP events REST API v1 reference
+      File: ptp-events-rest-api-reference
 - Name: Kubernetes NMState
   Dir: k8s_nmstate
   Topics:

--- a/networking/advanced_networking/ptp/ptp-cloud-events-consumer-dev-reference.adoc
+++ b/networking/advanced_networking/ptp/ptp-cloud-events-consumer-dev-reference.adoc
@@ -22,7 +22,7 @@ include::snippets/deprecated-feature.adoc[]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../networking/ptp/ptp-events-rest-api-reference.adoc#ptp-events-rest-api-reference[PTP events REST API v1 reference]
+* xref:../../../networking/advanced_networking/ptp/ptp-events-rest-api-reference.adoc#ptp-events-rest-api-reference[PTP events REST API v1 reference]
 
 include::modules/cnf-about-ptp-fast-event-notifications-framework.adoc[leveloffset=+1]
 
@@ -33,7 +33,7 @@ include::modules/cnf-configuring-the-ptp-fast-event-publisher.adoc[leveloffset=+
 [role="_additional-resources"]
 .Additional resources
 
-* For a complete example CR that configures `linuxptp` services as an ordinary clock with PTP fast events, see xref:../../networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-ordinary-clock_configuring-ptp[Configuring linuxptp services as ordinary clock].
+* For a complete example CR that configures `linuxptp` services as an ordinary clock with PTP fast events, see xref:../../../networking/advanced_networking/ptp/configuring-ptp.adoc#configuring-linuxptp-services-as-ordinary-clock_configuring-ptp[Configuring linuxptp services as ordinary clock].
 
 include::modules/ptp-events-consumer-application.adoc[leveloffset=+1]
 
@@ -44,7 +44,7 @@ include::modules/ptp-subscribing-consumer-app-to-events.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../networking/ptp/ptp-events-rest-api-reference.adoc#api-ocloud-notifications-v1-subscriptions_using-ptp-hardware-fast-events-framework-v1[api/ocloudNotifications/v1/subscriptions]
+* xref:../../../networking/advanced_networking/ptp/ptp-events-rest-api-reference.adoc#api-ocloud-notifications-v1-subscriptions_using-ptp-hardware-fast-events-framework-v1[api/ocloudNotifications/v1/subscriptions]
 
 include::modules/ptp-verifying-events-consumer-app-is-receiving-events.adoc[leveloffset=+1]
 
@@ -53,6 +53,6 @@ include::modules/cnf-monitoring-fast-events-metrics.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer.adoc#accessing-metrics-as-a-developer[Accessing metrics as a developer]
+* xref:../../../observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer.adoc#accessing-metrics-as-a-developer[Accessing metrics as a developer]
 
 include::modules/nw-ptp-operator-metrics-reference.adoc[leveloffset=+1]


### PR DESCRIPTION
OCPBUGS-61722: Reverting PTP v1 content removed in error

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-61722

Link to docs preview:
- https://99103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/ptp-cloud-events-consumer-dev-reference
- https://99103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/ptp-events-rest-api-reference

No QE needed this was a docs error.
