### PR TITLE
[SRVKE-1797] Authorization and EventPolicy in Eventing is TP in 1.36

### DIFF
--- a/eventing/serverless-event-authorization-eventpolicy.adoc
+++ b/eventing/serverless-event-authorization-eventpolicy.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Authorization and EventPolicy in Knative Eventing
+include::snippets/technology-preview.adoc[]
+
 Knative Eventing provides a mechanism to secure event delivery to prevent unauthorized access. Event-driven systems often rely on multiple producers and consumers of events, and without proper authorization controls, malicious or unintended event flows could compromise the system.
 
 To achieve fine-grained access control, Knative Eventing introduces the EventPolicy custom resource. This resource allows administrators and developers to define which entities are authorized to send events to specific consumers within a namespace. By applying EventPolicies, you can ensure that only trusted event sources or service accounts are able to send data to selected event consumers and this improves the overall security posture of their event-driven architecture.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -18,6 +18,11 @@ The following table provides information about which {ServerlessProductName} fea
 |1.35
 |1.36
 
+|Authorization and EventPolicy in Knative Eventing
+|-
+|-
+|TP
+
 |`EventTransform` API for JSON event transformation
 |-
 |-


### PR DESCRIPTION
Version(s):
- serverless-docs-1.36 (-> none for cherry-picking)

Issue:
- https://issues.redhat.com/browse/SRVKE-1797

Link to docs preview:
 - [Authorization and EventPolicy in Knative Eventing](https://99690--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/serverless-event-authorization-eventpolicy.html)

 - [TP and GA features](https://99690--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes) 

QE review:
- [x] QE has approved this change.

