### PR TITLE
OSDOCS-16361: Added new verification command to k8s-nmstate-deploying…

### DIFF
--- a/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
+++ b/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
@@ -11,7 +11,6 @@ You can install the Kubernetes NMState Operator by using the OpenShift CLI (`oc)
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).
-
 * You are logged in as a user with `cluster-admin` privileges.
 
 .Procedure
@@ -106,10 +105,17 @@ spec:
 ----
 $ oc apply -f <filename>.yaml
 ----
++
+.. Monitor the `nmstate` CRD until the resource reaches the `Available` condition by running the following command. Ensure that you set a value for the `--timeout` option so that if the `Available` condition is not met within this set maximum waiting time, the command times out and generates an error message.
++
+[source,yaml]
+----
+$ oc wait --for=condition=Available nmstate/nmstate --timeout=600s
+----
 
 .Verification
 
-* Verify that all pods for the NMState Operator have the `Running` status by entering the following command:
+. Verify that all pods for the NMState Operator have the `Running` status by entering the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-16361](https://issues.redhat.com/browse/OSDOCS-16361)

Link to docs preview:
* [Viewing metrics collected by the Kubernetes NMState Operator](https://99905--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.html#viewing-stats-collected-kubernetes-nmtate-op_k8s-nmstate-operator)

- [x] SME has approved this change (Enrique).
- [x] QE has approved this change (Meina Li).
