### PR TITLE
OSDOCS-14489:Pruning Architecture book

### DIFF
--- a/architecture/architecture.adoc
+++ b/architecture/architecture.adoc
@@ -1,6 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
+ifndef::openshift-rosa[]
 [id="architecture"]
 = {product-title} architecture
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+[id="architecture"]
+= {product-title}
+endif::openshift-rosa[]
 include::_attributes/common-attributes.adoc[]
 :context: architecture
 

--- a/architecture/rosa-architecture-models.adoc
+++ b/architecture/rosa-architecture-models.adoc
@@ -7,10 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-rosa} (ROSA) has the following cluster topologies:
-
-* Hosted control plane (HCP) - The control plane is hosted in a Red{nbsp}Hat account and the worker nodes are deployed in the customer's AWS account.
-* Classic - The control plane and the worker nodes are deployed in the customer's AWS account.
+{product-title} has a classic architecture cluster topology meaning the control plane and the worker nodes are deployed in the customer's AWS account.
 
 include::modules/rosa-hcp-classic-comparison.adoc[leveloffset=+1]
 
@@ -23,8 +20,14 @@ endif::openshift-rosa-hcp[]
 
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-security-regulation-compliance_rosa-policy-process-security[Security and regulation compliance]
 
+ifdef::openshift-rosa-hcp[]
 include::modules/rosa-hcp-architecture.adoc[leveloffset=+1]
+endif::openshift-rosa-hcp[]
+
+ifdef::openshift-rosa[]
 include::modules/rosa-architecture.adoc[leveloffset=+1]
+endif::openshift-rosa[]
+
 include::modules/osd-aws-privatelink-architecture.adoc[leveloffset=+2]
 include::modules/rosa-architecture-local-zones.adoc[leveloffset=+2]
 

--- a/modules/nvidia-gpu-csps.adoc
+++ b/modules/nvidia-gpu-csps.adoc
@@ -7,19 +7,16 @@
 ifndef::openshift-dedicated,openshift-rosa[]
 = GPUs and CSPs
 endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-rosa[]
-= GPUs and ROSA
-endif::openshift-rosa[]
-ifdef::openshift-dedicated[]
-= GPUs and OSD
-endif::openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+= GPUs and {product-title}
+endif::openshift-rosa,openshift-dedicated[]
 
 ifndef::openshift-dedicated,openshift-rosa[]
 You can deploy {product-title} to one of the major cloud service providers (CSPs): Amazon Web Services ({aws-short}), Google Cloud Platform ({gcp-short}), or Microsoft Azure.
 
 Two modes of operation are available: a fully managed deployment and a self-managed deployment.
 
-* In a fully managed deployment, everything is automated by Red{nbsp}Hat in collaboration with CSP. You can request an OpenShift instance through the CSP web console, and the cluster is automatically created and fully managed by Red{nbsp}Hat. You do not have to worry about node failures or errors in the environment. Red{nbsp}Hat is fully responsible for maintaining the uptime of the cluster. The fully managed services are available on {aws-short}, {azure-short}, and {gcp-short}. For {aws-short}, the OpenShift service is called ROSA (Red{nbsp}Hat OpenShift Service on AWS). For Azure, the service is called Azure Red{nbsp}Hat OpenShift. For {gcp-short}, the service is called OpenShift Dedicated on {gcp-short}.
+* In a fully managed deployment, everything is automated by Red{nbsp}Hat in collaboration with CSP. You can request an OpenShift instance through the CSP web console, and the cluster is automatically created and fully managed by Red{nbsp}Hat. You do not have to worry about node failures or errors in the environment. Red{nbsp}Hat is fully responsible for maintaining the uptime of the cluster. The fully managed services are available on {aws-short}, {azure-short}, and {gcp-short}. For {aws-short}, the OpenShift service is called (Red{nbsp}Hat OpenShift Service on AWS). For Azure, the service is called Azure Red{nbsp}Hat OpenShift. For {gcp-short}, the service is called OpenShift Dedicated on {gcp-short}.
 
 * In a self-managed deployment, you are responsible for instantiating and maintaining the OpenShift cluster. Red{nbsp}Hat provides the OpenShift-install utility to support the deployment of the OpenShift cluster in this case. The self-managed services are available globally to all CSPs.
 endif::openshift-dedicated,openshift-rosa[]

