### PR TITLE
OSDOCS-14915: adds 4.20.0 async release notes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-20-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-20-release-notes.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-{product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate single-node clusters in low-resource edge environments.
+{product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate a single node in low-resource edge environments.
 
 {microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
@@ -15,7 +15,7 @@ toc::[]
 
 Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {ocp-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
 
-You can deploy {microshift-short} clusters to on-premise, cloud, disconnected, and offline environments.
+You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
 
 {microshift-short} {product-version} is supported on {op-system-base-full} {op-system-version}.
 
@@ -26,70 +26,46 @@ For lifecycle information, see the link:https://access.redhat.com/product-life-c
 
 This release adds improvements related to the following components and concepts.
 
-//L3 major categories with features in each as L4s
-//[id="microshift-4-20-rhel_{context}"]
-//=== {op-system-base-full}
-
-//[id="microshift-4-20-rhel-image-mode_{context}"]
-//==== {op-system-base} image mode delta updates available
-//placeholder for delta updates
-
 //4.20 is an EUS release, so two minor version updates are supported
-
 [id="microshift-4-20-updating_{context}"]
 === Updating
 
 Updating two minor EUS versions in a single step is supported in {product-version}. Updates for both single-version minor releases and patch releases are also supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
 
 //TODO add new features and enhancements as needed, follow doc TOC titles as L3s, then add L4 headings for each feature
-
 [id="microshift-4-20-configuring_{context}"]
 === Configuring {microshift-short}
 
 [id="microshift-4-20-ingress-controller-three-config_{context}"]
 ==== Inspect ingress for your use case with additional logging parameters
 
-With this release, you can configure custom error code pages and logging parameters in the router, and you can capture HTTP headers and cookies in the ingress controller access logs. For more information, see xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} cluster].
+With this release, you can configure custom error code pages and logging parameters in the router, and you can capture HTTP headers and cookies in the ingress controller access logs. For more information, see xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} node].
 
 [id="microshift-4-20-running-apps_{context}"]
 === Running applications
 
 [id="microshift-4-20-install-cert-manager_{context}"]
-==== Install MicroShift certificate manager
+==== The cert manager Operator is now available with {microshift-short}
 
 With this release, {microshift-short} users can securely manage certificates for their components by using the cert-manager Operator. This enhancement automates the issuance and renewal of SSL/TLS certificates, enhancing data protection and ensuring regulatory compliance. It enables standardized certificate management, enhances node security, and results in more secure and standardized communication within and between user services. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift[cert-manager Operator for Red Hat OpenShift].
-
-//[id="microshift-4-20-new-feature_{context}"]
-//==== placeholder RAs feature
-
-//[id="microshift-4-20-support_{context}"]
-//=== Support
-
-//[id="microshift-4-20-new-feature_{context}"]
-//==== placeholder support feature
 
 [id="microshift-4-20-doc-enhancements_{context}"]
 === Documentation enhancements
 
-With this release, instructions on uninstalling {microshift-short} are now included. For more information, see xref:../microshift_install_rpm/microshift-uninstall-rpm.adoc#microshift-uninstall-rpm[Uninstalling {microshift-short}].
+[id="microshift-4-20-uninstall_{context}"]
+==== Instructions for uninstalling {microshift-short} now available
+* With this release, instructions on uninstalling {microshift-short} are now included. For more information, see xref:../microshift_install_rpm/microshift-uninstall-rpm.adoc#microshift-uninstall-rpm[Uninstalling {microshift-short}].
 
-With this release, prerequisites and instructions for installing image mode for RHEL for {microshift-short} are updated. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-image[Installing and publishing a bootc image to a registry].
+[id="microshift-4-20-bootc-doc-updates_{context}"]
+==== Additional documentation for {op-system-image}
+* With this release, prerequisites and instructions for installing image mode for RHEL for {microshift-short} are updated. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-image[Installing and publishing a bootc image to a registry].
 
-With this release, information about physically-bound container images for fully self-contained bootc images is now included. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-physically-bound.adoc#microshift-install-bootc-physically-bound[Creating a fully self-contained bootc image].
+* With this release, information about physically-bound container images for fully self-contained bootc images is now included. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-physically-bound.adoc#microshift-install-bootc-physically-bound[Creating a fully self-contained bootc image].
 
