### PR TITLE
OSDOCS-16369: AMD-SEV deprecation RN

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -74,7 +74,7 @@ The default namespace for the {lvms} Operator is now `openshift-lvm-storage`. Yo
 [id="ocp-release-edge-computing-default-clusterinstance_{context}"]
 ==== SiteConfig CR to ClusterInstance CR migration tool
 
-{product-title} {product-version} introduces the `siteconfig-converter` tool to help migrate managed clusters from using a `SiteConfig` custom resource (CR) to a `ClusterInstance` CR. Using a `SiteConfig` CR to define a managed cluster is deprecated and will be removed in a future release. The `ClusterInstance` CR provides a more unified and generic approach to defining clusters and is the preferred method for managing cluster deployments in the {ztp} workflow. 
+{product-title} {product-version} introduces the `siteconfig-converter` tool to help migrate managed clusters from using a `SiteConfig` custom resource (CR) to a `ClusterInstance` CR. Using a `SiteConfig` CR to define a managed cluster is deprecated and will be removed in a future release. The `ClusterInstance` CR provides a more unified and generic approach to defining clusters and is the preferred method for managing cluster deployments in the {ztp} workflow.
 
 Using the `siteconfig-converter` tool, you can convert `SiteConfig` CRs to `ClusterInstance` CRs and then incrementally migrate one or more clusters at a time. Existing and new pipelines run in parallel, so you can migrate clusters in a controlled, phased manner and without downtime.
 
@@ -748,6 +748,19 @@ This prevents users from discovering certain problems only after the cache is po
 // |Feature |4.18 |4.19 |4.20
 // |====
 
+[id="ocp-release-note-machine-manage-dep-rem_{context}"]
+=== Machine Management deprecated and removed features
+
+.Machine management deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.18 |4.19|4.20
+
+|Confidential Computing with AMD Secure Encrypted Virtualization for {gcp-first}
+|General Availability
+|General Availability
+|Deprecated
+|====
 
 [id="ocp-release-note-networking-dep-rem_{context}"]
 === Networking deprecated and removed features
@@ -939,6 +952,13 @@ This prevents users from discovering certain problems only after the cache is po
 
 [id="ocp-release-deprecated-features_{context}"]
 === Deprecated features
+
+[id="ocp-release-amd-sev-deprecation_{context}"]
+==== Deprecation of AMD Secure Encrypted Virtualization
+
+The use of Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV) on {gcp-first} has been deprecated and might be removed in a future release.
+
+You can use AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP) instead.
 
 [id="ocp-release-removed-features_{context}"]
 === Removed features


### PR DESCRIPTION
[OSDOCS-16369](https://issues.redhat.com/browse/OSDOCS-16369)

Version(s): 4.20

This PR adds info in the release notes about the deprecation of AMD-SEV

QE review:
- [x] QE has approved this change.

Previews:
- [Machine Management deprecated and removed features](https://99973--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-machine-manage-dep-rem_release-notes)
- [Deprecation notice](https://99973--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-amd-sev-deprecation_release-notes)
