### PR TITLE
OSDOCS-16200: Added dependent application of NNCPs to a node in The N…

### DIFF
--- a/modules/node-network-configuration-policy-file.adoc
+++ b/modules/node-network-configuration-policy-file.adoc
@@ -8,6 +8,17 @@
 
 A `NodeNetworkConfigurationPolicy` (NNCP) manifest file defines policies that the Kubernetes NMState Operator uses to configure networking for nodes that exist in an {product-title} cluster. 
 
+[IMPORTANT]
+====
+If you want to apply multiple NNCP CRs to a node, you must create the NNCPs in a logical order that is based on the alphanumeric sorting of the policy names. The Kubernetes NMState Operator continuously checks for a newly created NNCP CR so that the Operator can instantly apply the CR to node. Consider the following logical order issue example:
+
+. You create NNCP 1 for defining the bridge interface that listens on a VLAN port, such as `eth1.1000`.
+. You create NNCP 2 for defining the VLAN interface and specify the port for this interface, such as `eth1.1000`.
+. You apply NNCP 1 before you apply NNCP 2 to the node.
+
+The node experiences a node connectivity issue because port `eth1.1000` does not exist. As a result, the cluster fails.
+====
+
 After you apply a node network policy to a node, the Kubernetes NMState Operator configures the networking configuration for nodes according to the node network policy details. 
 
 [WARNING]

--- a/modules/virt-nmstate-example-policy-configurations.adoc
+++ b/modules/virt-nmstate-example-policy-configurations.adoc
@@ -8,7 +8,7 @@
 
 Before you read the different example `NodeNetworkConfigurationPolicy` (NNCP) manifest configurations, consider the following factors when you apply a policy to nodes so that your cluster runs under its best performance conditions:
 
-* When you need to apply a policy to more than one node, create a `NodeNetworkConfigurationPolicy` manifest for each target node. The Kubernetes NMState Operator applies the policy to each node with a defined NNCP in an unspecified order. Scoping a policy with this approach reduces the length of time for policy application but risks a cluster-wide outage if an error exists in the configuration of the cluster. To avoid this type of error, initially apply an NNCP to some nodes, confirm the NNCP is configured correctly for these nodes, and then proceed with applying the policy to the remaining nodes.
+* If you want to apply multiple NNCP CRs to a node, you must create the NNCPs in a logical order that is based on the alphanumeric sorting of the policy names. The Kubernetes NMState Operator continuously checks for a newly created NNCP CR so that the Operator can instantly apply the CR to node.
 
 * When you need to apply a policy to many nodes but you only want to create a single NNCP for all the nodes, the Kubernetes NMState Operator applies the policy to each node in sequence. You can set the speed and coverage of policy application for target nodes with the `maxUnavailable` parameter in the cluster's configuration file. By setting a lower percentage value for the parameter, you can reduce the risk of a cluster-wide outage if the outage impacts the small percentage of nodes that are receiving the policy application.
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-16200](https://issues.redhat.com/browse/OSDOCS-16200)

Link to docs preview:
* [The NodeNetworkConfigurationPolicy manifest file](https://99258--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#node-network-configuration-policy-file_k8s-nmstate-updating-node-network-config)

- [x] SME has approved this change (Mat K.).
- [x] QE has approved this change (Gris G.).
