### PR TITLE
OSDOCS-16449 added ESO and ZTWIM to 4-20 additional release notes

### DIFF
--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -35,6 +35,8 @@ link:https://docs.redhat.com/en/documentation/red_hat_developer_hub/#Release%20N
 
 E::
 xref:../networking/networking_operators/external_dns_operator/external-dns-operator-release-notes.adoc#external-dns-operator-release-notes[External DNS Operator]
++
+xref:../security/external_secrets_operator/external-secrets-operator-release-notes.adoc#cert-manager-operator-release-notes[{external-secrets-operator}]
 
 F::
 xref:../security/file_integrity_operator/file-integrity-operator-release-notes.adoc#file-integrity-operator-release-notes-v0[File Integrity Operator]
@@ -99,3 +101,6 @@ S::
 xref:../nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc#nodes-secondary-scheduler-release-notes[{secondary-scheduler-operator-full}]
 +
 xref:../security/security_profiles_operator/spo-release-notes.adoc#spo-release-notes[Security Profiles Operator]
+
+Z::
+xref:../security/zero_trust_workload_identity_manager/zero-trust-manager-release-notes.adoc#zero-trust-manager-release-notes[{zero-trust-full}]


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-16449

Link to docs preview:
https://100215--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/addtl-release-notes.html


QE review:
- [ ] QE has approved this change.


Additional information:

