### PR TITLE
[WIP] OSDOCS#16270: Replacing ROSA product names with attributes

### DIFF
--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-admin-rights.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-admin-rights.adoc
@@ -9,7 +9,7 @@ toc::[]
 //rosaworkshop.io content metadata
 //Brought into ROSA product docs 2023-11-30
 
-Administration (admin) privileges are not automatically granted to users that you add to your cluster. If you want to grant admin-level privileges to certain users, you will need to manually grant them to each user. You can grant admin privileges from either the ROSA command-line interface (CLI) or the Red{nbsp}Hat OpenShift Cluster Manager web user interface (UI).
+Administration (admin) privileges are not automatically granted to users that you add to your cluster. If you want to grant admin-level privileges to certain users, you will need to manually grant them to each user. You can grant admin privileges from either the {rosa-cli-first} or the Red{nbsp}Hat {cluster-manager} web user interface (UI).
 
 Red{nbsp}Hat offers two types of admin privileges:
 
@@ -17,7 +17,7 @@ Red{nbsp}Hat offers two types of admin privileges:
 
 * `dedicated-admin`: `dedicated-admin` privileges allow the admin user to complete most administrative tasks with certain limitations to prevent cluster damage. It is best practice to use `dedicated-admin` when elevated privileges are needed.
 
-For more information on admin privileges, see the 
+For more information on admin privileges, see the
 ifdef::openshift-rosa-hcp[]
 link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.html#rosa-create-cluster-admins_rosa-sts-accessing-cluster[administering a cluster] documentation.
 endif::openshift-rosa-hcp[]
@@ -25,7 +25,7 @@ ifndef::openshift-rosa-hcp[]
 xref:../../rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc#rosa-create-cluster-admins_rosa-sts-accessing-cluster[administering a cluster] documentation.
 endif::openshift-rosa-hcp[]
 
-== Using the ROSA CLI
+== Using the {rosa-cli}
 
 . Assuming you are the user who created the cluster, run one of the following commands to grant admin privileges:
 +

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-deleting.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-deleting.adoc
@@ -9,9 +9,9 @@ toc::[]
 //rosaworkshop.io content metadata
 //Brought into ROSA product docs 2024-01-11
 
-You can delete your {product-title} (ROSA) cluster using either the command-line interface (CLI) or the user interface (UI). 
+You can delete your {product-title} cluster using either the command-line interface (CLI) or the user interface (UI).
 
-== Deleting a ROSA cluster using the CLI
+== Deleting a {product-title} cluster using the CLI
 
 . *Optional:* List your clusters to make sure you are deleting the correct one by running the following command:
 +
@@ -65,7 +65,7 @@ $ rosa delete operator-roles -c <clusterID> --mode auto --yes
 This command requires the cluster ID and not the cluster name.
 ====
 
-. Only remove the remaining account roles if they are no longer needed by other clusters in the same account. If you want to create other ROSA clusters in this account, do not perform this step.
+. Only remove the remaining account roles if they are no longer needed by other clusters in the same account. If you want to create other {product-title} clusters in this account, do not perform this step.
 +
 To delete the account roles, you need to know the prefix used when creating them. The default is "ManagedOpenShift" unless you specified otherwise.
 +
@@ -76,7 +76,7 @@ Delete the account roles by running the following command:
 $ rosa delete account-roles --prefix <prefix> --mode auto --yes
 ----
 
-== Deleting a ROSA cluster using the UI
+== Deleting a {product-title} cluster using the UI
 
 . Log in to the {cluster-manager-url}, and locate the cluster you want to delete.
 

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
@@ -9,9 +9,9 @@ toc::[]
 
 //rosaworkshop.io content metadata
 //Brought into ROSA product docs 2023-11-21
-//Updated for HCP 2024-07-01  
+//Updated for HCP 2024-07-01
 
-Follow this workshop to deploy a sample {product-title} (ROSA) cluster. You can then use your cluster in the next workshops.
+Follow this workshop to deploy a sample {product-title} cluster. You can then use your cluster in the next workshops.
 
 .Workshop objectives
 
@@ -19,26 +19,26 @@ Follow this workshop to deploy a sample {product-title} (ROSA) cluster. You can 
 ** Create a sample virtual private cloud (VPC)
 ** Create sample OpenID Connect (OIDC) resources
 * Create sample environment variables
