### PR TITLE
Add auto-generated ROSA CLI command ref

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -522,6 +522,8 @@ Topics:
   #   File: rosa-cli-openshift-console
   - Name: Getting started with the ROSA CLI
     File: rosa-get-started-cli
+  - Name: ROSA CLI command reference
+    File: rosa-cli-commands
   - Name: Managing objects with the ROSA CLI
     File: rosa-manage-objects-cli
   - Name: Checking account and version information with the ROSA CLI

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -314,16 +314,18 @@ Topics:
   #   File: rosa-cli-openshift-console
   - Name: Getting started with the ROSA CLI
     File: rosa-get-started-cli
-  - Name: Managing objects with the ROSA CLI
-    File: rosa-manage-objects-cli
-  - Name: Checking account and version information with the ROSA CLI
-    File: rosa-checking-acct-version-cli
-  - Name: Checking logs with the ROSA CLI
-    File: rosa-checking-logs-cli
+  - Name: ROSA CLI command reference
+    File: rosa-cli-commands
+  #- Name: Managing objects with the ROSA CLI
+  #  File: rosa-manage-objects-cli
+  #- Name: Checking account and version information with the ROSA CLI
+  #  File: rosa-checking-acct-version-cli
+  #- Name: Checking logs with the ROSA CLI
+  #  File: rosa-checking-logs-cli
   - Name: Least privilege permissions for ROSA CLI commands
     File: rosa-cli-permission-examples
-  - Name: Managing AWS billing accounts with the ROSA CLI
-    File: rosa-updating-billing-account-cli
+  #- Name: Managing AWS billing accounts with the ROSA CLI
+  #  File: rosa-updating-billing-account-cli
 ---
 Name: Red Hat OpenShift Cluster Manager
 Dir: ocm

--- a/adding_service_cluster/rosa-available-services.adoc
+++ b/adding_service_cluster/rosa-available-services.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 You can add services to your existing {product-title} (ROSA) cluster using the xref:../adding_service_cluster/adding-service.adoc#adding-service[{cluster-manager-first} console].
 
-These services can also be installed xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-managing-objects-cli[using the `rosa` CLI].
+These services can also be installed xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-cli-commands[using the `rosa` CLI].
 
 
 include::modules/aws-cloudwatch.adoc[leveloffset=+1]

--- a/cli_reference/rosa_cli/rosa-cli-commands.adoc
+++ b/cli_reference/rosa_cli/rosa-cli-commands.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="rosa-cli-commands"]
+= ROSA CLI command reference
+include::_attributes/common-attributes.adoc[]
+:context: rosa-cli-commands
+
+toc::[]
+
+This reference provides descriptions and example commands for ROSA CLI (`rosa`) commands.
+
+Run `rosa -h` to list all commands or run `rosa <command> --help` to get additional details for a specific command.
+
+// The following file is auto-generated from the openshift/rosa repository
+// ROSA CLI (rosa) commands
+include::modules/rosa-by-example-content.adoc[leveloffset=+1]