--- a/modules/openshift-architecture-common-terms.adoc
+++ b/modules/openshift-architecture-common-terms.adoc
@@ -3,8 +3,14 @@
 // * architecture/index.adoc
 
 :_mod-docs-content-type: REFERENCE
+ifndef::openshift-rosa[]
 [id="openshift-architecture-common-terms_{context}"]
 = Glossary of common terms for {product-title} architecture
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+[id="openshift-architecture-common-terms_{context}"]
+= Glossary of common terms for {product-title}
+endif::openshift-rosa[]
 
 This glossary defines common terms that are used in the architecture content.
 
@@ -16,12 +22,12 @@ Admission plugins enforce security policies, resource limitations, or configurat
 
 authentication::
 // The following variations have only minor differences, but are separated for maintainability.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 To control access to an {product-title} cluster, a cluster administrator can configure user authentication to ensure only approved users access the cluster. To interact with an {product-title} cluster, you must authenticate with the {product-title} API. You can authenticate by providing an OAuth access token or an X.509 client certificate in your requests to the {product-title} API.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 To control access to a {product-title} cluster, an administrator with the `dedicated-admin` role can configure user authentication to ensure only approved users access the cluster. To interact with a {product-title} cluster, you must authenticate with the {product-title} API. You can authenticate by providing an OAuth access token or an X.509 client certificate in your requests to the {product-title} API.
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-dedicated[]
 To control access to an {product-title} cluster, an administrator with the `dedicated-admin` role can configure user authentication to ensure only approved users access the cluster. To interact with an {product-title} cluster, you must authenticate with the {product-title} API. You can authenticate by providing an OAuth access token or an X.509 client certificate in your requests to the {product-title} API.
 endif::openshift-dedicated[]
@@ -64,7 +70,7 @@ A Kubernetes resource object that maintains the life cycle of an application.
 
 Dockerfile::
 A text file that contains the user commands to perform on a terminal to assemble the image.
