### PR TITLE
Telcodocs 2270 rn update

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -74,7 +74,7 @@ The default namespace for the {lvms} Operator is now `openshift-lvm-storage`. Yo
 [id="ocp-release-edge-computing-default-clusterinstance_{context}"]
 ==== SiteConfig CR to ClusterInstance CR migration tool
 
-{product-title} {product-version} introduces the `siteconfig-converter` tool to help migrate managed clusters from using a `SiteConfig` custom resource (CR) to a `ClusterInstance` CR. Using a `SiteConfig` CR to define a managed cluster is deprecated and will be removed in a future release. The `ClusterInstance` CR provides a more unified and generic approach to defining clusters and is the preferred method for managing cluster deployments in the {ztp} workflow. 
+{product-title} {product-version} introduces the `siteconfig-converter` tool to help migrate managed clusters from using a `SiteConfig` custom resource (CR) to a `ClusterInstance` CR. Using a `SiteConfig` CR to define a managed cluster is deprecated and will be removed in a future release. The `ClusterInstance` CR provides a more unified and generic approach to defining clusters and is the preferred method for managing cluster deployments in the {ztp} workflow.
 
 Using the `siteconfig-converter` tool, you can convert `SiteConfig` CRs to `ClusterInstance` CRs and then incrementally migrate one or more clusters at a time. Existing and new pipelines run in parallel, so you can migrate clusters in a controlled, phased manner and without downtime.
 
@@ -592,7 +592,7 @@ Previously, creating an SR-IOV network required a cluster administrator to confi
 
 * Simplified permissions: You can now simplify permissions and reduce operational overhead by using namespaced SR-IOV networks.
 
-For more information, see xref:../networking/hardware_networks/configuring-namespaced-sriov-resources.html#configuring-namespaced-sriov-resources[Configuring namespaced SR-IOV resources].
+For more information, see xref:../networking/hardware_networks/configuring-namespaced-sriov-resources.adoc#configuring-namespaced-sriov-resources[Configuring namespaced SR-IOV resources].
 
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
@@ -627,7 +627,7 @@ include::snippets/osdk-release-notes-operator-images.adoc[]
 [id="ocp-release-notes-numa-resources-operator-replicas_{context}"]
 ==== Configuring NUMA-aware scheduler replicas and high availability (Technology Preview)
 
-In {product-title} {product-version}, the NUMA Resources Operator automatically enables high availability (HA) mode by default. In this mode, the NUMA Resources Operator creates one scheduler replica for each control-plane node in the cluster to ensure redundancy. This default behavior occurs if the `spec.replicas` field is not specified in the `NUMAResourcesScheduler` Custom Resource (CR). Alternatively, you can explicitly set a specific number of scheduler replicas to override the default HA behavior or disable the scheduler entirely by setting the `spec.replicas` field to `0`.
+In {product-title} {product-version}, the NUMA Resources Operator automatically enables high availability (HA) mode by default. In this mode, the NUMA Resources Operator creates one scheduler replica for each control-plane node in the cluster to ensure redundancy. This default behavior occurs if the `spec.replicas` field is not specified in the `NUMAResourcesScheduler` custom resource. Alternatively, you can explicitly set a specific number of scheduler replicas to override the default HA behavior or disable the scheduler entirely by setting the `spec.replicas` field to `0`. The maximum number of replicas is 3, even if the number of control plane nodes exceeds 3.
 
 For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-managing-ha-nrop_numa-aware[Managing high availability (HA) for the NUMA-aware scheduler].
 


### PR DESCRIPTION
[TELCODOCS-2270]: topology-aware scheduler: HA by default

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2270
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://100184--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-numa-resources-operator-replicas_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to](https://96669--ocpdocs-pr.netlify.app/openshift-enterprise/latest/network) merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->