-* Deploy a sample ROSA cluster
+* Deploy a sample {product-title} cluster
 
 .Prerequisites
 
-* ROSA version 1.2.31 or later
+* {product-title} version 1.2.31 or later
 * Amazon Web Service (AWS) command-line interface (CLI)
-* ROSA CLI (`rosa`)
+* {rosa-cli} (`rosa`)
 
 == Creating your cluster prerequisites
 
-Before deploying a ROSA cluster, you must have both a VPC and OIDC resources. We will create these resources first. ROSA uses the bring your own VPC (BYO-VPC) model.
+Before deploying a {product-title} cluster, you must have both a VPC and OIDC resources. We will create these resources first. {product-title} uses the bring your own VPC (BYO-VPC) model.
 
 === Creating a VPC
-. Make sure your AWS CLI (`aws`) is configured to use a region where ROSA is available. See the regions supported by the AWS CLI by running the following command:
+. Make sure your AWS CLI (`aws`) is configured to use a region where {product-title} is available. See the regions supported by the AWS CLI by running the following command:
 +
 [source,terminal]
 ----
 $ rosa list regions --hosted-cp
 ----
-    
+
 . Create the VPC. For this workshop, the following link:https://github.com/openshift-cs/rosaworkshop/blob/master/rosa-workshop/rosa/resources/setup-vpc.sh[script] creates the VPC and its required components. It uses the region configured in your `aws` CLI.
 +
 [source,bash]
@@ -47,7 +47,7 @@ $ rosa list regions --hosted-cp
 
 set -e
 ##########
-# This script will create the network requirements for a ROSA cluster. This will be
+# This script will create the network requirements for a {product-title} cluster. This will be
 # a public cluster. This creates:
 # - VPC
 # - Public and private subnets
@@ -126,7 +126,7 @@ echo -n "Creating a route table for the private subnet to the NAT gateway..."
 PRIVATE_ROUTE_TABLE_ID=$(aws ec2 create-route-table --vpc-id $VPC_ID --query RouteTable.RouteTableId --output text)
 
 aws ec2 create-tags --resources $PRIVATE_ROUTE_TABLE_ID $NAT_IP_ADDRESS --tags Key=Name,Value=$CLUSTER_NAME-private
- 
+
 aws ec2 create-route --route-table-id $PRIVATE_ROUTE_TABLE_ID --destination-cidr-block 0.0.0.0/0 --gateway-id $NAT_GATEWAY_ID > /dev/null 2>&1
 
 aws ec2 associate-route-table --subnet-id $PRIVATE_SUBNET_ID --route-table-id $PRIVATE_ROUTE_TABLE_ID > /dev/null 2>&1
@@ -180,7 +180,7 @@ Private Subnet: subnet-011fe340000000000
 ----
 
 === Creating your OIDC configuration
-In this workshop, we will use the automatic mode when creating the OIDC configuration. We will also store the OIDC ID as an environment variable for later use. The command uses the ROSA CLI to create your cluster's unique OIDC configuration. 
+In this workshop, we will use the automatic mode when creating the OIDC configuration. We will also store the OIDC ID as an environment variable for later use. The command uses the {rosa-cli} to create your cluster's unique OIDC configuration.
 
 * Create the OIDC configuration by running the following command:
 +
