### PR TITLE
OSDOCS-15095 Updated AWS AMIs for 4.20

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,106 +23,109 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-0163621ea085783d8`
+|`ami-03ec26381f6a347be`
 
 |`ap-east-1`
-|`ami-033db3b659641feea`
+|`ami-04332931a972c8398`
+
+|`ap-east-2`
+|`ami-0ac916d2813a7b18a`
 
 |`ap-northeast-1`
-|`ami-0baf16f8c6bd53f63`
+|`ami-0a3254abafd41cbda`
 
 |`ap-northeast-2`
-|`ami-01a92be7f419359cc`
+|`ami-001d35f0b7a38999e`
 
 |`ap-northeast-3`
-|`ami-0f16895f6f50e656e`
+|`ami-012a97b7293096c47`
 
 |`ap-south-1`
-|`ami-0272be2f6528576f3`
+|`ami-021b5ab76f755886f`
 
 |`ap-south-2`
-|`ami-0311119df2ebc0bbc`
+|`ami-038f598890a52f3c9`
 
 |`ap-southeast-1`
-|`ami-0637678b0ad540477`
+|`ami-0d191a1bffd735ebe`
 
 |`ap-southeast-2`
-|`ami-0b67b492c091ac746`
+|`ami-007439e088223214a`
 
 |`ap-southeast-3`
-|`ami-0a9e63bf1df36a936`
+|`ami-0e024a0bbbdf621da`
 
 |`ap-southeast-4`
-|`ami-0f153b95673592039`
+|`ami-0929268b6d28ba1e9`
 
 |`ap-southeast-5`
-|`ami-025944207bb28ae8f`
+|`ami-0a9461ac20d4691fe`
 
 |`ap-southeast-7`
-|`ami-0b5e29c2ae4aaa66d`
+|`ami-0ae438f9ab8af4459`
 
 |`ca-central-1`
-|`ami-03263f0cfdfa8bbdb`
+|`ami-07079826624ddc0d3`
 
 |`ca-west-1`
-|`ami-0254620c2dc7dcacc`
+|`ami-0e0a89efe9e4aebd8`
 
 |`eu-central-1`
-|`ami-0a0a87862b24395d8`
+|`ami-0b9392304b25a1be6`
 
 |`eu-central-2`
-|`ami-015c8ca32f5d8300a`
+|`ami-004899c1b1392a416`
 
 |`eu-north-1`
-|`ami-0c4404a6ae5921a1b`
+|`ami-04db8de6d2660d477`
 
 |`eu-south-1`
-|`ami-0e0724943dd915bb2`
+|`ami-03f6525889efe953b`
 
 |`eu-south-2`
-|`ami-0e6cac787a21b221d`
+|`ami-0214e803d8564e890`
 
 |`eu-west-1`
-|`ami-0355d4c968e466965`
+|`ami-04ca111133e8458c6`
 
 |`eu-west-2`
-|`ami-0e079f8742280b034`
+|`ami-089d8892ef8f88156`
 
 |`eu-west-3`
-|`ami-06702aad076acda7b`
+|`ami-0cebb38e071808759`
 
 |`il-central-1`
-|`ami-0094ac2722d41c18c`
+|`ami-08ff4ee35db1e8b29`
 
 |`me-central-1`
-|`ami-03680a3dcecfbe79d`
+|`ami-0467b2b1a131cb070`
 
 |`me-south-1`
-|`ami-04e14a3c4be812ac7`
+|`ami-09fe6bcfb3cab07a7`
 
 |`mx-central-1`
-|`ami-0eac1c8d4154a417f`
+|`ami-0a7e97cb28cbb8354`
 
 |`sa-east-1`
-|`ami-07abd63bb465f89b6`
+|`ami-0ff7e5fea2302529b`
 
 |`us-east-1`
-|`ami-0e8fd9094e487d1ff`
+|`ami-09d23adad19cdb25c`
 
 |`us-east-2`
-|`ami-0d4a7b7677c0c883f`
+|`ami-082a55a580d5538ed`
 
 |`us-gov-east-1`
-|`ami-0b67e7ffd11a17645`
+|`ami-06eb65026809257f2`
 
 |`us-gov-west-1`
-|`ami-041e18a76f42c752c`
+|`ami-02d89c98e7cb51709`
 
 |`us-west-1`
-|`ami-0167f257577d883cc`
+|`ami-0788e768db7ced74d`
 
 |`us-west-2`
-|`ami-0b29d41f2ed6b8c94`
+|`ami-000b42519a25cacc5`
 
 |===
 
@@ -135,106 +138,109 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-009231bfc2490c6f9`
+|`ami-0148286cf26e84d1d`
 
 |`ap-east-1`
