### PR TITLE
CNV-64217: Add verification steps to CLI subscribing module

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -128,6 +128,7 @@ endif::[]
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.20
 :HCOVersion: 4.20.0
+:HCOVersionPrev: 4.19.0
 :CNVNamespace: openshift-cnv
 :CNVOperatorDisplayName: OpenShift Virtualization Operator
 :CNVSubscriptionSpecSource: redhat-operators

--- a/modules/virt-subscribing-cli.adoc
+++ b/modules/virt-subscribing-cli.adoc
@@ -11,12 +11,15 @@ Before you install {VirtProductName}, you must subscribe to the {VirtProductName
 To subscribe, configure `Namespace`, `OperatorGroup`, and `Subscription` objects by applying a single manifest to your cluster.
 
 .Prerequisites
+
 * Install {product-title} {product-version} on your cluster.
-* Install the OpenShift CLI (`oc`).
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
-ifdef::openshift-enterprise[]
+
+ifdef::openshift-enterprise,openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
 . Create a YAML file that contains the following manifest:
 //Note that there are two versions of the following YAML file; the first one is for openshift-enterprise and the second is for openshift-origin (aka OKD).
 +
@@ -52,9 +55,11 @@ spec:
 ----
 <1> Using the `stable` channel ensures that you install the version of
 {VirtProductName} that is compatible with your {product-title} version.
-endif::openshift-enterprise[]
+
+endif::openshift-enterprise,openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifdef::openshift-origin[]
+
 . Create a YAML file that contains the following manifest:
 +
 [source,yaml,subs="attributes+"]
@@ -85,6 +90,7 @@ spec:
 ----
 <1> Using the `stable` channel ensures that you install the version of
 {VirtProductName} that is compatible with your {product-title} version.
+
 endif::openshift-origin[]
 
 . Create the required `Namespace`, `OperatorGroup`, and `Subscription` objects
@@ -92,5 +98,76 @@ for {VirtProductName} by running the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f <file name>.yaml
+$ oc apply -f <filename>.yaml
+----
+
+.Verification
+
+You must verify that the subscription creation was successful before you can proceed with installing {VirtProductName}.
+
+. Check that the `ClusterServiceVersion` (CSV) object was created successfully. Run the following command and verify the output:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc get csv -n {CNVNamespace}
+----
++
+If the CSV was created successfully, the output shows an entry that contains a `NAME` value of `kubevirt-hyperconverged-operator-*`, a `DISPLAY` value of `{VirtProductName}`, and a `PHASE` value of `Succeeded`, as shown in the following example output:
++
+*Example output*
++
+[source,terminal,subs="attributes+"]
+----
+NAME                                       DISPLAY                    VERSION   REPLACES                                   PHASE
+kubevirt-hyperconverged-operator.v{HCOVersion}   {VirtProductName}   {HCOVersion}    kubevirt-hyperconverged-operator.v{HCOVersionPrev}   Succeeded
+----
+
+. Check that the `HyperConverged` custom resource (CR) has the correct version. Run the following command and verify the output:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc get hco -n {CNVNamespace} kubevirt-hyperconverged -o json | jq .status.versions
+----
++
+*Example output*
++
+[source,terminal,subs="attributes+"]
+----
+{
+"name": "operator",
+"version": "{HCOVersion}"
+}
+----
+
+. Verify the `HyperConverged` CR conditions. Run the following command and check the output:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc get hco kubevirt-hyperconverged -n {CNVNamespace} -o json | jq -r '.status.conditions[] | {type,status}'
+----
++
+*Example output*
++
+[source,terminal]
+----
+{
+  "type": "ReconcileComplete",
+  "status": "True"
+}
+{
+  "type": "Available",
+  "status": "True"
+}
+{
+  "type": "Progressing",
+  "status": "False"
+}
+{
+  "type": "Degraded",
+  "status": "False"
+}
+{
+  "type": "Upgradeable",
+  "status": "True"
+}
 ----


### PR DESCRIPTION
Version(s):
4.21 for this PR to `main` - I will manually cherrypick this change back to older versions so that I can include the correct product versions in the example output for each branch.

Issue:
https://issues.redhat.com//browse/CNV-64217

Link to docs preview:
https://100197--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/installing-virt.html#virt-subscribing-cli_installing-virt

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
In this PR I have tried to include what I think is a simplified version of the comments / additions under https://github.com/openshift/openshift-docs/pull/98531

There was a comment from @ousleyp about moving all the install via CLI docs into one module, which I agree is a good idea, but I think is outside the scope of this Jira for now.
