### PR TITLE
networking/bgp: fix AsciiDoc syntax in BGP routing enable/disable mod…

### DIFF
--- a/modules/nw-bgp-routing-disable.adoc
+++ b/modules/nw-bgp-routing-disable.adoc
@@ -25,9 +25,7 @@ As a cluster administrator, you can disable BGP routing support for your cluster
 +
 [source,terminal]
 ----
-$ oc patch network.operator cluster -p '{
-  "spec": {
-    "additionalRoutingCapabilities": null
-  }
+$ oc patch Network.operator.openshift.io/cluster --type=merge -p '{
+  "spec": { "additionalRoutingCapabilities": null }
 }'
 ----

--- a/modules/nw-bgp-routing-enable.adoc
+++ b/modules/nw-bgp-routing-enable.adoc
@@ -27,9 +27,11 @@ As a cluster administrator, you can enable BGP routing support for your cluster.
 +
 [source,terminal]
 ----
-$ oc patch network.operator cluster -p '{
+$ oc patch Network.operator.openshift.io/cluster --type=merge -p '{
   "spec": {
-    "additionalRoutingCapabilities": ["FRR"]
+    "additionalRoutingCapabilities": {
+      "providers": ["FRR"]
+    }
   }
 }'
 ----


### PR DESCRIPTION
Summary
Update the BGP enable/disable modules to use the current Network.operator API and valid `oc patch` invocations.

What changed
- Use the fully qualified resource form and merge patch:
  - `oc patch Network.operator.openshift.io/cluster --type=merge ...`
- Switch `.spec.additionalRoutingCapabilities` to the object form with `providers`:
  - Enable:  `{"spec":{"additionalRoutingCapabilities":{"providers":["FRR"]}}}`
  - Disable: `{"spec":{"additionalRoutingCapabilities":null}}`

Why
- The latest API defines `additionalRoutingCapabilities` as an **object** with a required `providers` array; `"FRR"` is the valid value. The old array-of-strings form is no longer correct.
- The resource path `Network.operator.openshift.io/cluster` and `--type=merge` are consistent with current usage in docs and kubernetes examples.

Files
- `modules/nw-bgp-routing-enable.adoc`
- `modules/nw-bgp-routing-disable.adoc`

Notes
- Docs-only change; no product code change.

<img width="758" height="531" alt="image" src="https://github.com/user-attachments/assets/76f8d2d1-1254-4744-8bba-51c05b03b97f" />

