### PR TITLE
OSDOCS#15473: Two-Node with Arbiter GA - Remove tech preview status

### DIFF
--- a/modules/ipi-install-config-local-arbiter-node.adoc
+++ b/modules/ipi-install-config-local-arbiter-node.adoc
@@ -6,10 +6,7 @@
 [id="ipi-install-config-local-arbiter-node_{context}"]
 = Configuring a local arbiter node
 
-You can configure an {product-title} cluster with two control plane nodes and one local arbiter node so to retain high availability (HA) while reducing infrastructure costs for your cluster. This configuration is supported only for bare-metal installations.
-
-:FeatureName: Configuring a local arbiter node
-include::snippets/technology-preview.adoc[]
+You can configure an {product-title} cluster with two control plane nodes and one local arbiter node so as to retain high availability (HA) while reducing infrastructure costs for your cluster.
 
 A local arbiter node is a lower-cost, co-located machine that participates in control plane quorum decisions. Unlike a standard control plane node, the arbiter node does not run the full set of control plane services. You can use this configuration to maintain HA in your cluster with only two fully provisioned control plane nodes instead of three.
 
@@ -22,9 +19,6 @@ To deploy a cluster with two control plane nodes and one local arbiter node, you
 
 * 2 control plane nodes
 * 1 arbiter node
-
-You must enable the `TechPreviewNoUpgrade` feature set in the `FeatureGate` custom resource (CR) to enable the arbiter node feature. 
-For more information about feature gates, see "Understanding feature gates".
 
 The arbiter node must meet the following minimum system requirements:
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-15473](https://issues.redhat.com/browse/OSDOCS-15473)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Configuring a local node arbiter](https://99341--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#ipi-install-config-local-arbiter-node_ipi-install-installation-workflow)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
