### PR TITLE
OSDOCS#16350: Create RN for hitless TLS certificate rotation

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -915,6 +915,11 @@ With this release, you can use the `PerformanceProfile` custom resource to confi
 
 With this release, you can use the `PerformanceProfile` custom resource to configure worker nodes on machines equipped with AMD Turin CPUs. These CPUs are fully supported when configured with a single NUMA domain (NPS=1).
 
+[id="ocp-release-notes-hitless-tls-certificate-rotation_{context}"]
+==== Hitless TLS certificate rotation for the Kubernetes API
+
+This new feature enhances TLS certificate rotations in {product-title}, ensuring 95% expected cluster availability. It is particularly beneficial for high-transaction-rate clusters and {sno} deployments, ensuring seamless operation even under heavy loads.
+
 [id="ocp-release-notes-security_{context}"]
 === Security
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-16350](https://issues.redhat.com/browse/OSDOCS-16350)

Link to docs preview:
[Hitless TLS certificate rotation for the Kubernetes API](https://100284--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-hitless-tls-certificate-rotation_release-notes)

QE review:
- [x] QE has approved this change.

Additional information:

I was unsure of where to place this release note. Considering it's for the API server and relates to expected cluster availability, I placed it under "Scalability and performance". Please let me know if there's a more appropriate location.