### PR TITLE
OCPBUGS#62682: Updating port to 636 for LDAPS

### DIFF
--- a/modules/ldap-auto-syncing.adoc
+++ b/modules/ldap-auto-syncing.adoc
@@ -118,7 +118,7 @@ data:
   sync.yaml: |                                 <1>
     kind: LDAPSyncConfig
     apiVersion: v1
-    url: ldaps://10.0.0.0:389                  <2>
+    url: ldaps://10.0.0.0:636                  <2>
     insecure: false
     bindDN: cn=admin,dc=example,dc=com         <3>
     bindPassword:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-62682

Link to docs preview:
https://99970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/ldap-syncing.html#ldap-auto-syncing_ldap-syncing-groups

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
