### PR TITLE
OSDOCS-14501: Prune Operators

### DIFF
--- a/modules/olm-about-catalogs.adoc
+++ b/modules/olm-about-catalogs.adoc
@@ -10,7 +10,14 @@ An Operator catalog is a repository of metadata that Operator Lifecycle Manager 
 
 An index image, based on the Operator bundle format, is a containerized snapshot of a catalog. It is an immutable artifact that contains the database of pointers to a set of Operator manifest content. A catalog can reference an index image to source its content for OLM on the cluster.
 
-As catalogs are updated, the latest versions of Operators change, and older versions may be removed or altered. In addition, when OLM runs on an {product-title} cluster in a restricted network environment, it is unable to access the catalogs directly from the internet to pull the latest content.
+As catalogs are updated, the latest versions of Operators change, and older versions may be removed or altered. In addition, when OLM runs on 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+an {product-title} 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+a {product-title} 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+cluster in a restricted network environment, it is unable to access the catalogs directly from the internet to pull the latest content.
 
 As a cluster administrator, you can create your own custom index image, either based on a Red Hat-provided catalog or from scratch, which can be used to source the catalog content on the cluster. Creating and updating your own index image provides a method for customizing the set of Operators available on the cluster, while also avoiding the aforementioned restricted network environment issues.
 

--- a/modules/olm-catalog-source-and-psa.adoc
+++ b/modules/olm-catalog-source-and-psa.adoc
@@ -8,13 +8,25 @@
 
 _Pod security admission_ was introduced in {product-title} 4.11 to ensure pod security standards. Catalog sources built using the SQLite-based catalog format and a version of the `opm` CLI tool released before {product-title} 4.11 cannot run under restricted pod security enforcement.
 
-In {product-title} {product-version}, namespaces do not have restricted pod security enforcement by default and the default catalog source security mode is set to `legacy`.
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+In {product-title} {product-version}, 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[] 
+In {product-title}, 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[] 
+namespaces do not have restricted pod security enforcement by default and the default catalog source security mode is set to `legacy`.
 
 Default restricted enforcement for all namespaces is planned for inclusion in a future {product-title} release. When restricted enforcement occurs, the security context of the pod specification for catalog source pods must match the restricted pod security standard. If your catalog source image requires a different pod security standard, the pod security admissions label for the namespace must be explicitly set.
 
 [NOTE]
 ====
-If you do not want to run your SQLite-based catalog source pods as restricted, you do not need to update your catalog source in {product-title} {product-version}.
+If you do not want to run your SQLite-based catalog source pods as restricted, you do not need to update your catalog source in 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+{product-title} {product-version}.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[] 
+{product-title}. 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 However, it is recommended that you take action now to ensure your catalog sources run under restricted pod security enforcement. If you do not take action to ensure your catalog sources run under restricted pod security enforcement, your catalog sources might not run in future {product-title} releases.
 ====

--- a/modules/olm-catalogsource-image-template.adoc
+++ b/modules/olm-catalogsource-image-template.adoc
@@ -12,7 +12,13 @@ endif::[]
 [id="olm-catalogsource-image-template_{context}"]
 = Image template for custom catalog sources
 
-Operator compatibility with the underlying cluster can be expressed by a catalog source in various ways. One way, which is used for the default Red Hat-provided catalog sources, is to identify image tags for index images that are specifically created for a particular platform release, for example {product-title} {product-version}.
+Operator compatibility with the underlying cluster can be expressed by a catalog source in various ways. One way, which is used for the default Red Hat-provided catalog sources, is to identify image tags for index images that are specifically created for a particular platform release, for example 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+{product-title} {product-version}.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+{product-title}.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 During a cluster upgrade, the index image tag for the default Red Hat-provided catalog sources are updated automatically by the Cluster Version Operator (CVO) so that Operator Lifecycle Manager (OLM) pulls the updated version of the catalog. For example during an upgrade from {product-title} {ocp-nminus1} to {product-version}, the `spec.image` field in the `CatalogSource` object for the `redhat-operators` catalog is updated from:
 
