### PR TITLE
OSDOCS-14495: Prune Observability and Logging

### DIFF
--- a/modules/monitoring-about-managing-alerts.adoc
+++ b/modules/monitoring-about-managing-alerts.adoc
@@ -9,7 +9,7 @@
 In the {product-title}, the Alerting UI enables you to manage alerts, silences, and alerting rules.
 
 * *Alerting rules*. Alerting rules contain a set of conditions that outline a particular state within a cluster. Alerts are triggered when those conditions are true. An alerting rule can be assigned a severity that defines how the alerts are routed.
-* *Alerts*. An alert is fired when the conditions defined in an alerting rule are true. Alerts provide a notification that a set of circumstances are apparent within an {product-title} cluster.
+* *Alerts*. An alert is fired when the conditions defined in an alerting rule are true. Alerts provide a notification that a set of circumstances are apparent within your {product-title} cluster.
 * *Silences*. A silence can be applied to an alert to prevent notifications from being sent when the conditions for an alert are true. You can mute an alert after the initial notification, while you work on resolving the issue.
 
 [NOTE]

--- a/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
+++ b/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
@@ -30,14 +30,14 @@ After you add a secret to the config map, the secret is mounted as a volume at `
 * You have created the `cluster-monitoring-config` config map.
 // end::CPM[]
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have created the secret to be configured in Alertmanager in the `{namespace-name}` project.
 * You have installed the {oc-first}.

--- a/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
+++ b/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
@@ -34,14 +34,14 @@ You can assign tolerations to the components that monitor user-defined projects,
 // end::CPM[]
 
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists in the `openshift-user-workload-monitoring` namespace. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have installed the {oc-first}.
 

--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -28,14 +28,14 @@ You can attach custom labels to all time series and alerts leaving Prometheus by
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 // end::CPM[]
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have installed the {oc-first}.
 

--- a/modules/monitoring-common-terms.adoc
+++ b/modules/monitoring-common-terms.adoc
@@ -24,7 +24,7 @@ config map::
 A config map provides a way to inject configuration data into pods. You can reference the data stored in a config map in a volume of type `ConfigMap`. Applications running in a pod can use this data.
 
 Container::
-A container is a lightweight and executable image that includes software and all its dependencies. Containers virtualize the operating system. As a result, you can run containers anywhere from a data center to a public or private cloud as well as a developer’s laptop.
+A container is a lightweight and executable image that includes software and all its dependencies. Containers virtualize the operating system. As a result, you can run containers anywhere from a data center to a public or private cloud as well as a developer's laptop.
 
 custom resource (CR)::
 A CR is an extension of the Kubernetes API. You can create custom resources.
@@ -61,7 +61,7 @@ node::
 A compute machine in the {product-title} cluster. A node is either a virtual machine (VM) or a physical machine.
 
 Operator::
-The preferred method of packaging, deploying, and managing a Kubernetes application in an {product-title} cluster. An Operator takes human operational knowledge and encodes it into software that is packaged and shared with customers.
+The preferred method of packaging, deploying, and managing a Kubernetes application in your {product-title} cluster. An Operator takes human operational knowledge and encodes it into software that is packaged and shared with customers.
 
 Operator Lifecycle Manager (OLM)::
 OLM helps you install, update, and manage the lifecycle of Kubernetes native applications. OLM is an open source toolkit designed to manage Operators in an effective, automated, and scalable way.
@@ -85,16 +85,16 @@ Silences::
 A silence can be applied to an alert to prevent notifications from being sent when the conditions for an alert are true. You can mute an alert after the initial notification, while you work on resolving the underlying issue.
 
 storage::
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 {product-title} supports many types of storage, both for on-premise and cloud providers.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-dedicated[]
 {product-title} supports many types of storage on AWS and GCP.
 endif::openshift-dedicated[]
-ifdef::openshift-rosa[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 {product-title} supports many types of storage on AWS.
-endif::openshift-rosa[]
-You can manage container storage for persistent and non-persistent data in an {product-title} cluster.
+endif::openshift-rosa,openshift-rosa-hcp[]
+You can manage container storage for persistent and non-persistent data in your {product-title} cluster.
 
 Thanos Ruler::
 The Thanos Ruler is a rule evaluation engine for Prometheus that is deployed as a separate process. In {product-title}, Thanos Ruler provides rule and alerting evaluation for the monitoring of user-defined projects.

--- a/modules/monitoring-components-for-monitoring-user-defined-projects.adoc
+++ b/modules/monitoring-components-for-monitoring-user-defined-projects.adoc
@@ -7,9 +7,9 @@
 = Components for monitoring user-defined projects
 
 {product-title}
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 {product-version}
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 includes an optional enhancement to the monitoring stack that helps you monitor services and pods in user-defined projects. This feature includes the following components:
 
 .Components for monitoring user-defined projects
@@ -26,9 +26,9 @@ includes an optional enhancement to the monitoring stack that helps you monitor 
 
 |Thanos Ruler
 |The Thanos Ruler is a rule evaluation engine for Prometheus that is deployed as a separate process. In {product-title}
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 {product-version}
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 , Thanos Ruler provides rule and alerting evaluation for the monitoring of user-defined projects.
 
 |Alertmanager
@@ -36,11 +36,11 @@ endif::openshift-dedicated,openshift-rosa[]
 
 |===
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 The components in the preceding table are deployed after you enable monitoring for user-defined projects.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 The monitoring stack monitors all components for user-defined projects. The components are automatically updated when {product-title} is updated.

--- a/modules/monitoring-configurable-monitoring-components.adoc
+++ b/modules/monitoring-configurable-monitoring-components.adoc
@@ -25,12 +25,12 @@
 This table shows the monitoring components you can configure and the keys used to specify the components in the `{configmap-name}` config map.
 
 // tag::UWM[]
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [WARNING]
 ====
 Do not modify the monitoring components in the `cluster-monitoring-config` `ConfigMap` object. Red{nbsp}Hat Site Reliability Engineers (SRE) use these components to monitor the core cluster components and Kubernetes services.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 
 // tag::CPM[]
@@ -55,7 +55,7 @@ endif::openshift-dedicated,openshift-rosa[]
 // end::CPM[]
 |====
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [WARNING]
 ====
 Different configuration changes to the `ConfigMap` object result in different outcomes:
@@ -72,7 +72,7 @@ Different configuration changes to the `ConfigMap` object result in different ou
 
 Each procedure that requires a change in the config map includes its expected outcome.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Unset the source code block attributes just to be safe.
 :!configmap-name:

--- a/modules/monitoring-configuring-a-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-persistent-volume-claim.adoc
@@ -28,14 +28,14 @@ To use a persistent volume (PV) for monitoring components, you must configure a 
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 // end::CPM[]
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have installed the {oc-first}.
 

--- a/modules/monitoring-configuring-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-configuring-alert-routing-for-user-defined-projects.adoc
@@ -10,13 +10,13 @@ If you are a non-administrator user who has been given the `alert-routing-edit` 
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * A cluster administrator has enabled monitoring for user-defined projects.
 * A cluster administrator has enabled alert routing for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Alert routing has been enabled for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You are logged in as a user that has the `alert-routing-edit` cluster role for the project for which you want to create alert routing.
 * You have installed the {oc-first}.
 

--- a/modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc
+++ b/modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc
@@ -15,11 +15,11 @@ All features of a supported version of upstream Alertmanager are also supported 
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have enabled a separate instance of Alertmanager for user-defined alert routing.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-rosa,openshift-dedicated[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 endif::[]
 * You have installed the {oc-first}.

--- a/modules/monitoring-configuring-external-alertmanagers.adoc
+++ b/modules/monitoring-configuring-external-alertmanagers.adoc
@@ -39,14 +39,14 @@ If you add the same external Alertmanager configuration for multiple clusters an
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 // end::CPM[]
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have installed the {oc-first}.
 

--- a/modules/monitoring-configuring-persistent-storage.adoc
+++ b/modules/monitoring-configuring-persistent-storage.adoc
@@ -21,11 +21,11 @@ In multi-node clusters, you must configure persistent storage for Prometheus, Al
 [id="persistent-storage-prerequisites_{context}"]
 == Persistent storage prerequisites
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Use the block type of storage.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Dedicate sufficient persistent storage to ensure that the disk does not become full.
 
 * Use `Filesystem` as the storage type value for the `volumeMode` parameter when you configure the persistent volume.
@@ -38,4 +38,4 @@ ifndef::openshift-dedicated,openshift-rosa[]
 For example, some NFS file system implementations are not POSIX compliant.
 If you want to use an NFS file system for storage, verify with the vendor that their NFS implementation is fully POSIX compliant.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
+++ b/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
@@ -42,15 +42,15 @@ You can configure pod topology spread constraints for monitoring pods by using t
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 // end::CPM[]
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have installed the {oc-first}.
 

--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -27,14 +27,14 @@ You can configure remote write storage to enable Prometheus to send ingested met
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 // end::CPM[]
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have installed the {oc-first}.
 * You have set up a remote write compatible endpoint (such as Thanos) and know the endpoint URL. See the link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Prometheus remote endpoints and storage documentation] for information about endpoints that are compatible with the remote write feature.

--- a/modules/monitoring-controlling-the-impact-of-unbound-attributes-in-user-defined-projects.adoc
+++ b/modules/monitoring-controlling-the-impact-of-unbound-attributes-in-user-defined-projects.adoc
@@ -10,12 +10,12 @@ Developers can create labels to define attributes for metrics in the form of key
 
 Every assigned key-value pair has a unique time series. The use of many unbound attributes in labels can result in an exponential increase in the number of time series created. This can impact Prometheus performance and can consume a lot of disk space.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Cluster administrators
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 A `dedicated-admin`
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 can use the following measures to control the impact of unbound metrics attributes in user-defined projects:
 
 * Limit the number of samples that can be accepted per target scrape in user-defined projects

--- a/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
+++ b/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
@@ -20,7 +20,7 @@
 
 You can create cluster ID labels for metrics by adding the `write_relabel` settings for remote write storage in the `{configmap-name}` config map in the `{namespace-name}` namespace.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // tag::UWM[]
 [NOTE]
 ====
@@ -29,7 +29,7 @@ This behavior ensures that the final namespace label value is equal to the names
 You cannot override this default configuration by setting the value of the `honorLabels` field to `true` for `PodMonitor` or `ServiceMonitor` objects.
 ====
 // end::UWM[]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Prerequisites
 
@@ -38,14 +38,14 @@ endif::openshift-dedicated,openshift-rosa[]
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 // end::CPM[]
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` ConfigMap object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have installed the {oc-first}.
 * You have configured remote write storage.

