### PR TITLE
OSDOCS-16223#extending Metal3 firmware updates

### DIFF
--- a/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+++ b/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
@@ -90,6 +90,8 @@ include::modules/bmo-getting-the-hostfirmwarecomponents-resource.adoc[leveloffse
 include::modules/bmo-editing-the-hostfirmwarecomponents-resource-of-a-provisioned-host.adoc[leveloffset=+2]
 // Patching the HostFirmawareComponents resource
 include::modules/bmo-performing-a-live-update-to-the-hostfirmwarecomponents-resource.adoc[leveloffset=+2]
+// Identifying the NICs `HostFirmwareComponents` resources you can update
+include::modules/bmo-getting-the-hostfirmwarecomponents-resource_nic.adoc[leveloffset=+2]
 // About the HostUpdatePolicy resource
 include::modules/bmo-about-the-hostupdatepolicy-resource.adoc[leveloffset=+2]
 // Setting the HostUpdatePolicy resource

--- a/modules/bmo-about-the-hostfirmwarecomponents-resource.adoc
+++ b/modules/bmo-about-the-hostfirmwarecomponents-resource.adoc
@@ -6,14 +6,21 @@
 [id="bmo-about-the-hostfirmwarecomponents-resource_{context}"]
 = About the HostFirmwareComponents resource
 
-Metal^3^ provides the `HostFirmwareComponents` resource, which describes BIOS and baseboard management controller (BMC) firmware versions. The `HostFirmwareComponents` resource contains two sections:
+Metal^3^ provides the `HostFirmwareComponents` resource, which describes BIOS, baseboard management controller (BMC), and network interface controllers (NICs).
+
+To update NIC host firmware components, the server must support Redfish and must permit you to use Redfish to update NIC firmware. You can use Metal^3^ to update NIC host firmware components for the Intel Ethernet 800 Series (`ice` driver) and the NVIDIA Mellanox ConnectX-6 (CX6) and ConnectX-7 (CX7) (`mlx_5` driver). The updates are validated on Dell hardware. The following list outlines important considerations before you update the NICs:
+
+* If you have more than one network adapter with the same type of NIC, for example, Intel Ethernet 800 Series, when you update one NIC the update might be applied to multiple NICs. Redfish identifies all components that can benefit from the update and then applies the image to all these components.
+* You cannot necessarily update a listed network adapter. A machine might use Redfish to display their NIC and firmware information, but prevent you from updating the adapter through Redfish. For more information about checking if you can update a network adapter, see "Identifying the NICs HostFirmwareComponents resources you can update".
+
+The `HostFirmwareComponents` resource contains two sections:
 
 . The `HostFirmwareComponents` spec
 . The `HostFirmwareComponents` status
 
 == HostFirmwareComponents spec
 
-The `spec` section of the `HostFirmwareComponents` resource defines the desired state of the host's BIOS and BMC versions.
+The `spec` section of the `HostFirmwareComponents` resource defines the desired state of the BIOS and BMC versions of the host, and the NIC firmware components of the host if the information is available by using Redfish.
 
 .HostFirmwareComponents spec
 [options="header"]
@@ -28,7 +35,7 @@ updates:
 ----
 a| The `updates` configuration setting contains the components to update. The fields are:
 
-* `component`: The name of the component. The valid settings are `bios` or `bmc`.
+* `component`: The name of the component. The valid settings are `bios`, `bmc`, or `nic:<ID>`.
 
 * `url`: The URL to the component's firmware specification and version.
 |====
@@ -36,7 +43,7 @@ a| The `updates` configuration setting contains the components to update. The fi
 
 == HostFirmwareComponents status
 
-The `status` section of the `HostFirmwareComponents` resource returns the current status of the host's BIOS and BMC versions.
+The `status` section of the `HostFirmwareComponents` resource returns the current status of the BIOS and BMC versions of the host, and the NIC firmware components of the host if the information is available by using Redfish.
 
 .HostFirmwareComponents status
 [options="header"]
@@ -54,7 +61,7 @@ components:
 ----
 a| The `components` section contains the status of the components. The fields are:
 
-* `component`: The name of the firmware component. It returns `bios` or `bmc`.
+* `component`: The name of the firmware component. It returns `bios`, `bmc`, `nic:<ID1>`, or `nic:<ID2>`.
 
 * `initialVersion`: The initial firmware version of the component. Ironic retrieves this information when creating the `BareMetalHost` resource. You cannot change it.
 

--- a/modules/bmo-getting-the-hostfirmwarecomponents-resource.adoc
+++ b/modules/bmo-getting-the-hostfirmwarecomponents-resource.adoc
@@ -63,6 +63,12 @@ status:
   - component: bmc
     currentVersion: "1.00"
     initialVersion: "1.00"
+  - component: nic:<ID1>
+    currentVersion: 0.10.0
+    initialVersion: 0.10.0
+  - component: nic:<ID2>
+    currentVersion: 1.8.1
+    initialVersion: 1.8.1
   conditions:
   - lastTransitionTime: "2024-04-25T20:32:06Z"
     message: ""

--- a/modules/bmo-getting-the-hostfirmwarecomponents-resource_nic.adoc
+++ b/modules/bmo-getting-the-hostfirmwarecomponents-resource_nic.adoc
@@ -1,0 +1,192 @@
+// This is included in the following assemblies:
+//
+// * installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="bmo-getting-the-hostfirmwarecomponents-resource_nic_{context}"]
+= Identifying the NICs HostFirmwareComponents resources you can update
+
+You can use the Redfish `NetworkAdapters` resource to identify network interface controllers (NICs) that were added to the `HostFirmwareComponents` custom resource (CR). The NIC is displayed in the CR with the prefix `nic:` followed by the network adapter ID of the resource. For example, `nic:AD007`.
+
+.Procedure
+
+. Get the detailed list of `HostFirmwareComponents` NIC resources by running the following command:
++
+[source,terminal]
+----
+$ curl -ksu “$USER:$PASS” https://<BMC>/redfish/v1/Chassis/<SystemID>/NetworkAdapters | jq .
+----
+The `<SystemID>` is based on the value that you set for `bmh` in the `spec.bmc.address`.
++
+.Example output
+[source,yaml]
+----
+{
+  "@odata.context": "/redfish/v1/$metadata#NetworkAdapterCollection.NetworkAdapterCollection",
+  "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters",
+  "@odata.type": "#NetworkAdapterCollection.NetworkAdapterCollection",
+  "Description": "Collection Of Network Adapter",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Integrated.1"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Slot.3"
+    }
+  ],
+  "Members@odata.count":2,
+  "Name": "Network Adapter Collection"
+}
+----
+
+. Identify the corresponding network adapter in the firmware inventory resource, as the network adapter does not indicate if you can update firmware with Redfish, by running the following command:
++
+[source,terminal]
+----
+$ curl -ksu “$USER:$PASS” https://<BMC>/redfish/v1/UpdateService/FirmwareInventory | jq .
+----
++
+.Example output
+[source,yaml]
+----
+{
+  "@odata.context": "/redfish/v1/$metadata#SoftwareInventoryCollection.SoftwareInventoryCollection",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
+  "@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
+  "Description": "Collection of Firmware Inventory",
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Current-102303-22.0.9__NIC.Integrated.1-2-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Current-102303-22.0.9__NIC.Integrated.1-3-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Current-102303-22.0.9__NIC.Integrated.1-4-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Current-102378-22.0.9__NIC.Integrated.1-1-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Current-104480-14.31.22.50__NIC.Slot.3-1-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Current-104480-14.31.22.50__NIC.Slot.3-2-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Installed-102303-22.0.9__NIC.Integrated.1-2-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Installed-102303-22.0.9__NIC.Integrated.1-3-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Installed-102303-22.0.9__NIC.Integrated.1-4-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Installed-102378-22.0.9__NIC.Integrated.1-1-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Installed-104480-14.31.22.50__NIC.Slot.3-1-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Installed-104480-14.31.22.50__NIC.Slot.3-2-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Previous-102303-20.0.17__NIC.Integrated.1-2-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Previous-102303-20.0.17__NIC.Integrated.1-3-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Previous-102303-20.0.17__NIC.Integrated.1-4-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Previous-102378-20.0.17__NIC.Integrated.1-1-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Previous-104480-14.24.80.00__NIC.Slot.3-1-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Previous-104480-14.24.80.00__NIC.Slot.3-2-1"
+    }
+  ],
+  "Members@odata.count": 18,
+  "Name": "Firmware Inventory Collection"
+}
+----
+
+. Check if the parameter is set to `true` by running the following command:
++
+[source,terminal]
+----
+$ curl -ksu "$USER:$PASS" https://<BMC>/redfish/v1/UpdateService/FirmwareInventory/Current-102303-22.0.9__NIC.Integrated.1-2-1 | jq .
+----
++
+.Example output
+[source,yaml]
+----
+{
+  "@odata.context": "/redfish/v1/$metadata#SoftwareInventory.SoftwareInventory",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Current-102303-22.0.9__NIC.Integrated.1-2-1",
+  "@odata.type": "#SoftwareInventory.v1_9_0.SoftwareInventory",
+  "Description": "Represents Firmware Inventory",
+  "Id": "Current-102303-22.0.9__NIC.Integrated.1-2-1",
+  "Name": "Intel(R) Ethernet 10G X710 rNDC - E4:43:4B:4B:60:B1",
+  "Oem": {
+    "Dell": {
+      "@odata.type": "#DellOem.v1_3_0.DellOemResources",
+      "DellSoftwareInventory": {
+        "@odata.context": "/redfish/v1/$metadata#DellSoftwareInventory.DellSoftwareInventory",
+        "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/Current-102303-22.0.9__NIC.Integrated.1-2-1/Oem/Dell/DellSoftwareInventory/DCIM:CURRENT_0x23_701__NIC.Integrated.1-2-1",
+        "@odata.type": "#DellSoftwareInventory.v1_2_0.DellSoftwareInventory",
+        "BuildNumber": 0,
+        "Classifications": [
+          "Firmware"
+        ],
+        "Classifications@odata.count": 1,
+        "ComponentID": "102303",
+        "ComponentType": "FRMW",
+        "Description": "The DellSoftwareInventory resource is a representation of an available device firmware in the managed system.",
+        "DeviceID": "1572",
+        "ElementName": "Intel(R) Ethernet 10G X710 rNDC - E4:43:4B:4B:60:B1",
+        "HashValue": "1158cfbfdf6cb387bc0806999b28b83892cfaf1307b466abd6546ff8e5ea1459",
+        "Id": "DCIM:CURRENT_0x23_701__NIC.Integrated.1-2-1",
+        "IdentityInfoType": [
+          "OrgID:ComponentType:VendorID:DeviceID:SubVendorID:SubDeviceID"
+        ],
+        "IdentityInfoType@odata.count": 1,
+        "IdentityInfoValue": [
+          "DCIM:firmware:8086:1572:1028:0000"
+        ],
+        "IdentityInfoValue@odata.count": 1,
+        "InstallationDate": "NA",
+        "IsEntity": true,
+        "MajorVersion": 22,
+        "MinorVersion": 0,
+        "Name": "DellSoftwareInventory",
+        "PLDMCapabilitiesDuringUpdate": "0x00000000",
+        "PLDMFDPCapabilitiesDuringUpdate": "0x00000000",
+        "RevisionNumber": 9,
+        "RevisionString": null,
+        "SidebandUpdateCapable": false,
+        "Status": "AvailableForInstallation",
+        "SubDeviceID": "0000",
+        "SubVendorID": "1028",
+        "VendorID": "8086",
+        "impactsTPMmeasurements": true
+      }
+    }
+  },
+  "ReleaseDate": "2023-03-03T00:00:00Z",
+  "SoftwareId": "102303",
+  "Status": {
+    "Health": "OK",
+    "State": "Enabled"
+  },
+  "Updateable": true,
+  "Version": "22.0.9"
+}
+----
+*  `Updateable`: Indicates the value the parameter is set to.
+
+. Where the `Updateable` parameter is set to `true`, you can use Redfish to update the network adapter.

