### PR TITLE
OSDOCS-16442:Reduced overly permissive permissions in OSD-GCP docs

### DIFF
--- a/modules/ccs-gcp-iam.adoc
+++ b/modules/ccs-gcp-iam.adoc
@@ -70,7 +70,7 @@ The `sd-sre-platform-gcp-access` Google group is granted access to the GCP proje
 
 [NOTE]
 ====
-* For information regarding the roles within the `sd-sre-platform-gcp-access`  group that are specific to clusters created when using the Workload Identity Federation (WIF) authentication type, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.17/vanilla.yaml[managed-cluster-config].
+* For information regarding the roles within the `sd-sre-platform-gcp-access`  group that are specific to clusters created when using the Workload Identity Federation (WIF) authentication type, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.19/vanilla.yaml[managed-cluster-config].
 * For information about creating a cluster using the Workload Identity Federation authentication type, see _Additional resources_.
 ====
 The following roles are attached to the group:

--- a/modules/create-wif-cluster-cli.adoc
+++ b/modules/create-wif-cluster-cli.adoc
@@ -84,7 +84,7 @@ Creating and managing workload identity pools and providers in a dedicated proje
 2024/09/26 13:05:52 IAM service account cloud-credential-operator-oeub created
 2024/09/26 13:05:52 IAM service account openshift-cloud-network-c-oeub created
 2024/09/26 13:05:53 IAM service account openshift-ingress-gcp-oeub created
-2024/09/26 13:05:55 Role "osd_deployer_v4.18" updated
+2024/09/26 13:05:55 Role "osd_deployer_v4.19" updated
 ----
 --
 +
@@ -101,6 +101,11 @@ $ ocm gcp create wif-config --name <wif_name> \ <1>
 +
 Once the WIF is configured, the following service accounts, roles, and groups are created.
 +
+[NOTE]
+====
+Red{nbsp}Hat custom roles are versioned with every OpenShift y-stream release, for example 4.19.
+====
++
 .WIF configuration service accounts, group and roles
 [cols="2a,3a",options="header"]
 |===
@@ -110,8 +115,7 @@ Once the WIF is configured, the following service accounts, roles, and groups ar
 
 
 |osd-deployer
-|osd_deployer_v4.18
-
+|osd_deployer_v<y-stream-version>
 
 |osd-control-plane
 |- compute.instanceAdmin
@@ -124,35 +128,34 @@ Once the WIF is configured, the following service accounts, roles, and groups ar
 - compute.viewer
 
 |cloud-credential-operator-gcp-ro-creds
-|cloud_credential_operator_gcp_ro_creds_v{product-version}
+|cloud_credential_operator_gcp_ro_creds_v<y-stream-version>
 
 |openshift-cloud-network-config-controller-gcp
-|openshift_cloud_network_config_controller_gcp_v{product-version}
+|openshift_cloud_network_config_controller_gcp_v<y-stream-version>
 
 |openshift-gcp-ccm
-|openshift_gcp_ccm_v{product-version}
+|openshift_gcp_ccm_v<y-stream-version>
 
 |openshift-gcp-pd-csi-driver-operator
 |- compute.storageAdmin
 - iam.serviceAccountUser
 - resourcemanager.tagUser
-- openshift_gcp_pd_csi_driver_operator_v{product-version}
+- openshift_gcp_pd_csi_driver_operator_v<y-stream-version>
 
 |openshift-image-registry-gcp
-|openshift_image_registry_gcs_v{product-version}
+|openshift_image_registry_gcs_v<y-stream-version>
 
 |openshift-ingress-gcp
-|openshift_ingress_gcp_v{product-version}
+|openshift_ingress_gcp_v<y-stream-version>
 
 |openshift-machine-api-gcp
-|openshift_machine_api_gcp_v{product-version}
+|openshift_machine_api_gcp_v<y-stream-version>
 
 |Access via SRE group:sd-sre-platform-gcp-access
 |sre_managed_support
-
 |===
 
-For further details about WIF configuration roles and their assigned permissions, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.18/vanilla.yaml[managed-cluster-config].
+For the complete list of WIF configuration roles and their assigned permissions, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.19/vanilla.yaml[managed-cluster-config].
 
 [id="create-wif-cluster_{context}"]
 == Creating a WIF cluster
@@ -246,8 +249,32 @@ Updating a WIF configuration is only applicable for y-stream updates. For an ove
 ====
 Before upgrading a WIF-enabled {product-title} cluster to a newer version, you must update the wif-config to that version as well. If you do not update the wif-config version before attempting to upgrade the cluster version, the cluster version upgrade will fail.
 
-You can update a wif-config to a specific {product-title} version by running the following command:
+As part of Red{nbsp}Hat's ongoing commitment to the principle of least privilege, certain permissions previously assigned to the `osd-deployer` service account in WIF configurations have been removed. These changes help enhance the security of your clusters by ensuring that service accounts have only the permissions they need to perform their functions.
 
