### PR TITLE
OSDOCS-15577_a#moving attributes directive above title

### DIFF
--- a/installing/installing_aws/ipi/installing-aws-customizations.adoc
+++ b/installing/installing_aws/ipi/installing-aws-customizations.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="installing-aws-customizations"]
 = Installing a cluster on {aws-short} with customizations
-include::_attributes/common-attributes.adoc[]
 :context: installing-aws-customizations
 :platform: AWS
 


### PR DESCRIPTION
Versions: 
4.20+


Issue:
https://issues.redhat.com/browse/OSDOCS-15577 

Link to docs preview:
[Installing a cluster on AWS with customizations](https://100187--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations.html)

QE review:
N/A

Additional information:
As the variable {aws-short} is used in the assembly title, I'm moving the include attributes directive above the anchor ID - see note in [Assembly file metadata](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#assembly-file-metadata). 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