--- a/modules/rosa-by-example-content.adoc
+++ b/modules/rosa-by-example-content.adoc
@@ -1,0 +1,1509 @@
+// NOTE: The contents of this file are auto-generated
+:_mod-docs-content-type: REFERENCE
+[id="rosa-cli-commands_{context}"]
+= ROSA CLI commands
+
+
+
+== rosa create account-roles
+Create account-wide IAM roles before creating your cluster.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create default account roles for ROSA clusters using STS
+  rosa create account-roles
+
+  # Create account roles with a specific permissions boundary
+  rosa create account-roles --permissions-boundary arn:aws:iam::123456789012:policy/perm-boundary
+----
+
+
+
+== rosa create admin
+Creates an admin user to login to the cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create an admin user to login to the cluster
+  rosa create admin -c mycluster -p MasterKey123
+----
+
+
+
+== rosa create autoscaler
+Create an autoscaler for a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Interactively create an autoscaler to a cluster named "mycluster"
+  rosa create autoscaler --cluster=mycluster --interactive
+
+  # Create a cluster-autoscaler where it should skip nodes with local storage
+  rosa create autoscaler --cluster=mycluster --skip-nodes-with-local-storage
+
+  # Create a cluster-autoscaler with log verbosity of '3'
+  rosa create autoscaler --cluster=mycluster --log-verbosity 3
+
+  # Create a cluster-autoscaler with total CPU constraints
+  rosa create autoscaler --cluster=mycluster --min-cores 10 --max-cores 100
+----
+
+
+
+== rosa create break-glass-credential
+Create a break glass credential for a cluster.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Interactively create a break glass credential to a cluster named "mycluster"
+  rosa create break-glass-credential --cluster=mycluster --interactive
+----
+
+
+
+== rosa create cluster
+Create cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create a cluster named "mycluster"
+  rosa create cluster --cluster-name=mycluster
+
+  # Create a cluster in the us-east-2 region
+  rosa create cluster --cluster-name=mycluster --region=us-east-2
+----
+
+
+
+== rosa create decision
+Create a decision for an Access Request
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create a decision for an Access Request to approve it
+  rosa create decision --access-request <access_request_id> --decision Approved
+----
+
+
+
+== rosa create dns-domain
+Create DNS Domain.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create DNS Domain
+	rosa create dns-domain
+----
+
+
+
+== rosa create external-auth-provider
+Create an external authentication provider for a cluster.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Interactively create an external authentication provider to a cluster named "mycluster"
+  rosa create external-auth-provider --cluster=mycluster --interactive
+----
+
+
+
+== rosa create iamserviceaccount
+Create IAM role for Kubernetes service account
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create an IAM role for a service account
+  rosa create iamserviceaccount --cluster my-cluster --name my-app --namespace default
+----
+
+
+
+== rosa create idp
+Add IDP for cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Add a GitHub identity provider to a cluster named "mycluster"
+  rosa create idp --type=github --cluster=mycluster
+
+  # Add an identity provider following interactive prompts
+  rosa create idp --cluster=mycluster --interactive
+----
+
+
+
+== rosa create image-mirror
+Create image mirror for a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create an image mirror for cluster "mycluster"
+  rosa create image-mirror --cluster=mycluster \
+    --source=registry.example.com/team \
+    --mirrors=mirror.corp.com/team,backup.corp.com/team
+
+  # Create with a specific type (digest is default and only supported type)
+  rosa create image-mirror --cluster=mycluster \
+    --type=digest --source=docker.io/library \
+    --mirrors=internal-registry.company.com/dockerhub
+----
+
+
+
+== rosa create kubeletconfig
+Create a custom kubeletconfig for a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create a custom kubeletconfig with a pod-pids-limit of 5000
+  rosa create kubeletconfig --cluster=mycluster --pod-pids-limit=5000
+----
+
+
+
+== rosa create machinepool
+Add machine pool to cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Interactively add a machine pool to a cluster named "mycluster"
+  rosa create machinepool --cluster=mycluster --interactive
+  # Add a machine pool mp-1 with 3 replicas of m5.xlarge to a cluster
+  rosa create machinepool --cluster=mycluster --name=mp-1 --replicas=3 --instance-type=m5.xlarge
+  # Add a machine pool mp-1 with autoscaling enabled and 3 to 6 replicas of m5.xlarge to a cluster
+  rosa create machinepool --cluster=mycluster --name=mp-1 --enable-autoscaling \
+	--min-replicas=3 --max-replicas=6 --instance-type=m5.xlarge
+  # Add a machine pool with labels to a cluster
+  rosa create machinepool -c mycluster --name=mp-1 --replicas=2 --instance-type=r5.2xlarge --labels=foo=bar,bar=baz,
+  # Add a machine pool with spot instances to a cluster
+  rosa create machinepool -c mycluster --name=mp-1 --replicas=2 --instance-type=r5.2xlarge --use-spot-instances \
+    --spot-max-price=0.5
+  # Add a machine pool to a cluster and set the node drain grace period
+  rosa create machinepool -c mycluster --name=mp-1 --node-drain-grace-period="90 minutes"
+----
+
+
+
+== rosa create network
+Network AWS cloudformation stack
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create a AWS cloudformation stack
+  rosa create network <template-name> --param Param1=Value1 --param Param2=Value2 
+
+  # ROSA quick start HCP VPC example with one availability zone
+  rosa create network rosa-quickstart-default-vpc --param Region=us-west-2 --param Name=quickstart-stack --param AvailabilityZoneCount=1 --param VpcCidr=10.0.0.0/16
+
+  # ROSA quick start HCP VPC example with two explicit availability zones
+  rosa create network rosa-quickstart-default-vpc --param Region=us-west-2 --param Name=quickstart-stack --param AZ1=us-west-2b --param AZ2=us-west-2d --param VpcCidr=10.0.0.0/16
+
+  # To delete the AWS cloudformation stack
+  aws cloudformation delete-stack --stack-name <name> --region <region>
+
+# TEMPLATE_NAME:
+Specifies the name of the template to use. This should match the name of a directory 
+under the path specified by '--template-dir' or the 'OCM_TEMPLATE_DIR' environment variable.
+The directory should contain a YAML file defining the custom template structure.
+
+If no TEMPLATE_NAME is provided, or if no matching directory is found, the default 
+built-in template 'rosa-quickstart-default-vpc' will be used.
+----
+
+
+
+== rosa create ocm-role
+Create role used by OCM
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create default ocm role for ROSA clusters using STS
+  rosa create ocm-role
+
+  # Create ocm role with a specific permissions boundary
+  rosa create ocm-role --permissions-boundary arn:aws:iam::123456789012:policy/perm-boundary
+----
+
+
+
+== rosa create oidc-config
+Create OIDC config compliant with OIDC protocol.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create OIDC config
+	rosa create oidc-config
+----
+
+
+
+== rosa create oidc-provider
+Create OIDC provider for an STS cluster.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create OIDC provider for cluster named "mycluster"
+  rosa create oidc-provider --cluster=mycluster
+----
+
+
+
+== rosa create operator-roles
+Create operator IAM roles for a cluster.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create default operator roles for cluster named "mycluster"
+  rosa create operator-roles --cluster=mycluster
+
+  # Create operator roles with a specific permissions boundary
+  rosa create operator-roles -c mycluster --permissions-boundary arn:aws:iam::123456789012:policy/perm-boundary
+----
+
+
+
+== rosa create tuning-configs
+Add tuning config
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Add a tuning config with name "tuned1" and spec from a file "file1" to a cluster named "mycluster"
+ rosa create tuning-config --name=tuned1 --spec-path=file1 --cluster=mycluster"
+----
+
+
+
+== rosa create user-role
+Create user role to verify account association
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create user roles
+  rosa create user-role
+
+  # Create user role with a specific permissions boundary
+  rosa create user-role --permissions-boundary arn:aws:iam::123456789012:policy/perm-boundary
+----
+
+
+
+== rosa delete account-roles
+Delete Account Roles
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete Account roles"
+  rosa delete account-roles -p prefix
+----
+
+
+
+== rosa delete admin
+Deletes the admin user
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete the admin user
+  rosa delete admin --cluster=mycluster
+----
+
+
+
+== rosa delete autoscaler
+Delete autoscaler for cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete the autoscaler config for cluster named "mycluster"
+  rosa delete autoscaler --cluster=mycluster
+----
+
+
+
+== rosa delete cluster
+Delete cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete a cluster named "mycluster"
+  rosa delete cluster --cluster=mycluster
+----
+
+
+
+== rosa delete dns-domain
+Delete DNS domain
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete a DNS domain with ID github-1
+  rosa delete dns-domain github-1
+----
+
+
+
+== rosa delete external-auth-provider
+Delete external authentication provider
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete an external authentication provider named exauth-1
+  rosa delete external-auth-provider exauth-1  --cluster=mycluster
+----
+
+
+
+== rosa delete iamserviceaccount
+Delete IAM role for Kubernetes service account
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete IAM role for service account
+  rosa delete iamserviceaccount --cluster my-cluster \
+    --name my-app \
+    --namespace default
+----
+
+
+
+== rosa delete idp
+Delete cluster IDPs
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete an identity provider named github-1
+  rosa delete idp github-1 --cluster=mycluster
+----
+
+
+
+== rosa delete image-mirror
+Delete image mirror from a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete image mirror with ID "abc123" from cluster "mycluster"
+  rosa delete image-mirror --cluster=mycluster abc123
+
+  # Delete without confirmation prompt
+  rosa delete image-mirror --cluster=mycluster abc123 --yes
+
+  # Alternative: using the --id flag
+  rosa delete image-mirror --cluster=mycluster --id=abc123
+----
+
+
+
+== rosa delete ingress
+Delete cluster ingress
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete ingress with ID a1b2 from a cluster named 'mycluster'
+  rosa delete ingress --cluster=mycluster a1b2
+
+  # Delete secondary ingress using the sub-domain name
+  rosa delete ingress --cluster=mycluster apps2
+----
+
+
+
+== rosa delete kubeletconfig
+Delete a kubeletconfig from a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete the KubeletConfig for ROSA Classic cluster 'foo'
+  rosa delete kubeletconfig --cluster foo
+  # Delete the KubeletConfig named 'bar' from cluster 'foo'
+  rosa delete kubeletconfig --cluster foo --name bar
+----
+
+
+
+== rosa delete machinepool
+Delete machine pool
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete machine pool with ID mp-1 from a cluster named 'mycluster'
+  rosa delete machinepool --cluster=mycluster mp-1
+----
+
+
+
+== rosa delete ocm-role
+Delete OCM role
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete OCM role
+rosa delete ocm-role --role-arn arn:aws:iam::123456789012:role/xxx-OCM-Role-1223456778
+----
+
+
+
+== rosa delete oidc-config
+Delete OIDC Config
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete OIDC config based on registered OIDC Config ID that has been supplied
+	rosa delete oidc-config --oidc-config-id <oidc_config_id>
+----
+
+
+
+== rosa delete oidc-provider
+Delete OIDC Provider
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete OIDC provider for cluster named "mycluster"
+  rosa delete oidc-provider --cluster=mycluster
+----
+
+
+
+== rosa delete operator-roles
+Delete Operator Roles
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete Operator roles for cluster named "mycluster"
+  rosa delete operator-roles --cluster=mycluster
+----
+
+
+
+== rosa delete tuning-configs
+Delete tuning config
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete tuning config with name tuned1 from a cluster named 'mycluster'
+  rosa delete tuning-config --cluster=mycluster tuned1
+----
+
+
+
+== rosa delete user-role
+Delete user role
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete user role
+rosa delete user-role --role-arn {prefix}-User-{username}-Role
+----
+
+
+
+== rosa describe access-request
+Show details of an Access Request
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Describe an Access Request wit id <access_request_id>
+  rosa describe access-request --id <access_request_id>
+----
+
+
+
+== rosa describe addon
+Show details of an add-on
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Describe an add-on named "codeready-workspaces"
+  rosa describe addon codeready-workspaces
+----
+
+
+
+== rosa describe addon-installation
+Show details of an add-on installation
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Describe the 'bar' add-on installation on cluster 'foo'
+  rosa describe addon-installation --cluster foo --addon bar
+----
+
+
+
+== rosa describe admin
+Show details of the cluster-admin user
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Describe cluster-admin user of a cluster named mycluster
+  rosa describe admin -c mycluster
+----
+
+
+
+== rosa describe autoscaler
+Show details of the autoscaler for a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Describe the autoscaler for cluster 'foo'
+rosa describe autoscaler --cluster foo
+----
+
+
+
+== rosa describe break-glass-credential
+Show details of a break glass credential on a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Show details of a break glass credential with ID "12345" on a cluster named "mycluster"
+  rosa describe break-glass-credential 12345 --cluster=mycluster
+----
+
+
+
+== rosa describe cluster
+Show details of a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Describe a cluster named "mycluster"
+  rosa describe cluster --cluster=mycluster
+----
+
+
+
+== rosa describe external-auth-provider
+Show details of an external authentication provider on a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Show details of an external authentication provider named "exauth" on a cluster named "mycluster"
+  rosa describe external-auth-provider exauth --cluster=mycluster
+----
+
+
+
+== rosa describe iamserviceaccount
+Describe IAM role for Kubernetes service account
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Describe IAM role for service account
+  rosa describe iamserviceaccount --cluster my-cluster \
+    --name my-app \
+    --namespace default
+----
+
+
+
+== rosa describe ingress
+Show details of the specified ingress within cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+rosa describe ingress <ingress_id> -c mycluster
+----
+
+
+
+== rosa describe kubeletconfig
+Show details of a kubeletconfig for a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Describe the custom kubeletconfig for ROSA Classic cluster 'foo'
+  rosa describe kubeletconfig --cluster foo
+  # Describe the custom kubeletconfig named 'bar' for cluster 'foo'
+  rosa describe kubeletconfig --cluster foo --name bar
+----
+
+
+
+== rosa describe machinepool
+Show details of a machine pool on a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Show details of a machine pool named "mymachinepool" on a cluster named "mycluster"
+  rosa describe machinepool --cluster=mycluster --machinepool=mymachinepool
+----
+
+
+
+== rosa describe tuning-configs
+Show details of tuning config
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Describe the 'tuned1' tuned config on cluster 'foo'
+  rosa describe tuning-config --cluster foo tuned1
+----
+
+
+
+== rosa describe upgrade
+Show details of an upgrade
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Describe an upgrade-policy"
+  rosa describe upgrade
+----
+
+
+
+== rosa download openshift-client
+Download OpenShift client tools
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Download oc client tools
+  rosa download oc
+----
+
+
+
+== rosa download rosa-client
+Download ROSA client tools
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Download rosa client tools
+  rosa download rosa
+----
+
+
+
+== rosa edit addon
+Edit add-on installation parameters on cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Edit the parameters of the Red Hat OpenShift logging operator add-on installation
+  rosa edit addon --cluster=mycluster cluster-logging-operator
+----
+
+
+
+== rosa edit autoscaler
+Edit the autoscaler of a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Interactively edit an autoscaler to a cluster named "mycluster"
+  rosa edit autoscaler --cluster=mycluster --interactive
+
+  # Edit a cluster-autoscaler to skip nodes with local storage
+  rosa edit autoscaler --cluster=mycluster --skip-nodes-with-local-storage
+
+  # Edit a cluster-autoscaler with log verbosity of '3'
+  rosa edit autoscaler --cluster=mycluster --log-verbosity 3
+
+  # Edit a cluster-autoscaler with total CPU constraints
+  rosa edit autoscaler --cluster=mycluster --min-cores 10 --max-cores 100
+----
+
+
+
+== rosa edit cluster
+Edit cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Edit a cluster named "mycluster" to make it private
+  rosa edit cluster -c mycluster --private
+
+  # Edit a cluster named "mycluster" to enable User Workload Monitoring
+  rosa edit cluster -c mycluster --disable-workload-monitoring=false
+
+  # Edit all options interactively
+  rosa edit cluster -c mycluster --interactive
+----
+
+
+
+== rosa edit image-mirror
+Edit image mirror for a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Update mirrors for image mirror with ID "abc123" on cluster "mycluster"
+  rosa edit image-mirror --cluster=mycluster abc123 \
+    --mirrors=mirror.corp.com/team,backup.corp.com/team,new-mirror.corp.com/team
+
+  # Alternative: using the --id flag
+  rosa edit image-mirror --cluster=mycluster --id=abc123 \
+    --mirrors=mirror.corp.com/team,backup.corp.com/team,new-mirror.corp.com/team
+----
+
+
+
+== rosa edit ingress
+Edit a cluster ingress (load balancer)
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Make additional ingress with ID 'a1b2' private on a cluster named 'mycluster'
+  rosa edit ingress --private --cluster=mycluster a1b2
+
+  # Update the router selectors for the additional ingress with ID 'a1b2'
+  rosa edit ingress --label-match=foo=bar --cluster=mycluster a1b2
+
+  # Update the default ingress using the sub-domain identifier
+  rosa edit ingress --private=false --cluster=mycluster apps
+
+  # Update the load balancer type of the apps2 ingress 
+  rosa edit ingress --lb-type=nlb --cluster=mycluster apps2
+----
+
+
+
+== rosa edit kubeletconfig
+Edit a kubeletconfig for a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Edit a KubeletConfig to have a pod-pids-limit of 10000
+  rosa edit kubeletconfig --cluster=mycluster --pod-pids-limit=10000
+  # Edit a KubeletConfig named 'bar' to have a pod-pids-limit of 10000
+  rosa edit kubeletconfig --cluster=mycluster --name=bar --pod-pids-limit=10000
+----
+
+
+
+== rosa edit machinepool
+Edit machine pool
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Set 4 replicas on machine pool 'mp1' on cluster 'mycluster'
+	rosa edit machinepool --replicas=4 --cluster=mycluster mp1
+	# Enable autoscaling and Set 3-5 replicas on machine pool 'mp1' on cluster 'mycluster'
+	rosa edit machinepool --enable-autoscaling --min-replicas=3 --max-replicas=5 --cluster=mycluster mp1
+	# Set the node drain grace period to 1 hour on machine pool 'mp1' on cluster 'mycluster'
+	rosa edit machinepool --node-drain-grace-period="1 hour" --cluster=mycluster mp1
+----
+
+
+
+== rosa edit tuning-configs
+Edit tuning config
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Update the tuning config with name 'tuning-1' with the spec defined in file1
+  rosa edit tuning-config --cluster=mycluster tuning-1 --spec-path file1
+----
+
+
+
+== rosa grant user
+Grant user access to cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Add cluster-admin role to a user
+  rosa grant user cluster-admin --user=myusername --cluster=mycluster
+
+  # Grant dedicated-admins role to a user
+  rosa grant user dedicated-admin --user=myusername --cluster=mycluster
+----
+
+
+
+== rosa init
+Applies templates to support Red Hat OpenShift Service on AWS
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Configure your AWS account to allow IAM (non-STS) ROSA clusters
+  rosa init
+
+  # Configure a new AWS account using pre-existing OCM credentials
+  rosa init --token=$OFFLINE_ACCESS_TOKEN
+----
+
+
+
+== rosa install addon
+Install add-ons on cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Add the CodeReady Workspaces add-on installation to the cluster
+  rosa install addon --cluster=mycluster codeready-workspaces
+----
+
+
+
+== rosa link ocm-role
+Link OCM role to specific OCM organization.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Link OCM role
+  rosa link ocm-role --role-arn arn:aws:iam::123456789012:role/ManagedOpenshift-OCM-Role
+----
+
+
+
+== rosa link user-role
+Link user role to specific OCM account.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Link user roles
+  rosa link user-role --role-arn arn:aws:iam::{accountid}:role/{prefix}-User-{username}-Role
+----
+
+
+
+== rosa list access-request
+List Access Requests
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all Access Requests for cluster 'foo'
+  rosa list access-request --cluster foo
+----
+
+
+
+== rosa list account-roles
+List account roles and policies
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all account roles
+  rosa list account-roles
+----
+
+
+
+== rosa list addons
+List add-on installations
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all add-on installations on a cluster named "mycluster"
+  rosa list addons --cluster=mycluster
+----
+
+
+
+== rosa list break-glass-credentials
+List break glass credential
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all break glass credentials for a cluster named 'mycluster'"
+  rosa list break-glass-credentials -c mycluster
+----
+
+
+
+== rosa list clusters
+List clusters
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all clusters
+  rosa list clusters
+----
+
+
+
+== rosa list dns-domain
+List DNS Domains
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all DNS Domains tied to your organization ID"
+  rosa list dns-domain
+----
+
+
+
+== rosa list external-auth-providers
+List external authentication provider
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all external authentication providers for a cluster named 'mycluster'"
+  rosa list external-auth-provider -c mycluster
+----
+
+
+
+== rosa list gates
+List available OCP Gates
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all OCP gates for OCP version
+  rosa list gates --version 4.9
+
+  # List all STS gates for OCP version
+  rosa list gates --gate sts --version 4.9
+
+  # List all OCP gates for OCP version
+  rosa list gates --gate ocp --version 4.9
+
+  # List available gates for cluster upgrade version
+  rosa list gates -c <cluster_id> --version 4.9.15
+----
+
+
+
+== rosa list iamserviceaccounts
+List IAM roles for Kubernetes service accounts
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List IAM roles for service accounts
+  rosa list iamserviceaccounts --cluster my-cluster
+----
+
+
+
+== rosa list idps
+List cluster IDPs
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all identity providers on a cluster named "mycluster"
+  rosa list idps --cluster=mycluster
+----
+
+
+
+== rosa list image-mirrors
+List cluster image mirrors
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all image mirrors on a cluster named "mycluster"
+  rosa list image-mirrors --cluster=mycluster
+----
+
+
+
+== rosa list ingresses
+List cluster Ingresses
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all routes on a cluster named "mycluster"
+  rosa list ingresses --cluster=mycluster
+----
+
+
+
+== rosa list instance-types
+List Instance types
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all instance types
+	rosa list instance-types
+----
+
+
+
+== rosa list kubeletconfigs
+List kubeletconfigs
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List the kubeletconfigs for cluster 'foo'
+rosa list kubeletconfig --cluster foo
+----
+
+
+
+== rosa list machinepools
+List cluster machine pools
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all machine pools on a cluster named "mycluster"
+  rosa list machinepools --cluster=mycluster
+  
+  # List machine pools showing all information
+  rosa list machinepools --cluster=mycluster --all
+----
+
+
+
+== rosa list ocm-roles
+List ocm roles
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all ocm roles
+rosa list ocm-roles
+----
+
+
+
+== rosa list oidc-config
+List OIDC Configuration resources
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all OIDC Configurations tied to your organization ID"
+  rosa list oidc-config
+----
+
+
+
+== rosa list oidc-providers
+List OIDC providers
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all oidc providers
+  rosa list oidc-providers
+----
+
+
+
+== rosa list operator-roles
+List operator roles and policies
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all operator roles
+  rosa list operator-roles
+----
+
+
+
+== rosa list regions
+List available regions
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all available regions
+  rosa list regions
+----
+
+
+
+== rosa list tuning-configs
+List tuning configs
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all tuning configuration for a cluster named 'mycluster'"
+  rosa list tuning-configs -c mycluster
+----
+
+
+
+== rosa list user-roles
+List user roles
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all user roles
+rosa list user-roles
+----
+
+
+
+== rosa list users
+List cluster users
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all users on a cluster named "mycluster"
+  rosa list users --cluster=mycluster
+----
+
+
+
+== rosa list versions
+List available versions
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all OpenShift versions
+  rosa list versions
+----
+
+
+
+== rosa login
+Log in to your Red Hat account
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Login to the OpenShift API with an existing token generated from https://console.redhat.com/openshift/token/rosa
+  rosa login --token=$OFFLINE_ACCESS_TOKEN
+----
+
+
+
+== rosa logs
+Show installation or uninstallation logs for a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Show install logs for a cluster named 'mycluster'
+  rosa logs install --cluster=mycluster
+
+  # Show uninstall logs for a cluster named 'mycluster'
+  rosa logs uninstall --cluster=mycluster
+----
+
+
+
+== rosa logs install
+Show cluster installation logs
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Show last 100 install log lines for a cluster named "mycluster"
+  rosa logs install mycluster --tail=100
+
+  # Show install logs for a cluster using the --cluster flag
+  rosa logs install --cluster=mycluster
+----
+
+
+
+== rosa logs uninstall
+Show cluster uninstallation logs
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Show last 100 uninstall log lines for a cluster named "mycluster"
+  rosa logs uninstall mycluster --tail=100
+
+  # Show uninstall logs for a cluster using the --cluster flag
+  rosa logs uninstall --cluster=mycluster
+----
+
+
+
+== rosa register oidc-config
+Registers unmanaged OIDC config with Openshift Clusters Manager.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Register OIDC config
+	rosa register oidc-config
+----
+
+
+
+== rosa revoke break-glass-credentials
+Revoke break glass credentials
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Revoke all break glass credentials
+  rosa revoke break-glass-credentials --cluster=mycluster
+----
+
+
+
+== rosa revoke user
+Revoke role from users
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Revoke cluster-admin role from a user
+  rosa revoke user cluster-admins --user=myusername --cluster=mycluster
+
+  # Revoke dedicated-admin role from a user
+  rosa revoke user dedicated-admins --user=myusername --cluster=mycluster
+----
+
+
+
+== rosa uninstall addon
+Uninstall add-on from cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Remove the CodeReady Workspaces add-on installation from the cluster
+  rosa uninstall addon --cluster=mycluster codeready-workspaces
+----
+
+
+
+== rosa unlink ocm-role
+Unlink ocm role from a specific OCM organization
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+#Unlink ocm role
+rosa unlink ocm-role --role-arn arn:aws:iam::123456789012:role/ManagedOpenshift-OCM-Role
+----
+
+
+
+== rosa unlink user-role
+Unlink user role from a specific OCM account
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Unlink user role
+rosa unlink user-role --role-arn arn:aws:iam::{accountid}:role/{prefix}-User-{username}-Role
+----
+
+
+
+== rosa upgrade account-roles
+Upgrade account-wide IAM roles to the latest version.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Upgrade account roles for ROSA STS clusters
+  rosa upgrade account-roles
+----
+
+
+
+== rosa upgrade cluster
+Upgrade cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Interactively schedule an upgrade on the cluster named "mycluster"
+  rosa upgrade cluster --cluster=mycluster --interactive
+
+  # Schedule a cluster upgrade within the hour
+  rosa upgrade cluster -c mycluster --version 4.12.20
+
+  # Check if any gates need to be acknowledged prior to attempting an upgrading
+  rosa upgrade cluster -c mycluster --version 4.12.20 --dry-run
+----
+
+
+
+== rosa upgrade machinepool
+Upgrade machinepool
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Interactively schedule an upgrade on the cluster named "mycluster"" for a machinepool named "np1"
+  rosa upgrade machinepool np1 --cluster=mycluster --interactive
+
+  # Schedule a machinepool upgrade within the hour
+  rosa upgrade machinepool np1 -c mycluster --version 4.12.20
+----
+
+
+
+== rosa upgrade operator-roles
+Upgrade operator IAM roles for a cluster.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Upgrade cluster-specific operator IAM roles
+  rosa upgrade operators-roles
+----
+
+
+
+== rosa upgrade roles
+Upgrade cluster-specific IAM roles to the latest version.
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Upgrade cluster roles for ROSA STS clusters
+		rosa upgrade roles -c <cluster_key>
+----
+
+
+
+== rosa verify network
+Verify VPC subnets are configured correctly
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Verify two subnets
+	rosa verify network --subnet-ids subnet-03046a9b92b5014fb,subnet-03046a9c92b5014fb
+----
+
+
+
+== rosa verify openshift-client
+Verify OpenShift client tools
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Verify oc client tools
+  rosa verify oc
+----
+
+
+
+== rosa verify permissions
+Verify AWS permissions are ok for non-STS cluster install
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Verify AWS permissions are configured correctly
+  rosa verify permissions
+
+  # Verify AWS permissions in a different region
+  rosa verify permissions --region=us-west-2
+----
+
+
+
+== rosa verify quota
+Verify AWS quota is ok for cluster install
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Verify AWS quotas are configured correctly
+  rosa verify quota
+
+  # Verify AWS quotas in a different region
+  rosa verify quota --region=us-west-2
+----
+
+
+
+== rosa verify rosa-client
+Verify ROSA client tools
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Verify rosa client tools
+  rosa verify rosa
+----
+
+
+
+== rosa whoami
+Displays user account information
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Displays user information
+  rosa whoami
+----
+
+

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc
@@ -47,8 +47,8 @@ include::modules/rosa-hcp-sts-example-external-auth-provider.adoc[leveloffset=+2
 * link:https://learn.microsoft.com/en-us/entra/fundamentals/whatis[What is Microsoft Entra ID?] (Microsoft documentation)
 * xref:../cloud_experts_tutorials/cloud-experts-entra-id-idp.adoc#cloud-experts-entra-id-idp[Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider]
 * link:https://www.keycloak.org/guides[Keycloak documentaton]
-* For information about the similar `idps` tool in the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-idp_rosa-managing-objects-cli[`create idp`].
-* For more information about options in the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-external-auth-provider_rosa-managing-objects-cli[`create external-auth-provider`], xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-list-external-auth-provider_rosa-managing-objects-cli[`list external-auth-provider`], and xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-delete-external-auth-provider_rosa-managing-objects-cli[`delete external-auth-provider`].
+* For information about the similar `idps` tool in the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-create-idp[`rosa create idp` in the ROSA CLI command reference].
+* For more information about options in the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-create-external-auth-provider[`rosa create external-auth-provider`], xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-list-external-auth-providers[`rosa list external-auth-providers`], and xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-delete-external-auth-provider[`rosa delete external-auth-provider`].
 
 // Step 3: Create, list, and revoke a break glass credential
 include::modules/rosa-hcp-sts-creating-a-break-glass-cred-cli.adoc[leveloffset=+1]

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -54,7 +54,7 @@ include::modules/rosa-sts-creating-a-cluster-using-customizations.adoc[leveloffs
 include::modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
-* xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster] in _Managing objects with the ROSA CLI_
+* xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-create-cluster[`rosa create cluster`] in _ROSA CLI command reference_
 * xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies-creation-methods_rosa-sts-about-iam-resources[Methods of account-wide role creation]
 
 include::modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc[leveloffset=+2]

--- a/rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-deleting-cluster.adoc
@@ -40,6 +40,5 @@ include::modules/rosa-unlinking-and-deleting-ocm-and-user-iam-roles.adoc[levelof
 [id="additional-resources_rosa-sts-deleting-cluster"]
 == Additional resources
 
-* For information about the cluster delete protection feature, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-edit-objects_rosa-managing-objects-cli[Edit objects].
 * For information about the AWS IAM resources for ROSA clusters that use STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources].
 * For information on cluster errors that are due to missing IAM roles, see xref:../support/troubleshooting/rosa-troubleshooting-deployments.adoc#rosa-troubleshooting-cluster-deletion_rosa-troubleshooting-cluster-deployments[Repairing a cluster that cannot be deleted].

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -152,7 +152,7 @@ ifdef::openshift-rosa[]
 * **Learning tutorials for {product-title} cluster and application deployment.** You can now use the xref:../cloud_experts_tutorials/cloud-experts-getting-started/cloud-experts-getting-started-deploying/cloud-experts-getting-started-choose-deployment-method.adoc#cloud-experts-getting-started-choose-deployment-method[Getting started with {product-title}] tutorials to quickly deploy a {product-title} cluster for demo or learning purposes. You can also use the xref:../cloud_experts_tutorials/cloud-experts-deploying-application/cloud-experts-deploying-application-intro.adoc#cloud-experts-deploying-application-intro[Deploying an application] tutorials to deploy an application on your demo cluster.
 endif::openshift-rosa[]
 
-* **Create a VPC using the ROSA CLI.** The `rosa create network` command lets you use the ROSA CLI to create a VPC for your cluster based on an AWS CloudFormation template. You can use this command to create and configure a VPC before creating your cluster. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-network_rosa-managing-objects-cli[create network].
+* **Create a VPC using the ROSA CLI.** The `rosa create network` command lets you use the ROSA CLI to create a VPC for your cluster based on an AWS CloudFormation template. You can use this command to create and configure a VPC before creating your cluster. For more information, see xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-create-network[`rosa create network`].
 
 ifdef::openshift-rosa-hcp[]
 * **Create additional security groups in {product-title} clusters.** Starting with ROSA CLI version 1.2.47, you can now create additional security groups using the ROSA CLI when creating {product-title} clusters. Note that additional security group IDs attached to the machine pool cannot be modified. To remove or add more security group IDs, replace the entire machine pool with a new one.
@@ -204,14 +204,14 @@ endif::openshift-rosa-hcp[]
 +
 Elevated access requests to ROSA clusters and the corresponding cloud accounts can be created by Red{nbsp}Hat SRE either in response to a customer-initiated support ticket or in response to alerts received by a Red{nbsp}Hat SRE, as part of the standard incident response process. For more information, see xref:../support/approved-access.adoc#approved-access[Approved Access].
 
-* **`rosa` command enhancement.** The `rosa describe` command has a new optional argument, `--get-role-policy-bindings`. This new argument allows users to view the policies attached to STS roles assigned to the selected cluster. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-describe-cluster_rosa-managing-objects-cli[describe cluster].
+* **`rosa` command enhancement.** The `rosa describe` command has a new optional argument, `--get-role-policy-bindings`. This new argument allows users to view the policies attached to STS roles assigned to the selected cluster. For more information, see xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-describe-cluster[`rosa describe cluster`].
 
 * **Expanded customer-managed policy capabilities.** You can now attach customer-managed policies to the IAM roles required to run {product-title} clusters. Furthermore, these customer-managed policies, including the permissions attached to those policies, are not modified during cluster or role upgrades. For more information, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-aws-customer-managed-policies_rosa-sts-about-iam-resources[Customer-managed policies].
 
 ifdef::openshift-rosa[]
 * **Permission boundaries for the installer role policy.** You can apply a policy as a _permissions boundary_ on the {product-title} installer role. The combination of policy and boundary policy limits the maximum permissions for the Amazon Web Services(AWS) Identity and Access Management (IAM) entity role. {product-title} includes a set of three prepared permission boundary policy files, with which you can restrict permissions for the installer role since changing the installer policy itself is not supported. For more information, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-aws-requirements-attaching-boundary-policy_rosa-sts-about-iam-resources[Permission boundaries for the installer role].
 
-* **Cluster delete protection.** You can now enable the cluster delete protection option, which helps to prevent you from accidentally deleting a cluster. For more information on using the cluster delete protection option with the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-edit-cluster_rosa-managing-objects-cli[edit cluster]. For more information on using the cluster delete protection option in the UI, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-using-defaults-ocm_rosa-sts-creating-a-cluster-quickly[Creating a cluster with the default options using OpenShift Cluster Manager].
+* **Cluster delete protection.** You can now enable the cluster delete protection option, which helps to prevent you from accidentally deleting a cluster. For more information on using the cluster delete protection option with the ROSA CLI, see xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-edit-cluster[`rosa edit cluster`]. For more information on using the cluster delete protection option in the UI, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-using-defaults-ocm_rosa-sts-creating-a-cluster-quickly[Creating a cluster with the default options using OpenShift Cluster Manager].
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
 * **{product-title} regions added.** {product-title} is now available in the following regions:
@@ -229,10 +229,10 @@ For more information on region availabilities, see xref:../rosa_architecture/ros
 * **Added support for external authentication providers.** You can now create clusters configured with external authentication providers, such as Microsoft Entra ID and KeyCloak. For more information, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-ext-auth.adoc#rosa-hcp-sts-creating-a-cluster-ext-auth[Creating ROSA with HCP clusters with external authentication].
 endif::openshift-rosa-hcp[]
 
-* **Longer cluster names enhancement.** You can now specify a cluster name that is longer than 15 characters. For cluster names that are longer than 15 characters, you can customize the domain prefix for the cluster URL by using the `domain-prefix` flag in the ROSA CLI (`rosa`) or by selecting the **Create custom domain prefix** checkbox in the {hybrid-console}. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster in Managing objects with the ROSA CLI].
+* **Longer cluster names enhancement.** You can now specify a cluster name that is longer than 15 characters. For cluster names that are longer than 15 characters, you can customize the domain prefix for the cluster URL by using the `domain-prefix` flag in the ROSA CLI (`rosa`) or by selecting the **Create custom domain prefix** checkbox in the {hybrid-console}. For more information, see xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-create-cluster[`rosa create cluster`].
 
 ifdef::openshift-rosa-hcp[]
