### PR TITLE
MCO, Node, Custom Autoscaler release notes 4.20

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -481,6 +481,50 @@ For more information, see xref:../installing/installing_azure/ipi/installing-azu
 [id="ocp-release-notes-machine-config-operator_{context}"]
 === Machine Config Operator
 
+[id="ocp-release-notes-machine-config-operator-boot_{context}"]
+==== Updated boot images for vSphere now supported (Technology Preview) 
+
+Updated boot images is now supported as a Technology Preview feature for {vmw-first} clusters. This feature allows you configure your cluster to update the node boot image whenever you update your cluster. By default, the boot image in your cluster is not updated along with your cluster. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images].
+
+[id="ocp-release-notes-machine-config-operator-ocl-ga_{context}"]
+==== {image-mode-os-on-caps} reboot improvements
+
+The following machine configuration changes no longer cause a reboot of nodes with on-cluster custom layered images:
+
+* Modifying the configuration files in the `/var` or `/etc` directory
+* Adding or modifying a systemd service
+* Changing SSH keys
+* Removing mirroring rules from `ICSP`, `ITMS`, and `IDMS` objects
+* Changing the trusted CA, by updating the `user-ca-bundle` configmap in the `openshift-config` namespace
+
+For more information, see xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-configuring-on-limitations_mco-coreos-layering[On-cluster image mode known limitations].
+
+[id="ocp-release-notes-machine-config-operator-boot-image_{context}"]
+==== {image-mode-os-on-caps} status reporting improvements
+
+When {image-mode-os-lower} is configured, there are improvements to error reporting including the following changes:
+
+* In certain scenarios after the custom layered image has been built and pushed, errors could cause the build process to fail. If this happens, the MCO now reports the errors and the `machineosbuild` object and builder pod are reported as failed. 
+
+* The `oc describe mcp` output has a new `ImageBuildDegraded` status field that reports if a custom layered image build has failed. 
+
+[id="ocp-release-notes-machine-config-operator-cert-changes_{context}"]
+==== Setting the kernel type parameter is now supported on {image-mode-os-on-lower} nodes
+
+You can now use the `kernelType` parameter in a `MachineConfig` object on nodes with on-cluster custom layered images in order to install a realtime kernel on the node. Previously, on nodes with on-cluster custom layered images the `kernelType` parameter was ignored. For information, see xref:../machine_configuration/machine-configs-configure.adoc#nodes-nodes-rtkernel-arguments_machine-configs-configure[Adding a real-time kernel to nodes].
+
+[id="ocp-release-notes-machine-config-operator-pin_{context}"]
+==== Pinning images to nodes
+
+In clusters with slow, unreliable connections to an image registry, you can use a `PinnedImageSet` object to pull the images in advance, before they are needed, then associate those images with a machine config pool. This ensures that the images are available to the nodes in that pool when needed. The `must-gather` for the Machine Config Operator includes all `PinnedImageSet` objects in the cluster. For more information, see xref:../machine_configuration/machine-config-pin-preload-images-about.adoc#machine-config-pin-preload-images_machine-config-operator[Pinning images to nodes].
+
+[id="ocp-release-notes-machine-config-operator-mcn_{context}"]
+==== Improved MCO state reporting is now generally available
+
+The machine config nodes custom resource, which you can use to monitor the progress of machine configuration updates to nodes, is now generally available. 
+
+You can now view the status of updates to custom machine config pools in addition to the control plane and worker pools. The functionality for the feature has not changed. However, some of the information in the command output and in the status fields in the `MachineConfigNode` object has been updated. The `must-gather` for the Machine Config Operator now includes all `MachineConfigNodes` objects in the cluster. For more information, see xref:../machine_configuration/index.adoc#checking-mco-node-status_machine-config-overview[About checking machine config node status]. 
+
 [id="ocp-release-notes-machine-management_{context}"]
 === Machine management
 
@@ -488,6 +532,11 @@ For more information, see xref:../installing/installing_azure/ipi/installing-azu
 ==== Additional {aws-short} Capacity Reservation configuration options
 
 On clusters that manage machines with the Cluster API, you can specify additional constraints to determine whether your compute machines use {aws-short} capacity reservations. For more information, see xref:../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#machine-feature-agnostic-capacity-reservation_cluster-api-config-options-aws[Capacity Reservation configuration options].
+
+[id="ocp-release-notes-machine-management-ca-scale-up_{context}"]
+==== Cluster autoscaler scale up delay
+
+You can now configure a delay before the cluster autoscaler recognizes newly pending pods and schedules the pods to a new node by using the `spec.scaleUp.newPodScaleUpDelay` parameter in the `ClusterAutoscaler` CR. If the node remains unscheduled after the delay, the cluster autoscaler can scale up a new node. This delay gives the cluster autoscaler additional time to locate an appropriate node or it can wait for space on an existing pod to become available. For more information, see xref:../machine_management/applying-autoscaling.adoc#configuring-clusterautoscaler_applying-autoscaling[Configuring the cluster autoscaler].
 
 [id="ocp-release-notes-monitoring_{context}"]
 === Monitoring
