### PR TITLE
OSDOCS-16392 Updating remaining install config param tables for readability

### DIFF
--- a/modules/agent-configuration-parameters.adoc
+++ b/modules/agent-configuration-parameters.adoc
@@ -21,19 +21,21 @@ These settings are used for installation only, and cannot be modified after inst
 Required Agent configuration parameters are described in the following table:
 
 .Required parameters
-[cols=".^4l,.^4,.^2a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |apiVersion:
 |The API version for the `agent-config.yaml` content.
 The current version is `v1beta1`.
 The installation program might also support older API versions.
-|String
+
+*Value:* String
 
 |metadata:
 |Kubernetes resource `ObjectMeta`, from which only the `name` parameter is consumed.
-|Object
+
+*Value:* Object
 
 |metadata:
   name:
@@ -41,7 +43,8 @@ The installation program might also support older API versions.
 DNS records for the cluster are all subdomains of `{{.metadata.name}}.{{.baseDomain}}`.
 The value entered in the `agent-config.yaml` file is ignored, and instead the value specified in the `install-config.yaml` file is used.
 When you do not provide `metadata.name` through either the `install-config.yaml` or `agent-config.yaml` files, for example when you use only ZTP manifests, the cluster name is set to `agent-cluster`.
-|String of lowercase letters and hyphens (`-`), such as `dev`.
+
+*Value:* String of lowercase letters and hyphens (`-`), such as `dev`.
 |====
 
 
@@ -51,63 +54,72 @@ When you do not provide `metadata.name` through either the `install-config.yaml`
 Optional Agent configuration parameters are described in the following table:
 
 .Optional parameters
-[cols=".^2l,.^4,.^4a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |rendezvousIP:
 |The IP address of the node that performs the bootstrapping process as well as running the `assisted-service` component.
 You must provide the rendezvous IP address when you do not specify at least one host's IP address in the `networkConfig` parameter.
 If this address is not provided, one IP address is selected from the provided hosts' `networkConfig`.
-|IPv4 or IPv6 address.
+
+*Value:* IPv4 or IPv6 address.
 
 |bootArtifactsBaseURL:
 |When you use the Agent-based Installer to generate a minimal ISO image, this parameter specifies a URL where the rootfs image file can be retrieved from during cluster installation. This parameter is optional for booting minimal ISO images in connected environments.
 
 When you use the Agent-based Installer to generate an iPXE script, this parameter specifies the URL of the server to upload Preboot Execution Environment (PXE) assets to.
 For more information, see "Preparing PXE assets for {product-title}".
-|String.
+
+*Value:* String.
 
 |additionalNTPSources:
 |A list of Network Time Protocol (NTP) sources to be added to all cluster hosts, which are added to any NTP sources that are configured through other means.
-|List of hostnames or IP addresses.
+
+*Value:* List of hostnames or IP addresses.
 
 |hosts:
 |Host configuration.
 An optional list of hosts.
 The number of hosts defined must not exceed the total number of hosts defined in the `install-config.yaml` file, which is the sum of the values of the `compute.replicas` and `controlPlane.replicas` parameters.
-|An array of host configuration objects.
+
+*Value:* An array of host configuration objects.
 
 |hosts:
   hostname:
 |Hostname.
 Overrides the hostname obtained from either the Dynamic Host Configuration Protocol (DHCP) or a reverse DNS lookup.
 Each host must have a unique hostname supplied by one of these methods, although configuring a hostname through this parameter is optional.
-|String.
+
+*Value:* String.
 
 |hosts:
   interfaces:
 |Provides a table of the name and MAC address mappings for the interfaces on the host.
 If a `NetworkConfig` section is provided in the `agent-config.yaml` file, this table must be included and the values must match the mappings provided in the `NetworkConfig` section.
-|An array of host configuration objects.
+
+*Value:* An array of host configuration objects.
 
 |hosts:
   interfaces:
     name:
 |The name of an interface on the host.
-|String.
+
+*Value:* String.
 
 |hosts:
   interfaces:
     macAddress:
 |The MAC address of an interface on the host.
-|A MAC address such as the following example: `00-B0-D0-63-C2-26`.
+
+*Value:* A MAC address such as the following example: `00-B0-D0-63-C2-26`.
 
 |hosts:
   role:
 |Defines whether the host is a `master` or `worker` node.
 If no role is defined in the `agent-config.yaml` file, roles will be assigned at random during cluster installation.
-|`master` or `worker`.
+
+*Value:* `master` or `worker`.
 
 |hosts:
   rootDeviceHints:
@@ -115,20 +127,23 @@ If no role is defined in the `agent-config.yaml` file, roles will be assigned at
 The installation program examines the devices in the order it discovers them, and compares the discovered values with the hint values.
 It uses the first discovered device that matches the hint value.
 This is the device that the operating system is written on during installation.
-|A dictionary of key-value pairs.
+
+*Value:* A dictionary of key-value pairs.
 For more information, see "Root device hints" in the "Setting up the environment for an OpenShift installation" page.
 
 |hosts:
   rootDeviceHints:
     deviceName:
 |The name of the device the {op-system} image is provisioned to.
-|String.
+
+*Value:* String.
 
 |hosts:
   networkConfig:
 |The host network definition.
 The configuration must match the Host Network Management API defined in the link:https://nmstate.io/[nmstate documentation].
-|A dictionary of host network configuration objects.
+
+*Value:* A dictionary of host network configuration objects.
 
 |minimalISO:
 |Defines whether the Agent-based Installer generates a full ISO or a minimal ISO image. When this parameter is set to `True`, the Agent-based Installer generates an ISO without a rootfs image file, and instead contains details about where to pull the rootfs file from.
@@ -136,5 +151,6 @@ The configuration must match the Host Network Management API defined in the link
 When you generate a minimal ISO, if you do not specify a rootfs URL through the `bootArtifactsBaseURL` parameter, the Agent-based Installer embeds a default URL that is accessible in environments with an internet connection.
 
 The default value is `False`.
-|Boolean.
+
+*Value:* Boolean.
 |====

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -89,21 +89,24 @@ endif::agent[]
 Required installation configuration parameters are described in the following table:
 
 .Required parameters
-[cols=".^2l,.^3,.^5a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |apiVersion:
 |The API version for the `install-config.yaml` content. The current version is `v1`. The installation program might also support older API versions.
-|String
+
+*Value:* String
 
 |baseDomain:
 |The base domain of your cloud provider. The base domain is used to create routes to your {product-title} cluster components. The full DNS name for your cluster is a combination of the `baseDomain` and `metadata.name` parameter values that uses the `<metadata.name>.<baseDomain>` format.
-|A fully-qualified domain or subdomain name, such as `example.com`.
+
+*Value:* A fully-qualified domain or subdomain name, such as `example.com`.
 
 |metadata:
 |Kubernetes resource `ObjectMeta`, from which only the `name` parameter is consumed.
-|Object
+
+*Value:* Object
 
 |metadata:
   name:
@@ -111,11 +114,12 @@ Required installation configuration parameters are described in the following ta
 ifdef::agent[]
 The cluster name is set to `agent-cluster` when you do not provide the `metadata.name` parameter through either the `install-config.yaml` or `agent-config.yaml` files. For example, installations that only use ZTP manifests do not provide the `metadata.name` parameter.
 endif::agent[]
+
 ifndef::bare,nutanix,vsphere[]
-|String of lowercase letters, hyphens (`-`), and periods (`.`), such as `dev`.
+*Value:* String of lowercase letters, hyphens (`-`), and periods (`.`), such as `dev`.
 endif::bare,nutanix,vsphere[]
 ifdef::bare,nutanix,vsphere[]
-|String of lowercase letters and hyphens (`-`), such as `dev`.
+*Value:* String of lowercase letters and hyphens (`-`), such as `dev`.
 endif::bare,nutanix,vsphere[]
 ifdef::osp[]
 The string must be 14 characters or fewer long.
@@ -128,12 +132,14 @@ endif::agent[]
 ifdef::agent[]
 |The configuration for the specific platform upon which to perform the installation: `baremetal`, `external`, `none`, `vsphere`, or `nutanix`.
 endif::agent[]
-|Object
+
+*Value:* Object
 
 ifndef::openshift-origin[]
 |pullSecret:
 |Get a {cluster-manager-url-pull} to authenticate downloading container images for {product-title} components from services such as Quay.io.
-|
+
+*Value:*
 [source,json]
 ----
 {
@@ -156,25 +162,29 @@ ifdef::ibm-power-vs[]
   powervs:
     userID:
 |The UserID is the login for the user's {ibm-cloud-name} account.
-|String. For example, `existing_user_id`.
+
+*Value:* String. For example, `existing_user_id`.
 
 |platform:
   powervs:
     powervsResourceGroup:
 |The PowerVSResourceGroup is the resource group in which {ibm-power-server-name} resources are created. If using an existing VPC, the existing VPC and subnets should be in this resource group.
-|String. For example, `existing_resource_group`.
+
+*Value:* String. For example, `existing_resource_group`.
 
 |platform:
   powervs:
     region:
 |Specifies the {ibm-cloud-name} region where the cluster is created.
-|String. For example, `existing_region`.
+
+*Value:* String. For example, `existing_region`.
 
 |platform:
   powervs:
     zone:
 |Specifies the {ibm-cloud-name} colo region where the cluster is created.
-|String. For example, `existing_zone`.
+
+*Value:* String. For example, `existing_zone`.
 
 endif::ibm-power-vs[]
 |====
@@ -240,13 +250,14 @@ Globalnet is not supported with {rh-storage-first} disaster recovery solutions. 
 endif::osp[]
 
 .Network parameters
-[cols=".^2l,.^3a,.^3a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |networking:
 |The configuration for the cluster network.
-|Object
+
+*Value:* Object
 
 [NOTE]
 ====
@@ -256,7 +267,8 @@ You cannot change parameters specified by the `networking` object after installa
 |networking:
   networkType:
 |The {openshift-networking} network plugin to install.
-|
+
+*Value:*
 ifdef::openshift-origin[]
 `OVNKubernetes`.
 endif::openshift-origin[]
@@ -271,13 +283,13 @@ endif::openshift-origin[]
 
 |networking:
   clusterNetwork:
-|
-The IP address blocks for pods.
+|The IP address blocks for pods.
 
 The default value is `10.128.0.0/14` with a host prefix of `/23`.
 
 If you specify multiple IP address blocks, the blocks must not overlap.
-|An array of objects. For example:
+
+*Value:* An array of objects. For example:
 
 [source,yaml]
 ----
@@ -300,8 +312,7 @@ endif::agent,bare[]
 |networking:
   clusterNetwork:
     cidr:
-|
-Required if you use `networking.clusterNetwork`. An IP address block.
+|Required if you use `networking.clusterNetwork`. An IP address block.
 
 ifndef::agent,bare[]
 An IPv4 network.
@@ -310,9 +321,8 @@ endif::agent,bare[]
 ifdef::agent,bare[]
 If you use the OVN-Kubernetes network plugin, you can specify IPv4 and IPv6 networks.
 endif::agent,bare[]
-|
-An IP address block in Classless Inter-Domain Routing (CIDR) notation.
-The prefix length for an IPv4 block is between `0` and `32`.
+
+*Value:* An IP address block in Classless Inter-Domain Routing (CIDR) notation. The prefix length for an IPv4 block is between `0` and `32`.
 ifdef::agent,bare[]
 The prefix length for an IPv6 block is between `0` and `128`. For example, `10.128.0.0/14` or `fd01::/48`.
 endif::agent,bare[]
@@ -321,22 +331,20 @@ endif::agent,bare[]
   clusterNetwork:
     hostPrefix:
 |The subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23` then each node is assigned a `/23` subnet out of the given `cidr`. A `hostPrefix` value of `23` provides 510 (2^(32 - 23) - 2) pod IP addresses.
-|
-A subnet prefix.
+
+*Value:* A subnet prefix.
 
 ifndef::agent,bare[]
 The default value is `23`.
 endif::agent,bare[]
 
 ifdef::agent,bare[]
-For an IPv4 network the default value is `23`.
-For an IPv6 network the default value is `64`. The default value is also the minimum value for IPv6.
+For an IPv4 network the default value is `23`. For an IPv6 network the default value is `64`. The default value is also the minimum value for IPv6.
 endif::agent,bare[]
 
 |networking:
   serviceNetwork:
-|
-The IP address block for services. The default value is `172.30.0.0/16`.
+|The IP address block for services. The default value is `172.30.0.0/16`.
 
 The OVN-Kubernetes network plugins supports only a single IP address block for the service network.
 
@@ -344,8 +352,7 @@ ifdef::agent,bare[]
 If you use the OVN-Kubernetes network plugin, you can specify an IP address block for both of the IPv4 and IPv6 address families.
 endif::agent,bare[]
 
-|
-An array with an IP address block in CIDR format. For example:
+*Value:* An array with an IP address block in CIDR format. For example:
 
 [source,yaml]
 ----
@@ -364,8 +371,7 @@ endif::agent,bare[]
 
 |networking:
   machineNetwork:
-|
-The IP address blocks for machines.
+|The IP address blocks for machines.
 
 ifndef::ibm-power-vs[]
 If you specify multiple IP address blocks, the blocks must not overlap.
@@ -374,7 +380,8 @@ endif::ibm-power-vs[]
 ifdef::ibm-z,ibm-power[]
 If you specify multiple IP kernel arguments, the `machineNetwork.cidr` value must be the CIDR of the primary network.
 endif::ibm-z,ibm-power[]
-|An array of objects. For example:
+
+*Value:* An array of objects. For example:
 
 [source,yaml]
 ----
@@ -386,13 +393,13 @@ networking:
 |networking:
   machineNetwork:
     cidr:
-|
-Required if you use `networking.machineNetwork`. An IP address block. The default value is `10.0.0.0/16` for all platforms other than libvirt and {ibm-power-server-name}. For libvirt, the default value is `192.168.126.0/24`. For {ibm-power-server-name}, the default value is `192.168.0.0/24`.
+|Required if you use `networking.machineNetwork`. An IP address block. The default value is `10.0.0.0/16` for all platforms other than libvirt and {ibm-power-server-name}. For libvirt, the default value is `192.168.126.0/24`. For {ibm-power-server-name}, the default value is `192.168.0.0/24`.
+
 ifdef::ibm-cloud[]
 If you are deploying the cluster to an existing Virtual Private Cloud (VPC), the CIDR must contain the subnets defined in `platform.ibmcloud.controlPlaneSubnets` and `platform.ibmcloud.computeSubnets`.
 endif::ibm-cloud[]
-|
-An IP network block in CIDR notation.
+
+*Value:* An IP network block in CIDR notation.
 
 ifndef::agent,bare,ibm-power-vs[]
 For example, `10.0.0.0/16`.
@@ -413,10 +420,9 @@ Set the `networking.machineNetwork` to match the CIDR that the preferred NIC res
   ovnKubernetesConfig:
     ipv4:
       internalJoinSubnet:
-|
-Configures the IPv4 join subnet that is used internally by `ovn-kubernetes`. This subnet must not overlap with any other subnet that {product-title} is using, including the node network. The size of the subnet must be larger than the number of nodes. You cannot change the value after installation.
+|Configures the IPv4 join subnet that is used internally by `ovn-kubernetes`. This subnet must not overlap with any other subnet that {product-title} is using, including the node network. The size of the subnet must be larger than the number of nodes. You cannot change the value after installation.
 
-|An IP network block in CIDR notation. The default value is `100.64.0.0/16`.
+*Value:* An IP network block in CIDR notation. The default value is `100.64.0.0/16`.
 
 |====
 
@@ -426,35 +432,41 @@ Configures the IPv4 join subnet that is used internally by `ovn-kubernetes`. Thi
 Optional installation configuration parameters are described in the following table:
 
 .Optional parameters
-[cols=".^2l,.^3a,.^3a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |additionalTrustBundle:
 |A PEM-encoded X.509 certificate bundle that is added to the nodes' trusted certificate store. This trust bundle might also be used when a proxy has been configured.
-|String
+
+*Value:* String
 
 |capabilities:
 |Controls the installation of optional core cluster components. You can reduce the footprint of your {product-title} cluster by disabling optional components. For more information, see the "Cluster capabilities" page in _Installing_.
-|String array
+
+*Value:* String array
 
 |capabilities:
   baselineCapabilitySet:
 |Selects an initial set of optional capabilities to enable. Valid values are `None`, `v4.11`, `v4.12` and `vCurrent`. The default value is `vCurrent`.
-|String
+
+*Value:* String
 
 |capabilities:
   additionalEnabledCapabilities:
 |Extends the set of optional capabilities beyond what you specify in `baselineCapabilitySet`. You can specify multiple capabilities in this parameter.
-|String array
+
+*Value:* String array
 
 |cpuPartitioningMode:
 |Enables workload partitioning, which isolates {product-title} services, cluster management workloads, and infrastructure pods to run on a reserved set of CPUs. You can only enable workload partitioning during installation. You cannot disable it after installation. While this field enables workload partitioning, it does not configure workloads to use specific CPUs. For more information, see the _Workload partitioning_ page in the _Scalability and Performance_ section.
-|`None` or `AllNodes`. `None` is the default value.
+
+*Value:* `None` or `AllNodes`. `None` is the default value.
 
 |compute:
 |The configuration for the machines that comprise the compute nodes.
-|Array of `MachinePool` objects.
+
+*Value:* Array of `MachinePool` objects.
 
 ifndef::openshift-origin[]
 
@@ -462,38 +474,44 @@ ifndef::agent,aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
 |compute:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
-|String
+
+*Value:* String
 endif::agent,aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
 
 ifdef::aws,azure,gcp,bare[]
 |compute:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
+
 ifdef::aws,azure[]
- Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
+Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
 endif::aws,azure[]
-|String
+
+*Value:* String
 endif::aws,azure,gcp,bare[]
 
 ifdef::ibm-z[]
 |compute:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. The valid value is the default: `s390x`.
-|String
+
+*Value:* String
 endif::ibm-z[]
 
 ifdef::ibm-power,ibm-power-vs[]
 |compute:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. The valid value is the default: `ppc64le`.
-|String
+
+*Value:* String
 endif::ibm-power,ibm-power-vs[]
 
 ifdef::agent[]
 |compute:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64`, `arm64`, `ppc64le`, and `s390x`.
-|String
+
+*Value:* String
 endif::agent[]
 
 endif::openshift-origin[]
@@ -502,36 +520,43 @@ ifdef::openshift-origin[]
 |compute:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. The valid value is the default: `amd64`.
+
 ifdef::aws[]
 See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
 endif::aws[]
-|String
+
+*Value:* String
 endif::openshift-origin[]
 ifndef::vsphere[]
 |compute:
   hyperthreading:
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on compute machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
+
 [IMPORTANT]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance.
 ====
-|`Enabled` or `Disabled`
+
+*Value:* `Enabled` or `Disabled`
 endif::vsphere[]
 ifdef::ibm-power-vs[]
 |compute:
   smtLevel:
 |The SMTLevel specifies the level of SMT to set to the control plane and compute machines. Valid values are `1`, `2`, `3`, `4`, `5`, `6`, `7`, `8`, `off`, and `on`.
-|String
+
+*Value:* String
 endif::ibm-power-vs[]
 
 |compute:
   name:
 |Required if you use `compute`. The name of the machine pool.
-|`worker`
+
+*Value:* `worker`
 
 |compute:
   platform:
 |Required if you use `compute`. Use this parameter to specify the cloud provider to host the worker machines. This parameter value must match the `controlPlane.platform` parameter value.
+
 ifdef::ibm-power-vs[]
 Example usage, `compute.platform.powervs.sysType`.
 
@@ -540,66 +565,77 @@ Example usage, `compute.platform.powervs.sysType`.
     powervs:
       sysType:
 |Defines the system type for the instance.
-|The available system types depend on the zone you want to target. Supported values are `e980`, `s922`, `e1080`, or `s1022`.
+
+*Value:* The available system types depend on the zone you want to target. Supported values are `e980`, `s922`, `e1080`, or `s1022`.
 
 endif::ibm-power-vs[]
+*Value:*
 ifndef::agent[]
-|`aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`
+`aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`
 endif::agent[]
 ifdef::agent[]
-|`baremetal`, `vsphere`, or `{}`
+`baremetal`, `vsphere`, or `{}`
 endif::agent[]
 
 |compute:
   replicas:
 |The number of compute machines, which are also known as worker machines, to provision.
-|A positive integer greater than or equal to `2`. The default value is `3`.
+
+*Value:* A positive integer greater than or equal to `2`. The default value is `3`.
 
 |featureSet:
 |Enables the cluster for a feature set. A feature set is a collection of {product-title} features that are not enabled by default. For more information about enabling a feature set during installation, see "Enabling features using feature gates".
-|String. The name of the feature set to enable, such as `TechPreviewNoUpgrade`.
+
+*Value:* String. The name of the feature set to enable, such as `TechPreviewNoUpgrade`.
 
 |controlPlane:
 |The configuration for the machines that form the control plane.
-|Array of `MachinePool` objects.
+
+*Value:* Array of `MachinePool` objects.
 
 ifndef::openshift-origin[]
 ifndef::agent,aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
 |controlPlane:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
-|String
+
+*Value:* String
 endif::agent,aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
 
 ifdef::aws,azure,gcp,bare[]
 |controlPlane:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
+
 ifdef::aws,azure[]
- Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
+Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
 endif::aws,azure[]
-|String
+
+*Value:* String
 endif::aws,azure,gcp,bare[]
 
 ifdef::ibm-z[]
 |controlPlane:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. The valid value is the default: `s390x`.
-|String
+
+*Value:* String
 endif::ibm-z[]
 
 ifdef::ibm-power,ibm-power-vs[]
 |controlPlane:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. The valid value is the default: `ppc64le`.
-|String
+
+*Value:* String
 endif::ibm-power,ibm-power-vs[]
 
 ifdef::agent[]
 |controlPlane:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64`, `arm64`, `ppc64le`, and `s390x`.
-|String
+
+*Value:* String
 endif::agent[]
 
 endif::openshift-origin[]
@@ -608,31 +644,37 @@ ifdef::openshift-origin[]
 |controlPlane:
   architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. The valid value is `amd64`.
+
 ifdef::aws[]
 See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
 endif::aws[]
-|String
+
+*Value:* String
 endif::openshift-origin[]
 
 ifndef::vsphere[]
 |controlPlane:
   hyperthreading:
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on control plane machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
+
 [IMPORTANT]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance.
 ====
-|`Enabled` or `Disabled`
+
+*Value:* `Enabled` or `Disabled`
 endif::vsphere[]
 
 |controlPlane:
   name:
 |Required if you use `controlPlane`. The name of the machine pool.
-|`master`
+
+*Value:* `master`
 
 |controlPlane:
   platform:
 |Required if you use `controlPlane`. Use this parameter to specify the cloud provider that hosts the control plane machines. This parameter value must match the `compute.platform` parameter value.
+
 ifdef::ibm-power-vs[]
 Example usage, `controlPlane.platform.powervs.processors`.
 
@@ -641,23 +683,28 @@ Example usage, `controlPlane.platform.powervs.processors`.
     powervs:
       sysType:
 |Defines the system type for the instance.
-|The available system types depend on the zone you want to target. Supported values are `e980`, `s922`, `e1080`, or `s1022`.
+
+*Value:* The available system types depend on the zone you want to target. Supported values are `e980`, `s922`, `e1080`, or `s1022`.
 endif::ibm-power-vs[]
+
+*Value:*
 ifndef::agent[]
-|`aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`
+`aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`
 endif::agent[]
 ifdef::agent[]
-|`baremetal`, `vsphere`, or `{}`
+`baremetal`, `vsphere`, or `{}`
 endif::agent[]
 
 |controlPlane:
   replicas:
 |The number of control plane machines to provision.
+
+*Value:*
 ifndef::agent[]
-|Supported values are `3`, or `1` when deploying {sno}.
+Supported values are `3`, or `1` when deploying {sno}.
 endif::agent[]
 ifdef::agent[]
-|Supported values are `3`, `4`, `5`, or `1` when deploying {sno}.
+Supported values are `3`, `4`, `5`, or `1` when deploying {sno}.
 endif::agent[]
 
 |credentialsMode:
@@ -667,7 +714,8 @@ endif::agent[]
 ====
 Not all CCO modes are supported for all cloud providers. For more information about CCO modes, see the "Managing cloud provider credentials" entry in the _Authentication and authorization_ content.
 ====
-|`Mint`, `Passthrough`, `Manual` or an empty string (`""`).
+
+*Value:* `Mint`, `Passthrough`, `Manual` or an empty string (`""`).
 
 ifndef::openshift-origin,ibm-power-vs[]
 |fips:
@@ -679,21 +727,25 @@ include::snippets/fips-snippet.adoc[]
 ====
 If you are using Azure File storage, you cannot enable FIPS mode.
 ====
-|`false` or `true`
+
+*Value:* `false` or `true`
 endif::openshift-origin,ibm-power-vs[]
 |imageContentSources:
 |Sources and repositories for the release-image content.
-|Array of objects. Includes a `source` and, optionally, `mirrors`, as described in the following rows of this table.
+
+*Value:* Array of objects. Includes a `source` and, optionally, `mirrors`, as described in the following rows of this table.
 
 |imageContentSources:
   source:
 |Required if you use `imageContentSources`. Specify the repository that users refer to, for example, in image pull specifications.
-|String
+
+*Value:* String
 
 |imageContentSources:
   mirrors:
 |Specify one or more repositories that might also contain the same images.
-|Array of strings
+
+*Value:* Array of strings
 
 ifndef::openshift-origin[]
 ifdef::aws[]
@@ -701,13 +753,15 @@ ifdef::aws[]
   aws:
     lbType:
 |Required to set the NLB load balancer type in AWS. Valid values are `Classic` or `NLB`. If no value is specified, the installation program defaults to `Classic`. The installation program sets the value provided here in the ingress cluster configuration object. If you do not specify a load balancer type for other Ingress Controllers, they use the type set in this parameter.
-|`Classic` or `NLB`. The default value is `Classic`.
+
+*Value:* `Classic` or `NLB`. The default value is `Classic`.
 endif::aws[]
 endif::openshift-origin[]
 
 |publish:
 |How to publish or expose the user-facing endpoints of your cluster, such as the Kubernetes API, OpenShift routes.
-|
+
+*Value:*
 ifdef::aws,gcp,ibm-cloud[]
 `Internal` or `External`. To deploy a private cluster that cannot be accessed from the internet, set the `publish` parameter to `Internal`. The default value is `External`.
 endif::[]
@@ -730,73 +784,85 @@ endif::ibm-power-vs[]
 endif::[]
 
 |sshKey:
-| The SSH key to authenticate access to your cluster machines.
+|The SSH key to authenticate access to your cluster machines.
+
 [NOTE]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
-a|For example, `sshKey: ssh-ed25519 AAAA..`.
+
+*Value:* For example, `sshKey: ssh-ed25519 AAAA..`.
 
 ifdef::ibm-power-vs[]
 |platform:
   powervs:
     vpcRegion:
 |Specifies the {ibm-cloud-name} region in which to create VPC resources.
-|String. For example, `existing_vpc_region`.
+
+*Value:* String. For example, `existing_vpc_region`.
 
 |platform:
   powervs:
     vpcSubnets:
 |Specifies existing subnets by name where cluster resources are created.
-|String. For example, `powervs_region_example_subnet`.
+
+*Value:* String. For example, `powervs_region_example_subnet`.
 
 |platform:
   powervs:
     vpcName:
 |Specifies the {ibm-cloud-name} name.
-|String. For example, `existing_vpcName`.
+
+*Value:* String. For example, `existing_vpcName`.
 
 |platform:
   powervs:
     serviceInstanceGUID:
 |Specifies the ID of the Power IAAS instance created from the {ibm-cloud-name} Catalog.
-|String. For example, `existing_service_instance_GUID`.
+
+*Value:* String. For example, `existing_service_instance_GUID`.
 
 |platform:
   powervs:
     clusterOSImage:
 |Specifies a pre-created {ibm-power-server-name} boot image that overrides the default image for cluster nodes.
-|String. For example, `existing_cluster_os_image`.
+
+*Value:* String. For example, `existing_cluster_os_image`.
 
 |platform:
   powervs:
     defaultMachinePlatform:
 |Specifies the default configuration used when installing on {ibm-power-server-name} for machine pools that do not define their own platform configuration.
-|String. For example, `existing_machine_platform`.
+
+*Value:* String. For example, `existing_machine_platform`.
 
 |platform:
   powervs:
     memoryGiB:
 |Specifies the size of a virtual machine's memory, in GB.
-|The valid integer must be an integer number of GB that is at least `2` and no more than `64`, depending on the machine type.
+
+*Value:* The valid integer must be an integer number of GB that is at least `2` and no more than `64`, depending on the machine type.
 
 |platform:
   powervs:
     procType:
 |Defines the processor sharing model for the instance.
-|The valid values are `Capped`, `Dedicated`, and `Shared`.
+
+*Value:* The valid values are `Capped`, `Dedicated`, and `Shared`.
 
 |platform:
   powervs:
     processors:
 |Defines the processing units for the instance.
-|The number of processors must be from `.5` to `32` cores. The processors must be in increments of `.25`.
+
+*Value:* The number of processors must be from `.5` to `32` cores. The processors must be in increments of `.25`.
 
 |platform:
   powervs:
     tgName:
 |Defines the name of an existing Transit Gateway.
-|String. For example, `existing_tgName`.
+
+*Value:* String. For example, `existing_tgName`.
 endif::ibm-power-vs[]
 |====
 
@@ -1114,9 +1180,9 @@ ifdef::osp[]
 Additional {rh-openstack} configuration parameters are described in the following table:
 
 .Additional {rh-openstack} parameters
-[cols=".^2l,.^3a,^5a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |compute:
   platform:
@@ -1124,7 +1190,8 @@ Additional {rh-openstack} configuration parameters are described in the followin
       rootVolume:
         size:
 |For compute machines, the size in gigabytes of the root volume. If you do not set this value, machines use ephemeral storage.
-|Integer, for example `30`.
+
+*Value:* Integer, for example `30`.
 
 |compute:
   platform:
@@ -1132,7 +1199,8 @@ Additional {rh-openstack} configuration parameters are described in the followin
       rootVolume:
         types:
 |For compute machines, the root volume types.
-|A list of strings, for example, {`performance-host1`, `performance-host2`, `performance-host3`}. ^[1]^
+
+*Value:* A list of strings, for example, {`performance-host1`, `performance-host2`, `performance-host3`}. ^[1]^
 
 |compute:
   platform:
@@ -1140,7 +1208,8 @@ Additional {rh-openstack} configuration parameters are described in the followin
       rootVolume:
         type:
 |For compute machines, the root volume's type. This property is deprecated and is replaced by `compute.platform.openstack.rootVolume.types`.
-|String, for example, `performance`. ^[2]^
+
+*Value:* String, for example, `performance`. ^[2]^
 
 |compute:
   platform:
@@ -1148,7 +1217,8 @@ Additional {rh-openstack} configuration parameters are described in the followin
       rootVolume:
         zones:
 |For compute machines, the Cinder availability zone to install root volumes on. If you do not set a value for this parameter, the installation program selects the default availability zone. This parameter is mandatory when `compute.platform.openstack.zones` is defined.
-|A list of strings, for example `["zone-1", "zone-2"]`.
+
+*Value:* A list of strings, for example `["zone-1", "zone-2"]`.
 
 |controlPlane:
   platform:
@@ -1156,7 +1226,8 @@ Additional {rh-openstack} configuration parameters are described in the followin
       rootVolume:
         size:
 |For control plane machines, the size in gigabytes of the root volume. If you do not set this value, machines use ephemeral storage.
-|Integer, for example `30`.
+
+*Value:* Integer, for example `30`.
 
 |controlPlane:
   platform:
@@ -1164,7 +1235,8 @@ Additional {rh-openstack} configuration parameters are described in the followin
       rootVolume:
         types:
 |For control plane machines, the root volume types.
-|A list of strings, for example, {`performance-host1`, `performance-host2`, `performance-host3`}. ^[1]^
+
+*Value:* A list of strings, for example, {`performance-host1`, `performance-host2`, `performance-host3`}. ^[1]^
 
 |controlPlane:
   platform:
@@ -1172,7 +1244,8 @@ Additional {rh-openstack} configuration parameters are described in the followin
       rootVolume:
         type:
 |For control plane machines, the root volume's type. This property is deprecated and is replaced by `compute.platform.openstack.rootVolume.types`.
-|String, for example, `performance`. ^[2]^
+
+*Value:* String, for example, `performance`. ^[2]^
 
 |controlPlane:
   platform:
@@ -1180,7 +1253,8 @@ Additional {rh-openstack} configuration parameters are described in the followin
       rootVolume:
         zones:
 |For control plane machines, the Cinder availability zone to install root volumes on. If you do not set this value, the installation program selects the default availability zone. This parameter is mandatory when `controlPlane.platform.openstack.zones` is defined.
-|A list of strings, for example `["zone-1", "zone-2"]`.
+
+*Value:* A list of strings, for example `["zone-1", "zone-2"]`.
 
 |platform:
   openstack:
@@ -1189,13 +1263,14 @@ Additional {rh-openstack} configuration parameters are described in the followin
 
 In the cloud configuration in the `clouds.yaml` file, if possible, use application credentials rather than a user name and password combination. Using application credentials avoids disruptions from secret propogation that follow user name and password rotation.
 
-|String, for example `MyCloud`.
+*Value:* String, for example `MyCloud`.
 
 |platform:
   openstack:
     externalNetwork:
 |The {rh-openstack} external network name to be used for installation.
-|String, for example `external`.
+
+*Value:* String, for example `external`.
 
 |platform:
   openstack:
@@ -1204,12 +1279,12 @@ In the cloud configuration in the `clouds.yaml` file, if possible, use applicati
 
 This property is deprecated. To use a flavor as the default for all machine pools, add it as the value of the `type` key in the `platform.openstack.defaultMachinePlatform` property. You can also set a flavor value for each machine pool individually.
 
-|String, for example `m1.xlarge`.
+*Value:* String, for example `m1.xlarge`.
 |====
 
 . If the machine pool defines `zones`, the count of types can either be a single item or match the number of items in `zones`. For example, the count of types cannot be 2 if there are 3 items in `zones`.
 
-. If you have any existing reference to this property, the installer populates the corresponding value in the `controlPlane.platform.openstack.rootVolume.types` field.
+. If you have any existing reference to this property, the installation program populates the corresponding value in the `controlPlane.platform.openstack.rootVolume.types` field.
 
 
 [id="installation-configuration-parameters-optional-osp_{context}"]
@@ -1218,23 +1293,25 @@ This property is deprecated. To use a flavor as the default for all machine pool
 Optional {rh-openstack} configuration parameters are described in the following table:
 
 .Optional {rh-openstack} parameters
-[%header, cols=".^2l,.^3,.^5a"]
+[%header, cols=".^l,.^a"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |compute:
   platform:
     openstack:
       additionalNetworkIDs:
 |Additional networks that are associated with compute machines. Allowed address pairs are not created for additional networks.
-|A list of one or more UUIDs as strings. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
+
+*Value:* A list of one or more UUIDs as strings. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
 
 |compute:
   platform:
     openstack:
       additionalSecurityGroupIDs:
 |Additional security groups that are associated with compute machines.
-|A list of one or more UUIDs as strings. For example, `7ee219f3-d2e9-48a1-96c2-e7429f1b0da7`.
+
+*Value:* A list of one or more UUIDs as strings. For example, `7ee219f3-d2e9-48a1-96c2-e7429f1b0da7`.
 
 |compute:
   platform:
@@ -1242,7 +1319,7 @@ Optional {rh-openstack} configuration parameters are described in the following 
       zones:
 |{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installation program relies on the default settings for Nova that the {rh-openstack} administrator configured.
 
-|A list of strings. For example, `["zone-1", "zone-2"]`.
+*Value:* A list of strings. For example, `["zone-1", "zone-2"]`.
 
 |compute:
   platform:
@@ -1253,7 +1330,8 @@ Optional {rh-openstack} configuration parameters are described in the following 
 An `affinity` policy prevents migrations and therefore affects {rh-openstack} upgrades. The `affinity` policy is not supported.
 
 If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is required during instance migration.
-|A server group policy to apply to the machine pool. For example, `soft-affinity`.
+
+*Value:* A server group policy to apply to the machine pool. For example, `soft-affinity`.
 
 |controlPlane:
   platform:
@@ -1262,14 +1340,16 @@ If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is
 |Additional networks that are associated with control plane machines. Allowed address pairs are not created for additional networks.
 
 Additional networks that are attached to a control plane machine are also attached to the bootstrap node.
-|A list of one or more UUIDs as strings. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
+
+*Value:* A list of one or more UUIDs as strings. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
 
 |controlPlane:
   platform:
     openstack:
       additionalSecurityGroupIDs:
 |Additional security groups that are associated with control plane machines.
-|A list of one or more UUIDs as strings. For example, `7ee219f3-d2e9-48a1-96c2-e7429f1b0da7`.
+
+*Value:* A list of one or more UUIDs as strings. For example, `7ee219f3-d2e9-48a1-96c2-e7429f1b0da7`.
 
 |controlPlane:
   platform:
@@ -1277,7 +1357,7 @@ Additional networks that are attached to a control plane machine are also attach
       zones:
 |{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installation program relies on the default settings for Nova that the {rh-openstack} administrator configured.
 
-|A list of strings. For example, `["zone-1", "zone-2"]`.
+*Value:* A list of strings. For example, `["zone-1", "zone-2"]`.
 
 |controlPlane:
   platform:
@@ -1288,7 +1368,8 @@ Additional networks that are attached to a control plane machine are also attach
 An `affinity` policy prevents migrations, and therefore affects {rh-openstack} upgrades. The `affinity` policy is not supported.
 
 If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is required during instance migration.
-|A server group policy to apply to the machine pool. For example, `soft-affinity`.
+
+*Value:* A server group policy to apply to the machine pool. For example, `soft-affinity`.
 
 |platform:
   openstack:
@@ -1296,7 +1377,8 @@ If you use a strict `anti-affinity` policy, an additional {rh-openstack} host is
 |The location from which the installation program downloads the {op-system} image.
 
 You must set this parameter to perform an installation in a restricted network.
-|An HTTP or HTTPS URL, optionally with an SHA-256 checksum.
+
+*Value:* An HTTP or HTTPS URL, optionally with an SHA-256 checksum.
 
 For example, `\http://mirror.example.com/images/rhcos-43.81.201912131630.0-openstack.x86_64.qcow2.gz?sha256=ffebbd68e8a1f2a245ca19522c16c86f67f9ac8e4e0c1f0a812b068b16f7265d`.
 The value can also be the name of an existing Glance image, for example `my-rhcos`.
@@ -1304,12 +1386,13 @@ The value can also be the name of an existing Glance image, for example `my-rhco
 |platform:
   openstack:
     clusterOSImageProperties:
-|Properties to add to the installer-uploaded ClusterOSImage in Glance. This property is ignored if `platform.openstack.clusterOSImage` is set to an existing Glance image.
+|Properties to add to the installation program-uploaded ClusterOSImage in Glance. This property is ignored if `platform.openstack.clusterOSImage` is set to an existing Glance image.
 
 You can use this property to exceed the default persistent volume (PV) limit for {rh-openstack} of 26 PVs per node. To exceed the limit, set the `hw_scsi_model` property value to `virtio-scsi` and the `hw_disk_bus` value to  `scsi`.
 
 You can also use this property to enable the QEMU guest agent by including the `hw_qemu_guest_agent` property with a value of `yes`.
-|A set of string properties. For example:
+
+*Value:* A set of string properties. For example:
 
 [source,yaml]
 ----
@@ -1325,7 +1408,8 @@ clusterOSImageProperties:
       fixedIPs:
 
 |Subnets for the machines to use.
-|A list of subnet names or UUIDs to use in cluster installation.
+
+*Value:* A list of subnet names or UUIDs to use in cluster installation.
 
 
 |platform:
@@ -1333,13 +1417,15 @@ clusterOSImageProperties:
     controlPlanePort:
       network:
 |A network for the machines to use.
-|The UUID or name of an {rh-openstack} network to use in cluster installation.
+
+*Value:* The UUID or name of an {rh-openstack} network to use in cluster installation.
 
 |platform:
   openstack:
     defaultMachinePlatform:
 |The default machine pool platform configuration.
-|
+
+*Value:*
 [source,json]
 ----
 {
@@ -1355,25 +1441,29 @@ clusterOSImageProperties:
   openstack:
     ingressFloatingIP:
 |An existing floating IP address to associate with the Ingress port. To use this property, you must also define the `platform.openstack.externalNetwork` property.
-|An IP address, for example `128.0.0.1`.
+
+*Value:* An IP address, for example `128.0.0.1`.
 
 |platform:
   openstack:
     apiFloatingIP:
 |An existing floating IP address to associate with the API load balancer. To use this property, you must also define the `platform.openstack.externalNetwork` property.
-|An IP address, for example `128.0.0.1`.
+
+*Value:* An IP address, for example `128.0.0.1`.
 
 |platform:
   openstack:
     externalDNS:
 |IP addresses for external DNS servers that cluster instances use for DNS resolution.
-|A list of IP addresses as strings. For example, `["8.8.8.8", "192.168.1.12"]`.
+
+*Value:* A list of IP addresses as strings. For example, `["8.8.8.8", "192.168.1.12"]`.
 
 |platform:
   openstack:
     loadbalancer:
 |Whether or not to use the default, internal load balancer. If the value is set to `UserManaged`, this default load balancer is disabled so that you can deploy a cluster that uses an external, user-managed load balancer. If the parameter is not set, or if the value is `OpenShiftManagedDefault`, the cluster uses the default load balancer.
-|`UserManaged` or `OpenShiftManagedDefault`.
+
+*Value:* `UserManaged` or `OpenShiftManagedDefault`.
 
 |platform:
   openstack:
@@ -1384,7 +1474,7 @@ The first item in `networking.machineNetwork` must match the value of `machinesS
 
 If you deploy to a custom subnet, you cannot specify an external DNS server to the {product-title} installer. Instead, link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/subnet[add DNS to the subnet in {rh-openstack}].
 
-|A UUID as a string. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
+*Value:* A UUID as a string. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
 |====
 endif::osp[]
 
@@ -1401,9 +1491,9 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
 ====
 
 .Additional Azure parameters
-[cols=".^2l,.^3a,.^3a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |compute:
   platform:
@@ -1419,7 +1509,8 @@ The following values are associated with the boot diagnostics type:
 `Managed`:: When you set `type` to `Managed`, {azure-short} stores the boot diagnostics data blobs  in a managed storage account.
 
 `Disabled`:: When you set `type` to `Disabled`, you turn off the parameter.
-|String, for example `Enabled`.
+
+*Value:* String, for example `Enabled`.
 
 |compute:
   platform:
@@ -1427,7 +1518,8 @@ The following values are associated with the boot diagnostics type:
       bootDiagnostics:
         resourceGroup:
 |Specifies the name of the {azure-short} resource group that contains the diagnostic storage account for compute machines. Use `resourceGroup` only when you set `type` to `UserManaged`.
-|String.
+
+*Value:* String.
 
 |compute:
   platform:
@@ -1435,14 +1527,16 @@ The following values are associated with the boot diagnostics type:
       bootDiagnostics:
         storageAccountName:
 |Specifies the {azure-short} storage account to store the diagnostic logs for compute machines. Use `storageAccountName` only when you set`type` to `UserManaged`.
-|String.
+
+*Value:* String.
 
 |compute:
   platform:
     azure:
       encryptionAtHost:
 |Enables host-level encryption for compute machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached and un-managed disks on the VM host. This is not a prerequisite for user-managed server-side encryption.
-|`true` or `false`. The default is `false`.
+
+*Value:* `true` or `false`. The default is `false`.
 
 |compute:
   platform:
@@ -1450,7 +1544,8 @@ The following values are associated with the boot diagnostics type:
       osDisk:
         diskSizeGB:
 |The Azure disk size for the VM.
-|Integer that represents the size of the disk in GB. The default is `128`.
+
+*Value:* Integer that represents the size of the disk in GB. The default is `128`.
 
 |compute:
   platform:
@@ -1458,14 +1553,16 @@ The following values are associated with the boot diagnostics type:
       osDisk:
         diskType:
 |Defines the type of disk.
-|`standard_LRS`, `premium_LRS`, or `standardSSD_LRS`. The default is `premium_LRS`.
+
+*Value:* `standard_LRS`, `premium_LRS`, or `standardSSD_LRS`. The default is `premium_LRS`.
 
 |compute:
   platform:
     azure:
       ultraSSDCapability:
 |Enables the use of Azure ultra disks for persistent storage on compute nodes. This requires that your Azure region and zone have ultra disks available.
-|`Enabled`, `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled`, `Disabled`. The default is `Disabled`.
 
 |compute:
   platform:
@@ -1474,7 +1571,8 @@ The following values are associated with the boot diagnostics type:
         diskEncryptionSet:
           resourceGroup:
 |The name of the Azure resource group that contains the disk encryption set from the installation prerequisites. This resource group should be different from the resource group where you install the cluster to avoid deleting your Azure encryption key when the cluster is destroyed. This value is only necessary if you intend to install the cluster with user-managed disk encryption.
-|String, for example `production_encryption_resource_group`.
+
+*Value:* String, for example `production_encryption_resource_group`.
 
 |compute:
   platform:
@@ -1483,7 +1581,8 @@ The following values are associated with the boot diagnostics type:
         diskEncryptionSet:
           name:
 |The name of the disk encryption set that contains the encryption key from the installation prerequisites.
-|String, for example `production_disk_encryption_set`.
+
+*Value:* String, for example `production_disk_encryption_set`.
 
 |compute:
   platform:
@@ -1492,7 +1591,8 @@ The following values are associated with the boot diagnostics type:
         diskEncryptionSet:
           subscriptionId:
 |Defines the Azure subscription of the disk encryption set where the disk encryption set resides. This secondary disk encryption set is used to encrypt compute machines.
-|String, in the format `00000000-0000-0000-0000-000000000000`.
+
+*Value:* String, in the format `00000000-0000-0000-0000-000000000000`.
 
 |compute:
   platform:
@@ -1500,7 +1600,8 @@ The following values are associated with the boot diagnostics type:
       osImage:
         publisher:
 |Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot compute machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for compute machines only.
-|String. The name of the image publisher.
+
+*Value:* String. The name of the image publisher.
 
 |compute:
   platform:
@@ -1508,7 +1609,8 @@ The following values are associated with the boot diagnostics type:
       osImage:
         offer:
 |The name of Azure Marketplace offer that is associated with the custom {op-system} image. If you use `compute.platform.azure.osImage.publisher`, this field is required.
-|String. The name of the image offer.
+
+*Value:* String. The name of the image offer.
 
 |compute:
   platform:
@@ -1516,7 +1618,8 @@ The following values are associated with the boot diagnostics type:
       osImage:
         sku:
 |An instance of the Azure Marketplace offer. If you use `compute.platform.azure.osImage.publisher`, this field is required.
-|String. The SKU of the image offer.
+
+*Value:* String. The SKU of the image offer.
 
 |compute:
   platform:
@@ -1524,7 +1627,8 @@ The following values are associated with the boot diagnostics type:
       osImage:
         version:
 |The version number of the image SKU. If you use `compute.platform.azure.osImage.publisher`, this field is required.
-|String. The version of the image to use.
+
+*Value:* String. The version of the image to use.
 
 |compute:
   platform:
@@ -1535,7 +1639,8 @@ The following values are associated with the boot diagnostics type:
 The `UserAssigned` identity is a standalone Azure resource provided by the user and assigned to compute virtual machines.
 If you specify `identity.type` as `UserAssigned`, but do not provide a user-assigned identity, the installation program creates the identity.
 If you provide a user-assigned identity, the Azure account that you use to create the identity must have either the "User Access Administrator" or "RBAC Access Admin" roles.
-|`UserAssigned` or `None`. If you do not specify a value, the installation program generates a user-assigned identity.
+
+*Value:* `UserAssigned` or `None`. If you do not specify a value, the installation program generates a user-assigned identity.
 
 |compute:
   platform:
@@ -1548,28 +1653,32 @@ If you provide a user-assigned identity, the Azure account that you use to creat
 |A group of parameters that specify the name of the user-assigned identity, and the resource group and subscription that contain the identity. All three values must be provided to specify a user-assigned identity.
 Only one user-assigned identity can be supplied.
 Supplying more than one user-assigned identity is an experimental feature, which may be enabled with the `MachineAPIMigration` feature gate.
-|Array of strings.
+
+*Value:* Array of strings.
 
 |compute:
   platform:
     azure:
       vmNetworkingType:
-|Enables accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, improving its networking performance. If instance type of compute machines support `Accelerated` networking, by default, the installer enables `Accelerated` networking, otherwise the default networking type is `Basic`.
-|`Accelerated` or `Basic`.
+|Enables accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, improving its networking performance. If instance type of compute machines support `Accelerated` networking, by default, the installation program enables `Accelerated` networking, otherwise the default networking type is `Basic`.
+
+*Value:* `Accelerated` or `Basic`.
 
 |compute:
   platform:
     azure:
       type:
 |Defines the Azure instance type for compute machines.
-|String
+
+*Value:* String
 
 |compute:
   platform:
     azure:
       zones:
 |The availability zones where the installation program creates compute machines.
-|String list
+
+*Value:* String list
 
 |compute:
   platform:
@@ -1577,7 +1686,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       settings:
         securityType:
 |Enables confidential VMs or trusted launch for compute nodes. This option is not enabled by default.
-|`ConfidentialVM` or `TrustedLaunch`.
+
+*Value:* `ConfidentialVM` or `TrustedLaunch`.
 
 |compute:
   platform:
@@ -1587,7 +1697,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
           uefiSettings:
             secureBoot:
 |Enables secure boot on compute nodes if you are using confidential VMs.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |compute:
   platform:
@@ -1597,7 +1708,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
           uefiSettings:
             virtualizedTrustedPlatformModule:
 |Enables the virtualized Trusted Platform Module (vTPM) feature on compute nodes if you are using confidential VMs.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |compute:
   platform:
@@ -1607,7 +1719,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
           uefiSettings:
             secureBoot:
 |Enables secure boot on compute nodes if you are using trusted launch.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |compute:
   platform:
@@ -1617,7 +1730,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
           uefiSettings:
             virtualizedTrustedPlatformModule:
 |Enables the vTPM feature on compute nodes if you are using trusted launch.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |compute:
   platform:
@@ -1626,7 +1740,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
         securityProfile:
           securityEncryptionType:
 |Enables the encryption of the virtual machine guest state for compute nodes. This parameter can only be used if you use Confidential VMs.
-|`VMGuestStateOnly` is the only supported value.
+
+*Value:* `VMGuestStateOnly` is the only supported value.
 
 |controlPlane:
   platform:
@@ -1637,7 +1752,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
 The `UserAssigned` identity is a standalone Azure resource provided by the user and assigned to control plane virtual machines.
 If you specify `identity.type` as `UserAssigned`, but do not provide a user-assigned identity, the installation program creates the identity.
 If you provide a user-assigned identity, the Azure account that you use to create the identity must have either the "User Access Administrator" or "RBAC Access Admin" roles.
-|`UserAssigned` or `None`. If you do not specify a value, the installation program generates a user-assigned identity.
+
+*Value:* `UserAssigned` or `None`. If you do not specify a value, the installation program generates a user-assigned identity.
 
 |controlPlane:
   platform:
@@ -1654,7 +1770,7 @@ The following values are associated with the boot diagnostics type:
 
 `Disabled`:: When you set `type` to `Disabled`, you turn off the parameter.
 
-|String. For control plane machines, the default value is `Managed`.
+*Value:* String. For control plane machines, the default value is `Managed`.
 
 |controlPlane:
   platform:
@@ -1667,7 +1783,8 @@ The following values are associated with the boot diagnostics type:
 |A group of parameters that specify the name of the user-assigned identity, and the resource group and subscription that contain the identity. All three values must be provided to specify a user-assigned identity.
 Only one user-assigned identity can be supplied.
 Supplying more than one user-assigned identity is an experimental feature, which may be enabled with the `MachineAPIMigration` feature gate.
-|Array of strings.
+
+*Value:* Array of strings.
 
 |controlPlane:
   platform:
@@ -1675,7 +1792,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       bootDiagnostics:
         resourceGroup:
 |Specifies the name of the {azure-short} resource group that contains the diagnostic storage account for control plane machines. Use `resourceGroup` only when you set `type` to `UserManaged`.
-|String.
+
+*Value:* String.
 
 |controlPlane:
   platform:
@@ -1683,7 +1801,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       bootDiagnostics:
         storageAccountName:
 |Specifies the {azure-short} storage account to store the diagnostic logs for control plane machines. Use `storageAccountName` only when you set `type` to `UserManaged`.
-|String.
+
+*Value:* String.
 
 |controlPlane:
   platform:
@@ -1691,7 +1810,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       settings:
         securityType:
 |Enables confidential VMs or trusted launch for control plane nodes. This option is not enabled by default.
-|`ConfidentialVM` or `TrustedLaunch`.
+
+*Value:* `ConfidentialVM` or `TrustedLaunch`.
 
 |controlPlane:
   platform:
@@ -1701,7 +1821,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
           uefiSettings:
             secureBoot:
 |Enables secure boot on control plane nodes if you are using confidential VMs.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |controlPlane:
   platform:
@@ -1711,7 +1832,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
           uefiSettings:
             virtualizedTrustedPlatformModule:
 |Enables the vTPM feature on control plane nodes if you are using confidential VMs.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |controlPlane:
   platform:
@@ -1721,7 +1843,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
           uefiSettings:
             secureBoot:
 |Enables secure boot on control plane nodes if you are using trusted launch.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |controlPlane:
   platform:
@@ -1731,7 +1854,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
           uefiSettings:
             virtualizedTrustedPlatformModule:
 |Enables the vTPM feature on control plane nodes if you are using trusted launch.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |controlPlane:
   platform:
@@ -1740,21 +1864,24 @@ Supplying more than one user-assigned identity is an experimental feature, which
         securityProfile:
           securityEncryptionType:
 |Enables the encryption of the virtual machine guest state for control plane nodes. This parameter can only be used if you use Confidential VMs.
-|`VMGuestStateOnly` is the only supported value.
+
+*Value:* `VMGuestStateOnly` is the only supported value.
 
 |controlPlane:
   platform:
     azure:
       type:
 |Defines the Azure instance type for control plane machines.
-|String
+
+*Value:* String
 
 |controlPlane:
   platform:
     azure:
       zones:
 |The availability zones where the installation program creates control plane machines.
-|String list
+
+*Value:* String list
 
 |platform:
   azure:
@@ -1770,7 +1897,8 @@ The following values are associated with the boot diagnostics type:
 `Managed`:: When you set `type` to `Managed`, {azure-short} stores the boot diagnostics data blobs in a managed storage account.
 
 `Disabled`:: When you set `type` to `Disabled`, you turn off the parameter.
-|String, for example `Enabled`.
+
+*Value:* String, for example `Enabled`.
 
 |platform:
   azure:
@@ -1778,7 +1906,8 @@ The following values are associated with the boot diagnostics type:
        bootDiagnostics:
         resourceGroup:
 |Specifies the name of the {azure-short} resource group that contains the diagnostic storage account for all machines. Use `resourceGroup` only when you set `type` to `UserManaged`.
-|String.
+
+*Value:* String.
 
 |platform:
   azure:
@@ -1786,7 +1915,8 @@ The following values are associated with the boot diagnostics type:
        bootDiagnostics:
         storageAccountName:
 |Specifies the {azure-short} storage account to store the diagnostic logs for all machines. Use `storageAccountName` only when you set `type` to `UserManaged`.
-|String.
+
+*Value:* String.
 
 |platform:
   azure:
@@ -1794,7 +1924,8 @@ The following values are associated with the boot diagnostics type:
       settings:
         securityType:
 |Enables confidential VMs or trusted launch for all nodes. This option is not enabled by default.
-|`ConfidentialVM` or `TrustedLaunch`.
+
+*Value:* `ConfidentialVM` or `TrustedLaunch`.
 
 |platform:
   azure:
@@ -1804,7 +1935,8 @@ The following values are associated with the boot diagnostics type:
           uefiSettings:
             secureBoot:
 |Enables secure boot on all nodes if you are using confidential VMs.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |platform:
   azure:
@@ -1814,7 +1946,8 @@ The following values are associated with the boot diagnostics type:
           uefiSettings:
             virtualizedTrustedPlatformModule:
 |Enables the virtualized Trusted Platform Module (vTPM) feature on all nodes if you are using confidential VMs.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |platform:
   azure:
@@ -1824,7 +1957,8 @@ The following values are associated with the boot diagnostics type:
           uefiSettings:
             secureBoot:
 |Enables secure boot on all nodes if you are using trusted launch.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |platform:
   azure:
@@ -1834,7 +1968,8 @@ The following values are associated with the boot diagnostics type:
           uefiSettings:
             virtualizedTrustedPlatformModule:
 |Enables the vTPM feature on all nodes if you are using trusted launch.
-|`Enabled` or `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default is `Disabled`.
 
 |platform:
   azure:
@@ -1845,7 +1980,8 @@ The following values are associated with the boot diagnostics type:
 The `UserAssigned` identity is a standalone Azure resource provided by the user and assigned to all virtual machines.
 If you specify `identity.type` as `UserAssigned`, but do not provide a user-assigned identity, the installation program creates the identity.
 If you provide a user-assigned identity, the Azure account that you use to create the identity must have either the "User Access Administrator" or "RBAC Access Admin" roles.
-|`UserAssigned` or `None`. If you do not specify a value, the installation program generates a user-assigned identity.
+
+*Value:* `UserAssigned` or `None`. If you do not specify a value, the installation program generates a user-assigned identity.
 
 |platform:
   azure:
@@ -1858,7 +1994,8 @@ If you provide a user-assigned identity, the Azure account that you use to creat
 |A group of parameters that specify the name of the user-assigned identity, and the resource group and subscription that contain the identity. All three values must be provided to specify a user-assigned identity.
 Only one user-assigned identity can be supplied.
 Supplying more than one user-assigned identity is an experimental feature, which may be enabled with the `MachineAPIMigration` feature gate.
-|Array of strings.
+
+*Value:* Array of strings.
 
 |platform:
   azure:
@@ -1867,14 +2004,16 @@ Supplying more than one user-assigned identity is an experimental feature, which
         securityProfile:
           securityEncryptionType:
 |Enables the encryption of the virtual machine guest state for all nodes. This parameter can only be used if you use Confidential VMs.
-|`VMGuestStateOnly` is the only supported value.
+
+*Value:* `VMGuestStateOnly` is the only supported value.
 
 |platform:
   azure:
     defaultMachinePlatform:
       encryptionAtHost:
 |Enables host-level encryption for compute machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached, and un-managed disks on the VM host. This parameter is not a prerequisite for user-managed server-side encryption.
-|`true` or `false`. The default is `false`.
+
+*Value:* `true` or `false`. The default is `false`.
 
 |platform:
   azure:
@@ -1883,7 +2022,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
         diskEncryptionSet:
           name:
 |The name of the disk encryption set that contains the encryption key from the installation prerequisites.
-|String, for example, `production_disk_encryption_set`.
+
+*Value:* String, for example, `production_disk_encryption_set`.
 
 |platform:
   azure:
@@ -1892,7 +2032,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
         diskEncryptionSet:
           resourceGroup:
 |The name of the Azure resource group that contains the disk encryption set from the installation prerequisites. To avoid deleting your Azure encryption key when the cluster is destroyed, this resource group must be different from the resource group where you install the cluster. This value is necessary only if you intend to install the cluster with user-managed disk encryption.
-|String, for example, `production_encryption_resource_group`.
+
+*Value:* String, for example, `production_encryption_resource_group`.
 
 |platform:
   azure:
@@ -1901,7 +2042,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
         diskEncryptionSet:
           subscriptionId:
 |Defines the Azure subscription of the disk encryption set where the disk encryption set resides. This secondary disk encryption set is used to encrypt compute machines.
-|String, in the format `00000000-0000-0000-0000-000000000000`.
+
+*Value:* String, in the format `00000000-0000-0000-0000-000000000000`.
 
 |platform:
   azure:
@@ -1909,7 +2051,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osDisk:
         diskSizeGB:
 |The Azure disk size for the VM.
-|Integer that represents the size of the disk in GB. The default is `128`.
+
+*Value:* Integer that represents the size of the disk in GB. The default is `128`.
 
 |platform:
   azure:
@@ -1917,7 +2060,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osDisk:
         diskType:
 |Defines the type of disk.
-|`premium_LRS` or `standardSSD_LRS`. The default is `premium_LRS`.
+
+*Value:* `premium_LRS` or `standardSSD_LRS`. The default is `premium_LRS`.
 
 |platform:
   azure:
@@ -1925,7 +2069,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osImage:
         publisher:
 |Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane and compute machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for both types of machines. Control plane machines do not contribute to licensing costs when using the default image. But, if you apply an Azure Marketplace image for a control plane machine, usage costs do apply.
-|String. The name of the image publisher.
+
+*Value:* String. The name of the image publisher.
 
 |platform:
   azure:
@@ -1933,7 +2078,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osImage:
         offer:
 |The name of Azure Marketplace offer that is associated with the custom {op-system} image. If you use `platform.azure.defaultMachinePlatform.osImage.publisher`, this field is required.
-|String. The name of the image offer.
+
+*Value:* String. The name of the image offer.
 
 |platform:
   azure:
@@ -1941,7 +2087,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osImage:
         sku:
 |An instance of the Azure Marketplace offer. If you use `platform.azure.defaultMachinePlatform.osImage.publisher`, this field is required.
-|String. The SKU of the image offer.
+
+*Value:* String. The SKU of the image offer.
 
 |platform:
   azure:
@@ -1949,28 +2096,32 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osImage:
         version:
 |The version number of the image SKU. If you use `platform.azure.defaultMachinePlatform.osImage.publisher`, this field is required.
-|String. The version of the image to use.
+
+*Value:* String. The version of the image to use.
 
 |platform:
   azure:
     defaultMachinePlatform:
       type:
 |The Azure instance type for control plane and compute machines.
-|The Azure instance type.
+
+*Value:* The Azure instance type.
 
 |platform:
   azure:
     defaultMachinePlatform:
       zones:
 |The availability zones where the installation program creates compute and control plane machines.
-|String list.
+
+*Value:* String list.
 
 |controlPlane:
   platform:
     azure:
       encryptionAtHost:
 |Enables host-level encryption for control plane machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached and un-managed disks on the VM host. This is not a prerequisite for user-managed server-side encryption.
-|`true` or `false`. The default is `false`.
+
+*Value:* `true` or `false`. The default is `false`.
 
 |controlPlane:
   platform:
@@ -1979,7 +2130,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
         diskEncryptionSet:
           resourceGroup:
 |The name of the Azure resource group that contains the disk encryption set from the installation prerequisites. This resource group should be different from the resource group where you install the cluster to avoid deleting your Azure encryption key when the cluster is destroyed. This value is only necessary if you intend to install the cluster with user-managed disk encryption.
-|String, for example `production_encryption_resource_group`.
+
+*Value:* String, for example `production_encryption_resource_group`.
 
 |controlPlane:
   platform:
@@ -1988,7 +2140,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
         diskEncryptionSet:
           name:
 |The name of the disk encryption set that contains the encryption key from the installation prerequisites.
-|String, for example `production_disk_encryption_set`.
+
+*Value:* String, for example `production_disk_encryption_set`.
 
 |controlPlane:
   platform:
@@ -1997,7 +2150,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
         diskEncryptionSet:
           subscriptionId:
 |Defines the Azure subscription of the disk encryption set where the disk encryption set resides. This secondary disk encryption set is used to encrypt control plane machines.
-|String, in the format `00000000-0000-0000-0000-000000000000`.
+
+*Value:* String, in the format `00000000-0000-0000-0000-000000000000`.
 
 |controlPlane:
   platform:
@@ -2005,7 +2159,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osDisk:
         diskSizeGB:
 |The Azure disk size for the VM.
-|Integer that represents the size of the disk in GB. The default is `1024`.
+
+*Value:* Integer that represents the size of the disk in GB. The default is `1024`.
 
 |controlPlane:
   platform:
@@ -2013,7 +2168,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osDisk:
         diskType:
 |Defines the type of disk.
-|`premium_LRS` or `standardSSD_LRS`. The default is `premium_LRS`.
+
+*Value:* `premium_LRS` or `standardSSD_LRS`. The default is `premium_LRS`.
 
 |controlPlane:
   platform:
@@ -2021,7 +2177,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osImage:
         publisher:
 |Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane machines. You can override the default behavior by using a custom {op-system} image that is available from the Azure Marketplace. The installation program uses this image for control plane machines only. Control plane machines do not contribute to licensing costs when using the default image. But, if you apply an Azure Marketplace image for a control plane machine, usage costs do apply.
-|String. The name of the image publisher.
+
+*Value:* String. The name of the image publisher.
 
 |controlPlane:
   platform:
@@ -2029,7 +2186,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osImage:
         offer:
 |The name of Azure Marketplace offer that is associated with the custom {op-system} image. If you use `controlPlane.platform.azure.osImage.publisher`, this field is required.
-|String. The name of the image offer.
+
+*Value:* String. The name of the image offer.
 
 |controlPlane:
   platform:
@@ -2037,7 +2195,8 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osImage:
         sku:
 |An instance of the Azure Marketplace offer. If you use `controlPlane.platform.azure.osImage.publisher`, this field is required.
-|String. The SKU of the image offer.
+
+*Value:* String. The SKU of the image offer.
 
 |controlPlane:
   platform:
@@ -2045,33 +2204,38 @@ Supplying more than one user-assigned identity is an experimental feature, which
       osImage:
         version:
 |The version number of the image SKU. If you use `controlPlane.platform.azure.osImage.publisher`, this field is required.
-|String. The version of the image to use.
+
+*Value:* String. The version of the image to use.
 
 |controlPlane:
   platform:
     azure:
       ultraSSDCapability:
 |Enables the use of Azure ultra disks for persistent storage on control plane machines. This requires that your Azure region and zone have ultra disks available.
-|`Enabled`, `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled`, `Disabled`. The default is `Disabled`.
 
 |controlPlane:
   platform:
     azure:
       vmNetworkingType:
-|Enables accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, improving its networking performance. If instance type of control plane machines support `Accelerated` networking, by default, the installer enables `Accelerated` networking, otherwise the default networking type is `Basic`.
-|`Accelerated` or `Basic`.
+|Enables accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, improving its networking performance. If instance type of control plane machines support `Accelerated` networking, by default, the installation program enables `Accelerated` networking, otherwise the default networking type is `Basic`.
+
+*Value:* `Accelerated` or `Basic`.
 
 |platform:
   azure:
     baseDomainResourceGroupName:
 |The name of the resource group that contains the DNS zone for your base domain.
-|String, for example `production_cluster`.
+
+*Value:* String, for example `production_cluster`.
 
 |platform:
   azure:
     resourceGroupName:
 | The name of an already existing resource group to install your cluster to. This resource group must be empty and only used for this specific cluster; the cluster components assume ownership of all resources in the resource group. If you limit the service principal scope of the installation program to this resource group, you must ensure all other resources used by the installation program in your environment have the necessary permissions, such as the public DNS zone and virtual network. Destroying the cluster by using the installation program deletes this resource group.
-|String, for example `existing_resource_group`.
+
+*Value:* String, for example `existing_resource_group`.
 
 |platform:
   azure:
@@ -2087,20 +2251,22 @@ For more information about the support scope of Red Hat Technology Preview featu
 ====
 //You can't put a snippet within a conditional.
 
-|`LoadBalancer`, `UserDefinedRouting`, or `NatGateway`. The default is `LoadBalancer`.
+*Value:* `LoadBalancer`, `UserDefinedRouting`, or `NatGateway`. The default is `LoadBalancer`.
 
 |platform:
   azure:
     region:
 |The name of the Azure region that hosts your cluster.
-|Any valid region name, such as `centralus`.
+
+*Value:* Any valid region name, such as `centralus`.
 
 |platform:
   azure:
     zone:
 |List of availability zones to place machines in. For high availability, specify
 at least two zones.
-|List of zones, for example `["1", "2", "3"]`.
+
+*Value:* List of zones, for example `["1", "2", "3"]`.
 
 |platform:
   azure:
@@ -2108,7 +2274,8 @@ at least two zones.
       keyVault:
         name:
 |Specifies the name of the key vault that contains the encryption key that is used to encrypt Azure storage.
-|String.
+
+*Value:* String.
 
 |platform:
   azure:
@@ -2116,7 +2283,8 @@ at least two zones.
       keyVault:
         keyName:
 |Specifies the name of the user-managed encryption key that is used to encrypt Azure storage.
-|String.
+
+*Value:* String.
 
 |platform:
   azure:
@@ -2124,68 +2292,79 @@ at least two zones.
       keyVault:
         resourceGroup:
 |Specifies the name of the resource group that contains the key vault and managed identity.
-|String.
+
+*Value:* String.
 
 |platform:
   azure:
     customerManagedKey:
       userAssignedIdentityKey:
 |Specifies the name of the user-assigned managed identity that resides in the resource group with the key vault and has access to the user-managed key.
-|String.
+
+*Value:* String.
 
 |platform:
   azure:
     defaultMachinePlatform:
       ultraSSDCapability:
 |Enables the use of Azure ultra disks for persistent storage on control plane and compute machines. This requires that your Azure region and zone have ultra disks available.
-|`Enabled`, `Disabled`. The default is `Disabled`.
+
+*Value:* `Enabled`, `Disabled`. The default is `Disabled`.
 
 |platform:
   azure:
     networkResourceGroupName:
 |The name of the resource group that contains the existing VNet that you want to deploy your cluster to. This name cannot be the same as the `platform.azure.baseDomainResourceGroupName`.
-|String.
+
+*Value:* String.
 
 |platform:
   azure:
     virtualNetwork:
 |The name of the existing VNet that you want to deploy your cluster to.
-|String.
+
+*Value:* String.
 
 |platform:
   azure:
     controlPlaneSubnet:
 |The name of the existing subnet in your VNet that you want to deploy your control plane machines to.
-|Valid CIDR, for example `10.0.0.0/16`.
+
+*Value:* Valid CIDR, for example `10.0.0.0/16`.
 
 |platform:
   azure:
     computeSubnet:
 |The name of the existing subnet in your VNet that you want to deploy your compute machines to.
-|Valid CIDR, for example `10.0.0.0/16`.
+
+*Value:* Valid CIDR, for example `10.0.0.0/16`.
 
 |platform:
   azure:
     cloudName:
 |The name of the Azure cloud environment that is used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the default value `AzurePublicCloud` is used.
-|Any valid cloud environment, such as `AzurePublicCloud` or `AzureUSGovernmentCloud`.
+
+*Value:* Any valid cloud environment, such as `AzurePublicCloud` or `AzureUSGovernmentCloud`.
 
 |platform:
   azure:
     defaultMachinePlatform:
       vmNetworkingType:
 |Enables accelerated networking. Accelerated networking enables single root I/O virtualization (SR-IOV) to a VM, improving its networking performance.
-|`Accelerated` or `Basic`. If instance type of control plane and compute machines support `Accelerated` networking, by default, the installer enables `Accelerated` networking, otherwise the default networking type is `Basic`.
+
+*Value:* `Accelerated` or `Basic`. If instance type of control plane and compute machines support `Accelerated` networking, by default, the installation program enables `Accelerated` networking, otherwise the default networking type is `Basic`.
 
 |operatorPublishingStrategy:
   apiserver:
 |Determines whether the load balancers that service the API are public or private. Set this parameter to `Internal` to prevent the API server from being accessible outside of your VNet. Set this parameter to `External` to make the API server accessible outside of your VNet. If you set this parameter, you must set the `publish` parameter to `Mixed`.
-|`External` or `Internal`. The default value is `External`.
+
+*Value:* `External` or `Internal`. The default value is `External`.
 
 |operatorPublishingStrategy:
   ingress:
 |Determines whether the DNS resources that the cluster creates for ingress traffic are publicly visible. Set this parameter to `Internal` to prevent the ingress VIP from being publicly accessible. Set this parameter to `External` to make the ingress VIP publicly accessible. If you set this parameter, you must set the `publish` parameter to `Mixed`.
-|`External` or `Internal`. The default value is `External`.
+
+*Value:* `External` or `Internal`. The default value is `External`.
 
 |====
 
@@ -2212,9 +2391,9 @@ Configuring these fields at install time eliminates the need to set them as a Da
 ====
 
 .Additional bare metal parameters
-[cols=".^2l,.^3a,.^3a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |platform:
   baremetal:
@@ -2222,7 +2401,8 @@ Configuring these fields at install time eliminates the need to set them as a Da
 |The IP address within the cluster where the provisioning services run.
 Defaults to the third IP address of the provisioning subnet.
 For example, `172.22.0.3` or `2620:52:0:1307::3`.
-|IPv4 or IPv6 address.
+
+*Value:* IPv4 or IPv6 address.
 
 |platform:
   baremetal:
@@ -2237,60 +2417,68 @@ When set to `Disabled`, you can use only virtual media based provisioning on Day
 If `Disabled` and using power management, BMCs must be accessible from the bare-metal network.
 If Disabled, you must provide two IP addresses on the bare-metal network that are used for the provisioning services.
 
-|`Managed` or `Disabled`.
+*Value:* `Managed` or `Disabled`.
 
 |platform:
   baremetal:
     provisioningMACAddress:
 |The MAC address within the cluster where provisioning services run.
-|MAC address.
+
+*Value:* MAC address.
 
 |platform:
   baremetal:
     provisioningNetworkCIDR:
 |The CIDR for the network to use for provisioning.
 This option is required when not using the default address range on the provisioning network.
-|Valid CIDR, for example `10.0.0.0/16`.
+
+*Value:* Valid CIDR, for example `10.0.0.0/16`.
 
 |platform:
   baremetal:
     provisioningNetworkInterface:
 |The name of the network interface on nodes connected to the provisioning network.
 Use the `bootMACAddress` configuration setting to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` configuration setting to identify the name of the NIC.
-|String.
+
+*Value:* String.
 
 |platform:
   baremetal:
     provisioningDHCPRange:
 |Defines the IP range for nodes on the provisioning network, for example `172.22.0.10,172.22.0.254`.
-|IP address range.
+
+*Value:* IP address range.
 
 |platform:
   baremetal:
     hosts:
 |Configuration for bare metal hosts.
-|Array of host configuration objects.
+
+*Value:* Array of host configuration objects.
 
 |platform:
   baremetal:
     hosts:
       name:
 |The name of the host.
-|String.
+
+*Value:* String.
 
 |platform:
   baremetal:
     hosts:
       bootMACAddress:
 |The MAC address of the NIC used for provisioning the host.
-|MAC address.
+
+*Value:* MAC address.
 
 |platform:
   baremetal:
     hosts:
       bmc:
 |Configuration for the host to connect to the baseboard management controller (BMC).
-|Dictionary of BMC configuration objects.
+
+*Value:* Dictionary of BMC configuration objects.
 
 |platform:
   baremetal:
@@ -2298,7 +2486,8 @@ Use the `bootMACAddress` configuration setting to enable Ironic to identify the 
       bmc:
         username:
 |The username for the BMC.
-|String.
+
+*Value:* String.
 
 |platform:
   baremetal:
@@ -2306,7 +2495,8 @@ Use the `bootMACAddress` configuration setting to enable Ironic to identify the 
       bmc:
         password:
 |Password for the BMC.
-|String.
+
+*Value:* String.
 
 |platform:
   baremetal:
@@ -2317,7 +2507,8 @@ Use the `bootMACAddress` configuration setting to enable Ironic to identify the 
 The address configuration setting specifies the protocol.
 For example, `redfish+http://10.10.10.1:8000/redfish/v1/Systems/1234` enables Redfish.
 For more information, see "BMC addressing" in the "Deploying installer-provisioned clusters on bare metal" section.
-|URL.
+
+*Value:* URL.
 
 |platform:
   baremetal:
@@ -2326,7 +2517,8 @@ For more information, see "BMC addressing" in the "Deploying installer-provision
         disableCertificateVerification:
 |`redfish` and `redfish-virtualmedia` need this parameter to manage BMC addresses.
 The value should be `True` when using a self-signed certificate for BMC addresses.
-|Boolean.
+
+*Value:* Boolean.
 
 |====
 endif::agent[]
@@ -2339,9 +2531,9 @@ ifdef::gcp[]
 Additional GCP configuration parameters are described in the following table:
 
 .Additional GCP parameters
-[cols=".^1l,.^6a,.^3a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |controlPlane:
   platform:
@@ -2349,7 +2541,8 @@ Additional GCP configuration parameters are described in the following table:
       osImage:
         project:
 |Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane machines. You can override the default behavior by specifying the location of a custom {op-system} image that the installation program is to use for control plane machines only. Control plane machines do not contribute to licensing costs when using the default image. But, if you apply a GCP Marketplace image for a control plane machine, usage costs do apply.
-|String. The name of GCP project where the image is located.
+
+*Value:* String. The name of GCP project where the image is located.
 
 |controlPlane:
   platform:
@@ -2357,7 +2550,8 @@ Additional GCP configuration parameters are described in the following table:
       osImage:
         name:
 |The name of the custom {op-system} image that the installation program is to use to boot control plane machines. If you use `controlPlane.platform.gcp.osImage.project`, this field is required.
-|String. The name of the {op-system} image.
+
+*Value:* String. The name of the {op-system} image.
 
 |compute:
   platform:
@@ -2365,7 +2559,8 @@ Additional GCP configuration parameters are described in the following table:
       osImage:
         project:
 |Optional. By default, the installation program downloads and installs the {op-system} image that is used to boot compute machines. You can override the default behavior by specifying the location of a custom {op-system} image that the installation program is to use for compute machines only.
-|String. The name of GCP project where the image is located.
+
+*Value:* String. The name of GCP project where the image is located.
 
 |compute:
   platform:
@@ -2373,32 +2568,37 @@ Additional GCP configuration parameters are described in the following table:
       osImage:
         name:
 |The name of the custom {op-system} image that the installation program is to use to boot compute machines. If you use `compute.platform.gcp.osImage.project`, this field is required.
-|String. The name of the {op-system} image.
+
+*Value:* String. The name of the {op-system} image.
 
 |compute:
   platform:
     gcp:
       serviceAccount:
 |Specifies the email address of a {gcp-short} service account to be used during installations. This service account is used to provision compute machines.
-|String. The email address of the service account.
+
+*Value:* String. The email address of the service account.
 
 |platform:
   gcp:
     network:
 |The name of the existing Virtual Private Cloud (VPC) where you want to deploy your cluster. If you want to deploy your cluster into a shared VPC, you must set `platform.gcp.networkProjectID` with the name of the GCP project that contains the shared VPC.
-|String.
+
+*Value:* String.
 
 |platform:
   gcp:
     networkProjectID:
 |Optional. The name of the GCP project that contains the shared VPC where you want to deploy your cluster.
-|String.
+
+*Value:* String.
 
 |platform:
   gcp:
     projectID:
 |The name of the GCP project where the installation program installs the cluster.
-|String.
+
+*Value:* String.
 
 |platform:
   gcp:
@@ -2406,7 +2606,8 @@ Additional GCP configuration parameters are described in the following table:
       privateZone:
         name:
 |The name of the private DNS zone. This parameter is only used during shared VPC installations. You can use a private DNS zone in a service project that is distinct from the projects specified by the `projectID` or `networkProjectID` parameters.
-|String.
+
+*Value:* String.
 
 |platform:
   gcp:
@@ -2414,39 +2615,45 @@ Additional GCP configuration parameters are described in the following table:
       privateZone:
         projectID:
 |The ID of the project that contains the private zone from the `privateZone.name` parameter.
-|String.
+
+*Value:* String.
 
 |platform:
   gcp:
     userProvisionedDNS:
 |Enables user-provisioned DNS instead of the default cluster-provisioned DNS solution. If you use this feature, you must provide your own DNS solution that includes records for `api.<cluster_name>.<base_domain>.` and `*.apps.<cluster_name>.<base_domain>.`.
-|`Enabled` or `Disabled`. The default value is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default value is `Disabled`.
 `userProvisionedDNS` is a Technology Preview feature.
 
 |platform:
   gcp:
     region:
 |The name of the GCP region that hosts your cluster.
-|Any valid region name, such as `us-central1`.
+
+*Value:* Any valid region name, such as `us-central1`.
 
 |platform:
   gcp:
     controlPlaneSubnet:
 |The name of the existing subnet where you want to deploy your control plane machines.
-|The subnet name.
+
+*Value:* The subnet name.
 
 |platform:
   gcp:
     computeSubnet:
 |The name of the existing subnet where you want to deploy your compute machines.
-|The subnet name.
+
+*Value:* The subnet name.
 
 |platform:
   gcp:
     defaultMachinePlatform:
       zones:
 |The availability zones where the installation program creates machines.
-|A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
+
+*Value:* A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 [IMPORTANT]
 ====
@@ -2459,7 +2666,8 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
       osDisk:
         diskSizeGB:
 |The size of the disk in gigabytes (GB).
-|Any size between 16 GB and 65536 GB.
+
+*Value:* Any size between 16 GB and 65536 GB.
 
 |platform:
   gcp:
@@ -2467,7 +2675,8 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
       osDisk:
         diskType:
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type].
-|The default disk type for all machines. Valid values are `pd-balanced`, `pd-ssd`, `pd-standard`, or `hyperdisk-balanced`. The default value is `pd-ssd`. Control plane machines cannot use the `pd-standard` disk type, so if you specify `pd-standard` as the default machine platform disk type, you must specify a different disk type using the `controlPlane.platform.gcp.osDisk.diskType` parameter.
+
+*Value:* The default disk type for all machines. Valid values are `pd-balanced`, `pd-ssd`, `pd-standard`, or `hyperdisk-balanced`. The default value is `pd-ssd`. Control plane machines cannot use the `pd-standard` disk type, so if you specify `pd-standard` as the default machine platform disk type, you must specify a different disk type using the `controlPlane.platform.gcp.osDisk.diskType` parameter.
 
 |platform:
   gcp:
@@ -2475,7 +2684,8 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
       osImage:
         project:
 |Optional. By default, the installation program downloads and installs the {op-system} image that is used to boot control plane and compute machines. You can override the default behavior by specifying the location of a custom {op-system} image that the installation program is to use for both types of machines.
-|String. The name of GCP project where the image is located.
+
+*Value:* String. The name of GCP project where the image is located.
 
 |platform:
   gcp:
@@ -2483,21 +2693,24 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
       osImage:
         name:
 |The name of the custom {op-system} image that the installation program is to use to boot control plane and compute machines. If you use `platform.gcp.defaultMachinePlatform.osImage.project`, this field is required.
-|String. The name of the RHCOS image.
+
+*Value:* String. The name of the RHCOS image.
 
 |platform:
   gcp:
     defaultMachinePlatform:
       tags:
 |Optional. Additional network tags to add to the control plane and compute machines.
-|One or more strings, for example `network-tag1`.
+
+*Value:* One or more strings, for example `network-tag1`.
 
 |platform:
   gcp:
     defaultMachinePlatform:
       type:
 |The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane and compute machines.
-|The GCP machine type, for example `n1-standard-4`.
+
+*Value:* The GCP machine type, for example `n1-standard-4`.
 
 |platform:
   gcp:
@@ -2507,7 +2720,8 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
           kmsKey:
             name:
 |The name of the customer managed encryption key to be used for machine disk encryption.
-|The encryption key name.
+
+*Value:* The encryption key name.
 
 |platform:
   gcp:
@@ -2517,7 +2731,8 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
           kmsKey:
             keyRing:
 |The name of the Key Management Service (KMS) key ring to which the KMS key belongs.
-|The KMS key ring name.
+
+*Value:* The KMS key ring name.
 
 |platform:
   gcp:
@@ -2527,7 +2742,8 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
           kmsKey:
             location:
 |The link:https://cloud.google.com/kms/docs/locations[GCP location] in which the KMS key ring exists.
-|The GCP location.
+
+*Value:* The GCP location.
 
 |platform:
   gcp:
@@ -2537,7 +2753,8 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
           kmsKey:
             projectID:
 |The ID of the project in which the KMS key ring exists. This value defaults to the value of the `platform.gcp.projectID` parameter if it is not set.
-|The GCP project ID.
+
+*Value:* The GCP project ID.
 
 |platform:
   gcp:
@@ -2546,14 +2763,16 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
         encryptionKey:
           kmsKeyServiceAccount:
 |The GCP service account used for the encryption request for control plane and compute machines. If absent, the Compute Engine default service account is used. For more information about GCP service accounts, see Google's documentation on link:https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account[service accounts].
-|The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
+
+*Value:* The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
 
 |platform:
   gcp:
     defaultMachinePlatform:
       secureBoot:
 |Whether to enable Shielded VM secure boot for all machines in the cluster. Shielded VMs have additional security protocols such as secure boot, firmware and integrity monitoring, and rootkit protection. For more information on Shielded VMs, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
-|`Enabled` or `Disabled`. The default value is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default value is `Disabled`.
 
 |platform:
   gcp:
@@ -2570,14 +2789,16 @@ Supported values are:
 * `IntelTrustedDomainExtensions`, which enables Confidential Computing with Intel Trusted Domain Extensions (Intel TDX)
 
 If you specify any value other than `Disabled`, you must set `platform.gcp.defaultMachinePlatform.onHostMaintenance` to `Terminate`, and you must specify a region and machine type that support Confidential Computing. For more information, see Google's documentation about link:https://cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#machine-type-cpu-zone[Supported configurations].
-|String.
+
+*Value:* String.
 
 |platform:
   gcp:
     defaultMachinePlatform:
       onHostMaintenance:
 |Specifies the behavior of all VMs during a host maintenance event, such as a software or hardware update. For Confidential VMs, this parameter must be set to `Terminate`. Confidential VMs do not support live VM migration.
-|`Terminate` or `Migrate`. The default value is `Migrate`.
+
+*Value:* `Terminate` or `Migrate`. The default value is `Migrate`.
 
 |controlPlane:
   platform:
@@ -2587,7 +2808,8 @@ If you specify any value other than `Disabled`, you must set `platform.gcp.defau
           kmsKey:
             name:
 |The name of the customer managed encryption key to be used for control plane machine disk encryption.
-|The encryption key name.
+
+*Value:* The encryption key name.
 
 |controlPlane:
   platform:
@@ -2597,7 +2819,8 @@ If you specify any value other than `Disabled`, you must set `platform.gcp.defau
           kmsKey:
             keyRing:
 |For control plane machines, the name of the KMS key ring to which the KMS key belongs.
-|The KMS key ring name.
+
+*Value:* The KMS key ring name.
 
 |controlPlane:
   platform:
@@ -2607,7 +2830,8 @@ If you specify any value other than `Disabled`, you must set `platform.gcp.defau
           kmsKey:
             location:
 |For control plane machines, the GCP location in which the key ring exists. For more information about KMS locations, see Google's documentation on link:https://cloud.google.com/kms/docs/locations[Cloud KMS locations].
-|The GCP location for the key ring.
+
+*Value:* The GCP location for the key ring.
 
 |controlPlane:
   platform:
@@ -2617,7 +2841,8 @@ If you specify any value other than `Disabled`, you must set `platform.gcp.defau
           kmsKey:
             projectID:
 |For control plane machines, the ID of the project in which the KMS key ring exists. This value defaults to the VM project ID if not set.
-|The GCP project ID.
+
+*Value:* The GCP project ID.
 
 |controlPlane:
   platform:
@@ -2626,7 +2851,8 @@ If you specify any value other than `Disabled`, you must set `platform.gcp.defau
         encryptionKey:
           kmsKeyServiceAccount:
 |The GCP service account used for the encryption request for control plane machines. If absent, the Compute Engine default service account is used. For more information about GCP service accounts, see Google's documentation on link:https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account[service accounts].
-|The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
+
+*Value:* The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
 
 |controlPlane:
   platform:
@@ -2634,7 +2860,8 @@ If you specify any value other than `Disabled`, you must set `platform.gcp.defau
       osDisk:
         diskSizeGB:
 |The size of the disk in gigabytes (GB). This value applies to control plane machines.
-|Any integer between 16 and 65536.
+
+*Value:* Any integer between 16 and 65536.
 
 |controlPlane:
   platform:
@@ -2642,28 +2869,32 @@ If you specify any value other than `Disabled`, you must set `platform.gcp.defau
       osDisk:
         diskType:
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for control plane machines.
-|Valid values are `pd-balanced`, `pd-ssd`, or `hyperdisk-balanced`. The default value is `pd-ssd`.
+
+*Value:* Valid values are `pd-balanced`, `pd-ssd`, or `hyperdisk-balanced`. The default value is `pd-ssd`.
 
 |controlPlane:
   platform:
     gcp:
       tags:
 |Optional. Additional network tags to add to the control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.tags` parameter for control plane machines.
-|One or more strings, for example `control-plane-tag1`.
+
+*Value:* One or more strings, for example `control-plane-tag1`.
 
 |controlPlane:
   platform:
     gcp:
       type:
 |The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter.
-|The GCP machine type, for example `n1-standard-4`.
+
+*Value:* The GCP machine type, for example `n1-standard-4`.
 
 |controlPlane:
   platform:
     gcp:
       zones:
 |The availability zones where the installation program creates control plane machines.
-|A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
+
+*Value:* A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 [IMPORTANT]
 ====
@@ -2675,7 +2906,8 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
     gcp:
       secureBoot:
 |Whether to enable Shielded VM secure boot for control plane machines. Shielded VMs have additional security protocols such as secure boot, firmware and integrity monitoring, and rootkit protection. For more information on Shielded VMs, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
-|`Enabled` or `Disabled`. The default value is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default value is `Disabled`.
 
 |controlPlane:
   platform:
@@ -2692,14 +2924,16 @@ Supported values are:
 * `IntelTrustedDomainExtensions`, which enables Confidential Computing with Intel Trusted Domain Extensions (Intel TDX)
 
 If you specify any value other than `Disabled`, you must set `controlPlane.platform.gcp.defaultMachinePlatform.onHostMaintenance` to `Terminate`.
-|String.
+
+*Value:* String.
 
 |controlPlane:
   platform:
     gcp:
       onHostMaintenance:
 |Specifies the behavior of control plane VMs during a host maintenance event, such as a software or hardware update. For Confidential VMs, this parameter must be set to `Terminate`. Confidential VMs do not support live VM migration.
-|`Terminate` or `Migrate`. The default value is `Migrate`.
+
+*Value:* `Terminate` or `Migrate`. The default value is `Migrate`.
 
 |controlPlane:
   platform:
@@ -2708,9 +2942,10 @@ If you specify any value other than `Disabled`, you must set `controlPlane.platf
 |Specifies the email address of a {gcp-short} service account to be used during installations. This service account is used to provision control plane machines.
 [IMPORTANT]
 ====
-In the case of shared VPC installations, when the service account is not provided, the installer service account must have the `resourcemanager.projects.getIamPolicy` and `resourcemanager.projects.setIamPolicy` permissions in the host project.
+In the case of shared VPC installations, when the service account is not provided, the installation program service account must have the `resourcemanager.projects.getIamPolicy` and `resourcemanager.projects.setIamPolicy` permissions in the host project.
 ====
-|String. The email address of the service account.
+
+*Value:* String. The email address of the service account.
 
 |compute:
   platform:
@@ -2720,7 +2955,8 @@ In the case of shared VPC installations, when the service account is not provide
           kmsKey:
             name:
 |The name of the customer managed encryption key to be used for compute machine disk encryption.
-|The encryption key name.
+
+*Value:* The encryption key name.
 
 |compute:
   platform:
@@ -2730,7 +2966,8 @@ In the case of shared VPC installations, when the service account is not provide
           kmsKey:
             keyRing:
 |For compute machines, the name of the KMS key ring to which the KMS key belongs.
-|The KMS key ring name.
+
+*Value:* The KMS key ring name.
 
 |compute:
   platform:
@@ -2740,7 +2977,8 @@ In the case of shared VPC installations, when the service account is not provide
           kmsKey:
             location:
 |For compute machines, the GCP location in which the key ring exists. For more information about KMS locations, see Google's documentation on link:https://cloud.google.com/kms/docs/locations[Cloud KMS locations].
-|The GCP location for the key ring.
+
+*Value:* The GCP location for the key ring.
 
 |compute:
   platform:
@@ -2750,7 +2988,8 @@ In the case of shared VPC installations, when the service account is not provide
           kmsKey:
             projectID:
 |For compute machines, the ID of the project in which the KMS key ring exists. This value defaults to the VM project ID if not set.
-|The GCP project ID.
+
+*Value:* The GCP project ID.
 
 |compute:
   platform:
@@ -2759,7 +2998,8 @@ In the case of shared VPC installations, when the service account is not provide
         encryptionKey:
           kmsKeyServiceAccount:
 |The GCP service account used for the encryption request for compute machines. If this value is not set, the Compute Engine default service account is used. For more information about GCP service accounts, see Google's documentation on link:https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account[service accounts].
-|The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
+
+*Value:* The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
 
 |compute:
   platform:
@@ -2767,7 +3007,8 @@ In the case of shared VPC installations, when the service account is not provide
       osDisk:
         diskSizeGB:
 |The size of the disk in gigabytes (GB). This value applies to compute machines.
-|Any integer between 16 and 65536.
+
+*Value:* Any integer between 16 and 65536.
 
 |compute:
   platform:
@@ -2775,28 +3016,32 @@ In the case of shared VPC installations, when the service account is not provide
       osDisk:
         diskType:
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for compute machines.
-|Valid values are `pd-balanced`, `pd-ssd`, `pd-standard`, or `hyperdisk-balanced`. The default value is `pd-ssd`.
+
+*Value:* Valid values are `pd-balanced`, `pd-ssd`, `pd-standard`, or `hyperdisk-balanced`. The default value is `pd-ssd`.
 
 |compute:
   platform:
     gcp:
       tags:
 |Optional. Additional network tags to add to the compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.tags` parameter for compute machines.
-|One or more strings, for example `compute-network-tag1`.
+
+*Value:* One or more strings, for example `compute-network-tag1`.
 
 |compute:
   platform:
     gcp:
       type:
 |The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter.
-|The GCP machine type, for example `n1-standard-4`.
+
+*Value:* The GCP machine type, for example `n1-standard-4`.
 
 |compute:
   platform:
     gcp:
       zones:
 |The availability zones where the installation program creates compute machines.
-|A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
+
+*Value:* A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 [IMPORTANT]
 ====
@@ -2808,7 +3053,8 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
     gcp:
       secureBoot:
 |Whether to enable Shielded VM secure boot for compute machines. Shielded VMs have additional security protocols such as secure boot, firmware and integrity monitoring, and rootkit protection. For more information on Shielded VMs, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
-|`Enabled` or `Disabled`. The default value is `Disabled`.
+
+*Value:* `Enabled` or `Disabled`. The default value is `Disabled`.
 
 |compute:
   platform:
@@ -2825,14 +3071,16 @@ Supported values are:
 * `IntelTrustedDomainExtensions`, which enables Confidential Computing with Intel Trusted Domain Extensions (Intel TDX)
 
 If you specify any value other than `Disabled`, you must set `compute.platform.gcp.onHostMaintenance` to `Terminate`.
-|String.
+
+*Value:* String.
 
 |compute:
   platform:
     gcp:
       onHostMaintenance:
 |Specifies the behavior of compute VMs during a host maintenance event, such as a software or hardware update. For Confidential VMs, this parameter must be set to `Terminate`. Confidential VMs do not support live VM migration.
-|`Terminate` or `Migrate`. The default value is `Migrate`.
+
+*Value:* `Terminate` or `Migrate`. The default value is `Migrate`.
 
 |====
 
@@ -2844,9 +3092,9 @@ ifdef::ibm-cloud[]
 Additional {ibm-cloud-name} configuration parameters are described in the following table:
 
 .Additional {ibm-cloud-name} parameters
-[cols=".^1l,.^6a,.^3a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |controlPlane:
   platform:
@@ -2854,7 +3102,8 @@ Additional {ibm-cloud-name} configuration parameters are described in the follow
       bootVolume:
         encryptionKey:
 |An {ibm-name} Key Protect for {ibm-cloud-name} (Key Protect) root key that should be used to encrypt the root (boot) volume of only control plane machines.
-d|The Cloud Resource Name (CRN) of the root key.
+
+*Value:* The Cloud Resource Name (CRN) of the root key.
 
 The CRN must be enclosed in quotes ("").
 
@@ -2864,7 +3113,8 @@ The CRN must be enclosed in quotes ("").
       bootVolume:
         encryptionKey:
 |A Key Protect root key that should be used to encrypt the root (boot) volume of only compute machines.
-d|The CRN of the root key.
+
+*Value:* The CRN of the root key.
 
 The CRN must be enclosed in quotes ("").
 
@@ -2873,10 +3123,11 @@ The CRN must be enclosed in quotes ("").
     defaultMachinePlatform:
       bootvolume:
         encryptionKey:
-d|A Key Protect root key that should be used to encrypt the root (boot) volume of all of the cluster's machines.
+|A Key Protect root key that should be used to encrypt the root (boot) volume of all of the cluster's machines.
 
 When specified as part of the default machine configuration, all managed storage classes are updated with this key. Data volumes that are provisioned after the installation are also encrypted using this key.
-d|The CRN of the root key.
+
+*Value:* The CRN of the root key.
 
 The CRN must be enclosed in quotes ("").
 
@@ -2889,14 +3140,15 @@ By default, an installer-provisioned VPC and cluster resources are created and p
 If you are deploying the cluster into an existing VPC, the installation-program-provisioned cluster resources are placed in this resource group. The installation program creates the resource group for the cluster if you do not specify these parameters. The VPC resources that you have provisioned must exist in a resource group that you specify using the `networkResourceGroupName` parameter.
 
 In either case, this resource group must only be used for a single cluster installation, as the cluster components assume ownership of all of the resources in the resource group. [^1^]
-|String, for example `existing_resource_group`.
+
+*Value:* String, for example `existing_resource_group`.
 
 |platform:
   ibmcloud:
     serviceEndpoints:
       - name:
         url:
-a|A list of service endpoint names and URIs.
+|A list of service endpoint names and URIs.
 
 By default, the installation program and cluster components use public service endpoints to access the required {ibm-cloud-name} services.
 
@@ -2914,7 +3166,7 @@ You can specify only one alternate service endpoint for each of the following se
 * Resource Manager
 * VPC
 
-a|A valid service endpoint name and fully qualified URI.
+*Value:* A valid service endpoint name and fully qualified URI.
 
 Valid names include:
 
@@ -2932,50 +3184,57 @@ Valid names include:
   ibmcloud:
     networkResourceGroupName:
 |The name of an existing resource group. This resource contains the existing VPC and subnets to which the cluster is deployed. This parameter is required when deploying the cluster to a VPC that you have provisioned.
-|String, for example `existing_network_resource_group`.
+
+*Value:* String, for example `existing_network_resource_group`.
 
 |platform:
   ibmcloud:
     dedicatedHosts:
       profile:
 |The new dedicated host to create. If you specify a value for `platform.ibmcloud.dedicatedHosts.name`, this parameter is not required.
-|Valid {ibm-cloud-name} dedicated host profile, such as `cx2-host-152x304`. [^2^]
+
+*Value:* Valid {ibm-cloud-name} dedicated host profile, such as `cx2-host-152x304`. [^2^]
 
 |platform:
   ibmcloud:
     dedicatedHosts:
       name:
 |An existing dedicated host. If you specify a value for `platform.ibmcloud.dedicatedHosts.profile`, this parameter is not required.
-|String, for example `my-dedicated-host-name`.
+
+*Value:* String, for example `my-dedicated-host-name`.
 
 |platform:
   ibmcloud:
     type:
 |The instance type for all {ibm-cloud-name} machines.
-|Valid {ibm-cloud-name} instance type, such as `bx2-8x32`. [^2^]
+
+*Value:* Valid {ibm-cloud-name} instance type, such as `bx2-8x32`. [^2^]
 
 |platform:
   ibmcloud:
     vpcName:
 | The name of the existing VPC that you want to deploy your cluster to.
-| String.
+
+*Value:* String.
 
 |platform:
   ibmcloud:
     controlPlaneSubnets:
 | The name(s) of the existing subnet(s) in your VPC that you want to deploy your control plane machines to. Specify a subnet for each availability zone.
-| String array
+
+*Value:* String array
 
 |platform:
   ibmcloud:
     computeSubnets:
 | The name(s) of the existing subnet(s) in your VPC that you want to deploy your compute machines to. Specify a subnet for each availability zone. Subnet IDs are not supported.
-| String array
+
+*Value:* String array
 
 |====
 [.small]
 --
-1. Whether you define an existing resource group, or if the installer creates one, determines how the resource group is treated when the cluster is uninstalled. If you define a resource group, the installer removes all of the installer-provisioned resources, but leaves the resource group alone; if a resource group is created as part of the installation, the installer removes all of the installer-provisioned resources and the resource group.
+1. Whether you define an existing resource group, or if the installation program creates one, determines how the resource group is treated when the cluster is uninstalled. If you define a resource group, the installation program removes all of the installer-provisioned resources, but leaves the resource group alone; if a resource group is created as part of the installation, the installation program removes all of the installer-provisioned resources and the resource group.
 2. To determine which profile best meets your needs, see https://cloud.ibm.com/docs/vpc?topic=vpc-profiles&interface=ui[Instance Profiles] in the {ibm-name} documentation.
 --
 endif::ibm-cloud[]
@@ -2987,14 +3246,15 @@ ifdef::agent,vsphere[]
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2l,.^4a,.^2a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |platform:
   vsphere:
 |Describes your account on the cloud platform that hosts your cluster. You can use the parameter to customize the platform. If you provide additional configuration settings for compute and control plane machines in the machine pool, the parameter is not required.
-|A dictionary of vSphere configuration objects
+
+*Value:* A dictionary of vSphere configuration objects
 
 ifdef::vsphere[]
 |platform:
@@ -3005,27 +3265,31 @@ ifdef::vsphere[]
 ====
 This parameter applies only to installer-provisioned infrastructure without an external load balancer configured. You must not specify this parameter in user-provisioned infrastructure.
 ====
-|Multiple IP addresses
+
+*Value:* Multiple IP addresses
 
 |platform:
   vsphere:
     diskType:
 |Optional: The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
-|Valid values are `thin`, `thick`, or `eagerZeroedThick`.
+
+*Value:* Valid values are `thin`, `thick`, or `eagerZeroedThick`.
 endif::vsphere[]
 
 |platform:
   vsphere:
     failureDomains:
 |Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-|An array of failure domain configuration objects.
+
+*Value:* An array of failure domain configuration objects.
 
 |platform:
   vsphere:
     failureDomains:
       name:
 |The name of the failure domain.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
@@ -3041,7 +3305,7 @@ OpenShift zones support for vSphere host groups is a Technology Preview feature 
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 
-|String
+*Value:* String
 
 |platform:
   vsphere:
@@ -3056,14 +3320,15 @@ OpenShift zones support for vSphere host groups is a Technology Preview feature 
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 
-|String
+*Value:* String
 
 |platform:
   vsphere:
     failureDomains:
       server:
 |Specifies the fully-qualified hostname or IP address of the VMware vCenter server, so that a client can access failure domain resources. You must apply the `server` role to the vSphere vCenter server location.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
@@ -3079,7 +3344,7 @@ OpenShift zones support for vSphere host groups is a Technology Preview feature 
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 
-|String
+*Value:* String
 
 |platform:
   vsphere:
@@ -3094,7 +3359,7 @@ OpenShift zones support for vSphere host groups is a Technology Preview feature 
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 
-|String
+*Value:* String
 
 |platform:
   vsphere:
@@ -3102,7 +3367,8 @@ For more information about the support scope of Red Hat Technology Preview featu
       topology:
         computeCluster:
 |The path to the vSphere compute cluster.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
@@ -3111,7 +3377,8 @@ For more information about the support scope of Red Hat Technology Preview featu
         datacenter:
 |Lists and defines the data centers where {product-title} virtual machines (VMs) operate.
 The list of data centers must match the list of data centers specified in the `vcenters` field.
-|String
+
+*Value:* String
 
 ifdef::vsphere[]
 |platform:
@@ -3120,7 +3387,8 @@ ifdef::vsphere[]
       topology:
         datastore:
 |Specifies the path to a vSphere datastore that stores virtual machines files for a failure domain. You must apply the `datastore` role to the vSphere vCenter datastore location.
-|String
+
+*Value:* String
 endif::vsphere[]
 ifdef::agent[]
 |platform:
@@ -3137,7 +3405,8 @@ Red{nbsp}Hat does not support Storage vMotion, so you must disable Storage vMoti
 
 If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
 ====
-|String
+
+*Value:* String
 endif::agent[]
 
 |platform:
@@ -3149,7 +3418,8 @@ endif::agent[]
 ifdef::vsphere[]
 If you do not provide this value, the installation program creates a top-level folder in the data center virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
 endif::vsphere[]
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
@@ -3165,7 +3435,7 @@ OpenShift zones support for vSphere host groups is a Technology Preview feature 
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 
-|String
+*Value:* String
 
 |platform:
   vsphere:
@@ -3173,7 +3443,8 @@ For more information about the support scope of Red Hat Technology Preview featu
       topology:
         networks:
 |Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
@@ -3185,7 +3456,8 @@ For more information about the support scope of Red Hat Technology Preview featu
 ifdef::vsphere[]
 If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<data_center_name>/host/<cluster_name>/Resources`.
 endif::vsphere[]
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
@@ -3193,7 +3465,8 @@ endif::vsphere[]
       topology
         template:
 |Specifies the absolute path to a pre-existing {op-system-first} image template or virtual machine. The installation program can use the image template or virtual machine to quickly install {op-system} on vSphere hosts. Consider using this parameter as an alternative to uploading an {op-system} image on vSphere hosts. This parameter is available for use only on installer-provisioned infrastructure.
-|String
+
+*Value:* String
 
 ifdef::vsphere[]
 |platform:
@@ -3204,49 +3477,56 @@ ifdef::vsphere[]
 ====
 This parameter applies only to installer-provisioned infrastructure without an external load balancer configured. You must not specify this parameter in user-provisioned infrastructure.
 ====
-|Multiple IP addresses
+
+*Value:* Multiple IP addresses
 endif::vsphere[]
 
 |platform:
   vsphere:
     vcenters:
 |Configures the connection details so that services can communicate with a vCenter server.
-|An array of vCenter configuration objects.
+
+*Value:* An array of vCenter configuration objects.
 
 |platform:
   vsphere:
     vcenters:
       datacenters:
 |Lists and defines the data centers where {product-title} virtual machines (VMs) operate. The list of data centers must match the list of data centers specified in the `failureDomains` field.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
     vcenters:
       password:
 |The password associated with the vSphere user.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
     vcenters:
       port:
 |The port number used to communicate with the vCenter server.
-|Integer
+
+*Value:* Integer
 
 |platform:
   vsphere:
     vcenters:
       server:
 |The fully qualified host name (FQHN) or IP address of the vCenter server.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
     vcenters:
       user:
 |The username associated with the vSphere user.
-|String
+
+*Value:* String
 |====
 
 [id="deprecated-parameters-vsphere_{context}"]
@@ -3257,9 +3537,9 @@ In {product-title} 4.13, the following vSphere configuration parameters are depr
 The following table lists each deprecated vSphere configuration parameter:
 
 .Deprecated VMware vSphere cluster parameters
-[cols=".^2l,.^4a,.^2a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 ifdef::vsphere[]
 
 |platform:
@@ -3271,32 +3551,37 @@ ifdef::vsphere[]
 ====
 In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
 ====
-|An IP address, for example `128.0.0.1`.
+
+*Value:* An IP address, for example `128.0.0.1`.
 endif::vsphere[]
 
 |platform:
   vsphere:
     cluster:
 |The vCenter cluster to install the {product-title} cluster in.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
     datacenter:
 |Defines the data center where {product-title} virtual machines (VMs) operate.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
     defaultDatastore:
 |The name of the default datastore to use for provisioning volumes.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
     folder:
 |Optional: The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
-|String, for example, `/<data_center_name>/vm/<folder_name>/<subfolder_name>`.
+
+*Value:* String, for example, `/<data_center_name>/vm/<folder_name>/<subfolder_name>`.
 
 ifdef::vsphere[]
 |platform:
@@ -3307,26 +3592,30 @@ ifdef::vsphere[]
 ====
 In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
 ====
-|An IP address, for example `128.0.0.1`.
+
+*Value:* An IP address, for example `128.0.0.1`.
 
 |platform:
   vsphere:
     network:
 |The network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
-|String
+
+*Value:* String
 endif::vsphere[]
 
 |platform:
   vsphere:
     password:
 |The password for the vCenter user name.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
     resourcePool:
 |Optional: The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<data_center_name>/host/<cluster_name>/Resources`.
-|String, for example, `/<data_center_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
+
+*Value:* String, for example, `/<data_center_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
 |platform:
   vsphere:
@@ -3335,13 +3624,15 @@ endif::vsphere[]
 the roles and privileges that are required for
 link:https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/vcp-roles.md[static or dynamic persistent volume provisioning]
 in vSphere.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
     vCenter:
 |The fully-qualified hostname or IP address of a vCenter server.
-|String
+
+*Value:* String
 |====
 endif::agent,vsphere[]
 
@@ -3352,40 +3643,45 @@ ifdef::vsphere[]
 Optional VMware vSphere machine pool configuration parameters are described in the following table:
 
 .Optional VMware vSphere machine pool parameters
-[cols=".^2l,.^4a,.^2a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |platform:
   vsphere:
     clusterOSImage:
 |The location from which the installation program downloads the {op-system-first} image. Before setting a path value for this parameter, ensure that the default {op-system} boot image in the {product-title} release matches the {op-system} image template or virtual machine version; otherwise, cluster installation might fail.
-|An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, `\https://mirror.openshift.com/images/rhcos-<version>-vmware.<architecture>.ova`.
+
+*Value:* An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, `\https://mirror.openshift.com/images/rhcos-<version>-vmware.<architecture>.ova`.
 
 |platform:
   vsphere:
     osDisk:
       diskSizeGB:
 |The size of the disk in gigabytes.
-|Integer
+
+*Value:* Integer
 
 |platform:
   vsphere:
     cpus:
 |The total number of virtual processor cores to assign a virtual machine. The value of `platform.vsphere.cpus` must be a multiple of `platform.vsphere.coresPerSocket` value.
-|Integer
+
+*Value:* Integer
 
 |platform:
   vsphere:
     coresPerSocket:
 |The number of cores per socket in a virtual machine, where `platform.vsphere.cpus` divided by `platform.vsphere.coresPerSocket` determines the number of virtual sockets on a virtual machine. Control plane nodes and compute nodes default to `4` virtual sockets on a virtual machine.
-|Integer
+
+*Value:* Integer
 
 |platform:
   vsphere:
     memoryMB:
 |The size of a virtual machine's memory in megabytes.
-|Integer
+
+*Value:* Integer
 
 |platform:
   vsphere:
@@ -3401,21 +3697,24 @@ Installing {product-title} on {vmw-full} using multiple data disks is a Technolo
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 //You can't put a snippet within a conditional.
-|String
+
+*Value:* String
 
 |platform:
   vsphere:
     dataDisks:
       sizeGiB:
 |The size of the data disk to add to the virtual machines. The maximum size is 16384 GiB.
-|Integer
+
+*Value:* Integer
 
 |platform:
   vsphere:
     dataDisks:
       provisioningMode:
 |Optional: The data disk provisioning method. This value defaults to the vSphere default storage policy, if not set.
-|Valid values are `Thin`, `Thick`, or `EagerlyZeroed`.
+
+*Value:* Valid values are `Thin`, `Thick`, or `EagerlyZeroed`.
 |====
 endif::vsphere[]
 
@@ -3426,9 +3725,9 @@ ifdef::ash[]
 Additional Azure configuration parameters are described in the following table:
 
 .Additional Azure Stack Hub parameters
-[cols=".^2l,.^3a,.^3a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |compute:
   platform:
@@ -3436,7 +3735,8 @@ Additional Azure configuration parameters are described in the following table:
       osDisk:
         diskSizeGB:
 |The Azure disk size for the VM.
-|Integer that represents the size of the disk in GB. The default is `128`.
+
+*Value:* Integer that represents the size of the disk in GB. The default is `128`.
 
 |compute:
   platform:
@@ -3444,14 +3744,16 @@ Additional Azure configuration parameters are described in the following table:
       osDisk:
         diskType:
 |Defines the type of disk.
-|`standard_LRS` or `premium_LRS`. The default is `premium_LRS`.
+
+*Value:* `standard_LRS` or `premium_LRS`. The default is `premium_LRS`.
 
 |compute:
   platform:
     azure:
       type:
 |Defines the azure instance type for compute machines.
-|String
+
+*Value:* String
 
 |controlPlane:
   platform:
@@ -3459,7 +3761,8 @@ Additional Azure configuration parameters are described in the following table:
       osDisk:
         diskSizeGB:
 |The Azure disk size for the VM.
-|Integer that represents the size of the disk in GB. The default is `1024`.
+
+*Value:* Integer that represents the size of the disk in GB. The default is `1024`.
 
 |controlPlane:
   platform:
@@ -3467,14 +3770,16 @@ Additional Azure configuration parameters are described in the following table:
       osDisk:
         diskType:
 |Defines the type of disk.
-|`premium_LRS`.
+
+*Value:* `premium_LRS`.
 
 |controlPlane:
   platform:
     azure:
       type:
 |Defines the azure instance type for control plane machines.
-|String
+
+*Value:* String
 
 |platform:
   azure:
@@ -3482,7 +3787,8 @@ Additional Azure configuration parameters are described in the following table:
       osDisk:
         diskSizeGB:
 |The Azure disk size for the VM.
-|Integer that represents the size of the disk in GB. The default is `128`.
+
+*Value:* Integer that represents the size of the disk in GB. The default is `128`.
 
 |platform:
   azure:
@@ -3490,54 +3796,63 @@ Additional Azure configuration parameters are described in the following table:
       osDisk:
         diskType:
 |Defines the type of disk.
-|`standard_LRS` or `premium_LRS`. The default is `premium_LRS`.
+
+*Value:* `standard_LRS` or `premium_LRS`. The default is `premium_LRS`.
 
 |platform:
   azure:
     defaultMachinePlatform:
       type:
 |The Azure instance type for control plane and compute machines.
-|The Azure instance type.
+
+*Value:* The Azure instance type.
 
 |platform:
   azure:
     armEndpoint:
 |The URL of the Azure Resource Manager endpoint that your Azure Stack Hub operator provides.
-|String
+
+*Value:* String
 
 |platform:
   azure:
     baseDomainResourceGroupName:
 |The name of the resource group that contains the DNS zone for your base domain.
-|String, for example `production_cluster`.
+
+*Value:* String, for example `production_cluster`.
 
 |platform:
   azure:
     region:
 |The name of your Azure Stack Hub local region.
-|String
+
+*Value:* String
 
 |platform:
   azure:
     resourceGroupName:
 |The name of an already existing resource group to install your cluster to. This resource group must be empty and only used for this specific cluster; the cluster components assume ownership of all resources in the resource group. If you limit the service principal scope of the installation program to this resource group, you must ensure all other resources used by the installation program in your environment have the necessary permissions, such as the public DNS zone and virtual network. Destroying the cluster by using the installation program deletes this resource group.
-|String, for example `existing_resource_group`.
+
+*Value:* String, for example `existing_resource_group`.
 
 |platform:
   azure:
     outboundType:
 |The outbound routing strategy used to connect your cluster to the internet. If you are using user-defined routing, you must have pre-existing networking available. The outbound routing must be configured before installing a cluster. The installation program does not configure user-defined routing.
-|`LoadBalancer` or `UserDefinedRouting`. The default is `LoadBalancer`.
+
+*Value:* `LoadBalancer` or `UserDefinedRouting`. The default is `LoadBalancer`.
 
 |platform:
   azure:
     cloudName:
 |The name of the Azure cloud environment that is used to configure the Azure SDK with the appropriate Azure API endpoints.
-|`AzureStackCloud`
+
+*Value:* `AzureStackCloud`
 
 |clusterOSImage:
 |The URL of a storage blob in the Azure Stack environment that contains an {op-system} VHD.
-|String, for example, \https://vhdsa.blob.example.example.com/vhd/rhcos-410.84.202112040202-0-azurestack.x86_64.vhd
+
+*Value:* String, for example, \https://vhdsa.blob.example.example.com/vhd/rhcos-410.84.202112040202-0-azurestack.x86_64.vhd
 
 |====
 endif::ash[]
@@ -3549,9 +3864,9 @@ ifdef::nutanix[]
 Additional Nutanix configuration parameters are described in the following table:
 
 .Additional Nutanix cluster parameters
-[cols=".^2l,.^3a,.^3a",options="header"]
+[cols=".^l,.^a",options="header"]
 |====
-|Parameter|Description|Values
+|Parameter|Description
 
 |compute:
   platform:
@@ -3559,7 +3874,8 @@ Additional Nutanix configuration parameters are described in the following table
       categories:
         key:
 |The name of a prism category key to apply to compute VMs. This parameter must be accompanied by the `value` parameter, and both `key` and `value` parameters must exist in Prism Central. For more information on categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3567,16 +3883,18 @@ Additional Nutanix configuration parameters are described in the following table
       categories:
         value:
 |The value of a prism category key-value pair to apply to compute VMs. This parameter must be accompanied by the `key` parameter, and both `key` and `value` parameters must exist in Prism Central.
-|String
+
+*Value:* String
 
 |compute:
   platform:
     nutanix:
      failureDomains:
-d|The failure domains that apply to only compute machines.
+|The failure domains that apply to only compute machines.
 
 Failure domains are specified in `platform.nutanix.failureDomains`.
-d|List.
+
+*Value:* List.
 
 The name of one or more failures domains.
 
@@ -3586,7 +3904,8 @@ The name of one or more failures domains.
       gpus:
         type:
 |The type of identifier used to attach a GPU to a compute machine. Valid values are "Name" or "DeviceID".
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3594,7 +3913,8 @@ The name of one or more failures domains.
       gpus:
         name:
 |The name of the GPU device to attach to a compute machine. This parameter is required if the GPU `type` is "Name".
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3602,7 +3922,8 @@ The name of one or more failures domains.
       gpus:
         deviceID:
 |The device identifier of the GPU device to attach to a compute machine. This information is available in Prism Central. This parameter is required if the GPU `type` is "DeviceID".
-|Integer
+
+*Value:* Integer
 
 |compute:
   platform:
@@ -3610,7 +3931,8 @@ The name of one or more failures domains.
       project:
         type:
 |The type of identifier you use to select a project for compute VMs.  Projects define logical groups of user roles for managing permissions, networks, and other parameters. For more information on projects, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_9:ssp-app-mgmt-project-env-c.html[Projects Overview].
-|`name` or `uuid`
+
+*Value:* `name` or `uuid`
 
 |compute:
   platform:
@@ -3618,14 +3940,16 @@ The name of one or more failures domains.
       project:
         name: or uuid:
 |The name or UUID of a project with which compute VMs are associated. This parameter must be accompanied by the `type` parameter.
-|String
+
+*Value:* String
 
 |compute:
   platform:
     nutanix:
       bootType:
 |The boot type that the compute machines use. You must use the `Legacy` boot type in {product-title} {product-version}. For more information on boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment].
-|`Legacy`, `SecureBoot` or `UEFI`. The default is `Legacy`.
+
+*Value:* `Legacy`, `SecureBoot` or `UEFI`. The default is `Legacy`.
 
 |compute:
   platform:
@@ -3634,7 +3958,8 @@ The name of one or more failures domains.
         dataSourceImage:
           name:
 |Optional. The name of the data source image for the virtual machine disk in Prism Central.
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3643,7 +3968,8 @@ The name of one or more failures domains.
         dataSourceImage:
           referenceName:
 |Optional. The reference name of the data source image in the failure domain. If you use this parameter, you must configure a matching `dataSourceImage` with the same `referenceName` in each failure domain that the compute nodes occupy. For more information about configuring failure domains, see _Configuring failure domains_ in the _Installing a cluster on Nutanix_ page.
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3652,7 +3978,8 @@ The name of one or more failures domains.
         dataSourceImage:
           uuid:
 |The UUID of the data source image in Prism Central. This value is required.
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3662,7 +3989,8 @@ The name of one or more failures domains.
           adapterType:
 |The adapter type of the disk address. If the disk type is "Disk", valid values are "SCSI", "IDE", "PCI", "SATA" or "SPAPR".
 If the disk type is "CDRom", valid values are "IDE" or "SATA".
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3671,7 +3999,8 @@ If the disk type is "CDRom", valid values are "IDE" or "SATA".
         deviceProperties:
           deviceIndex:
 |The index of the disk address. Valid values are non-negative integers including `0`. The device index for disks that share the same adapter type should start at 0 and increase consecutively. The default value is `0`. For each virtual machine, the `Disk.SCSI.0` and `CDRom.IDE.0` indices are reserved. If you use the `Disk.SCSI` or `CDRom.IDE` disk and adapter types, the `deviceIndex` should start at `1`.
-|Non-negative integer, including `0`.
+
+*Value:* Non-negative integer, including `0`.
 
 |compute:
   platform:
@@ -3680,7 +4009,8 @@ If the disk type is "CDRom", valid values are "IDE" or "SATA".
         deviceProperties:
           deviceType:
 |The disk device type. Valid values are "Disk" and "CDRom".
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3688,7 +4018,8 @@ If the disk type is "CDRom", valid values are "IDE" or "SATA".
       dataDisks:
         diskSize:
 |The size of the disk to attach to the virtual machine. The minimum size is 1Gb.
-|Quantity format, such as 100G or 100Gi. For more information on this format, see link:https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Format.
+
+*Value:* Quantity format, such as 100G or 100Gi. For more information on this format, see link:https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Format.
 
 |compute:
   platform:
@@ -3697,7 +4028,8 @@ If the disk type is "CDRom", valid values are "IDE" or "SATA".
         storageConfig:
           diskMode:
 |The disk mode. Valid values are `Standard` or `Flash`, and the default is `Standard`.
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3707,7 +4039,8 @@ If the disk type is "CDRom", valid values are "IDE" or "SATA".
           storageContainer:
             name:
 |Optional. The name of the storage container object used by the virtual machine disk in Prism Central.
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3717,7 +4050,8 @@ If the disk type is "CDRom", valid values are "IDE" or "SATA".
           storageContainer:
             referenceName:
 |Optional. The reference name of the storage container in the failure domain. If you use this, you must configure a matching `storageContainer` with the same `referenceName` in each failure domain the compute nodes occupy. For more information about configuring failure domains, see _Configuring failure domains_ in the _Installing a cluster on Nutanix_ page.
-|String
+
+*Value:* String
 
 |compute:
   platform:
@@ -3727,7 +4061,8 @@ If the disk type is "CDRom", valid values are "IDE" or "SATA".
           storageContainer:
             uuid:
 |The UUID of the storage container in Prism Central.
-|String
+
+*Value:* String
 
 |controlPlane:
   platform:
@@ -3735,7 +4070,8 @@ If the disk type is "CDRom", valid values are "IDE" or "SATA".
       categories:
         key:
 |The name of a prism category key to apply to control plane VMs. This parameter must be accompanied by the `value` parameter, and both `key` and `value` parameters must exist in Prism Central. For more information on categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
-|String
+
+*Value:* String
 
 |controlPlane:
   platform:
@@ -3743,16 +4079,18 @@ If the disk type is "CDRom", valid values are "IDE" or "SATA".
       categories:
         value:
 |The value of a prism category key-value pair to apply to control plane VMs. This parameter must be accompanied by the `key` parameter, and both `key` and `value` parameters must exist in Prism Central.
-|String
+
+*Value:* String
 
 |controlPlane:
   platform:
     nutanix:
      failureDomains:
-d|The failure domains that apply to only control plane machines.
+|The failure domains that apply to only control plane machines.
 
 Failure domains are specified in `platform.nutanix.failureDomains`.
-d|List.
+
+*Value:* List.
 
 The name of one or more failures domains.
 
@@ -3762,7 +4100,8 @@ The name of one or more failures domains.
       project:
         type:
 |The type of identifier you use to select a project for control plane VMs.  Projects define logical groups of user roles for managing permissions, networks, and other parameters. For more information on projects, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_9:ssp-app-mgmt-project-env-c.html[Projects Overview].
-|`name` or `uuid`
+
+*Value:* `name` or `uuid`
 
 |controlPlane:
   platform:
@@ -3770,7 +4109,8 @@ The name of one or more failures domains.
       project:
         name: or uuid:
 |The name or UUID of a project with which control plane VMs are associated. This parameter must be accompanied by the `type` parameter.
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
@@ -3778,7 +4118,8 @@ The name of one or more failures domains.
       categories:
         key:
 |The name of a prism category key to apply to all VMs. This parameter must be accompanied by the `value` parameter, and both `key` and `value` parameters must exist in Prism Central. For more information on categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
@@ -3786,16 +4127,18 @@ The name of one or more failures domains.
       categories:
         value:
 |The value of a prism category key-value pair to apply to all VMs. This parameter must be accompanied by the `key` parameter, and both `key` and `value` parameters must exist in Prism Central.
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
     defaultMachinePlatform:
       failureDomains:
-d|The failure domains that apply to both control plane and compute machines.
+|The failure domains that apply to both control plane and compute machines.
 
 Failure domains are specified in `platform.nutanix.failureDomains`.
-d|List.
+
+*Value:* List.
 
 The name of one or more failures domains.
 
@@ -3805,7 +4148,8 @@ The name of one or more failures domains.
       project:
         type:
 |The type of identifier you use to select a project for all VMs. Projects define logical groups of user roles for managing permissions, networks, and other parameters. For more information on projects, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_9:ssp-app-mgmt-project-env-c.html[Projects Overview].
-|`name` or `uuid`.
+
+*Value:* `name` or `uuid`.
 
 |platform:
   nutanix:
@@ -3813,20 +4157,23 @@ The name of one or more failures domains.
       project:
         name: or uuid:
 |The name or UUID of a project with which all VMs are associated. This parameter must be accompanied by the `type` parameter.
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
     defaultMachinePlatform:
       bootType:
 |The boot type for all machines. You must use the `Legacy` boot type in {product-title} {product-version}. For more information on boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment].
-|`Legacy`, `SecureBoot` or `UEFI`. The default is `Legacy`.
+
+*Value:* `Legacy`, `SecureBoot` or `UEFI`. The default is `Legacy`.
 
 |platform:
   nutanix:
     apiVIP:
 |The virtual IP (VIP) address that you configured for control plane API access.
-|IP address
+
+*Value:* IP address
 
 |platform:
   nutanix:
@@ -3837,11 +4184,12 @@ The name of one or more failures domains.
         uuid:
       subnetUUIDs:
       -
-a|By default, the installation program installs cluster machines to a single Prism Element instance. A maximum of 32 subnets for each failure domain (Prism Element) in an {product-title} cluster is supported. All `subnetUUID` values must be unique. You can specify additional Prism Element instances for fault tolerance, and then apply them to:
+|By default, the installation program installs cluster machines to a single Prism Element instance. A maximum of 32 subnets for each failure domain (Prism Element) in an {product-title} cluster is supported. All `subnetUUID` values must be unique. You can specify additional Prism Element instances for fault tolerance, and then apply them to:
 
 * The cluster's default machine configuration
 * Only control plane or compute machine pools
-d|A list of configured failure domains.
+
+*Value:* A list of configured failure domains.
 
 For more information on usage, see "Configuring a failure domain" in "Installing a cluster on Nutanix".
 
@@ -3849,7 +4197,8 @@ For more information on usage, see "Configuring a failure domain" in "Installing
   nutanix:
     ingressVIP:
 |The virtual IP (VIP) address that you configured for cluster ingress.
-|IP address
+
+*Value:* IP address
 
 |platform:
   nutanix:
@@ -3857,7 +4206,8 @@ For more information on usage, see "Configuring a failure domain" in "Installing
       endpoint:
         address:
 |The Prism Central domain name or IP address.
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
@@ -3865,27 +4215,31 @@ For more information on usage, see "Configuring a failure domain" in "Installing
       endpoint:
         port:
 |The port that is used to log into Prism Central.
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
     prismCentral:
       password:
 |The password for the Prism Central user name.
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
     preloadedOSImageName:
 |Instead of creating and uploading a {op-system} image object for each {product-title} cluster, this parameter uses the named, preloaded {op-system} image object from the Prism Elements to which the {product-title} cluster is deployed.
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
     prismCentral:
       username:
 |The user name that is used to log into Prism Central.
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
@@ -3893,7 +4247,8 @@ For more information on usage, see "Configuring a failure domain" in "Installing
       endpoint:
         address:
 |The Prism Element domain name or IP address. [^1^]
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
@@ -3901,26 +4256,30 @@ For more information on usage, see "Configuring a failure domain" in "Installing
       endpoint:
         port:
 |The port that is used to log into Prism Element.
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
     prismElements:
       uuid:
 |The universally unique identifier (UUID) for Prism Element.
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
     subnetUUIDs:
 |The UUID of the Prism Element network that contains the virtual IP addresses and DNS records that you configured. [^2^]
-|String
+
+*Value:* String
 
 |platform:
   nutanix:
     clusterOSImage:
 |Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
-|An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, \http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2
+
+*Value:* An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, \http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2
 |====
 [.small]
 --


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-16392

Link to docs preview:
[AWS](https://100007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws)
[Azure](https://100007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure)
[Azure Stack Hub](https://100007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installation-config-parameters-ash#installation-configuration-parameters_installation-config-parameters-ash)
[GCP](https://100007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp)
[IBM Cloud](https://100007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/installation-config-parameters-ibm-cloud-vpc#installation-configuration-parameters_installation-config-parameters-ibm-cloud-vpc)
[Nutanix](https://100007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installation-config-parameters-nutanix#installation-configuration-parameters-additional-nutanix_installation-config-parameters-nutanix)
[Agent based](https://100007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installation-config-parameters-agent)
[Bare metal](https://100007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installation-config-parameters-bare-metal)
[OpenStack](https://100007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installation-config-parameters-openstack#installation-configuration-parameters-optional-osp_installation-config-parameters-openstack)
[vSphere](https://100007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)

QE review:
Not needed, this is a structural change only.

Additional information:
Continuing the work from https://github.com/openshift/openshift-docs/pull/99962
The PR is removing the 3rd column from all of the installation configuration parameter tables, and moving the 3rd column's contents into the 2nd column as "Value: <content here>" text. This is essentially because the rendering on the docs site makes these tables unreadable as-is.
There is no new content in the PR, but for full transparency the rearranging was done by Claude on the command line.