### PR TITLE
remove regex following main

### DIFF
--- a/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/accept.txt
@@ -1,8 +1,5 @@
 # Regex terms added to accept.txt are ignored by the Vale linter and override RedHat Vale rules.
 # Add terms that have a corresponding incorrectly capitalized form to reject.txt.
-# URL slugs
-(.*/)+
-(?<!.*-)operator
 [Ff]ronthaul
 [Mm]idhaul
 [Oo]n-premise

--- a/.vale/styles/config/vocabularies/OpenShiftDocs/reject.txt
+++ b/.vale/styles/config/vocabularies/OpenShiftDocs/reject.txt
@@ -1,7 +1,6 @@
 # Regex terms added to reject.txt are highlighted as errors by the Vale linter and override RedHat Vale rules.
 # Add terms that have a corresponding correctly capitalized form to accept.txt.
 
-(?<!.*-)operators
 [Dd]eployment [Cc]onfigs?
 [Dd]eployment [Cc]onfigurations?
 [Oo]peratorize


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12-4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Additional information: the `main` branch has this pattern removed and now that vale checks run on enterprise branches, this PR removes the pattern to be inline with `main` and prevent issues related to vale checks
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
