### PR TITLE
OSDOCS-16084: Restructured Subnet Tagging info

### DIFF
--- a/modules/rosa-hcp-vpc-subnet-tagging.adoc
+++ b/modules/rosa-hcp-vpc-subnet-tagging.adoc
@@ -3,12 +3,21 @@
 // * rosa_hcp/rosa-hcp-quickstart-guide.adoc
 // * rosa_hcp/rosa-hcp-creating-cluster-with-aws-kms-key.adoc
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+ifeval::["{context}" == "rosa-hcp-prereqs"]
+:hcp-preqs:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="rosa-hcp-vpc-subnet-tagging_{context}"]
 = Tagging your subnets
 
-Before you can use your VPC to create a {product-title} cluster, you must tag your VPC subnets. Automated service preflight checks verify that these resources are tagged correctly before you can use these resources for a cluster. The following table shows how your resources should be tagged:
+ifdef::hcp-preqs[]
+If you created your own VPC to create a {product-title} cluster, you must tag your VPC subnets. 
+endif::hcp-preqs[]
+ifndef::hcp-preqs[]
+Before you can use your VPC to create a {product-title} cluster, you must tag your VPC subnets.  
+endif::hcp-preqs[]
+Automated service preflight checks verify that these resources are tagged correctly before you can use these resources for a cluster. The following table shows how your resources should be tagged:
 
 [cols="3a,8a,8a", options="header"]
 |===
@@ -38,7 +47,7 @@ You must tag at least one private subnet and, if applicable, one public subnet.
 
 .Procedure
 
-. Tag your resources in your terminal by running the following commands:
+* Tag your resources in your terminal by running the following commands:
 .. For public subnets, run:
 +
 [source,terminal]
@@ -68,3 +77,6 @@ $ aws ec2 describe-tags --filters "Name=resource-id,Values=<subnet_id>"
 TAGS    Name                    <subnet-id>        subnet  <prefix>-subnet-public1-us-east-1a
 TAGS    kubernetes.io/role/elb  <subnet-id>        subnet  1
 ----
+ifeval::["{context}" == "rosa-hcp-prereqs"]
+:!hcp-preqs:
+endif::[]

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -125,6 +125,7 @@ include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
 include::modules/rosa-hcp-firewall-prerequisites.adoc[leveloffset=+2]
+include::modules/rosa-hcp-vpc-subnet-tagging.adoc[leveloffset=+2]
 endif::openshift-rosa-hcp[]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
`enterprise-4.19+`

Issue:
**[OSDOCS-16084](https://issues.redhat.com/browse/OSDOCS-16084)**

Link to docs preview:
- [Tagging your subnets](https://99933--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-sts-aws-prereqs#rosa-hcp-vpc-subnet-tagging_rosa-hcp-prereqs)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR changes the Subnet tagging details for VPCs into a module that is then placed throughout the docs, including in the HCP prerequisites.