### PR TITLE
PR for SRVCOM-3990: Incorporate latest changes into 1.36.1 OpenShift Serverless Release Notes

### DIFF
--- a/modules/serverless-rn-1-36-1.adoc
+++ b/modules/serverless-rn-1-36-1.adoc
@@ -16,4 +16,4 @@
 [id="known-issues-1-36-1_{context}"]
 == Known issues
 
-* The `kn func build --remote` command on an {ocp-product-title} s390x cluster triggers a known issue that causes the build task to hang. As a consequence, the build process does not complete.
+* Deploying a Quarkus function with the `kn func deploy --remote` command on an {ocp-product-title} s390x cluster triggers a known issue that causes the build task to hang. As a result, the build process does not complete.


### PR DESCRIPTION
**Affected versions:** 
`serverless-docs-1.37`
`serverless-docs-1.36`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3990

**Doc preview:** [Red Hat OpenShift Serverless 1.36.1](https://99623--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-36-1_serverless-release-notes)

**Reviews:**

- [x] QE has approved this change.
- [x] SME has approved this change.
- [x] Peer has approved this change.