### PR TITLE
ROX-30434: Updates to install docs for admission controller changes

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -57,6 +57,7 @@ endif::[]
 :ocp: OpenShift Container Platform
 :ocp-short: OCP
 :osp: Red{nbsp}Hat OpenShift
+:product-registry: OpenShift image registry
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
 :rhacs-version: 4.9.0
@@ -64,6 +65,7 @@ endif::[]
 :ocp-latest-version: 4.17
 :pipelines-shortname: OpenShift Pipelines
 :plugin-acs-latest-version: 0.0.4
+:product-registry: OpenShift image registry
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS
 :product-rosa-short: ROSA
 :product-title: Red{nbsp}Hat Advanced Cluster Security for Kubernetes

--- a/modules/roxctl-sensor-generate.adoc
+++ b/modules/roxctl-sensor-generate.adoc
@@ -22,23 +22,29 @@ $ roxctl sensor generate [flags]
 |`--admission-controller-disable-bypass`
 |Disable the bypass annotations for the admission controller. The default value is `false`.
 
+|`--admission-controller-enforcement`
+|Valid values are `true` and `false`. The default value is `true`. When set to `true`, the admission controller enforces policies by rejecting creation or update attempts that are in violation of an enabled policy. When set to `false`, the admission controller does not enforce policies.
+
 |`--admission-controller-enforce-on-creates`
-|Dynamic enable for enforcing on object creation in the admission controller. The default value is `false`.
+|This field is deprecated and has no effect. Use the `--admission-controller-enforcement` option to configure enforcement.
 
 |`--admission-controller-enforce-on-updates`
-|Enable dynamic enforcement of object updates in the admission controller. The default value is `false`.
+|This field is deprecated and has no effect. Use the `--admission-controller-enforcement` option to configure enforcement.
+
+|`--admission-controller-fail-on-error`
+| This parameter determines whether the API server request is allowed (fail open) or blocked (fail closed) if an error or timeout happens in the {product-title-short} validating webhook's evaluation. Valid values are `true` and `false`. The default value is `false`, which allows the request. When set to `true`, the request is blocked. 
 
 |`--admission-controller-listen-on-creates`
-|Configure the admission controller webhook to listen to deployment creation. The default value is `false`.
+|This field is deprecated. The `sensor generate` command behaves as if this flag has been specified.
 
 |`--admission-controller-listen-on-updates`
-|Configure the admission controller webhook to listen to deployment updates. The default value is `false`.
+|This field is deprecated. The `sensor generate` command behaves as if this flag has been specified.
 
 |`--admission-controller-scan-inline`
-|Get scans inline when using the admission controller. The default value is `false`.
+|This field is deprecated. The `sensor generate` command behaves as if this flag has been specified.
 
 |`--admission-controller-timeout int32`
-|Set the timeout in seconds for the admission controller. The default value is `3`.
+|This field is deprecated and using it has no effect.
 
 |`--central string`
 |Set the endpoint to which you want to connect Sensor. The default value is `central.stackrox:443`.

--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -8,7 +8,7 @@
 When you create a Central instance, the Operator lists the following configuration options for the `Central` custom resource.
 
 [id="required-configuration-settings_{context}"]
-== Required Configuration Settings
+== Required configuration settings
 
 [cols="1,3"]
 |===
@@ -33,19 +33,17 @@ To change the name, you must delete and re-create the object.
 |===
 | Parameter | Description
 
+|`admissionControl.enforcement`
+| This parameter determines if you configured the admission controller to enforce policies that have enforcement enabled. For a new secured cluster deployed with {product-title-short} 4.9, the default value is `Enabled`. For secured clusters updating from {product-title-short} versions before 4.9, previous values for the admission controller configuration parameters determine the value of this parameter. Before the update, if either of the `admissionControl.listenOnCreates` or `admissionControl.listenOnUpdates` parameters was set to `true`, the value of this parameter defaults to `Enabled` after upgrade. If both of these parameters were set to `false`, the default value becomes `Disabled` on update. 
+
 | `admissionControl.listenOnCreates`
