### PR TITLE
OLS-2168: Disabling the OpenShift Container Platform documentation RAG database

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -30,6 +30,14 @@ include::modules/ols-granting-access-to-user-group.adoc[leveloffset=+2]
 include::modules/ols-filtering-and-redacting-information.adoc[leveloffset=+1]
 include::modules/ols-about-the-byo-knowledge-tool.adoc[leveloffset=+1]
 include::modules/ols-providing-custom-knowledge-to-the-llm.adoc[leveloffset=+2]
+include::modules/ols-disabling-ocp-documentation-rag-database.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources-byok_{context}"]
+.Additional resources
+
+* xref:../configure/ols-configuring-openshift-lightspeed.adoc#providing-custom-knowledge-to-the-llm_ols-configuring-openshift-lightspeed[Providing custom knowledge to the LLM]
+
 include::modules/ols-about-cluster-interaction.adoc[leveloffset=+1]
 include::modules/ols-enabling-cluster-interaction.adoc[leveloffset=+2]
 include::modules/ols-enabling-custom-mcp-server.adoc[leveloffset=+2]

--- a/modules/ols-disabling-ocp-documentation-rag-database.adoc
+++ b/modules/ols-disabling-ocp-documentation-rag-database.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="disabling-ocp-index_{context}"]
+= Disabling the {ocp-product-title} documentation RAG database 
+
+Modify the `OLSConfig` custom resource (CR) file to disable the built-in Retrieval-Augmented Generation (RAG) database that contains the {ocp-product-title} documentation. Then, the only RAG databases {ols-long} uses are the ones that you provide using the BYO Knowledge feature.
+
+.Prerequisites
+
+* You are logged in to the {ocp-product-title} web console as a user account with permission to create a cluster-scoped CR file, such as a user with the `cluster-admin` role.
+
+* You have installed the {ols-long} Operator.
+
+* You have configured the large language model provider.
+
+* You have configured the `OLSConfig` CR file, which automatically deploys the {ols-long} Service.
+
+* You have created a RAG database that contains the content you want to use, as described in "Providing custom knowledge to the LLM".
+
+.Procedure 
+
+. In the {ocp-product-title} web console, click *Operators* -> *Installed Operators*. 
+
+. Select *All Projects* in the  *Project* list at the top of the screen.
+
+. Click *{ols-long} Operator*.
+
+. Click *OLSConfig*, then click the `cluster` configuration instance in the list.
+
+. Click the *YAML* tab.
+
+. Insert the `spec.ols.byokRAGOnly` YAML code.
++
+.Example `OLSconfig` CR file
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+spec:
+  ols:
+    byokRAGOnly: true <1>
+----
+<1> Specify `true` so that {ols-long} only uses RAG databases that you create using the BYO Knowledge feature. When `true`, {ols-long} does not use the default RAG database that contains the {ocp-product-title} documentation.
+
+. Click *Save*.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2168
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://100164--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#disabling-ocp-index_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
