### PR TITLE
remove TP

### DIFF
--- a/virt/release_notes/virt-4-19-release-notes.adoc
+++ b/virt/release_notes/virt-4-19-release-notes.adoc
@@ -265,11 +265,6 @@ In {VirtProductName} 4.19.6 and later, installing {VirtProductName} on OCI is ge
 
 // CNV-55104: 4.18 - Unresolved
 * If you perform storage class migration for a stopped VM, the VM might not be able to start because of a missing bootable device. To prevent this, do not attempt storage class migration if the VM is not running. (link:https://issues.redhat.com/browse/CNV-55104[*CNV-55104*])
-+
---
-:FeatureName: Storage class migration
-include::snippets/technology-preview.adoc[]
---
 
 [discrete]
 [id="virt-4-19-ki-virtualization_{context}"]


### PR DESCRIPTION
Version(s): 4.19

Issue: Removing TP notice for Migrating VM disks 

Link to docs preview: https://99883--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-19-release-notes.html

QE review:
- [x] QE has approved this change.