-|`ami-0a23fad8fb25f5bb7`
+|`ami-020178428baa4d29d`
+
+|`ap-east-2`
+|`ami-0dc346212bfae9a5a`
 
 |`ap-northeast-1`
-|`ami-0754a269f165f227c`
+|`ami-04cd61839a245df4e`
 
 |`ap-northeast-2`
-|`ami-0d81f596571ce27d8`
+|`ami-09f756251f513af27`
 
 |`ap-northeast-3`
-|`ami-01eb2f8b176229523`
+|`ami-0d2f277e312013de9`
 
 |`ap-south-1`
-|`ami-0be3b34441044e437`
+|`ami-0bc01c2ad16fef268`
 
 |`ap-south-2`
-|`ami-02a86359661950bb0`
+|`ami-0961ddf05f99aa1ac`
 
 |`ap-southeast-1`
-|`ami-0c70d35c9b5b190be`
+|`ami-086c5fdb20edc12c7`
 
 |`ap-southeast-2`
-|`ami-0310f2acbeca636ed`
+|`ami-0cd7e64385588d5af`
 
 |`ap-southeast-3`
-|`ami-04db4055063382442`
+|`ami-09a4ec979ba4d8804`
 
 |`ap-southeast-4`
-|`ami-0e2e40cc31633d7d6`
+|`ami-030445ba8507a3ec6`
 
 |`ap-southeast-5`
-|`ami-0cf0c9ee9f324f763`
+|`ami-013bd53f7db86068d`
 
 |`ap-southeast-7`
-|`ami-04cdafcdc85bf9040`
+|`ami-026b8f665827ffda4`
 
 |`ca-central-1`
-|`ami-0aee20271a9396925`
+|`ami-0dd67b8ff235b962c`
 
 |`ca-west-1`
-|`ami-03ca778cd4265aad9`
+|`ami-09469dfe86edf2a39`
 
 |`eu-central-1`
-|`ami-0281dddee0884d9f0`
+|`ami-00bd76511738f7c79`
 
 |`eu-central-2`
-|`ami-00fc4e5e3926530af`
+|`ami-0e72cf40ed8ca51f3`
 
 |`eu-north-1`
-|`ami-0696b5b31d326ccc6`
+|`ami-06ce6706d18914e38`
 
 |`eu-south-1`
-|`ami-04090792b7bdb9e0f`
+|`ami-0d3c5dedab43b8daa`
 
 |`eu-south-2`
-|`ami-0d45a2586055d5daa`
+|`ami-06c0dd7efd3688e89`
 
 |`eu-west-1`
-|`ami-02f08479c3613ed0e`
+|`ami-0ba6941055f037421`
 
 |`eu-west-2`
-|`ami-0ef2fc25f02a2d475`
+|`ami-0934f6e7344143299`
 
 |`eu-west-3`
-|`ami-0ba5d0a0e5d796da8`
+|`ami-0faeee552170fef71`
 
 |`il-central-1`
-|`ami-0e5b8f3b8e71961e7`
+|`ami-0f6dbbdd757912184`
 
 |`me-central-1`
-|`ami-0d13d6a91da2ba547`
+|`ami-0f9afa7909fa8890b`
 
 |`me-south-1`
-|`ami-0183dab9f96845e3f`
+|`ami-0f7e06ef6b630d78c`
 
 |`mx-central-1`
-|`ami-072535d81a5de8e76`
+|`ami-08956a7d43f06c11a`
 
 |`sa-east-1`
-|`ami-0977fa46dff272ba9`
+|`ami-0774d29f6ed96935b`
 
 |`us-east-1`
-|`ami-083de3282c55be3f7`
+|`ami-05834415546b16278`
 
 |`us-east-2`
-|`ami-02f30107e3441227b`
+|`ami-0c59bfd7b7a7cc3e7`
 
 |`us-gov-east-1`
-|`ami-0abaadf7322cfc258`
+|`ami-04c3ea90e1fec5a29`
 
 |`us-gov-west-1`
-|`ami-0ca27128d77d732aa`
+|`ami-05fce4dea56fdf75f`
 
 |`us-west-1`
-|`ami-05a9426ae7c35740c`
+|`ami-0104db843a42a4455`
 
 |`us-west-2`
-|`ami-0cd6ec50e0480b3a3`
+|`ami-0b745e03468dc48d2`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-15095

Link to docs preview:
https://99950--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra

QE review:
- [x] QE has approved this change.