-* **Additional Security Groups for {product-title}.** Starting with ROSA CLI version 1.2.37, you can now use the `--additional-security-group-ids <sec_group_id>` when creating machine pools on {hcp-title} clusters. For more information, see xref:../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#creating_machine_pools_cli_rosa-managing-worker-nodes[Creating a machine pool using the ROSA CLI] and the xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-machinepool_rosa-managing-objects-cli[create machinepool] section of the ROSA CLI reference.
+* **Additional Security Groups for {product-title}.** Starting with ROSA CLI version 1.2.37, you can now use the `--additional-security-group-ids <sec_group_id>` when creating machine pools on {hcp-title} clusters. For more information, see xref:../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#creating_machine_pools_cli_rosa-managing-worker-nodes[Creating a machine pool using the ROSA CLI] and the xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-create-machinepool[`rosa create machinepool`] section of the ROSA CLI reference.
 endif::openshift-rosa-hcp[]
 
 * **Node management improvements.** Now, you can perform specific tasks to make clusters more efficient. You can cordon, uncordon, and drain a specific node. For more information, see xref:../nodes/nodes/nodes-nodes-working.adoc[Working with nodes].
@@ -247,7 +247,7 @@ endif::openshift-rosa-hcp[]
 === Q1 2024
 
 ifdef::openshift-rosa-hcp[]
