### PR TITLE
[RHDEVDOCS-6657] Release notes for Pipelines 1.20 (FIXED_2)

### DIFF
--- a/modules/op-configuration-rbac-trusted-ca-flags.adoc
+++ b/modules/op-configuration-rbac-trusted-ca-flags.adoc
@@ -2,7 +2,7 @@
 // * install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="op-configuration-rbac-trusted-ca-flags_{context}"]
+[id="op-configuration-rbac-trusted-ca-flags.adoc_{context}"]
 = Configuration of RBAC and Trusted CA flags
 
 The {pipelines-title} Operator provides independent control over RBAC resource creation and Trusted CA bundle config map through two separate flags, `createRbacResource` and `createCABundleConfigMaps`.

--- a/release_notes/op-release-notes-1-20.adoc
+++ b/release_notes/op-release-notes-1-20.adoc
@@ -34,7 +34,7 @@ include::modules/op-release-notes-1-20-0.adoc[leveloffset=+1]
 //Additional resources 1.20
 .Additional resources
 * xref:../secure/using-buildah-ns-tekton-task.adoc#op-differences-between-buildah-buildah-ns-tasks_using-buildah-ns-tekton-task[Differences between `buildah` and `buildah-ns` tasks]
-* xref:../install_config/customizing-configurations-in-the-tektonconfig-cr.adoc#op-configuration-rbac-trusted-ca-flags_customizing-configurations-in-the-tektonconfig-cr[Configuration of RBAC and Trusted CA flags].  
+//* xref:../install_config/customizing-configurations-in-the-tektonconfig-cr.adoc#op-configuration-rbac-trusted-ca-flags_customizing-configurations-in-the-tektonconfig-cr[Configuration of RBAC and Trusted CA flags].  
 * xref:../install_config/customizing-configurations-in-the-tektonconfig-cr.adoc#event-pruner-configuration_customizing-configurations-in-the-tektonconfig-cr[Enabling the event-based pruner]
 * xref:../pac/install-config-pipelines-as-code.adoc#customizing-pipelines-as-code-configuration_install-config-pipelines-as-code[Customizing {pac} configuration]
 * xref:../pac/creating-pipeline-runs-pac.adoc#op-parameters-pipeline-run-using-pipelines-as-code_creating-pipeline-runs-pac[Commit and URL Information]


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.20

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6657

Link to docs preview:
- [Pipelines 1.20 release notes](https://99699--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-20.html)

QE review:
- [x] QE has approved this change.

Additional info:
- reviews done on https://github.com/openshift/openshift-docs/pull/98437