### PR TITLE
OCPBUGS#13160: removing bare metal statement

### DIFF
--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -108,8 +108,6 @@ If you set the platform to `vSphere`, `baremetal`, or `none`, you can configure 
 * IPv4
 * IPv6
 * IPv4 and IPv6 in parallel (dual-stack)
-
-IPv6 is supported only on bare metal platforms.
 ====
 +
 .Example of dual-stack networking


### PR DESCRIPTION
[OCPBUGS-13160](https://issues.redhat.com/browse/OCPBUGS-13160)

Version(s): 4.12+ 

Removing a statement about IPv6 support that seems to contradict the content stated earlier in the note, per Yuki's comment on [the Jira issue](https://issues.redhat.com/browse/OCPBUGS-13160).

QE review:
- [x] QE has approved this change.

Preview:  [Creating the preferred configuration inputs](https://99347--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent-inputs_installing-with-agent-based-installer)