### PR TITLE
OSDOCS#16352: removing external platform from list

### DIFF
--- a/nodes/nodes/nodes-nodes-adding-node-iso.adoc
+++ b/nodes/nodes/nodes-nodes-adding-node-iso.adoc
@@ -28,7 +28,6 @@ The following platforms are supported for this method of adding nodes:
 * `vsphere`
 * `nutanix`
 * `none`
-* `external`
 
 [id="supported-architectures_{context}"]
 == Supported architectures


### PR DESCRIPTION
[OSDOCS-16352](https://issues.redhat.com/browse/OSDOCS-16352)

Version(s): 4.17+

This PR removes the external platform from the list of supported platforms for the node addition procedure.

QE review:
- [x] QE has approved this change.

Preview: [Supported platforms](https://99886--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso.html#supported-platforms_adding-node-iso)