### PR TITLE
OSDOCS-16272:Remove duplicate Q3 2025 heading from OSD release notes.

### DIFF
--- a/osd_whats_new/osd-whats-new.adoc
+++ b/osd_whats_new/osd-whats-new.adoc
@@ -20,10 +20,7 @@ With its foundation in Kubernetes, {product-title} is a complete {OCP} cluster p
 * **Workload Identify Federation (WIF) is now the default authentication type for {product-title} clusters on {GCP}.**
 In alignment with the principle of least privilege as well as Google Cloud's preferred method of credential authentication, WIF is now the default authentication type when creating an {product-title} cluster on {GCP}. WIF greatly improves an {product-title} cluster's resilience against unauthorized access by using short-lived, least-privilege credentials and eliminating the need for static service account keys. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc[Creating a cluster on GCP with Workload Identity Federation authentication].
 
-[id="osd-q2-2025_{context}"]
-
-=== Q3 2025
-* ** Support for managing workload identity pools and providers in a dedicated {GCP} project.**
+* **Support for managing workload identity pools and providers in a dedicated {GCP} project.**
 {product-title} on {GCP} now supports the option of creating and managing workload identity pools and providers in a specified dedicated project during the creation of a WIF configuration. Red{nbsp}Hat plans on offering this option for existing WIF configurations in an upcoming release. For more information, see  xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-configuration_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a WIF configuration].
 
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-16272

Link to docs preview:
https://99626--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
