### PR TITLE
TELCODOCS-2273 - RN - unnumbered BGP Peering - GA

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -594,6 +594,15 @@ Previously, creating an SR-IOV network required a cluster administrator to confi
 
 For more information, see xref:../networking/hardware_networks/configuring-namespaced-sriov-resources.html#configuring-namespaced-sriov-resources[Configuring namespaced SR-IOV resources].
 
+[id="ocp-4-20-unnumbered-bgp-peering_{context}"]
+==== Unnumbered BGP peering 
+
+With this release, {product-title} includes unnumbered BGP peering.
+This was previously available as a Technology Preview feature. 
+You can use the `spec.interface` field of the BGP peer custom resource to configure unnumbered BGP peering.
+
+For more information, see xref:../networking/ingress_load_balancing/metallb/metallb-frr-k8s.adoc#nw-metallb-frrconfiguration-crd-interface[Configuring the integration of MetalLB and FRR-K8s ].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 
@@ -1551,7 +1560,7 @@ In the following tables, features are marked with the following statuses:
 |Unnumbered BGP peering
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Load balancing across the aggregated bonded interface with xmitHashPolicy
 |Not Available


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> [TELCODOCS-2273](https://issues.redhat.com//browse/TELCODOCS-2273) - Release Note - Ununmbered BGP Peering goes from Tech Preview to GA

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2273
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Unnumbered BGP peering](https://100042--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-unnumbered-bgp-peering_release-notes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