--- a/modules/monitoring-creating-cross-project-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-creating-cross-project-alerting-rules-for-user-defined-projects.adoc
@@ -12,14 +12,14 @@ Therefore, you can have generic alerting rules that apply to multiple user-defin
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you are a cluster administrator, you have access to the cluster as a user with the `cluster-admin` cluster role.
 * If you are a non-administrator user, you have access to the cluster as a user with the following user roles:
 ** The `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project to edit the `user-workload-monitoring-config` config map.
 ** The `monitoring-rules-edit` cluster role for the project where you want to create an alerting rule.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 +
 [NOTE]
@@ -27,7 +27,7 @@ ifdef::openshift-dedicated,openshift-rosa[]
 If you are a non-administrator user, you can still create cross-project alerting rules if you have the `monitoring-rules-edit` cluster role for the project where you want to create an alerting rule. However, that project needs to be configured in the `user-workload-monitoring-config` config map under the `namespacesWithoutLabelEnforcement` property, which can be done only by cluster administrators.
 ====
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/monitoring-default-monitoring-targets.adoc
+++ b/modules/monitoring-default-monitoring-targets.adoc
@@ -6,15 +6,15 @@
 [id="default-monitoring-targets_{context}"]
 = Default monitoring targets
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 In addition to the components of the stack itself, the default monitoring stack monitors additional platform components.
 
 The following are examples of monitoring targets:
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 The following are examples of targets monitored by Red{nbsp}Hat Site Reliability Engineers (SRE) in your {product-title} cluster:
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 * CoreDNS
 * etcd
@@ -24,20 +24,20 @@ endif::openshift-dedicated,openshift-rosa[]
 * Kubernetes API server
 * Kubernetes controller manager
 * Kubernetes scheduler
-ifndef::openshift-rosa[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 * OpenShift API server
 * OpenShift Controller Manager
 * Operator Lifecycle Manager (OLM)
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 The exact list of targets can vary depending on your cluster capabilities and installed components.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 * The exact list of targets can vary depending on your cluster capabilities and installed components.
@@ -47,4 +47,4 @@ link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&
 ====
 
 Other {product-title} framework components might be exposing metrics as well. For details, see their respective documentation.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/monitoring-disabling-cross-project-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-disabling-cross-project-alerting-rules-for-user-defined-projects.adoc
@@ -13,12 +13,12 @@ Creating cross-project alerting rules for user-defined projects is enabled by de
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/monitoring-editing-silences.adoc
+++ b/modules/monitoring-editing-silences.adoc
@@ -11,12 +11,12 @@ You can edit a silence, which expires the existing silence and creates a new one
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you are a cluster administrator, you have access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you are a cluster administrator, you have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you are a non-administrator user, you have access to the cluster as a user with the following user roles:
 ** The `cluster-monitoring-view` cluster role, which allows you to access Alertmanager.
 ** The `monitoring-alertmanager-edit` role, which permits you to create and silence alerts.

--- a/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
@@ -6,21 +6,21 @@
 [id="enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing_{context}"]
 = Enabling a separate Alertmanager instance for user-defined alert routing
 
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 In some clusters, you might want to deploy a dedicated Alertmanager instance for user-defined projects, which can help reduce the load on the default platform Alertmanager instance and can better separate user-defined alerts from default platform alerts.
 endif::[]
-ifdef::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 In {product-title}, you may want to deploy a dedicated Alertmanager instance for user-defined projects, which provides user-defined alerts separate from default platform alerts.
 endif::[]
 In these cases, you can optionally enable a separate instance of Alertmanager to send alerts for user-defined projects only.
 
 .Prerequisites
 
-ifdef::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::[]
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have enabled monitoring for user-defined projects.
 endif::[]
@@ -58,7 +58,7 @@ If you set this value to `false` or if the key is omitted, user-defined alerts a
 
 .Verification
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Verify that the `user-workload` Alertmanager instance has started:
 +
 [source,terminal]
@@ -73,10 +73,10 @@ $ oc -n openshift-user-workload-monitoring get alertmanager
 NAME            VERSION   REPLICAS   AGE
 user-workload   0.24.0    2          100s
 ----
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // In ROSA/OSD, a dedicated-admin doesn't have permission to view the alertmanager resource.
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Verify that the `alert-manager-user-workload` pods are running:
 +
 [source,terminal]
@@ -93,4 +93,4 @@ alertmanager-user-workload-0           6/6     Running   0          38s
 alertmanager-user-workload-1           6/6     Running   0          38s
 ...
 ----
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/monitoring-expiring-silences.adoc
+++ b/modules/monitoring-expiring-silences.adoc
@@ -17,12 +17,12 @@ Expired silences older than 120 hours are garbage collected.
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you are a cluster administrator, you have access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you are a cluster administrator, you have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you are a non-administrator user, you have access to the cluster as a user with the following user roles:
 ** The `cluster-monitoring-view` cluster role, which allows you to access Alertmanager.
 ** The `monitoring-alertmanager-edit` role, which permits you to create and silence alerts.

--- a/modules/monitoring-getting-detailed-information-about-a-target.adoc
+++ b/modules/monitoring-getting-detailed-information-about-a-target.adoc
@@ -8,21 +8,21 @@
 
 You can use the {product-title} web console to view, search, and filter the endpoints that are currently targeted for scraping, which helps you to identify and troubleshoot problems. For example, you can view the current status of targeted endpoints to see when {product-title} monitoring is not able to scrape metrics from a targeted component.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 The *Metrics targets* page shows targets for default {product-title} projects and for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 The *Metrics targets* page shows targets for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as an administrator for the project for which you want to view metrics targets.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Procedure
 

--- a/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
@@ -10,11 +10,11 @@ You can grant users permission to configure alert routing for user-defined proje
 
 .Prerequisites
 
-ifdef::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::[]
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have enabled monitoring for user-defined projects.
 endif::[]

--- a/modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc
+++ b/modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc
@@ -6,20 +6,20 @@
 [id="listing-alerting-rules-for-all-projects-in-a-single-view_{context}"]
 = Listing alerting rules for all projects in a single view
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a cluster administrator,
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a `dedicated-admin`,
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 you can list alerting rules for core {product-title} and user-defined projects together in a single view.
 
 .Prerequisites
 
-ifdef::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 endif::[]
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` role.
 endif::[]
 * You have installed the {oc-first}.

