### PR TITLE
OLS-2130: Create OLS 1.0.6 release notes

### DIFF
--- a/modules/ols-1-0-6-fixed-issues.adoc
+++ b/modules/ols-1-0-6-fixed-issues.adoc
@@ -1,0 +1,13 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-6-fixed-issues_{context}"]
+= Fixed issues
+
+{ols-official} 1.0.6 fixes the following issues:
+
+* Before this update, when the {ols-long} Service was connecting to {azure-openai} using an additional TLS certificate, the Service  was not able to successfully connect to the large language model (LLM). Now, the Service adds the TLS certificate to the trust bundle. As a result, the Service connects to the LLM. https://issues.redhat.com/browse/OLS-2112[OLS-2112]
+
+* Before this update when you disabled transcript and feedback collection, the {ols-long} Service failed to deploy the Model Context Protocol (MCP) server. Now, when you disable transcript and feedback collection, the Service deploys the MCP server. https://issues.redhat.com/browse/OLS-2113[OLS-2113]

--- a/modules/ols-1-0-6-release-notes.adoc
+++ b/modules/ols-1-0-6-release-notes.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-6-release-notes_{context}"]
+= {ols-long} version 1.0.6
+
+{ols-official} 1.0.6 is now available on {ocp-product-title} 4.16 and later.
+
+[id="ols-1-0-6-enhancements_{context}"]
+== Enhancements
+
+{ols-official} 1.0.6 provides the following enhancements:
+
+* This release makes {ols-official} 1.0.6 generally available, and is supported on {ocp-product-title} 4.16 and later.
+
+* When viewing the *Cluster Overview* page in the Red Hat Advanced Cluster Management for Kubernetes web console, you can attach the `ManagedCluster` and `ManagedClusterInfo` YAML using the *Attach* menu.
+
+* This release introduces a check for the total size of all uploaded attachments. This is in addition to the existing check for individual attachment sizes. The check for total size helps prevent exceeding the context window size of the large language model (LLM) so that the model does not receive more text than it can process in a single request.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -13,6 +13,8 @@ The release notes highlight what is new and what has changed with each {ols-offi
 {ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
 ====
 
+include::modules/ols-1-0-6-release-notes.adoc[leveloffset=+1]
+include::modules/ols-1-0-6-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-5-release-notes.adoc[leveloffset=+1]
 include::modules/ols-1-0-5-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-4-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2130

Link to docs preview:
https://99844--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-1-0-6-release-notes_ols-release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
