### PR TITLE
OSDOCS-16179 [NETOBSERV] CLI Updates 1.10

### DIFF
--- a/modules/network-observability-netobserv-cli-reference.adoc
+++ b/modules/network-observability-netobserv-cli-reference.adoc
@@ -4,7 +4,7 @@
 [id="network-observability-netobserv-cli-reference_{context}"]
 = Network Observability CLI usage
 
-You can use the Network Observability CLI (`oc netobserv`) to pass command-line arguments to capture flows data, packets data, and metrics for further analysis and enable features supported by the Network Observability Operator.
+You can use the Network Observability CLI (`oc netobserv`) to pass command line arguments to capture flows data, packets data, and metrics for further analysis and enable features supported by the Network Observability Operator.
 
 [id="cli-syntax_{context}"]
 == Syntax
@@ -55,44 +55,45 @@ $ oc netobserv flows [<feature_option>] [<command_options>]
 [cols="1,1,1",options="header"]
 |===
 | Option | Description | Default
-|--enable_all|                enable all eBPF features                   | false
-|--enable_dns|                enable DNS tracking                        | false
-|--enable_ipsec|              enable IPsec tracking                      | false
-|--enable_network_events|     enable network events monitoring           | false
-|--enable_pkt_translation|    enable packet translation                  | false
-|--enable_pkt_drop|           enable packet drop                         | false
-|--enable_rtt|                enable RTT tracking                        | false
-|--enable_udn_mapping|        enable User Defined Network mapping | false
-|--get-subnets|               get subnets information                   | false
-|--sampling|                  value that determines the ratio of packets being sampled | 1
-|--background|                run in background                          | false
-|--copy|                      copy the output files locally              | prompt
-|--log-level|                 components logs                            | info
-|--max-time|                  maximum capture time                       | 5m
-|--max-bytes|                 maximum capture bytes                      | 50000000 = 50MB
-|--action|                    filter action                              | Accept
-|--cidr|                      filter CIDR                                | 0.0.0.0/0
-|--direction|                 filter direction                           | –
-|--dport|                     filter destination port                    | –
-|--dport_range|               filter destination port range              | –
-|--dports|                    filter on either of two destination ports  | –
-|--drops|                     filter flows with only dropped packets     | false
-|--icmp_code|                 filter ICMP code                           | –
-|--icmp_type|                 filter ICMP type                           | –
-|--node-selector|             capture on specific nodes                  | –
-|--peer_ip|                   filter peer IP                             | –
-|--peer_cidr|                 filter peer CIDR                           | –
-|--port_range|                filter port range                          | –
-|--port|                      filter port                                | –
-|--ports|                     filter on either of two ports              | –
-|--protocol|                  filter protocol                            | –
-|--query|                     filter flows by using a custom query          | –
-|--sport_range|               filter source port range                   | –
-|--sport|                     filter source port                         | –
-|--sports|                    filter on either of two source ports       | –
-|--tcp_flags|                 filter TCP flags                           | –
-|--interfaces|                list of interfaces to monitor, comma separated     | –
-|--exclude_interfaces|        list of interfaces to exclude, comma separated     | lo
+|--enable_all|                enable all eBPF features                              | false
+|--enable_dns|                enable DNS tracking                                   | false
+|--enable_ipsec|              enable IPsec tracking                                 | false
+|--enable_network_events|     enable network events monitoring                      | false
+|--enable_pkt_translation|    enable packet translation                             | false
+|--enable_pkt_drop|           enable packet drop                                    | false
+|--enable_rtt|                enable RTT tracking                                   | false
+|--enable_udn_mapping|        enable User Defined Network mapping                   | false
+|--get-subnets|               get subnets information                               | false
+|--privileged|                force eBPF agent privileged mode                      | auto
+|--sampling|                  packets sampling interval                             | 1
+|--background|                run in background                                     | false
+|--copy|                      copy the output files locally                         | prompt
+|--log-level|                 components logs                                       | info
+|--max-time|                  maximum capture time                                  | 5m
+|--max-bytes|                 maximum capture bytes                                 | 50000000 = 50MB
+|--action|                    filter action                                         | Accept
+|--cidr|                      filter CIDR                                           | 0.0.0.0/0
+|--direction|                 filter direction                                      | -
+|--dport|                     filter destination port                               | -
+|--dport_range|               filter destination port range                         | -
+|--dports|                    filter on either of two destination ports             | -
+|--drops|                     filter flows with only dropped packets                | false
+|--icmp_code|                 filter ICMP code                                      | -
+|--icmp_type|                 filter ICMP type                                      | -
+|--node-selector|             capture on specific nodes                             | -
+|--peer_ip|                   filter peer IP                                        | -
+|--peer_cidr|                 filter peer CIDR                                      | -
+|--port_range|                filter port range                                     | -
+|--port|                      filter port                                           | -
+|--ports|                     filter on either of two ports                         | -
+|--protocol|                  filter protocol                                       | -
+|--query|                     filter flows using a custom query                     | -
+|--sport_range|               filter source port range                              | -
+|--sport|                     filter source port                                    | -
+|--sports|                    filter on either of two source ports                  | -
+|--tcp_flags|                 filter TCP flags                                      | -
+|--interfaces|                list of interfaces to monitor, comma separated        | -
+|--exclude_interfaces|        list of interfaces to exclude, comma separated        | lo
 |===
 
 .Example running flows capture on TCP protocol and port 49051 with PacketDrop and RTT features enabled:
