### PR TITLE
PR for SRVCOM-3977: Document Release notes, known issues and bug fixes for 1.36.1

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -29,6 +29,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 // Release notes included, most to least recent
 
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-36-1.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-36-0.adoc[leveloffset=+1]
 
 // OCP + OSD + ROSA

--- a/modules/serverless-rn-1-36-1.adoc
+++ b/modules/serverless-rn-1-36-1.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-rn-1-36-1_{context}"]
+= Red{nbsp}Hat {ServerlessProductName} 1.36.1
+
+{ServerlessProductName} 1.36.1 is now available. This release of {ServerlessProductName} addresses identified Common Vulnerabilities and Exposures (CVEs) to enhance security and reliability. Fixed issues and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="fixed-issues-1-36-1_{context}"]
+== Fixed issues
+
+* Before this update, the {ServerlessProductName} Functions client failed to build remotely with {pipelines-title} version 1.19, causing pipeline runs to remain in the `Pending` state on the `fetch-sources` task and report admission webhook errors. With this release, the issue is resolved, and remote builds complete successfully.
+
+[id="known-issues-1-36-1_{context}"]
+== Known issues
+
+* The `kn func build --remote` command on an {ocp-product-title} s390x cluster triggers a known issue that causes the build task to hang. As a consequence, the build process does not complete.


### PR DESCRIPTION
**Affected versions:** 
`serverless-docs-1.37`
`serverless-docs-1.36`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3977

**Doc preview:** [Red Hat OpenShift Serverless 1.36.1](https://99456--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-36-1_serverless-release-notes)

**Reviews:**

- [x] QE has approved this change.
- [x] SME has approved this change.
- [x] Peer has approved this change.