### PR TITLE
OBSDOCS-1805: Tailored Network Policies for Cluster Logging Operator

### DIFF
--- a/configuring/cluster-logging-collector.adoc
+++ b/configuring/cluster-logging-collector.adoc
@@ -23,4 +23,27 @@ include::modules/configuring-the-collector-to-listen-for-connections-as-a-syslog
 
 include::modules/configuring-pod-rollout-strategy.adoc[leveloffset=+1]
 
+[id="network_policies-to-override-restrictive-network-in-a-cluster_{context}"]
+== Network policies to override restrictive network in a cluster
+
+{clo} optionally provides permissive `NetworkPolicy` resources to override any restrictive network policies present in an {ocp-product-title} cluster.
+
+The `NetworkPolicy` resource ensures that all ingress and egress traffic is allowed even when the following restrictions are in place:
+
+* Restrictive default `NetworkPolicies` resource has been defined in the cluster.
+* `AdminNetworkPolicy` configuration that limits pod communications is applied.
+* Namespace-level network restrictions are defined.
+
+{clo} provides permissive `NetworkPolicy` resources for the collector and the `LogFileMetricExporter`.
+
+include::modules/collector-network-policy.adoc[leveloffset=+2]
+
+include::modules/configuring-network-policy-rule-set-for-a-collector.adoc[leveloffset=+2]
+
+include::modules/logfilemetricexporter-network-policy.adoc[leveloffset=+2]
+
+include::modules/configuring-network-policy-rule-set-for-logfilemetricexporter.adoc[leveloffset=+2]
+
+include::modules/creating-an-adminnetworkpolicy-rule-for-collector-network-policy.adoc[leveloffset=+2]
+
 //include::modules/cluster-logging-collector-tuning.adoc[leveloffset=+1]

--- a/configuring/configuring-log-forwarding.adoc
+++ b/configuring/configuring-log-forwarding.adoc
@@ -172,4 +172,3 @@ include::modules/input-spec-filter-labels-expressions.adoc[leveloffset=+2]
 include::modules/logging-content-filter-prune-records.adoc[leveloffset=+2]
 include::modules/input-spec-filter-audit-infrastructure.adoc[leveloffset=+1]
 include::modules/input-spec-filter-namespace-container.adoc[leveloffset=+1]
-

--- a/modules/collector-network-policy.adoc
+++ b/modules/collector-network-policy.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * configuring/cluster-logging-collector.adoc
+
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-10-13
+:_mod-docs-content-type: CONCEPT
+
+[id="collector-network-policy_{context}"]
+= Collector network policy
+
+[role="_abstract"]
+{clo} creates a `NetworkPolicy` resource for the collector pods when a `ClusterLogForwarder` resource is deployed if you specify a network policy rule set in the `ClusterLogForwarder` custom resource (CR).
+`NetworkPolicy` resources are automatically created, updated, and removed along with the component deployment lifecycle.
+
+You can specify the network policy rule set by defining the `networkPolicy.ruleSet` field in the collector specification.
+The collector supports the following network policy rule set types:
+
+`AllowAllIngressEgress`::
+ Allows all ingress and egress traffic.
+
+`RestrictIngressEgress`::
+Restricts traffic to specific ports based on the configured inputs, outputs, and the metrics port.
+
+If you do not define a `spec.collector.networkPolicy` field, the Operator will not create a `NetworkPolicy` resource for the collector. 
+Without a `NetworkPolicy` resource, logging components might not function if a cluster-wide `AdminNetworkPolicy` restricts traffic or other restrictive network policies are in place.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/network_security/index#network-policy-apis[Understanding network policy APIs]

--- a/modules/configuring-network-policy-rule-set-for-a-collector.adoc
+++ b/modules/configuring-network-policy-rule-set-for-a-collector.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * configuring/cluster-logging-collector.adoc
+
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-10-13
+:_mod-docs-content-type: PROCEDURE
+
+[id="configuring-network-policy-rule-set-for-a-collector_{context}"]
+= Configuring network policy rule set for a collector
+
+[role="_abstract"]
+Define a network policy rule set so that {clo} creates a `NetworkPolicy` resource for the collector pods when the `ClusterLogForwarder` resource is deployed.
+The `NetworkPolicy` resource overrides network restrictions to ensure that the permitted ingress and egress traffic for the collector pods is allowed to flow.
+
+.Prerequisites
+* You have administrator permissions.
+* You have installed the {oc-first}.
+* You have installed the {clo}.
+* You have created a `ClusterLogForwarder` custom resource (CR).
+
+.Procedure
+. Update the `ClusterLogForwarder` CR:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: my-forwarder
+  namespace: openshift-logging
+spec:
+  collector:
+    networkPolicy:
+      ruleSet: <RestrictIngressEgress_or_AllowAllIngressEgress>
+  # ... 
+----
++
+Where the value for the `ruleSet` field can be either `RestrictIngressEgress` or `AllowAllIngressEgress`.
+
+. Apply the configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----