-| Specify `true` to enable preventive policy enforcement for object creations.
-The default value is `true`.
+| This parameter is deprecated. {product-title-short} checks the value during updates to version 4.9 and is used to set a default value for the new `admissionControl.enforcement` parameter. On new installations, changing this parameter has no effect.
 
 | `admissionControl.listenOnEvents`
-| Specify `true` to enable monitoring and enforcement for Kubernetes events, such as `port-forward` and `exec` events.
-It is used to control access to resources through the Kubernetes API.
-The default value is `true`.
+| This parameter is deprecated. {product-title-short} checks the value during updates to version 4.9 and is used to set a default value for the new `admissionControl.enforcement` parameter. On new installations, changing this parameter has no effect.
 
 | `admissionControl.listenOnUpdates`
-| Specify `true` to enable preventive policy enforcement for object updates.
-It will not have any effect unless `Listen On Creates` is set to `true` as well.
-The default value is `true`.
+| This parameter is deprecated and {product-title-short} ignores its value.
 
 | `admissionControl.nodeSelector`
 | If you want this component to only run on specific nodes, you can configure a node selector using this parameter.
@@ -63,29 +61,27 @@ The default value is `true`.
 | Use this parameter to override the default resource requests for the admission controller.
 
 | `admissionControl.bypass`
-a| Use one of the following values to configure the bypassing of admission controller enforcement:
+a| Use one of the following values to configure whether {product-title-short} allows bypassing the admission controller enforcement:
 
-    * `BreakGlassAnnotation` to enable bypassing the admission controller via the `admission.stackrox.io/break-glass` annotation.
+    * `BreakGlassAnnotation` to enable bypassing the admission controller by using the `admission.stackrox.io/break-glass` annotation.
     * `Disabled` to disable the ability to bypass admission controller enforcement for the secured cluster.
 
 The default value is `BreakGlassAnnotation`.
 
 | `admissionControl.contactImageScanners`
-a| Use one of the following values to specify if the admission controller must connect to the image scanner:
+| This field is deprecated. Setting it has no effect.
 
-    * `ScanIfMissing` if the scan results for the image are missing.
-    * `DoNotScanInline` to skip scanning the image when processing the admission request.
-
-The default value is `DoNotScanInline`.
+|`admissionControl.failurePolicy`
+| Determines whether the API server request is allowed (fail open) or blocked (fail closed) if an error or timeout happens in the {product-title-short} validating webhook's evaluation. Valid values are `Ignore` and `Fail`. The default value is `Ignore` to fail open. 
 
 | `admissionControl.timeoutSeconds`
-| Use this parameter to specify the maximum number of seconds {product-title-short} must wait for an admission review before marking it as fail open. If the admission webhook does not receive information that it is requesting before the end of the timeout period, it fails, but in fail open status, it still allows the operation to succeed. For example, the admission controller would allow a deployment to be created even if a scan had timed out and {product-title-short} could not determine if the deployment violated a policy. Beginning in release 4.5, Red{nbsp}Hat reduced the default timeout setting for the {product-title-short} admission controller webhooks from 20 seconds to 10 seconds, resulting in an effective timeout of 12 seconds within the `ValidatingWebhookConfiguration`. This change does not negatively affect {ocp} users because {ocp} caps the timeout at 13 seconds.
+| The ability to configure this parameter is deprecated. {product-title-short} uses a preset value for the timeout period and you cannot change it. This parameter is ignored. 
 |===
 
 [id="scanner-configuration-settings_{context}"]
 == Scanner configuration settings for the Operator
 
-Use Scanner configuration settings to modify the local cluster scanner for the integrated OpenShift image registry.
+Use Scanner configuration settings to modify the local cluster scanner for the integrated {product-registry}.
 
 [cols="1,3"]
 |===

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -24,6 +24,7 @@ ifeval::["{context}" == "install-secured-cluster-other"]
 :kube:
 endif::[]
 
+//Helm parameters
 
 |===
 | Parameter | Description
