### PR TITLE
OSDOCS-16360: remove step for tabs that don't exist

### DIFF
--- a/modules/microshift-install-bootc-get-published-image.adoc
+++ b/modules/microshift-install-bootc-get-published-image.adoc
@@ -22,8 +22,6 @@ You can use the {microshift-short} container images to install {op-system-image}
 
 . Open the container image page of the {microshift-short} container image.
 
-. See the `Overview` and `Technical Information` tabs to get more details about the image.
-
 . Select the `Get this image` tab to view instructions for downloading the image.
 
 . Get access to the latest image on x86_64 and AArch64 platforms by logging into the registry using the following command:


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-16360](https://issues.redhat.com/browse/OSDOCS-16360)

Link to docs preview:
[get-published-image_microshift-install-bootc-image](https://100069--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_bootc/microshift-install-bootc-image.html#microshift-install-bootc-get-published-image_microshift-install-bootc-image)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
