### PR TITLE
[monitoring-docs-4.18] Fix vale warnings (excluding callouts and block titles)

### DIFF
--- a/config-map-reference/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/config-map-reference/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -4,9 +4,9 @@
 // make edits, read the docgen utility instructions in the source code for the
 // CMO.
 :_mod-docs-content-type: REFERENCE
+include::_attributes/common-attributes.adoc[]
 [id="config-map-reference-for-the-cluster-monitoring-operator"]
 = Config map reference for the Cluster Monitoring Operator
-include::_attributes/common-attributes.adoc[]
 :context: config-map-reference-for-the-cluster-monitoring-operator
 
 toc::[]

--- a/modules/monitoring-disabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-disabling-monitoring-for-user-defined-projects.adoc
@@ -39,7 +39,9 @@ data:
 
 . Save the file to apply the changes. Monitoring for user-defined projects is then disabled automatically.
 
-. Check that the `prometheus-operator`, `prometheus-user-workload` and `thanos-ruler-user-workload` pods are terminated in the `openshift-user-workload-monitoring` project. This might take a short while:
+.Verification
+
+. Verify that the `prometheus-operator`, `prometheus-user-workload` and `thanos-ruler-user-workload` pods are terminated in the `openshift-user-workload-monitoring` project. This might take a short while:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
+++ b/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
@@ -22,8 +22,6 @@ Because log rotation is not supported, only enable this feature temporarily when
 
 .Procedure
 
-You can enable query logging for Thanos Querier in the `openshift-monitoring` project:
-
 . Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
 +
 [source,terminal]
@@ -45,8 +43,6 @@ data:
     thanosQuerier:
       enableRequestLogging: <value> <1>
       logLevel: <value> <2>
-
-
 ----
 <1> Set the value to `true` to enable logging and `false` to disable logging. The default value is `false`.
 <2> Set the value to `debug`, `info`, `warn`, or `error`. If no value exists for `logLevel`, the log level defaults to `error`.

--- a/modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc
+++ b/modules/monitoring-getting-information-about-alerts-silences-and-alerting-rules.adoc
@@ -22,7 +22,7 @@ The Alerting UI provides detailed information about alerts and their governing a
 .Procedure
 
 // tag::ADM[]
-To obtain information about alerts:
+* To obtain information about alerts:
 
 . From the *Administrator* perspective of the {ocp} web console, go to the *Observe* -> *Alerting* -> *Alerts* page.
 
@@ -34,14 +34,14 @@ To obtain information about alerts:
 
 . Click the name of an alert to view its *Alert details* page. The page includes a graph that illustrates alert time series data. It also provides the following information about the alert:
 
-* A description of the alert
-* Messages associated with the alert
-* A link to the runbook page on GitHub for the alert, if the page exists
-* Labels attached to the alert
-* A link to its governing alerting rule
-* Silences for the alert, if any exist
+** A description of the alert
+** Messages associated with the alert
+** A link to the runbook page on GitHub for the alert, if the page exists
+** Labels attached to the alert
+** A link to its governing alerting rule
+** Silences for the alert, if any exist
 
-To obtain information about silences:
+* To obtain information about silences:
 
 . From the *Administrator* perspective of the {ocp} web console, go to the *Observe* -> *Alerting* -> *Silences* page.
 
@@ -53,13 +53,13 @@ To obtain information about silences:
 
 . Select the name of a silence to view its *Silence details* page. The page includes the following details:
 
-* Alert specification
-* Start time
-* End time
-* Silence state
-* Number and list of firing alerts
+** Alert specification
+** Start time
+** End time
+** Silence state
+** Number and list of firing alerts
 
-To obtain information about alerting rules:
+* To obtain information about alerting rules:
 
 . From the *Administrator* perspective of the {ocp} web console, go to the *Observe* -> *Alerting* -> *Alerting rules* page.
 
@@ -69,31 +69,31 @@ To obtain information about alerting rules:
 
 . Select the name of an alerting rule to view its *Alerting rule details* page. The page provides the following details about the alerting rule:
 