-With this release, instructions on encrypting etcd data are now included. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.19/html/getting_ready_to_install_microshift/microshift-install-get-ready#microshift-encrypt-etcd-data_microshift-install-get-ready[Encrypt etcd data].
+[id="microshift-4-20-encrypt-etcd_{context}"]
+==== Information about encrypting etcd is added to installation planning
+* With this release, instructions on encrypting etcd data are now included. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/getting_ready_to_install_microshift/microshift-install-get-ready#microshift-encrypt-etcd-data_microshift-install-get-ready[Encrypt etcd data].
 
-//[id="microshift-4-20-storage-docs-update_{context}"]
-//==== Updated content in the storage section
-
-//[id="microshift-4-20-RAs-update_{context}"]
-//==== Updated content in the Running Applications section(s)
-
-//[id="microshift-4-20-notable-technical-changes_{context}"]
-//== Notable technical changes
-
-//[id="microshift-4-20-palceholder-ntc_{context}"]
-//=== placeholder
 
 [id="microshift-4-20-tech-preview_{context}"]
 == Technology Preview features
@@ -101,34 +77,34 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [id="microshift-4-20-Generic-Device-Plugin_{context}"]
 === Generic Device Plugin feature
 
-* The Generic Device Plugin (GDP) is a Kubernetes device plugin that enables applications running in pods to access host devices such as serial ports, cameras, and sound cards securely. This Technology Preview capability is especially important for edge and IoT environments where direct hardware interaction is a common requirement. The GDP integrates with the kubelet to advertise available devices to the cluster and facilitate their allocation to pods without requiring elevated privileges within the container itself.
+The Generic Device Plugin (GDP) is a Kubernetes device plugin that enables applications running in pods to access host devices such as serial ports, cameras, and sound cards securely. This Technology Preview capability is especially important for edge and IoT environments where direct hardware interaction is a common requirement. The GDP integrates with the kubelet to advertise available devices to the node and facilitate their allocation to pods without requiring elevated privileges within the container itself.
 
-//[id="microshift-4-20-ai_{context}"]
-//=== Red{nbsp}Hat OpenShift AI with {microshift-short}
+[id="microshift-4-20-ai_{context}"]
+=== Red{nbsp}Hat OpenShift AI with {microshift-short}
 
-//[id="microshift-4-20-rhoai-ga_{context}"]
-//==== Serve your trained models on edge deployments
-
-//With this release, a streamlined version of {rhoai-full} {rhoai} is Generally Available. {rhoai} can be used to serve artificial intelligence or machine learning (AI/ML) models on {microshift-short}. Develop and train your AI models in the data center or cloud, then deploy them to the edge where these models can make decisions without a human user. For more information, see xref:../microshift_ai/microshift-rhoai.adoc#microshift-rhoai[Using Red{nbsp}Hat OpenShift AI with {microshift-short}].
-
-//[id="microshift-4-20-deprecated-and-removed-features_{context}"]
-//== Deprecated and removed features
-
-//Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in and continues to be supported, but will be removed in a future release. Deprecated features and functionality are not recommended for new deployments.
-
-//[id="microshift-4-20-x-deprecated_{context}"]
-//=== placeholder
+With this release, you can access the most recent updates and improvements to supported Red Hat OpenShift AI (RHOAI) model-serving releases. The latest RHOAI release improves compatibility with the new Hugging Face Model Detector and Variable Length Language Model (VLLM) runtimes.
 
 //NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
-//[id="microshift-4-20-bug-fixes_{context}"]
-//== Bug fixes
+[id="microshift-4-20-bug-fixes_{context}"]
+== Bug fixes
 
