### PR TITLE
OSDOCS#16369: AMD-SEV deprecation notice

### DIFF
--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -48,6 +48,10 @@ include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-first} configuration parameters]
+
 include::modules/installation-gcp-managing-dns-solution.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -54,6 +54,10 @@ include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-first} configuration parameters]
+
 include::modules/installation-gcp-managing-dns-solution.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -51,6 +51,10 @@ include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-first} configuration parameters]
+
 include::modules/installation-gcp-managing-dns-solution.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-gcp-shared-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-shared-vpc.adoc
@@ -40,6 +40,10 @@ include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-first} configuration parameters]
+
 include::modules/installation-gcp-managing-dns-solution.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -85,6 +85,11 @@ include::modules/installation-initializing-manual.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]
 include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-first} configuration parameters]
+
 include::modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -83,6 +83,11 @@ include::modules/installation-initializing.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]
 include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-first} configuration parameters]
+
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 //include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -47,6 +47,10 @@ include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-first} configuration parameters]
+
 include::modules/installation-gcp-managing-dns-solution.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -59,6 +59,10 @@ include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-first} configuration parameters]
+
 include::modules/installation-gcp-managing-dns-solution.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -82,6 +82,11 @@ include::modules/installation-initializing.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]
 include::modules/installation-gcp-enabling-confidential-vms.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional {gcp-first} configuration parameters]
+
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+2]
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2783,9 +2783,19 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
 Supported values are:
 
 * `Enabled`, which automatically selects a Confidential Computing platform
++
+[IMPORTANT]
+====
+The `Enabled` value selects Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV), which is deprecated.
+====
 * `Disabled`, which disables Confidential Computing
-* `AMDEncryptedVirtualization`, which enables Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV)
 * `AMDEncryptedVirtualizationNestedPaging`, which enables Confidential Computing with AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP)
+* `AMDEncryptedVirtualization`, which enables Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV)
++
+[IMPORTANT]
+====
+The use of Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV) has been deprecated and will be removed in a future release.
+====
 * `IntelTrustedDomainExtensions`, which enables Confidential Computing with Intel Trusted Domain Extensions (Intel TDX)
 
 If you specify any value other than `Disabled`, you must set `platform.gcp.defaultMachinePlatform.onHostMaintenance` to `Terminate`, and you must specify a region and machine type that support Confidential Computing. For more information, see Google's documentation about link:https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#machine-type-cpu-zone[Supported configurations].
@@ -2918,9 +2928,19 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
 Supported values are:
 
 * `Enabled`, which automatically selects a Confidential Computing platform
++
+[IMPORTANT]
+====
+The `Enabled` value selects Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV), which is deprecated.
+====
 * `Disabled`, which disables Confidential Computing
-* `AMDEncryptedVirtualization`, which enables Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV)
 * `AMDEncryptedVirtualizationNestedPaging`, which enables Confidential Computing with AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP)
+* `AMDEncryptedVirtualization`, which enables Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV)
++
+[IMPORTANT]
+====
+The use of Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV) has been deprecated and will be removed in a future release.
+====
 * `IntelTrustedDomainExtensions`, which enables Confidential Computing with Intel Trusted Domain Extensions (Intel TDX)
 
 If you specify any value other than `Disabled`, you must set `controlPlane.platform.gcp.defaultMachinePlatform.onHostMaintenance` to `Terminate`.
@@ -3065,9 +3085,19 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
 Supported values are:
 
 * `Enabled`, which automatically selects a Confidential Computing platform
++
+[IMPORTANT]
+====
+The `Enabled` value selects Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV), which is deprecated.
+====
 * `Disabled`, which disables Confidential Computing
-* `AMDEncryptedVirtualization`, which enables Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV)
 * `AMDEncryptedVirtualizationNestedPaging`, which enables Confidential Computing with AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP)
+* `AMDEncryptedVirtualization`, which enables Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV)
++
+[IMPORTANT]
+====
+The use of Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV) has been deprecated and will be removed in a future release.
+====
 * `IntelTrustedDomainExtensions`, which enables Confidential Computing with Intel Trusted Domain Extensions (Intel TDX)
 
 If you specify any value other than `Disabled`, you must set `compute.platform.gcp.onHostMaintenance` to `Terminate`.