+For the complete list of WIF configuration roles and their assigned permissions, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.19/vanilla.yaml[managed-cluster-config].
+
+To align your existing WIF configurations with these updated permissions, you can run the `ocm gcp update wif-config` command. This command updates the WIF configuration to include the latest permissions and roles required for optimal operation.
+
+When you update a wif-config or create a new one, ensure your {cluster-manager} CLI (`ocm`) is up to date. Not updating to the latest version of the `ocm` can result in error messages and service disruptions.
+
+.Example output
+[source,text]
+----
+Error: failed to create wif-config: failed to create wif-config: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400', at '2025-10-06T15:18:37Z' and operation identifier is 'f9551d63-a58a-4e3c-b847-5f99ba1b0b74': Client version is out of date for WIF operations. Please update from vOCM-CLI/1.0.7 to v1.0.8 and try again.
+----
+
+.Procedure
+. To check the version of your `ocm`, run the following command:
++
+[source,terminal]
+----
+$ ocm version
+----
++
+. Optional: If your `ocm` version is not the latest available, download and install the latest version from the link:https://console.redhat.com/openshift/downloads[Downloads] page on {cluster-manager}.
++
+. Update a wif-config to a specific {product-title} version by running the following command:
++
 [source,terminal]
 ----
 ocm gcp update wif-config <wif_name> \ <1>
@@ -255,6 +282,90 @@ ocm gcp update wif-config <wif_name> \ <1>
 ----
 <1> Replace `<wif_name>` with the name of the WIF configuration you want to update.
 <2> Optional: Replace `<version>` with the {product-title} y-stream version you plan to update the cluster to. If you do not specify a version, the wif-config will be updated to support the latest {product-title} y-stream version as well as the last three {product-title} supported y-stream versions (beginning with version 4.17).
+
+[id="wif-removing-stale-permissions_{context}"]
+== Removing stale permissions from service accounts managed by a WIF configuration
+
+The stale set of permissions previously assigned to the `osd-deployer` service account will remain on the account after updating the wif-config. You need to manually access the roles and remove these stale permissions from them.
+
+[id="wif-removing-stale-deployer-permissions_{context}"]
+=== Removing stale deployer permissions from service accounts managed by a WIF configuration
+
+To remove the stale deployer permissions, run the following commands on a terminal with access to the Google Cloud project hosting the service accounts.
+
+.Procedure
+
+. Retrieve the existing role definition, ensuring the `PROJECT_ID` environment variable points to your Google Cloud project:
++
+[source,terminal]
+----
+$ gcloud iam roles describe \
+  osd_deployer_v4.18 \
+  --project $PROJECT_ID \
+  --format=yaml > /tmp/role.yaml
+----
++
+. Remove the unwanted permissions. You can do this by filtering out the unwanted permissions from the role definition file and saving the updated definition to a new file:
++
+[source,terminal]
+----
+$ cat /tmp/role.yaml | \
+grep -v "resourcemanager.projects.setIamPolicy" | \
+grep -v "iam.serviceAccounts.signBlob" | \
+grep -v "iam.serviceAccounts.actAs" > /tmp/updated_role.yaml
+----
++
+. Review the changes in the output between the original and updated role definitions to ensure only the unwanted permissions have been removed:
++
+[source,terminal]
+----
+$ diff /tmp/role.yaml /tmp/updated_role.yaml
+----
++
+. Update the role in Google Cloud with the updated role definition file, ensuring the `PROJECT_ID` environment variable points to your Google Cloud project:
++
+[source,terminal]
+----
+$ gcloud iam roles update \
+  osd_deployer_v4.18 \
+  --project=$PROJECT_ID \
+  --file=/tmp/updated_role.yaml
+----
+
+[id="wif-removing-stale-support-permissions_{context}"]
+=== Removing stale support permissions from service accounts managed by a WIF configuration
+
+To remove stale support permissions, run the following commands on a terminal with access to the Google Cloud project hosting the service accounts.
+
+.Procedure
+
+. Retrieve the existing role defintion, ensuring the `PROJECT_ID` environment variable points to your Google Cloud project:
++
+[source,terminal]
+----
+$ gcloud iam roles describe sre_managed_support --project $PROJECT_ID --format=yaml > /tmp/role.yaml
+----
++
+. Remove the unwanted permissions. You can do this by filtering out the unwanted permissions from the role definition file and saving the updated definition to a new file:
++
+[source,terminal]
+----
+$ cat /tmp/role.yaml | grep -v "compute.firewalls.create"  > /tmp/updated_role.yaml
+----
++
+. Review the changes in the output between the original and updated role definitions to ensure only the unwanted permissions have been removed:
++
+[source,terminal]
+----
+$ diff /tmp/role.yaml /tmp/updated_role.yaml
+----
++
+. Update the role in Google Cloud with the updated role definition file, ensuring the `PROJECT_ID` environment variable points to your Google Cloud project:
++
+[source,terminal]
+----
+$ gcloud iam roles update sre_managed_support --project $PROJECT_ID --file=/tmp/updated_role.yaml
+----
 
 [id="ocm-cli-verify-wif-commands_{context}"]
 == Verifying a WIF configuration

