### PR TITLE
OSDOCS-16281: Fixed the Deployment example in nw-metallb-configure-vr…

### DIFF
--- a/modules/nw-metallb-configure-vrf-bgppeer.adoc
+++ b/modules/nw-metallb-configure-vrf-bgppeer.adoc
@@ -143,12 +143,10 @@ spec:
     spec:
       containers:
       - name: server
-        image: registry.redhat.io/ubi9/ubi
+        image: nginx
         ports:
         - name: http
-          containerPort: 30100
-        command: ["/bin/sh", "-c"]
-        args: ["sleep INF"]
+          containerPort: 80
 ---
 apiVersion: v1
 kind: Service
@@ -158,9 +156,9 @@ metadata:
 spec:
   ports:
   - name: http
-    port: 30100
+    port: 80
     protocol: TCP
-    targetPort: 30100
+    targetPort: 80
   selector:
     app: server
   type: LoadBalancer


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-16281](https://issues.redhat.com/browse/OSDOCS-16281)

Link to docs preview:
* [Exposing a service through a network VRF](https://100100--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-configure-bgp-peers.html#nw-metallb-bgp-peer-vrf_configure-metallb-bgp-peers)

- [x] SME has approved this change (Ori Braunshtein).
- [x] QE has approved this change (Evgeny Levin).

