### PR TITLE
[monitoring-docs-4.15] OBSDOCS-2447: Add abstract tag back to assemblies on main

### DIFF
--- a/about-ocp-monitoring/about-ocp-monitoring.adoc
+++ b/about-ocp-monitoring/about-ocp-monitoring.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 ifndef::openshift-dedicated,openshift-rosa[]
 {ocp} includes a preconfigured, preinstalled, and self-updating monitoring stack that provides monitoring for core platform components. You also have the option to xref:../configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#enabling-monitoring-for-user-defined-projects-uwm_preparing-to-configure-the-monitoring-stack-uwm[enable monitoring for user-defined projects].
 

--- a/about-ocp-monitoring/monitoring-stack-architecture.adoc
+++ b/about-ocp-monitoring/monitoring-stack-architecture.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 The {ocp}
 ifdef::openshift-rosa[]
 (ROSA)

--- a/accessing-metrics/accessing-metrics-as-a-developer.adoc
+++ b/accessing-metrics/accessing-metrics-as-a-developer.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can access metrics to monitor the performance of your cluster workloads.
 
 [role="_additional-resources"]

--- a/accessing-metrics/accessing-metrics-as-an-administrator.adoc
+++ b/accessing-metrics/accessing-metrics-as-an-administrator.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can access metrics to monitor the performance of cluster components and your workloads.
 
 [role="_additional-resources"]

--- a/accessing-metrics/accessing-monitoring-apis-by-using-the-cli.adoc
+++ b/accessing-metrics/accessing-monitoring-apis-by-using-the-cli.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {ocp}, you can access web service APIs for some monitoring components from the command-line interface (CLI).
 
 [IMPORTANT]

--- a/configuring-core-platform-monitoring/configuring-alerts-and-notifications.adoc
+++ b/configuring-core-platform-monitoring/configuring-alerts-and-notifications.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure a local or external Alertmanager instance to route alerts from Prometheus to endpoint receivers. You can also attach custom labels to all time series and alerts to add useful metadata information.
 
 //Configuring external Alertmanager instances

--- a/configuring-core-platform-monitoring/configuring-metrics.adoc
+++ b/configuring-core-platform-monitoring/configuring-metrics.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Configure the collection of metrics to monitor how cluster components and your own workloads are performing.
 
 You can send ingested metrics to remote systems for long-term storage and add cluster ID labels to the metrics to identify the data coming from different clusters.

--- a/configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc
+++ b/configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure the monitoring stack to optimize the performance and scale of your clusters. The following documentation provides information about how to distribute the monitoring components and control the impact of the monitoring stack on CPU and memory resources.
 
 [role="_additional-resources"]

--- a/configuring-core-platform-monitoring/preparing-to-configure-the-monitoring-stack.adoc
+++ b/configuring-core-platform-monitoring/preparing-to-configure-the-monitoring-stack.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 The {ocp} installation program provides only a low number of configuration options before installation. Configuring most {ocp} framework components, including the cluster monitoring stack, happens after the installation.
 
 This section explains which monitoring components can be configured and how to prepare for configuring the monitoring stack.

--- a/configuring-core-platform-monitoring/storing-and-recording-data.adoc
+++ b/configuring-core-platform-monitoring/storing-and-recording-data.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Store and record your metrics and alerting data, configure logs to specify which activities are recorded, control how long Prometheus retains stored data, and set the maximum amount of disk space for the data. These actions help you protect your data and use them for troubleshooting.
 
 // Configuring persistent storage

--- a/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm.adoc
+++ b/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure a local or external Alertmanager instance to route alerts from Prometheus to endpoint receivers. You can also attach custom labels to all time series and alerts to add useful metadata information.
 
 //Configuring external Alertmanager instances

--- a/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc
+++ b/configuring-user-workload-monitoring/configuring-metrics-uwm.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Configure the collection of metrics to monitor how cluster components and your own workloads are performing.
 
 You can send ingested metrics to remote systems for long-term storage and add cluster ID labels to the metrics to identify the data coming from different clusters.

--- a/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
+++ b/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can configure the monitoring stack to optimize the performance and scale of your clusters. The following documentation provides information about how to distribute the monitoring components and control the impact of the monitoring stack on CPU and memory resources.
 
 [id="controlling-placement-and-distribution-of-monitoing-components_{context}"]

