### PR TITLE
Update ocp-4-19-release-notes.adoc

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2200,6 +2200,19 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |====
 
+[id="ocp-release-notes-insights-operator-tech-preview_{context}"]
+=== Insights Operator Technology Preview features
+
+.Insights Operator Technology Preview tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.17 |4.18 |4.19
+
+|Insights Runtime Extractor
+|Not Available
+|Technology Preview
+|Technology Preview
+|====
 
 [id="ocp-release-notes-installing-tech-preview_{context}"]
 === Installation Technology Preview features

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -513,17 +513,6 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 2. Persistent non-shared storage must be provisioned by using local storage, such as iSCSI, FC, or by using LSO with DASD, FCP, or EDEV/FBA.
 --
 
-[id="ocp-release-notes-insights-operator-enhancements_{context}"]
-=== Insights Operator
-
-
-[id="ocp-release-notes-insights-operator-runtime-extractor_{context}"]
-==== Insights Runtime Extractor is generally available
-
-In {product-title} 4.18, the Insights Operator introduced the _Insights Runtime Extractor_ workload data collection feature as a Technology Preview feature to help Red{nbsp}Hat better understand the workload of your containers.
-Now, in version 4.19, the feature is generally available.
-The Insights Runtime Extractor feature gathers runtime workload data and sends it to Red{nbsp}Hat.
-
 [id="ocp-release-notes-installation-and-update_{context}"]
 === Installation and update
 


### PR DESCRIPTION
Added Technology preview table for "Insights Runtime Extractor"

Version(s):
4.19

Issue:
[OSDOCS-16108](https://issues.redhat.com/browse/OSDOCS-16108)

Link to docs preview:
* [Insights Operator Technology Preview features](https://99132--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-insights-operator-tech-preview_release-notes)


QE review:
- [ ] QE has approved this change.
