### PR TITLE
OSDOCS-16222: Cluster API AWS capacityReservationPreference rel note

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -460,6 +460,11 @@ For more information, see xref:../installing/installing_azure/ipi/installing-azu
 [id="ocp-release-notes-machine-management_{context}"]
 === Machine management
 
+[id="ocp-4-20-capi-aws-capacity-preferences_{context}"]
+==== Additional {aws-short} Capacity Reservation configuration options
+
+On clusters that manage machines with the Cluster API, you can specify additional constraints to determine whether your compute machines use {aws-short} capacity reservations. For more information, see xref:../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#machine-feature-agnostic-capacity-reservation_cluster-api-config-options-aws[Capacity Reservation configuration options].
+
 [id="ocp-release-notes-monitoring_{context}"]
 === Monitoring
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-15656](https://issues.redhat.com//browse/OSDOCS-15656) and [OSDOCS-16428](https://issues.redhat.com//browse/OSDOCS-16428)

Link to docs preview:
[Additional AWS Capacity Reservation configuration options](https://99346--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-capi-aws-capacity-preferences_release-notes)

QE review:
- [x] QE has approved this change.

Additional information:
Feature docs #99344