### PR TITLE
OSDOCS-16223_RN#extending Metal3 firmware updates release note

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -504,6 +504,12 @@ With this release, you can install a bare-metal environment that supports multi-
 
 For more information, see xref:../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc#configuring-your-cluster-with-multi-architecture-compute-machines[Configuring your cluster with multi-architecture compute machines].
 
+[id="ocp-release-notes-installation-nic-firmware-updates_{context}"]
+==== Support for updating the host firmware components of NICs for bare metal
+With this release, the `HostFirmwareComponents` resource for bare metal describes network interface controllers (NICs). To update NIC host firmware components, the server must support Redfish and must permit you to use Redfish to update NIC firmware.
+
+For more information, see xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bmo-about-the-hostfirmwarecomponents-resource_bare-metal-postinstallation-configuration[About the HostFirmwareComponents resource].
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 === Machine Config Operator
 
@@ -670,10 +676,10 @@ Previously, creating an SR-IOV network required a cluster administrator to confi
 For more information, see xref:../networking/hardware_networks/configuring-namespaced-sriov-resources.html#configuring-namespaced-sriov-resources[Configuring namespaced SR-IOV resources].
 
 [id="ocp-4-20-unnumbered-bgp-peering_{context}"]
-==== Unnumbered BGP peering 
+==== Unnumbered BGP peering
 
 With this release, {product-title} includes unnumbered BGP peering.
-This was previously available as a Technology Preview feature. 
+This was previously available as a Technology Preview feature.
 You can use the `spec.interface` field of the BGP peer custom resource to configure unnumbered BGP peering.
 
 For more information, see xref:../networking/ingress_load_balancing/metallb/metallb-frr-k8s.adoc#nw-metallb-frrconfiguration-crd-interface[Configuring the integration of MetalLB and FRR-K8s ].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version:
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-16223

Link to docs preview:
[Support for updating the host firmware components of NICs for bare metal](https://100289--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-installation-nic-firmware-updates_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
