### PR TITLE
[RHDEVDOCS-6764] Add IBM Z env into 1.20 RN

### DIFF
--- a/modules/op-release-notes-1-20-0.adoc
+++ b/modules/op-release-notes-1-20-0.adoc
@@ -184,7 +184,7 @@ $ oc patch configmap pipelines-as-code -n openshift-pipelines --type=json -p='[{
 * Using `opc pr logs` in the OpenShift namespace may fail with repeated `Failed to list objects from openshift namespace` errors for both admin and non-admin users. 
 
 .{tekton-cache}
-* On IBM P environments, the `cache-fetch` step may fail with the error `failed to change ownership: operation not permitted`. This typically occurs because of filesystem permission restrictions on the underlying storage.
+* On IBM P and IBM Z environments, the `cache-fetch` step might fail with the `failed to change ownership: operation not permitted` error message. This issue occurs due to filesystem permission restrictions on the underlying storage.
 
 .{tekton-chains}
 * Pod anti-affinity rules are not applied to `tekton-chains-controller` replicas.
@@ -236,7 +236,7 @@ data:
 
 * Before this update, the `git-clone` task failed with a `No such remote 'origin'` error messgae if the `origin` remote was missing from the repository. With this update, the task automatically adds the `origin` remote to the repository configuration, ensuring correct setup and successful cloning.
 
-* Before this update, {pac} failed immediately when resource quotas were exceeded, canceling the run and interrupting user workflows. With this update, the controllers retry and automatically rerun if resources become available, reducing unnecessary cancellations and improving pipeline reliability.
+* Before this update, the `pipeline` controller failed immediately when resource quotas were exceeded, canceling the run and interrupting user workflows. With this update, the controller retries and automatically reruns if resources become available, reducing unnecessary cancellations and improving pipeline reliability.
 
 * Before this update, the pipeline builder UI failed to save a pipeline when the `buildah` task `BUILD_ARGS` parameter had the default value `[""]`. The validation incorrectly rejected empty strings in arrays, even though the task could run successfully.
 With this update, the issue is fixed, allowing pipelines with default `BUILD_ARGS` parameter to be saved correctly.


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6764

Link to docs preview:
- [1.20 RNs](https://99761--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-20.html)

QE review:
- [ ] QE has approved this change.