@@ -146,42 +147,36 @@ If you specify it as `true`, no tolerations are applied, and the collector pods 
 | `collector.serviceTLS.key`
 | The internal service-to-service TLS certificate key that Collector uses.
 
+|`admissionControl.enforce`
+| This parameter determines if the admission controller has been configured to enforce policies that have enforcement enabled. For a new secured cluster deployed with {product-title-short} 4.9, the default value is `true`. For secured clusters updating from {product-title-short} versions before 4.9, previous values for the admission controller configuration parameters determine the value of this parameter. Before the update, if either of the `admissionControl.enforceOnCreates` or `admissionControl.enforceOnUpdates` parameters was set to `true`, the value of this parameter defaults to `true` after upgrade. If both of these parameters were set to `false`, the default value becomes `false` on update.
+
+|`admissionControl.failurePolicy`
+| Determines whether API server request is allowed (fail open) or blocked (fail closed) if an error or timeout happens in the {product-title-short} validating webhook's evaluation. Valid values are `Ignore` and `Fail`. The default value is `Ignore` to fail open.
+
 | `admissionControl.listenOnCreates`
-| This setting controls whether Kubernetes is configured to contact {product-title} with `AdmissionReview` requests for workload creation events.
+| This parameter is deprecated and {product-title-short} ignores its value.
 
 | `admissionControl.listenOnUpdates`
-| When you set this parameter as `false`, {product-title} creates the `ValidatingWebhookConfiguration` in a way that causes the Kubernetes API server not to send object update events.
-Since the volume of object updates is usually higher than the object creates, leaving this as `false` limits the load on the admission control service and decreases the chances of a malfunctioning admission control service.
+| This parameter is deprecated and {product-title-short} ignores its value. 
 
 | `admissionControl.listenOnEvents`
-| This setting controls whether the cluster is configured to contact {product-title} with `AdmissionReview` requests for Kubernetes `exec` and `portforward` events.
-{product-title-short} does not support this feature on {ocp} 3.11.
+| This parameter is deprecated and {product-title-short} ignores its value.
 
 | `admissionControl.dynamic.enforceOnCreates`
-| This setting controls whether {product-title} evaluates policies;
-if it is disabled, all AdmissionReview requests are automatically accepted.
+| This parameter is deprecated. {product-title-short} checks its value during updates to version 4.9 and uses it to set a default value for the new `admissionControl.enforce` parameter. On new installations, changing this parameter has no effect.
 
 | `admissionControl.dynamic.enforceOnUpdates`
-| This setting controls the behavior of the admission control service.
-You must specify `listenOnUpdates` as `true` for this to work.
+| This parameter is deprecated. {product-title-short} checks its value during updates to version 4.9 and uses it to set a default value for the new `admissionControl.enforce` parameter. On new installations, changing this parameter has no effect.
 
 | `admissionControl.dynamic.scanInline`
-| If you set this option to `true`, the admission control service requests an image scan before making an admission decision.
-Since image scans take several seconds, enable this option only if you can ensure that all images used in your cluster are scanned before deployment (for example, by a CI integration during image build).
-This option corresponds to the *Contact image scanners* option in the {product-title-short} portal.
+| This parameter is deprecated and {product-title-short} ignores its value.
 
 | `admissionControl.dynamic.disableBypass`
-| Set it to `true` to disable bypassing the Admission controller.
+| Set this parameter to `true` to disable bypassing the admission controller. The default value is `false`.
 //TODO: Link to admission controller docs
 
 | `admissionControl.dynamic.timeout`
-| Use this parameter to specify the maximum number of seconds {product-title-short} must wait for an admission review before marking it as fail open. If the admission webhook does not receive information that it is requesting before the end of the timeout period, it fails, but in fail open status, it still allows the operation to succeed. For example, the admission controller would allow a deployment to be created even if a scan had timed out and {product-title-short} could not determine if the deployment violated a policy. Beginning in release 4.5, Red{nbsp}Hat reduced the default timeout setting for the {product-title-short} admission controller webhooks from 20 seconds to 10 seconds, resulting in an effective timeout of 12 seconds within the `ValidatingWebhookConfiguration`.
-ifndef::kube[]
-This change does not negatively affect {ocp} users because {ocp} caps the timeout at 13 seconds.
-endif::kube[]
-ifndef::openshift[]
-For Kubernetes clusters, image scanning and pulling that are done as part of the webhook execution might require you to configure a longer timeout value.
-endif::openshift[]
+| The ability to configure this parameter is deprecated. {product-title-short} uses a preset value for the timeout period and you cannot change it. This parameter is ignored. 
 
 | `admissionControl.resources.requests.memory`
 | The memory request for the Admission Control container. Use this parameter to override the default value.
