### PR TITLE
OSDOCS#16438: Update the OPP compatibility matrix for OCP 4.19

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -38,32 +38,32 @@
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
 // These variable are the current product release versions for the OPP products
-:ocp-supported-version: 4.18
-:rhacs-version: 4.7
-:quay-version: 3.14
-:rhacm-version: 2.13
-:odf-version: 4.18
+:ocp-supported-version: 4.19
+:rhacs-version: 4.8
+:quay-version: 3.15
+:rhacm-version: 2.14
+:odf-version: 4.19
 // These variables are for the immediate past 4 OPP product versions that are in the compatibility table
-:ocp-supported-version-1: 4.17
-:rhacs-version-1: 4.6
-:quay-version-1: 3.13
-:rhacm-version-1: 2.12
-:odf-version-1: 4.17
-:ocp-supported-version-2: 4.16
-:rhacs-version-2: 4.5
-:quay-version-2: 3.12
-:rhacm-version-2: 2.11
-:odf-version-2: 4.16
-:ocp-supported-version-3: 4.15
-:rhacs-version-3: 4.4
-:quay-version-3: 3.11
-:rhacm-version-3: 2.10
-:odf-version-3: 4.15
-:ocp-supported-version-4: 4.14
-:rhacs-version-4: 4.3
-:quay-version-4: 3.10
-:rhacm-version-4: 2.9
-:odf-version-4: 4.14
+:ocp-supported-version-1: 4.18
+:rhacs-version-1: 4.7
+:quay-version-1: 3.14
+:rhacm-version-1: 2.13
+:odf-version-1: 4.18
+:ocp-supported-version-2: 4.17
+:rhacs-version-2: 4.6
+:quay-version-2: 3.13
+:rhacm-version-2: 2.12
+:odf-version-2: 4.17
+:ocp-supported-version-3: 4.16
+:rhacs-version-3: 4.5
+:quay-version-3: 3.12
+:rhacm-version-3: 2.11
+:odf-version-3: 4.16
+:ocp-supported-version-4: 4.15
+:rhacs-version-4: 4.4
+:quay-version-4: 3.11
+:rhacm-version-4: 2.10
+:odf-version-4: 4.15
 // Following variables are required for publishing using PV2
 :product-title: OpenShift Platform Plus
 :product-version: .1


### PR DESCRIPTION
Version(s):
This PR is based on the ‘opp-docs-main’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add the ‘Continuous Release’ milestone to this PR.

Issue:
[OSDOCS-16438](https://issues.redhat.com//browse/OSDOCS-16438)

Link to docs preview:
[Compatibility matrix](https://100147--ocpdocs-pr.netlify.app/openshift-opp/latest/architecture/opp-architecture.html#opp-architecture-compatibility-matrix_opp-architecture)

QE review:
- [ x] QE has approved this change.

Additional information:
The product versions that are listed might not be the latest available version for the product. The versions listed in the compatibility matrix are the latest verified versions for OPP.

Per Kathryn, the rendering on DRC should be OK. The preview is likely missing a file from `main`, and is why it looks different from the final output.