-* Alerting rule name, severity, and description.
-* The expression that defines the condition for firing the alert.
-* The time for which the condition should be true for an alert to fire.
-* A graph for each alert governed by the alerting rule, showing the value with which the alert is firing.
-* A table of all alerts governed by the alerting rule.
+** Alerting rule name, severity, and description.
+** The expression that defines the condition for firing the alert.
+** The time for which the condition should be true for an alert to fire.
+** A graph for each alert governed by the alerting rule, showing the value with which the alert is firing.
+** A table of all alerts governed by the alerting rule.
 // end::ADM[]
 
 // tag::DEV[]
-To obtain information about alerts, silences, and alerting rules:
+* To obtain information about alerts, silences, and alerting rules:
 
 . From the *Developer* perspective of the {ocp} web console, go to the *Observe* -> *<project_name>* -> *Alerts* page.
 
 . View details for an alert, silence, or an alerting rule:
 
-* *Alert details* can be viewed by clicking a greater than symbol (*>*) next to an alert name and then selecting the alert from the list.
+** *Alert details* can be viewed by clicking a greater than symbol (*>*) next to an alert name and then selecting the alert from the list.
 
-* *Silence details* can be viewed by clicking a silence in the *Silenced by* section of the *Alert details* page. The *Silence details* page includes the following information:
+** *Silence details* can be viewed by clicking a silence in the *Silenced by* section of the *Alert details* page. The *Silence details* page includes the following information:
 
-** Alert specification
-** Start time
-** End time
-** Silence state
-** Number and list of firing alerts
+*** Alert specification
+*** Start time
+*** End time
+*** Silence state
+*** Number and list of firing alerts
 
-* *Alerting rule details* can be viewed by clicking the {kebab} menu next to an alert in the *Alerts* page and then clicking *View Alerting Rule*.
+** *Alerting rule details* can be viewed by clicking the {kebab} menu next to an alert in the *Alerts* page and then clicking *View Alerting Rule*.
 
 [NOTE]
 ====

--- a/modules/monitoring-silencing-alerts.adoc
+++ b/modules/monitoring-silencing-alerts.adoc
@@ -37,7 +37,7 @@ endif::openshift-dedicated,openshift-rosa[]
 .Procedure
 
 // tag::ADM[]
-To silence a specific alert:
+* To silence a specific alert:
 
 . From the *Administrator* perspective of the {ocp} web console, go to *Observe* -> *Alerting* -> *Alerts*.
 
@@ -52,7 +52,7 @@ You must add a comment before saving a silence.
 
 . To save the silence, click *Silence*.
 
-To silence a set of alerts:
+* To silence a set of alerts:
 
 . From the *Administrator* perspective of the {ocp} web console, go to *Observe* -> *Alerting* -> *Silences*.
 
@@ -69,7 +69,7 @@ You must add a comment before saving a silence.
 // end::ADM[]
 
 // tag::DEV[]
-To silence a specific alert:
+* To silence a specific alert:
 
 . From the *Developer* perspective of the {ocp} web console, go to *Observe* and go to the *Alerts* tab.
 
@@ -90,7 +90,7 @@ You must add a comment before saving a silence.
 
 . To save the silence, click *Silence*.
 
-To silence a set of alerts:
+* To silence a set of alerts:
 
 . From the *Developer* perspective of the {ocp} web console, go to *Observe* and go to the *Silences* tab.
 

--- a/modules/monitoring-using-node-selectors-to-move-monitoring-components.adoc
+++ b/modules/monitoring-using-node-selectors-to-move-monitoring-components.adoc
@@ -12,7 +12,6 @@ By doing so, you can control the placement and distribution of the monitoring co
 
 By controlling placement and distribution of monitoring components, you can optimize system resource use, improve performance, and separate workloads based on specific requirements or policies.
 
-[discrete]
 == How node selectors work with other constraints
 
 If you move monitoring components by using node selector constraints, be aware that other constraints to control pod scheduling might exist for a cluster:


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/100031 to 4.18 standalone