### PR TITLE
CNV#68723: [DOC] Storage migration still marked as Technical Preview in 4.19

### DIFF
--- a/modules/virt-migrating-storage-class-ui.adoc
+++ b/modules/virt-migrating-storage-class-ui.adoc
@@ -16,9 +16,6 @@ With the {VirtProductName} Operator, you can only start storage class migration 
 {mtc-full} is not part of {VirtProductName} and requires separate installation.
 ====
 
-:FeatureName: Storage class migration
-include::snippets/technology-preview.adoc[]
-
 .Prerequisites
 
 * You must have a data volume or a persistent volume claim (PVC) available for storage class migration.


### PR DESCRIPTION
Version(s): 4.19+

Issue: [CNV-68723](https://issues.redhat.com/browse/CNV-68723)

Link to docs preview: https://99845--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virtual_disks/virt-migrating-storage-class.html

QE review:
- [x] QE has approved this change.

