### PR TITLE
OSDOCS#16152: Update the z-stream RNs for 4.18.24

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3028,6 +3028,69 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.24
+[id="ocp-4-18-24_{context}"]
+=== RHBA-2025:15714 - {product-title} {product-version}.24 bug fix update
+
+Issued: 17 September 2025
+
+{product-title} release {product-version}.24 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:15714[RHBA-2025:15714] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:15712[RHBA-2025:15712] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.24 --pullspecs
+----
+
+[id="ocp-4-18-24-enhancements_{context}"]
+==== Enhancements
+
+* With this update, the `cluster-etcd-operator` in {product-title} platforms is proactive, modifying the `etcdDatabaseQuotaLowSpace alert`. It triggers at many levels, for example, information, warning, critical, when the etcd quota usage approaches 95%. This enhancement provides cluster administrators with time to address potential issues before the API server is impacted, resulting in a more stable and manageable environment. (link:https://issues.redhat.com/browse/OCPBUGS-61235[OCPBUGS-61235])
+
+* The name of the `MachineOSConfig` object that was used with {op-system-first} image layering must now be the same as the machine configuration pool where the custom layered image is deployed. Previously, you could use any name. This change was made to prevent attempts to use many `MachineOSConfig` objects with each machine configuration pool. For more information, see xref:../machine_configuration/mco-coreos-layering.adoc#mco-coreos-layering[Image mode for OpenShift].
+
+* With this update, the system ensures balanced distribution of live API connections across many Kubernetes API servers when primary nodes are online. This prevents any single primary node from reaching 100% CPU use, improving system performance and stability during primary node restarts or quorum establishment. This change maintains optimal performance and stability of the system by evenly distributing live API connections and preventing a single Kubernetes API server from handling the majority of connections during primary node or Kubernetes API server outages. (link:https://issues.redhat.com/browse/OCPBUGS-61039[OCPBUGS-61039])
+
+[id="ocp-4-18-24-known-issues_{context}"]
+==== Known issues
+
+* A Berkley Packet Filter (BPF) program creation failure due to a denied permission in the container runtime version 1.23 on {product-title} 4.18.22 caused a failed Graphics Processing Unit (GPU) stack deployment. To correct this failure, the `no-cgroups = true` variable was added to the GPU worker node `/var/usrlocal/nvidia/toolkit/.config/nvidia-container-runtime/config.toml` file. As a result, the GPU stack deploys successfully on {product-title} 4.18.22. (link:https://issues.redhat.com/browse/OCPBUGS-60663[OCPBUGS-60663]) 
+
+
+[id="ocp-4-18-24-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, LDAP integration created excessive health check alerts due to many config maps for each user. As a consequence, the user interface was cluttered with excessive alerts. With this release, excessive health check alerts from the user config maps are removed. As a result, users experience reduced console alerts and improved usability. (link:https://issues.redhat.com/browse/OCPBUGS-50983[OCPBUGS-50983])
+
+* Before this update, an incorrect cloud configuration path in {azure-first} Stack Hub caused the Container Storage Interface (CSI) driver to use an incorrect environment configuration. As a consequence, users experienced unhealthy CSI driver pods. With this release, the incorrect environment configuration for the CSI operator on {azure-short} Stack Hub is fixed and the CSI driver correctly reads the cloud configuration. (link:https://issues.redhat.com/browse/OCPBUGS-55053[OCPBUGS-55053])
+
+* Before this update, multiple mirrors in the `imagecontentsourcepolicy` policy caused a {hcp-capital} payload error during an image lookup. As a consequence, the {hcp-capital} payload failed to handle multiple mirrors, and caused cluster creation failures. With this release, the {hcp-capital} payload supports multiple mirrors and avoids creation errors. (link:https://issues.redhat.com/browse/OCPBUGS-57142[OCPBUGS-57142])
+
+* Before this update, bonded network configurations with `mode=active-backup` and `fail_over_mac=follow` variables failed because of a race condition in the `configure-ovs.sh` file. This condition caused interfaces to change to an unpredictable state. As a consequence, bonded network flapping occurred and affected high availability. With this release, the race condition that handles the `configure-ovs.sh` file is improved, and ensures that bonded network configurations with the `fail_over_mac=follow` variable functions without flapping. (link:https://issues.redhat.com/browse/OCPBUGS-57357[OCPBUGS-57357])
+
+* Before this update, an incorrect URL in the `Alertmanager` configuration created logs in `user-workload` pods on {product-title} 4.16 clusters. As a consequence, user workload monitoring failed due to an invalid Slack URL in the configuration. With this release, invalid URLs are allowed in  the `Alertmanager` configuration. As a result, the `Alertmanager` configuration errors are resolved, which improves monitoring stability on clusters earlier than {product-title} 4.19. (link:https://issues.redhat.com/browse/OCPBUGS-58194[OCPBUGS-58194]) 
+
+* Before this update, multiple IP addresses on the primary interface caused the API server to connect to an unmatched etcd IP address during a single node {product-title} 4.18 deployment. This action resulted in an API server pod failure during deployment and cluster initialization issues. With this release, a deployment with multiple IP addresses on the primary interface is fixed, ensuring the API server connects to etcd using the correct IP address in the certificate, and prevents a failure during a single node deployment. (link:https://issues.redhat.com/browse/OCPBUGS-59992[OCPBUGS-59992])
+
+* Before this update, insufficient obfuscation of new network data types in {hcp-capital} exposed user data. As a consequence, sensitive information was not protected. With this release, obfuscation for new network data types is implemented. As a result, obfuscated network data in {hcp-capital} improves data privacy. (link:https://issues.redhat.com/browse/OCPBUGS-60301[OCPBUGS-60301])
+
+* Before this update, a hosted cluster rejected certificates with multiple Storage Area Network (SAN) entries due to conflicting Domain Name System (DNS) names. As a consequence, users encountered invalid configuration errors after deploying hosted clusters with the certificates. With this release, the cluster accepts certificates with multiple SAN entries. As a result, deployment errors are eliminated. (link:https://issues.redhat.com/browse/OCPBUGS-60485[OCPBUGS-60485])
+
+* Before this update, the Cluster Network Operator (CNO) missed setting the `release.openshift.io/version` annotation on a `DaemonSet` API object and in the `openshift-multus` namespace during an upgrade from {product-title} 4.18.6 to {product-title} 4.18.22. As a consequence, the upgrade failed due to missing annotations. With this release, the CNO sets the annotation for the `DaemonSet` object and for the deployment during an upgrade. As a result, upgrading a cluster completes without stopping due to missing annotations in the `openshift-multus` namespace. (link:https://issues.redhat.com/browse/OCPBUGS-60795[OCPBUGS-60795])
+
+* Before this update, improper machine deletion handling during cluster autoscaling caused the last node to retain the `ToBeDeletedByClusterAutoscaler` taint. As a consequence, resource allocation was affected during cluster scaling. With this release, the `ToBeDeletedByClusterAutoscaler` taint removal after scaling down a machine set is implemented. As a result, the last node does not retain the unwanted taint after scaling down a machine set. (link:https://issues.redhat.com/browse/OCPBUGS-60908[OCPBUGS-60908])
+
+* Before this update, disabling the {product-title} image registry left legacy pull secrets with persistent finalizers, which prevented their deletion. As a consequence, users were unable to delete `Dockercfg` secrets after disabling the image registry. With this release, legacy pull secrets do not block namespace deletion after the registry is removed. As a result, pull secret finalizers do not block namespace deletion when the registry is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-61002[OCPBUGS-61002])
+
+* Before this update, {ibm-cloud-title} was omitted from the list of platforms that supported single-node installations in the validation code. As a consequence, users could not install a single-node configuration on {ibm-cloud-title} because of a validation error. With this release, {ibm-cloud-title} support for single-node installations is enabled. As a result, users can complete single-node installations on {ibm-cloud-title}. (link:https://issues.redhat.com/browse/OCPBUGS-61178[OCPBUGS-61178])
+
+[id="ocp-4-18-24-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.23
 [id="ocp-4-18-23_{context}"]
 === RHSA-2025:14820 - {product-title} {product-version}.23 bug fix and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-16152](https://issues.redhat.com//browse/OSDOCS-16152)

Link to docs preview:
[4.18.24](https://99179--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-24_release-notes)

QE review:
- [ ] QE has approved this change.
Not required for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 9/17/25
