### PR TITLE
Telcodocs 2269-RN: Support for schedulable control-plane in NUMAResourcesOperator

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -582,6 +582,15 @@ In {product-title} {product-version}, the NUMA Resources Operator automatically 
 
 For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-managing-ha-nrop_numa-aware[Managing high availability (HA) for the NUMA-aware scheduler].
 
+[id="ocp-release-notes-numa-resources-operator-schedulable-control-planes_{context}"]
+==== NUMA Resources Operator now supports schedulable control plane nodes
+
+With this release, the NUMA Resources Operator can now manage control plane nodes that are configured as schedulable. This capability allows you to deploy topology-aware workloads on control plane nodes, which is especially useful in resource-constrained environments like compact clusters.
+
+This enhancement helps the NUMA Resources Operator schedule your NUMA-aware pods on the node with the most suitable NUMA topology, even on control plane nodes. 
+
+For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-numa-resource-operator-support-scheduling-cp_numa-aware[NUMA Resources Operator support for schedulable control-plane nodes].
+
 [id="ocp-4-20-receive-packet-steering-disabled_{context}"]
 ==== Receive Packet Steering (RPS) is now disabled by default
 


### PR DESCRIPTION
[TELCODOCS-2269]: Support for schedulable control-plane in NUMAResourcesOperator

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2269
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://99106--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-numa-resources-operator-schedulable-control-planes_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