@@ -597,6 +646,45 @@ For more information, see xref:../networking/hardware_networks/configuring-names
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 
+[id="ocp-release-notes-machine-config-operator-sigtore_{context}"]
+==== sigstore support is now generally available
+
+Support for sigstore `ClusterImagePolicy` and `ImagePolicy` objects is now generally available. The API version is now `config.openshift.io/v1`. For more information, see xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-using[Manage secure signatures with sigstore].
+
+[NOTE]
+====
+The default `openshift` cluster image policy is Technology Preview and is active only in clusters that have enabled Technology Preview features. 
+====
+
+[id="ocp-release-notes-machine-config-operator-sigtore-pki_{context}"]
+=== Support for sigstore bring your own PKI (BYOPKI) image validation
+
+You can now use sigstore `ClusterImagePolicy` and `ImagePolicy` objects to generate BYOPKI config to the `policy.json` file, enabling you to verify image signatures with link:https://developers.redhat.com/articles/2025/09/08/verify-cosign-bring-your-own-pki-signature-openshift?source=sso#configure_openshift_for_pki_verification[BYOPKI]. For more information, see xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-configure-parameters_nodes-sigstore-using[About cluster and image policy parameters].
+
+[id="ocp-release-notes-machine-config-operator-namespace_{context}"]
+==== Linux user namespace support is now generally available
+
+Support for deploying pods and containers into Linux user namespaces is now generally available and enabled by default. Running pods and containers in individual user namespaces can mitigate several vulnerabilities that a compromised container can pose to other pods and the node itself. This change also includes two new security context constraints, `restricted-v3` and `nested-container`, that are specifically designed for use with user namespaces. You can also configure the `/proc` file system in pods as `unmasked`. For more information, see xref:../nodes/pods/nodes-pods-user-namespaces.adoc#nodes-pods-user-namespaces[Running pods in Linux user namespaces].
+
+[id="ocp-release-notes-machine-config-operator-in-place_{context}"]
+==== Adjust pod resource levels without pod disruption
+
+By using the in-place pod resizing feature, you can apply a resize policy to change the CPU and memory resources for containers within a running pod without re-creating or restarting the pod. For more information, see xref:../nodes/pods/nodes-pods-adjust-resources-in-place.adoc#nodes-pods-adjust-resources-in-place[Manually adjust pod resource levels].
+
+[id="ocp-release-notes-machine-config-operator-mount-oci_{context}"]
+==== Mounting an OCI image into a pod
+
+You can you use an image volume to mount an Open Container Initiative (OCI)-compliant container image or artifact directly into a pod. 
+
+// Activate link when assembly/module is available: For more information, see ../nodes/pods/nodes-pods-image-volume.adoc#odes-pods-image-volume[Mounting an OCI image into a pod].
+
+[id="ocp-release-notes-machine-config-operator-allocate-gpu_{context}"]
+==== Allocating specific GPUs to pods (Technology Preview)
+
+You can now enable pods to request GPUs based on specific device attributes, such as product name, GPU memory capacity, compute capability, vendor name, and driver version. These attributes are exposed by the by using a third-party DRA resource driver that you install. 
+
+// Activate link when assembly/module is available: For more information, see /nodes/pods/nodes-pods-allocate-dra.adoc#nodes-pods-allocate-dra[Allocating GPUs to pods].
+
 [id="ocp-release-notes-openshift-cli_{context}"]
 === OpenShift CLI (oc)
 
@@ -667,6 +755,11 @@ This action restores the prior functionality at the cost of globally reducing ne
 
 [id="ocp-release-notable-technical-changes_{context}"]
 == Notable technical changes
+
+[id="notable-technical-changes-mosc-naming_{context}"]
+=== MachineOSConfig naming changes
+
+The name of the `MachineOSConfig` object used with {image-mode-os-on-lower} must now be the same as the machine config pool where you want to deploy the custom layered image. Previously, you could use any name. This change was made to prevent attempts to use multiple `MachineOSConfig` objects with each machine config pool.
 
 [id="ocp-4-20-oc-mirror-v2-verify-creds_{context}"]
 === oc-mirror plugin v2 verifies credentials and certificates before mirroring operations
@@ -1326,15 +1419,20 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.18 |4.19 |4.20
 
-|Improved MCO state reporting (`oc get machineconfigpool`)
+|Improved MCO state reporting (`oc get machineconfignode`)
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
-|Image mode for OpenShift/On-cluster RHCOS image layering
+|Image mode for OpenShift/On-cluster RHCOS image layering for {aws-short} and {gcp-short}
 |Technology Preview
 |General Availability
 |General Availability
+
+|Image mode for OpenShift/On-cluster RHCOS image layering for {vmw-short}
+|Not available
+|Not available
+|Technology Preview
 
 |====
 
@@ -1576,8 +1674,22 @@ In the following tables, features are marked with the following statuses:
 |sigstore support
 |Technology Preview
 |Technology Preview
+|General Availability
+
+|Default sigstore `openshift` cluster image policy
+|Technology Preview
+|Technology Preview
 |Technology Preview
 
+|Linux user namespace support
+|Technology Preview
+|Technology Preview
+|General Availability
+
+|Attribute-Based GPU Allocation
+|Not Available
+|Not Available
+|Technology Preview
 |====
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-15056
https://issues.redhat.com/browse/OSDOCS-15066

Link to docs preview:
New features and enhancements:
* [Machine Config Operator](https://100081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-machine-config-operator_release-notes)
* Machine Management -> [Cluster Autoscaler](https://100081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-machine-management-ca-scale-up_release-notes)
* [Nodes](https://100081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-nodes_release-notes)

Notable technical changes -> [MachineOSConfig naming changes](https://100081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#notable-technical-changes-mosc-naming_release-notes)

[Technology Preview features status](https://100081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-technology-preview-tables_release-notes):
* Machine Config Operator Technology Preview features, Table 22
* Node Technology Preview features, table 27