-* **Machine pool update.** You can now upgrade machine pools that are configured on ROSA with HCP clusters. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-upgrade-machinepool_rosa-managing-objects-cli[upgrade machinepool].
+* **Machine pool update.** You can now upgrade machine pools that are configured on ROSA with HCP clusters. For more information, see xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-upgrade-machinepool[`rosa upgrade machinepool`].
 
 * **{product-title} regions added.** {product-title} is now available in the following regions:
 +
@@ -270,7 +270,7 @@ endif::openshift-rosa-hcp[]
 
 * **Log linking is enabled by default** - Beginning with {product-title} 4.15, log linking is enabled by default. Log linking gives you access to the container logs for your pods.
 
-* **Delete cluster command enhancement.** With the release of ROSA CLI (`rosa`) version 1.2.31, the `--best-effort` argument was added, which allows you to force-delete clusters when using the `rosa delete cluster` command. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-delete-cluster_rosa-managing-objects-cli[delete cluster].
+* **Delete cluster command enhancement.** With the release of ROSA CLI (`rosa`) version 1.2.31, the `--best-effort` argument was added, which allows you to force-delete clusters when using the `rosa delete cluster` command. For more information, see xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-delete-cluster[`rosa delete cluster`].
 
 ifdef::openshift-rosa[]
 [id="rosa-q4-2023_{context}"]
