### PR TITLE
OSDOCS-16036: Removing an unneeded legal notice from Introduction to ROSA

### DIFF
--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -34,8 +34,8 @@ Distros: openshift-rosa-hcp
 Topics:
 - Name: Welcome
   File: index
-- Name: Legal notice
-  File: legal-notice
+# - Name: Legal notice
+#   File: legal-notice
 - Name: ROSA overview
   File: about-hcp
 - Name: AWS STS and ROSA explained


### PR DESCRIPTION
[OSDOCS-16036](https://issues.redhat.com/browse/OSDOCS-16036): Removing an unneeded legal notice from Introduction to ROSA

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-16036

Link to docs preview:
https://99667--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/
An extra legal notice was present between Welcome and ROSA overview and is no longer visible.

QE review:
N/A

Additional information:
Commenting it out to see if the change is synced into GitLab.