--- a/modules/installation-gcp-enabling-confidential-vms.adoc
+++ b/modules/installation-gcp-enabling-confidential-vms.adoc
@@ -30,13 +30,16 @@ Confidential VMs are currently not supported on 64-bit ARM architectures.
 controlPlane:
   platform:
     gcp:
-       confidentialCompute: Enabled <1>
+       confidentialCompute: AMDEncryptedVirtualizationNestedPaging <1>
        type: n2d-standard-8 <2>
        onHostMaintenance: Terminate <3>
 ----
-<1> Enable confidential VMs.
-<2> Specify a machine type that supports Confidential VMs. Confidential VMs require the N2D or C2D series of machine types. For more information on supported machine types, see link:https://cloud.google.com/compute/confidential-vm/docs/os-and-machine-type#machine-type[Supported operating systems and machine types].
++
+--
+<1> Enable confidential VMs with AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP). For more information about available options, see "Additional {gcp-first} configuration parameters".
+<2> Specify a machine type that supports Confidential VMs. Confidential VMs require the N2D, C2D, C3D, or C3 series of machine types. For more information on supported machine types, see link:https://cloud.google.com/compute/confidential-vm/docs/os-and-machine-type#machine-type[Supported operating systems and machine types].
 <3> Specify the behavior of the VM during a host maintenance event, such as a hardware or software update. For a machine that uses Confidential VM, this value must be set to `Terminate`, which stops the VM. Confidential VMs do not support live VM migration.
+--
 +
 .. To use confidential VMs for only compute machines:
 +
@@ -45,7 +48,7 @@ controlPlane:
 compute:
 - platform:
     gcp:
-       confidentialCompute: Enabled
+       confidentialCompute: AMDEncryptedVirtualizationNestedPaging
        type: n2d-standard-8
        onHostMaintenance: Terminate
 ----
@@ -57,7 +60,7 @@ compute:
 platform:
   gcp:
     defaultMachinePlatform:
-       confidentialCompute: Enabled
+       confidentialCompute: AMDEncryptedVirtualizationNestedPaging
        type: n2d-standard-8
        onHostMaintenance: Terminate
 ----

--- a/modules/machineset-gcp-confidential-vm.adoc
+++ b/modules/machineset-gcp-confidential-vm.adoc
@@ -59,12 +59,22 @@ endif::cpmso[]
 <1> Specify whether Confidential VM is enabled. The following values are valid:
 
 `Enabled`:: Enables Confidential VM with a default selection of Confidential VM technology. The default selection is AMD Secure Encrypted Virtualization (AMD SEV).
++
+[IMPORTANT]
+====
+The `Enabled` value selects Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV), which is deprecated.
+====
 
 `Disabled`:: Disables Confidential VM.
 
-`AMDEncryptedVirtualization`:: Enables Confidential VM using AMD SEV. AMD SEV supports c2d, n2d, and c3d machines.
-
 `AMDEncryptedVirtualizationNestedPaging`:: Enables Confidential VM using AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP). AMD SEV-SNP supports n2d machines.
+
+`AMDEncryptedVirtualization`:: Enables Confidential VM using AMD SEV. AMD SEV supports c2d, n2d, and c3d machines.
++
+[IMPORTANT]
+====
+The use of Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV) has been deprecated and will be removed in a future release.
+====
 
 `IntelTrustedDomainExtensions`:: Enables Confidential VM using Intel Trusted Domain Extensions (Intel TDX). Intel TDX supports n2d machines.
 +


### PR DESCRIPTION
[OSDOCS-16369](https://issues.redhat.com/browse/OSDOCS-16369)

Version(s): 4.20+

This PR adds deprecation notices about the use of AMD-SEV for confidential computing

QE review:
- [x] QE has approved this change.

Previews:
- [Additional Google Cloud Platform (GCP) configuration parameters](https://99963--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp)
- [Configuring Confidential VM by using machine sets](https://99963--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-gcp-confidential-vm_creating-machineset-gcp)
- [Enabling Confidential VMs](https://99963--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installation-gcp-enabling-confidential-vms_installing-gcp-customizations)