### PR TITLE
CNV#62398: 4.20 RN descheduler profile tp to ga

### DIFF
--- a/virt/release_notes/virt-4-20-release-notes.adoc
+++ b/virt/release_notes/virt-4-20-release-notes.adoc
@@ -69,6 +69,10 @@ This release adds new features and enhancements related to the following compone
 
 [id="virt-4-20-virtualization_{context}"]
 === Virtualization
+
+// CNV-62399
+* The descheduler profile `DevKubeVirtRelieveAndMigrate` has been renamed to `KubeVirtRelieveAndMigrate` and is now generally available. The updated profile improves VM eviction stability during live migrations by enabling background evictions and reducing oscillatory behavior. For more information, see xref:../../virt/managing_vms/advanced_vm_management/virt-enabling-descheduler-evictions.adoc#virt-configuring-descheduler-evictions_virt-enabling-descheduler-evictions[Configuring descheduler evictions for virtual machines].
+
 //CNV-61642
 * You can now use the `kube_application_aware_resourcequota` and `kube_application_aware_resourcequota_creation_timestamp` metrics to query the current usage and creation times of the Application-Aware Quota (AAQ) Operator resources. For more information, see xref:../../virt/monitoring/virt-prometheus-queries.adoc#virt-promql-AAQ-metrics_context[AAQ Operator metrics].
 
@@ -136,9 +140,6 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 //CNV-58005
 * {VirtProductName} is now supported on link:https://learn.microsoft.com/en-us/azure/azure-boost/overview[Azure Boost].
-
-// CNV-58423
-* The `DevKubeVirtRelieveAndMigrate` descheduler profile is xref:../../virt/managing_vms/advanced_vm_management/virt-enabling-descheduler-evictions.adoc#nodes-descheduler-profiles_virt-enabling-descheduler-evictions[now available]. This profile enhances the `LongLifecycle` profile by supporting load-aware descheduling, dynamic soft taints, and improved workload rebalancing.
 
 [id="virt-4-20-bug-fixes_{context}"]
 == Bug fixes


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/CNV-62398

Link to docs preview:
https://100207--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-20-release-notes.html#virt-4-20-virtualization_virt-4-20-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
