### PR TITLE
Moving PIS and MCN release notes to 4.19.12 and updating PIS tech preview table to GA

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2333,7 +2333,7 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.17 |4.18 |4.19
 
-|Improved MCO state reporting (`oc get machineconfigpool`)
+|Improved MCO state reporting (`oc get machineconfignode`)
 |Technology Preview
 |Technology Preview
 |Technology Preview
@@ -2343,8 +2343,14 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 
-|====
+|Pinned Image Sets
+|Technology Preview
+|Technology Preview
+|General Availability ^1^
 
+|====
+[.small]
+. This feature is GA starting in {product-title} 4.19.12. Earlier 4.19.x versions remain in Technology Preview.
 
 [id="ocp-release-notes-machine-management-tech-preview_{context}"]
 === Machine management Technology Preview features
@@ -2698,11 +2704,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 
-|Pinned Image Sets
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
 |NUMA-aware scheduling supported on {hcp}
 |Not Available
 |Not Available
@@ -2960,6 +2961,10 @@ $ oc adm release info 4.19.12 --pullspecs
 
 * With this update, the collection of command line logs from `virt-launcher` pods across a Kubernetes cluster are enabled. JSON-encoded logs are saved at the path `namespaces/<namespace_name>/pods/<pod_name>/virt-launcher.json`, facilitating troubleshooting and debugging of virtual machines. (link:https://issues.redhat.com/browse/OCPBUGS-61485[OCPBUGS-61485])
 
+* With this update, the machine config nodes custom resource, which you can use to monitor the progress of machine configuration updates to nodes, is now generally available. With the promotion to General Availability, you can view the status of updates to custom machine config pools, in addition to the control plane and worker pools. The functionality for the feature has not changed. However, some of the information in the command output and in the status fields in the `MachineConfigNode` object have been updated. The `must-gather` for the Machine Config Operator includes all `MachineConfigNodes` objects in the cluster. For more information, see xref:../machine_configuration/index.adoc#checking-mco-node-status_machine-config-overview[About checking machine config node status].
+
+* With this update, the `PinnedImageSet` object, which you can use to get the container images in advance, before they are actually needed, is now generally available. You can associate these images with a machine config pool. In clusters with slow, unreliable connections to an image registry, pinning images ensures that the images are available when needed. The `must-gather` for the Machine Config Operator now includes all `PinnedImageSet` objects in the cluster. For more information, see xref:../machine_configuration/machine-config-pin-preload-images-about.adoc#machine-config-pin-preload-images_machine-config-operator[Pinning images to nodes].
+
 [id="ocp-4-19-12-bug-fixes_{context}"]
 ==== Bug fixes
 
@@ -2994,10 +2999,6 @@ $ oc adm release info 4.19.11 --pullspecs
 
 [id="ocp-4-19-11-enhancements_{context}"]
 ==== Enhancements
-
-* The machine config nodes custom resource, which you can use to monitor the progress of machine configuration updates to nodes, is now generally available. With the promotion to General Availability, you can view the status of updates to custom machine config pools, in addition to the control plane and worker pools. The functionality for the feature has not changed. However, some of the information in the command output and in the status fields in the `MachineConfigNode` object have been updated. The `must-gather` for the Machine Config Operator includes all `MachineConfigNodes` objects in the cluster. For more information, see xref:../machine_configuration/index.adoc#checking-mco-node-status_machine-config-overview[About checking machine config node status].
-
-* In clusters with slow, unreliable connections to an image registry, you can use a `PinnedImageSet` object to get the images in advance, before they are actually needed. You can associate those images with a machine config pool. This ensures that the images are available when needed. The `must-gather` for the Machine Config Operator now includes all `PinnedImageSet` objects in the cluster. For more information, see xref:../machine_configuration/machine-config-pin-preload-images-about.adoc#machine-config-pin-preload-images_machine-config-operator[Pinning images to nodes].
 
 * With this update, the Kubernetes API server distribution is optimized, ensuring a balanced load among all primary nodes after a quorum is reestablished. This addresses the issue of a single API server receiving the majority of live connections, and causing high CPU usage. Resource utilization is improved and CPU spikes are reduced during primary node or API server restarts. (link:https://issues.redhat.com/browse/OCPBUGS-60121[OCPBUGS-60121])
 


### PR DESCRIPTION
Per private message in Slack, the MCO Pinned Image Set feature (PIS) was released in 4.19.12, not 4.19.11. Also, the PIS was listed in an incorrect Tech Preview list and needed to be updated to GA for 4.19.

Just moving a pair of bullets from one z-stream to another.  **NO CHANGE TO TEXT** except for [line 2336](https://github.com/openshift/openshift-docs/pull/99799/files#diff-3cd80cf8c0941fd008fb420fadb07ca907ac2dbf27f8aa98e708cb3ac6f3f327R2336).

Previews:
Machine Config Operator Technology Preview features -- Updated `oc get  machineconfignode`.
4.19.12 Enhancements -- Moved 3rd and 4th bullets from 4.19.11. **NO CHANGE TO TEXT**
