### PR TITLE
OSDOCS WMCO 10.20.0 release notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2876,8 +2876,8 @@ Topics:
   Topics:
   - Name: Red Hat OpenShift support for Windows Containers release notes
     File: windows-containers-release-notes
-  - Name: Past releases
-    File: windows-containers-release-notes-past
+#  - Name: Past releases
+#    File: windows-containers-release-notes-past
   - Name: Windows Machine Config Operator prerequisites
     File: windows-containers-release-notes-prereqs
   - Name: Windows Machine Config Operator known limitations

--- a/modules/windows-containers-release-notes-10-20-0.adoc
+++ b/modules/windows-containers-release-notes-10-20-0.adoc
@@ -6,17 +6,26 @@
 [id="windows-containers-release-notes-10-20-0_{context}"]
 = Release notes for Red Hat Windows Machine Config Operator 10.20.0
 
-Issued: 
+Issued: 21 October 2025
 
-The components of the WMCO 10.20.0 were released in .
+// The components of the Red Hat Windows Machine Config Operator (WMCO) 10.20.0 were released in TBD.
 
 [id="wmco-10-20-0-new-features"]
 == New features and improvements
 
 [id="wmco-10-20-0-new-features-kubernetes"]
 === Kubernetes upgrade
-The WMCO now uses Kubernetes .
+
+The WMCO now uses Kubernetes version 1.33.
 
 [id="wmco-10-20-0-bug-fixes"]
 == Bug fixes
-* Previously,  (link:https://issues.redhat.com/browse/OCPBUGS-46473[*OCPBUGS-46473*])
+
+* Previously, if you made a configuration change that required the WMCO to delete and recreate an internal config map, such as changing the proxy settings of the cluster, the WMCO pod panicked and entered a crash loop due to a nil pointer dereference panic. With this fix, the error handling logic is reworked. As a result, the WMCO pod no longer crashes when an internal config map is recreated. (link:https://issues.redhat.com/browse/OCPBUGS-60688[OCPBUGS-60688])
+
+* Previously, during secret reconciliations, secret change data was being added to the logs on each reconciliation loop. As a result, this secret change data was persisting, causing the logs to grow in size with unrelated data. With this fix, only the current secret change data is being logged, reducing the size and complexity of the logs. (link:https://issues.redhat.com/browse/OCPBUGS-61559[OCPBUGS-61559])
+
+* Previously, the `hybridOverlay` service was not using the trusted CA bundle when connecting to Kubernetes, because the `hybridOverlay` service command was missing the `--k8s-cacert` option. Because of this, users could encounter trust issues or failures when the `hybridOverlay` service attempted to communicate securely with Kubernetes clusters using custom or internal CAs. With this fix, the `hybridOverlay` service command now includes the `--k8s-cacert flag` pointing to the trusted CA bundle. As a result, the `hybridOverlay` service uses the trusted CA bundle for secure communication, preventing trust issues and ensuring compatibility with the cluster. 
+// Hide until the Jira is set to Security: None. (link: //issues.redhat.com/browse/OCPBUGS-59637[OCPBUGS-59637])
+
+* Previously, the WMCO neglected to close SSH connections when finishing node reconciliation. As a consequence, after adding a new Windows node to a cluster, the node SSH server eventually would refuse new connections due to being overwhelmed, causing node management issues. With this fix, the WMCO now properly closes SSH connections. As a result, the node SSH servers no longer refuse new connections due to this problem. (link:https://issues.redhat.com/browse/OCPBUGS-60482[OCPBUGS-60482])

--- a/windows_containers/wmco_rn/windows-containers-release-notes-prereqs.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes-prereqs.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator (WMCO). See the vSphere documentation for any information that is relevant to only that platform.
 
-[id="wmco-prerequisites-supported-install-10.17.0_{context}"]
+[id="wmco-prerequisites-supported-install_{context}"]
 == WMCO supported installation method
 
 The WMCO fully supports installing Windows nodes into installer-provisioned infrastructure (IPI) clusters. This is the preferred {product-title} installation method.

--- a/windows_containers/wmco_rn/windows-containers-release-notes.adoc
+++ b/windows_containers/wmco_rn/windows-containers-release-notes.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="windows-containers-release-notes"]
-= {productwinc} release notes
 include::_attributes/common-attributes.adoc[]
+[id="windows-containers-release-notes"]
+= Release notes
 :context: windows-containers-release-notes
 
 toc::[]


### PR DESCRIPTION
https://issues.redhat.com/browse/WINC-1461

Previews:
[Release notes for Red Hat Windows Machine Config Operator 10.20.0](https://100159--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes.html#windows-containers-release-notes-10-20-0_windows-containers-release-notes) -- New bug texts. Will update release date and link to errata when available.