--- a/modules/monitoring-managing-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-managing-alerting-rules-for-user-defined-projects.adoc
@@ -9,12 +9,12 @@
 
 In {product-title}, you can view, edit, and remove alerting rules in user-defined projects.
 
-ifdef::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 Managing alerting rules for user-defined projects is only available in {product-title} version 4.11 and later.
 ====
-endif::[]
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 .Alerting rule considerations
 

--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -40,14 +40,14 @@ Data compaction occurs every two hours. Therefore, a persistent volume (PV) migh
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 // end::CPM[]
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have installed the {oc-first}.
 

--- a/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
+++ b/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
@@ -10,14 +10,14 @@ By default, for user-defined projects, Thanos Ruler automatically retains metric
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/monitoring-monitoring-stack-in-ha-clusters.adoc
+++ b/modules/monitoring-monitoring-stack-in-ha-clusters.adoc
@@ -11,11 +11,11 @@ By default, in multi-node clusters, the following components run in high-availab
 * Prometheus
 * Alertmanager
 * Thanos Ruler
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Thanos Querier
 * Metrics Server
 * Monitoring plugin
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 The component is replicated across two pods, each running on a separate node. This means that the monitoring stack can tolerate the loss of one pod.
 

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -43,14 +43,14 @@ It is not permitted to move components to control plane or infrastructure nodes.
 // end::CPM[]
 
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have installed the {oc-first}.
 // end::UWM[]
 

