### PR TITLE
OBSDOCS-2461: Add S3 output to ClusterLogForwarder

### DIFF
--- a/configuring/configuring-log-forwarding.adoc
+++ b/configuring/configuring-log-forwarding.adoc
@@ -166,6 +166,9 @@ include::modules/creating-an-aws-role.adoc[leveloffset=+2]
 include::modules/cluster-logging-collector-log-forward-secret-cloudwatch.adoc[leveloffset=+2]
 include::modules/cluster-logging-collector-log-forward-sts-cloudwatch.adoc[leveloffset=+2]
 
+include::modules/forwarding-logs-to-amazon-s3-endpoint.adoc[leveloffset=+2]
+
+
 include::modules/logging-content-filter-drop-records.adoc[leveloffset=+2]
 include::modules/logging-audit-log-filtering.adoc[leveloffset=+2]
 include::modules/input-spec-filter-labels-expressions.adoc[leveloffset=+2]

--- a/modules/forwarding-logs-to-amazon-s3-endpoint.adoc
+++ b/modules/forwarding-logs-to-amazon-s3-endpoint.adoc
@@ -1,0 +1,64 @@
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-10-27
+:_mod-docs-content-type: PROCEDURE
+
+[id="forwarding-logs-to-amazon-s3-endpoint_{context}"]
+= Forwarding logs to Amazon S3 endpoint
+
+You can collect logs by using the {clo} and forward them to an S3 configured endpoint.
+
+.Prerequisites
+* You have installed {clo}.
+* You have configured a credential secret.
+* You have administrator access to {ocp-product-title}.
+* You have installed {oc-first}
+
+.Procedure
+
+. Create or update a `ClusterLogForwarder` custom resource (CR):
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: <log_forwarder_name>
+  namespace: openshift-logging
+spec:
+  serviceAccount:
+    name: <service_account_name>
+  outputs:
+   - name: s3-output
+     type: s3
+     s3:
+       keyPrefix: 's3{.log_type||"missing"}'
+       bucket: <bucket_name>
+       region: us-east-2
+       authentication:
+         type: iamRole
+         iamRole:
+           roleARN:
+             key: role_arn 
+             secretName: sts-secret
+           token:
+             from: serviceAccount  
+  pipelines:
+    - name: to-s3
+      inputRefs:
+        - infrastructure
+        - audit
+        - application
+      outputRefs:
+        - s3-output
+----
++
+* `keyPrefix`: Defines the S3 key prefix for log objects.
+You can use static or dynamic values consisting of field paths separated by `||` and ending with a static fallback value.
+* `bucket`: Specifies the S3 bucket name where logs will be stored. 
+
+. Apply the `ClusterLogForwarder` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----


### PR DESCRIPTION
Version(s): 6.4
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2461
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://100034--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-log-forwarding.html#forwarding-logs-to-amazon-s3-endpoint_configuring-log-forwarding
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
