### PR TITLE
[enterprise-4.17] CNV-55236: Remove outdated hotplug commands

### DIFF
--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -301,12 +301,6 @@ Optional:
 
 |`virtctl removevolume <vm_name> --volume-name=<virtual_disk>`
 |Hot unplug a virtual disk.
-
-|`virtctl addinterface <vm_name> --network-attachment-definition-name <net_attach_def_name> --name <interface_name>`
-|Hot plug a Linux bridge network interface.
-
-|`virtctl removeinterface <vm_name> --name <interface_name>`
-|Hot unplug a Linux bridge network interface.
 |===
 
 [id='image-upload-commands_{context}']
@@ -324,4 +318,3 @@ You use the `virtctl image-upload` commands to upload a VM image to a data volum
 |`virtctl image-upload dv <datavolume_name> --size=<datavolume_size> --image-path=</path/to/image>`
 |Upload a VM image to a new data volume of a specified requested size.
 |===
-


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/CNV-55236

Link to docs preview:
https://100155--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-using-the-cli-tools.html#hot-plug-and-hot-unplug-commands_virt-using-the-cli-tools

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->