### PR TITLE
OADP-6701 Remove discrete tag from MTC

### DIFF
--- a/migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
+++ b/migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
@@ -24,7 +24,6 @@ include::modules/migration-state-migration-cli.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources-for-state-migration_{context}"]
-[discrete]
 === Additional resources
 
 * See xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-excluding-pvcs_advanced-migration-options-mtc[Excluding PVCs from migration] to select PVCs for state migration.
@@ -48,7 +47,6 @@ include::modules/migration-converting-storage-classes.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources-for-editing-pv-attributes_{context}"]
-[discrete]
 ==== Additional resources
 
 * For details about the `move` and `copy` actions, see xref:../migration_toolkit_for_containers/about-mtc.adoc#migration-mtc-workflow_about-mtc[MTC workflow].

--- a/migration_toolkit_for_containers/installing-mtc-restricted.adoc
+++ b/migration_toolkit_for_containers/installing-mtc-restricted.adoc
@@ -49,7 +49,6 @@ OpenShift environments have the `PodSecurityAdmission` controller enabled by def
 
 To guarantee successful data transfer in all environments, {mtc-short} 1.7.5 introduced changes in Rsync pods, including running Rsync pods as non-root user by default. This ensures that data transfer is possible even for workloads that do not necessarily require higher privileges. This change was made because it is best to run workloads with the lowest level of privileges possible.
 
-[discrete]
 [id="migration-rsync-override-data-transfer_{context}"]
 === Manually overriding default non-root operation for data transfer
 

--- a/migration_toolkit_for_containers/migrating-applications-with-mtc.adoc
+++ b/migration_toolkit_for_containers/migrating-applications-with-mtc.adoc
@@ -40,7 +40,6 @@ include::modules/migration-adding-cluster-to-cam.adoc[leveloffset=+2]
 include::modules/migration-adding-replication-repository-to-cam.adoc[leveloffset=+2]
 include::modules/migration-creating-migration-plan-cam.adoc[leveloffset=+2]
 
-[discrete]
 [id="additional-resources-for-persistent-volume-copy-methods_{context}"]
 [role="_additional-resources"]
 === Additional resources for persistent volume copy methods

--- a/migration_toolkit_for_containers/troubleshooting-mtc.adoc
+++ b/migration_toolkit_for_containers/troubleshooting-mtc.adoc
@@ -17,7 +17,6 @@ For known issues, see the xref:../migration_toolkit_for_containers/release_notes
 
 include::modules/migration-mtc-workflow.adoc[leveloffset=+1]
 
-[discrete]
 include::modules/migration-about-mtc-custom-resources.adoc[leveloffset=+2]
 
 include::modules/migration-mtc-cr-manifests.adoc[leveloffset=+1]
@@ -59,7 +58,6 @@ include::modules/migration-rolling-back-migration-manually.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources-uninstalling_{context}"]
-[discrete]
 === Additional resources
 
 * xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-cluster[Deleting Operators from a cluster using the web console]


### PR DESCRIPTION
Description of change:
Remove [discrete] tags from MTC files for DITA preparation as per [Removing discrete tags (main)](https://docs.google.com/spreadsheets/d/1sdUaypuUhe73j-gOLsl6Z5NyPwuaKyyx178iTelmmyk/edit?gid=702376038#gid=702376038).

Version(s):
OCP 4.19-4.20

Issue:
[OADP-6701](https://issues.redhat.com/browse/OADP-6701)

Link to docs preview:
- [Advanced migration options](https://99605--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/advanced-migration-options-mtc.html)
- [Installing the Migration Toolkit for Containers in a restricted network environment](https://99605--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc-restricted.html)
- [Migrating your applications](https://99605--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/migrating-applications-with-mtc.html)
- [Troubleshooting](https://99605--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/troubleshooting-mtc.html)

QE review:
- Bypassing QE review since this is formatting change only.