### PR TITLE
OSDOCS-15102 Updating 4.20 TechPreviewNoUpgrade featureset list

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -23,19 +23,21 @@ The following Technology Preview features are enabled by this feature set:
 ** `AdditionalRoutingCapabilities`
 ** `AdminNetworkPolicy`
 ** `AlibabaPlatform`
-** `automatedEtcdBackup`
+** `AutomatedEtcdBackup`
 ** `AWSClusterHostedDNS`
-** `AWSEFSDriverVolumeMetrics`
+//** `AWSClusterHostedDNSInstall` TP in 4.20.z, QE says to remove for 4.20.0. https://github.com/openshift/openshift-docs/pull/99971/files#r2418324446
+//** `AWSDedicatedHosts` Planned TP in 4.21 https://github.com/openshift/openshift-docs/pull/99971/files#r2418426941
+** `AWSServiceLBNetworkSecurityGroup`
+//** `AzureClusterHostedDNSInstall` Planned 4.21 https://github.com/openshift/openshift-docs/pull/99971/files#r2418323357
+//** `AzureDedicatedHosts` Target version 4.21 https://github.com/openshift/openshift-docs/pull/99971/files#r2418333707
+** `AzureMultiDisk`
 ** `AzureWorkloadIdentity`
-** `BareMetalLoadBalancer`
 ** `BootcNodeManagement`
 ** `BuildCSIVolumes`
-** `ChunkSizeMiB`
-** `CloudDualStackNodeIPs`
 ** `ClusterMonitoringConfig`
+** `ClusterVersionOperatorConfiguration`
 ** `ConsolePluginContentSecurityPolicy`
 ** `CPMSMachineNamePrefix`
-** `DisableKubeletCloudCredentialProviders`
 ** `DNSNameResolver`
 ** `DynamicResourceAllocation`
 ** `DyanmicServiceEndpointIBMCloud`
@@ -45,31 +47,33 @@ The following Technology Preview features are enabled by this feature set:
 ** `ExternalOIDCWithUIDAndExtraClaimMappings`
 ** `GatewayAPI`
 ** `GatewayAPIController`
-** `gcpClusterHostedDNS`
+** `GCPClusterHostedDNSInstall`
 ** `GCPCustomAPIEndpoints`
-** `GCPLabelsTags`
-** `HardwareSpeed`
+//** `GCPCustomAPIEndpointsInstall` Moved to 4.21 https://github.com/openshift/openshift-docs/pull/99971/files#r2418310866
 ** `HighlyAvailableArbiter`
+** `ImageModeStatusReporting`
 ** `ImageStreamImportMode`
+** `ImageVolume`
 ** `IngressControllerDynamicConfigurationManager`
 ** `IngressControllerLBSubnetsAWS`
 ** `InsightsConfig`
 ** `InsightsConfigAPI`
 ** `InsightsOnDemandDataGather`
-** `InsightsRuntimeExtractor`
+** `IrreconcilableMachineConfig`
 ** `KMSEncryptionProvider`
 ** `KMSv1`
 ** `MachineAPIMigration`
-** `MachineAPIProviderOpenStack`
 ** `MachineConfigNodes`
 ** `ManagedBootImages`
 ** `ManagedBootImagesAWS`
+** `ManagedBootImagesAzure`
+** `ManagedBootImagesvSphere`
 ** `MaxUnavailableStatefulSet`
 ** `MetricsCollectionProfiles`
 ** `MinimumKubeletVersion`
 ** `MixedCPUsAllocation`
-** `MultiArchInstallAWS`
-** `MultiArchInstallGCP`
+** `MultiDiskSetup`
+** `MutatingAdmissionPolicy`
 ** `NetworkDiagnosticsConfig`
 ** `NetworkLiveMigration`
 ** `NetworkSegmentation`
@@ -77,36 +81,33 @@ The following Technology Preview features are enabled by this feature set:
 ** `NewOLMCatalogdAPIV1Metas`
 ** `NewOLMOwnSingleNamespace`
 ** `NewOLMPreflightPermissionChecks`
-** `NodeDisruptionPolicy`
+** `NewOLMWebhookProviderOpenshiftServiceCA`
 ** `NodeSwap`
+** `NoRegistryClusterOperations`
 ** `NutanixMultiSubnets`
-** `OnClusterBuild`
 ** `OpenShiftPodSecurityAdmission`
 ** `OVNObservability`
-** `PersistentIPsForVirtualization`
 ** `PinnedImages`
-** `PlatformOperators`
-** `PrivateHostedZoneAWS`
+** `PreconfiguredUDNAddresses`
 ** `ProcMountType`
 ** `RouteAdvertisements`
 ** `RouteExternalCertificate`
+** `SELinuxMount`
 ** `ServiceAccountTokenNodeBinding`
 ** `SetEIPForNLBIngressController`
 ** `SignatureStores`
 ** `SigstoreImageVerification`
+** `SigstoreImageVerificationPKI`
 ** `TranslateStreamCloseWebsocketRequests`
-** `UpgradeStatus`
 ** `UserNamespacesPodSecurityStandards`
 ** `UserNamespacesSupport`
-** `ValidatingAdmissionPolicy`
 ** `VolumeAttributesClass`
 ** `VolumeGroupSnapshot`
 ** `VSphereConfigurableMaxAllowedBlockVolumesPerNode`
-** `VSphereDriverConfiguration`
 ** `VSphereHostVMGroupZonal`
+** `VSphereMixedNodeEnv`
 ** `VSphereMultiDisk`
 ** `VSphereMultiNetworks`
-** `VSphereMultiVCenters`
 --
 
 ////


### PR DESCRIPTION
Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-15102](https://issues.redhat.com/browse/OSDOCS-15102)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://99971--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR updates the TechPreviewNoUpgrade featureset to the[ 4.20 list](https://github.com/openshift/api/blob/release-4.20/features.md).
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
