### PR TITLE
OSDOCS-16386 Combining values column of install config parameters into description column for readability

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -823,30 +823,33 @@ ifdef::aws[]
 Optional AWS configuration parameters are described in the following table:
 
 .Optional AWS parameters
-[cols=".^2l,.^3,.^5a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |compute:
   platform:
     aws:
       amiID:
 |The AWS AMI used to boot compute machines for the cluster. This is required for regions that require a custom {op-system} AMI.
-|Any published or custom {op-system} AMI that belongs to the set AWS region. See _{op-system} AMIs for AWS infrastructure_ for available AMI IDs.
+
+*Value:* Any published or custom {op-system} AMI that belongs to the set AWS region. See _{op-system} AMIs for AWS infrastructure_ for available AMI IDs.
 
 |compute:
   platform:
     aws:
       iamProfile:
 |The name of the IAM instance profile that you use for the machine. If you want the installation program to create the IAM instance profile for you, do not use the `iamProfile` parameter. You can specify either the `iamProfile` or `iamRole` parameter, but you cannot specify both.
-|String
+
+*Value:* String
 
 |compute:
   platform:
     aws:
       iamRole:
 |The name of the IAM instance role that you use for the machine. When you specify an IAM role, the installation program creates an instance profile. If you want the installation program to create the IAM instance role for you, do not select the `iamRole` parameter. You can specify either the `iamRole` or `iamProfile` parameter, but you cannot specify both.
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -854,7 +857,8 @@ Optional AWS configuration parameters are described in the following table:
       rootVolume:
         iops:
 |The Input/Output Operations Per Second (IOPS) that is reserved for the root volume.
-|Integer, for example `4000`.
+
+*Value:* Integer, for example `4000`.
 
 |compute:
   platform:
@@ -862,7 +866,8 @@ Optional AWS configuration parameters are described in the following table:
       rootVolume:
         size:
 |The size in GiB of the root volume.
-|Integer, for example `500`.
+
+*Value:* Integer, for example `500`.
 
 |compute:
   platform:
@@ -870,8 +875,8 @@ Optional AWS configuration parameters are described in the following table:
       rootVolume:
         type:
 |The type of the root volume.
-|Valid link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html[AWS EBS volume type],
-such as `io1`.
+
+*Value:* Valid link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html[AWS EBS volume type], such as `io1`.
 
 |compute:
   platform:
@@ -879,43 +884,48 @@ such as `io1`.
       rootVolume:
         kmsKeyARN:
 |The Amazon Resource Name (key ARN) of a KMS key. This is required to encrypt operating system volumes of worker nodes with a specific KMS key.
-|Valid link:https://docs.aws.amazon.com/kms/latest/developerguide/find-cmk-id-arn.html[key ID or the key ARN].
+
+*Value:* Valid link:https://docs.aws.amazon.com/kms/latest/developerguide/find-cmk-id-arn.html[key ID or the key ARN].
 
 |compute:
   platform:
     aws:
       type:
 |The EC2 instance type for the compute machines.
-|Valid {aws-short} instance type, such as `m4.2xlarge`. See the "Tested instance types for AWS" table on the "Installing a cluster on AWS with customizations" page.
+
+*Value:* Valid {aws-short} instance type, such as `m4.2xlarge`. See the "Tested instance types for AWS" table on the "Installing a cluster on AWS with customizations" page.
 
 |compute:
   platform:
     aws:
       zones:
 |The availability zones where the installation program creates machines for the compute machine pool. If you provide your own VPC, you must provide a subnet in that availability zone.
-|A list of valid AWS availability zones, such as `us-east-1c`, in a
-link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
+
+*Value:* A list of valid AWS availability zones, such as `us-east-1c`, in a link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
 |controlPlane:
   platform:
     aws:
       amiID:
 |The AWS AMI used to boot control plane machines for the cluster. This is required for regions that require a custom {op-system} AMI.
-|Any published or custom {op-system} AMI that belongs to the set AWS region. See _{op-system} AMIs for AWS infrastructure_ for available AMI IDs.
+
+*Value:* Any published or custom {op-system} AMI that belongs to the set AWS region. See _{op-system} AMIs for AWS infrastructure_ for available AMI IDs.
 
 |controlPlane:
   platform:
     aws:
       iamProfile:
 |The name of the IAM instance profile that you use for the machine. If you want the installation program to create the IAM instance profile for you, do not use the `iamProfile` parameter. You can specify either the `iamProfile` or `iamRole` parameter, but you cannot specify both.
-|String
+
+*Value:* String
 
 |controlPlane:
   platform:
     aws:
       iamRole:
 |The name of the IAM instance role that you use for the machine. When you specify an IAM role, the installation program creates an instance profile. If you want the installation program to create the IAM instance role for you, do not use the `iamRole` parameter. You can specify either the `iamRole` or `iamProfile` parameter, but you cannot specify both.
-|String
+
+*Value:* String
 
 |controlPlane:
   platform:
@@ -923,7 +933,8 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
       rootVolume:
         iops:
 |The Input/Output Operations Per Second (IOPS) that is reserved for the root volume on control plane machines.
-|Integer, for example `4000`.
+
+*Value:* Integer, for example `4000`.
 
 |controlPlane:
   platform:
@@ -931,7 +942,8 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
       rootVolume:
         size:
 |The size in GiB of the root volume for control plane machines.
-|Integer, for example `500`.
+
+*Value:* Integer, for example `500`.
 
 |controlPlane:
   platform:
@@ -939,8 +951,8 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
       rootVolume:
         type:
 |The type of the root volume for control plane machines.
-|Valid link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html[AWS EBS volume type],
-such as `io1`.
+
+*Value:* Valid link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html[AWS EBS volume type], such as `io1`.
 
 |controlPlane:
   platform:
@@ -948,51 +960,58 @@ such as `io1`.
       rootVolume:
         kmsKeyARN:
 |The Amazon Resource Name (key ARN) of a KMS key. This is required to encrypt operating system volumes of control plane nodes with a specific KMS key.
-|Valid link:https://docs.aws.amazon.com/kms/latest/developerguide/find-cmk-id-arn.html[key ID and the key ARN].
+
+*Value:* Valid link:https://docs.aws.amazon.com/kms/latest/developerguide/find-cmk-id-arn.html[key ID and the key ARN].
 
 |controlPlane:
   platform:
     aws:
       type:
 |The EC2 instance type for the control plane machines.
-|Valid {aws-short} instance type, such as `m6i.xlarge`. See the "Tested instance types for AWS" table on the "Installing a cluster on AWS with customizations" page.
+
+*Value:* Valid {aws-short} instance type, such as `m6i.xlarge`. See the "Tested instance types for AWS" table on the "Installing a cluster on AWS with customizations" page.
 
 |controlPlane:
   platform:
     aws:
       zones:
-|The availability zones where the installation program creates machines for the
-control plane machine pool.
-|A list of valid AWS availability zones, such as `us-east-1c`, in a link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
+|The availability zones where the installation program creates machines for the control plane machine pool.
+
+*Value:* A list of valid AWS availability zones, such as `us-east-1c`, in a link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
 |platform:
   aws:
     amiID:
-|The AWS AMI used to boot all machines for the cluster. If set, the AMI must
-belong to the same region as the cluster. This is required for regions that require a custom {op-system} AMI.
-|Any published or custom {op-system} AMI that belongs to the set AWS region. See _{op-system} AMIs for AWS infrastructure_ for available AMI IDs.
+|The AWS AMI used to boot all machines for the cluster. If set, the AMI must belong to the same region as the cluster. This is required for regions that require a custom {op-system} AMI.
+
+*Value:* Any published or custom {op-system} AMI that belongs to the set AWS region. See _{op-system} AMIs for AWS infrastructure_ for available AMI IDs.
 
 |platform:
   aws:
     hostedZone:
 |An existing Route 53 private hosted zone for the cluster. You can only use a pre-existing hosted zone when also supplying your own VPC. The hosted zone must already be associated with the user-provided VPC before installation. Also, the domain of the hosted zone must be the cluster domain or a parent of the cluster domain. If undefined, the installation program creates a new hosted zone.
-|String, for example `Z3URY6TWQ91KVV`.
+
+*Value:* String, for example `Z3URY6TWQ91KVV`.
 
 |platform:
   aws:
     hostedZoneRole:
 |An Amazon Resource Name (ARN) for an existing IAM role in the account containing the specified hosted zone. The installation program and cluster operators assume this role when performing operations on the hosted zone. Use this parameter only when you are installing a cluster into a shared VPC.
-|String, for example `arn:aws:iam::1234567890:role/shared-vpc-role`.
+
+*Value:* String, for example `arn:aws:iam::1234567890:role/shared-vpc-role`.
 
 |platform:
   aws:
     region:
 |The AWS region that the installation program creates all cluster resources in.
-|Any valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`. You can use the AWS CLI to access the regions available based on your selected instance type by running the following command:
+
+*Value:* Any valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`. You can use the AWS CLI to access the regions available based on your selected instance type by running the following command:
+
 [source,terminal]
 ----
 $ aws ec2 describe-instance-type-offerings --filters Name=instance-type,Values=c7g.xlarge
 ----
+
 ifndef::openshift-origin[]
 [IMPORTANT]
 ====
@@ -1006,13 +1025,15 @@ endif::openshift-origin[]
       - name:
         url:
 |The AWS service endpoint name and URL. Custom endpoints are only required for cases where alternative AWS endpoints, such as FIPS, must be used. Custom API endpoints can be specified for EC2, S3, IAM, Elastic Load Balancing, Tagging, Route 53, and STS AWS services.
-|Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] name and valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] URL.
+
+*Value:* Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] name and valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] URL.
 
 |platform:
   aws:
     userTags:
 |A map of keys and values that the installation program adds as tags to all resources that it creates.