@@ -113,32 +114,32 @@ $ oc netobserv packets [<option>]
 [cols="1,1,1",options="header"]
 |===
 | Option | Description | Default
-|--background|                run in background                          | false
-|--copy|                      copy the output files locally              | prompt
-|--log-level|                 components logs                            | info
-|--max-time|                  maximum capture time                       | 5m
-|--max-bytes|                 maximum capture bytes                      | 50000000 = 50MB
-|--action|                    filter action                              | Accept
-|--cidr|                      filter CIDR                                | 0.0.0.0/0
-|--direction|                 filter direction                           | –
-|--dport|                     filter destination port                    | –
-|--dport_range|               filter destination port range              | –
-|--dports|                    filter on either of two destination ports  | –
-|--drops|                     filter flows with only dropped packets     | false
-|--icmp_code|                 filter ICMP code                           | –
-|--icmp_type|                 filter ICMP type                           | –
-|--node-selector|             capture on specific nodes                  | –
-|--peer_ip|                   filter peer IP                             | –
-|--peer_cidr|                 filter peer CIDR                           | –
-|--port_range|                filter port range                          | –
-|--port|                      filter port                                | –
-|--ports|                     filter on either of two ports              | –
-|--protocol|                  filter protocol                            | –
-|--query|                     filter flows by using a custom query          | –
-|--sport_range|               filter source port range                   | –
-|--sport|                     filter source port                         | –
-|--sports|                    filter on either of two source ports       | –
-|--tcp_flags|                 filter TCP flags                           | –
+|--background|                run in background                                     | false
+|--copy|                      copy the output files locally                         | prompt
+|--log-level|                 components logs                                       | info
+|--max-time|                  maximum capture time                                  | 5m
+|--max-bytes|                 maximum capture bytes                                 | 50000000 = 50MB
+|--action|                    filter action                                         | Accept
+|--cidr|                      filter CIDR                                           | 0.0.0.0/0
+|--direction|                 filter direction                                      | -
+|--dport|                     filter destination port                               | -
+|--dport_range|               filter destination port range                         | -
+|--dports|                    filter on either of two destination ports             | -
+|--drops|                     filter flows with only dropped packets                | false
+|--icmp_code|                 filter ICMP code                                      | -
+|--icmp_type|                 filter ICMP type                                      | -
+|--node-selector|             capture on specific nodes                             | -
+|--peer_ip|                   filter peer IP                                        | -
+|--peer_cidr|                 filter peer CIDR                                      | -
+|--port_range|                filter port range                                     | -
+|--port|                      filter port                                           | -
+|--ports|                     filter on either of two ports                         | -
+|--protocol|                  filter protocol                                       | -
+|--query|                     filter flows using a custom query                     | -
+|--sport_range|               filter source port range                              | -
+|--sport|                     filter source port                                    | -
+|--sports|                    filter on either of two source ports                  | -
+|--tcp_flags|                 filter TCP flags                                      | -
 |===
 
 .Example running packets capture on TCP protocol and port 49051:
@@ -158,76 +159,48 @@ $ oc netobserv metrics [<option>]
 [cols="1,1,1",options="header"]
 |===
 | Option | Description | Default
