### PR TITLE
OSDOCS-16435: Updated the note in the modules/patching-ovnk-address-r…

### DIFF
--- a/modules/patching-ovnk-address-ranges.adoc
+++ b/modules/patching-ovnk-address-ranges.adoc
@@ -17,7 +17,7 @@ The following procedure can be used to patch CIDR ranges that are in use by Open
 
 [NOTE]
 ====
-This is an optional procedure and must only be used if the migration was blocked after using the `oc patch Network.config.openshift.io cluster --type='merge' --patch '{"metadata":{"annotations":{"network.openshift.io/network-type-migration":""}},"spec":{"networkType":"OVNKubernetes"}}'` command "Initiating the limited live migration process".
+Only use this optional procedure if your cluster or network environment overlaps with the `100.64.0.0/16` subnet or the `100.88.0.0/16` subnet. Ensure that you run the steps in the procedure before you start the limited live migration operation.
 ====
 
 .Prerequisites


### PR DESCRIPTION
The targeted file is only visible in 4.17 and 4.16 docs, but the file still exists in the 4.18 to 4.20 docs. 

Version(s):
4.16+

Issue:
[OSDOCS-16435](https://issues.redhat.com/browse/OSDOCS-16435)

Link to docs preview:


- [x] SME has approved this change (Will R.).
- [x] QE has approved this change (Zhanqi Zhao).

Add. information:

* https://github.com/openshift/openshift-docs/pull/81120