--- a/modules/gcp-limits.adoc
+++ b/modules/gcp-limits.adoc
@@ -21,7 +21,7 @@ A standard {product-title} cluster uses the following resources. Note that some 
 |Resources removed after bootstrap
 
 
-|Service account |IAM	|Global	|5 |0
+|Service account |IAM	|Global	|10 |0
 |Firewall Rules	|Compute	|Global	|11 |1
 |Forwarding Rules	|Compute	|Global	|2	|0
 |In-use global IP addresses	|Compute	|Global	|4	|1

--- a/osd_whats_new/osd-whats-new.adoc
+++ b/osd_whats_new/osd-whats-new.adoc
@@ -17,11 +17,21 @@ With its foundation in Kubernetes, {product-title} is a complete {OCP} cluster p
 
 [id="osd-q3-2025_{context}"]
 === Q3 2025
+
+* **Updates to Workload Identity Federation (WIF) permissions and roles.**
+The default IAM permissions for WIF in the link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.19/vanilla.yaml[managed-cluster-config] template have been updated. This means newly created WIF configurations will have fewer, less overly permissive permissions by default.
+** The `sd-sre-platform-gcp-access@redhat.com` principal no longer needs the `compute.firewalls.create` permission. If Red{nbsp}Hat SREs ever need this permission, they will reach out through a support case.
+** The `osd-deployer` service account no longer requires the `resourcemanager.projects.setIamPolicy` permission, which has been removed.
+** The `osd-deployer` service account no longer uses the `iam.serviceAccounts.signBlob` permission. This has been replaced with the `iam.serviceAccountTokenCreator` role, which is now specifically assigned to the service accounts that require it.
+** The `osd-deployer` service account no longer uses the `iam.serviceAccounts.actAs` permission. This has been replaced with the `iam.serviceAccountUser` role, which is now specifically assigned to the service accounts that require it.
+
+If you have existing `wif-config` instances, you can get these new, less permissive permissions by running the `ocm gcp update wif-config` command. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#wif-configuration-update_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Updating a WIF configuration].
+
 * **Workload Identify Federation (WIF) is now the default authentication type for {product-title} clusters on {GCP}.**
 In alignment with the principle of least privilege as well as Google Cloud's preferred method of credential authentication, WIF is now the default authentication type when creating an {product-title} cluster on {GCP}. WIF greatly improves an {product-title} cluster's resilience against unauthorized access by using short-lived, least-privilege credentials and eliminating the need for static service account keys. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc[Creating a cluster on GCP with Workload Identity Federation authentication].
 
 * **Support for managing workload identity pools and providers in a dedicated {GCP} project.**
-{product-title} on {GCP} now supports the option of creating and managing workload identity pools and providers in a specified dedicated project during the creation of a WIF configuration. Red{nbsp}Hat plans on offering this option for existing WIF configurations in an upcoming release. For more information, see  xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-configuration_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a WIF configuration].
+{product-title} on {GCP} now supports the option of creating and managing workload identity pools and providers in a specified dedicated project during the creation of a WIF configuration. Red{nbsp}Hat plans on offering this option for existing WIF configurations in an upcoming release. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-configuration_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a WIF configuration].
 
 
 
@@ -36,8 +46,6 @@ If your cluster uses the OpenShift SDN network plugin, you cannot upgrade to fut
 For more information about migrating to OVN-Kubernetes, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn-osd.adoc#migrate-from-openshift-sdn[Migrating from OpenShift SDN network plugin to OVN-Kubernetes network plugin].
 
 * **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.19 are now available for new clusters.
-// re-add once upgrade to 4.19 is available
-// For more information about upgrading to this latest version, see xref:../upgrading/osd-upgrades.adoc#osd-upgrades[Red Hat OpenShift Dedicated cluster upgrades].
 
 * **Support for enabling and disabling Secure Boot for Shielded VMs on a per machine basis.**
 {product-title} on {GCP} users can now enable or disable Secure Boot for Shielded VMs on a per machine basis. For more information, see xref:../osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.adoc#osd-managing-worker-nodes[Managing compute nodes].


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OSDOCS-16442

Link to docs preview:

- [Updating a WIF configuration](https://100264--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.html#wif-configuration-update_osd-creating-a-cluster-on-gcp-with-workload-identity-federation)
- [What's new](https://100264--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new#osd-q3-2025_osd-whats-new)
- [GCP account limits](https://100264--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs#gcp-limits_gcp-ccs)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [ ] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
