### PR TITLE
[monitoring-docs-main] OBSDOCS-2230: Fluentd is incorrectly referred in RHOCP 4.18+ monitori…

### DIFF
--- a/modules/monitoring-common-terms.adoc
+++ b/modules/monitoring-common-terms.adoc
@@ -32,13 +32,6 @@ A CR is an extension of the Kubernetes API. You can create custom resources.
 etcd::
 etcd is the key-value store for {ocp}, which stores the state of all resource objects.
 
-Fluentd::
-Fluentd is a log collector that resides on each {ocp} node. It gathers application, infrastructure, and audit logs and forwards them to different outputs.
-+
---
-include::snippets/logging-fluentd-dep-snip.adoc[]
---
-
 Kubelets::
 Runs on nodes and reads the container manifests. Ensures that the defined containers have started and are running.
 


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/99181