### PR TITLE
CNV-62192: Update namespace name to remove confusion

### DIFF
--- a/modules/virt-creating-udn-namespace-cli.adoc
+++ b/modules/virt-creating-udn-namespace-cli.adoc
@@ -6,14 +6,15 @@
 [id="virt-creating-udn-namespace-cli_{context}"]
 = Creating a namespace for user-defined networks by using the CLI
 
-You can create a namespace to be used with primary user-defined networks (UDNs) by using the CLI.
+You can create a namespace to be used with primary user-defined networks (UDNs) by using the {oc-first}.
 
 .Prerequisites
-* You have access to the cluster as a user with `cluster-admin` permissions.
-* You have installed the OpenShift CLI (`oc`).
 
+* You have access to the cluster as a user with `cluster-admin` permissions.
+* You have installed the {oc-first}.
 
 .Procedure
+
 . Create a `Namespace` object as a YAML file similar to the following example:
 +
 [source,yaml]
@@ -21,7 +22,7 @@ You can create a namespace to be used with primary user-defined networks (UDNs) 
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: udn_namespace
+  name: my-namespace
   labels:
     k8s.ovn.org/primary-user-defined-network: "" # <1>
 # ...
@@ -32,5 +33,5 @@ metadata:
 +
 [source, terminal]
 ----
-oc apply -f <filename>.yaml
+$ oc apply -f <filename>.yaml
 ----


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/CNV-62192

Link to docs preview:
https://100222--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-primary-udn.html#virt-creating-udn-namespace-cli_virt-connecting-vm-to-primary-udn

QE review:
Not required, just changing an example value to match other modules, doesn't change meaning of the docs.

Additional information:
Peer reviewed by @aspauldi :)
