### PR TITLE
OSDOCS-16161: Refined the note on Configuring the audit log policy wi…

### DIFF
--- a/modules/nodes-nodes-audit-policy-custom.adoc
+++ b/modules/nodes-nodes-audit-policy-custom.adoc
@@ -12,7 +12,7 @@ These custom rules take precedence over the top-level profile field. The custom 
 
 [IMPORTANT]
 ====
-Custom rules are ignored if the top-level profile field is set to `None`.
+If you set the top-level profile field to `None`, an API server, such as the Kubernetes API server, ignores custom rules and disables audit logging.
 ====
 
 .Prerequisites
@@ -47,11 +47,6 @@ spec:
 ----
 <1> Add one or more groups and specify the profile to use for that group. These custom rules take precedence over the top-level profile field. The custom rules are evaluated from top to bottom, and the first that matches is applied.
 <2> Set to `Default`, `WriteRequestBodies`, or `AllRequestBodies`. If you do not set this top-level profile field, it defaults to the `Default` profile.
-+
-[WARNING]
-====
-Do not set the top-level profile field to `None` if you want to use custom rules. Custom rules are ignored if the top-level profile field is set to `None`.
-====
 
 . Save the file to apply the changes.
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-16161](https://issues.redhat.com/browse/OSDOCS-16161)

Link to docs preview:
* [Configuring the audit log policy with custom rules](https://99113--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/audit-log-policy-config.html#configuring-audit-policy-custom_audit-log-policy-config)

- [x] SME has approved this change (SAYED AMRIN HANIF/Damien Grisonnet).
- [x] QE has approved this change (Rahul Gangwar).