@@ -38,7 +44,7 @@ Starting in {product-title} 4.9, cluster administrators can add the `olm.catalog
 
 [NOTE]
 ====
-You must specify the Kubernetes cluster version and not an {product-title} cluster version, as the latter is not currently available for templating.
+You must specify the Kubernetes cluster version and not the {product-title} cluster version, as the latter is not currently available for templating.
 ====
 
 Provided that you have created and pushed an index image with a tag specifying the updated Kubernetes version, setting this annotation enables the index image versions in custom catalogs to be automatically changed after a cluster upgrade. The annotation value is used to set or update the image reference in the `spec.image` field of the `CatalogSource` object. This helps avoid cluster upgrades leaving Operator installations in unsupported states or without a continued update path.
@@ -77,7 +83,14 @@ If the `spec.image` field and the `olm.catalogImageTemplate` annotation are both
 If the `spec.image` field is not set and the annotation does not resolve to a usable pull spec, OLM stops reconciliation of the catalog source and sets it into a human-readable error condition.
 ====
 
-For an {product-title} {product-version} cluster, which uses Kubernetes 1.33, the `olm.catalogImageTemplate` annotation in the preceding example resolves to the following image reference:
+For 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+an {product-title} {product-version} 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+a {product-title} 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+cluster, which uses Kubernetes 1.33, the `olm.catalogImageTemplate` annotation in the preceding example resolves to the following image reference:
 
 [source,terminal]
 ----

--- a/modules/olm-colocation-namespaces.adoc
+++ b/modules/olm-colocation-namespaces.adoc
@@ -20,21 +20,21 @@ These scenarios can lead to the following issues:
 
 These issues usually surface because, when installing Operators with the {product-title} web console, the default behavior installs Operators that support the *All namespaces* install mode into the default `openshift-operators` global namespace.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a cluster administrator,
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As an administrator with the `dedicated-admin` role,
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 you can bypass this default behavior manually by using the following workflow:
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 . Create a namespace for the installation of the Operator.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // In OSD/ROSA, dedicated-admins can create projects, but not namespaces.
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 . Create a project for the installation of the Operator.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 . Create a custom _global Operator group_, which is an Operator group that watches all namespaces. By associating this Operator group with the namespace you just created, it makes the installation namespace a global namespace, which makes Operators installed there available in all namespaces.
 . Install the desired Operator in the installation namespace.
 

--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -26,39 +26,39 @@ endif::[]
 = Adding a catalog source to a cluster
 
 Adding a catalog source to an {product-title} cluster enables the discovery and installation of Operators for users.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Cluster administrators
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Administrators with the `dedicated-admin` role
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 can create a `CatalogSource` object that references an index image. OperatorHub uses catalog sources to populate the user interface.
 
 // In OSD/ROSA, a dedicated-admin can see catalog sources here, but can't add, edit, or delete them.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [TIP]
 ====
 Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, update, delete, disable, and enable individual sources.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // In OSD/ROSA, a dedicated-admin can update catalog sources in the console by searching for them.
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [TIP]
 ====
 Alternatively, you can use the web console to manage catalog sources. From the *Home* -> *Search* page, select a project, click the *Resources* drop-down and search for `CatalogSource`. You can create, update, delete, disable, and enable individual sources.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Prerequisites
 
 * You built and pushed an index image to a registry.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Procedure
 

--- a/modules/olm-creating-etcd-cluster-from-operator.adoc
+++ b/modules/olm-creating-etcd-cluster-from-operator.adoc
@@ -6,12 +6,12 @@ This procedure walks through creating a new etcd cluster using the etcd Operator
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Access to an {product-title} {product-version} cluster.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-* Access to an {product-title} cluster.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+* Access to a {product-title} cluster.
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * The etcd Operator already installed cluster-wide by an administrator.
 
 .Procedure
@@ -19,12 +19,12 @@ endif::openshift-dedicated,openshift-rosa[]
 . Create a new project in the {product-title} web console for this procedure. This example uses a project called `my-etcd`.
 
 . Navigate to the *Operators -> Installed Operators* page. The Operators that have been installed to the cluster by the
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 cluster administrator
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 dedicated-admin
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 and are available for use are shown here as a list of cluster service versions (CSVs). CSVs are used to launch and manage the software provided by the Operator.
 +
 [TIP]
@@ -59,10 +59,10 @@ $ oc policy add-role-to-user edit <user> -n <target_project>
 ----
 
 You now have an etcd cluster that will react to failures and rebalance data as pods become unhealthy or are migrated between nodes in the cluster. Most importantly,
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 cluster administrators
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 dedicated-admins
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 or developers with proper access can now easily use the database with their applications.

--- a/modules/olm-csv.adoc
+++ b/modules/olm-csv.adoc
@@ -5,7 +5,7 @@
 [id="olm-csv_{context}"]
 = Cluster service version
 
-A _cluster service version_ (CSV) represents a specific version of a running Operator on an {product-title} cluster. It is a YAML manifest created from Operator metadata that assists Operator Lifecycle Manager (OLM) in running the Operator in the cluster.
+A _cluster service version_ (CSV) represents a specific version of a running Operator on your {product-title} cluster. It is a YAML manifest created from Operator metadata that assists Operator Lifecycle Manager (OLM) in running the Operator in the cluster.
 
 OLM requires this metadata about an Operator to ensure that it can be kept running safely on a cluster, and to provide information about how updates should be applied as new versions of the Operator are published. This is similar to packaging software for a traditional operating system; think of the packaging step for OLM as the stage at which you make your `rpm`, `deb`, or `apk` bundle.
 

--- a/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
@@ -11,13 +11,13 @@ Cluster administrators can delete installed Operators from a selected namespace 
 
 .Prerequisites
 
-- You have access to an {product-title} cluster using an account with
+- You have access to the {product-title} cluster using an account with
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 `dedicated-admin` permissions.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 - The OpenShift CLI (`oc`) is installed on your workstation.
 
 .Procedure

--- a/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
@@ -13,7 +13,7 @@ Cluster administrators can delete installed Operators from a selected namespace 
 
 .Prerequisites
 
-- You have access to an {product-title} cluster web console using an account with
+- You have access to the {product-title} cluster web console using an account with
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]

--- a/modules/olm-dependency-resolution-preferences.adoc
+++ b/modules/olm-dependency-resolution-preferences.adoc
@@ -10,7 +10,7 @@ There can be many options that equally satisfy a dependency of an Operator. The 
 [id="olm-dependency-catalog-priority_{context}"]
 == Catalog priority
 
-On {product-title} cluster, OLM reads catalog sources to know which Operators are available for installation.
+On {product-title} clusters, OLM reads catalog sources to know which Operators are available for installation.
 
 .Example `CatalogSource` object
 [source,yaml]
@@ -40,7 +40,7 @@ There are two rules that govern catalog preference:
 [id="olm-dependency-catalog-ordering_{context}"]
 == Channel ordering
 
-An Operator package in a catalog is a collection of update channels that a user can subscribe to in an {product-title} cluster. Channels can be used to provide a particular stream of updates for a minor release (`1.2`, `1.3`) or a release frequency (`stable`, `fast`).
+An Operator package in a catalog is a collection of update channels that a user can subscribe to in {product-title} clusters. Channels can be used to provide a particular stream of updates for a minor release (`1.2`, `1.3`) or a release frequency (`stable`, `fast`).
 
 It is likely that a dependency might be satisfied by Operators in the same package, but different channels. For example, version `1.2` of an Operator might exist in both the `stable` and `fast` channels.
 

--- a/modules/olm-filtering-fbc.adoc
+++ b/modules/olm-filtering-fbc.adoc
@@ -23,14 +23,14 @@ You can use the `opm` CLI to update or filter a catalog image that uses the file
 You can then rebuild the image as an updated version of the catalog.
 
 // This note points to a topic that's excluded from OSD and ROSA.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 Alternatively, if you already have a catalog image on a mirror registry, you can use the oc-mirror CLI plugin to automatically prune any removed images from an updated source version of that catalog image while mirroring it to the target registry.
 
 For more information about the oc-mirror plugin and this use case, see the "Keeping your mirror registry content updated" section, and specifically the "Pruning images" subsection, of "Mirroring images for a disconnected installation using the oc-mirror plugin".
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Prerequisites
 * You have the following on your workstation:

--- a/modules/olm-injecting-custom-ca.adoc
+++ b/modules/olm-injecting-custom-ca.adoc
@@ -6,25 +6,25 @@
 [id="olm-inject-custom-ca_{context}"]
 = Injecting a custom CA certificate
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 When a cluster administrator
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 When an administrator with the `dedicated-admin` role
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 adds a custom CA certificate to a cluster using a config map, the Cluster Network Operator merges the user-provided certificates and system CA certificates into a single bundle. You can inject this merged bundle into your Operator running on Operator Lifecycle Manager (OLM), which is useful if you have a man-in-the-middle HTTPS proxy.
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Access to an {product-title} cluster using an account with
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Access to a {product-title} cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Custom CA certificate added to the cluster using a config map.
 * Desired Operator installed and running on OLM.
 

--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -27,17 +27,17 @@ In most cases, the web console method of this procedure is preferred because it 
 .Prerequisites
 
 ifndef::olm-user[]
-* Access to an {product-title} cluster using an account with
+* Access to your {product-title} cluster using an account with
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 the `dedicated-admin` role.
 endif::[]
 endif::[]
 
 ifdef::olm-user[]
-* Access to an {product-title} cluster using an account with Operator installation permissions.
+* Access to your {product-title} cluster using an account with Operator installation permissions.
 endif::[]
 
 * You have installed the OpenShift CLI (`oc`).

--- a/modules/olm-installing-from-operatorhub-using-web-console.adoc
+++ b/modules/olm-installing-from-operatorhub-using-web-console.adoc
@@ -85,12 +85,20 @@ ifdef::olm-admin[]
 endif::[]
 ifdef::olm-user[]
 .. Choose a specific, single namespace in which to install the Operator. The Operator will only watch and be made available for use in this single namespace.
-endif::[]
+endif::olm-user[]
 
+ifndef::openshift-rosa[]
 .. For clusters on cloud providers with token authentication enabled:
 +
 --
-* If the cluster uses {aws-short} {sts-full} (*STS Mode* in the web console), enter the Amazon Resource Name (ARN) of the AWS IAM role of your service account in the *role ARN* field. To create the role's ARN, follow the procedure described in link:https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/tutorials/cloud-experts-deploy-api-data-protection#prepare-aws-account_cloud-experts-deploy-api-data-protection[Preparing AWS account].
+* If the cluster uses {aws-short} {sts-full} (*STS Mode* in the web console), enter the Amazon Resource Name (ARN) of the AWS IAM role of your service account in the *role ARN* field. To create the role's ARN, follow the procedure described in link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/tutorials/cloud-experts-deploy-api-data-protection#prepare-aws-account_cloud-experts-deploy-api-data-protection[Preparing AWS account].
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+.. For clusters on cloud providers with token authentication enabled:
++
+--
+* If the cluster uses {aws-short} {sts-full} (*STS Mode* in the web console), enter the Amazon Resource Name (ARN) of the AWS IAM role of your service account in the *role ARN* field. To create the role's ARN, follow the procedure described in link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/tutorials/cloud-experts-deploy-api-data-protection[Preparing AWS account].
+endif::openshift-rosa[]
 
 * If the cluster uses {entra-first} (*Workload Identity / Federated Identity Mode* in the web console), add the client ID, tenant ID, and subscription ID in the appropriate fields.
 

--- a/modules/olm-installing-global-namespaces.adoc
+++ b/modules/olm-installing-global-namespaces.adoc
@@ -8,27 +8,27 @@
 
 When installing Operators with the {product-title} web console, the default behavior installs Operators that support the *All namespaces* install mode into the default `openshift-operators` global namespace. This can cause issues related to shared install plans and update policies between all Operators in the namespace. For more details on these limitations, see "Multitenancy and Operator colocation".
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a cluster administrator,
 endif::[]
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As an administrator with the `dedicated-admin` role,
 endif::[]
 you can bypass this default behavior manually by creating a custom global namespace and using that namespace to install your individual or scoped set of Operators and their dependencies.
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Procedure
 
 // In OSD/ROSA, dedicated-admins can't create namespaces directly but can create projects.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 . Before installing the Operator, create a namespace for the installation of your desired Operator. This installation namespace will become the custom global namespace:
 
 .. Define a `Namespace` resource and save the YAML file, for example, `global-operators.yaml`:
@@ -47,16 +47,16 @@ metadata:
 ----
 $ oc create -f global-operators.yaml
 ----
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // Slightly different step for OSD/ROSA since dedicated-admins can't create namespaces directly.
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 . Before installing the Operator, create a namespace for the installation of your desired Operator. You can do this by creating a project. The namespace for this project will become the custom global namespace:
 +
 [source,terminal]
 ----
 $ oc new-project global-operators
 ----
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 . Create a custom _global Operator group_, which is an Operator group that watches all namespaces:
 

--- a/modules/olm-installing-operators-from-operatorhub.adoc
+++ b/modules/olm-installing-operators-from-operatorhub.adoc
@@ -17,16 +17,16 @@ endif::[]
 
 OperatorHub is a user interface for discovering Operators; it works in conjunction with Operator Lifecycle Manager (OLM), which installs and manages Operators on a cluster.
 
-ifndef::olm-user,openshift-dedicated,openshift-rosa[]
+ifndef::olm-user,openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a cluster administrator, you can install an Operator from OperatorHub by using the {product-title}
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 web console or CLI. Subscribing an Operator to one or more namespaces makes the Operator available to developers on your cluster.
 endif::[]
 endif::[]
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a `dedicated-admin`, you can install an Operator from OperatorHub by using the {product-title} web console or CLI. Subscribing an Operator to one or more namespaces makes the Operator available to developers on your cluster.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 ifdef::olm-user[]
 As a user with the proper permissions, you can install an Operator from OperatorHub by using the {product-title} web console or CLI.
@@ -35,7 +35,7 @@ endif::[]
 During installation, you must determine the following initial settings for the Operator:
 
 ifndef::olm-user[]
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa,openshift-dedicated[]
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 Installation Mode:: Choose *All namespaces on the cluster (default)* to have the Operator installed on all namespaces or choose individual namespaces, if available, to only install the Operator on selected namespaces. This example chooses *All namespaces...* to make the Operator available to all users and projects.
 endif::[]
 endif::[]
@@ -51,10 +51,10 @@ Approval Strategy:: You can choose automatic or manual updates.
 If you choose automatic updates for an installed Operator, when a new version of that Operator is available in the selected channel, Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without human intervention.
 +
 If you select manual updates, when a newer version of an Operator is available, OLM creates an update request. As a
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 cluster administrator,
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 `dedicated-admin`,
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 you must then manually approve that update request to have the Operator updated to the new version.

--- a/modules/olm-migrating-sqlite-catalog-to-fbc.adoc
+++ b/modules/olm-migrating-sqlite-catalog-to-fbc.adoc
@@ -11,13 +11,17 @@ You can update your deprecated SQLite database format catalogs to the file-based
 .Prerequisites
 
 * You have a SQLite database catalog source.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-* You have the latest version of the `opm` CLI tool released with {product-title} {product-version} on your workstation.
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+* You have the latest version of the `opm` CLI tool released with {product-title} 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+{product-version} 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+on your workstation.
 
 .Procedure
 

--- a/modules/olm-multitenancy-solution.adoc
+++ b/modules/olm-multitenancy-solution.adoc
@@ -9,12 +9,12 @@
 While a *Multinamespace* install mode does exist, it is supported by very few Operators. As a middle ground solution between the standard *All namespaces* and *Single namespace* install modes, you can install multiple instances of the same Operator, one for each tenant, by using the following workflow:
 
 // In OSD/ROSA, dedicated-admins can create projects, but not namespaces.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 . Create a namespace for the tenant Operator that is separate from the tenant's namespace.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 . Create a namespace for the tenant Operator that is separate from the tenant's namespace. You can do this by creating a project.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 . Create an Operator group for the tenant Operator scoped only to the tenant's namespace.
 . Install the Operator in the tenant Operator namespace.
@@ -40,9 +40,9 @@ You cannot use different versions of the same Operator on the same cluster. Even
 ====
 
 // In OSD/ROSA, tenants shouldn't be able to install Operators. Dedicated-admins can, but they can't grant non-admin users the ability to install their own Operators.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 [WARNING]
 ====
 As an administrator, use caution when allowing non-cluster administrators to install Operators self-sufficiently, as explained in "Allowing non-cluster administrators to install Operators". These tenants should only have access to a curated catalog of Operators that are known to not have dependencies. These tenants must also be forced to use the same version line of an Operator, to ensure the CRDs do not change. This requires the use of namespace-scoped catalogs and likely disabling the global default catalogs.
 ====
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/olm-node-selector.adoc
+++ b/modules/olm-node-selector.adoc
@@ -9,9 +9,9 @@
 .Prerequisites
 
 * A `CatalogSource` object of source type `grpc` with `spec.image` is defined.
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Procedure
 

--- a/modules/olm-operator-framework.adoc
+++ b/modules/olm-operator-framework.adoc
@@ -8,7 +8,13 @@
 The Operator Framework is a family of tools and capabilities to deliver on the customer experience described above. It is not just about writing code; testing, delivering, and updating Operators is just as important. The Operator Framework components consist of open source tools to tackle these problems:
 
 Operator Lifecycle Manager::
-Operator Lifecycle Manager (OLM) controls the installation, upgrade, and role-based access control (RBAC) of Operators in a cluster. It is deployed by default in {product-title} {product-version}.
+Operator Lifecycle Manager (OLM) controls the installation, upgrade, and role-based access control (RBAC) of Operators in a cluster. It is deployed by default in 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+{product-title} {product-version}.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+{product-title}.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 Operator Registry::
 The Operator Registry stores cluster service versions (CSVs) and custom resource definitions (CRDs) for creation in a cluster and stores Operator metadata about packages and channels. It runs in a Kubernetes or OpenShift cluster to provide this Operator catalog data to OLM.

--- a/modules/olm-operatorhub-architecture.adoc
+++ b/modules/olm-operatorhub-architecture.adoc
@@ -11,7 +11,7 @@ The OperatorHub UI component is driven by the Marketplace Operator by default on
 == OperatorHub custom resource
 
 The Marketplace Operator manages an `OperatorHub` custom resource (CR) named `cluster` that manages the default `CatalogSource` objects provided with OperatorHub.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 You can modify this resource to enable or disable the default catalogs, which is useful when configuring {product-title} in restricted network environments.
 
 .Example `OperatorHub` custom resource
@@ -32,4 +32,4 @@ spec:
 ----
 <1> `disableAllDefaultSources` is an override that controls availability of all default catalogs that are configured by default during an {product-title} installation.
 <2> Disable default catalogs individually by changing the `disabled` parameter value per source.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/olm-overriding-operator-pod-affinity.adoc
+++ b/modules/olm-overriding-operator-pod-affinity.adoc
@@ -33,10 +33,10 @@ By default, when you install an Operator, {product-title} installs the Operator 
 
 The following examples describe situations where you might want to schedule an Operator pod to a specific node or set of nodes:
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If an Operator requires a particular platform, such as `amd64` or `arm64`
 * If an Operator requires a particular operating system, such as Linux or Windows
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * If you want Operators that work together scheduled on the same host or on hosts located on the same rack
 * If you want Operators dispersed throughout the infrastructure to avoid downtime due to network or hardware issues
 

--- a/modules/olm-overriding-operatorconditions.adoc
+++ b/modules/olm-overriding-operatorconditions.adoc
@@ -6,30 +6,30 @@
 [id="olm-supported-operatorconditions_{context}"]
 = Overriding Operator conditions
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a cluster administrator,
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As an administrator with the `dedicated-admin` role,
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 you might want to ignore a supported Operator condition reported by an Operator. When present, Operator conditions in the `Spec.Overrides` array override the conditions in the `Spec.Conditions` array, allowing
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 cluster administrators
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 `dedicated-admin` administrators
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 to deal with situations where an Operator is incorrectly reporting a state to Operator Lifecycle Manager (OLM).
 
 [NOTE]
 ====
 By default, the `Spec.Overrides` array is not present in an `OperatorCondition` object until it is added by
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 a cluster administrator
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 an administrator with the `dedicated-admin` role
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 . The `Spec.Conditions` array is also not present until it is either added by a user or as a result of custom Operator logic.
 ====
 
@@ -37,12 +37,12 @@ For example, consider a known version of an Operator that always communicates th
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * An Operator with an `OperatorCondition` object, installed using OLM.
 
 .Procedure
@@ -77,9 +77,9 @@ spec:
     message: "The operator is performing a migration."
     lastTransitionTime: "2020-08-24T23:15:55Z"
 ----
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 <1> Allows the cluster administrator to change the upgrade readiness to `True`.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 <1> Allows the `dedicated-admin` user to change the upgrade readiness to `True`.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/modules/olm-overriding-proxy-settings.adoc
+++ b/modules/olm-overriding-proxy-settings.adoc
@@ -7,12 +7,12 @@
 = Overriding proxy settings of an Operator
 
 If a cluster-wide egress proxy is configured, Operators running with Operator Lifecycle Manager (OLM) inherit the cluster-wide proxy settings on their deployments.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Cluster administrators
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Administrators with the `dedicated-admin` role
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 can also override these proxy settings by configuring the subscription of an Operator.
 
 [IMPORTANT]
@@ -22,15 +22,15 @@ Operators must handle setting environment variables for proxy settings in the po
 
 .Prerequisites
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Access to an {product-title} cluster using an account with
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * Access to a {product-title} cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Procedure
 

--- a/modules/olm-overview.adoc
+++ b/modules/olm-overview.adoc
@@ -33,20 +33,19 @@ ifndef::cluster-caps[]
 .{olmv0} workflow
 image::olm-workflow.png[]
 
-OLM runs by default in {product-title} {product-version}, which aids
-ifndef::openshift-dedicated,openshift-rosa[]
-cluster administrators
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
-administrators with the `dedicated-admin` role
-endif::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+OLM runs by default in {product-title} {product-version}, which aids cluster administrators
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+OLM runs by default in {product-title}, which aids administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 in installing, upgrading, and granting access to Operators running on their cluster. The {product-title} web console provides management screens for
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 cluster administrators
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 `dedicated-admin` administrators
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 to install Operators, as well as grant specific projects access to use the catalog of Operators available on the cluster.
 
 For developers, a self-service experience allows provisioning and configuring instances of databases, monitoring, and big data services without having to be subject matter experts, because the Operator has that knowledge baked into it.

--- a/modules/olm-preparing-multitenant-operators.adoc
+++ b/modules/olm-preparing-multitenant-operators.adoc
@@ -6,21 +6,21 @@
 [id="olm-preparing-operators-multitenant_{context}"]
 = Preparing for multiple instances of an Operator for multitenant clusters
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As a cluster administrator,
 endif::[]
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 As an administrator with the `dedicated-admin` role,
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 you can add multiple instances of an Operator for use in multitenant clusters. This is an alternative solution to either using the standard *All namespaces* install mode, which can be considered to violate the principle of least privilege, or the *Multinamespace* mode, which is not widely adopted. For more information, see "Operators in multitenant clusters".
 
 In the following procedure, the _tenant_ is a user or group of users that share common access and privileges for a set of deployed workloads. The _tenant Operator_ is the instance of an Operator that is intended for use by only that tenant.
 
 .Prerequisites
 
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * All instances of the Operator you want to install must be the same version across a given cluster.
 +
 [IMPORTANT]
@@ -31,7 +31,7 @@ For more information on this and other limitations, see "Operators in multitenan
 .Procedure
 
 // In OSD/ROSA, dedicated-admins can't create namespaces directly but can create projects.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 . Before installing the Operator, create a namespace for the tenant Operator that is separate from the tenant's namespace. For example, if the tenant's namespace is `team1`, you might create a `team1-operator` namespace:
 
 .. Define a `Namespace` resource and save the YAML file, for example, `team1-operator.yaml`:
@@ -50,16 +50,16 @@ metadata:
 ----
 $ oc create -f team1-operator.yaml
 ----
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // Slightly different step for OSD/ROSA since dedicated-admins can't create namespaces directly.
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 . Before installing the Operator, create a namespace for the tenant Operator that is separate from the tenant's namespace. You can do this by creating a project. For example, if the tenant's namespace is `team1`, you might create a `team1-operator` project:
 +
 [source,terminal]
 ----
 $ oc new-project team1-operator
 ----
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 . Create an Operator group for the tenant Operator scoped to the tenant's namespace, with only that one namespace entry in the `spec.targetNamespaces` list:
 

--- a/modules/olm-priority-class-name.adoc
+++ b/modules/olm-priority-class-name.adoc
@@ -16,9 +16,9 @@ endif::[]
 .Prerequisites
 
 * A `CatalogSource` object of source type `grpc` with `spec.image` is defined.
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Procedure
 

--- a/modules/olm-sqlite-catalog-configuring-elevated-permissions.adoc
+++ b/modules/olm-sqlite-catalog-configuring-elevated-permissions.adoc
@@ -19,12 +19,12 @@ The SQLite database catalog format is deprecated, but still supported by Red Hat
 .Prerequisites
 
 * You have a SQLite database catalog source.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have a target namespace that supports running pods with the elevated pod security admission standard of `baseline` or `privileged`.
 
 .Procedure
@@ -48,7 +48,11 @@ spec:
 +
 [TIP]
 ====
-In {product-title} {product-version}, the `spec.grpcPodConfig.securityContextConfig` field is set to `legacy` by default. In a future release of {product-title}, it is planned that the default setting will change to `restricted`. If your catalog cannot run under restricted enforcement, it is recommended that you manually set this field to `legacy`.
+In {product-title} 
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+{product-version}, 
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+the `spec.grpcPodConfig.securityContextConfig` field is set to `legacy` by default. In a future release of {product-title}, it is planned that the default setting will change to `restricted`. If your catalog cannot run under restricted enforcement, it is recommended that you manually set this field to `legacy`.
 ====
 
 . Edit your `<namespace>.yaml` file to add elevated pod security admission standards to your catalog source namespace, as shown in the following example:

--- a/modules/olm-tolerations.adoc
+++ b/modules/olm-tolerations.adoc
@@ -9,9 +9,9 @@
 .Prerequisites
 
 * A `CatalogSource` object of source type `grpc` with `spec.image` is defined.
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 .Procedure
 

--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -14,12 +14,12 @@ endif::[]
 = Updating a SQLite-based index image
 
 After configuring OperatorHub to use a catalog source that references a custom index image,
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 cluster administrators
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 administrators with the `dedicated-admin` role
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 can keep the available Operators on their cluster up-to-date by adding bundle images to the index image.
 
 You can update an existing index image using the `opm index add` command.

--- a/modules/olm-updating-sqlite-catalog-to-a-new-opm-version.adoc
+++ b/modules/olm-updating-sqlite-catalog-to-a-new-opm-version.adoc
@@ -11,13 +11,17 @@ You can rebuild your SQLite database catalog image with the latest version of th
 .Prerequisites
 
 * You have a SQLite database catalog source.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `cluster-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