--- a/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
@@ -20,7 +20,7 @@ To create CSI-provisioned PVs that mount to {gcp-short} Filestore Storage assets
 
 * The _{gcp-short} Filestore CSI driver_ enables you to create and mount {gcp-short} Filestore PVs.
 
-{product-title} {gcp-short} Filestore supports Workload Identity. This allows users to access Google Cloud resources using federated identities instead of a service account key. {gcp-wid-short} must be enabled globally during installation, and then configured for the {gcp-short} Filestore CSI Driver Operator. For more information, see xref:../../storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc#installing-the-gcp-filestore-csi-driver-operator[Installing the {gcp-short} Filestore CSI Driver Operator].
+{product-title} {gcp-short} Filestore supports Workload Identity. This allows users to access Google Cloud resources using federated identities instead of a service account key. {gcp-wid-short} must be enabled globally during installation, and then configured for the {gcp-short} Filestore CSI Driver Operator.
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Versions:
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16223

Link to docs preview:

- [About the HostFirmwareComponents resource](https://99876--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#bmo-about-the-hostfirmwarecomponents-resource_bare-metal-postinstallation-configuration) 
- [HostFirmwareComponents spec](https://99876--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#hostfirmwarecomponents-spec)
- [HostFirmwareComponents status](https://99876--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#hostfirmwarecomponents-status) 
- [Identifying the NICs HostFirmwareComponents resources you can update](https://99876--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#bmo-getting-the-hostfirmwarecomponents-resource_nic_bare-metal-postinstallation-configuration)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
