### PR TITLE
PR for SRVKE-1741: Document "IntegrationSink" section in OpenShift Serverless Eventing docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -269,6 +269,8 @@ Topics:
     File: serverless-kafka-developer-sink
   - Name: JobSink
     File: serverless-jobsink
+  - Name: Getting started with IntegrationSink
+    File: serverless-getting-started-integrationsink
 - Name: Brokers
   Dir: brokers
   Topics:

--- a/eventing/event-sinks/serverless-getting-started-integrationsink.adoc
+++ b/eventing/event-sinks/serverless-getting-started-integrationsink.adoc
@@ -1,0 +1,39 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-getting-started-integrationsink"]
+= Getting started with IntegrationSink
+include::_attributes/common-attributes.adoc[]
+:context: serverless-integrationsink
+
+toc::[]
+
+:FeatureName: {ServerlessProductName} IntegrationSink feature
+include::snippets/technology-preview.adoc[]
+
+The `IntegrationSink` API is a Knative Eventing custom resource (CR) that enables you to send events from Knative into external systems. It leverages selected Kamelets from the Apache Camel project.
+
+Kamelets act as reusable connectors that can function either as sources or sinks.By using an `IntegrationSink` API, you can reliably deliver CloudEvents produced within Knative Eventing to third-party services and external systems.
+
+{ServerlessProductName} supports the following Kamelet sinks:
+
+* AWS Simple Storage Service (S3) 
+* AWS Simple Notification Service (SNS) 
+* AWS Simple Queue Service (SQS) 
+* Generic logger sink 
+
+include::modules/serverless-integrationsink-creating-aws-credentials.adoc[leveloffset=+1]
+
+include::modules/serverless-integrationsink-aws-simple-storage-service.adoc[leveloffset=+1]
+
+include::modules/serverless-creating-integrationsink-aws-sss.adoc[leveloffset=+2]
+
+include::modules/serverless-integrationsink-aws-simple-notification-service.adoc[leveloffset=+1]
+
+include::modules/serverless-creating-integrationsink-aws-sns.adoc[leveloffset=+2]
+
+include::modules/serverless-integrationsink-aws-simple-queue-service.adoc[leveloffset=+1]
+
+include::modules/serverless-creating-integrationsink-aws-sqs.adoc[leveloffset=+2]
+
+include::modules/serverless-integrationsink-generic-logger-sink.adoc[leveloffset=+1]
+
+include::modules/serverless-creating-integrationsink-for-logger.adoc[leveloffset=+2]

--- a/modules/serverless-creating-integrationsink-aws-sns.adoc
+++ b/modules/serverless-creating-integrationsink-aws-sns.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sinks/serverless-integrationsink.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-creating-integrationsink-aws-sns_{context}"]
+= Creating an IntegrationSink for AWS SNS
+
+You can create an `IntegrationSink` API resource to publish CloudEvents from Knative Eventing to an Amazon Simple Notification Service (SNS) topic by applying a YAML manifest.
+
+.Prerequisites
+
+* You have created your AWS credentials and stored them in a Kubernetes Secret in the same namespace as the resource.
+* You have the OpenShift CLI (oc) installed and are logged in to the cluster.
+* You know the namespace where the `IntegrationSink` resource will be created.
+* A Knative broker or another event source exists to produce CloudEvents to be delivered to this sink.
+
+.Procedure
+
+. Save the following YAML manifest as `integration-sink-aws-sns.yaml`:
++
+[source,yaml]
+----
+apiVersion: sinks.knative.dev/v1alpha1
+kind: IntegrationSink
+metadata:
+  name: integration-sink-aws-sns
+  namespace: knative-samples
+spec:
+  aws:
+    sns:
+      arn: "arn:aws:sns:<region>:<account>:my-topic"
+      region: "eu-north-1"
+    auth:
+      secret:
+        ref:
+          name: "my-secret"
+----
+
+. Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f integration-sink-aws-sns.yaml
+----
++
+This manifest configures the `IntegrationSink` API to publish CloudEvents to the SNS topic identified by its ARN in the `eu-north-1` region. The `auth.secret.ref.name` field references the Kubernetes Secret (`my-secret`) that stores your AWS credentials.

