### PR TITLE
OCPBUGS-59964-416: Documented configuring dual-stack networking for an Eg…

### DIFF
--- a/modules/nw-egress-ips-object-dual-stack.adoc
+++ b/modules/nw-egress-ips-object-dual-stack.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-egress-ips-object-dual-stack_{context}"]
+= Configuring dual-stack networking for an EgressIP object
+
+For a cluster configured for dual-stack networking, you can apply dual-stack networking to a single `EgressIP` object. The `EgressIP` object can then extend dual-stack networking capabilities to a pod.
+
+////
+[IMPORTANT]
+====
+KNOWN ISSUE FROM https://issues.redhat.com/browse/OCPBUGS-61833
+====
+////
+
+[IMPORTANT]
+====
+Red{nbsp}Hat does not support creating two `EgressIP` objects to represent dual-stack networking capabilities. For example, specifying IPv4 addresses with one object and using another object to specify IPv6 addresses. This configuration limit impacts address-type assignments to pods. 
+====
+
+.Prerequisites
+
+* You created two egress nodes so that an `EgressIP` object can allocate IPv4 addresses to one node and IPv6 addresses to the other node. For more information, see "Assignment of egress IP addresses to nodes".
+
+.Procedure
+
+* Create an `EgressIP` object and configure IPv4 and IPv6 addresses for the object. The following example `EgressIP` object uses selectors to identify which pods use the specified egress IP addresses for their outbound traffic:
++
+[source,yaml]
+----
+kind: EgressIP
+metadata:
+  name: egressip-dual
+spec:
+  egressIPs:
+    - 192.168.118.30
+    - 2600:52:7:94::30
+  namespaceSelector:
+    matchLabels:
+      env: qa
+  podSelector:
+    matchLabels:
+      egressip: ds  
+# ...
+----
+
+.Verification
+
+. Create a `Pod` manifest file to test and validate your `EgressIP` object. The pod serves as a client workload that sends outbound traffic to verify that your `EgressIP` policy works as expected. 
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ubi-egressip-pod
+  namespace: test
+  labels:
+    egressip: ds
+spec:
+  containers:
+  - name: fedora-curl
+    image: registry.redhat.io/ubi9/ubi
+    command: ["/bin/bash", "-c", "sleep infinity"]
+# ...
+----
++
+--
+where:
+
+`<labels>`:: Sets custom identifiers so that the `EgressIP` object can use these labels to apply egress IP address to target pods.
+--
+
+. Run a `curl` request from inside a pod to an external server. This action verifies that outbound traffic correctly uses an address that you specified in the `EgressIP` object.
++
+[source,source]
+----
+$ curl <ipv_address>
+----
++
+--
+where:
+
+`<ipv_address>`:: Depending on the `EgressIP` object, enter an IPv4 or IPv6 address.
+--

--- a/modules/nw-egress-ips-object.adoc
+++ b/modules/nw-egress-ips-object.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="nw-egress-ips-object_{context}"]
 = EgressIP object
 

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -21,6 +21,9 @@ include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 include::modules/nw-egress-ips-object.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa[]
+// Configuring dual-stack networking for an EgressIP object
+include::modules/nw-egress-ips-object-dual-stack.adoc[leveloffset=+1]
+
 // The egressIPConfig object
 include::modules/nw-egress-ips-config-object.adoc[leveloffset=+1]
 endif::openshift-rosa[]


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OCPBUGS-59964](https://issues.redhat.com/browse/OCPBUGS-59964)
[ECOENGCL-402](https://issues.redhat.com/browse/ECOENGCL-402)

Link to docs preview:
* [Configuring dual-stack networking for an EgressIP object](https://98803--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-object-dual-stack_configuring-egress-ips-ovn)
* [ROSA docs](https://98803--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html)

- [x] SME has approved this change (El Hadji, Carlos G., Martin K.).
- [x] QE has approved this change (Jean Chen).

Additional Jira to note (created after OCPBUGS-59964): https://issues.redhat.com/browse/OCPBUGS-61833