--- a/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
+++ b/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
@@ -7,7 +7,14 @@
 = Querying metrics by using the federation endpoint for Prometheus
 
 You can use the federation endpoint for Prometheus to scrape platform and user-defined metrics from a network location outside the cluster.
-To do so, access the Prometheus `/federate` endpoint for the cluster via an {product-title} route.
+To do so, access the Prometheus `/federate` endpoint for the cluster via 
+ifndef::openshift-rosa,openshift-hcp[]
+an {product-title} 
+endif::openshift-rosa,openshift-hcp[]
+ifdef::openshift-rosa,openshift-hcp[]
+a {product-title} 
+endif::openshift-rosa,openshift-hcp[]
+route.
 
 [IMPORTANT]
 ====

--- a/modules/monitoring-querying-metrics-for-all-projects-with-mon-dashboard.adoc
+++ b/modules/monitoring-querying-metrics-for-all-projects-with-mon-dashboard.adoc
@@ -12,31 +12,31 @@
 You can use the {product-title} metrics query browser to run Prometheus Query Language (PromQL) queries to examine metrics visualized on a plot. This functionality provides information about the state of a cluster and any user-defined workloads that you are monitoring.
 
 As a
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 cluster administrator
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 `dedicated-admin`
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 or as a user with view permissions for all projects, you can access metrics for all default {product-title} and user-defined projects in the Metrics UI.
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 Only dedicated administrators have access to the third-party UIs provided with {product-title} monitoring.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 The Metrics UI includes predefined queries, for example, CPU, memory, bandwidth, or network packet for all projects. You can also run custom Prometheus Query Language (PromQL) queries.
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or with view permissions for all projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role or with view permissions for all projects.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/monitoring-querying-metrics-for-user-defined-projects-with-mon-dashboard.adoc
+++ b/modules/monitoring-querying-metrics-for-user-defined-projects-with-mon-dashboard.adoc
@@ -13,12 +13,12 @@ As a developer, you must specify a project name when querying metrics. You must 
 
 The Metrics UI includes predefined queries, for example, CPU, memory, bandwidth, or network packet. These queries are restricted to the selected project. You can also run custom Prometheus Query Language (PromQL) queries for the project.
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 Developers cannot access the third-party UIs provided with {product-title} monitoring.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Prerequisites
 

