### PR TITLE
OSDOCS#16195 removing [discrete] tags from ROSA and OSD

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
@@ -30,7 +30,6 @@ Ensure that you have the following resources and tools before starting this proc
 * `oc` CLI
 * `jq` CLI
 
-[discrete]
 [id="cloud-experts-aws-secret-manager-preparing-environment"]
 === Additional environment requirements
 
@@ -59,7 +58,7 @@ $ oc get authentication.config.openshift.io cluster -o json \
 ----
 +
 If your output is different, do not proceed.
-See 
+See
 ifndef::openshift-rosa-hcp[]
 xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Red{nbsp}Hat documentation on creating an STS cluster] before continuing this process.
 endif::openshift-rosa-hcp[]

--- a/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-prerequisites.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-prerequisites.adoc
@@ -22,7 +22,7 @@ endif::openshift-rosa[]
 
 . The OpenShift Command Line Interface (CLI)
 +
-For more information, see 
+For more information, see
 ifdef::openshift-rosa-hcp[]
 link:https://docs.openshift.com/rosa/cli_reference/openshift_cli/getting-started-cli.html#cli-getting-started[Getting started with the OpenShift CLI].
 endif::openshift-rosa-hcp[]
@@ -35,5 +35,5 @@ endif::openshift-rosa-hcp[]
 Use your existing GitHub account or register at link:https://github.com/signup[https://github.com/signup].
 
 include::modules/rosa-sts-understanding-aws-account-association.adoc[leveloffset=+2]
-[discrete]
+
 include::modules/rosa-sts-associating-your-aws-account.adoc[leveloffset=+2]

--- a/modules/rosa-hcp-create-network.adoc
+++ b/modules/rosa-hcp-create-network.adoc
@@ -24,11 +24,11 @@ If you do not specify a template, CloudFormation uses a default template that cr
 | Availability zones
 | 1
 
-| Region 
+| Region
 | `us-east-1`
-  
-| VPC CIDR 
-| `10.0.0.0/16` 
+
+| VPC CIDR
+| `10.0.0.0/16`
 |===
 
 You can create and customize CloudFormation templates to use with the `rosa create network` command. See the additional resources of this section for information on the default VPC template.
@@ -339,25 +339,25 @@ endif::rosa-egress-lockdown[]
 +
 [source,bash]
 ----
-INFO[0140] Resources created in stack:                  
-INFO[0140] Resource: AttachGateway, Type: AWS::EC2::VPCGatewayAttachment, ID: <gateway_id> 
-INFO[0140] Resource: EC2VPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id> 
+INFO[0140] Resources created in stack:
+INFO[0140] Resource: AttachGateway, Type: AWS::EC2::VPCGatewayAttachment, ID: <gateway_id>
+INFO[0140] Resource: EC2VPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id>
 INFO[0140] Resource: EcrApiVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id>
-INFO[0140] Resource: EcrDkrVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id> 
+INFO[0140] Resource: EcrDkrVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id>
 INFO[0140] Resource: ElasticIP1, Type: AWS::EC2::EIP, ID: <IP>
-INFO[0140] Resource: ElasticIP2, Type: AWS::EC2::EIP, ID: <IP> 
-INFO[0140] Resource: InternetGateway, Type: AWS::EC2::InternetGateway, ID: igw-016e1a71b9812464e 
-INFO[0140] Resource: KMSVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id> 
-INFO[0140] Resource: NATGateway1, Type: AWS::EC2::NatGateway, ID: <nat-gateway_id> 
-INFO[0140] Resource: PrivateRoute, Type: AWS::EC2::Route, ID: <route_id> 
-INFO[0140] Resource: PrivateRouteTable, Type: AWS::EC2::RouteTable, ID: <route_id> 
+INFO[0140] Resource: ElasticIP2, Type: AWS::EC2::EIP, ID: <IP>
+INFO[0140] Resource: InternetGateway, Type: AWS::EC2::InternetGateway, ID: igw-016e1a71b9812464e
+INFO[0140] Resource: KMSVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id>
+INFO[0140] Resource: NATGateway1, Type: AWS::EC2::NatGateway, ID: <nat-gateway_id>
+INFO[0140] Resource: PrivateRoute, Type: AWS::EC2::Route, ID: <route_id>
+INFO[0140] Resource: PrivateRouteTable, Type: AWS::EC2::RouteTable, ID: <route_id>
 INFO[0140] Resource: PrivateSubnetRouteTableAssociation1, Type: AWS::EC2::SubnetRouteTableAssociation, ID: <route_id>
