### PR TITLE
ROX-30851: Document Prometheus metrics and server

### DIFF
--- a/configuration/monitor-acs.adoc
+++ b/configuration/monitor-acs.adoc
@@ -17,6 +17,10 @@ include::modules/monitor-osp-disable-helm.adoc[leveloffset=+2]
 include::modules/enable-monitoring-central-operator.adoc[leveloffset=+2]
 include::modules/enable-monitoring-central-helm.adoc[leveloffset=2]
 include::modules/prometheus-service-monitor.adoc[leveloffset=+2]
+include::modules/custom-prometheus-metrics.adoc[leveloffset=+2]
+include::modules/configuring-custom-prometheus-metrics.adoc[leveloffset=+3]
+include::modules/prometheus-server-example.adoc[leveloffset=+3]
+
 
 [role="_additional-resources"]
 [id="additional-resources_monitoring-acs"]

--- a/modules/configuring-custom-prometheus-metrics.adoc
+++ b/modules/configuring-custom-prometheus-metrics.adoc
@@ -1,0 +1,70 @@
+//module included in the following assemblies:
+// * configuration/monitor-acs.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-custom-prometheus-metrics_{context}"]
+= Configuring custom Prometheus metrics
+
+[role="_abstract"]
+Use the API to configure custom Prometheus metrics for {product-title-short}. The metrics configuration is a part of the private config section of the `/v1/config` service request or response payload.
+
+.Procedure
+
+. Get the current configuration by running the following command:
++
+[source,terminal]
+----
+$ curl $ROX_API_ENDPOINT/v1/config -H "$ROX_AUTH" | jq
+{
+  "publicConfig": { ... }
+  "privateConfig": { ... }
+}
+----
+. Add some metrics to the configuration. For example, run the following command to add some image vulnerability data, including namespace and deployment data:
++
+[source,terminal]
+----
+$ curl -X PUT "$ROX_API_ENDPOINT/v1/config" -H "$ROX_AUTH" --data='
+{
+  "config": {
+    "publicConfig": { ... }
+    "privateConfig": {
+      ...
+      "metrics": {
+        "imageVulnerabilities": {
+          "gatheringPeriodMinutes": 10,
+          "descriptors": {
+            "deployment_severity": {
+              "labels": [
+                "Cluster",
+                "Namespace",
+                "Deployment",
+                "IsPlatformWorkload",
+                "IsFixable",
+                "Severity"
+              ]
+            },
+            "namespace_severity": {
+              "labels": [
+                "Cluster",
+                "Namespace",
+                "Severity"
+              ]
+            }
+          }
+        }
+...
+}
+'
+----
+. You can edit the configuration content with a single command, as shown in the following example:
++
+[source,text]
+----
+curl $API_ENDPOINT/v1/config -H "$ROX_AUTH" | \
+  jq '.privateConfig.metrics.policyViolations.descriptors += {
+        component_severity: { labels: [ "Component", "Severity" ] }
+      } |
+      { config: . }' | \
+  curl -X PUT $API_ENDPOINT/v1/config -H "$ROX_AUTH" --data-binary @-
+----

--- a/modules/custom-prometheus-metrics.adoc
+++ b/modules/custom-prometheus-metrics.adoc
@@ -1,0 +1,101 @@
+//module included in the following assemblies:
+// * configuration/monitor-acs.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="custom-prometheus-metrics_{context}"]
+= Using custom Prometheus metrics
+
+[role="_abstract"]
+You can enable some {product-title-short} product metrics and use them with a dedicated Prometheus server in another application to display custom metrics for {product-title-short}. 
+
+You can use a tool such as link:https://perses.dev/perses/docs/overview/[Perses] to consume these metrics. For example, you can create a Perses dashboard to use in the {ocp} console that displays {product-title-short} data. 
+
+To configure custom metrics, you enable the Prometheus metrics that you want to be exposed on the `/metrics` path of the central API endpoint. The available metric categories include:
+
+* Image vulnerabilities
+* Node vulnerabilities
+* Policy violations
+* Total policy numbers
+* Cluster health
+* Certificate expiry
+
+Each category is configured with a data gathering period and a list of metrics. A metric is associated with a set of labels.
+
+[NOTE]
+====
+The `/metrics` path is accessible for API tokens with Administration resource view permissions. The values of the labels are subject to scoped access control.
+====
+
+The currently enabled metrics are shown on the *System Configuration* page of the *Platform Configuration* section of the {product-title-short} portal. In edit mode, you can enable or disable one of the predefined metrics.
+
+You can use the `/v1/config` API to configure metrics with custom metric names and a custom set of labels.
+
+Accepted image vulnerability labels include the following:
+
+* Cluster
+* Namespace
+* Deployment
+* IsPlatformWorkload
+* ImageID
+* ImageRegistry
+* ImageRemote
+* ImageTag
+* Component
+* ComponentVersion
+* OperatingSystem
+* CVE
+* CVSS
+* Severity
+* EPSSPercentile
+* EPSSProbability
+* IsFixable
+
+Accepted node vulnerability labels include the following:
+
+* Cluster
+* Node
+* Kernel
+* OperatingSystem
+* OSImage
+* Component
+* ComponentVersion
+* CVE
+* CVSS
+* Severity
+* EPSSPercentile
+* EPSSProbability
+* IsFixable
+* IsSnoozed
+
+Accepted policy violation labels include the following:
+
+* Cluster
+* Namespace
+* Resource
+* Deployment
+* IsDeploymentActive
+* IsPlatformComponent
+* Policy
+* Categories
+* Severity
+* Action
+* Message
+* Stage
+* State
+* Entity
+* EntityName
+
+The total policy numbers are exposed as the `rox_central_cfg_total_policies` metric, which contains the following label:
+
+* Enabled
+
+The cluster health metric is exposed as `rox_central_health_cluster_info`, and contains the following labels:
+
+* Cluster
+* Type
+* Status
+* Upgradeability
+
+The certificate expiry metric is exposed as `rox_central_cert_exp_hours`, and contains the following label:
+
+* Component

--- a/modules/prometheus-server-example.adoc
+++ b/modules/prometheus-server-example.adoc
@@ -1,0 +1,86 @@
+//module included in the following assemblies:
+// * configuration/monitor-acs.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="prometheus-server-example_{context}"]
+= Setting up a Perses dashboard in {ocp} to monitor {product-title-short}
+
+[role="_abstract"]
+You can configure Prometheus server to work with {product-title-short} and a tool such as Perses in {ocp} or another application to monitor {product-title-short}.
+
+.Procedure
+
+. Use the Prometheus Operator or another installation method to install Prometheus in the `stackrox` namespace. 
+. Verify that the Prometheus custom resource (CR) contains the following information:
++
+[source,yaml]
+----
+  serviceAccountName: prometheus-server
+  volumes:
+  - name: prometheus-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: token
+          expirationSeconds: 3600
+  volumeMounts:
+  - name: prometheus-token
+    mountPath: /var/run/secrets/tokens
+    readOnly: true
+  additionalScrapeConfigs:
+    name: prometheus-additional-scrape-configs
+    key: prometheus-additional.yaml
+----
+. Create the additional scrape configuration secret as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-additional-scrape-configs
+  namespace: stackrox
+stringData:
+  prometheus-additional.yaml: |
+    - job_name: 'central-metrics'
+      scheme: https
+      metrics_path: /metrics
+      bearer_token_file: /var/run/secrets/tokens/token
+      tls_config:
+        insecure_skip_verify: true
+      static_configs:
+      - targets: ['central.stackrox.svc.cluster.local:443']
+----
+. Perform role mapping to ensure that the Prometheus server can access the Central API with a service account token:
+.. Add a role mapping to the machine access configuration of type `KUBE_SERVICE_ACCOUNT` for key sub and value `system:serviceaccount:stackrox:prometheus-server`. 
+.. Create and assign a role with the appropriate permission set and scope.
+//is this what we are listing in the prerequisite or something else?
+. Create the Perses data source as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: rhacs-datasource
+  namespace: stackrox
+spec:
+  client:
+    tls:
+      caCert:
+        certPath: /ca/service-ca.crt
+        type: file
+      enable: true
+  config:
+    default: true
+    display:
+      name: RHACS Prometheus Datasource
+    plugin:
+      kind: PrometheusDatasource
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: 'http://prometheus-operated.stackrox.svc.cluster.local:9090'
+----
+


### PR DESCRIPTION
Original PR: #95141 

Version(s): 4.9+

[Issue](https://issues.redhat.com/browse/ROX-30851)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

https://100006--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/monitor-acs#prometheus-server-metrics_monitor-acs

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