-endif::openshift-dedicated,openshift-rosa[]
-* You have the latest version of the `opm` CLI tool released with {product-title} {product-version} on your workstation.
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+* You have the latest version of the `opm` CLI tool released with {product-title} 
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+{product-version} 
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+on your workstation.
 
 .Procedure
 

--- a/operators/admin/olm-adding-operators-to-cluster.adoc
+++ b/operators/admin/olm-adding-operators-to-cluster.adoc
@@ -11,12 +11,11 @@ toc::[]
 
 Using Operator Lifecycle Manager (OLM),
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-cluster administrators
+cluster administrators can install OLM-based Operators to an {product-title} cluster.
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-administrators with the `dedicated-admin` role
+administrators with the `dedicated-admin` role can install OLM-based Operators to a {product-title} cluster.
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-can install OLM-based Operators to an {product-title} cluster.
 
 [NOTE]
 ====

--- a/operators/admin/olm-configuring-proxy-support.adoc
+++ b/operators/admin/olm-configuring-proxy-support.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-If a global proxy is configured on the {product-title} cluster, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. However, you can also configure installed Operators to override the global proxy or inject a custom CA certificate.
+If a global proxy is configured on your {product-title} cluster, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. However, you can also configure installed Operators to override the global proxy or inject a custom CA certificate.
 
 [role="_additional-resources"]
 .Additional resources
