### PR TITLE
OSDOCS-16183: Kueue upgrade procedure docs 1.1

### DIFF
--- a/ai_workloads/kueue/install-disconnected.adoc
+++ b/ai_workloads/kueue/install-disconnected.adoc
@@ -24,6 +24,8 @@ include::modules/kueue-install-kueue-operator.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../security/cert_manager_operator/cert-manager-operator-install.adoc#installing-the-cert-manager-operator-for-red-hat-openshift[Installing the {cert-manager-operator}]
 
+include::modules/upgrading-kueue.adoc[leveloffset=+1]
+
 include::modules/kueue-create-kueue-cr.adoc[leveloffset=+1]
 
 include::modules/kueue-label-namespaces.adoc[leveloffset=+1]

--- a/ai_workloads/kueue/install-kueue.adoc
+++ b/ai_workloads/kueue/install-kueue.adoc
@@ -14,8 +14,9 @@ include::modules/kueue-install-kueue-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../../security/cert_manager_operator/cert-manager-operator-install.adoc#installing-the-cert-manager-operator-for-red-hat-openshift[Installing the {cert-manager-operator}]
+
+include::modules/upgrading-kueue.adoc[leveloffset=+1]
 
 include::modules/kueue-create-kueue-cr.adoc[leveloffset=+1]
 

--- a/modules/upgrading-kueue.adoc
+++ b/modules/upgrading-kueue.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/install-disconnected.adoc
+// * ai_workloads/kueue/install-kueue.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="upgrading-kueue_{context}"]
+= Upgrading {kueue-name}
+
+[role="_abstract"]
+If you have previously installed {kueue-name}, you must manually upgrade your deployment to the latest version to use the latest bug fixes and feature enhancements.
+
+.Prerequisites
+
+* You have installed a previous version of {kueue-name}.
+* You are logged in to the {product-title} web console with cluster administrator permissions.
+
+.Procedure
+
+. In the {product-title} web console, click *Operators* -> *Installed Operators*, then select *{kueue-name}* from the list.
+
+. From the *Actions* drop-down menu, select *Uninstall Operator*.
+
+. The *Uninstall Operator?* dialog box opens. Click *Uninstall*.
++
+[IMPORTANT]
+====
+Selecting the *Delete all operand instances for this operator* checkbox before clicking *Uninstall* deletes all existing resources from the cluster, including:
+
+* The `Kueue` CR
+* Any cluster queues, local queues, or resource flavors that you have created
+
+Leave this box unchecked when upgrading your cluster to retain your created resources.
+====
+
+. In the {product-title} web console, click *Operators* -> *OperatorHub*.
+
+. Choose *{kueue-op}* from the list of available Operators, and click *Install*.
+
+.Verification
+
+. Go to *Operators* -> *Installed Operators*.
+
+. Confirm that the *{kueue-op}* is listed with *Status* as *Succeeded*.
+
+. Confirm that the version shown under the Operator name in the list is the latest version.


### PR DESCRIPTION
Version(s):
`kueue-migration-1.1`

Issue:
https://issues.redhat.com/browse/OSDOCS-16183

Link to docs preview:

Download HTML previews:

- https://github.com/user-attachments/files/22605325/install-kueue.html
- https://github.com/user-attachments/files/22605326/install-disconnected.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The uninstall procedure for Kueue will be documented separately in https://issues.redhat.com/browse/OSDOCS-16318