@@ -250,7 +245,7 @@ If you do not create this account, you must complete future upgrades manually if
 | If you set this option to `true`, {product-title} disables the audit log detection features used to detect access and modifications to configuration maps and secrets.
 
 | `scanner.disable`
-| If you set this option to `false`, {product-title} deploys a Scanner-slim and Scanner DB in the secured cluster to allow scanning images on the integrated OpenShift image registry. Enabling Scanner-slim is supported on {ocp} and Kubernetes secured clusters. Defaults to `true`.
+| If you set this option to `false`, {product-title} deploys a Scanner-slim and Scanner DB in the secured cluster to allow scanning images on the integrated {product-registry}. Enabling Scanner-slim is supported on {ocp} and Kubernetes secured clusters. Defaults to `true`.
 
 | `scanner.dbTolerations`
 | If the node selector selects tainted nodes, use this parameter to specify a taint toleration key, value, and effect for Scanner DB.

--- a/modules/update-admission-controller.adoc
+++ b/modules/update-admission-controller.adoc
@@ -86,5 +86,6 @@ $ oc -n stackrox apply -f admission-controller.yaml <1>
 
 [WARNING]
 ====
-By default, the `--listenOnEvents` option is set to `false` during the upgrade. It controls the deployment of the admission controller webhook, which listens for `exec` and `portforward` events. If you are using {ocp} version 3.11, do not set the `--listenOnEvents` option to `true`. Since these events are not available for {ocp} 3.11, enabling them causes errors. For more information, see link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
+By default, the `--listenOnEvents` option is set to `false` during the upgrade. It controls the deployment of the admission controller webhook, which listens for `exec` and `portforward` events. If you are using {ocp} version 3.11, do not set the `--listenOnEvents` option to `true`. Because these events are not available for {ocp} 3.11, enabling them causes errors. For more information, see link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
 ====
+//changes in PR#100022

--- a/modules/update-validating-webhook-configuration.adoc
+++ b/modules/update-validating-webhook-configuration.adoc
@@ -17,3 +17,4 @@ Earlier {product-title-short} versions included a wrong entry in the ValidatingW
 $ oc patch validatingwebhookconfiguration stackrox -p '{"webhooks":[{"name": "k8sevents.stackrox.io", "rules": [{"apiGroups": ["*"], "apiVersions": ["*"], "operations": ["CONNECT"], "resources": ["pods", "pods/exec", "pods/portforward"]}]}]}' <1>
 ----
 <1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+//Changes in PR #100022


### PR DESCRIPTION
Version(s): 4.9+

[Issue](https://issues.redhat.com/browse/ROX-30434)

Links to docs previews:

**Parameters**
- **roxctl**: https://100082--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/command-reference/roxctl-sensor.html
- **Helm, Cloud**: https://100082--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.html#configure-secured-cluster-services-helm-chart-customizations-cloud-ocp
- **Helm, on-prem**: https://100082--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp#secured-cluster-services-config_install-secured-cluster-ocp
- **Operator**: https://100082--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp#admission-controller-settings_install-secured-cluster-config-options-ocp

**GUI instructions**

- The GUI instructions refer users to "Configuring secured cluster services options for RHACS using the Operator" which has the admission controller parameters listed in the tables that were changed in the links above, Operator section. No other updates are needed to GUI instructions for installing secured clusters.

QE review: **ACS has no QE, approved by SMEs**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Related PRs:

https://github.com/openshift/openshift-docs/pull/100022 - general doc changes for admission controller changes
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
