### PR TITLE
Fix vale warnings (excluding callouts and block titles)

### DIFF
--- a/config-map-reference/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/config-map-reference/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -4,9 +4,9 @@
 // make edits, read the docgen utility instructions in the source code for the
 // CMO.
 :_mod-docs-content-type: REFERENCE
+include::_attributes/common-attributes.adoc[]
 [id="config-map-reference-for-the-cluster-monitoring-operator"]
 = Config map reference for the Cluster Monitoring Operator
-include::_attributes/common-attributes.adoc[]
 :context: config-map-reference-for-the-cluster-monitoring-operator
 
 toc::[]

--- a/modules/monitoring-disabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-disabling-monitoring-for-user-defined-projects.adoc
@@ -39,7 +39,9 @@ data:
 
 . Save the file to apply the changes. Monitoring for user-defined projects is then disabled automatically.
 
-. Check that the `prometheus-operator`, `prometheus-user-workload` and `thanos-ruler-user-workload` pods are terminated in the `openshift-user-workload-monitoring` project. This might take a short while:
+.Verification
+
+. Verify that the `prometheus-operator`, `prometheus-user-workload` and `thanos-ruler-user-workload` pods are terminated in the `openshift-user-workload-monitoring` project. This might take a short while:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
+++ b/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
@@ -22,8 +22,6 @@ Because log rotation is not supported, only enable this feature temporarily when
 
 .Procedure
 
-You can enable query logging for Thanos Querier in the `openshift-monitoring` project:
-
 . Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
 +
 [source,terminal]
@@ -45,8 +43,6 @@ data:
     thanosQuerier:
       enableRequestLogging: <value> <1>
       logLevel: <value> <2>
-
-
 ----
 <1> Set the value to `true` to enable logging and `false` to disable logging. The default value is `false`.
 <2> Set the value to `debug`, `info`, `warn`, or `error`. If no value exists for `logLevel`, the log level defaults to `error`.

--- a/modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc
+++ b/modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc
@@ -15,7 +15,7 @@ The Alerting UI provides detailed information about alerts and their governing a
 
 .Procedure
 
-To obtain information about alerts:
+* To obtain information about alerts:
 
 . In the {ocp} web console, go to the *Observe* -> *Alerting* -> *Alerts* page.
 
@@ -27,14 +27,14 @@ To obtain information about alerts:
 
 . Click the name of an alert to view its *Alert details* page. The page includes a graph that illustrates alert time series data. It also provides the following information about the alert:
 
-* A description of the alert
-* Messages associated with the alert
-* A link to the runbook page on GitHub for the alert, if the page exists
-* Labels attached to the alert
-* A link to its governing alerting rule
-* Silences for the alert, if any exist
+** A description of the alert
+** Messages associated with the alert
+** A link to the runbook page on GitHub for the alert, if the page exists
+** Labels attached to the alert
+** A link to its governing alerting rule
+** Silences for the alert, if any exist
 
-To obtain information about silences:
+* To obtain information about silences:
 
 . In the {ocp} web console, go to the *Observe* -> *Alerting* -> *Silences* page.
 
@@ -46,13 +46,13 @@ To obtain information about silences:
 
 . Select the name of a silence to view its *Silence details* page. The page includes the following details:
 
-* Alert specification
-* Start time
-* End time
-* Silence state
-* Number and list of firing alerts
+** Alert specification
+** Start time
+** End time
+** Silence state
+** Number and list of firing alerts
 
-To obtain information about alerting rules:
+* To obtain information about alerting rules:
 
 . In the {ocp} web console, go to the *Observe* -> *Alerting* -> *Alerting rules* page.
 
@@ -62,8 +62,8 @@ To obtain information about alerting rules:
 
 . Select the name of an alerting rule to view its *Alerting rule details* page. The page provides the following details about the alerting rule:
 
-* Alerting rule name, severity, and description.
-* The expression that defines the condition for firing the alert.
-* The time for which the condition should be true for an alert to fire.
-* A graph for each alert governed by the alerting rule, showing the value with which the alert is firing.
-* A table of all alerts governed by the alerting rule.
+** Alerting rule name, severity, and description.
+** The expression that defines the condition for firing the alert.
+** The time for which the condition should be true for an alert to fire.
+** A graph for each alert governed by the alerting rule, showing the value with which the alert is firing.
+** A table of all alerts governed by the alerting rule.

--- a/modules/monitoring-silencing-alerts.adoc
+++ b/modules/monitoring-silencing-alerts.adoc
@@ -23,7 +23,7 @@ endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 
-To silence a specific alert:
+* To silence a specific alert:
 
 . In the {ocp} web console, go to *Observe* -> *Alerting* -> *Alerts*.
 
@@ -38,7 +38,7 @@ You must add a comment before saving a silence.
 
 . To save the silence, click *Silence*.
 
-To silence a set of alerts:
+* To silence a set of alerts:
 
 . In the {ocp} web console, go to *Observe* -> *Alerting* -> *Silences*.
 

--- a/modules/monitoring-using-node-selectors-to-move-monitoring-components.adoc
+++ b/modules/monitoring-using-node-selectors-to-move-monitoring-components.adoc
@@ -12,7 +12,6 @@ By doing so, you can control the placement and distribution of the monitoring co
 
 By controlling placement and distribution of monitoring components, you can optimize system resource use, improve performance, and separate workloads based on specific requirements or policies.
 
-[discrete]
 == How node selectors work with other constraints
 
 If you move monitoring components by using node selector constraints, be aware that other constraints to control pod scheduling might exist for a cluster:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2450
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* [Disabling monitoring for user-defined projects](https://100031--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm#disabling-monitoring-for-user-defined-projects_preparing-to-configure-the-monitoring-stack-uwm)
* [Enabling query logging for Thanos Querier](https://100031--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-core-platform-monitoring/storing-and-recording-data#enabling-query-logging-for-thanos-querier_storing-and-recording-data)
* [Getting information about alerts, silences, and alerting rules](https://100031--ocpdocs-pr.netlify.app/openshift-monitoring/latest/managing-alerts/managing-alerts-as-an-administrator#getting-information-about-alerts-silences-and-alerting-rules_managing-alerts-as-an-administrator)
* [Silencing alerts](https://100031--ocpdocs-pr.netlify.app/openshift-monitoring/latest/managing-alerts/managing-alerts-as-an-administrator#silencing-alerts_managing-alerts-as-an-administrator)
* [Using node selectors to move monitoring components](https://100031--ocpdocs-pr.netlify.app/openshift-monitoring/latest/key-concepts/key-concepts#using-node-selectors-to-move-monitoring-components_key-concepts)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: `n/a`
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
