### PR TITLE
OSDOCS#14738: Add MicroShift cert-mgr RN info to 4.20 RNs

### DIFF
--- a/microshift_release_notes/microshift-4-20-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-20-release-notes.adoc
@@ -51,8 +51,13 @@ Updating two minor EUS versions in a single step is supported in {product-versio
 
 With this release, you can configure custom error code pages and logging parameters in the router, and you can capture HTTP headers and cookies in the ingress controller access logs. For more information, see xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} cluster].
 
-//[id="microshift-4-20-running-apps_{context}"]
-//=== Running applications
+[id="microshift-4-20-running-apps_{context}"]
+=== Running applications
+
+[id="microshift-4-20-install-cert-manager_{context}"]
+==== Install MicroShift certificate manager
+
+With this release, {microshift-short} users can securely manage certificates for their components by using the cert-manager Operator. This enhancement automates the issuance and renewal of SSL/TLS certificates, enhancing data protection and ensuring regulatory compliance. It enables standardized certificate management, enhances node security, and results in more secure and standardized communication within and between user services. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift[cert-manager Operator for Red Hat OpenShift].
 
 //[id="microshift-4-20-new-feature_{context}"]
 //==== placeholder RAs feature


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-14738](https://issues.redhat.com/browse/OSDOCS-14738)

Link to docs preview:
[Install MicroShift certificate manager](https://99441--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-20-release-notes.html#microshift-4-20-install-cert-manager_release-notes)

QE review:
- [x ] QE has approved this change.