-//*
+* Before this update, embedding container images into a bootc build could fail because HTTP proxy environment variables were defined in the bootc image. Proxy errors occurred during container image embedding and prevented successful builds. With this release, the bootc image no longer sets HTTP proxy environment variables, thereby eliminating the issue. As a result, you can now embed container images without encountering proxy errors. (link:https://issues.redhat.com/browse/OCPBUGS-61433[OCPBUGS-61433])
+
+* Before this update, a bare-metal node reboot caused the deployment progress deadline to be surpassed. This resulted in the greenboot health check failing with a false-positive error. With this release, the `ProgressDeadlineExceeded` condition for deployments is removed to allow time for reboots that exceed the default time limit. Now, the full timeout duration is provided for the deployment to become ready, reducing false-positive greenboot health check errors. (link:https://issues.redhat.com/browse/OCPBUGS-59175[OCPBUGS-59175])
+
+* Before this update, duplicated dependencies and firewall configurations were included in blueprints. This update streamlines blueprint installation by eliminating unnecessary packages and firewall configurations, enhancing efficiency. (link:https://issues.redhat.com/browse/OCPBUGS-55818[OCPBUGS-55818])
+
+* Before this update, the ROUTER_ENABLE_EXTERNAL_CERTIFICATE environment variable was not set by default, despite the Route `ExternalCertificate` feature being supported in {microshift-short}. Because of this, you could not configure routes with third-party certificate management solutions by using the `.spec.tls.externalCertificate` field of the route API. With this release, the environment variable value is set to `True` and the Route `ExternalCertificate` feature is enabled. You can reference externally managed TLS certificates through secrets, eliminating the need for manual certificate management. (link:https://issues.redhat.com/browse/OCPBUGS-58357[OCPBUGS-58357])
+** For more information, see also https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/ingress_and_load_balancing/configuring-routes#nw-ingress-route-secret-load-external-cert_secured-routes[Creating a route with externally managed certificates].
+
+* Before this update, the lack of an {OCP} pull-secret caused excessive telemetry collection failure logs. As a consequence, telemetry errors flooded the journald logs With this release, the telemetry pull secret error rate is reduced. As a result, telemetry collection messages no longer flood the logs. (link:https://issues.redhat.com/browse/OCPBUGS-57777[OCPBUGS-57777])
+
+* In this release, the backend implementation of the observability YAML file is streamlined to prevent accidental overwriting of custom observability configuration when you update {microshift-short}. (link:https://issues.redhat.com/browse/OCPBUGS-56157[OCPBUGS-56157])
 
 [id="microshift-4-20-known-issues_{context}"]
 == Known issues
 
-* The maximum transmission unit (MTU) value in {microshift-short} OVN-K overlay networking must be 100 bytes smaller than the MTU value of the base network. {microshift-short} automatically configures the value using the MTU value of the default gateway of the host. If the auto-configuration does not work correctly, the MTU value must be configured manually. For more information, see xref:../microshift_networking/microshift-cni.adoc#microshift-network-topology_microshift-about-ovn-k-plugin[Network topology].
+* The maximum transmission unit (MTU) value in {microshift-short} OVN-K overlay networking must be 100 bytes smaller than the MTU value of the base network. {microshift-short} automatically configures the value using the MTU value of the default gateway of the host. If the auto-configuration does not work correctly, you must configure the the MTU value manually. For more information, see xref:../microshift_networking/microshift-cni.adoc#microshift-network-topology_microshift-about-ovn-k-plugin[Network topology].
 
 [id="microshift-4-20-additional-release-notes_{context}"]
 == Additional release notes
@@ -150,29 +126,28 @@ See the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9
 === {rhoai} release notes
 See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/release_notes/index[Release notes] for more information about {rhoai}.
 
-[id="microshift-4-20-asynchronous-errata-updates_{context}"]
-== Asynchronous errata updates
+[id="microshift-4-20-asynchronous-updates_{context}"]
+== Asynchronous updates
 
-Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red{nbsp}Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
+Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released asynchronously through the Red{nbsp}Hat Network. All {microshift-short} {product-version} updates are https://access.redhat.com/downloads/content/290/[available on the Red{nbsp}Hat Customer Portal]. For more information about asynchronous updates, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
 
-Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
+Red{nbsp}Hat Customer Portal users can enable update notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When notifications are enabled, you are notified through email whenever new updates relevant to your registered systems are released.
 
 [NOTE]
 ====
-Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
+Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} update notification emails to generate.
 ====
 
-This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
 
-//NOTE: We expect this to be a Konflux release without Errata; the links here are expected to change.
 [id="microshift-4-20-0-dp_{context}"]
-=== RHEA-2024:XXXXX- {microshift-short} 4.20.0 bug fix and security update advisory
+=== RHEA-2025:10667 - {microshift-short} 4.20.0 bug fix and enhancement update
 
-Issued: XX MONTH 20XX
+Issued: 21 October 2025
 
-{product-title} release 4.20.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2025:XXXXX[RHEA-2025:XXXXX] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHEA-2025:XXXXX[RHEA-2025:XXXXX] advisory.
+{product-title} release 4.20.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2025:10667[RHEA-2025:10667] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:9562[RHBA-2025:9562] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:
 
 * xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
-* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-14915](https://issues.redhat.com/browse/OSDOCS-14915)

Link to docs preview:
[microshift-4-20-bug-fixes_release-notes](https://100062--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-20-release-notes.html#microshift-4-20-bug-fixes_release-notes)
[RHOAI bug/enhancement release note](https://100062--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-20-release-notes.html#microshift-4-20-ai_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
