### PR TITLE
OSDOCS#16220: Update the z-stream RNs for 4.14.57

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3420,6 +3420,33 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.57
+[id="ocp-4-14-57_{context}"]
+=== RHSA-2025:16165 - {product-title} 4.14.57 bug fix and security update
+
+Issued: 25 September 2025
+
+{product-title} release 4.14.57, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:16165[RHSA-2025:16165] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:16163[RHBA-2025:16163] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.57 --pullspecs
+----
+
+[id="ocp-4-14-57-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, cluster installations failed due to a missing application programming interface (API) endpoint certificate in affected versions. This occurrence caused unresponsive certificate issues and installation problems. With this release, certificate issues during a {hcp-capital} cluster installation are resolved, and the Advanced Cluster Management (ACM) agent does not stall. (link:https://issues.redhat.com/browse/OCPBUGS-61176[OCPBUGS-61176])
+
+[id="ocp-4-14-57-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.56
 [id="ocp-4-14-56_{context}"]
 === RHSA-2025:14855 - {product-title} 4.14.56 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-16220](https://issues.redhat.com//browse/OSDOCS-16220)

Link to docs preview:
[4.14.57](https://99670--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-57_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
The errata URLs will return 404 until the go-live date of 9/25/25.