--- a/modules/serverless-creating-integrationsink-aws-sqs.adoc
+++ b/modules/serverless-creating-integrationsink-aws-sqs.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sinks/serverless-integrationsink.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-creating-integrationsink-aws-sqs_{context}"]
+= Creating an IntegrationSink for AWS SQS
+
+You can create an `IntegrationSink` API resource to send CloudEvents to an Amazon SQS queue by applying a YAML manifest.
+
+.Prerequisites
+
+* You have created your AWS credentials and stored them in a Kubernetes Secret in the same namespace as the resource.
+* You have the OpenShift CLI (oc) installed and are logged in to the cluster.
+* You know the namespace where the `IntegrationSink` resource will be created.
+* A Knative broker or another event source exists to produce CloudEvents that will be delivered to this sink.
+
+.Procedure
+
+. Save the following YAML manifest as `integration-sink-aws-sqs.yaml`:
++
+[source,yaml]
+----
+apiVersion: sinks.knative.dev/v1alpha1
+kind: IntegrationSink
+metadata:
+  name: integration-sink-aws-sqs
+  namespace: knative-samples
+spec:
+  aws:
+    sqs:
+      arn: "arn:aws:sqs:<region>:<account>:my-queue"
+      region: "eu-north-1"
+    auth:
+      secret:
+        ref:
+          name: "my-secret"
+----
+
+. Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f integration-sink-aws-sqs.yaml
+----
++
+This manifest configures the `IntegrationSink` API to send CloudEvents to the SQS queue identified by its ARN in the `eu-north-1` region. The `auth.secret.ref.name` field references the Kubernetes Secret (`my-secret`) that stores your AWS credentials.

--- a/modules/serverless-creating-integrationsink-aws-sss.adoc
+++ b/modules/serverless-creating-integrationsink-aws-sss.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sinks/serverless-integrationsink.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-creating-integrationsink-aws-sss_{context}"]
+= Creating an IntegrationSink for AWS S3
+
+You can create an `IntegrationSink` API resource to deliver CloudEvents from Knative Eventing to an Amazon Simple Storage Service (S3) bucket. This enables you to persist event data as objects in S3, where it can be stored for long-term use, processed by analytics tools, or consumed by downstream applications. You can create an `IntegrationSink` to deliver CloudEvents to an Amazon S3 bucket by applying a YAML manifest.
+
+.Prerequisites
+
+* You have created your AWS credentials and stored them in a Kubernetes Secret in the same namespace as the resource.
+* You have the OpenShift CLI (oc) installed and are logged in to the cluster.
+* You know the namespace where the `IntegrationSink` resource will be created.
+* A Knative broker or another event source exists to produce CloudEvents to be delivered to this sink.
+
+.Procedure
+
+. Save the following YAML manifest as `integration-sink-aws-s3.yaml`:
++
+[source,yaml]
+----
+apiVersion: sinks.knative.dev/v1alpha1
+kind: IntegrationSink
+metadata:
+  name: integration-sink-aws-s3
+  namespace: knative-samples
+spec:
+  aws:
+    s3:
+      arn: "arn:aws:s3:::my-bucket"
+      region: "eu-north-1"
+    auth:
+      secret:
+        ref:
+          name: "my-secret"
+----
+
+. Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f integration-sink-aws-s3.yaml
+----
++
+This manifest configures the `IntegrationSink` API to deliver CloudEvents to the Amazon S3 bucket identified by its ARN (`arn:aws:s3:::my-bucket`) in the `eu-north-1` region. The `auth.secret.ref.name` field references the Kubernetes Secret (`my-secret`) that stores your AWS credentials.

--- a/modules/serverless-creating-integrationsink-for-logger.adoc
+++ b/modules/serverless-creating-integrationsink-for-logger.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sinks/serverless-integrationsink.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-creating-integrationsink-for-logger_{context}"]
+= Creating an IntegrationSink for the Logger
+
+You can create an `IntegrationSink` API resource to log CloudEvents by applying a YAML manifest.
+
+.Prerequisites
+
+* You have the OpenShift CLI (oc) installed and are logged in to the cluster.
+* You know the namespace where the `IntegrationSink` resource will be created.
+* A Knative broker or another event source exists to produce CloudEvents to be delivered to this sink.
+
+.Procedure
+
+. Save the following YAML manifest as `integration-log-sink.yaml`:
++
+[source,yaml]
+----
+apiVersion: sinks.knative.dev/v1alpha1
+kind: IntegrationSink
+metadata:
+  name: integration-log-sink
+  namespace: knative-samples
+spec:
+  log:
+    showHeaders: true
+    level: INFO
+----
+
+. Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f integration-log-sink.yaml
+----
++
+This manifest configures the `IntegrationSink` API resource to log all CloudEvents it receives at the `INFO` level. The `showHeaders` option is set to `true`, which means the HTTP headers of the event will also be logged.

