### PR TITLE
OSDOCS-13110: Update PatternFly guidelines for PF6 in OCP content

### DIFF
--- a/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
+++ b/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
@@ -55,14 +55,16 @@ When creating your plugin, follow these guidelines for using PatternFly:
 
 * Use link:https://www.patternfly.org/components/all-components/[PatternFly] components and PatternFly CSS variables. Core PatternFly components are available through the SDK. Using PatternFly components and variables help your plugin look consistent in future console versions.
 ifndef::openshift-rosa-hcp[]
-** Use Patternfly 4.x if you are using {product-title} versions 4.14 and earlier.
-** Use Patternfly 5.x if you are using {product-title} 4.15 or later.
+** Use PatternFly 4.x if you are using {product-title} versions 4.14 and earlier.  
+** Use PatternFly 5.x if you are using {product-title} versions 4.15 through 4.18.  
+** Use PatternFly 6.x if you are using {product-title} versions 4.19 and later.
+
 endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa-hcp[]
 ** Use Patternfly 5.x.
 endif::openshift-rosa-hcp[]
 * Make your plugin accessible by following link:https://www.patternfly.org/accessibility/accessibility-fundamentals/[PatternFly's accessibility fundamentals].
-* Avoid using other CSS libraries such as Bootstrap or Tailwind. They might conflict with PatternFly and not match the rest of the console. Plugins should only include styles that are specific to their user interfaces to be evaluated on top of base PatternFly styles. Avoid importing styles such as `@patternfly/react-styles/**/*.css` or any styles from the `@patternfly/patternfly` package in your plugin.
-* The console application is responsible for loading base styles for all supported PatternFly version(s).
+* Avoid using other CSS libraries such as Bootstrap or Tailwind. They might conflict with PatternFly and not match the rest of the console. Plugins should only include styles that are specific to their user interfaces to be evaluated on top of base PatternFly styles. Do not import styles directly from `@patternfly/react-styles/**/*.css` or `@patternfly/patternfly`. Instead, use components and CSS variables provided by the console SDK.
+* The console application is responsible for loading base styles for all supported PatternFly versions.
 
 include::modules/dynamic-plugin-localization.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): Fix version 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-13110](https://issues.redhat.com/browse/OSDOCS-13110)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: I made changes to this topic: [7.1.4 PatternFly guidelines
](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/web_console/index#patternfly-guidelines)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