-|Any valid YAML map, such as key value pairs in the `<key>: <value>` format. For more information about AWS tags, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html[Tagging Your Amazon EC2 Resources] in the AWS documentation.
+
+*Value:* Any valid YAML map, such as key value pairs in the `<key>: <value>` format. For more information about AWS tags, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html[Tagging Your Amazon EC2 Resources] in the AWS documentation.
 
 [NOTE]
 ====
@@ -1022,14 +1043,16 @@ You can add up to 25 user-defined tags during installation. The remaining 25 tag
 |platform:
   aws:
     propagateUserTags:
-| A flag that directs in-cluster Operators to include the specified user tags in the tags of the AWS resources that the Operators create.
-| Boolean values, for example `true` or `false`.
+|A flag that directs in-cluster Operators to include the specified user tags in the tags of the AWS resources that the Operators create.
+
+*Value:* Boolean values, for example `true` or `false`.
 
 |platform:
   aws:
     publicIpv4Pool:
 |The public IPv4 pool ID that is used to allocate Elastic IPs (EIPs) when `publish` is set to `External`. You must provision and advertise the pool in the same {aws-short} account and region of the cluster. You must ensure that you have 2n + 1 IPv4 addresses available in the pool where _n_ is the total number of {aws-short} zones used to deploy the Network Load Balancer (NLB) for API, NAT gateways, and bootstrap node. For more information about bring your own IP addresses (BYOIP) in {aws-short}, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-byoip.html#byoip-onboard[Onboard your BYOIP].