@@ -278,7 +278,7 @@ ifdef::openshift-rosa[]
 
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.32[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 
-* **Delete cluster command enhancement.** With the release of ROSA CLI (`rosa`) version 1.2.31, the `--best-effort` argument was added, which allows you to force-delete clusters when using the `rosa delete cluster` command. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-delete-cluster_rosa-managing-objects-cli[delete cluster].
+* **Delete cluster command enhancement.** With the release of ROSA CLI (`rosa`) version 1.2.31, the `--best-effort` argument was added, which allows you to force-delete clusters when using the `rosa delete cluster` command. For more information, see xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-delete-cluster[`rosa delete cluster`].
 
 ifdef::openshift-rosa-hcp[]
 * ** {product-title} that uses {hcp} is now generally available.** For more information, see xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-sts-creating-a-cluster-quickly[Creating {product-title} clusters using the default options].
@@ -293,7 +293,7 @@ ifdef::openshift-rosa-hcp[]
 xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-security-groups_rosa-hcp-prereqs[Security groups].
 endif::openshift-rosa-hcp[]
 
-* **Command update.** With the release of ROSA CLI (`rosa`) version 1.2.28, a new command, `rosa describe machinepool`, was added that allows you to check detailed information regarding a specific ROSA cluster machine pool. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-describe-machinepool_rosa-managing-objects-cli[describe machinepool].
+* **Command update.** With the release of ROSA CLI (`rosa`) version 1.2.28, a new command, `rosa describe machinepool`, was added that allows you to check detailed information regarding a specific ROSA cluster machine pool. For more information, see xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-describe-machinepool[`rosa describe machinepool`].
 
 * **Documentation update.** The Operators section was added to the ROSA documentation. Operators are the preferred method of packaging, deploying, and managing services on the control plane. For more information, see xref:../operators/index.adoc[Operators overview].
 

--- a/support/troubleshooting/rosa-troubleshooting-installations-hcp.adoc
+++ b/support/troubleshooting/rosa-troubleshooting-installations-hcp.adoc
@@ -36,7 +36,7 @@ include::modules/rosa-hcp-ready-no-console-access.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* For more information about the `rosa describe machinepool` command, see xref:../../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-list-objects[List and describe objects].
+* For more information about the `rosa describe machinepool` command, see xref:../../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-cli-commands[ROSA CLI command reference].
 
 include::modules/rosa-hcp-private-ready-no-console-access.adoc[leveloffset=+1]
 

--- a/upgrading/rosa-hcp-upgrading.adoc
+++ b/upgrading/rosa-hcp-upgrading.adoc
@@ -9,7 +9,7 @@ toc::[]
 include::modules/rosa-hcp-upgrade-options.adoc[leveloffset=+1]
 
 .Additional resources
-* xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-edit-machinepool_rosa-managing-objects-cli[ROSA CLI reference: `rosa edit machinepool`]
+* xref:../cli_reference/rosa_cli/rosa-cli-commands.adoc#rosa-edit-machinepool[ROSA CLI command reference: `rosa edit machinepool`]
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.adoc#rosa-sdpolicy-node-lifecycle_rosa-service-definition[Node lifecycle]
 
 //This cannot be a module if we want to use the xrefs


### PR DESCRIPTION
This PR adds an experimental auto-generated ROSA CLI command ref module, similar to the oc CLI command ref.

Version(s):
- 4.19+

Issue:
N/A

Link to docs preview:
https://100360--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/rosa_cli/rosa-cli-commands.html

QE review:
- N/A
