### PR TITLE
MIG-1772: Docs mention annotation is not supported in OCP 4.19

### DIFF
--- a/migration_toolkit_for_containers/mtc-migrating-vms.adoc
+++ b/migration_toolkit_for_containers/mtc-migrating-vms.adoc
@@ -57,13 +57,6 @@ Enable the feature gate by running the following command:
 $ oc annotate --overwrite -n openshift-cnv hco kubevirt-hyperconverged kubevirt.kubevirt.io/jsonpatch='[ {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-", "value": "VolumesUpdateStrategy"}, {"op": "add", "path": "/spec/configuration/developerConfiguration/featureGates/-", "value": "VolumeMigration"} ]'
 ----
 
-[WARNING]
-====
-Red{nbsp}Hat does not support clusters with the annotation enabling this feature gate.
-
-Do not add this annotation in a production cluster, if you add that annotation you receive a cluster wide alert indicating that your cluster is no longer supported.
-====
-
 For more information about the deployments and custom resource definitions (CRDs) that the migration controller uses to manipulate the VMs, see xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migration-controller-options_advanced-migration-options-3-4[Migration controller options].
 
 [NOTE]

--- a/migration_toolkit_for_containers/mtc-migrating-vms.adoc
+++ b/migration_toolkit_for_containers/mtc-migrating-vms.adoc
@@ -48,7 +48,7 @@ To support storage live migration, you need to deploy {VirtProductName} version 
 
 You also need to configure `KubeVirt` to enable storage live migration according to the xref:../virt/live_migration/virt-configuring-live-migration.adoc#virt-configuring-live-migration-limits_virt-configuring-live-migration[Configuring live migration].
 
-In {VirtProductName} 4.17.0, not all the required feature gates are enabled. However, to use the storage live migration feature, you must enable the feature gate.
+If the required feature gate to use the storage live migration feature are not enabled, you can enable the feature gate.
 
 Enable the feature gate by running the following command:
 


### PR DESCRIPTION
### JIRA

* [MIG-1772](https://issues.redhat.com/browse/MIG-1772)

In the 4.19 documentation, we see the following [warning](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/migration_toolkit_for_containers/mtc-migrating-vms#mtc-vm-storage-prerequisites-for-migration_mtc-migrating-vms):
```
Warning
Red Hat does not support clusters with the annotation enabling this feature gate.
Do not add this annotation in a production cluster, if you add that annotation you receive a cluster wide alert indicating that your cluster is no longer supported. 
```
 
This is only relating to OCP 4.17, so remove entirely as it relates specifically to 4.17.

### VERSIONS

* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19
* OCP 4.20 → branch/enterprise-4.20

### Link to docs preview:

* [Prerequisites](https://99683--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-migrating-vms.html#mtc-vm-storage-prerequisites-for-migration_mtc-migrating-vms)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
