### PR TITLE
OSDOCS Add link to MCO, Node, Custom Autoscaler release notes

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -700,16 +700,12 @@ By using the in-place pod resizing feature, you can apply a resize policy to cha
 [id="ocp-release-notes-machine-config-operator-mount-oci_{context}"]
 ==== Mounting an OCI image into a pod
 
-You can you use an image volume to mount an Open Container Initiative (OCI)-compliant container image or artifact directly into a pod.
-
-// Activate link when assembly/module is available: For more information, see ../nodes/pods/nodes-pods-image-volume.adoc#odes-pods-image-volume[Mounting an OCI image into a pod].
+You can you use an image volume to mount an Open Container Initiative (OCI)-compliant container image or artifact directly into a pod. For more information, see xref:../nodes/pods/nodes-pods-image-volume.adoc#odes-pods-image-volume[Mounting an OCI image into a pod].
 
 [id="ocp-release-notes-machine-config-operator-allocate-gpu_{context}"]
 ==== Allocating specific GPUs to pods (Technology Preview)
 
-You can now enable pods to request GPUs based on specific device attributes, such as product name, GPU memory capacity, compute capability, vendor name, and driver version. These attributes are exposed by the by using a third-party DRA resource driver that you install.
-
-// Activate link when assembly/module is available: For more information, see /nodes/pods/nodes-pods-allocate-dra.adoc#nodes-pods-allocate-dra[Allocating GPUs to pods].
+You can now enable pods to request GPUs based on specific device attributes, such as product name, GPU memory capacity, compute capability, vendor name, and driver version. These attributes are exposed by the by using a third-party DRA resource driver that you install. For more information, see xref:../nodes/pods/nodes-pods-allocate-dra.adoc#nodes-pods-allocate-dra[Allocating GPUs to pods].
 
 [id="ocp-release-notes-openshift-cli_{context}"]
 === OpenShift CLI (oc)


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-docs/pull/100081. Adding a link to Allocating specific GPUs to pods.

Link to docs preview:
[Mounting an OCI image into a pod](https://100359--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-machine-config-operator-mount-oci_release-notes) -- Added the _For more information_ link. Existing text previously reviewed.
[Allocating specific GPUs to pods](https://100359--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-machine-config-operator-in-place_release-notes) -- Added the _For more information_ link. Existing text previously reviewed.