### PR TITLE
[RHDEVDOCS-6713] Document the new `auto-configure-new-github-repo` parameter

### DIFF
--- a/modules/op-customizing-pipelines-as-code-configuration.adoc
+++ b/modules/op-customizing-pipelines-as-code-configuration.adoc
@@ -38,6 +38,8 @@ To customize {pac}, cluster administrators can configure the following parameter
 
 | `auto-configure-repo-namespace-template` | Configures a template to automatically generate the namespace for your new repository, if `auto-configure-new-github-repo` is enabled. | `{repo_name}-pipelines`
 
+| `auto-configure-repo-repository-template` | Configures a template to automatically generate the name for your new `Repository` custom resource (CR), if `auto-configure-new-github-repo` is enabled. | `{{repo_name}}-repo-cr`
+
 | `error-log-snippet` | Enables or disables the view of a log snippet for the failed tasks, with an error in a pipeline. You can disable this parameter in the case of data leakage from your pipeline. | `true`
 
 | `error-detection-from-container-logs` | Enables or disables the inspection of container logs to detect error message and expose them as annotations on the pull request. This setting applies only if you are using the GitHub app. | `true`


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.20

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6713?src=confmacro

Link to docs preview:
- [Table 1. Customizing Pipelines as Code configuration](https://99328--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/install-config-pipelines-as-code#customizing-pipelines-as-code-configuration_install-config-pipelines-as-code)

QE review:
- [x] QE has approved this change.

Additional info: 
- https://redhat-internal.slack.com/archives/C03A1MBHN81/p1758193205686509?thread_ts=1756957841.956759&cid=C03A1MBHN81
