### PR TITLE
OSDOCS-16287: Adjusted/Removed the IPV6 prereq from nw-dual-stack-con…

### DIFF
--- a/modules/nw-dual-stack-convert-back-single-stack.adoc
+++ b/modules/nw-dual-stack-convert-back-single-stack.adoc
@@ -14,7 +14,6 @@ If you originally converted your IPv4 single-stack cluster network to a dual-sta
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `cluster-admin` privileges.
 * Your cluster uses the OVN-Kubernetes network plugin.
-* The cluster nodes have IPv6 addresses.
 * You have enabled dual-stack networking.
 
 .Procedure

--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -42,7 +42,7 @@ If you already upgraded your cluster to {product-title} 4.16 or later and you ne
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `cluster-admin` privileges.
 * Your cluster uses the OVN-Kubernetes network plugin.
-* The cluster nodes have IPv6 addresses.
+* IPv6 single-stack cluster only: During cluster installation, you configured IPv6 addresses for the node network interface during cluster installation.
 * You have configured an IPv6-enabled router based on your infrastructure.
 
 .Procedure

--- a/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
+++ b/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can convert your IPv4 single-stack cluster to a dual-network cluster network that supports IPv4 and IPv6 address families. After converting to dual-stack networking, new and existing pods have dual-stack networking enabled.
+As a cluster administrator, you can convert your IPv4 or IPv6 single-stack cluster to a dual-network cluster network that supports IPv4 and IPv6 address families. After converting to dual-stack networking, new and existing pods have dual-stack networking enabled.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-16287](https://issues.redhat.com/browse/OSDOCS-16287)

Link to docs preview:
* [Converting to a dual-stack cluster network](https://100002--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html#nw-dual-stack-convert_converting-to-dual-stack)


- [ ] SME has approved this change (Mat K.).
- [ ] QE has approved this change.
