### PR TITLE
OBSDOCS-2502 [DOC] POWERMON 1.0 GA: API spec update

### DIFF
--- a/modules/power-monitoring-api-specifications.adoc
+++ b/modules/power-monitoring-api-specifications.adoc
@@ -17,34 +17,37 @@ PowerMonitor is the schema for the PowerMonitor API.
 
 | *apiVersion*
 | string
-| kepler.system.sustainable.computing.io/v1alpha1
+| `kepler.system.sustainable.computing.io/v1alpha1`
 | true
 
 | *kind*
 | string
-| PowerMonitor
+| `PowerMonitor`
 | true
 
+| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[*metadata*]
 | object
-| Refer to the Kubernetes API documentation for the fields of the metadata field.
+| Refer to the Kubernetes API documentation for the fields of the `metadata` field.
 | true
 
 | *spec*
 | object
-| PowerMonitorSpec defines the desired state of Power Monitor
+| `PowerMonitorSpec` defines the desired state of the Power Monitor.
 | false
 
 | *status*
 | object
-| PowerMonitorStatus defines the observed state of the Power Monitor.
+| `PowerMonitorStatus` defines the observed state of the Power Monitor.
 | false
 |===
 
+---
+
 == PowerMonitor.spec
 
-PowerMonitorSpec defines the desired state of Power Monitor
+`PowerMonitorSpec` defines the desired state of the Power Monitor.
 
-[cols="1,1,3,1", options="header"]
+[cols="1,1,4,1", options="header"]
 |===
 | Name
 | Type
@@ -53,11 +56,282 @@ PowerMonitorSpec defines the desired state of Power Monitor
 
 | *kepler*
 | object
-|
+| Defines the configuration for the Kepler components.
 | true
 |===
 