--- a/modules/serverless-integrationsink-aws-simple-notification-service.adoc
+++ b/modules/serverless-integrationsink-aws-simple-notification-service.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sinks/serverless-integrationsink.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-integrationsink-aws-simple-notification-service_{context}"]
+= AWS SNS with IntegrationSink
+
+The Amazon Web Services (AWS) Simple Notification Service (SNS) Kamelet enables you to deliver CloudEvents from Knative Eventing to an SNS topic. This integration is useful when you need broad distribution like email, SMS, HTTP subscribers, SQS queues, Lambda functions, etc. via SNS subscriptions.
+
+To configure an `IntegrationSink` API resource for AWS SNS, reference a Kubernetes Secret with valid AWS credentials, specify the SNS topic Amazon Resource Name (ARN) and region, and configure the event source that will produce the CloudEvents.

--- a/modules/serverless-integrationsink-aws-simple-queue-service.adoc
+++ b/modules/serverless-integrationsink-aws-simple-queue-service.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sinks/serverless-integrationsink.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-integrationsink-aws-simple-queue-service_{context}"]
+= AWS SQS with IntegrationSink
+
+The Amazon Web Services (AWS) Simple Queue Service (SQS) Kamelet allows you to send CloudEvents from Knative Eventing into an SQS queue. This integration is useful when you need reliable, decoupled message delivery between event producers and consumers, or when downstream systems process events asynchronously from a queue.
+
+To configure an `IntegrationSink` API resource for AWS SQS, you must reference a Kubernetes Secret with valid AWS credentials, specify the queue Amazon Resource Name (ARN) and region, and configure the event source that produces the CloudEvents.

--- a/modules/serverless-integrationsink-aws-simple-storage-service.adoc
+++ b/modules/serverless-integrationsink-aws-simple-storage-service.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sinks/serverless-integrationsink.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-integrationsink-aws-simple-storage-service_{context}"]
+= AWS S3 with IntegrationSink
+
+The Amazon Web Services (AWS) Simple Storage Service (S3) Kamelet allows you to deliver CloudEvents from Knative Eventing into an Amazon S3 bucket. This integration makes it possible to store events as objects for long-term storage, analytics, or downstream processing.
+
+To configure an `IntegrationSink` API for AWS S3, you must reference a Kubernetes Secret with valid AWS credentials, specify the Amazon S3 bucket Amazon Resource Name (ARN) and its region, and configure the source that produces the CloudEvents.

--- a/modules/serverless-integrationsink-creating-aws-credentials.adoc
+++ b/modules/serverless-integrationsink-creating-aws-credentials.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sinks/serverless-integrationsink.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-integrationsink-creating-aws-credentials_{context}"]
+= Creating AWS credentials
+
+Several `IntegrationSink` API resources require access to Amazon Web Services (AWS) services such as S3, SNS, and SQS. To connect securely, you must create a Kubernetes Secret containing valid AWS credentials in the namespace where the `IntegrationSink` API resource will be created.
+
+The Secret must include an AWS access key ID and secret access key with sufficient permissions to access the target AWS service. This Secret will then be referenced in each `IntegrationSink` configuration.
+
+.Prerequisites
+
+* You have an AWS account with an access key ID and secret access key that provide access to the relevant service.
+* You have the OpenShift CLI (oc) installed and are logged in to the cluster.
+* You have identified the namespace in which the `IntegrationSink` resource will be created.
+
+.Procedure
+
+* Create the secret by running the following command:
++
+[source,terminal]
+----
+$ oc -n <namespace> create secret generic my-secret \
+  --from-literal=aws.accessKey=<accessKey> \
+  --from-literal=aws.secretKey=<secretKey>
+----
++
+Replace `<namespace>` with the namespace where the `IntegrationSink` resource will be created, and substitute `<accessKey>` and `<secretKey>` with the appropriate AWS credentials.

--- a/modules/serverless-integrationsink-generic-logger-sink.adoc
+++ b/modules/serverless-integrationsink-generic-logger-sink.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sinks/serverless-integrationsink.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-integrationsink-generic-logger-sink_{context}"]
+= Generic logger sink with IntegrationSink
+
+The Log Sink Kamelet allows you to output CloudEvents from Knative Eventing directly to the application log. This sink is primarily used for debugging or testing event flows, as it provides visibility into the event payloads and metadata without requiring an external system.
+
+To configure a `IntegrationSink` API resource for the logger, you can set the logging level and optionally display event headers.


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.37`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVKE-1741

**Doc preview:** [Getting started with IntegrationSink](https://99900--ocpdocs-pr.netlify.app/openshift-serverless/latest/eventing/event-sinks/serverless-getting-started-integrationsink)

**Reviews:**

- [x] QE has approved this change.
- [x] SME has approved this change.
- [x] Peer has approved this change.