### PR TITLE
[OBSDOCS-1401_6-3] Include notice about req log store version for 6.3

### DIFF
--- a/installing/installing-logging.adoc
+++ b/installing/installing-logging.adoc
@@ -19,7 +19,8 @@ You can use either the {ocp-product-title} web console or the {ocp-product-title
 
 [IMPORTANT]
 ====
-You must configure the {clo} after the {loki-op}.
+* You must configure the {clo} after the {loki-op}.
+* You must install the {clo} and the {loki-op} with the same major and minor version.
 ====
 
 

--- a/upgrading/upgrading-to-logging-60.adoc
+++ b/upgrading/upgrading-to-logging-60.adoc
@@ -69,7 +69,8 @@ The only managed log storage solution available in this release is a LokiStack, 
 
 [IMPORTANT]
 ====
-To continue using an existing Red{nbsp}Hat-managed Elasticsearch or Kibana deployment provided by the `elasticsearch-operator`, remove the owner references from the `Elasticsearch` resource named `elasticsearch`, and  the `Kibana` resource named `kibana` in the `openshift-logging` namespace before removing the `ClusterLogging` resource named `instance` in the same namespace.
+* You must install the {clo} and the {loki-op} with the same major and minor version.
+* To continue using an existing Red{nbsp}Hat-managed Elasticsearch or Kibana deployment provided by the `elasticsearch-operator`, remove the owner references from the `Elasticsearch` resource named `elasticsearch`, and  the `Kibana` resource named `kibana` in the `openshift-logging` namespace before removing the `ClusterLogging` resource named `instance` in the same namespace.
 ====
 
 To upgrade Loki storage, follow these steps:


### PR DESCRIPTION
Version(s):
_none for cherry-picking_

Issue:
- https://issues.redhat.com/browse/OBSDOCS-1401

Link to docs preview:
- [Installing](https://100265--ocpdocs-pr.netlify.app/openshift-logging/latest/installing/installing-logging.html)
- [Upgrading log storage](https://100265--ocpdocs-pr.netlify.app/openshift-logging/latest/upgrading/upgrading-to-logging-60.html#log-storage_upgrading-to-logging-6)

QE review:
- [x] QE has approved this change - inherited from the parent [PR](https://github.com/openshift/openshift-docs/pull/99602)