### PR TITLE
OBSDOCS-2230: Fluentd is incorrectly referred in RHOCP 4.18+ monitoring docs

### DIFF
--- a/modules/monitoring-common-terms.adoc
+++ b/modules/monitoring-common-terms.adoc
@@ -32,13 +32,6 @@ A CR is an extension of the Kubernetes API. You can create custom resources.
 etcd::
 etcd is the key-value store for {product-title}, which stores the state of all resource objects.
 
-Fluentd::
-Fluentd is a log collector that resides on each {product-title} node. It gathers application, infrastructure, and audit logs and forwards them to different outputs.
-+
---
-include::snippets/logging-fluentd-dep-snip.adoc[]
---
-
 Kubelets::
 Runs on nodes and reads the container manifests. Ensures that the defined containers have started and are running.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2230
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://99181--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/about-ocp-monitoring/monitoring-stack-architecture.html#monitoring-common-terms_monitoring-stack-architecture
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
