### PR TITLE
OSDOCS 16446 add API field for new pod scale up delay to ClusterAutoscaler resource

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -42,7 +42,9 @@ spec:
     delayAfterFailure: 30s # <15>
     unneededTime: 5m # <16>
     utilizationThreshold: "0.4" # <17>
-  expanders: ["Random"] # <18>
+  scaleUp: <18>
+    newPodScaleUpDelay: "10s" <19>
+  expanders: ["Random"] # <20>
 ----
 <1> Specify the priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Enter a 32-bit integer value. The `podPriorityThreshold` value is compared to the value of the `PriorityClass` that you assign to each pod.
 <2> Specify the maximum number of nodes to deploy. This value is the total number of machines that are deployed in your cluster, not just the ones that the autoscaler controls. Ensure that this value is large enough to account for all of your control plane and compute machines and the total number of replicas that you specify in your `MachineAutoscaler` resources.
@@ -74,7 +76,9 @@ If you do not specify a value, the default value of `1` is used.
 <17> Optional:  Specify the _node utilization level_. Nodes below this utilization level are eligible for deletion.
 +
 The node utilization level is the sum of the requested resources divided by the allocated resources for the node, and must be a value greater than `"0"` but less than `"1"`. If you do not specify a value, the cluster autoscaler uses a default value of `"0.5"`, which corresponds to 50% utilization. You must express this value as a string.
-<18> Optional: Specify any expanders that you want the cluster autoscaler to use.
+<18> In this section, you can specify the period to wait before recognizing newly pending pods by using any valid link:https://golang.org/pkg/time/#ParseDuration[ParseDuration] interval, including `ns`, `us`, `ms`, `s`, `m`, and `h`. 
+<19> Optional: Specify the period to ignore a new unschedulable pod before adding a new node. If you do not specify a value, the default value of `0s` is used.
+<20> Optional: Specify any expanders that you want the cluster autoscaler to use.
 The following values are valid:
 +
 --


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16446

Preview:
[Cluster autoscaler resource definition](https://100196--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html)
* Added new parameters 18 and 19. Moved the current 18 to 20 with no change. 
* Added new callouts 18 and 19. I tried to mirror the wording in 11 and 13 to 16. Moved the current 18 to 20 with no change. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
