### PR TITLE
OSDOCS-15182: Installing New ROSA & OSD Cluster with OCP 4.20

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -10,6 +10,7 @@
 [options="header"]
 |===
 |Version    |General availability   |End of life
+|4.20       |Oct 21, 2025           |Feb 21, 2027
 |4.19       |Jun 16, 2025           |Oct 21, 2026
 |4.18       |Feb 26, 2025           |Jun 21, 2026
 |4.17       |Oct 14, 2024           |Feb 14, 2026

--- a/modules/osd-release-notes-Q4-2025.adoc
+++ b/modules/osd-release-notes-Q4-2025.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+// * osd-whats-new.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="osd-q4-2025_{context}"]
+=== Q4 2025
+
+* **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.20 are now available for new clusters.
+

--- a/modules/rosa-release-notes-Q4-2025.adoc
+++ b/modules/rosa-release-notes-Q4-2025.adoc
@@ -5,6 +5,8 @@
 [id="rosa-q4-2025_{context}"]
 = Q4 2025
 
+* **New version of {product-title} available.** {product-title} version 4.20 is now available for new clusters.
+
 ifdef::openshift-rosa-hcp[]
 * ** ImageDigestMirrorSets (IDMS) now supported.**
 {product-title} now supports ImageDigestMirrorSets (IDMS), enabling clusters to redirect image pulls to a private, mirrored registry. This critical enhancement means customers in air-gapped or restricted networks can host their own mirrors for third-party images while satisfying strict security and compliance requirements. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/images/index#images-registry-mirroring_image-configuration-hcp[Image registry mirroring for {product-title}].

--- a/osd_whats_new/osd-whats-new.adoc
+++ b/osd_whats_new/osd-whats-new.adoc
@@ -15,6 +15,8 @@ With its foundation in Kubernetes, {product-title} is a complete {OCP} cluster p
 [id="osd-new-changes-and-updates_{context}"]
 == New changes and updates
 
+include::modules/rosa-release-notes-Q4-2025.adoc[leveloffset=+1]
+
 [id="osd-q3-2025_{context}"]
 === Q3 2025
 

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -10,10 +10,7 @@ toc::[]
 [role="_abstract"]
 Find new additions, recent changes, and relevant updates for {product-title} listed below in quarterly increments.
 
-//remove the conditional if Classic notes are added to the module
-ifdef::openshift-rosa-hcp[]
 include::modules/rosa-release-notes-Q4-2025.adoc[leveloffset=+1]
-endif::openshift-rosa-hcp[]
 
 include::modules/rosa-release-notes-Q3-2025.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-15182

Link to docs preview:
[Life Cycle Dates](https://99648--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html#sd-life-cycle-dates_rosa-hcp-life-cycle)
[OSD Whats New](https://99648--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html)
[ROSA Whats New](https://99648--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html)
[Classic Whats New](https://99648--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html)

QE review:
QE approval is NOT required as no procedural change.

