### PR TITLE
OSDOCS-16150-v1: core OCP release note 4.13 z-stream

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4584,3 +4584,22 @@ $ oc adm release info 4.13.59 --pullspecs
 [id="ocp-4-13-59-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.13.60
+[id="ocp-4-13-60_{context}"]
+=== RHSA-2025:15673 - {product-title} 4.13.60 bug fix and security updates
+
+Issued: 18 September 2025
+
+{product-title} release 4.13.60, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:15673[RHSA-2025:15673] advisory. There are no RPM packages for this advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.60 --pullspecs
+----
+
+[id="ocp-4-13-60-updating_{context}"]
+==== Updating
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-16150

Link to docs preview:
https://99407--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-60_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
This PR is based off of PR https://github.com/openshift/openshift-docs/pull/99342. PR https://github.com/openshift/openshift-docs/pull/99342 has been closed.