--- a/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc
+++ b/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 This section explains which user-defined monitoring components can be configured, how to enable user workload monitoring, and how to prepare for configuring the user workload monitoring stack.
 
 [IMPORTANT]

--- a/configuring-user-workload-monitoring/storing-and-recording-data-uwm.adoc
+++ b/configuring-user-workload-monitoring/storing-and-recording-data-uwm.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Store and record your metrics and alerting data, configure logs to specify which activities are recorded, control how long Prometheus retains stored data, and set the maximum amount of disk space for the data. These actions help you protect your data and use them for troubleshooting.
 
 // Configuring persistent storage

--- a/getting-started/core-platform-monitoring-first-steps.adoc
+++ b/getting-started/core-platform-monitoring-first-steps.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 After {ocp} is installed, core platform monitoring components immediately begin collecting metrics, which you can query and view.
 The default in-cluster monitoring stack includes the core platform Prometheus instance that collects metrics from your cluster and the core Alertmanager instance that routes alerts, among other components.
 Depending on who will use the monitoring stack and for what purposes, as a cluster administrator, you can further configure these monitoring components to suit the needs of different users in various scenarios.

--- a/getting-started/developer-and-non-administrator-steps.adoc
+++ b/getting-started/developer-and-non-administrator-steps.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 After monitoring for user-defined projects is enabled and configured, developers and other non-administrator users can then perform the following activities to set up and use monitoring for their own projects:
 
 * xref:../configuring-user-workload-monitoring/configuring-metrics-uwm.adoc#setting-up-metrics-collection-for-user-defined-projects_configuring-metrics-uwm[Deploy and monitor services].

--- a/getting-started/user-workload-monitoring-first-steps.adoc
+++ b/getting-started/user-workload-monitoring-first-steps.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As a cluster administrator, you can optionally enable monitoring for user-defined projects in addition to core platform monitoring.
 Non-administrator users such as developers can then monitor their own projects outside of core platform monitoring.
 

--- a/key-concepts/key-concepts.adoc
+++ b/key-concepts/key-concepts.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Get familiar with the {ocp} monitoring concepts and terms. Learn about how you can improve performance and scale of your cluster, store and record data, manage metrics and alerts, and more.
 
 [id="about-performance-and-scalability_{context}"]

--- a/managing-alerts/managing-alerts-as-a-developer.adoc
+++ b/managing-alerts/managing-alerts-as-a-developer.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {ocp}, the Alerting UI enables you to manage alerts, silences, and alerting rules.
 
 [NOTE]

--- a/managing-alerts/managing-alerts-as-an-administrator.adoc
+++ b/managing-alerts/managing-alerts-as-an-administrator.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {ocp}, the Alerting UI enables you to manage alerts, silences, and alerting rules.
 
 [NOTE]

--- a/release-notes/monitoring-release-notes.adoc
+++ b/release-notes/monitoring-release-notes.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 The {ocp} release notes for the in-cluster monitoring stack contain information about new features and enhancements, Technology Previews, deprecated and removed features, known issues, and fixed issues.
 
 For details about other changes in the {ocp} release, see the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html-single/release_notes/index#ocp-4-15-release-notes[{ocp} {product-version} release notes].

--- a/support-for-monitoring/maintenance-and-support-for-monitoring.adoc
+++ b/support-for-monitoring/maintenance-and-support-for-monitoring.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Not all configuration options for the monitoring stack are exposed. The only supported way of configuring {ocp} monitoring is by configuring the {cmo-first} using the options described in the xref:../config-map-reference/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}]. *Do not use other configurations, as they are unsupported.*
 
 Configuration paradigms might change across Prometheus releases, and such cases can only be handled gracefully if all configuration possibilities are controlled. If you use configurations other than those described in the xref:../config-map-reference/config-map-reference-for-the-cluster-monitoring-operator.adoc#cluster-monitoring-operator-configuration-reference[Config map reference for the {cmo-full}], your changes will disappear because the {cmo-short} automatically reconciles any differences and resets any unsupported changes back to the originally defined state by default and by design.

--- a/troubleshooting/troubleshooting-monitoring-issues.adoc
+++ b/troubleshooting/troubleshooting-monitoring-issues.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 ifndef::openshift-dedicated,openshift-rosa[]
 Find troubleshooting steps for common issues with core platform and user-defined project monitoring.
 endif::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/99453 to 4.15