--- a/modules/monitoring-reviewing-monitoring-dashboards-admin.adoc
+++ b/modules/monitoring-reviewing-monitoring-dashboards-admin.adoc
@@ -12,12 +12,12 @@ include::snippets/unified-perspective-web-console.adoc[]
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Procedure
 

--- a/modules/monitoring-sending-notifications-to-external-systems.adoc
+++ b/modules/monitoring-sending-notifications-to-external-systems.adoc
@@ -7,7 +7,11 @@
 [id="sending-notifications-to-external-systems_{context}"]
 = Sending notifications to external systems
 
-In {product-title} {product-version}, firing alerts can be viewed in the Alerting UI. Alerts are not configured by default to be sent to any notification systems. You can configure {product-title} to send alerts to the following receiver types:
+In {product-title} 
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+{product-version}
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+, firing alerts can be viewed in the Alerting UI. Alerts are not configured by default to be sent to any notification systems. You can configure {product-title} to send alerts to the following receiver types:
 
 * PagerDuty
 * Webhook

--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -47,15 +47,15 @@ The following log levels can be applied to the relevant component in the `{confi
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 // end::CPM[]
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have installed the {oc-first}.
 

--- a/modules/monitoring-setting-query-log-file-for-prometheus.adoc
+++ b/modules/monitoring-setting-query-log-file-for-prometheus.adoc
@@ -35,15 +35,15 @@ Because log rotation is not supported, only enable this feature temporarily when
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 // end::CPM[]
 // tag::UWM[]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // end::UWM[]
 * You have installed the {oc-first}.
 

--- a/modules/monitoring-setting-scrape-and-evaluation-intervals-limits-for-user-defined-projects.adoc
+++ b/modules/monitoring-setting-scrape-and-evaluation-intervals-limits-for-user-defined-projects.adoc
@@ -21,14 +21,14 @@ If you set sample or label limits, no further sample data is ingested for that t
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/monitoring-silencing-alerts.adoc
+++ b/modules/monitoring-silencing-alerts.adoc
@@ -11,12 +11,12 @@ You can silence a specific alert or silence alerts that match a specification th
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you are a cluster administrator, you have access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you are a cluster administrator, you have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you are a non-administrator user, you have access to the cluster as a user with the following user roles:
 ** The `cluster-monitoring-view` cluster role, which allows you to access Alertmanager.
 ** The `monitoring-alertmanager-edit` role, which permits you to create and silence alerts.

--- a/modules/monitoring-specifying-how-a-service-is-monitored.adoc
+++ b/modules/monitoring-specifying-how-a-service-is-monitored.adoc
@@ -12,13 +12,13 @@ This procedure shows you how to create a `ServiceMonitor` resource for a service
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` cluster role or the `monitoring-edit` cluster role.
 * You have enabled monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role or the `monitoring-edit` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * For this example, you have deployed the `prometheus-example-app` sample service in the `ns1` project.
 +
 [NOTE]

