### PR TITLE
[OSDOCS-8305]Document which specific components and traffic flows are encrypted in OSD

### DIFF
--- a/modules/policy-security-regulation-compliance.adoc
+++ b/modules/policy-security-regulation-compliance.adoc
@@ -28,6 +28,17 @@ Red Hat performs periodic vulnerability scanning of {product-title} using indust
 === Firewall and DDoS protection
 Each {product-title} cluster is protected by a secure network configuration at the cloud infrastructure level using firewall rules (AWS Security Groups or Google Cloud Compute Engine firewall rules). {product-title} customers on AWS are also protected against DDoS attacks with link:https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html[AWS Shield Standard].
 Similarly, all GCP load balancers and public IP addresses used by {product-title} on GCP are protected against DDoS attacks with link:https://cloud.google.com/armor/docs/managed-protection-overview[Google Cloud Armor Standard].
+
+[id="Component-traffic-flow-encryption_{context}"]
+=== Component and traffic flow encryption
+{product-title} components are configured to use Transport Layer Security (TLS) for secure communication, prioritizing TLS 1.3 for its performance and security enhancements. For components not yet supporting TLS 1.3, robust TLS 1.2 cipher suites are configured. This comprehensive TLS configuration ensures the encryption of various traffic flows within and to the OpenShift Dedicated environment. For more information, refer to link:https://access.redhat.com/articles/5348961#openshift-4-10[TLS configuration on OpenShift] and link:https://www.redhat.com/en/about/appendices[Appendix 4(Online Subscription Services).]
+
+** Starting with version 4.7, the OpenShift API server (port 6443), kube-controller (port 10257), and kube-scheduler (port 10259) are configured to use TLS 1.3 with a reduced set of secure cipher suites.
+** The Web Console and etcd also use secure default cipher suites. As OpenShift is updated, older and more vulnerable cipher options are deprecated for these components.
+** The Kubelet (ports 10248, 10250) secures node-level operations using TLS 1.3, while also allowing the explicit configuration of specific TLS 1.2 cipher suites.
+** Ingress traffic is secured by the {product-title} Router through a robust TLS configuration. By default, it uses a hardened set of TLS 1.2 cipher suites, and in OpenShift 4.6 and later, it also supports TLS 1.3 for enhanced security.
+** By default, OpenShift 4 enables secure TLS configurations on numerous internal services to protect their communications. These services include the Machine Config Server (ports 22623-22624), Node Exporter (ports 9100-9101), and Kube RBAC Proxy (port 9192).
+
 [id="private-clusters_{context}"]
 === Private clusters and network connectivity
 Customers can optionally configure their {product-title} cluster endpoints (web console, API, and application router) to be made private so that the cluster control plane or applications are not accessible from the Internet.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.19+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8305
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://99666--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/policy-process-security.html#Component-traffic-flow-encryption_policy-process-security
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
