### PR TITLE
OSDOCS-16429 Reducing GCP permissions

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
@@ -39,7 +39,7 @@ Ensure that the host project applies one of the following configurations to the 
 * `roles/compute.networkUser`
 ====
 
-If you do not supply a service account for control plane nodes in the `install-config.yaml` file, please grant the below permissions to the service account in the host project. If you do not supply a service account for compute nodes in the `install-config.yaml` file, please grant the below permissions to the service account in the host project for cluster destruction.
+If you do not supply a service account for control plane nodes in the `install-config.yaml` file, please grant the following permissions to the service account in the host project. If you do not supply a service account for compute nodes in the `install-config.yaml` file, please grant the following permissions to the service account in the host project for cluster destruction. If you do supply service accounts for control plane and compute nodes, you do not need to grant the following permissions.
 
 [%collapsible]
 ====

--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -8,7 +8,7 @@
 
 When you attach the `Owner` role to the service account that you create, you grant that service account all permissions, including those that are required to install {product-title}.
 
-If your organization’s security policies require a more restrictive set of permissions, you can create link:https://cloud.google.com/iam/docs/creating-custom-roles[custom roles] with the necessary permissions. The following permissions are required for the installer-provisioned infrastructure for creating and deleting the {product-title} cluster.
+If your organization's security policies require a more restrictive set of permissions, you can create link:https://cloud.google.com/iam/docs/creating-custom-roles[custom roles] with the necessary permissions. The following permissions are required for the installer-provisioned infrastructure for creating and deleting the {product-title} cluster.
 
 .Required permissions for creating network resources
 [%collapsible]
@@ -96,6 +96,7 @@ If your organization’s security policies require a more restrictive set of per
 * `iam.serviceAccountKeys.get`
 * `iam.serviceAccountKeys.list`
 * `iam.serviceAccounts.actAs`
+** This permission can be limited to act as the control plane and compute service accounts. Alternatively, you may grant the service account that the installation program uses the `iam.serviceAccountUser` role on the control plane and compute service accounts.
 * `iam.serviceAccounts.create`
 * `iam.serviceAccounts.delete`
 * `iam.serviceAccounts.get`
@@ -103,6 +104,7 @@ If your organization’s security policies require a more restrictive set of per
 * `resourcemanager.projects.get`
 * `resourcemanager.projects.getIamPolicy`
 * `resourcemanager.projects.setIamPolicy`
+** This permission is not required if you use `credentialsMode: Manual` and supply your own service accounts for compute and control plane nodes.
 ====
 
 .Required permissions for creating compute resources
@@ -268,7 +270,6 @@ If your organization’s security policies require a more restrictive set of per
 * `iam.serviceAccounts.get`
 * `iam.serviceAccounts.list`
 * `resourcemanager.projects.getIamPolicy`
-* `resourcemanager.projects.setIamPolicy`
 ====
 
 .Required permissions for deleting compute resources


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-16429

Link to docs preview:
https://100149--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#minimum-required-permissions-ipi-gcp_installing-gcp-account

QE review:
- [x] QE has approved this change.
