### PR TITLE
[OSDOCS-16293]: Clarifying prereq for HCP on OpenShift Virtualization

### DIFF
--- a/modules/hcp-virt-prereqs.adoc
+++ b/modules/hcp-virt-prereqs.adoc
@@ -19,7 +19,7 @@ $ oc patch ingresscontroller -n openshift-ingress-operator default \
 ----
 * The {product-title} management cluster has {VirtProductName}, version 4.14 or later, installed on it. For more information, see "Installing OpenShift Virtualization using the web console".
 * The {product-title} management cluster is on-premise bare metal.
-* The {product-title} management cluster is configured with OVNKubernetes as the default pod network CNI.
+* The {product-title} management cluster must be configured with `OVNKubernetes` as the default pod network Container Network Interface (CNI). Live migration is supported for nodes only if the CNI is OVN-Kubernetes.
 * The {product-title} management cluster has a default storage class. For more information, see "Postinstallation storage configuration". The following example shows how to set a default storage class:
 +
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-62115
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://99568--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-virt.html#hcp-virt-prereqs_hcp-deploy-virt
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
