### PR TITLE
OSDOCS#16441:Update the OPP product RN links

### DIFF
--- a/modules/opp-architecture-relnotes.adoc
+++ b/modules/opp-architecture-relnotes.adoc
@@ -8,8 +8,8 @@
 
 The release note information for each product is accessible from the following list:
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/release_notes/ocp-4-15-release-notes[{ocp}]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/release_notes/release-notes[{rh-rhacm} for Kubernetes]
-* link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.11/html/red_hat_quay_release_notes/release-notes-311[{quay} Release Notes]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/4.4/html/release_notes/release-notes-44[{acs} for Kubernetes 4.4]
-* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.15/html/4.15_release_notes/index[{rh-storage-data-foundation}]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes[{ocp}]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/release_notes/acm-release-notes[{rh-rhacm} for Kubernetes]
+* link:https://docs.redhat.com/en/documentation/red_hat_quay/3.15/html/red_hat_quay_release_notes/release-notes-315[{quay} Release Notes]
+* link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.8/html/release_notes/release-notes-48[{acs} for Kubernetes 4.8]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.19/html/4.19_release_notes/index[{rh-storage-data-foundation}]


### PR DESCRIPTION
Version(s):
This PR is based on the ‘opp-docs-main’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add the ‘Continuous Release’ milestone to this PR.

Issue:
[OSDOCS-16441](https://issues.redhat.com//browse/OSDOCS-16441)

Link to docs preview:
[Product release notes](https://100170--ocpdocs-pr.netlify.app/openshift-opp/latest/architecture/opp-architecture.html#opp-architecture-relnotes_opp-architecture)

QE review:
- [ ] QE has approved this change.

Additional information:
The product versions that are listed might not be the latest available version for the product. The versions listed in the compatibility matrix are the latest verified versions for OPP.

Per Kathryn, the rendering on DRC should be OK. The preview is likely missing a file from main, and is why it looks different from the final output.