--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -13,7 +13,7 @@ Backward compatibility for metrics, recording rules, or alerting rules is not gu
 
 The following modifications are explicitly not supported:
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * *Creating additional `ServiceMonitor`, `PodMonitor`, and `PrometheusRule` objects in the `openshift-&#42;` and `kube-&#42;` projects.*
 * *Modifying any resources or objects deployed in the `openshift-monitoring` or `openshift-user-workload-monitoring` projects.* The resources created by the {product-title} monitoring stack are not meant to be used by any other resources, as there are no guarantees about their backward compatibility.
 +
@@ -30,9 +30,9 @@ This procedure is a supported exception to the preceding statement.
 * *Enabling symptom based monitoring by using the `Probe` custom resource definition (CRD) in Prometheus Operator.*
 * *Manually deploying monitoring resources into namespaces that have the `openshift.io/cluster-monitoring: "true"` label.* 
 * *Adding the `openshift.io/cluster-monitoring: "true"` label to namespaces.* This label is reserved only for the namespaces with core {product-title} components and Red{nbsp}Hat certified components.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 * *Installing custom Prometheus instances on {product-title}.* A custom instance is a Prometheus custom resource (CR) managed by the Prometheus Operator.
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * *Modifying the default platform monitoring components.* You should not modify any of the components defined in the `cluster-monitoring-config` config map. Red Hat SRE uses these components to monitor the core cluster components and Kubernetes services.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/monitoring-targets-for-user-defined-projects.adoc
+++ b/modules/monitoring-targets-for-user-defined-projects.adoc
@@ -6,13 +6,13 @@
 [id="monitoring-targets-for-user-defined-projects_{context}"]
 = Monitoring targets for user-defined projects
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 When monitoring is enabled for user-defined projects, you can monitor:
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Monitoring is enabled by default for {product-title} user-defined projects. You can monitor:
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 * Metrics provided through service endpoints in user-defined projects.
 * Pods running in user-defined projects.