-INFO[0140] Resource: PublicRoute, Type: AWS::EC2::Route, ID: <route_id> 
-INFO[0140] Resource: PublicRouteTable, Type: AWS::EC2::RouteTable, ID: <route_id> 
-INFO[0140] Resource: PublicSubnetRouteTableAssociation1, Type: AWS::EC2::SubnetRouteTableAssociation, ID: <route_id> 
-INFO[0140] Resource: S3VPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id> 
-INFO[0140] Resource: STSVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id> 
-INFO[0140] Resource: SecurityGroup, Type: AWS::EC2::SecurityGroup, ID: <security-group_id> 
+INFO[0140] Resource: PublicRoute, Type: AWS::EC2::Route, ID: <route_id>
+INFO[0140] Resource: PublicRouteTable, Type: AWS::EC2::RouteTable, ID: <route_id>
+INFO[0140] Resource: PublicSubnetRouteTableAssociation1, Type: AWS::EC2::SubnetRouteTableAssociation, ID: <route_id>
+INFO[0140] Resource: S3VPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id>
+INFO[0140] Resource: STSVPCEndpoint, Type: AWS::EC2::VPCEndpoint, ID: <vpce_id>
+INFO[0140] Resource: SecurityGroup, Type: AWS::EC2::SecurityGroup, ID: <security-group_id>
 INFO[0140] Resource: SubnetPrivate1, Type: AWS::EC2::Subnet, ID: <private_subnet_id-1> \ <1>
 INFO[0140] Resource: SubnetPublic1, Type: AWS::EC2::Subnet, ID: <public_subnet_id-1> \ <1>
 INFO[0140] Resource: VPC, Type: AWS::EC2::VPC, ID: <vpc_id>
@@ -367,7 +367,6 @@ INFO[0140] Stack rosa-network-stack-5555 created \ <2>
 <2> The network stack name is used to delete the resource later.
 
 ifdef::rosa-egress-lockdown[]
-[discrete]
 [id="rosa-hcp-vpc-subnet-tagging-rosa-network_{context}"]
 == Tagging your subnets
 
@@ -380,11 +379,11 @@ Before you can use your VPC to create a {product-title} cluster, you must tag yo
 | Value
 
 | Public subnet
-| `kubernetes.io/role/elb`	
+| `kubernetes.io/role/elb`
 | `1` or no value
 
-| Private subnet 
-| `kubernetes.io/role/internal-elb`	
+| Private subnet
+| `kubernetes.io/role/internal-elb`
 | `1` or no value
 
 |===

--- a/modules/rosa-hcp-vpc-manual.adoc
+++ b/modules/rosa-hcp-vpc-manual.adoc
@@ -18,7 +18,6 @@ If you choose to manually create your AWS Virtual Private Cloud (VPC) instead of
 include::snippets/rosa-existing-vpc-requirements.adoc[leveloffset=+0]
 
 ifdef::rosa-egress-lockdown[]
-[discrete]
 [id="rosa-hcp-vpc-subnet-tagging-manual_{context}"]
 == Tagging your subnets
 
@@ -31,11 +30,11 @@ Before you can use your VPC to create a {product-title} cluster, you must tag yo
 | Value
 
 | Public subnet
-| `kubernetes.io/role/elb`	
+| `kubernetes.io/role/elb`
 | `1` or no value
 
-| Private subnet 
-| `kubernetes.io/role/internal-elb`	
+| Private subnet
+| `kubernetes.io/role/internal-elb`
 | `1` or no value
 
 |===

--- a/modules/rosa-hcp-vpc-terraform.adoc
+++ b/modules/rosa-hcp-vpc-terraform.adoc
@@ -126,7 +126,6 @@ $ subnet-0a6a57e0f784171aa,subnet-078e84e5b10ecf5b0
 
 endif::rosa-egress-lockdown[]
 ifdef::rosa-egress-lockdown[]
-[discrete]
 [id="rosa-hcp-vpc-subnet-tagging-terraform_{context}"]
 == Tagging your subnets
 
@@ -139,11 +138,11 @@ Before you can use your VPC to create a {product-title} cluster, you must tag yo
 | Value
 
 | Public subnet
-| `kubernetes.io/role/elb`	
+| `kubernetes.io/role/elb`
 | `1` or no value
 
-| Private subnet 
-| `kubernetes.io/role/internal-elb`	
+| Private subnet
+| `kubernetes.io/role/internal-elb`
 | `1` or no value
 
 |===

--- a/modules/rosa-sts-account-wide-role-and-policy-commands.adoc
+++ b/modules/rosa-sts-account-wide-role-and-policy-commands.adoc
@@ -7,7 +7,6 @@
 
 This section lists the `aws` CLI commands that the `rosa` command generates in the terminal. You can run the command in either manual or automatic mode.
 
-[discrete]
 [id="rosa-sts-account-wide-role-and-policy-aws-cli-manual-mode_{context}"]
 == Using manual mode for account role creation
 
@@ -92,7 +91,6 @@ aws iam create-policy \
 	--tags Key=rosa_openshift_version,Value=<openshift_version> Key=rosa_role_prefix,Value=ManagedOpenShift Key=operator_namespace,Value=openshift-image-registry Key=operator_name,Value=installer-cloud-credentials
 ----
 
-[discrete]
 [id="rosa-sts-account-wide-role-and-policy-aws-cli-auto-mode_{context}"]
 == Using auto mode for role creation
 

--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -14,13 +14,11 @@ The account-wide roles and policies are specific to an {product-title} minor rel
 
 You can create account-wide roles by using the {product-title} (ROSA) CLI, `rosa`, or the {cluster-manager-url} guided installation. You can create the roles manually or by using an automatic process that uses predefined names for these roles and policies.
 
