### PR TITLE
OSDOCS-15749: Kueue 1.1 release notes

### DIFF
--- a/ai_workloads/kueue/release-notes.adoc
+++ b/ai_workloads/kueue/release-notes.adoc
@@ -10,6 +10,8 @@ toc::[]
 
 include::modules/kueue-compatible-environments.adoc[leveloffset=+1]
 
+include::modules/kueue-release-notes-1.1.adoc[leveloffset=+1]
+
 include::modules/kueue-release-notes-1.0.1.adoc[leveloffset=+1]
 
 include::modules/kueue-release-notes-1.0.adoc[leveloffset=+1]

--- a/modules/kueue-compatible-environments.adoc
+++ b/modules/kueue-compatible-environments.adoc
@@ -13,7 +13,7 @@ Before you install {kueue-name}, review this section to ensure that your cluster
 [id="compatible-environments-arch_{context}"]
 == Supported architectures
 
-{kueue-name} is supported on the following architectures:
+{kueue-name} version 1.1 and later is supported on the following architectures:
 
 * ARM64
 * 64-bit x86
@@ -23,7 +23,7 @@ Before you install {kueue-name}, review this section to ensure that your cluster
 [id="compatible-environments-platforms_{context}"]
 == Supported platforms
 
-{kueue-name} is supported on the following platforms:
+{kueue-name} version 1.1 and later is supported on the following platforms:
 
 * {product-title}
 * {hcp-capital} for {product-title}

--- a/modules/kueue-release-notes-1.0.adoc
+++ b/modules/kueue-release-notes-1.0.adoc
@@ -6,28 +6,29 @@
 [id="release-notes-1.0_{context}"]
 = Release notes for {kueue-name} version 1.0
 
-{kueue-name} version 1.0 is a generally available release that is supported on {product-title} versions 4.18 and 4.19 on the 64-bit x86 architecture.
-
-{kueue-name} version 1.0 uses link:https://kueue.sigs.k8s.io/docs/overview/[Kueue] version 0.11.
+[role="_abstract"]
+{kueue-name} version 1.0 is a generally available release that is supported on {product-title} versions 4.18 and 4.19 on the 64-bit x86 architecture. {kueue-name} version 1.0 uses link:https://kueue.sigs.k8s.io/docs/overview/[Kueue] version 0.11.
 
 [id="release-notes-1.0-new-features_{context}"]
-== New features in {kueue-name} version 1.0
+== New features and enhancements
 
-The following features are supported in {kueue-name} version 1.0:
+Role-based access control (RBAC):: Role-based access control (RBAC) enables you to control which types of users can create which types of {kueue-name} resources.
 
-* Role-based access control (RBAC) enables you to control which types of users can create which types of {kueue-name} resources.
+Configure resource quotas:: Configuring resource quotas by creating cluster queues, resource flavors, and local queues enables you to control the amount of resources used by user-submitted jobs and workloads.
 
-* Configuring resource quotas by creating cluster queues, resource flavors, and local queues enables you to control the amount of resources used by user-submitted jobs and workloads.
+Control job and workload management:: Labeling namespaces and configuring label policies enable you to control which jobs and workloads are managed by {kueue-name}.
 
-* Labeling namespaces and configuring label policies enable you to control which jobs and workloads are managed by {kueue-name}.
-
-* Configuring cohorts, fair sharing, and gang scheduling settings enable you to share unused, borrowable resources between queues.
+Share borrowable resources between queues:: Configuring cohorts, fair sharing, and gang scheduling settings enable you to share unused, borrowable resources between queues.
 
 [id="release-notes-1.0-known-issues_{context}"]
-== Known issues in {kueue-name} version 1.0
+== Known issues
 
-* {kueue-name} uses the `managedJobsNamespaceSelector` configuration field, so that administrators can configure which namespaces opt in to be managed by {kueue-name}. Because namespaces must be manually configured to opt in to being managed by {kueue-name}, resources in system or third-party namespaces are not impacted or managed by {kueue-name}.
+Jobs in all namespaces are reconciled if they have the `kueue.x-k8s.io/queue-name` label:: {kueue-name} uses the `managedJobsNamespaceSelector` configuration field, so that administrators can configure which namespaces opt in to be managed by {kueue-name}. Because namespaces must be manually configured to opt in to being managed by {kueue-name}, resources in system or third-party namespaces are not impacted or managed by {kueue-name}.
 +
