### PR TITLE
OSDOCS-16288:Removed duplicate AWS prereqs section from HCP docs.

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -19,7 +19,7 @@ endif::openshift-dedicated[]
 ifdef::openshift-rosa[]
 [IMPORTANT]
 ====
-Only ROSA clusters deployed with PrivateLink can use a firewall to control egress traffic.
+Only {product-title} clusters deployed with PrivateLink can use a firewall to control egress traffic.
 ====
 endif::[]
 

--- a/modules/rosa-hcp-firewall-prerequisites.adoc
+++ b/modules/rosa-hcp-firewall-prerequisites.adoc
@@ -86,7 +86,7 @@
 |===
 
 Managed clusters require enabling telemetry to allow Red{nbsp}Hat to react more quickly to problems, better support the customers, and better understand how product upgrades impact clusters.
-For more information about how remote health monitoring data is used by Red{nbsp}Hat, see _About remote health monitoring_.
+For more information about how remote health monitoring data is used by Red{nbsp}Hat, see _About remote health monitoring_ in the _Additional resources_ section.
 
 == Domains for Amazon Web Services (AWS) APIs
 [cols="6,1,6",options="header"]

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -115,27 +115,25 @@ include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
 
 include::modules/mos-network-prereqs-min-bandwidth.adoc[leveloffset=+2]
 
+ifdef::openshift-rosa[]
 [id="osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs"]
 === AWS firewall prerequisites
 
 If you are using a firewall to control egress traffic from your {product-title} cluster, you must configure your firewall to grant access to the certain domain and port combinations below. {product-title} requires this access to provide a fully managed OpenShift service.
 
 include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
+endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
 include::modules/rosa-hcp-firewall-prerequisites.adoc[leveloffset=+2]
 endif::openshift-rosa-hcp[]
 
-ifdef::openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
-endif::openshift-rosa[]
 
-[discrete]
 == Next steps
 * xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-required-aws-service-quotas_rosa-sts-required-aws-service-quotas[Review the required AWS service quotas]
 
-[discrete]
 [role="_additional-resources"]
 [id="additional-resources_aws-prerequisites_{context}"]
 == Additional resources


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-16288

Link to docs preview:

- [Firewall prerequisites for Red Hat OpenShift Service on AWS](https://99848--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-sts-aws-prereqs.html#rosa-hcp-firewall-prerequisites_rosa-hcp-prereqs)
- [AWS firewall prerequisites](https://99848--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs)

Peer review:
- [ ] Peer reviewer has approved this change.

QE review:
- QE approval is not required to merge this PR 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
