### PR TITLE
CNV- 66740: Removed TP admonition

### DIFF
--- a/modules/virt-define-guest-agent-ping-probe.adoc
+++ b/modules/virt-define-guest-agent-ping-probe.adoc
@@ -9,9 +9,6 @@
 
 Define a guest agent ping probe by setting the `spec.readinessProbe.guestAgentPing` field of the virtual machine (VM) configuration.
 
-:FeatureName: The guest agent ping probe
-include::snippets/technology-preview.adoc[]
-
 .Prerequisites
 
 * The QEMU guest agent must be installed and enabled on the virtual machine.


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/CNV-66740

Link to docs preview:
https://99849--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-monitoring-vm-health.html#virt-define-guest-agent-ping-probe_virt-monitoring-vm-health

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Removed TP admonition