-[discrete]
 [id="rosa-sts-account-wide-roles-and-policies-creation-methods-manual_{context}"]
 === Manual ocm-role resource creation
 
 You can use the manual creation method if you have the necessary CLI access to create these roles on your system. You can run this option in your desired CLI tool or from {cluster-manager}. After you start the manual creation process, the CLI presents a series of commands for you to run that create the roles and link them to the needed policies.
 
-[discrete]
 [id="rosa-sts-account-wide-roles-and-policies-creation-methods-auto_{context}"]
 === Automatic ocm-role resource creation
 
@@ -204,7 +202,6 @@ include::https://raw.githubusercontent.com/openshift/managed-cluster-config/refs
 ----
 ====
 
-[discrete]
 [id="rosa-sts-account-wide-roles-and-policies-example-cli-output-for-policies-attached-to-a-role_{context}"]
 ==== Example CLI output for policies attached to a role
 

--- a/modules/rosa-sts-byo-oidc-options.adoc
+++ b/modules/rosa-sts-byo-oidc-options.adoc
@@ -14,7 +14,6 @@ The following options may be added to the `rosa create oidc-config` command. All
 You are required to register the unmanaged OIDC configuration by posting a request to `/oidc_configs` through OpenShift Cluster Manager. You receive an ID in the response. Use this ID to create a cluster.
 ====
 
-[discrete]
 [id="rosa-sts-byo-oidc-raw-files_{context}"]
 == raw-files
 
