### PR TITLE
OCPBUGS-62278: Updated the Platform support table for EgressIp addresses

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -2,13 +2,14 @@
 //
 // * networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: CONCEPT
 [id="nw-egress-ips-about_{context}"]
 = Egress IP address architectural design and implementation
 
-By using the {product-title} egress IP address functionality, you can ensure that the traffic from one or more pods in one or more namespaces has a consistent source IP address for services outside the cluster network. 
+By using the {product-title} egress IP address functionality, you can ensure that the traffic from one or more pods in one or more namespaces has a consistent source IP address for services outside the cluster network.
 
-For example, you might have a pod that periodically queries a database that is hosted on a server outside of your cluster. To enforce access requirements for the server, a packet filtering device is configured to allow traffic only from specific IP addresses. To ensure that you can reliably allow access to the server from only that specific pod, you can configure a specific egress IP address for the pod that makes the requests to the server.
+For example, you might have a pod that periodically queries a database that is hosted on a server outside of your cluster. To enforce access requirements for the server, a packet filtering device is configured to allow traffic only from specific IP addresses.
+To ensure that you can reliably allow access to the server from only that specific pod, you can configure a specific egress IP address for the pod that makes the requests to the server.
 
 An egress IP address assigned to a namespace is different from an egress router, which is used to send traffic to specific destinations.
 
@@ -31,11 +32,10 @@ ifndef::openshift-rosa[]
 [id="nw-egress-ips-platform-support_{context}"]
 == Platform support
 
-Support for the egress IP address functionality on various platforms is summarized in the following table:
+The Egress IP address feature that runs on a primary host network is supported on the following platforms:
 
 [cols="1,1",options="header"]
 |===
-
 | Platform | Supported
 
 | Bare metal | Yes
@@ -48,7 +48,16 @@ Support for the egress IP address functionality on various platforms is summariz
 | {ibm-z-name} and {ibm-linuxone-name} for {op-system-base-full} KVM | Yes
 | {ibm-power-name} | Yes
 | Nutanix | Yes
+|===
 
+// If platform support increases, ensure to update the lead-in sentence to the plural form.
+The Egress IP address feature that runs on secondary host networks is supported on the following platform:
+
+[cols="1,1",options="header"]
+|===
+| Platform | Supported
+
+| Bare metal | Yes
 |===
 endif::openshift-rosa[]
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-62278](https://issues.redhat.com/browse/OCPBUGS-62278)

Link to docs preview:
* [Platform support](https://100029--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-platform-support_configuring-egress-ips-ovn)

- [x] SME has approved this change (Carlos G.).
- [x] QE has approved this change (Jean Chen).


Additional info:

* [Past PR](https://github.com/openshift/openshift-docs/pull/94400/files)
