### PR TITLE
OCPBUGS 61202 MCO CA certificate not rotated after upgrade from OCP 4.18.9 to 4.19.2 – machine-config-server-ca Secret/ConfigMap missing

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -689,6 +689,11 @@ The MCS signing key is stored in the `machine-config-server-ca` secret in the `o
 
 The MCS CA and MCS cert are valid for 10 years and are automatically rotated by the MCO at approximately 8 years. Upon update to {product-title} {product-version}, the CA signing key is not present. As a result, the CA bundle is immediately considered expired when the MCO certificate controller comes up. This expiration causes an immediate certificate rotation, even if the cluster is not 10 years old. After that point, the next rotation takes place at the standard 8 year period.
 
+[NOTE]
+====
+This automatic certificate rotation applies only to clusters that use machine sets. For clusters that do not use machine sets, such as vSphere user-provisioned infrastructure clusters, you are required to manually rotate these certificates. For more information on manual certificate rotation, see the Red{nbsp}Hat Knowledgebase article link:https://access.redhat.com/articles/regenerating_cluster_certificates#regenerating-ca-certificates-for-the-machine-config-server-5[Regenerating CA certificates for the Machine Config Server]. 
+====
+
 For more information about the MCO certificates, see xref:../security/certificate_types_descriptions/machine-config-operator-certificates.adoc#cert-types-machine-config-operator-certificates[Machine Config Operator certificates].
 
 [id="ocp-release-notes-machine-management_{context}"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-61202

Link to docs preview:
[Changes to the Machine Config Operator certificates](https://100371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-machine-config-operator-cert-changes_release-notes) -- Added Note.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
