### PR TITLE
MCO 4.19 RN Fix Pinned Image Set

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -791,68 +791,10 @@ For more information, see (link:https://issues.redhat.com/browse/OCPBUGS-42671[O
 [id="ocp-release-notes-networking_{context}"]
 === Networking
 
-[id="ocp-4-19-support-for-route-advertisements-cudns-with-bgp_{context}"]
-==== Support for route advertisements for cluster user-defined networks (CUDNs) with Border Gateway Protocol (BGP)
-
-With route advertisements enabled, the OVN-Kubernetes network plugin supports the direct advertisement of routes for pods and services associated with cluster user-defined networks (CUDNs) to the provider network. This feature enables some of the following benefits:
-
-- Learns routes to pods dynamically
-- Advertises routes dynamically
-- Enables layer 3 notifications of EgressIP failovers in addition to the layer 2 ones based on gratuitous ARPs.
-- Supports external route reflectors, which reduces the number of BGP connections required in large networks
-
-For more information, see xref:../networking/advanced_networking/route_advertisements/about-route-advertisements.adoc#about-route-advertisements[About route advertisements].
-
 [id="ocp-4-19-networking-support-load-secrets_{context}"]
 ==== Creating a route with externally managed certificate (General Availability)
 
 With this release, {product-title} routes can be configured with third-party certificate management solutions, utilizing the `.spec.tls.externalCertificate` field in the route API. This allows you to reference externally managed TLS certificates through secrets, streamlining the process by eliminating manual certificate management. By using externally managed certificates, you reduce errors, ensure a smoother certificate update process, and enable the OpenShift router to promptly serve renewed certificates. For more information, see xref:../networking/ingress_load_balancing/routes/secured-routes.adoc#nw-ingress-route-secret-load-external-cert_secured-routes[Creating a route with externally managed certificate].
-
-[id="ocp-4-19-support-for-bgp-routing-protocol_{context}"]
-==== Support for the BGP routing protocol
-
-The Cluster Network Operator (CNO) now supports enabling Border Gateway Protocol (BGP) routing. With BGP, you can import and export routes to the underlying provider network and use multi-homing, link redundancy, and fast convergence. BGP configuration is managed with the `FRRConfiguration` custom resource (CR).
-
-When upgrading from an earlier version of {product-title} in which you installed the MetalLB Operator, you must manually migrate your custom frr-k8s configurations from the `metallb-system` namespace to the `openshift-frr-k8s` namespace. To move these CRs, enter the following commands:
-
-. To create the `openshift-frr-k8s` namespace, enter the following command:
-+
-[source,terminal]
-----
-$ oc create namespace openshift-frr-k8s
-----
-
-. To automate the migration, create a `migrate.sh` file with the following content:
-+
-[source,bash]
-----
-#!/bin/bash
-OLD_NAMESPACE="metallb-system"
-NEW_NAMESPACE="openshift-frr-k8s"
-FILTER_OUT="metallb-"
-oc get frrconfigurations.frrk8s.metallb.io -n "${OLD_NAMESPACE}" -o json |\
-  jq -r '.items[] | select(.metadata.name | test("'"${FILTER_OUT}"'") | not)' |\
-  jq -r '.metadata.namespace = "'"${NEW_NAMESPACE}"'"' |\
-  oc create -f -
-----
-
-. To run the migration script, enter the following command:
-+
-[source,terminal]
-----
-$ bash migrate.sh
-----
-
-. To verify that the migration succeeded, enter the following command:
-+
-[source,terminal]
-----
-$ oc get frrconfigurations.frrk8s.metallb.io -n openshift-frr-k8s
-----
-
-After the migration is complete, you can remove the `FRR-K8s` custom resources from the `metallb-system` namespace.
-
-For more information, see xref:../networking/advanced_networking/bgp_routing/about-bgp-routing.adoc#about-bgp-routing[About BGP routing].
 
 [id="ocp-4-19-networking-gateway-api-controller_{context}"]
 ==== Support for using Gateway API to configure cluster ingress traffic (General Availability)
@@ -2348,7 +2290,14 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 
+|Pinned Image Sets
+|Technology Preview
+|Technology Preview
+|General Availability ^[1]^
+
 |====
+[.small]
+. This feature is GA starting in {product-title} 4.19.11. Earlier versions remain in Technology Preview.
 
 
 [id="ocp-release-notes-machine-management-tech-preview_{context}"]
@@ -2703,11 +2652,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 
-|Pinned Image Sets
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
 |NUMA-aware scheduling supported on {hcp}
 |Not Available
 |Not Available
@@ -2905,42 +2849,6 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
-// 4.19.13
-[id="ocp-4-19-13_{context}"]
-=== RHBA-2025:16148 - {product-title} {product-version}.13 image release, bug fix, and security update advisory
-
-Issued: 23 September 2025
-
-{product-title} release {product-version}.13, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:16148[RHBA-2025:16148] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:16146[RHBA-2025:16146] advisory.
-
-Space precluded documenting all of the container images for this release in the advisory.
-
-You can view the container images in this release by running the following command:
-
-[source,terminal]
-----
-$ oc adm release info 4.19.13 --pullspecs
-----
-
-[id="ocp-4-19-13-bug-fixes_{context}"]
-==== Bug fixes
-
-* Before this update, the `config-sync-controller` did not log results due to missing logging statements in the code. As a consequence, users experienced silent failures in the `config-sync-controller`. With this release, the `config-sync-controller` logs results enhancing error diagnosis for users. (link:https://issues.redhat.com/browse/OCPBUGS-56788[OCPBUGS-56788])
-
-* Before this update, calls to retrieve an image manifest and metadata using a tagged image name did not cache the result of the lookup. As a consequence, hosted control plane memory usage quickly grew, which created performance issues. With this release, images in hosted control plane using a named tag or canonical name are cached for 12 hours. As a result, hosted control plane memory usage is optimized. (link:https://issues.redhat.com/browse/OCPBUGS-59933[OCPBUGS-59933])
-
-* Before this update, the `agent-based-installer` set the permissions for the etcd directory `/var/lib/etcd/member` as 0755 when using {sno} deployment instead of 0700, which is correctly set on a multi-node deployment. With this release, the etcd directory `/var/lib/etcd/member` permissions are set to 0700 for {sno} deployments. (link:https://issues.redhat.com/browse/OCPBUGS-61313[OCPBUGS-61313])
-
-* Before this update, the `PrometheusRemoteWriteBehind` alert fired if the remote endpoint never received any data. With this release, the `PrometheusRemoteWriteBehind` alert no longer fires if the remote endpoint has not yet received any data. (link:https://issues.redhat.com/browse/OCPBUGS-61486[OCPBUGS-61486])
-
-* Before this update, it was possible for webhook failures to trigger a `kube-apiserver` crash while generating an audit log entry for a request. As a consequence, API server disruptions were possible. With this release, the audit system has been updated so that the `kube-apiserver` no longer crashes and the API disruptions are resolved. (link:https://issues.redhat.com/browse/OCPBUGS-61488[OCPBUGS-61488])
-
-* Before this update, the *Operand details page* in the web console would show additional status items in a third column, which resulted in the content appearing squashed. With this update, the defect has been corrected, so that only two columns display in the details page. (link:https://issues.redhat.com/browse/OCPBUGS-61781[OCPBUGS-61781])
-
-[id="ocp-4-19-13-updating_{context}"]
-==== Updating
-To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
-
 // 4.19.12
 [id="ocp-4-19-12_{context}"]
 === RHBA-2025:15694 - {product-title} {product-version}.12 image release, bug fix, and security update advisory
@@ -2964,6 +2872,8 @@ $ oc adm release info 4.19.12 --pullspecs
 * With this update, the `cluster-etcd-operator` Operator now implements a multi-stage notification system for the `etcdDatabaseQuotaLowSpace` alert to proactively manage etcd storage quotas. This enhancement prevents API server instability by providing earlier warnings of low database space. As etcd disk space usage reaches 65%, 75% and 85%, administrators now receive alerts with a severity level of info, warning, or critical. (link:https://issues.redhat.com/browse/OCPBUGS-60443[OCPBUGS-60443])
 
 * With this update, the collection of command line logs from `virt-launcher` pods across a Kubernetes cluster are enabled. JSON-encoded logs are saved at the path `namespaces/<namespace_name>/pods/<pod_name>/virt-launcher.json`, facilitating troubleshooting and debugging of virtual machines. (link:https://issues.redhat.com/browse/OCPBUGS-61485[OCPBUGS-61485])
+
+* In clusters with slow, unreliable connections to an image registry, you can use a `PinnedImageSet` object to get the images in advance, before they are actually needed. You can associate those images with a machine config pool. This ensures that the images are available when needed. The `must-gather` for the Machine Config Operator now includes all `PinnedImageSet` objects in the cluster. For more information, see xref:../machine_configuration/machine-config-pin-preload-images-about.adoc#machine-config-pin-preload-images_machine-config-operator[Pinning images to nodes].
 
 [id="ocp-4-19-12-bug-fixes_{context}"]
 ==== Bug fixes
@@ -3001,8 +2911,6 @@ $ oc adm release info 4.19.11 --pullspecs
 ==== Enhancements
 
 * The machine config nodes custom resource, which you can use to monitor the progress of machine configuration updates to nodes, is now generally available. With the promotion to General Availability, you can view the status of updates to custom machine config pools, in addition to the control plane and worker pools. The functionality for the feature has not changed. However, some of the information in the command output and in the status fields in the `MachineConfigNode` object have been updated. The `must-gather` for the Machine Config Operator includes all `MachineConfigNodes` objects in the cluster. For more information, see xref:../machine_configuration/index.adoc#checking-mco-node-status_machine-config-overview[About checking machine config node status].
-
-* In clusters with slow, unreliable connections to an image registry, you can use a `PinnedImageSet` object to get the images in advance, before they are actually needed. You can associate those images with a machine config pool. This ensures that the images are available when needed. The `must-gather` for the Machine Config Operator now includes all `PinnedImageSet` objects in the cluster. For more information, see xref:../machine_configuration/machine-config-pin-preload-images-about.adoc#machine-config-pin-preload-images_machine-config-operator[Pinning images to nodes].
 
 * With this update, the Kubernetes API server distribution is optimized, ensuring a balanced load among all primary nodes after a quorum is reestablished. This addresses the issue of a single API server receiving the majority of live connections, and causing high CPU usage. Resource utilization is improved and CPU spikes are reduced during primary node or API server restarts. (link:https://issues.redhat.com/browse/OCPBUGS-60121[OCPBUGS-60121])
 


### PR DESCRIPTION
Per private message in Slack, the MCO Pinned Image Set feature (PIS) was released in 4.19.12, not 4.19.11. Also, the PIS was listed in an incorrect Tech Preview list and needed to be updated to GA for 4.19.