### PR TITLE
OSDOCS-16222: Cluster API AWS capacityReservationPreference

### DIFF
--- a/modules/machine-feature-agnostic-capacity-reservation.adoc
+++ b/modules/machine-feature-agnostic-capacity-reservation.adoc
@@ -45,7 +45,8 @@ spec:
   template:
     spec:
       capacityReservationId: <capacity_reservation> # <1>
-      marketType: <market_type> # <2>
+      capacityReservationPreference: <reservation_preference> # <2>
+      marketType: <market_type> # <3>
 # ...
 ----
 <1> Specify the ID of the 
@@ -53,7 +54,14 @@ ifdef::azure[Capacity Reservation group]
 ifdef::aws[Capacity Block for ML or On-Demand Capacity Reservation]
 that you want to deploy machines on.
 ifdef::aws[]
-<2> Specify the market type to use.
+<2> Specify your preferred capacity reservation behavior.
+The following values are valid:
+`CapacityReservationsOnly`:: Use this option to require a matching capacity reservation.
+If no matching capacity reservation is available, the instance fails to launch.
+`Open`:: Use this option to allow using an open capacity reservation that matches the availability zone and instance type.
+`None`:: Use this option to prohibit using a capacity reservation.
+You might use this option to help keep capacity reservations available for workloads that you want to use them.
+<3> Specify the market type to use.
 The following values are valid:
 `CapacityBlock`:: Use this market type with Capacity Blocks for ML.
 `OnDemand`:: Use this market type with On-Demand Capacity Reservations.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-16222](https://issues.redhat.com//browse/OSDOCS-16222)

Link to docs preview:
[Capacity Reservation configuration options](https://99344--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.html#machine-feature-agnostic-capacity-reservation_cluster-api-config-options-aws)

QE review:
- [x] QE has approved this change.

Additional information: