### PR TITLE
OSDOCS-16177 [NETOBSERV] Update network policy content

### DIFF
--- a/modules/network-observability-deploy-network-policy.adoc
+++ b/modules/network-observability-deploy-network-policy.adoc
@@ -5,11 +5,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-deploy-network-policy_{context}"]
-= Configuring an ingress network policy by using the FlowCollector custom resource
+= Configuring network policy by using the FlowCollector custom resource
 
-You can configure the `FlowCollector` custom resource (CR) to deploy an ingress network policy for network observability by setting the `spec.NetworkPolicy.enable` specification to `true`. By default, the specification is `false`.
+[role="_abstract"]
+You can set up ingress and egress network policies to control pod traffic. This enhances security and collects only the network flow data you need. This reduces noise, supports compliance, and improves visibility into network communication.
 
-If you have installed Loki, Kafka or any exporter in a different namespace that also has a network policy, you must ensure that the Network Observability components can communicate with them. Consider the following about your setup:
+You can configure the `FlowCollector` custom resource (CR) to deploy an egress and ingress network policy for network observability. By default, the `spec.NetworkPolicy.enable` specification is set to `true`.
+
+If you have installed Loki, Kafka or any exporter in a different namespace that also has a network policy, you must ensure that the network observability components can communicate with them. Consider the following about your setup:
 
    * Connection to Loki (as defined in the `FlowCollector` CR `spec.loki` parameter)
    * Connection to Kafka (as defined in the `FlowCollector` CR `spec.kafka` parameter)
@@ -33,9 +36,9 @@ metadata:
 spec:
   namespace: netobserv
   networkPolicy:
-    enable: true   <1>
+    enable: true <1>
     additionalNamespaces: ["openshift-console", "openshift-monitoring"] <2>
 # ...
 ----
-<1> By default, the `enable` value is `false`.
+<1> By default, the `enable` value is `true`.
 <2> Default values are `["openshift-console", "openshift-monitoring"]`.

--- a/observability/network_observability/network-observability-network-policy.adoc
+++ b/observability/network_observability/network-observability-network-policy.adoc
@@ -7,11 +7,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a user with the `admin` role, you can create a network policy for the `netobserv` namespace to secure inbound access to the Network Observability Operator.
+As a user with the `admin` role, you can create a network policy for the `netobserv` namespace to secure inbound and outbound access to the Network Observability Operator.
 
 include::modules/network-observability-deploy-network-policy.adoc[leveloffset=+1]
-
-include::modules/network-observability-create-network-policy.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
[OSDOCS-16177](https://issues.redhat.com//browse/OSDOCS-16177) [NETOBSERV] Update network policy content

Version(s):
Merge to only the `no-1.10` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the <no-.10> content just before its GA.

Note to self for integration branch: applies to OCP 4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-16177

Link to docs preview:
https://99820--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-network-policy.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
