### PR TITLE
OSDOCS-16290-4.19 Azure encrypted vnet installs

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -532,6 +532,11 @@ The Insights Runtime Extractor feature gathers runtime workload data and sends i
 
 In {product-title} {product-version}, the installation program uses the Cluster API instead of Terraform to provision cluster infrastructure during installations on {ibm-cloud-title}.
 
+[id="ocp-release-notes-installation-azure-encrypted-vnet_{context}"]
+==== Installing a cluster on {azure-full} with virtual network encryption
+
+With this release, you can install a cluster on {azure-short} using encrypted virtual networks. You are required to use {azure-short} virtual machines that have the `premiumIO` parameter set to `true`. See Microsoft's documentation about link:https://learn.microsoft.com/en-us/azure/virtual-network/how-to-create-encryption?tabs=portal[Creating a virtual network with encryption] and link:https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-encryption-overview#requirements[Requirements and Limitations] for more information.
+
 [id="ocp-4-19-installation-and-update-aws-malaysia-thailand_{context}"]
 ==== Installing a cluster on {aws-short} in the Malaysia and Thailand regions
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-16290

Link to docs preview:


QE review:
- [x] QE has approved this change.


Additional information:
Per [Jinyun Ma](https://github.com/openshift/openshift-docs/pull/99700#issuecomment-3342180884), encrypted vnet installs in 4.20 are also supported in 4.19 and [4.18](https://github.com/openshift/openshift-docs/pull/99923)

Change management approvals:
- [x] PX: @sferich888
- [x] QE: @jinyunma
- [x] Eng: @patrickdillon
- [x] PM: @makentenza 
- [x] DPM: @kalexand-rh