### PR TITLE
Fix PDF generated output 

### DIFF
--- a/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
+++ b/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
@@ -58,15 +58,19 @@ See xref:../../architecture/architecture-installation.adoc#installation-process_
 
 You can install a cluster on bare metal infrastructure that is provisioned by the {product-title} installation program, by using the following method:
 
-* **xref:../../installing/installing_bare_metal/ipi/ipi-install-overview.adoc#ipi-install-overview[Installing an installer-provisioned cluster on bare metal]**: You can install {product-title} on bare metal by using installer provisioning.
+**xref:../../installing/installing_bare_metal/ipi/ipi-install-overview.adoc#ipi-install-overview[Installing an installer-provisioned cluster on bare metal]**::
+You can install {product-title} on bare metal by using installer provisioning.
 
 [id="choosing-a-method-to-install-ocp-on-bare-metal-user-provisioned"]
 === Installing a cluster on user-provisioned infrastructure
 
 You can install a cluster on bare metal infrastructure that you provision, by using one of the following methods:
 
-* **xref:../../installing/installing_bare_metal/upi/installing-bare-metal.adoc#installing-bare-metal[Installing a user-provisioned cluster on bare metal]**: You can install {product-title} on bare metal infrastructure that you provision. For a cluster that contains user-provisioned infrastructure, you must deploy all of the required machines.
+**xref:../../installing/installing_bare_metal/upi/installing-bare-metal.adoc#installing-bare-metal[Installing a user-provisioned cluster on bare metal]**::
+You can install {product-title} on bare metal infrastructure that you provision. For a cluster that contains user-provisioned infrastructure, you must deploy all of the required machines.
 
-* **xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[Installing a user-provisioned bare metal cluster with network customizations]**: You can install a bare metal cluster on user-provisioned infrastructure with network-customizations. By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing MTU and VXLAN configurations. Most of the network customizations must be applied at the installation stage.
+**xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[Installing a user-provisioned bare metal cluster with network customizations]**::
+You can install a bare metal cluster on user-provisioned infrastructure with network-customizations. By customizing your network configuration, your cluster can coexist with existing IP address allocations in your environment and integrate with existing MTU and VXLAN configurations. Most of the network customizations must be applied at the installation stage.
 
-* **xref:../../installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[Installing a user-provisioned bare metal cluster on a restricted network]**: You can install a user-provisioned bare metal cluster on a restricted or disconnected network by using a mirror registry. You can also use this installation method to ensure that your clusters only use container images that satisfy your organizational controls on external content.
+**xref:../../installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[Installing a user-provisioned bare metal cluster on a restricted network]**::
+You can install a user-provisioned bare metal cluster on a restricted or disconnected network by using a mirror registry. You can also use this installation method to ensure that your clusters only use container images that satisfy your organizational controls on external content.


### PR DESCRIPTION
[OSDOCS-15310](https://issues.redhat.com//browse/OSDOCS-15310): Use a description list to fix the PDF output of it. 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): `main`, `4.19`

Issue:
https://issues.redhat.com/browse/OSDOCS-15310

Link to docs preview:
https://99585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/preparing-to-install-on-bare-metal.html#choosing-a-method-to-install-ocp-on-bare-metal-user-provisioned 

QE review:
N/A

Additional information:
The PDF output of d.r.h jumbles words that might make it seem like a typo when they are not. The [HTML version](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/installing_on_bare_metal/index#choosing-a-method-to-install-ocp-on-bare-metal-user-provisioned) renders fine.
<img width="1075" height="521" alt="image" src="https://github.com/user-attachments/assets/2b9c9581-ba19-4de7-bc68-27fe9668de95" />