@@ -191,7 +191,7 @@ $ export OIDC_ID=$(rosa create oidc-config --mode auto --managed --yes -o json |
 
 == Creating additional environment variables
 
-* Run the following command to set up environment variables. These variables make it easier to run the command to create a ROSA cluster:
+* Run the following command to set up environment variables. These variables make it easier to run the command to create a {product-title} cluster:
 +
 [source,terminal]
 ----
@@ -210,7 +210,7 @@ Run `rosa whoami` to find the VPC region.
 +
 [IMPORTANT]
 ====
-Only complete this step if this is the _first time_ you are deploying ROSA in this account and you have _not_ yet created your account roles and policies.
+Only complete this step if this is the _first time_ you are deploying {product-title} in this account and you have _not_ yet created your account roles and policies.
 ====
 +
 [source,terminal]
@@ -230,7 +230,7 @@ $ rosa create cluster --cluster-name $CLUSTER_NAME \
 --sts --mode auto --yes
 ----
 
-The cluster is ready after about 10 minutes. The cluster will have a control plane across three AWS availability zones in your selected region and create two worker nodes in your AWS account.  
+The cluster is ready after about 10 minutes. The cluster will have a control plane across three AWS availability zones in your selected region and create two worker nodes in your AWS account.
 
 == Checking the installation status
 . Run one of the following commands to check the status of the cluster:

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-idp.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-idp.adoc
@@ -9,12 +9,12 @@ toc::[]
 //rosaworkshop.io content metadata
 //Brought into ROSA product docs 2023-11-28
 
-To log in to your cluster, set up an identity provider (IDP). This tutorial uses GitHub as an example IDP. See the full list of 
+To log in to your cluster, set up an identity provider (IDP). This tutorial uses GitHub as an example IDP. See the full list of
 ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.html#understanding-idp-supported_rosa-sts-config-identity-providers[IDPs supported by ROSA].
+link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.html#understanding-idp-supported_rosa-sts-config-identity-providers[IDPs supported by {product-title}].
 endif::openshift-rosa-hcp[]
 ifndef::openshift-rosa-hcp[]
-xref:../../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc#understanding-idp-supported_rosa-sts-config-identity-providers[IDPs supported by ROSA].
+xref:../../rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc#understanding-idp-supported_rosa-sts-config-identity-providers[IDPs supported by {product-title}].
 endif::openshift-rosa-hcp[]
 
 * To view all IDP options, run the following command:
@@ -43,7 +43,7 @@ image::cloud-experts-getting-started-idp-new-org.png[]
 +
 image::cloud-experts-getting-started-idp-team.png[]
 
-. *Optional:* Add the GitHub IDs of other users to grant additional access to your ROSA cluster. You can also add them later.
+. *Optional:* Add the GitHub IDs of other users to grant additional access to your {product-title} cluster. You can also add them later.
 . Click *Complete Setup*.
 . *Optional:* Enter the requested information on the following page.
 . Click *Submit*.
@@ -110,4 +110,4 @@ image::cloud-experts-getting-started-idp-org.png[]
 image::cloud-experts-getting-started-idp-invite.png[]
 
 . Enter the GitHub ID of the new user, select the correct user, and click *Invite*.
-. Once the new user accepts the invitation, they will be able to log in to the ROSA cluster using the {hybrid-console-second} link and their GitHub credentials.
+. Once the new user accepts the invitation, they will be able to log in to the {product-title} cluster using the {hybrid-console-second} link and their GitHub credentials.

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-managing-worker-nodes.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-managing-worker-nodes.adoc
@@ -9,13 +9,13 @@ toc::[]
 //rosaworkshop.io content metadata
 //Brought into ROSA product docs 2023-11-30
 
-In {product-title} (ROSA), changing aspects of your worker nodes is performed through the use of machine pools. A machine pool allows users to manage many machines as a single entity. Every ROSA cluster has a default machine pool that is created when the cluster is created.
+In {product-title}, changing aspects of your worker nodes is performed through the use of machine pools. A machine pool allows users to manage many machines as a single entity. Every {product-title} cluster has a default machine pool that is created when the cluster is created.
 ifdef::openshift-rosa-hcp[]
 For more information, see the link:https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html[machine pool] documentation.
 endif::openshift-rosa-hcp[]
 
 == Creating a machine pool
-You can create a machine pool with either the command-line interface (CLI) or the user interface (UI). 
+You can create a machine pool with either the command-line interface (CLI) or the user interface (UI).
 
 === Creating a machine pool with the CLI
 . Run the following command:
@@ -44,7 +44,7 @@ I: To view all machine pools, run 'rosa list machinepools -c my-rosa-cluster'
 . *Optional:* Add node labels or taints to specific nodes in a new machine pool by running the following command:
 +
 [source,terminal]
----- 
+----
 rosa create machinepool --cluster=<cluster-name> --name=<machinepool-name> --replicas=<number-nodes> --labels=`<key=pair>`
 ----
 +
@@ -62,7 +62,7 @@ $ rosa create machinepool --cluster=my-rosa-cluster --name=db-nodes-mp --replica
 I: Machine pool 'db-nodes-mp' created successfully on cluster 'my-rosa-cluster'
 ----
 +
-This creates an additional 2 nodes that can be managed as a unit and also assigns them the labels shown.  
+This creates an additional 2 nodes that can be managed as a unit and also assigns them the labels shown.
 
 . Run the following command to confirm machine pool creation and the assigned labels:
 +
@@ -75,8 +75,8 @@ rosa list machinepools --cluster=<cluster-name>
 +
 [source,terminal]
 ----
-ID       AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONE  SUBNET                    DISK SIZE  VERSION  AUTOREPAIR  
-workers  Yes          2/2-4     m5.xlarge                          us-east-1f         subnet-<subnet_id>  300 GiB    4.14.36  Yes 
+ID       AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONE  SUBNET                    DISK SIZE  VERSION  AUTOREPAIR
+workers  Yes          2/2-4     m5.xlarge                          us-east-1f         subnet-<subnet_id>  300 GiB    4.14.36  Yes
 ----
 
 === Creating a machine pool with the UI

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-upgrading.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-upgrading.adoc
@@ -9,7 +9,7 @@ toc::[]
 //rosaworkshop.io content metadata
 //Brought into ROSA product docs 2024-01-08
 
-{product-title} (ROSA) executes all cluster upgrades as part of the managed service. You do not need to run any commands or make changes to the cluster. You can schedule the upgrades at a convenient time.
+{product-title} executes all cluster upgrades as part of the managed service. You do not need to run any commands or make changes to the cluster. You can schedule the upgrades at a convenient time.
 
 Ways to schedule a cluster upgrade include:
 

--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-s2i-deployments.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-s2i-deployments.adoc
@@ -5,12 +5,12 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-application-s2i-deployments
 toc::[]
 
-The integrated Source-to-Image (S2I) builder is one method to deploy applications in OpenShift. The S2I is a tool for building reproducible, Docker-formatted container images. For more information, see link:https://file.rdu.redhat.com/eponvell/OSDOCS-8400_Migrate-OpenShift-Concepts/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-openshift-concepts.html#source-to-image-s2i[OpenShift concepts]. 
+The integrated Source-to-Image (S2I) builder is one method to deploy applications in OpenShift. The S2I is a tool for building reproducible, Docker-formatted container images. For more information, see link:https://file.rdu.redhat.com/eponvell/OSDOCS-8400_Migrate-OpenShift-Concepts/cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-openshift-concepts.html#source-to-image-s2i[OpenShift concepts].
 
 [id="prereqs_deploying-application-s2i-deployments"]
 .Prerequisites
 
-* A ROSA cluster
+* A {product-title} cluster
 
 [id="retrieving-login_deploying-application-s2i-deployments"]
 == Retrieving your login command
@@ -113,7 +113,7 @@ $ oc new-app https://github.com/<UserName>/ostoy \
     --context-dir=microservice \
     --name=ostoy-microservice \
     --labels=app=ostoy
----- 
+----
 +
 .Example output
 [source,terminal]

--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-scaling.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-scaling.adoc
@@ -16,7 +16,7 @@ Manually or automatically scale your pods by using the Horizontal Pod Autoscaler
 
 [id="prereqs_deploying-application-scaling"]
 .Prerequisites
-* An active ROSA cluster 
+* An active {product-title} cluster
 * A deployed OSToy application
 
 [id="manual-pod_deploying-application-scaling"]
@@ -24,19 +24,19 @@ Manually or automatically scale your pods by using the Horizontal Pod Autoscaler
 
 You can manually scale your application's pods by using one of the following methods:
 
-* Changing your ReplicaSet or deployment definition 
+* Changing your ReplicaSet or deployment definition
 * Using the command line
 * Using the web console
 
 This workshop starts by using only one pod for the microservice. By defining a replica of `1` in your deployment definition, the Kubernetes Replication Controller strives to keep one pod alive. You then learn how to define pod autoscaling by using the link:https://docs.openshift.com/container-platform/latest/nodes/pods/nodes-pods-autoscaling.html[Horizontal Pod Autoscaler](HPA) which is based on the load and will scale out more pods when necessary.
 
-.Procedure 
+.Procedure
 
 . In the OSToy app, click the *Networking* tab in the navigational menu.
 . In the "Intra-cluster Communication" section, locate the box that randomly changes colors. Inside the box, you see the microservice's pod name. There is only one box in this example because there is only one microservice pod.
 +
 image::deploy-scale-network.png[HPA Menu]
-+ 
++
 
 . Confirm that there is only one pod running for the microservice by running the following command:
 +
@@ -106,8 +106,8 @@ ostoy-microservice-6666dcf455-tqzmn   1/1     Running   0          26m
 $ oc scale deployment ostoy-microservice --replicas=2
 ----
 +
-** From the navigational menu of the OpenShift web console UI, click *Workloads > Deployments > ostoy-microservice*.  
-** Locate the blue circle with a "3 Pod" label in the middle. 
+** From the navigational menu of the OpenShift web console UI, click *Workloads > Deployments > ostoy-microservice*.
+** Locate the blue circle with a "3 Pod" label in the middle.
 ** Selecting the arrows next to the circle scales the number of pods. Select the down arrow to `2`.
 +
 image::deploy-scale-uiscale.png[UI Scale]
@@ -160,11 +160,11 @@ $ oc autoscale deployment/ostoy-microservice --cpu-percent=80 --min=1 --max=10
 +
 This command creates an HPA that maintains between 1 and 10 replicas of the pods controlled by the ostoy-microservice deployment. During deployment, HPA increases and decreases the number of replicas to keep the average CPU use across all pods at 80% and 40 millicores.
 
-. On the *Pod Auto Scaling > Horizontal Pod Autoscaling* page, select *Increase the load*. 
+. On the *Pod Auto Scaling > Horizontal Pod Autoscaling* page, select *Increase the load*.
 +
 [IMPORTANT]
 ====
-Because increasing the load generates CPU intensive calculations, the page can become unresponsive. This is an expected response. Only click *Increase the Load* once. For more information about the process, see the link:https://github.com/openshift-cs/ostoy/blob/master/microservice/app.js#L32[microservice's GitHub repository]. 
+Because increasing the load generates CPU intensive calculations, the page can become unresponsive. This is an expected response. Only click *Increase the Load* once. For more information about the process, see the link:https://github.com/openshift-cs/ostoy/blob/master/microservice/app.js#L32[microservice's GitHub repository].
 ====
 +
 After a few minutes, the new pods display on the page represented by colored boxes.
@@ -200,17 +200,17 @@ ostoy-microservice-79894f6945-mgwk7   1/1     Running   0          4h24m
 ostoy-microservice-79894f6945-q925d   1/1     Running   0          3m14s
 ----
 
-* You can also verify autoscaling from the {cluster-manager} 
+* You can also verify autoscaling from the {cluster-manager}
 +
 . In the OpenShift web console navigational menu, click *Observe > Dashboards*.
 . In the dashboard, select *Kubernetes / Compute Resources / Namespace (Pods)* and your namespace *ostoy*.
 +
 image::deploy-scale-hpa-metrics.png[Select metrics]
 +
-. A graph appears showing your resource usage across CPU and memory. The top graph shows recent CPU consumption per pod and the lower graph indicates memory usage. The following lists the callouts in the graph: 
-.. The load increased (A). 
-.. Two new pods were created (B and C). 
-.. The thickness of each graph represents the CPU consumption and indicates which pods handled more load. 
+. A graph appears showing your resource usage across CPU and memory. The top graph shows recent CPU consumption per pod and the lower graph indicates memory usage. The following lists the callouts in the graph:
+.. The load increased (A).
+.. Two new pods were created (B and C).
+.. The thickness of each graph represents the CPU consumption and indicates which pods handled more load.
 .. The load decreased (D), and the pods were deleted.
 +
 image::deploy-scale-metrics.png[Select metrics]

--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-storage.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-storage.adoc
@@ -9,7 +9,7 @@ toc::[]
 //rosaworkshop.io content metadata
 //Brought into ROSA product docs 2024-04-30
 
-{rosa-classic-first} and Red Hat OpenShift Service on AWS (ROSA) support storing persistent volumes with either link:https://aws.amazon.com/ebs/[Amazon Web Services (AWS) Elastic Block Store (EBS)] or link:https://aws.amazon.com/efs/[AWS Elastic File System (EFS)].
+{product-title} supports storing persistent volumes with either link:https://aws.amazon.com/ebs/[Amazon Web Services (AWS) Elastic Block Store (EBS)] or link:https://aws.amazon.com/efs/[AWS Elastic File System (EFS)].
 
 [id="using-persistent-volumes_deploying-application-storage"]
 == Using persistent volumes
@@ -20,8 +20,8 @@ Use the following procedures to create a file, store it on a persistent volume i
 
 .Procedure
 . Navigate to the cluster's OpenShift web console.
-. Click *Storage* in the left menu, then click *PersistentVolumeClaims* to see a list of all the persistent volume claims. 
-. Click a persistence volume claim to see the size, access mode, storage class, and other additional claim details. 
+. Click *Storage* in the left menu, then click *PersistentVolumeClaims* to see a list of all the persistent volume claims.
+. Click a persistence volume claim to see the size, access mode, storage class, and other additional claim details.
 +
 [NOTE]
 ====
@@ -130,4 +130,4 @@ OpenShift is the greatest thing since sliced bread!
 [role="_additional-resources"]
 == Additional resources
 * For more information about persistent volume storage, see xref:../../storage/understanding-persistent-storage.adoc#persistent-volumes_understanding-persistent-storage[Understanding persistent storage].
-* For more information about ROSA storage options, see xref:../../storage/index.adoc#storage-overview[Storage overview].
+* For more information about {product-title} storage options, see xref:../../storage/index.adoc#storage-overview[Storage overview].

--- a/rosa_learning/deploying_application_workshop/learning-lab-overview.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-lab-overview.adoc
@@ -12,7 +12,7 @@ toc::[]
 [id="introduction_learning-lab-overview"]
 == Introduction
 
-After successfully provisioning your cluster, follow this workshop to deploy an application on it to understand the concepts of deploying and operating container-based applications. 
+After successfully provisioning your cluster, follow this workshop to deploy an application on it to understand the concepts of deploying and operating container-based applications.
 
 .Workshop objectives
 
@@ -22,20 +22,20 @@ After successfully provisioning your cluster, follow this workshop to deploy an 
 * Explore configuration management through ConfigMaps, secrets, and environment variables
 * Use persistent storage to share data across pod restarts
 * Explore networking in Kubernetes and applications
-* Familiarize yourself with ROSA and Kubernetes functionality
+* Familiarize yourself with {product-title} and Kubernetes functionality
 * Automatically scale pods based on loads from the Horizontal Pod Autoscaler (HPA)
 //* Use AWS Controllers for Kubernetes (ACK) to deploy and use an S3 bucket
 
 .Prerequisites
 
-* A provisioned ROSA cluster
+* A provisioned {product-title} cluster
 * The link:https://docs.openshift.com/rosa/cli_reference/openshift_cli/getting-started-cli.html[OpenShift command-line interface (CLI)]
 * A link:https://github.com/signup[GitHub account]
 
 [id="about-ostoy_learning-lab-overview"]
 == About the OSToy application
 
-OSToy is a Node.js application that deploys to a ROSA cluster to help explore the functionality of Kubernetes.
+OSToy is a Node.js application that deploys to a {product-title} cluster to help explore the functionality of Kubernetes.
 
 This application has a user interface where you can:
 
@@ -66,7 +66,7 @@ image::ostoy-homepage.png[Preview of the OSToy homepage]
 . *ENV Variables:* Shows environment variables available to the application
 . *Networking:* Networking tools
 . *Pod Auto Scaling:* Increase the load of the pods and test the Horizontal Pod Autoscaler (HPA)
-. *ACK S3:* Integrate with AWS S3 to read and write objects to a bucket 
+. *ACK S3:* Integrate with AWS S3 to read and write objects to a bucket
 +
 . *About:* Application information
 


### PR DESCRIPTION
[OSDOCS-16270](https://issues.redhat.com/browse/OSDOCS-16270): Replacing product names with attributes - ROSA and ROSA CLI with {product-title} and {rosa-cli}

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-16270

Link to docs preview:
Not adding preview links because they'll still show instances like ROSA with HCP because older attributes are still present, e.g. {hcp-title}.

QE review:
N/A

Additional information:
Will follow the ROSA HCP topic map order.
PR covers:

- rosa_learning