### PR TITLE
OSDOCS#16267: Reword note for using --v1 flag

### DIFF
--- a/disconnected/mirroring/installing-mirroring-disconnected.adoc
+++ b/disconnected/mirroring/installing-mirroring-disconnected.adoc
@@ -12,7 +12,7 @@ You can use the oc-mirror OpenShift CLI (`oc`) plugin to mirror images to a mirr
 
 [IMPORTANT]
 ====
-The oc-mirror v1 plugin is now deprecated. The default mirroring method is changing to the oc-mirror v2 plugin in a future release, requiring you to specify the `--v1` flag to continue using the oc-mirror v1 plugin. Transition to the xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#installation-oc-mirror-v2-about_about-installing-oc-mirror-v2[oc-mirror v2 plugin] for continued support and improvements.
+The oc-mirror v1 plugin is deprecated. To prevent failures in a future release, specify the `--v1` flag to continue using the v1 plugin, or migrate to the supported v2 plugin and use the `--v2` flag. Transition to the xref:../../disconnected/mirroring/about-installing-oc-mirror-v2.adoc#installation-oc-mirror-v2-about_about-installing-oc-mirror-v2[oc-mirror v2 plugin] for continued support and improvements.
 ====
 
 // About the oc-mirror plugin


### PR DESCRIPTION
Version(s):4.18+

Issue: https://issues.redhat.com/browse/OSDOCS-16267

Link to docs preview: https://99899--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/mirroring/installing-mirroring-disconnected.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
