### PR TITLE
CNV-55236: Remove outdated commands for hotplug

### DIFF
--- a/modules/virt-hot-plug-and-hot-unplug-commands.adoc
+++ b/modules/virt-hot-plug-and-hot-unplug-commands.adoc
@@ -5,7 +5,7 @@
 [id="hot-plug-and-hot-unplug-commands_{context}"]
 = Hot plug and hot unplug  commands
 
-
+[role="_abstract"]
 You can use the following `virtctl` commands to add or remove resources from running virtual machines (VMs) and VM instances (VMIs).
 
 .Hot plug and hot unplug commands
@@ -22,10 +22,4 @@ Optional:
 
 |`virtctl removevolume <vm_name> --volume-name=<virtual_disk>`
 |Hot unplug a virtual disk.
-
-|`virtctl addinterface <vm_name> --network-attachment-definition-name <net_attach_def_name> --name <interface_name>`
-|Hot plug a Linux bridge network interface.
-
-|`virtctl removeinterface <vm_name> --name <interface_name>`
-|Hot unplug a Linux bridge network interface.
 |===


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/CNV-55236

Link to docs preview:
https://100076--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-using-the-cli-tools.html#hot-plug-and-hot-unplug-commands_virt-using-the-cli-tools

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Due to changes made in https://github.com/openshift/openshift-docs/pull/97530/ I will need to open additional PRs for older versions (4.17-4.19)