-ifdef::openshift-rosa[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 hosted control planes::
 A {product-title} feature that enables hosting a control plane on the {product-title} cluster from its data plane and workers. This model performs the following actions:
 
@@ -72,8 +78,8 @@ A {product-title} feature that enables hosting a control plane on the {product-t
 * Improve the cluster creation time.
 * Enable hosting the control plane using the Kubernetes native high level primitives. For example, deployments and stateful sets.
 * Allow a strong network segmentation between the control plane and workloads.
-endif::openshift-rosa[]
-ifndef::openshift-dedicated,openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 hosted control planes::
 A {product-title} feature that enables hosting a control plane on the {product-title} cluster from its data plane and workers. This model performs the following actions:
 
@@ -81,7 +87,7 @@ A {product-title} feature that enables hosting a control plane on the {product-t
 * Improve the cluster creation time.
 * Enable hosting the control plane using the Kubernetes native high level primitives. For example, deployments and stateful sets.
 * Allow a strong network segmentation between the control plane and workloads.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 hybrid cloud deployments::
 Deployments that deliver a consistent platform across bare metal, virtual, private, and public cloud environments. This offers speed, agility, and portability.
@@ -131,10 +137,10 @@ A worker machine in the {product-title} cluster. A node is either a virtual mach
 OpenShift CLI (`oc`)::
 A command-line tool to run {product-title} commands on the terminal.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 OpenShift Dedicated::
 A managed {op-system-base} {product-title} offering on Amazon Web Services (AWS) and Google Cloud Platform (GCP). OpenShift Dedicated focuses on building and scaling applications.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 OpenShift Update Service (OSUS)::
 For clusters with internet access, {op-system-base-full} provides over-the-air updates by using an OpenShift update service as a hosted service located behind public APIs.
@@ -144,12 +150,12 @@ A registry provided by {product-title} to manage images.
 
 Operator::
 The preferred method of packaging, deploying, and managing a Kubernetes application in
-ifdef::openshift-rosa[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 a
-endif::openshift-rosa[]
-ifndef::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifndef::openshift-rosa,openshift-rosa-hcp[]
 an
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 {product-title} cluster. An Operator takes human operational knowledge and encodes it into software that is packaged and shared with customers.
 
 OperatorHub::
@@ -200,12 +206,12 @@ An image created based on the programming language of the application source cod
 storage::
 // OSD and ROSA definitions are separated here due to different indefinite
 // articles.
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 {product-title} supports many types of storage, both for on-premise and cloud providers. You can manage container storage for persistent and non-persistent data in an {product-title} cluster.
-endif::openshift-dedicated,openshift-rosa[]
-ifdef::openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 {product-title} supports many types of storage for cloud providers. You can manage container storage for persistent and non-persistent data in a {product-title} cluster.
-endif::openshift-rosa[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-dedicated[]
 {product-title} supports many types of storage for cloud providers. You can manage container storage for persistent and non-persistent data in an {product-title} cluster.
 endif::openshift-dedicated[]
@@ -216,10 +222,10 @@ A component to collect information such as size, health, and status of {product-
 template::
 A template describes a set of objects that can be parameterized and processed to produce a list of objects for creation by {product-title}.
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 user-provisioned infrastructure::
 You can install {product-title} on the infrastructure that you provide. You can use the installation program to generate the assets required to provision the cluster infrastructure, create the cluster infrastructure, and then deploy the cluster to the infrastructure that you provided.
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 web console::
 A user interface (UI) to manage {product-title}.

--- a/modules/rosa-architecture-local-zones.adoc
+++ b/modules/rosa-architecture-local-zones.adoc
@@ -3,16 +3,16 @@
 // * architecture/rosa-architecture-models.adoc
 :_mod-docs-content-type: REFERENCE
 [id="rosa-architecture-local-zones_{context}"]
-= ROSA architecture with Local Zones
+= {product-title} with Local Zones
 
-ROSA supports the use of AWS Local Zones, which are metropolis-centralized availability zones where customers can place latency-sensitive application workloads within a VPC. Local Zones are extensions of AWS Regions and are not enabled by default. When Local Zones are enabled and configured, the traffic is extended into the Local Zones for greater flexibility and lower latency. For more information, see "Configuring machine pools in Local Zones".
+{product-title} supports the use of AWS Local Zones, which are metropolis-centralized availability zones where customers can place latency-sensitive application workloads within a VPC. Local Zones are extensions of AWS Regions and are not enabled by default. When Local Zones are enabled and configured, the traffic is extended into the Local Zones for greater flexibility and lower latency. For more information, see "Configuring machine pools in Local Zones".
 
-The following diagram displays a ROSA cluster without traffic routed into a Local Zone.
+The following diagram displays a {product-title} cluster without traffic routed into a Local Zone.
 
-.ROSA cluster without traffic routed into Local Zones
-image::../images/354_OpenShift_ROSA_Local_Zones_0923_1.png[ROSA cluster without traffic routed into Local Zones]
+.{product-title} cluster without traffic routed into Local Zones
+image::../images/354_OpenShift_ROSA_Local_Zones_0923_1.png[{product-title} cluster without traffic routed into Local Zones]
 
-The following diagram displays a ROSA cluster with traffic routed into a Local Zone.
+The following diagram displays a {product-title} cluster with traffic routed into a Local Zone.
 
-.ROSA cluster with traffic routed into Local Zones
-image::../images/354_OpenShift_ROSA_Local_Zones_0923_2.png[ROSA cluster with traffic routed into Local Zones]
+.{product-title} cluster with traffic routed into Local Zones
+image::../images/354_OpenShift_ROSA_Local_Zones_0923_2.png[{product-title} cluster with traffic routed into Local Zones]

--- a/modules/rosa-architecture.adoc
+++ b/modules/rosa-architecture.adoc
@@ -3,31 +3,31 @@
 // * rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc
 
 [id="rosa-classic-architecture_{context}"]
-= ROSA Classic architecture
+= {product-title}
 
-In {product-rosa} (ROSA) Classic, both the control plane and the worker nodes are deployed in your VPC subnets.
+In {product-title}, both the control plane and the worker nodes are deployed in your VPC subnets.
 
 [id="rosa-classic-architecture-networks_{context}"]
-== ROSA Classic architecture on public and private networks
+== {product-title} on public and private networks
 
-With ROSA Classic, you can create clusters that are accessible over public or private networks.
+With {product-title}, you can create clusters that are accessible over public or private networks.
 
 You can customize access patterns for your API server endpoint and Red{nbsp}Hat SRE management in the following ways:
 
 * Public - API server endpoint and application routes are internet-facing.
 
-* Private - API server endpoint and application routes are private. Private ROSA Classic clusters use some public subnets, but no control plane or worker nodes are deployed in public subnets.
+* Private - API server endpoint and application routes are private. Private {product-title} clusters use some public subnets, but no control plane or worker nodes are deployed in public subnets.
 
-* Private with AWS PrivateLink - API server endpoint and application routes are private. Public subnets or NAT gateways are not required in your VPC for egress. ROSA SRE management uses AWS PrivateLink.
+* Private with AWS PrivateLink - API server endpoint and application routes are private. Public subnets or NAT gateways are not required in your VPC for egress. {product-title} SRE management uses AWS PrivateLink.
 
-The following image depicts the architecture of a ROSA Classic cluster deployed on both public and private networks.
+The following image depicts the architecture of a {product-title} cluster deployed on both public and private networks.
 
-.ROSA Classic deployed on public and private networks
-image::156_OpenShift_ROSA_Arch_0621_private_public_classic.png[ROSA deployed on public and private networks]
+.{product-title} deployed on public and private networks
+image::156_OpenShift_ROSA_Arch_0621_private_public_classic.png[{product-title} on public and private networks]
 
-ROSA Classic clusters include infrastructure nodes where OpenShift components such as the ingress controller, image registry, and monitoring are deployed. The infrastructure nodes and the OpenShift components deployed on them are managed by ROSA Service SREs.
+{product-title} clusters include infrastructure nodes where OpenShift components such as the ingress controller, image registry, and monitoring are deployed. The infrastructure nodes and the OpenShift components deployed on them are managed by {product-title} SREs.
 
-The following types of clusters are available with ROSA Classic:
+The following types of clusters are available with {product-title}:
 
 * Single zone cluster - The control plane and worker nodes are hosted on a single availability zone.
 

--- a/modules/rosa-hcp-architecture.adoc
+++ b/modules/rosa-hcp-architecture.adoc
@@ -3,23 +3,23 @@
 // * rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc
 
 [id="rosa-hcp-architecture_{context}"]
-= ROSA with HCP architecture
+= {product-title} with HCP architecture
 
-In {hcp-title-first}, the ROSA service hosts a highly-available, single-tenant OpenShift control plane. The hosted control plane is deployed across 3 availability zones with 2 API server instances and 3 etcd instances.
+{product-title} hosts a highly-available, single-tenant OpenShift control plane. The hosted control plane is deployed across 3 availability zones with 2 API server instances and 3 etcd instances.
 
-You can create a ROSA with HCP cluster with or without an internet-facing API server, with the latter considered a “private” cluster and the former considered a “public” cluster. Private API servers are only accessible from your VPC subnets. You access the hosted control plane through an AWS PrivateLink endpoint regardless of API privacy.
+You can create a {product-title} cluster with or without an internet-facing API server, with the latter considered a “private” cluster and the former considered a “public” cluster. Private API servers are only accessible from your VPC subnets. You access the hosted control plane through an AWS PrivateLink endpoint regardless of API privacy.
 
 The worker nodes are deployed in your AWS account and run on your VPC private subnets. You can add additional private subnets from one or more availability zones to ensure high availability. Worker nodes are shared by OpenShift components and applications. OpenShift components such as the ingress controller, image registry, and monitoring are deployed on the worker nodes hosted on your VPC.
 
-.ROSA with HCP architecture
-image::544_OpenShift_ROSA-HCP_architecture-model.png[ROSA with HCP architecture]
+.{product-title} architecture
+image::544_OpenShift_ROSA-HCP_architecture-model.png[{product-title} architecture]
 
 [id="rosa-hcp-network-architecture_{context}"]
-== ROSA with HCP architecture on public and private networks
-With ROSA with HCP, you can create your clusters on public or private networks. The following images depict the architecture of both public and private networks.
+== {product-title} architecture on public and private networks
+With {product-title}, you can create your clusters on public or private networks. The following images depict the architecture of both public and private networks.
 
-.ROSA with HCP deployed on a public network
-image::544_OpenShift_ROSA-HCP-and-ROSA-Classic-public.png[ROSA with HCP deployed on a public network]
+.{product-title} deployed on a public network
+image::544_OpenShift_ROSA-HCP-and-ROSA-Classic-public.png[{product-title} deployed on a public network]
 
-.ROSA with HCP deployed on a private network
-image::544_OpenShift_ROSA-HCP-and-ROSA-Classic-private.png[ROSA with HCP deployed on a private network]
+.{product-title} deployed on a private network
+image::544_OpenShift_ROSA-HCP-and-ROSA-Classic-private.png[{product-title} deployed on a private network]

--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="rosa-hcp-classic-comparison_{context}"]
-= Comparing ROSA with HCP and ROSA Classic
+= Comparing {hcp-title-first} and {rosa-classic-title}
 
-.ROSA architectures comparison table
+.{hcp-title-first} and {rosa-classic-title} architectures comparison table
 
 [cols="3a,8a,8a",options="header"]
 |===

--- a/modules/sd-vs-ocp.adoc
+++ b/modules/sd-vs-ocp.adoc
@@ -20,9 +20,9 @@ Review the following differences between {product-title} and a standard installa
 ifdef::openshift-dedicated[]
 {product-title} is installed through {cluster-manager-first} and in a standardized way that is optimized for performance, scalability, and security.
 endif::openshift-dedicated[]
-ifdef::openshift-rosa[]
-{product-title} is installed through {cluster-manager-first} or the ROSA CLI (`rosa`) and in a standardized way that is optimized for performance, scalability, and security.
-endif::openshift-rosa[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+{product-title} is installed through {cluster-manager-first} or the {rosa-cli-first} and in a standardized way that is optimized for performance, scalability, and security.
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 |Customers can choose their computing resources.
 |

--- a/rosa_architecture/about-hcp.adoc
+++ b/rosa_architecture/about-hcp.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="about-hcp"]
-= ROSA with HCP overview
+= {product-title} overview
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: about-hcp
@@ -10,21 +10,21 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-ROSA is a fully-managed turnkey application platform that allows you to focus on what matters most, delivering value to your customers by building and deploying applications. Red{nbsp}Hat and AWS SRE experts manage the underlying platform so you do not have to worry about infrastructure management. ROSA provides seamless integration with a wide range of AWS compute, database, analytics, machine learning, networking, mobile, AI and other services to further accelerate the building and delivering of differentiating experiences to your customers.
+{product-title} is a fully-managed turnkey application platform that allows you to focus on what matters most, delivering value to your customers by building and deploying applications. Red{nbsp}Hat and AWS SRE experts manage the underlying platform so you do not have to worry about infrastructure management. {product-title} provides seamless integration with a wide range of AWS compute, database, analytics, machine learning, networking, mobile, AI and other services to further accelerate the building and delivering of differentiating experiences to your customers.
 
-{hcp-title-first} offers a reduced-cost solution to create a managed ROSA cluster with a focus on efficiency and security. You can quickly create a new cluster and deploy applications in minutes.
+{product-title} offers a reduced-cost solution to create a managed {product-title} cluster with a focus on efficiency and security. You can quickly create a new cluster and deploy applications in minutes.
 
-You subscribe to the service directly from your AWS account. After you create clusters, you can operate your clusters with the OpenShift web console, the ROSA CLI, or through {cluster-manager-first}.
+You subscribe to the service directly from your AWS account. After you create clusters, you can operate your clusters with the OpenShift web console, the `rosa` CLI, or through {cluster-manager-first}.
 
-You receive OpenShift updates with new feature releases and a shared, common source for alignment with OpenShift Container Platform. ROSA supports the same versions of OpenShift as Red{nbsp}Hat OpenShift Container Platform to achieve version consistency.
+You receive OpenShift updates with new feature releases and a shared, common source for alignment with OpenShift Container Platform. {product-title} supports the same versions of OpenShift as Red{nbsp}Hat OpenShift Container Platform to achieve version consistency.
 
 image::291_OpenShift_on_AWS_Intro_1122_docs.png[{product-title}]
 
-ROSA uses AWS Security Token Service (STS) with AWS IAM to obtain credentials to manage infrastructure in your AWS account. AWS STS is a global web service that creates temporary credentials for IAM users/roles or federated users/roles. ROSA uses this to assign short-term, limited-privilege, security credentials. These credentials are associated with IAM roles that are specific to each component that makes AWS API calls. This method aligns with the principals of least privilege and secure practices in cloud service resource management. The ROSA command-line interface (CLI) tool manages the STS credentials that are assigned for unique tasks and takes action on AWS resources as part of OpenShift functionality. For a more detailed explanation, see xref:../rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc#cloud-experts-rosa-hcp-sts-explained[AWS STS and ROSA with HCP explained].
+{product-title} uses AWS Security Token Service (STS) with AWS IAM to obtain credentials to manage infrastructure in your AWS account. AWS STS is a global web service that creates temporary credentials for IAM users/roles or federated users/roles. {product-title} uses this to assign short-term, limited-privilege, security credentials. These credentials are associated with IAM roles that are specific to each component that makes AWS API calls. This method aligns with the principals of least privilege and secure practices in cloud service resource management. The ROSA command-line interface (CLI) tool manages the STS credentials that are assigned for unique tasks and takes action on AWS resources as part of OpenShift functionality. For a more detailed explanation, see xref:../rosa_architecture/cloud-experts-rosa-hcp-sts-explained.adoc#cloud-experts-rosa-hcp-sts-explained[AWS STS and ROSA with HCP explained].
 
-== Key features of {hcp-title}
+== Key features of {product-title}
 
-* *Cluster node scaling:* {hcp-title} requires a minimum of only two nodes, making it ideal for smaller projects while still being able to scale to support larger projects and enterprises. Easily add or remove compute nodes to match resource demand. Autoscaling allows you to automatically adjust the size of the cluster based on the current workload. See
+* *Cluster node scaling:* {product-title} requires a minimum of only two nodes, making it ideal for smaller projects while still being able to scale to support larger projects and enterprises. Easily add or remove compute nodes to match resource demand. Autoscaling allows you to automatically adjust the size of the cluster based on the current workload. See
 ifdef::openshift-rosa-hcp[]
 link:https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.html#rosa-nodes-about-autoscaling-nodes[About autoscaling nodes on a cluster] for more details.
 endif::openshift-rosa-hcp[]
@@ -51,9 +51,9 @@ endif::openshift-rosa[]
 
 include::modules/rosa-sdpolicy-am-billing.adoc[leveloffset=+1]
 
-== Getting started with {hcp-title}
+== Getting started with {product-title}
 
-Use the following sections to find content to help you learn about and use {hcp-title}.
+Use the following sections to find content to help you learn about and use {product-title}.
 
 [id="architect"]
 === Architect
@@ -124,13 +124,13 @@ endif::openshift-rosa-hcp[]
 |Learn about {hcp-title} |Deploy {hcp-title} |Manage {hcp-title} |Additional resources
 |
 ifdef::openshift-rosa-hcp[]
-link:https://docs.openshift.com/rosa/architecture/rosa-architecture-models.html#rosa-architecture-models[{hcp-title} architecture]
+link:https://docs.openshift.com/rosa/architecture/rosa-architecture-models.html#rosa-architecture-models[{product-title} architecture]
 endif::openshift-rosa-hcp[]
 ifndef::openshift-rosa-hcp[]
-xref:../architecture/rosa-architecture-models.adoc#rosa-architecture-models[{hcp-title} architecture]
+xref:../architecture/rosa-architecture-models.adoc#rosa-architecture-models[{product-title} architecture]
 endif::openshift-rosa-hcp[]
 |
-xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Installing {hcp-title}]
+xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Installing {product-title}]
 |
 ifdef::openshift-rosa-hcp[]
 link:https://docs.openshift.com/rosa/observability/logging/cluster-logging.html#cluster-logging[Logging]
@@ -160,7 +160,7 @@ xref:../observability/monitoring/about-ocp-monitoring/about-ocp-monitoring.adoc#
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa-hcp[]
-xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{hcp-title} life cycle]
+xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc#rosa-hcp-life-cycle[{product-title}life cycle]
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa-hcp[]
@@ -207,7 +207,7 @@ endif::openshift-rosa-hcp[]
 
 [options="header",cols="3*"]
 |===
-|Learn about application development in {hcp-title} |Deploy applications |Additional resources
+|Learn about application development in {product-title} |Deploy applications |Additional resources
 
 | link:https://developers.redhat.com/[Red{nbsp}Hat Developers site]
 |
@@ -256,12 +256,12 @@ endif::openshift-rosa-hcp[]
 
 |===
 
-=== Before creating your first ROSA cluster
+=== Before creating your first {product-title} cluster
 
 //Per PM review, commented out until we get a valid ROSA HCP demo.
 // Watch a link:https://youtu.be/KbzUbXWs6Ck[demo] of the cluster deployment process.
 
-For additional information about ROSA installation, see a qucik introdcution to the process in link:https://www.redhat.com/en/products/interactive-walkthrough/install-rosa[Installing Red{nbsp}Hat OpenShift Service on AWS (ROSA) interactive walkthrough].
+For additional information about ROSA installation, see a qucik introdcution to the process in link:https://www.redhat.com/en/products/interactive-walkthrough/install-rosa[Installing {product-title} interactive walkthrough].
 
 [role="_additional-resources"]
 == Additional resources

--- a/rosa_architecture/index.adoc
+++ b/rosa_architecture/index.adoc
@@ -21,7 +21,7 @@ image::291_OpenShift_on_AWS_Intro_1122_docs.png[{product-title}]
 To navigate the ROSA documentation, use the left navigation bar.
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
-Welcome to the official {product-title} (ROSA) documentation, where you can learn about ROSA and start exploring its features.
+Welcome to the official {product-title} documentation, where you can learn about {product-title} and start exploring its features.
 endif::openshift-rosa-hcp[]
 
 ifndef::openshift-rosa,openshift-rosa-hcp[]

--- a/rosa_architecture/rosa-architecture-models.adoc
+++ b/rosa_architecture/rosa-architecture-models.adoc
@@ -7,10 +7,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-rosa} (ROSA) has the following cluster topologies:
+{product-title} has the following cluster topology:
 
-* Hosted control plane (HCP) - The control plane is hosted in a Red{nbsp}Hat account and the worker nodes are deployed in the customer's AWS account.
-* Classic - The control plane and the worker nodes are deployed in the customer's AWS account.
+Hosted control plane (HCP) - The control plane is hosted in a Red{nbsp}Hat account and the worker nodes are deployed in the customer's AWS account.
 
 include::modules/rosa-hcp-classic-comparison.adoc[leveloffset=+1]
 

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -9,18 +9,24 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [.lead]
-ifndef::openshift-rosa,openshift-telco[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-telco[]
 Welcome to the official {product-title} {product-version} documentation, where you can learn about {product-title} and start exploring its features.
-endif::openshift-rosa,openshift-telco[]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-telco[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
+Welcome to the official {product-title} documentation, where you can learn about {product-title} and start exploring its features.
+To learn about {product-title}, interacting with {product-title} by using {cluster-manager-first} and command-line interface (CLI) tools, consumption experience, and integration with Amazon Web Services (AWS) services, start with
+ifdef::openshift-rosa-hcp[]
+xref:../rosa_architecture/about-hcp.adoc#about-hcp[{product-title} overview].
+endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa[]
-Welcome to the official {product-title} (ROSA) documentation, where you can learn about ROSA and start exploring its features.
-To learn about ROSA, interacting with ROSA by using {cluster-manager-first} and command-line interface (CLI) tools, consumption experience, and integration with Amazon Web Services (AWS) services, start with xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding[the Introduction to ROSA documentation].
-
-image::291_OpenShift_on_AWS_Intro_1122_docs.png[{product-title}]
+xref:../rosa_architecture/rosa-understanding.adoc#rosa-understanding[the Introduction to ROSA documentation].
 endif::openshift-rosa[]
 
+image::291_OpenShift_on_AWS_Intro_1122_docs.png[{product-title}]
+endif::openshift-rosa,openshift-rosa-hcp[]
+
 ifdef::openshift-rosa[]
-To navigate the ROSA documentation, use the left navigation bar.
+To navigate the {product-title} documentation, use the left navigation bar.
 endif::[]
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-dpu,openshift-telco[]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-14489

Link to docs preview:

Classic:
[Architecture](https://99613--ocpdocs-pr.netlify.app/openshift-rosa/latest/architecture/)

HCP:

- [Welcome](https://99613--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/index.html)
- [Architecture models](https://99613--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa-architecture-models.html)
- [Red Hat OpenShift Service on AWS overview](https://99613--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/about-hcp.html)


Peer review:
- [ ] Peer reviewer has approved this change.

QE review:
- QE approval is not required for this PR

Additional information:
Note to reviewer- I have verified that changes made to OSD and OCP docs are rendering correctly.
