### PR TITLE
OLS-2088: Document how to hide OLS icon

### DIFF
--- a/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
@@ -38,9 +38,11 @@ spec:
         models:
           - name: <model_name>
   ols:
+    hideIcon: true <1>  
     defaultModel: <model_name>
     defaultProvider: myOpenai
 ----
+<1> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 +
 .{rhelai} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -60,13 +62,15 @@ spec:
       type: rhelai_vllm
       url: <url> <2>
   ols:
+    hideIcon: true <3>    
     defaultProvider: rhelai
     defaultModel: models/<model_name>
     additionalCAConfigMapRef:
       name: openshift-service-ca.crt
 ----
 <1> By default, the {rhelai} API key requires a token as part of the request. If your {rhelai} configuration does not require a token, you must set the token value to any valid string for the request to authenticate.
-<2> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`. 
+<2> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`.
+<3> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 +
 .{rhoai} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -86,11 +90,13 @@ spec:
       type: rhoai_vllm 
       url: <url> <2>
   ols:
+    hideIcon: true <3>    
     defaultProvider: red_hat_openshift_ai
     defaultModel: <model_name>
 ----
 <1> By default, the {rhoai} API key requires a token as part of the request. If your {rhoai} configuration does not require a token, you must set the token value to any valid string for the request to authenticate.
-<2> The URL endpoint must end with `v1` to be valid. For example, `\https://<model_name>.<domain_name>.com:443/v1`. 
+<2> The URL endpoint must end with `v1` to be valid. For example, `\https://<model_name>.<domain_name>.com:443/v1`.
+<3> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 +
 .{azure-openai} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -112,9 +118,11 @@ spec:
         type: azure_openai
         url: <azure_ai_deployment_url>
   ols:
+    hideIcon: true <1>    
     defaultModel: <model_name>
     defaultProvider: myAzure
 ----
+<1> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 +
 .{watsonx} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -135,9 +143,11 @@ spec:
         models:
           - name: ibm/<model_name>
   ols:
+    hideIcon: true <1>    
     defaultModel: ibm/<model_name>
     defaultProvider: myWatsonx
 ----
+<1> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 
 . Run the following command:
 +

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
@@ -40,9 +40,11 @@ spec:
         models:
           - name: <model_name>
   ols:
+    hideIcon: true <1>
     defaultModel: <model_name>
     defaultProvider: myOpenai
 ----
+<1> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 +
 .{rhelai} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -62,11 +64,13 @@ spec:
       type: rhelai_vllm
       url: <url> <2>
   ols:
+    hideIcon: true <3>
     defaultProvider: rhelai
     defaultModel: models/<model_name>
 ----
 <1> By default, the {rhelai} API key requires a token as part of the request. If your {rhelai} configuration does not require a token, you must set the token value to any valid string for the request to authenticate.
 <2> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`. 
+<3> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 +
 .{rhoai} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -86,11 +90,13 @@ spec:
       type: rhoai_vllm 
       url: <url> <2>
   ols:
+    hideIcon: true <3>
     defaultProvider: red_hat_openshift_ai
     defaultModel: <model_name>
 ----
 <1> By default, the {rhoai} API key requires a token as part of the request. If your {rhoai} configuration does not require a token, you must set the token value to any valid string for the request to authenticate.
 <2> The URL endpoint must end with `v1` to be valid. For example, `\https://<model_name>.<domain_name>.com:443/v1`.
+<3> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 +
 .{azure-openai} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -112,9 +118,11 @@ spec:
         type: azure_openai
         url: <azure_ai_deployment_url>
   ols:
+    hideIcon: true <1>
     defaultModel: <model_name>
     defaultProvider: myAzure
 ----
+<1> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 +
 .{watsonx} CR file
 [source,yaml,subs="attributes,verbatim"]
@@ -135,8 +143,10 @@ spec:
         models:
           - name: ibm/<model_name>
   ols:
+    hideIcon: true <1>
     defaultModel: ibm/<model_name>
     defaultProvider: myWatsonx
 ----
+<1> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 
 . Click *Create*.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2088

Link to docs preview:
Web console task:
https://99506--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-creating-lightspeed-custom-resource-file-using-web-console_ols-configuring-openshift-lightspeed

CLI task:

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