-== PowerMonitor.status.conditions
+---
+
+== PowerMonitor.spec.kepler
+
+
+[cols="1,1,4,1", options="header"]
+|===
+| Name
+| Type
+| Description
+| Required
+
+| *config*
+| object
+| Defines the Kepler ConfigMap settings.
+| false
+
+| *deployment*
+| object
+| Defines the Kepler DaemonSet deployment settings.
+| false
+|===
+
+---
+
+== PowerMonitor.spec.kepler.config
+
+[cols="1,1,4,1", options="header"]
+|===
+| Name
+| Type
+| Description
+| Required
+
+| *additionalConfigMaps*
+| []object
+| A list of ConfigMap names that will be merged with the default ConfigMap. These must exist in the same namespace as the PowerMonitor components.
+| false
+
+| `*logLevel*`
+| string
+|
+The level of logs to expose.
+
+_Default_: `info`
+| false
+
+| `*maxTerminated*`
+| integer
+|
+Controls terminated workload tracking. A negative value tracks unlimited workloads, zero disables tracking, and a positive value tracks the top N workloads by energy consumption.
+
+_Format_: `int32`
+
+_Default_: `500`
+| false
+
+| *metricLevels*
+| []enum
+|
+Specifies which metric levels to export. Valid values are combinations of `node`, `process`, `container`, `vm`, and `pod`.
+
+_Default_: `[node, pod, vm]`
+| false
+
+| *sampleRate*
+| string
+|
+The interval for monitoring resources (e.g., "5s", "1m"). Must be a positive duration.
+
+_Default_: `5s`
+| false
+
+| *staleness*
+| string
+|
+How long to wait before considering calculated power values as stale (e.g., "500ms", "5s"). Must be a positive duration.
+
+_Default_: `500ms`
+| false
+|===
+
+---
+
+== PowerMonitor.spec.kepler.config.additionalConfigMaps[index]
+
+`ConfigMapRef` defines a reference to a ConfigMap.
+
+[cols="1,1,4,1", options="header"]
+|===
+| Name
+| Type
+| Description
+| Required
+
+| *name*
+| string
+| The name of the ConfigMap.
+| true
+|===
+
+---
+
+== PowerMonitor.spec.kepler.deployment
+
+[cols="1,1,4,1", options="header"]
+|===
+| Name
+| Type
+| Description
+| Required
+
+| *nodeSelector*
+| map[string]string
+|
+Defines which nodes the pod is scheduled on.
+
+_Default_: `map[kubernetes.io/os:linux]`
+| false
+
+| *secrets*
+| []object
+| Secrets to be mounted in the power monitor containers.
+| false
+
+| *security*
+| object
+| If set, defines the security mode and allowed `SA` names.
+| false
+
+| *tolerations*
+| []object
+|
+If specified, defines the pod's tolerations.
+
+_Default_: `[map[operator:Exists]]`
+| false
+|===
+
+---
+
+== PowerMonitor.spec.kepler.deployment.secrets[index]
+
+`SecretRef` defines a reference to a Secret to be mounted.
+
+Mount Path Cautions:
+Exercise caution when setting mount paths for secrets. Avoid mounting secrets to critical system paths
+that may interfere with Kepler's operation or container security:
+- /etc/kepler - Reserved for Kepler configuration files
+- /sys, /proc, /dev - System directories that should remain read-only
+- /usr, /bin, /sbin, /lib - System binaries and libraries
+- / - Root filesystem
+
+[cols="1,1,4,1", options="header"]
+|===
+| Name | Type | Description | Required
+
+| *mountPath*
+| string
+| The path where the secret should be mounted in the container.
+| true
+
+| *name*
+| string
+| The name of the secret in the same namespace as the Kepler deployment.
+| true
+
+| *readOnly*
+| boolean
+|
+Specifies whether the secret should be mounted as read-only.
+
+_Default_: `true`
+| false
+|===
+
+---
+
+== PowerMonitor.spec.kepler.deployment.security
+
+If set, defines the security mode and allowed `SA` names.
+
+[cols="1,1,4,1", options="header"]
+|===
+| Name
+| Type
+| Description
+| Required
+
+| *allowedSANames*
+| []string
+| A list of service account names that are allowed to access the metrics endpoint.
+| false
+
+| *mode*
+| enum
+|
+The security mode.
+
+_Enum_: `none`, `rbac`
+| false
+|===
+
+---
+
+== PowerMonitor.spec.kepler.deployment.tolerations[index]
+
+The pod this toleration is attached to tolerates any taint that matches the triple `<key,value,effect>` using the matching `<operator>`.
+
+[cols="1,1,4,1", options="header"]
+|===
+| Name
+| Type
+| Description
+| Required
+
+| *effect*
+| string
+| The taint effect to match. Allowed values are `NoSchedule`, `PreferNoSchedule`, and `NoExecute`. Empty means match all effects.
+| false
+
+| *key*
+| string
+| The taint key that the toleration applies to. Empty means match all taint keys.
+| false
+
+| *operator*
+| string
+| A key's relationship to the value. Valid operators are `Exists` and `Equal`. Defaults to `Equal`.
+| false
+
+| *tolerationSeconds*
+| integer
+|
+The period of time the toleration (with effect `NoExecute`) tolerates the taint. If not set, it tolerates the taint forever.
+
+_Format_: `int64`
+| false
+
+| *value*
+| string
+| The taint value the toleration matches. If the operator is `Exists`, the value should be empty.
+| false
+|===
+
+---
+
+== PowerMonitor.status
+
+`PowerMonitorStatus` defines the observed state of the Power Monitor.
+
+[cols="1,1,4,1", options="header"]
+|===
+| Name
+| Type
+| Description
+| Required
+
+| *conditions*
+| []object
+| Represents the latest available observations of the power-monitor.
+| true
+
+| *kepler*
+| object
+| Defines the observed state of the Kepler components.
+| false
+|===
+
+---
+
+== PowerMonitor.status.conditions[index]
 
 [cols="1,1,4,1", options="header"]
 |===
@@ -68,37 +342,44 @@ PowerMonitorSpec defines the desired state of Power Monitor
 
 | *lastTransitionTime*
 | string
-| The last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable. +
-Format: date-time
+|
+The last time the condition transitioned from one status to another.
+
+_Format_: `date-time`
 | true
 
 | *message*
 | string
-| A human-readable message indicating details about the transition. This may be an empty string.
+| A human-readable message indicating details about the transition.
 | true
 
 | *reason*
 | string