-| A valid link:https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-public-ipv4-pools.html[public IPv4 pool id]
+
+*Value:* A valid link:https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-public-ipv4-pools.html[public IPv4 pool id]
 
 [NOTE]
 ====
@@ -1040,18 +1063,24 @@ You can enable BYOIP only for customized installations that do not have any netw
   aws:
     preserveBootstrapIgnition:
 |Prevents the S3 bucket from being deleted after completion of bootstrapping.
-|`true` or `false`. The default value is `false`, which results in the S3 bucket being deleted.
+
+*Value:* `true` or `false`. The default value is `false`, which results in the S3 bucket being deleted.
 
 |platform:
   aws:
     vpc:
       subnets:
 |A list of subnets in an existing VPC to be used in place of automatically created subnets. You specify a subnet by providing the subnet ID and an optional list of roles that apply to that subnet. If you specify subnet IDs but do not specify roles for any subnet, the subnets' roles are decided automatically. If you do not specify any roles, you must ensure that any other subnets in your VPC have the `kubernetes.io/cluster/.*: .*` or `kubernetes.io/cluster/unmanaged: true` tags.
+
 The subnets must be part of the same `machineNetwork[].cidr` ranges that you specify.
+
 For a public cluster, specify a public and a private subnet for each availability zone.
+
 For a private cluster, specify a private subnet for each availability zone.
+
 For clusters that use AWS Local Zones, you must add AWS Local Zone subnets to this list to ensure edge machine pool creation.
-|List of pairs of `id` and `roles` parameters.
+
+*Value:* List of pairs of `id` and `roles` parameters.
 
 |platform:
   aws:
@@ -1059,7 +1088,8 @@ For clusters that use AWS Local Zones, you must add AWS Local Zone subnets to th
       subnets:
       - id:
 |The ID of an existing subnet to be used in place of a subnet created by the installation program.
-|String. The subnet ID must be a unique ID containing only alphanumeric characters, beginning with "subnet-". The ID must be exactly 24 characters long.
+
+*Value:* String. The subnet ID must be a unique ID containing only alphanumeric characters, beginning with "subnet-". The ID must be exactly 24 characters long.
 
 |platform:
   aws:
@@ -1069,8 +1099,10 @@ For clusters that use AWS Local Zones, you must add AWS Local Zone subnets to th
         roles:
         - type:
 |One or more roles that apply to the subnet specified by `platform.aws.vpc.subnets.id`. If you specify a role for any subnet, each subnet must have at least one assigned role, and the `ClusterNode`, `IngressControllerLB`, `ControlPlaneExternalLB`, `BootstrapNode`, and `ControlPlaneInternalLB` roles must be assigned to at least one subnet. However, if the cluster scope is internal, then the `ControlPlaneExternalLB` role is not required.
+
 You can only assign the `EdgeNode` role to subnets in {aws-short} Local Zones.
-|List of one or more role types. Valid values include `ClusterNode`, `EdgeNode`, `BootstrapNode`, `IngressControllerLB`, `ControlPlaneExternalLB`, and `ControlPlaneInternalLB`.
+
+*Value:* List of one or more role types. Valid values include `ClusterNode`, `EdgeNode`, `BootstrapNode`, `IngressControllerLB`, `ControlPlaneExternalLB`, and `ControlPlaneInternalLB`.
 
 |====
 endif::aws[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16386

Version: 4.19+

Testing out combining the Values column with the Description column in the installation configuration parameters table since the docs site is unable to render all three columns in a readable way. 

This PR only combines the columns for the "optional AWS configuration parameters" table so that the formatting can be observed on the docs site before combining the rest of the content.

Preview: https://99962--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-optional-aws_installation-config-parameters-aws 

No QA needed