### PR TITLE
[enterprise-4-18] OCPBUGS-61648: Remove NODE_NAME and fix indentation

### DIFF
--- a/modules/ptp-reference-deployment-and-service-crs.adoc
+++ b/modules/ptp-reference-deployment-and-service-crs.adoc
@@ -45,13 +45,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: NODE_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-              volumeMounts:
-                - name: pubsubstore
-                  mountPath: /store
+          volumeMounts:
+            - name: pubsubstore
+              mountPath: /store
           ports:
             - name: metrics-port
               containerPort: 9091


### PR DESCRIPTION
OCPBUGS-61648: Remove NODE_NAME and fix indentation

Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OCPBUGS-61648

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
