### PR TITLE
remove-operator-line-reject-text

### DIFF
--- a/.vale/styles/config/vocabularies/OpenShiftDocs/reject.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/reject.txt
@@ -1,7 +1,6 @@
 # Regex terms added to reject.txt are highlighted as errors by the Vale linter and override RedHat Vale rules.
 # Add terms that have a corresponding correctly capitalized form to accept.txt.
 
-(?<!.*-)operators
 [Dd]eployment [Cc]onfigs?
 [Dd]eployment [Cc]onfigurations?
 [Oo]peratorize


### PR DESCRIPTION
The reject.txt` file located on the [main branch](https://github.com/openshift/openshift-docs/blob/main/.vale/styles/config/vocabularies/OpenShiftDocs/reject.txt) does not include the "(?<!.*-)operators" line. However, this line does exist in the enterprise branches and it's causing the following issue to be flagged on a PR:

<img width="1001" height="255" alt="Screenshot From 2025-09-16 17-17-34" src="https://github.com/user-attachments/assets/e96df100-c77c-473a-87a8-d06c32184c52" />

Here is an example [PR](https://github.com/openshift/openshift-docs/pull/99132) that flags this rule.

Version(s):
4.14-4.19

Issue:
N/A (Internal fix)