--- a/modules/configuring-network-policy-rule-set-for-logfilemetricexporter.adoc
+++ b/modules/configuring-network-policy-rule-set-for-logfilemetricexporter.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * configuring/cluster-logging-collector.adoc
+
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-10-13
+:_mod-docs-content-type: PROCEDURE
+
+[id="configuring-network-policy-rule-set-for-logfilemetricexporter_{context}"]
+= Configuring network policy rule set for LogFileMetricExporter
+
+[role="_abstract"]
+Define a network policy rule set so that {clo} creates a `NetworkPolicy` resource for the `LogFileMetricExporter` pods when the `LogFileMetricExporter` resource is deployed.
+The `NetworkPolicy` resource overrides network restrictions to ensure that the permitted ingress and egress traffic for the `LogFileMetricExporter` pods is allowed to flow.
+
+.Prerequisites
+* You have administrator permissions.
+* You have installed the {oc-first}.
+* You have installed the {clo}.
+* You have created a `LogFileMetricExporter` CR.
+
+
+.Procedure
+
+. Update the `LogFileMetricExporter` CR:
++
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1alpha1
+kind: LogFileMetricExporter
+metadata:
+  name: my-lfme
+  namespace: openshift-logging
+spec:
+  networkPolicy:
+    ruleSet: <AllowAllIngressEgress_or_AllowIngressMetrics>
+#...
+----
++
+Where the value for the `ruleSet` field can be either `AllowAllIngressEgress` or `AllowIngressMetrics`.
+
+. Apply the configuration by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----

--- a/modules/creating-an-adminnetworkpolicy-rule-for-collector-network-policy.adoc
+++ b/modules/creating-an-adminnetworkpolicy-rule-for-collector-network-policy.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+//
+// * configuring/cluster-logging-collector.adoc
+
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-10-13
+:_mod-docs-content-type: PROCEDURE
+
+[id="creating-an-adminnetworkpolicy-rule-for-collector-network-policy_{context}"]
+= Creating an AdminNetworkPolicy rule for resources managed by {clo}
+
+[role="_abstract"]
+To ensure that the pods running resources managed by {clo} can communicate when an `AdminNetworkPolicy` configuration is blocking traffic, create an `AdminNetworkPolicy` rule that delegates to a `NetworkPolicy` definition.
+
+{ocp-product-title} network policy precedence:
+
+* `AdminNetworkPolicy`: Cluster-admin controlled, highest priority.
+* `BaselineAdminNetworkPolicy`: Default fallback rules.
+* `NetworkPolicy`: Namespace-level policies. This is where collector policies reside.
+
+.Prerequisites
+* You have administrator permissions.
+* You installed the {oc-first}.
+
+.Procedure
+. Create an `AdminNetworkPolicy` rule:
++
+[source,yaml]
+----
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: allow-logging-collector-delegation
+spec:
+  priority: 50 # Adjust based on your cluster's ANP priority scheme. Lower number means higher priority
+  subject:
+    pods: # Target the pods in openshift-logging namespace
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-logging
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: <name>
+          app.kubernetes.io/instance: <instance>
+          app.kubernetes.io/managed-by: cluster-logging-operator
+          app.kubernetes.io/part-of: cluster-logging
+          app.kubernetes.io/component: <component>
+  ingress:
+    - name: "delegate-to-collector-ingress"
+      action: "Pass"
+      from:
+        # Select all pods in all namespaces as the source.
+        - pods:
+            namespaceSelector: {}
+            podSelector: {}
+  egress:
+    - name: "delegate-to-collector-egress"
+      action: "Pass"
+      to:
+        # Select all pods in all namespaces for internal traffic.
+        - pods:
+            namespaceSelector: {}
+            podSelector: {}
+        # Select all external destinations for egress traffic.
+        - networks:
+          - "0.0.0.0/0"
+          - "::/0"
+----
++
+To apply this network policy to all the resources in a namespace, remove `app.kubernetes.io/name`, `app.kubernetes.io/instance`, and `app.kubernetes.io/component` fields. To apply the admin network policy to specific resources, define the fields as follows:  
++
+* Replace `<name>` with the name of the collector or the `LogFileMetricExporter` resource.
+* Replace `<instance>` with the instance name of the collector or the `LogFileMetricExporter` resource.
+* Replace `<component>` with the value `collector` or `logfilesmetricexporter`.
+
+
+. Apply the `AdminNetworkPolicy` rule by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/network_security/index#ovn-k-anp[OVN-Kubernetes AdminNetworkPolicy]

--- a/modules/logfilemetricexporter-network-policy.adoc
+++ b/modules/logfilemetricexporter-network-policy.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * configuring/cluster-logging-collector.adoc
+
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-10-13
+:_mod-docs-content-type: CONCEPT
+
+[id="logfilemetricexporter-network-policy_{context}"]
+= LogFileMetricExporter network policy
+
+[role="_abstract"]
+{clo} creates a `NetworkPolicy` resource for the metric exporter pods when a `LogFileMetricExporter` resource is deployed if you specify a network policy rule set in the `LogFileMetricExporter` custom resource (CR).
+`NetworkPolicy` resources are automatically created, updated, and removed along with the component deployment lifecycle.
+
+The `LogFileMetricExporter` resource supports the following network policy rule set types:
+
+`AllowIngressMetrics`:: Allows ingress traffic only on the metrics port, denies all egress traffic.
+`AllowAllIngressEgress`:: 
+Allows all ingress and egress traffic.
+
+If you do not define a `spec.networkPolicy` field, the Operator will not create a `NetworkPolicy` resource for the `LogFileMetricExporter`.
+Without a `NetworkPolicy` resource, logging components might not function if a cluster-wide `AdminNetworkPolicy` restricts traffic or other restrictive network policies are in place.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/network_security/index#network-policy-apis[Understanding network policy APIs]
+


### PR DESCRIPTION
Version(s): 6.4
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-1805
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://99768--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/cluster-logging-collector.html#network_policies-to-override-restrictive-network-in-a-cluster_cluster-logging-collector
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