-|--enable_all|                enable all eBPF features                   | false
-|--enable_dns|                enable DNS tracking                        | false
-|--enable_ipsec|              enable IPsec tracking                      | false
-|--enable_network_events|     enable network events monitoring           | false
-|--enable_pkt_translation|    enable packet translation                  | false
-|--enable_pkt_drop|           enable packet drop                         | false
-|--enable_rtt|                enable RTT tracking                        | false
-|--enable_udn_mapping|        enable User Defined Network mapping | false
-|--get-subnets|               get subnets information                   | false
-|--sampling|                  value that defines the ratio of packets being sampled | 1
-|--action|                    filter action                              | Accept
-|--cidr|                      filter CIDR                                | 0.0.0.0/0
-|--direction|                 filter direction                           | –
-|--dport|                     filter destination port                    | –
-|--dport_range|               filter destination port range              | –
-|--dports|                    filter on either of two destination ports  | –
-|--drops|                     filter flows with only dropped packets     | false
-|--icmp_code|                 filter ICMP code                           | –
-|--icmp_type|                 filter ICMP type                           | –
-|--node-selector|             capture on specific nodes                  | –
-|--peer_ip|                   filter peer IP                             | –
-|--peer_cidr|                 filter peer CIDR                           | –
-|--port_range|                filter port range                          | –
-|--port|                      filter port                                | –
-|--ports|                     filter on either of two ports              | –
-|--protocol|                  filter protocol                            | –
-|--query|                     filter flows by using a custom query          | –
-|--sport_range|               filter source port range                   | –
-|--sport|                     filter source port                         | –
-|--sports|                    filter on either of two source ports       | –
-|--tcp_flags|                 filter TCP flags                           | –
-|--include_list|              list of metric names to generate, comma separated           | namespace_flows_total,node_ingress_bytes_total,node_egress_bytes_total,workload_ingress_bytes_total
-|--interfaces|                list of interfaces to monitor, comma separated     | –
-|--exclude_interfaces|        list of interfaces to exclude, comma separated     | lo
+|--enable_all|                enable all eBPF features                              | false
+|--enable_dns|                enable DNS tracking                                   | false
+|--enable_ipsec|              enable IPsec tracking                                 | false
+|--enable_network_events|     enable network events monitoring                      | false
+|--enable_pkt_translation|    enable packet translation                             | false
+|--enable_pkt_drop|           enable packet drop                                    | false
+|--enable_rtt|                enable RTT tracking                                   | false
+|--enable_udn_mapping|        enable User Defined Network mapping                   | false
+|--get-subnets|               get subnets information                               | false
+|--privileged|                force eBPF agent privileged mode                      | auto
+|--sampling|                  packets sampling interval                             | 1
+|--background|                run in background                                     | false
+|--log-level|                 components logs                                       | info
+|--max-time|                  maximum capture time                                  | 1h
+|--action|                    filter action                                         | Accept
+|--cidr|                      filter CIDR                                           | 0.0.0.0/0
+|--direction|                 filter direction                                      | -
+|--dport|                     filter destination port                               | -
+|--dport_range|               filter destination port range                         | -
+|--dports|                    filter on either of two destination ports             | -
+|--drops|                     filter flows with only dropped packets                | false
+|--icmp_code|                 filter ICMP code                                      | -
+|--icmp_type|                 filter ICMP type                                      | -
+|--node-selector|             capture on specific nodes                             | -
+|--peer_ip|                   filter peer IP                                        | -
+|--peer_cidr|                 filter peer CIDR                                      | -
+|--port_range|                filter port range                                     | -
+|--port|                      filter port                                           | -
+|--ports|                     filter on either of two ports                         | -
+|--protocol|                  filter protocol                                       | -
+|--query|                     filter flows using a custom query                     | -
+|--sport_range|               filter source port range                              | -
+|--sport|                     filter source port                                    | -
+|--sports|                    filter on either of two source ports                  | -
+|--tcp_flags|                 filter TCP flags                                      | -
+|--include_list|              list of metric names to generate, comma separated     | namespace_flows_total,node_ingress_bytes_total,node_egress_bytes_total,workload_ingress_bytes_total
+|--interfaces|                list of interfaces to monitor, comma separated        | -
+|--exclude_interfaces|        list of interfaces to exclude, comma separated        | lo
 |===
 
 .Example running metrics capture for TCP drops
 [source,terminal]
 ----
 $ oc netobserv metrics --enable_pkt_drop --protocol=TCP
-----
-
-.Example running metrics capture for list of metric names to generate
-[source,terminal]
-----
-$ oc netobserv metrics --include_list=node,workload
-----
-
-[source,terminal]
-----
-$ oc netobserv metrics --include_list=node_egress_bytes_total,workload_egress_packets_total
-----
-
-[source,terminal]
-----
-$ oc netobserv metrics --enable_all --include_list=node,namespace,workload
-----
-
-.Example output for list of metric names
-[source, terminal]
-----
-opt: include_list, value: node,workload
-Matching metrics:
- - node_egress_bytes_total
- - node_ingress_bytes_total
- - workload_egress_bytes_total
- - workload_ingress_bytes_total
- - workload_egress_packets_total
- - workload_ingress_packets_total
- - workload_flows_total
- - workload_drop_packets_total
- - workload_drop_bytes_total
 ----


### PR DESCRIPTION
[OSDOCS-16179](https://issues.redhat.com//browse/OSDOCS-16179) [NETOBSERV] CLI Updates 1.10

Version(s):
Merge to only the `no-1.10` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the <no-.10> content just before its GA.

Note to self for integration branch: applies to OCP 4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-16179

Link to docs preview:
// Automatically generated by 'openshift-apidocs-gen'. Do not edit.
* Network Observability CLI: https://99908--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-reference.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