--- a/modules/monitoring-understanding-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-understanding-alert-routing-for-user-defined-projects.adoc
@@ -7,32 +7,32 @@
 = Understanding alert routing for user-defined projects
 
 [role="_abstract"]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a cluster administrator, you can enable alert routing for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a `dedicated-admin`, you can enable alert routing for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 With this feature, you can allow users with the `alert-routing-edit` cluster role to configure alert notification routing and receivers for user-defined projects.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 These notifications are routed by the default Alertmanager instance or, if enabled, an optional Alertmanager instance dedicated to user-defined monitoring.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 These notifications are routed by an Alertmanager instance dedicated to user-defined monitoring.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 Users can then create and configure user-defined alert routing by creating or editing the `AlertmanagerConfig` objects for their user-defined projects without the help of an administrator.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 After a user has defined alert routing for a user-defined project, user-defined alert notifications are routed as follows:
 
 * To the `alertmanager-main` pods in the `openshift-monitoring` namespace if using the default platform Alertmanager instance.
 
 * To the `alertmanager-user-workload` pods in the `openshift-user-workload-monitoring` namespace if you have enabled a separate instance of Alertmanager for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 After a user has defined alert routing for a user-defined project, user-defined alert notifications are routed to the `alertmanager-user-workload` pods in the `openshift-user-workload-monitoring` namespace.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 [NOTE]
 ====

--- a/modules/monitoring-understanding-metrics.adoc
+++ b/modules/monitoring-understanding-metrics.adoc
@@ -7,12 +7,12 @@
 = Understanding metrics
 
 [role="_abstract"]
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 In {product-title} {product-version},
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 In {product-title},
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 cluster components are monitored by scraping metrics exposed through service endpoints. You can also configure metrics collection for user-defined projects. Metrics enable you to monitor how cluster components and your own workloads are performing.
 
 You can define the metrics that you want to provide for your own workloads by using Prometheus client libraries at the application level.

--- a/modules/monitoring-understanding-the-monitoring-stack.adoc
+++ b/modules/monitoring-understanding-the-monitoring-stack.adoc
@@ -10,22 +10,22 @@
 The monitoring stack includes the following components:
 
 Default platform monitoring components::
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 A set of platform monitoring components are installed in the `openshift-monitoring` project by default during an {product-title} installation. This provides monitoring for core cluster components including Kubernetes services. The default monitoring stack also enables remote health monitoring for clusters.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 A set of platform monitoring components are installed in the `openshift-monitoring` project by default during a {product-title} installation. Red{nbsp}Hat Site Reliability Engineers (SRE) use these components to monitor core cluster components including Kubernetes services. This includes critical metrics, such as CPU and memory, collected from all of the workloads in every namespace.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 +
 You can see these components in the *Installed by default* section in the following diagram.
 
 Components for monitoring user-defined projects::
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 If you enable monitoring for user-defined projects, additional monitoring components are installed in the `openshift-user-workload-monitoring` project. This provides optional monitoring for user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 A set of user-defined project monitoring components are installed in the `openshift-user-workload-monitoring` project by default during a {product-title} installation. You can use these components to monitor services and pods in user-defined projects.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 +
 You can see these components in the *User* section in the following diagram.
 