@@ -15,9 +15,9 @@ If a global proxy is configured on the {product-title} cluster, Operator Lifecyc
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../networking/configuring_network_settings/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[Configuring the cluster-wide proxy]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
-ifdef::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.adoc#configuring-cluster-wide-proxy[Configuring a cluster-wide proxy]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // This xref points to a topic that is not currently included in the OSD and ROSA docs.
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]

--- a/operators/admin/olm-cs-podsched.adoc
+++ b/operators/admin/olm-cs-podsched.adoc
@@ -16,7 +16,7 @@ As an administrator, you can override these values by modifying fields in the `C
 
 [IMPORTANT]
 ====
-The Marketplace Operator, `openshift-marketplace`, manages the default `OperatorHub` custom resource's (CR). This CR manages `CatalogSource` objects. If you attempt to modify fields in the `CatalogSource` object’s `spec.grpcPodConfig` section, the Marketplace Operator automatically reverts these modifications.By default, if you modify fields in the `spec.grpcPodConfig` section of the   `CatalogSource` object, the Marketplace Operator automatically reverts these changes.
+The Marketplace Operator, `openshift-marketplace`, manages the default `OperatorHub` custom resource's (CR). This CR manages `CatalogSource` objects. If you attempt to modify fields in the `CatalogSource` object's `spec.grpcPodConfig` section, the Marketplace Operator automatically reverts these modifications. By default, if you modify fields in the `spec.grpcPodConfig` section of the   `CatalogSource` object, the Marketplace Operator automatically reverts these changes.
 
 To apply persistent changes to `CatalogSource` object, you must first disable a default `CatalogSource` object.
 ====

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -86,10 +86,7 @@ include::modules/olm-catalog-source-and-psa.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-// TODO-HCP remove conditions for HCP after cli_tools book is migrated
-ifndef::openshift-rosa-hcp[]
 * xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
-endif::openshift-rosa-hcp[]
 
 include::modules/olm-migrating-sqlite-catalog-to-fbc.adoc[leveloffset=+2]
 

--- a/operators/understanding/olm-multitenancy.adoc
+++ b/operators/understanding/olm-multitenancy.adoc
@@ -6,7 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The default behavior for Operator Lifecycle Manager (OLM) aims to provide simplicity during Operator installation. However, this behavior can lack flexibility, especially in multitenant clusters. In order for multiple tenants on a {product-title} cluster to use an Operator, the default behavior of OLM requires that administrators install the Operator in *All namespaces* mode, which can be considered to violate the principle of least privilege.
+The default behavior for Operator Lifecycle Manager (OLM) aims to provide simplicity during Operator installation. However, this behavior can lack flexibility, especially in multitenant clusters. In order for multiple tenants on 
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+an {product-title} 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+a {product-title} 
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+cluster to use an Operator, the default behavior of OLM requires that administrators install the Operator in *All namespaces* mode, which can be considered to violate the principle of least privilege.
 
 Consider the following scenarios to determine which Operator installation workflow works best for your environment and requirements.
 

--- a/operators/understanding/olm-packaging-format.adoc
+++ b/operators/understanding/olm-packaging-format.adoc
@@ -17,10 +17,8 @@ include::modules/olm-dependencies.adoc[leveloffset=+2]
 * xref:../../operators/understanding/olm/olm-understanding-dependency-resolution.adoc#olm-understanding-dependency-resolution[Operator Lifecycle Manager dependency resolution]
 
 include::modules/olm-about-opm.adoc[leveloffset=+2]
-// TODO-HCP remove conditions for HCP after cli_tools book is migrated
-ifndef::openshift-rosa-hcp[]
+
 * See xref:../../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[CLI tools] for steps on installing the `opm` CLI.
-endif::openshift-rosa-hcp[]
 
 ifdef::openshift-origin[]
 [id="olm-packaging-format-addtl-resources"]
@@ -70,9 +68,7 @@ include::modules/olm-fb-catalogs-guidelines.adoc[leveloffset=+2]
 === CLI usage
 
 For instructions about creating file-based catalogs by using the `opm` CLI, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-creating-fb-catalog-image_olm-managing-custom-catalogs[Managing custom catalogs].
-// TODO-HCP remove conditions for HCP after cli_tools book is migrated
-ifndef::openshift-rosa-hcp[]
+
 For reference documentation about the `opm` CLI commands related to managing file-based catalogs, see xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[CLI tools].
-endif::openshift-rosa-hcp[]
 
 include::modules/olm-fb-catalogs-automation.adoc[leveloffset=+2]


### PR DESCRIPTION
[OSDOCS-14501](https://issues.redhat.com//browse/OSDOCS-14501): Prune Operators

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-14501

Link to docs preview:
HCP: https://99307--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/operators/
Classic: https://99307--ocpdocs-pr.netlify.app/openshift-rosa/latest/operators/

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
