### PR TITLE
OSDOCS#16319: Update the z-stream RNs for 4.16.49

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3381,6 +3381,42 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.49
+[id="ocp-4-16-49_{context}"]
+=== RHBA-2025:16726 - {product-title} {product-version}.49 bug fix and security update
+
+Issued: 01 October 2025
+
+{product-title} release {product-version}.49 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:16726[RHBA-2025:16726] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.49 --pullspecs
+----
+
+[id="ocp-4-16-49-enhancements_{context}"]
+==== Enhancements
+
+* With this update, command line logs from `virt-launcher` pods in a Kubernetes cluster are collected, JSON-encoded, and saved in the `aggregated/virt-launcher/logs` path. This enhancement provides a central location for logs, improves troubleshooting and debugging of virtual machines, and streamlines the process for users. The feature is compatible with many {product-title} versions. (link:https://issues.redhat.com/browse/OCPBUGS-61973[OCPBUGS-61973])
+
+* With this update, the `cluster-etcd-operator` in {product-title} platforms is more proactive by introducing an enhanced `etcdDatabaseQuotaLowSpace` alert. The alert triggers for multiple levels (information, warning, critical) while the etcd quota use approaches 95%. This proactive alert system provides cluster administrators with enough time to solve potential issues before the API server is impacted, resulting in a more stable and manageable {product-title} environment. (link:https://issues.redhat.com/browse/OCPBUGS-61505[OCPBUGS-61505])
+
+[id="ocp-4-16-49-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, incorrect machine deletion handling during cluster autoscaling caused the last node to keep the `ToBeDeletedByClusterAutoscaler` taint. As a consequence, resource allocation was affected during cluster scaling. With this release, the `ToBeDeletedByClusterAutoscaler` taint is removed after scaling down a machine set. As a result, the last node does not retain the unwanted taint after scaling down a machine set. (link:https://issues.redhat.com/browse/OCPBUGS-60915[OCPBUGS-60915])
+
+* Before this update, an `ImageStream` resource could not import image tags with the `ImageTagMirrorSet` resource set to `NeverContactSource` in disconnected clusters. As a consequence, an image import failure occurred. With this release, an `ImageStream` resource imports image tags with this setting in disconnected clusters. As a result, image import functionality is restored in disconnected clusters with `ImageTagMirrorSet` resource set to `NeverContactSource`. (link:https://issues.redhat.com/browse/OCPBUGS-61474[OCPBUGS-61474])
+
+* Before this update, a Prometheus `remote-write` alert activation occurred due to sample dropping in a re-labeling configuration. As a consequence, user alerts were incorrectly triggered. With this release, the remote `write drop` rule for Prometheus is adjusted and does not affect alerts. As a result, the Prometheus `RemoteWriteBehind` alert activation does not drop samples. (link:https://issues.redhat.com/browse/OCPBUGS-61856[OCPBUGS-61856])
+
+[id="ocp-4-16-49-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.48
 [id="ocp-4-16-48_{context}"]
 === RHSA-2025:15680 - {product-title} {product-version}.48 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-16319](https://issues.redhat.com//browse/OSDOCS-16319)

Link to docs preview:
[4.16.49](https://99891--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes#ocp-4-16-49_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
The errata URLs will return 404 until the go-live date of 10/01/25.
