### PR TITLE
OSDOCS-16285: Updated a RHEL link inConfiguring IPsec encryption for …

### DIFF
--- a/modules/nw-ovn-ipsec-north-south-enable.adoc
+++ b/modules/nw-ovn-ipsec-north-south-enable.adoc
@@ -25,7 +25,7 @@ After you apply the machine config, the Machine Config Operator reboots affected
 
 .Procedure
 
-. Create an IPsec configuration with an NMState Operator node network configuration policy. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/securing_networks/configuring-a-vpn-with-ipsec_securing-networks#configuring-a-vpn-with-ipsec_securing-networks[Libreswan as an IPsec VPN implementation].
+. Create an IPsec configuration with an NMState Operator node network configuration policy. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/securing_networks/configuring-a-vpn-connection_securing-networks#libreswan-as-an-ipsec-vpn-implementation_configuring-a-vpn-with-ipsec[Libreswan as an IPsec VPN implementation].
 
 .. To identify the IP address of the cluster node that is the IPsec endpoint, enter the following command:
 +


### PR DESCRIPTION
Fixes an existing link so no engineer reviews are required. 

Version(s):
4.15+

Issue:
[OSDOCS-16285](https://issues.redhat.com/browse/OSDOCS-16285)

Link to docs preview:
* [Configuring IPsec encryption for external traffic](https://99990--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/network_security/configuring-ipsec-ovn.html#nw-ovn-ipsec-north-south-enable_configuring-ipsec-ovn)