-| Contains a programmatic identifier indicating the reason for the condition's last transition.
+| A programmatic identifier for the condition's last transition.
 | true
 
 | *status*
 | string
-| The status of the condition, which can be one of True, False, or Unknown.
+| The status of the condition, which can be one of `True`, `False`, or `Unknown`.
 | true
 
 | *type*
 | string
-| The type of Kepler Condition, such as Reconciled or Available.
+| The type of Kepler condition, such as `Reconciled` or `Available`.
 | true
 
 | *observedGeneration*
 | integer
-| Represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date. +
-Format: int64 +
-Minimum: 0
+|
+The `.metadata.generation` that the condition was set based upon.
+
+_Format_: `int64`
+
+_Minimum_: 0
 | false
 |===
+
+---
 
 == PowerMonitor.status.kepler
 
@@ -111,43 +392,57 @@ Minimum: 0
 
 | *currentNumberScheduled*
 | integer
-| The number of nodes that are running at least one power-monitor pod and are supposed to run it. +
-Format: int32
+|
+The number of nodes running at least one `power-monitor` pod as intended.
+
+_Format_: `int32`
 | true
 
 | *desiredNumberScheduled*
 | integer
-| The total number of nodes that should be running the power-monitor pod. +
-Format: int32
+|
+The total number of nodes that should be running the `power-monitor` pod.
+
+_Format_: `int32`
 | true
 
 | *numberMisscheduled*
 | integer
-| The number of nodes running the power-monitor pod that are not supposed to. +
-Format: int32
+|
+The number of nodes running the `power-monitor` pod that are not supposed to.
+
+_Format_: `int32`
 | true
 
 | *numberReady*
 | integer
-| The number of nodes that should be running the power-monitor pod and have at least one pod with a Ready condition. +
-Format: int32
+|
+The number of nodes that should be running the `power-monitor` pod and have at least one pod with a `Ready` condition.
+
+_Format_: `int32`
 | true
 
 | *numberAvailable*
 | integer
-| The number of nodes that should be running the power-monitor pod and have at least one pod running and available. +
-Format: int32
+|
+The number of nodes that should be running the `power-monitor` pod and have at least one pod running and available.
+
+_Format_: `int32`
 | false
 
 | *numberUnavailable*
 | integer
-| The number of nodes that should be running the power-monitor pod but have no pods running and available. +
-Format: int32
+|
+The number of nodes that should be running the `power-monitor` pod and have no pods running and available.
+
+_Format_: `int32`
 | false
 
 | *updatedNumberScheduled*
 | integer
-| The total number of nodes that are running an updated power-monitor pod. +
-Format: int32
+|
+The total number of nodes that are running an updated `power-monitor` pod.
+
+_Format_: `int32`
 | false
 |===

--- a/modules/power-monitoring-api-specifications.adoc
+++ b/modules/power-monitoring-api-specifications.adoc
@@ -25,7 +25,7 @@ PowerMonitor is the schema for the PowerMonitor API.
 | `PowerMonitor`
 | true
 
-| link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#objectmeta-v1-meta[*metadata*]
+| *metadata*
 | object
 | Refer to the Kubernetes API documentation for the fields of the `metadata` field.
 | true

--- a/observability/power_monitoring/power-monitoring-api-reference.adoc
+++ b/observability/power_monitoring/power-monitoring-api-reference.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Power monitoring
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 PowerMonitor is the Schema for the PowerMonitor API.
 
 include::modules/power-monitoring-api-specifications.adoc[leveloffset=+1]


### PR DESCRIPTION
[OBSDOCS-2502](https://issues.redhat.com//browse/OBSDOCS-2502) [DOC] POWERMON 1.0 GA: API spec update

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the `power-monitoring-1.0` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the <power-monitoring-1.0> content just before its GA.

Note to self for integration branch: applies to OCP 4.17+

Issue:
https://issues.redhat.com/browse/OBSDOCS-2502

Link to docs preview:

***// Automatically generated by 'kepler.system.sustainable.computing.io'. Do not edit.***
https://100157--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/power_monitoring/power-monitoring-api-reference.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
