### PR TITLE
OSDOCS-14901-14RE: Added network-type-migration- annotation step to n…

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -461,6 +461,13 @@ $ oc patch Network.operator.openshift.io cluster --type='merge' \
 ----
 $ oc delete namespace openshift-sdn
 ----
++
+.. After a successful migration operation, remove the `network.openshift.io/network-type-migration-` annotation from the `network.config` custom resource by entering the following command:
++
+[source,terminal]
+----
+$ oc annotate network.config cluster network.openshift.io/network-type-migration-
+----
 
 .Next steps
 


### PR DESCRIPTION
Version(s):
4.12 to 4.14

Issue:
[OSDOCS-14901](https://issues.redhat.com/browse/OSDOCS-14901)

Link to docs preview:
* [Rolling update](https://99786--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/rollback-to-ovn-kubernetes.html#nw-ovn-kubernetes-migration_roll-back-to-ovn-kubernetes)
* [Migrating to the OVN-Kubernetes network plugin by using the offline migration method](https://99786--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn)

- [x] SME has approved this change (Sanjay Tripathi).
- [x] QE has approved this change (Zhanqi Zhao).

