### PR TITLE
(enterprise-4.18) Moving PIS and MCN release notes to 4.19.12 and updating PIS tech preview table to GA

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2399,7 +2399,7 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.16 |4.17 |4.18
 
-|Improved MCO state reporting (`oc get machineconfigpool`)
+|Improved MCO state reporting (`oc get machineconfignode`)
 |Technology Preview
 |Technology Preview
 |Technology Preview
@@ -2423,6 +2423,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 |General Availability
+
+|Pinned Image Sets
+|Technology Preview
+|Technology Preview
+|Technology Preview
 
 |====
 
@@ -2785,11 +2790,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Using {rh-rhacm} `PolicyGenerator` resources to manage {ztp} cluster policies
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
-|Pinned Image Sets
 |Technology Preview
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/99799. I moved the PIS tech preview table and fixed a typo. No change to the PIS tech preview, as the feature is still TP.