### PR TITLE
OSDOCS-16247#adding multi-arch support

### DIFF
--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc
@@ -53,7 +53,7 @@ To create a cluster with multi-architecture compute machines with different inst
 .3+|xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal, {ibm-power-title}, or {ibm-z-title}]
 |Bare metal
 |&#10003;
-|
+|&#10003;
 |`aarch64` or `x86_64`
 |`aarch64`, `x86_64`
 


### PR DESCRIPTION
Versions:
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16247

Link to docs preview:
[Configuring your cluster with multi-architecture compute machines](https://99947--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.html#configuring-your-cluster-with-multi-architecture-compute-machines)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