-The current behavior in {kueue-name} allows reconciliation of `Job` resources that have the `kueue.x-k8s.io/queue-name` label, even if these resources are in namespaces that are not configured to opt in to being managed by {kueue-name}. This is inconsistent with the behavior for other core integrations like pods, deployments, and stateful sets, which are only reconciled if they are in namespaces that have been configured to opt in to being managed by {kueue-name}. (link:https://issues.redhat.com/browse/OCPBUGS-58205[OCPBUGS-58205])
+The behavior in {kueue-name} 1.0 allows reconciliation of `Job` resources that have the `kueue.x-k8s.io/queue-name` label, even if these resources are in namespaces that are not configured to opt in to being managed by {kueue-name}. This is inconsistent with the behavior for other core integrations like pods, deployments, and stateful sets, which are only reconciled if they are in namespaces that have been configured to opt in to being managed by {kueue-name}.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-58205[OCPBUGS-58205])
 
-* If you try to use the {product-title} web console to create a `Kueue` custom resource (CR) by using the form view, the web console shows an error and the resource cannot be created. As a workaround, use the YAML view to create a `Kueue` CR instead. (link:https://issues.redhat.com/browse/OCPBUGS-58118[OCPBUGS-58118])
+You cannot create a `Kueue` custom resource by using the {product-title} web console:: If you try to use the {product-title} web console to create a `Kueue` custom resource (CR) by using the form view, the web console shows an error and the resource cannot be created. As a workaround, use the YAML view to create a `Kueue` CR instead.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-58118[OCPBUGS-58118])

--- a/modules/kueue-release-notes-1.1.adoc
+++ b/modules/kueue-release-notes-1.1.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="kueue-release-notes-1.1_{context}"]
+= Release notes for {kueue-name} version 1.1
+
+[role="_abstract"]
+{kueue-name} version 1.1 is a generally available release that is supported on {product-title} versions 4.18 and later. {kueue-name} version 1.1 uses link:https://kueue.sigs.k8s.io/docs/overview/[Kueue] version 0.12.
+
+[IMPORTANT]
+====
+If you have a previously installed version of {kueue-name} on your cluster, you must uninstall the Operator and manually install version 1.1. For information see xref:../../ai_workloads/kueue/install-kueue.adoc#upgrading-kueue_install-kueue[Upgrading {kueue-name}].
+====
+
+[id="release-notes-1.1-new-features_{context}"]
+== New features and enhancements
+
+Configure a default local queue:: A default local queue serves as the local queue for newly created jobs that do not have the `kueue.x-k8s.io/queue-name` label. After you create a default local queue, any new jobs created in the namespace without a `kueue.x-k8s.io/queue-name` label automatically update to have the `kueue.x-k8s.io/queue-name: default` label.
++
+(link:https://issues.redhat.com/browse/RFE-7615[RFE-7615])
+
+Multi-architecture and {hcp-capital} support:: With this release, {kueue-name} is supported on multiple different architectures, including ARM64, 64-bit x86, ppc64le ({ibm-power-name}), and s390x ({ibm-z-name}), as well as on {hcp-capital} for {product-title}.
++
+(link:https://issues.redhat.com/browse/OCPSTRAT-2103[OCPSTRAT-2103])
++
+(link:https://issues.redhat.com/browse/OCPSTRAT-2106[OCPSTRAT-2106])
+
+[id="release-notes-1.1-fixed-issues_{context}"]
+== Fixed issues
+
+You can create a `Kueue` custom resource by using the {product-title} web console:: Before this update, if you tried to use the {product-title} web console to create a `Kueue` custom resource (CR) by using the form view, the web console showed an error and the resource could not be created. With this release, the default namespace was removed from the `Kueue` CR template. As a result, you can use the {product-title} web console to create a `Kueue` CR by using the form view.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-58118[OCPBUGS-58118])
+
+[id="release-notes-1.1-known-issues_{context}"]
+== Known issues
+
+`Kueue` CR description reads as "Not available" in the {product-title} web console:: After you install {kueue-name}, in the *Operator details* view, the description for the `Kueue` CR reads as "Not available". This issue does not affect or degrade the {kueue-name} Operator functionality.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-62185[OCPBUGS-62185])
+
+Custom resources are not deleted properly when you uninstall {kueue-name}:: After you uninstall the {kueue-op} using the *Delete all operand instances for this operator* option in the {product-title} web console, some {kueue-name} custom resources are not fully deleted. These resources can be viewed in the *Installed Operators* view with the status *Resource is being deleted*. As a workaround, you can manually delete the resource finalizers to remove them fully.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-62254[OCPBUGS-62254])


### PR DESCRIPTION
Version(s):
N/A - Kueue migration 1.1

Issue:
https://issues.redhat.com/browse/OSDOCS-15749

Link to docs preview:
Download HTML: https://github.com/user-attachments/files/22625080/release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Made updates to the 1.0 release notes (formatting only, no change req required) to align with new https://redhat-documentation.github.io/supplementary-style-guide/#release-notes guidelines