@@ -28,7 +27,6 @@ You use these files to set up the endpoint. This endpoint responds to `/.well-kn
 $ rosa create oidc-config --raw-files
 ----
 
-[discrete]
 [id="rosa-sts-byo-oidc-mode_{context}"]
 == mode
 
@@ -42,7 +40,6 @@ You receive the same OIDC configuration and AWS resources as the `manual` mode w
 $ rosa create oidc-config --mode=<auto|manual>
 ----
 
-[discrete]
 [id="rosa-sts-byo-oidc-managed_{context}"]
 == managed
 

--- a/osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes.adoc
+++ b/osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes.adoc
@@ -1,8 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="osd-nodes-about-autoscaling-nodes"]
 = About autoscaling nodes on a cluster
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: osd-nodes-about-autoscaling-nodes
+
 toc::[]
 
 [IMPORTANT]
@@ -28,7 +29,6 @@ Only cluster owners and organization admins can scale or delete a cluster.
 
 You can enable autoscaling on worker nodes to increase or decrease the number of nodes available by editing the machine pool definition for an existing cluster.
 
-[discrete]
 include::modules/ocm-enabling-autoscaling-nodes.adoc[leveloffset=+2]
 
 [id="osd-nodes-disabling-autoscaling-nodes"]
@@ -38,7 +38,6 @@ You can disable autoscaling on worker nodes to increase or decrease the number o
 
 You can disable autoscaling on a cluster using {cluster-manager} console.
 
-[discrete]
 include::modules/ocm-disabling-autoscaling-nodes.adoc[leveloffset=+2]
 
 Applying autoscaling to an {product-title} cluster involves deploying a cluster autoscaler and then deploying machine autoscalers for each machine type in your cluster.

--- a/rosa_architecture/rosa-oidc-overview.adoc
+++ b/rosa_architecture/rosa-oidc-overview.adoc
@@ -15,10 +15,10 @@ The OIDC protocol uses a configuration URL that contains the necessary informati
 include::modules/rosa-oidc-understanding.adoc[leveloffset=+1]
 
 include::modules/rosa-oidc-config-overview.adoc[leveloffset=+1]
-[discrete]
-include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+3]
-[discrete]
-include::modules/rosa-sts-byo-oidc-options.adoc[leveloffset=+3]
+
+include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+2]
+
+include::modules/rosa-sts-byo-oidc-options.adoc[leveloffset=+2]
 
 include::modules/rosa-sts-oidc-provider-command.adoc[leveloffset=+1]
 

--- a/rosa_architecture/rosa-sts-about-iam-resources.adoc
+++ b/rosa_architecture/rosa-sts-about-iam-resources.adoc
@@ -84,7 +84,6 @@ include::modules/rosa-sts-understanding-ocm-role.adoc[leveloffset=+2]
 .Additional resources
 * xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation]
 
-[discrete]
 include::modules/rosa-sts-ocm-role-creation.adoc[leveloffset=+2]
 
 AWS IAM roles link to your AWS account to create and manage the clusters.
@@ -149,9 +148,9 @@ For ROSA installations that use STS, you must create a cluster-specific OIDC pro
 include::modules/rosa-sts-oidc-provider-command.adoc[leveloffset=+2]
 
 include::modules/rosa-oidc-config-overview.adoc[leveloffset=+2]
-[discrete]
+
 include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+3]
-[discrete]
+
 include::modules/rosa-sts-byo-oidc-options.adoc[leveloffset=+3]
 
 include::modules/rosa-aws-scp.adoc[leveloffset=+1]

--- a/rosa_architecture/rosa-understanding.adoc
+++ b/rosa_architecture/rosa-understanding.adoc
@@ -3,6 +3,7 @@
 = Understanding ROSA
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-understanding
+
 toc::[]
 
 Learn about {product-title} (ROSA), interacting with ROSA by using {cluster-manager-first} and command-line interface (CLI) tools, consumption experience, and integration with Amazon Web Services (AWS) services.
@@ -48,15 +49,15 @@ For additional information about ROSA installation, see link:https://www.redhat.
 
 //This mode makes use of a pre-created IAM user with `AdministratorAccess` within the account that has proper permissions to create other roles and resources as needed. Using this account the service creates all the necessary resources that are needed for the cluster.
 
-include::modules/rosa-sdpolicy-am-billing.adoc[leveloffset=+1] 
+include::modules/rosa-sdpolicy-am-billing.adoc[leveloffset=+1]
 
 [id="rosa-understanding-getting-started_{context}"]
 == Getting started
 
 To get started with deploying your cluster, ensure your AWS account has met the prerequisites, you have a Red{nbsp}Hat account ready, and follow the procedures outlined in xref:../rosa_getting_started/rosa-getting-started.adoc#rosa-getting-started[Getting started with {product-title}].
 
-[discrete]
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 
 * xref:../ocm/ocm-overview.adoc#ocm-overview[OpenShift Cluster Manager]

--- a/rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
+++ b/rosa_cluster_admin/rosa-cluster-autoscaling-hcp.adoc
@@ -22,7 +22,6 @@ The cluster autoscaler increases the size of the cluster when there are pods tha
 
 The cluster autoscaler computes the total memory, CPU, and GPU only on the nodes that belong to autoscaling machine pools. All of the machine pool nodes that are not autoscaling are excluded from this aggregation. For example, if you set the `maxNodesTotal` to `50` on a {product-title} cluster with three machine pools in which a single machine pool is not autoscaling, the cluster autoscaler restricts the total nodes to `50` in only those two machine pools that are autoscaling. The single manually scaling machine pool can have additional nodes, making the overall cluster nodes total more than `50`.
 
-[discrete]
 [id="cluster-autoscaler-scale-down_{context}"]
 === Automatic node removal
 
@@ -44,7 +43,6 @@ If the following types of pods are present on a node, the cluster autoscaler wil
 
 For example, you set the maximum CPU limit to 64 cores and configure the cluster autoscaler to only create machines that have 8 cores each. If your cluster starts with 30 cores, the cluster autoscaler can add up to 4 more nodes with 32 cores, for a total of 62.
 
-[discrete]
 [id="cluster-autoscaler-limitations_{context}"]
 === Limitations
 
@@ -62,7 +60,6 @@ The cluster autoscaler only adds nodes in autoscaled node groups if doing so wou
 If the available node types cannot meet the requirements for a pod request, or if the node groups that could meet these requirements are at their maximum size, the cluster autoscaler cannot scale up.
 ====
 
-[discrete]
 [id="cluster-autoscaler-interaction_{context}"]
 === Interaction with other scheduling features
 

--- a/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.adoc
@@ -1,8 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="rosa-nodes-about-autoscaling-nodes"]
 = About autoscaling nodes on a cluster
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-nodes-about-autoscaling-nodes
+
 toc::[]
 
 ifdef::openshift-dedicated[]
@@ -30,7 +31,6 @@ Only cluster owners and organization admins can scale or delete a cluster.
 
 You can enable autoscaling on worker nodes to increase or decrease the number of nodes available by editing the machine pool definition for an existing cluster.
 
-[discrete]
 include::modules/ocm-enabling-autoscaling-nodes.adoc[leveloffset=+2]
 
 ifdef::openshift-rosa[]
@@ -48,7 +48,6 @@ endif::[]
 // endif::[]
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-[discrete]
 include::modules/rosa-enabling-autoscaling-nodes.adoc[leveloffset=+2]
 endif::[]
 
@@ -79,14 +78,13 @@ endif::[]
 // ====
 // endif::[]
 
-[discrete]
 include::modules/ocm-disabling-autoscaling-nodes.adoc[leveloffset=+2]
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-[discrete]
 include::modules/rosa-disabling-autoscaling-nodes.adoc[leveloffset=+2]
 endif::[]
 
+[role="_additional-resources"]
 [id="nodes-about-autoscaling-nodes-additional-resources"]
 == Additional resources
 * link:https://access.redhat.com/solutions/6821651[Troubleshooting: Autoscaling is not scaling down nodes]

--- a/rosa_getting_started/rosa-quickstart-guide-ui.adoc
+++ b/rosa_getting_started/rosa-quickstart-guide-ui.adoc
@@ -24,7 +24,7 @@ image::291_OpenShift_on_AWS_Intro_1122_docs.png[{product-title}]
 
 * You have read the documentation on the xref:../rosa_planning/rosa-planning-environment.adoc#rosa-planning-environment[guidelines for planning your environment].
 // Removed as part of OSDOCS-13310, until figures are verified.
-// xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] and 
+// xref:../rosa_planning/rosa-limits-scalability.adoc#rosa-limits-scalability[limits and scalability] and
 
 * You have reviewed the detailed xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prereqs[AWS prerequisites for ROSA with STS].
 
@@ -36,12 +36,10 @@ include::modules/rosa-getting-started-environment-setup.adoc[leveloffset=+1]
 
 
 //This content is pulled from rosa-getting-started-enable-rosa.adoc
-[discrete]
 include::modules/rosa-getting-started-enable-rosa.adoc[leveloffset=+2]
 
 
 //This content is pulled from rosa-getting-started-install-configure-cli-tools
-[discrete]
 include::modules/rosa-getting-started-install-configure-cli-tools.adoc[leveloffset=+2]
 
 
@@ -59,27 +57,22 @@ Before you can use the {cluster-manager} {hybrid-console-second} to deploy ROSA 
 
 
 //This content is pulled from rosa-sts-overview-of-the-default-cluster-specifications.adoc
-[discrete]
 include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[leveloffset=+2]
 
 
 //This content is pulled from rosa-sts-understanding-aws-account-association.adoc
-[discrete]
 include::modules/rosa-sts-understanding-aws-account-association.adoc[leveloffset=+2]
 
 
 //This content is pulled from rosa-sts-associating-your-aws-account.adoc
-[discrete]
 include::modules/rosa-sts-associating-your-aws-account.adoc[leveloffset=+2]
 
 
 //This content is pulled from rosa-sts-creating-account-wide-sts-roles-and-policies.adoc
-[discrete]
 include::modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+2]
 
 
 //This content is pulled from rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
-[discrete]
 include::modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc[leveloffset=+2]
 
 ////
@@ -102,9 +95,7 @@ include::modules/rosa-getting-started-create-cluster-admin-user.adoc[leveloffset
 //This content is pulled from rosa-getting-started-configure-an-idp-and-grant-access.adoc
 include::modules/rosa-getting-started-configure-an-idp-and-grant-access.adoc[leveloffset=+1]
 
-
 //This content is pulled from rosa-getting-started-configure-an-idp.adoc
-[discrete]
 include::modules/rosa-getting-started-configure-an-idp.adoc[leveloffset=+2]
 
 .Additional resource
@@ -113,12 +104,10 @@ include::modules/rosa-getting-started-configure-an-idp.adoc[leveloffset=+2]
 
 
 //This content is pulled from rosa-getting-started-grant-user-access.adoc
-[discrete]
 include::modules/rosa-getting-started-grant-user-access.adoc[leveloffset=+2]
 
 
 //This content is pulled from rosa-getting-started-grant-admin-privileges.adoc
-[discrete]
 include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -140,12 +129,10 @@ include::modules/rosa-getting-started-revoking-admin-privileges-and-user-access.
 
 
 //This content is pulled from rosa-getting-started-revoke-admin-privileges.adoc
-[discrete]
 include::modules/rosa-getting-started-revoke-admin-privileges.adoc[leveloffset=+2]
 
 
 //This content is pulled from rosa-getting-started-revoke-admin-privileges.adoc
-[discrete]
 include::modules/rosa-getting-started-revoke-user-access.adoc[leveloffset=+2]
 
 

--- a/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
+++ b/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
@@ -35,8 +35,7 @@ You must have a Virtual Private Cloud (VPC) to create {product-title} cluster. U
 The Terraform instructions are for testing and demonstration purposes. Your own installation requires some modifications to the VPC for your own use. You should also ensure that when you use this Terraform script it is in the same region that you intend to install your cluster. In these examples, use `us-east-2`.
 ====
 
-[discrete]
-include::modules/rosa-hcp-create-network.adoc[leveloffset=+3]
+include::modules/rosa-hcp-create-network.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources_rosa-hcp-create-network-kms-key"]
@@ -45,8 +44,7 @@ include::modules/rosa-hcp-create-network.adoc[leveloffset=+3]
 * link:https://aws.amazon.com/cloudformation/[AWS CloudFormation]
 * link:https://github.com/openshift/rosa/blob/master/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml[Default VPC AWS CloudFormation template]
 
-[discrete]
-include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
+include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources_rosa-hcp-vpc-terraform-kms-key"]
@@ -54,12 +52,10 @@ include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
 
 * link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC repository]
 
-[discrete]
 include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+2]
 
 include::snippets/vpc-troubleshooting.adoc[leveloffset=+2]
 
-[discrete]
 include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+3]
 
 [role="_additional-resources"]

--- a/rosa_hcp/rosa-hcp-egress-zero-install.adoc
+++ b/rosa_hcp/rosa-hcp-egress-zero-install.adoc
@@ -3,9 +3,10 @@
 = Creating {egress-zero-title}
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-egress-zero-install
+
 toc::[]
 
-Creating {product-title} with {egress-zero} provides a way to enhance your cluster's stability and security by allowing your cluster to use the image registry in the local region if the cluster cannot access the internet. Your cluster first tries to pull the images from Quay, and when they aren't reached, it instead pulls the images from the image registry in the local region. 
+Creating {product-title} with {egress-zero} provides a way to enhance your cluster's stability and security by allowing your cluster to use the image registry in the local region if the cluster cannot access the internet. Your cluster first tries to pull the images from Quay, and when they aren't reached, it instead pulls the images from the image registry in the local region.
 
 All public and private clusters with {egress-zero} get their Red{nbsp}Hat container images from an Amazon Elastic Container Registry (ECR) located in the local region of the cluster instead of gathering these images from various endpoints and registries on the internet. ECR provides storage for OpenShift release images as well as Red{nbsp}Hat Operators. All requests for ECR are kept within your AWS network by serving them over a VPC endpoint within your cluster.
 
@@ -20,7 +21,6 @@ See xref:../upgrading/rosa-hcp-upgrading.adoc#rosa-hcp-upgrading[Upgrading {prod
 Clusters created in restricted network environments may be unable to use certain {product-title} features including Red Hat Insights and Telemetry. These clusters may also experience potential failures for workloads that require public access to registries such as `quay.io`. When using clusters installed with {egress-zero}, you can also install Red Hat-owned Operators from the software catalog. For a complete list of Red Hat-owned Operators, see the link:https://catalog.redhat.com/search?searchType=software&target_platforms=Red%20Hat%20OpenShift&deployed_as=Operator&p=1&partnerName=Red%20Hat%2C%20Inc.%7CRed%20Hat[Red{nbsp}Hat Ecosystem Catalog]. Only the default Operator channel is mirrored for any Operator that is installed with {egress-zero}.
 ====
 
-[discrete]
 [id="rosa-glossary-disconnected_{context}"]
 == Glossary of network environment terms
 
@@ -62,7 +62,7 @@ A physical connection might exist between machines on the internal network and a
 
 [IMPORTANT]
 ====
-* You can use {egress-zero} on all supported versions of {product-title} that use the hosted control plane architecture; however, Red{nbsp}Hat suggests using the latest available z-stream release for each {ocp} version. 
+* You can use {egress-zero} on all supported versions of {product-title} that use the hosted control plane architecture; however, Red{nbsp}Hat suggests using the latest available z-stream release for each {ocp} version.
 
 * While you may install and upgrade your clusters as you would a regular cluster, due to an upstream issue with how the internal image registry functions in disconnected environments, your cluster that uses {egress-zero} will not be able to fully use all platform components, such as the image registry. You can restore these features by using the latest ROSA version when upgrading or installing your cluster.
 ====
@@ -70,7 +70,7 @@ A physical connection might exist between machines on the internal network and a
 include::modules/rosa-hcp-set-environment-variables.adoc[leveloffset=+1]
 
 [id="rosa-hcp-egress-zero-install-creating_{context}"]
-== Creating a Virtual Private Cloud for your {product-title} clusters 
+== Creating a Virtual Private Cloud for your {product-title} clusters
 
 You must have a Virtual Private Cloud (VPC) to create a {product-title} cluster. To pull images from the local ECR mirror over your VPC endpoint, you must configure a privatelink service connection and modify the default security groups with specific tags. Use one of the following methods to create a VPC:
 

--- a/rosa_hcp/rosa-hcp-quickstart-guide.adoc
+++ b/rosa_hcp/rosa-hcp-quickstart-guide.adoc
@@ -8,13 +8,12 @@ toc::[]
 
 Follow this guide to quickly create a {product-title} cluster using the {rosa-cli-first}, grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.
 
-[discrete]
-include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[leveloffset=+2]
+include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[leveloffset=+1]
 
 include::modules/rosa-getting-started-environment-setup.adoc[leveloffset=+1]
-[discrete]
+
 include::modules/rosa-getting-started-enable-rosa.adoc[leveloffset=+2]
-[discrete]
+
 include::modules/rosa-getting-started-install-configure-cli-tools.adoc[leveloffset=+2]
 
 .Next steps
@@ -37,8 +36,7 @@ You must have an AWS Virtual Private Cloud (VPC) to create a {product-title} clu
 The Terraform instructions are for testing and demonstration purposes. Your own installation requires some modifications to the VPC for your own use. You should also ensure that when you use this linked Terraform configuration, it is in the same region that you intend to install your cluster. In these examples, `us-east-2` is used.
 ====
 
-[discrete]
-include::modules/rosa-hcp-create-network.adoc[leveloffset=+3]
+include::modules/rosa-hcp-create-network.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources_rosa-hcp-create-network-quickstart"]
@@ -47,7 +45,6 @@ include::modules/rosa-hcp-create-network.adoc[leveloffset=+3]
 * link:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-ec2-vpc.html[AWS CloudFormation documentation]
 * link:https://github.com/openshift/rosa/blob/master/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml[Default VPC AWS CloudFormation template]
 
-[discrete]
 include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
@@ -56,12 +53,10 @@ include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
 
 * link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC repository]
 
-[discrete]
 include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+2]
 
 include::snippets/vpc-troubleshooting.adoc[leveloffset=+2]
 
-[discrete]
 include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
@@ -80,8 +75,6 @@ include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+1
 include::modules/rosa-getting-started-access-cluster-web-console.adoc[leveloffset=+1]
 include::modules/deploy-app.adoc[leveloffset=+1]
 include::modules/rosa-getting-started-revoking-admin-privileges-and-user-access.adoc[leveloffset=+1]
-[discrete]
 include::modules/rosa-getting-started-revoke-admin-privileges.adoc[leveloffset=+2]
-[discrete]
 include::modules/rosa-getting-started-revoke-user-access.adoc[leveloffset=+2]
 include::modules/rosa-getting-started-deleting-a-cluster.adoc[leveloffset=+1]

--- a/rosa_hcp/rosa-hcp-shared-vpc-config.adoc
+++ b/rosa_hcp/rosa-hcp-shared-vpc-config.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="rosa-hcp-shared-vpc-config"]
 = Configuring a shared VPC for {product-title} clusters
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-shared-vpc-config
 
 toc::[]
@@ -40,8 +40,7 @@ include::modules/rosa-hcp-sharing-vpc-creation-and-sharing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_hcp-shared-vpc_vpc-creation"]
-[discrete]
-=== Additional resources
+.Additional resources
 * See the AWS documentation for information about link:https://docs.aws.amazon.com/ram/latest/userguide/getting-started-sharing.html[sharing your AWS resources].
 
 include::modules/rosa-hcp-sharing-vpc-dns-and-roles.adoc[leveloffset=+1]

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/attributes-openshift-dedicated.adoc[]
-:context: rosa-hcp-sts-creating-a-cluster-quickly
 [id="rosa-hcp-sts-creating-a-cluster-quickly"]
 = Creating {product-title} clusters using the default options
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-hcp-sts-creating-a-cluster-quickly
 
 toc::[]
 
@@ -28,9 +28,8 @@ Since it is not possible to upgrade or convert existing {rosa-classic-title} clu
 
 For a full list of the supported certificates, see the xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-compliance_rosa-policy-process-security[Compliance] section of "Understanding process and security for Red{nbsp}Hat OpenShift Service on AWS".
 
-[discrete]
 [id="hcp-considerations_{context}"]
-=== Considerations regarding auto creation mode
+== Considerations regarding auto creation mode
 
 The procedures in this document use the `auto` mode in the ROSA CLI to immediately create the required IAM resources using the current AWS account. The required resources include the account-wide IAM roles and policies, cluster-specific Operator roles and policies, and OpenID Connect (OIDC) identity provider.
 
@@ -68,7 +67,6 @@ You must have a Virtual Private Cloud (VPC) to create {product-title} cluster. Y
 The Terraform instructions are for testing and demonstration purposes. Your own installation requires some modifications to the VPC for your own use. You should also ensure that when you use this Terraform configuration, it is in the same region that you intend to install your cluster. In these examples, `us-east-2` is used.
 ====
 
-[discrete]
 include::modules/rosa-hcp-create-network.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
@@ -78,7 +76,6 @@ include::modules/rosa-hcp-create-network.adoc[leveloffset=+3]
 * link:https://aws.amazon.com/cloudformation/[AWS CloudFormation documentation]
 * link:https://github.com/openshift/rosa/blob/master/cmd/create/network/templates/rosa-quickstart-default-vpc/cloudformation.yaml[Default VPC AWS CloudFormation template]
 
-[discrete]
 include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
@@ -87,12 +84,10 @@ include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
 
 * link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC repository]
 
-[discrete]
 include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+2]
 
 include::snippets/vpc-troubleshooting.adoc[leveloffset=+2]
 
-[discrete]
 include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+3]
 
 [role="_additional-resources"]

--- a/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc
+++ b/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc
@@ -17,7 +17,7 @@ The cluster creation process described below uses a Terraform configuration that
 
 include::modules/rosa-terraform-overview.adoc[leveloffset=+1]
 include::modules/rosa-sts-terraform-prerequisites.adoc[leveloffset=+1]
-[discrete]
+
 include::modules/rosa-sts-terraform-considerations.adoc[leveloffset=+1]
 
 include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[leveloffset=+1]

--- a/rosa_install_access_delete_clusters/rosa-shared-vpc-config.adoc
+++ b/rosa_install_access_delete_clusters/rosa-shared-vpc-config.adoc
@@ -1,11 +1,12 @@
-include::_attributes/attributes-openshift-dedicated.adoc[]
+:_mod-docs-content-type: ASSEMBLY
 [id="rosa-shared-vpc-config"]
 = Configuring a shared VPC for ROSA clusters
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-shared-vpc-config
 
 toc::[]
 
-You can create {product-title} 
+You can create {product-title}
 ifdef::openshift-rosa[]
 (ROSA)
 endif::openshift-rosa[]
@@ -48,8 +49,7 @@ include::modules/rosa-sharing-vpc-creation-and-sharing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_shared-vpc_vpc-creation"]
-[discrete]
-=== Additional resources
+== Additional resources
 * See the AWS documentation for link:https://docs.aws.amazon.com/ram/latest/userguide/getting-started-sharing.html[sharing your AWS resources].
 
 include::modules/rosa-sharing-vpc-dns-and-roles.adoc[leveloffset=+1]

--- a/rosa_install_access_delete_clusters/terraform/rosa-classic-creating-a-cluster-quickly-terraform.adoc
+++ b/rosa_install_access_delete_clusters/terraform/rosa-classic-creating-a-cluster-quickly-terraform.adoc
@@ -17,7 +17,6 @@ The cluster creation process described below uses a Terraform configuration that
 
 include::modules/rosa-terraform-overview.adoc[leveloffset=+1]
 include::modules/rosa-sts-terraform-prerequisites.adoc[leveloffset=+1]
-[discrete]
 include::modules/rosa-sts-terraform-considerations.adoc[leveloffset=+1]
 include::modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc[leveloffset=+1]
 

--- a/rosa_planning/rosa-hcp-aws-prereqs.adoc
+++ b/rosa_planning/rosa-hcp-aws-prereqs.adoc
@@ -1,8 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/attributes-openshift-dedicated.adoc[]
 //title and ID conditions so this can be shared between Classic and HCP docs while it remains accurate for both
-:context: rosa-hcp-aws-prereqs
+[id="rosa-hcp-aws-prereqs"]
 = Detailed requirements for deploying {rosa-short}
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-hcp-aws-prereqs
 
 toc::[]
 
@@ -41,7 +42,6 @@ include::modules/rosa-sts-aws-requirements-association-concept.adoc[leveloffset=
 include::modules/rosa-sts-aws-requirements-creating-association.adoc[leveloffset=+2]
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-[discrete]
 [role="_additional-resources"]
 [id="additional-resources_creating-association_{context}"]
 == Additional resources
@@ -78,11 +78,9 @@ If you are using a firewall to control egress traffic from your {rosa-short}, yo
 include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
 include::modules/rosa-hcp-firewall-prerequisites.adoc[leveloffset=+2]
 
-[discrete]
-== Next steps
+.Next steps
 * xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-required-aws-service-quotas_rosa-sts-required-aws-service-quotas[Review the required AWS service quotas]
 
-[discrete]
 [role="_additional-resources"]
 [id="additional-resources_aws-prerequisites_{context}"]
 == Additional resources

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -37,7 +37,7 @@ endif::openshift-rosa-hcp[]
 
 include::modules/rosa-sts-aws-requirements-account.adoc[leveloffset=+1]
 
-//Adding conditions around these in case the Additional resources don't get ported to HCP or have different file names / locations; keeping all included for now 
+//Adding conditions around these in case the Additional resources don't get ported to HCP or have different file names / locations; keeping all included for now
 ifdef::openshift-rosa[]
 [role="_additional-resources"]
 [id="additional-resources_aws-account-requirements_{context}"]
@@ -53,7 +53,7 @@ include::modules/rosa-sts-aws-requirements-support-req.adoc[leveloffset=+2]
 //TODO OSDOCS-11789: Need to have this re-validated by SRE/Support
 include::modules/rosa-sts-aws-requirements-security-req.adoc[leveloffset=+2]
 
-//Adding conditions around these in case the Additional resources don't get ported to HCP or have different file names / locations; keeping all included for now 
+//Adding conditions around these in case the Additional resources don't get ported to HCP or have different file names / locations; keeping all included for now
 [role="_additional-resources"]
 [id="additional-resources_aws-security-requirements_{context}"]
 .Additional resources
@@ -77,7 +77,6 @@ include::modules/rosa-sts-aws-requirements-association-concept.adoc[leveloffset=
 include::modules/rosa-sts-aws-requirements-creating-association.adoc[leveloffset=+2]
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-[discrete]
 [role="_additional-resources"]
 [id="additional-resources_creating-association_{context}"]
 == Additional resources

--- a/rosa_planning/rosa-sts-ocm-role.adoc
+++ b/rosa_planning/rosa-sts-ocm-role.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/attributes-openshift-dedicated.adoc[]
-:context: rosa-sts-ocm-role
 [id="rosa-sts-ocm-role"]
 = {product-title} IAM role resources
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-sts-ocm-role
 
 toc::[]
 
@@ -18,7 +18,6 @@ include::modules/rosa-prereq-roles-overview.adoc[leveloffset=+1]
 
 include::modules/rosa-sts-about-ocm-role.adoc[leveloffset=+1]
 
-[discrete]
 [id="additional-resources-about-ocm-role"]
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
[OSDOCS-16195](https://issues.redhat.com/browse/OSDOCS-16195): Removing [discrete] tags from ROSA and OSD

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-16195
https://issues.redhat.com/browse/OSDOCS-16194

**Link to docs preview:**
Previews for 4 assemblies where leveloffsets were modified. Please, check that content is still nested correctly.

1. **OpenID Connect Overview** in ROSA Classic (rosa_architecture/rosa-oidc-overview.adoc)
[Published doc](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/introduction_to_rosa/rosa-oidc-overview) VS https://99508--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-oidc-overview

2. **Install clusters** in ROSA HCP:

2.1 ROSA quick start guide (rosa_hcp/rosa-hcp-quickstart-guide.adoc)
[Published doc](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/rosa-hcp-quickstart-guide) VS https://99508--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-quickstart-guide

2.2 Creating Red Hat OpenShift Service on AWS clusters using the default options (rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc)
[Published doc](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/rosa-hcp-sts-creating-a-cluster-quickly) VS https://99508--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly

2.3 Creating ROSA with HCP clusters using a custom AWS KMS encryption key (rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc)
[Published doc](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/install_clusters/rosa-hcp-creating-cluster-with-aws-kms-key) VS https://99508--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key

QE review:
Not required.

Additional information:
This PR:
- Removes [discrete] tags from the ROSA and OSD docs (DITA migration requirement)
- Changes leveoffsets in several assemblies to address build issues. With no discrete tags a sequence of includes gets out of order. Check with the team because changes in leveloffsets might brake assemblies logic (see linked docs previews with affected guides).
- Reshuffles some of assemblies metadata to make them compliant with the OCP docs requirements: [doc_guidelines.adoc#assembly-file-metadata](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#assembly-file-metadata) Some changes will also be required for DITA migration.
-   Some changes are my vscode trimming white space at the end of the lines, please, ignore.