### PR TITLE
[OSDOCS-16009]: Adding evictionStrategy docs

### DIFF
--- a/hosted_control_planes/hcp-manage/hcp-manage-virt.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-virt.adoc
@@ -60,6 +60,8 @@ include::modules/hcp-virt-attach-nvidia-gpus.adoc[leveloffset=+1]
 
 include::modules/hcp-virt-attach-nvidia-gpus-np-api.adoc[leveloffset=+1]
 
+include::modules/hcp-virt-evict-vms.adoc[leveloffset=+1]
+
 include::modules/hcp-topology-spread-constraint.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/hcp-virt-evict-vms.adoc
+++ b/modules/hcp-virt-evict-vms.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-manage/hcp-manage-virt.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="hcp-virt-evict-vms_{context}"]
+= Evicting KubeVirt virtual machines
+
+In cases where KubeVirt virtual machines (VMs) cannot be live migrated, such as when you use GPU passthrough, the VMs must be evicted at the same time as the `NodePool` resource of the hosted cluster. Otherwise, the compute nodes might be shut down without being drained from the workload. This might also happen when you are upgrading the {VirtProductName} Operator. To achieve a synchronized restart, you can set the `evictionStrategy` parameter on the `hyperconverged` resource to ensure that only VMs that are drained from workloads are rebooted. 
+
+.Procedure
+
+. To learn more about the `hyperconverged` resource and the allowed values for the `evictionStrategy` parameter, enter the following command:
++
+[source,terminal]
+----
+$ oc explain hyperconverged.spec.evictionStrategy
+----
+
+. Patch the `hyperconverged` resource by entering the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-cnv patch hyperconverged kubevirt-hyperconverged \
+  --type=merge \
+  -p '{"spec": {"evictionStrategy": "External"}}'
+----
+
+. Patch the workload update strategy and the workload update methods by entering the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-cnv patch hyperconverged kubevirt-hyperconverged \
+  --type=merge \
+  -p '{"spec": {"workloadUpdateStrategy": {"workloadUpdateMethods": ["LiveMigrate","Evict"]}}}'
+----
++
+By applying this patch, you specify that VMs should be live-migrated if possible, and that only the VMs that cannot be live-migrated should be evicted.
+
+.Verification
+
+* Check whether the patch command was applied properly by entering the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-cnv get hyperconverged kubevirt-hyperconverged -ojsonpath='{.spec.evictionStrategy}'
+----
++
+.Example output
+[source,terminal]
+----
+External
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OCP 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-16009
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://99578--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-manage/hcp-manage-virt.html#hcp-virt-evict-vms_hcp-manage-virt
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This update also needs to be applied to ACM 2.10 and ACM 2.11, which correspond with the OCP 4.15 and 4.16 docs
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
