### PR TITLE
OBSDOCS-2251: Improve verification formatting in monitoring docs

### DIFF
--- a/modules/monitoring-configuring-alert-routing-default-platform-alerts.adoc
+++ b/modules/monitoring-configuring-alert-routing-default-platform-alerts.adoc
@@ -191,7 +191,9 @@ The previous example routes alerts of `critical` severity that are fired by the 
 $ oc -n openshift-monitoring create secret generic alertmanager-main --from-file=alertmanager.yaml --dry-run=client -o=yaml |  oc -n openshift-monitoring replace secret --filename=-
 ----
 
-. Verify your routing configuration by visualizing the routing tree:
+.Verification
+
+* Verify your routing configuration by visualizing the routing tree:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-configuring-audit-logs-for-metrics-server.adoc
+++ b/modules/monitoring-configuring-audit-logs-for-metrics-server.adoc
@@ -50,7 +50,9 @@ data:
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
 
-. Verify that the audit profile is applied:
+.Verification
+
+* Verify that the audit profile is applied:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
@@ -61,7 +61,9 @@ data:
 If you enable monitoring for user-defined projects, the `user-workload-monitoring-config` `ConfigMap` object is created by default.
 ====
 
-. Verify that the `prometheus-operator`, `prometheus-user-workload`, and `thanos-ruler-user-workload` pods are running in the `openshift-user-workload-monitoring` project. It might take a short while for the pods to start:
+.Verification
+
+* Verify that the `prometheus-operator`, `prometheus-user-workload`, and `thanos-ruler-user-workload` pods are running in the `openshift-user-workload-monitoring` project. It might take a short while for the pods to start:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
+++ b/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
@@ -60,7 +60,7 @@ data:
 ----
 $ oc -n openshift-monitoring get pods
 ----
-+
+
 . Run a test query using the following sample commands as a model:
 +
 [source,terminal]
@@ -68,6 +68,7 @@ $ oc -n openshift-monitoring get pods
 $ token=`oc create token prometheus-k8s -n openshift-monitoring`
 $ oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- curl -k -H "Authorization: Bearer $token" 'https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query?query=cluster_version'
 ----
+
 . Run the following command to read the query log:
 +
 [source,terminal]
@@ -79,6 +80,6 @@ $ oc -n openshift-monitoring logs <thanos_querier_pod_name> -c thanos-query
 ====
 Because the `thanos-querier` pods are highly available (HA) pods, you might be able to see logs in only one pod.
 ====
-+
+
 . After you examine the logged query information, disable query logging by changing the `enableRequestLogging` value to `false` in the config map.
 

--- a/modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc
@@ -16,7 +16,7 @@ As a cluster administrator, you can assign the `user-workload-monitoring-config-
 
 .Procedure
 
-. Assign the `user-workload-monitoring-config-edit` role to a user in the `openshift-user-workload-monitoring` project:
+* Assign the `user-workload-monitoring-config-edit` role to a user in the `openshift-user-workload-monitoring` project:
 +
 [source,terminal]
 ----
@@ -25,7 +25,9 @@ $ oc -n openshift-user-workload-monitoring adm policy add-role-to-user \
   --role-namespace openshift-user-workload-monitoring
 ----
 
-. Verify that the user is correctly assigned to the `user-workload-monitoring-config-edit` role by displaying the related role binding:
+.Verification
+
+* Verify that the user is correctly assigned to the `user-workload-monitoring-config-edit` role by displaying the related role binding:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
+++ b/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
@@ -174,7 +174,7 @@ data:
 ----
 +
 .. Save the file to apply the changes. The affected `prometheus-operator` pod is automatically redeployed.
-+
+
 .. Confirm that the `debug` log-level has been applied to the `prometheus-operator` deployment in the `openshift-user-workload-monitoring` project:
 +
 [source,terminal]
@@ -189,7 +189,7 @@ $ oc -n openshift-user-workload-monitoring get deploy prometheus-operator -o yam
 ----
 +
 Debug level logging will show all calls made by the Prometheus Operator.
-+
+
 .. Check that the `prometheus-operator` pod is running:
 +
 [source,terminal]
@@ -201,5 +201,5 @@ $ oc -n openshift-user-workload-monitoring get pods
 ====
 If an unrecognized Prometheus Operator `loglevel` value is included in the config map, the `prometheus-operator` pod might not restart successfully.
 ====
-+
+
 .. Review the debug logs to see if the Prometheus Operator is using the `ServiceMonitor` resource. Review the logs for other related errors.

--- a/modules/monitoring-resolving-the-kubepersistentvolumefillingup-alert-firing-for-prometheus.adoc
+++ b/modules/monitoring-resolving-the-kubepersistentvolumefillingup-alert-firing-for-prometheus.adoc
@@ -70,7 +70,9 @@ $ oc debug prometheus-k8s-0 -n openshift-monitoring \
 while read BLOCK; do rm -r /prometheus/$BLOCK; done'
 ----
 
-. Verify the usage of the mounted PV and ensure there is enough space available by running the following command:
+.Verification
+
+* Verify the usage of the mounted PV and ensure there is enough space available by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -101,6 +101,8 @@ The default value is `0`.
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
 
+.Verification
+
 . Verify that the log configuration is applied by reviewing the deployment or pod configuration in the related project. 
 
 ** The following example checks the log level for the `prometheus-operator` deployment:

--- a/modules/monitoring-setting-query-log-file-for-prometheus.adoc
+++ b/modules/monitoring-setting-query-log-file-for-prometheus.adoc
@@ -74,6 +74,8 @@ data:
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
 
+.Verification
+
 . Verify that the pods for the component are running. The following sample command lists the status of pods:
 +
 [source,terminal,subs="attributes+"]

--- a/modules/monitoring-specifying-how-a-service-is-monitored.adoc
+++ b/modules/monitoring-specifying-how-a-service-is-monitored.adoc
@@ -66,7 +66,9 @@ $ oc apply -f example-app-service-monitor.yaml
 +
 It takes some time to deploy the `ServiceMonitor` resource.
 
-. Verify that the `ServiceMonitor` resource is running:
+.Verification
+
+* Verify that the `ServiceMonitor` resource is running:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2251
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs previews: 
* https://99451--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-core-platform-monitoring/storing-and-recording-data
* https://99451--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-core-platform-monitoring/configuring-alerts-and-notifications
* https://99451--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm
* https://99451--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-user-workload-monitoring/storing-and-recording-data-uwm
* https://99451--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-user-workload-monitoring/configuring-metrics-uwm
* https://99451--ocpdocs-pr.netlify.app/openshift-monitoring/latest/troubleshooting/troubleshooting-monitoring-issues#resolving-the-kubepersistentvolumefillingup-alert-firing-for-prometheus_troubleshooting-monitoring-issues
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: `n/a`
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
