### PR TITLE
OCPBUGS-61691: Fixed multiple network sentences post removal of addit…

### DIFF
--- a/modules/support-matrix-for-udn-nad.adoc
+++ b/modules/support-matrix-for-udn-nad.adoc
@@ -12,7 +12,7 @@ User-defined networks and network attachment definitions can serve as both the p
 
 [NOTE]
 ====
-As of {product-title} 4.19, the `Localnet` topology is generally available for the `ClusterUserDefinedNetwork` CRs and is the preferred method for connecting physical networks to virtual networks. Alternatively, the `NetworkAttachmentDefinition` CR can also be used to create secondary networks with `Localnet` topologies.
+As of {product-title} 4.19, the use of the `Localnet` topology by `ClusterUserDefinedNetwork` CRs is generally available. This configuration is the preferred method for connecting physical networks to virtual networks. Alternatively, the `NetworkAttachmentDefinition` CR can also be used to create secondary networks with `Localnet` topologies.
 ====
 
 The following section highlights the supported features of the `UserDefinedNetwork` and `NetworkAttachmentDefinition` CRs when they are used as either the primary or secondary network. A separate table for the `ClusterUserDefinedNetwork` CR is also included.

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -30,7 +30,7 @@ For information about Network Attachment Definitions, see xref:../../networking/
 [id="additional-network-considerations"]
 == Usage scenarios for a secondary network
 
-You can use a secondary network, also known as a _secondary network_, in situations where network isolation is needed, including data plane and control plane separation. Isolating network traffic is useful for the following performance and security reasons:
+You can use a secondary network in situations where network isolation is needed, including data plane and control plane separation. Isolating network traffic is useful for the following performance and security reasons:
 
 . Performance
 +


### PR DESCRIPTION
Fixed internal typos. Please let me know if engineer approvals are needed. I don't think the changes merit them.

Version(s):
4.17+

Issue:
[OCPBUGS-61691](https://issues.redhat.com/browse/OCPBUGS-61691)

Link to docs preview:
* [UserDefinedNetwork and NetworkAttachmentDefinition support matrix](https://99143--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks.html#support-matrix-for-udn-nad_understanding-multiple-networks)
* [Usage scenarios for a secondary network](https://99143--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks.html#additional-network-considerations)