--- a/observability/logging/about-logging.adoc
+++ b/observability/logging/about-logging.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can deploy {logging} on an {product-title} cluster, and use it to collect and aggregate node system audit logs, application container logs, and infrastructure logs.
+As a cluster administrator, you can deploy {logging} on your {product-title} cluster, and use it to collect and aggregate node system audit logs, application container logs, and infrastructure logs.
 
 You can use {logging} to perform the following tasks:
 

--- a/observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.adoc
+++ b/observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.adoc
@@ -20,11 +20,7 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 In {product-title}, you can monitor your own projects in isolation from Red{nbsp}Hat Site Reliability Engineering (SRE) platform metrics. You can monitor your own projects without the need for an additional monitoring solution.
 
-The {product-title}
-ifdef::openshift-rosa,openshift-rosa-hcp[]
-(ROSA)
-endif::openshift-rosa,openshift-rosa-hcp[]
-monitoring stack is based on the link:https://prometheus.io/[Prometheus] open source project and its wider ecosystem.
+The {product-title} monitoring stack is based on the link:https://prometheus.io/[Prometheus] open source project and its wider ecosystem.
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 

--- a/observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer.adoc
+++ b/observability/monitoring/accessing-metrics/accessing-metrics-as-a-developer.adoc
@@ -34,6 +34,3 @@ include::modules/monitoring-reviewing-monitoring-dashboards-developer.adoc[level
 
 * xref:../../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#about-monitoring-dashboards_key-concepts[About monitoring dashboards]
 * xref:../../../applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc#monitoring-project-and-application-metrics-using-developer-perspective[Monitoring project and application metrics using the Developer perspective]
-
-
-

--- a/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
+++ b/observability/monitoring/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
@@ -65,12 +65,12 @@ include::modules/monitoring-specifying-limits-and-requests-for-monitoring-compon
 [id="controlling-the-impact-of-unbound-attributes-in-user-defined-projects_{context}"]
 == Controlling the impact of unbound metrics attributes in user-defined projects
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Cluster administrators
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 A `dedicated-admin`
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 can use the following measures to control the impact of unbound metrics attributes in user-defined projects:
 
 * Limit the number of samples that can be accepted per target scrape in user-defined projects

--- a/observability/monitoring/getting-started/sd-accessing-monitoring-for-user-defined-projects.adoc
+++ b/observability/monitoring/getting-started/sd-accessing-monitoring-for-user-defined-projects.adoc
@@ -6,18 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-When you install a {product-title}
-ifdef::openshift-rosa[]
-(ROSA)
-endif::openshift-rosa[]
-cluster, monitoring for user-defined projects is enabled by default. With monitoring for user-defined projects enabled, you can monitor your own
-ifdef::openshift-rosa[]
-ROSA
-endif::openshift-rosa[]
-ifdef::openshift-dedicated[]
-{product-title}
-endif::openshift-dedicated[]
-projects without the need for an additional monitoring solution.
+When you install a {product-title} cluster, monitoring for user-defined projects is enabled by default. With monitoring for user-defined projects enabled, you can monitor your own {product-title} projects without the need for an additional monitoring solution.
 
 The `dedicated-admin` user has default permissions to configure and access monitoring for user-defined projects.
 


### PR DESCRIPTION
[OSDOCS-14495](https://issues.redhat.com//browse/OSDOCS-14495): Prune Observability and Logging

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-14495
https://issues.redhat.com/browse/OSDOCS-14499

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
