### PR TITLE
OSDOCS-16290-4.18 Azure encrypted vnet install

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -643,6 +643,11 @@ The Insights Operator now gathers more data to detect the following scenarios, w
 
 The installation program now uses a newer version of the {cap-ibm-short} provider that includes Transit Gateway fixes. Because of the cost of Transit Gateways in {ibm-cloud-title}, you can now use the {product-title} to create a Transit Gateway when creating an {product-title} cluster. For more information, see (link:https://issues.redhat.com/browse/OCPBUGS-37588[OCPBUGS-37588]) and (link:https://issues.redhat.com/browse/OCPBUGS-41938[OCPBUGS-41938]).
 
+[id="ocp-release-notes-installation-azure-encrypted-vnet_{context}"]
+==== Installing a cluster on {azure-full} with virtual network encryption
+
+With this release, you can install a cluster on {azure-short} using encrypted virtual networks. You are required to use {azure-short} virtual machines that have the `premiumIO` parameter set to `true`, and that do not support NVMe storage. See Microsoft's documentation about link:https://learn.microsoft.com/en-us/azure/virtual-network/how-to-create-encryption?tabs=portal[Creating a virtual network with encryption] and link:https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-encryption-overview#requirements[Requirements and Limitations] for more information.
+
 [id="ocp-4-18-installation-and-update-ovn-kubernetes-join-subnet_{context}"]
 ==== Configuring the `ovn-kubernetes` join subnet during cluster installation
 With this release, you can configure the IPv4 join subnet that is used internally by `ovn-kubernetes` when installing a cluster. You can set the `internalJoinSubnet` parameter in the `install-config.yaml` file and deploy the cluster into an existing Virtual Private Cloud (VPC).


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-16290

Link to docs preview:


QE review:
- [x] QE has approved this change.


Additional information:
Per [Jinyun Ma](https://github.com/openshift/openshift-docs/pull/99700#issuecomment-3342180884), encrypted vnet installs in 4.20 are also supported in [4.19](https://github.com/openshift/openshift-docs/pull/99918) and 4.18.

The additional changes in this PR are the result of automatically removing trailing whitespace.

Change management approvals:
- [x] PX: @sferich888
- [x] QE: @jinyunma
- [x] Eng: @patrickdillon
- [x] PM: @makentenza 
- [x] DPM: @kalexand-rh