### PR TITLE
[RHDEVDOCS-6816] Merge 1.1x off-main changes into main and 1.21

### DIFF
--- a/modules/op-chains-generating-x509-secret.adoc
+++ b/modules/op-chains-generating-x509-secret.adoc
@@ -1,0 +1,54 @@
+// This module is included in the following assemblies:
+// * secure/using-tekton-chains-for-openshift-pipelines-supply-chain-security.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="chains-generating-x509-secret_{context}"]
+= Generating the x509 key pair by using the TektonConfig CR
+
+To use the `x509` signing scheme for {tekton-chains} secrets, you must generate the `x509` key pair.
+
+You can generate the `x509` key pair by setting the `generateSigningSecret` field in the `TektonConfig` custom resource (CR) to `true`. 
+The {pipelines-title} Operator generates an `ecdsa` type key pair: an `x509.pem` private key and an `x509-pub.pem` public key. The Operator stores the keys in the `signing-secrets` secret in the `openshift-pipelines` namespace.
+
+[WARNING]
+====
+If you set the `generateSigningSecret` field from `true` to `false`, the {pipelines-title} Operator overrides and empties any value in the `signing-secrets` secret. Ensure that you store the `x509-pub.pem` public key outside of the secret to protect the key from the deletion. The Operator can use the key at a later stage to verify artifact attestations.
+====
+
+The {pipelines-title} Operator does not provide the following functions to limit potential security issues:
+
+* Key rotation 
+* Auditing key usage
+* Proper access control to the key
+
+.Prerequisites
+
+* You installed the {oc-first} utility.
+* You are logged in to your {OCP} cluster with administrative rights for the `openshift-pipelines` namespace.
+
+.Procedure
+
+. Edit the `TektonConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit TektonConfig config
+----
+
+. In the `TektonConfig` CR, set the `generateSigningSecret` value to `true`:
++
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+# ...
+  chain:
+    disabled: false
+    generateSigningSecret: true 
+# ...
+----
++
+The default value is `false`. Setting the value to `true` generates the `ecdsa` key pair.

--- a/modules/op-configuration-rbac-trusted-ca-flags.adoc
+++ b/modules/op-configuration-rbac-trusted-ca-flags.adoc
@@ -2,7 +2,7 @@
 // * install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="op-configuration-rbac-trusted-ca-flags_{context}"]
+[id="op-configuration-rbac-trusted-ca-flags.adoc_{context}"]
 = Configuration of RBAC and Trusted CA flags
 
 The {pipelines-title} Operator provides independent control over RBAC resource creation and Trusted CA bundle config map through two separate flags, `createRbacResource` and `createCABundleConfigMaps`.

--- a/modules/op-release-notes-1-18.adoc
+++ b/modules/op-release-notes-1-18.adoc
@@ -1,0 +1,409 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-18.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes_{context}"]
+= Release notes for {pipelines-title} 1.18
+
+With this update, {pipelines-title} General Availability (GA) 1.18 is available on {OCP} 4.15 and later versions.
+
+[id="new-features-1-18_{context}"]
+== New features
+
+In addition to fixes and stability improvements, the following sections highlight what is new in {pipelines-title} 1.18:
+
+[id="pipelines-new-features-1-18_{context}"]
+=== Pipelines
+
+* With this release, log messages for the {pipelines-shortname} controller are improved to enhance readability, especially when empty variables are present.
+
+* With this release, you can configure resolution timeout settings for pipeline resolvers to gain greater flexibility and control when running a pipeline.
++
+.Example of configuring the timeout settings for pipeline resolvers
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+# ...
+  pipeline:
+    options:
+      configMaps:
+        config-defaults:
+          data:
+            default-maximum-resolution-timeout: 5m # <1>
+        bundleresolver-config:
+          data:
+            fetch-timeout: 1m # <2>
+# ...
+----
+<1> Specify a global maximum timeout for resolution requests. The default value is `1m`.
+<2> Specify a timeout that is used for bundle resolution requests.
+
+
+[id="Operator-new-features-1-18_{context}"]
+=== Operator
+
+* With this release, the {pipelines-shortname} now support community tasks.
++
+The following community tasks are installed by default in the `openshift-pipelines` namespace:
++
+** `argocd-task-sync-and-wait`
+** `git-cli`
+** `helm-upgrade-from-repo`
+** `helm-upgrade-from-source`
+** `jib-maven`
+** `kubeconfig-creator`
+** `pull-request`
+** `trigger-jenkins-job`
+
+* With this release, {pipelines-shortname} supports the deployment of new containers through the `TektonConfig` CR.
++
+.Example of deploying a new `kube-rbac-proxy` container by using the `TektonConfig` CR
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+# ...
+spec:
+  result:
+    options:
+      deployments:
+        tekton-results-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: kube-rbac-proxy
+                  args:
+                    - --secure-listen-address=0.0.0.0:8443
+                    - --upstream=http://127.0.0.1:9090/
+                    - --logtostderr=true
+                  image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+# ...
+----
+
+* With this release, the high availability options of the {pipelines-shortname} controller are enhanced with `StatefulSet` ordinals as an alternative to the existing leader election mechanism. This enables the Operator to use either quick recovery with leader election or consistent workload distribution with `StatefulSet` ordinals.
++
+Leader election, which is the default option, offers failover capabilities but might cause hot-spotting. In contrast, the new `StatefulSet` ordinals approach ensures keys are evenly spread across replicas for a more balanced workload distribution.
++
+You can switch to the `StatefulSet` ordinals method by setting the `statefulset-ordinals` parameter to `true` in the `TektonConfig` custom resource:
++
+--
+.Example of enabling the `StatefulSet` ordinals feature
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+# ...
+  pipeline:
+    performance:
+      disable-ha: false
+      buckets: 4
+      replicas: 4
+      statefulset-ordinals: true
+# ...
+----
+
+:FeatureName: Using `StatefulSet` ordinals for high availability
+include::snippets/technology-preview.adoc[]
+--
+
+[id="triggers-new-features-1-18_{context}"]
+=== Triggers
+
+* With this release, the `EventListener` object for {pipelines-shortname} triggers now includes the `ImagePullSecrets` field to specify a secret that the listener uses to pull images from private registries.
++
+.Example of using the `ImagePullSecrets` field
+[source,yaml]
+----
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: imagepullsecrets-example
+# ...
+spec:
+  serviceAccountName: triggers-example
+  resources:
+    kubernetesResource:
+      spec:
+        template:
+          spec:
+            imagePullSecrets:
+              - name: docker-login
+# ...
+----
+
+[id="cli-new-features-1-18_{context}"]
+=== CLI
+
+* With this release, the `opc` command line utility is now shipped with the following components:
+** {pac} version 0.33.0
+** CLI version 0.40.0
+** Results version 0.14.0
+** Manual Approval Gate version 0.5.0
+
+[id="pac-new-features-1-18_{context}"]
+=== {pac}
+
+* With this release, a `PipelineRun` resource can be triggered based on which files have changed by using the `on-path-change` and `on-path-change-ignore` annotations, which simplifies the process by not requiring writing complex CEL expressions.
++
+.Example of using the `on-path-change` and `on-path-change-ignore` annotations
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "on-path-change"
+  annotations:
+    pipelinesascode.tekton.dev/on-path-change: ["docs/**"] # <1>
+    pipelinesascode.tekton.dev/on-path-change-ignore: [".github/**"] #<2>
+spec:
+# ...
+----
+<1> Matches if changes occur in the `docs` directory.
+<2> Matches if no changes occur in the `.github` directory.
+
+* With this release, a `PipelineRun` resource can now be triggered by pushed commits on GitHub by using the `on-comment` annotation. This feature gives you more control over when a `PipelineRun` is triggered, enabling you to match it based on specific comments.
++
+You must configure a pipeline run to enable the triggering with the `on-comment` annotation:
++
+.Example of enabling triggering of a pipeline run through pushed commits
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "on-comment-pr"
+  annotations:
+    pipelinesascode.tekton.dev/on-comment: "^/hello-world" # <1>
+spec:
+# ...
+----
+<1> The example configures the `/hello-world` command. When you use this command on a pushed commit, for example, on the `main` branch, the `on-comment-pr` pipeline run is triggered.
+
+
+* With this release, you can use the `tkn pac info globbing [-s | -d] “<pattern>”` command to test patterns with sample input data or in the working directory where the command is run. The command tests if the patterns are working properly in the `PipelineRun` definition.
++
+For example, you can test the following `on-target-branch` annotation to ensure that it matches the `main` branch in the git event payload:
++
+.Example `on-target-branch` annotation
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "on-target-branch"
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/*]"
+spec:
+# ...
+----
++
+.Example command
+[source,console]
+----
+$ tkn pac info globbing -s "refs/heads/main" "refs/heads/*"
+----
+
+* With this release, {pac} supports commas within annotations by using the `&#44;` HTML entity. Now, you can use comma-separated values together with commas used directly in the values.
++
+For example, to match two branches called `main` and `branchWith,comma`, specify the annotation as follows:
++
+.Example annotation with commas
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "comma-annotation"
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main, branchWith&#44;comma]"
+spec:
+# ...
+----
+
+* With this release, after a pull request is closed or merged, all associated `PipelineRun` resources that have the `cancel-in-progress: true` annotation are automatically canceled. To enable this feature, specify the `cancel-in-progress` annotation in your `PipelineRun` definition:
++
+--
+.Example `cancel-in-progress` annotation
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "cancel-in-progress"
+  annotations:
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+spec:
+# ...
+----
+
+:FeatureName: Cancellation-in-progress in {pac}
+include::snippets/technology-preview.adoc[]
+--
+
+* With this release, an active `PipelineRun` resource that has the `cancel-in-progress: true` annotation is automatically canceled when a new `PipelineRun` resource with the same name is triggered by {pac}. Now, after a pull request is raised and triggers a `PipelineRun`, and subsequent commits to the same pull request trigger a new `PipelineRun`, the older obsolete `PipelineRun` is canceled to save resources.
++
+To enable the feature, set the `pipelinesascode.tekton.dev/cancel-in-progress` annotation to `true` in the `PipelineRun` resource:
++
+.Example of enabling the cancellation of older pipeline runs
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: "cancel-in-progress"
+  annotations:
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+spec:
+# ...
+----
+
+* Before this update, the `.pathChanged()` function used in CEL expressions with Bitbucket Data Center did not work. With this release, the functionality is implemented.
+
+* With this release, you can match pipeline runs to pull requests by using labels. To match a pipeline run to a label, set the `pipelinesascode.tekton.dev/on-label` annotation in `PipelineRun` resources. Adding the label to a pull request or push event immediately triggers the pipeline run. If a push request or pull event still has the label and is updated with a commit, the pipeline run is triggered again.
++
+This functionality is supported on GitHub, GitLab, and Gitea repository providers. It is not supported on Bitbucket Cloud and Bitbucket Data Center.
+
+[id="tekton-results-new-features-1-18_{context}"]
+=== {tekton-results}
+
+* With this release, {tekton-results} is a General Availability (GA) feature.
+
+* With this release, the Operator installs and adds configuration for {tekton-results} by default through the `TektonConfig` CR.
+
+* With this release, the {tekton-results} API server uses proxy environment variables in the {pipelines-shortname} console plugin to send authorization headers to the {tekton-results} API.
+
+* With this release, the {tekton-results} logging information fetched from LokiStack includes the container name for each log entry.
+
+[id="tekton-cache-new-features-1-18_{context}"]
+=== Tekton Cache
+
+With this release, {pipelines-shortname} includes the new `tekton-caches` tool functionality.
+
+:FeatureName: Tekton Cache
+include::snippets/technology-preview.adoc[]
+
+The `tekton-caches` tool includes the following features:
+
+* Use the `cache-upload` and `cache-fetch` step actions to preserve the cache directory where a build process keeps its dependencies, storing it in an S3 bucket, Google Cloud Services (GCS) bucket, or an OCI repository.
++
+The `cache-fetch` and `cache-upload` step actions are installed by default in the `openshift-pipelines` namespace.
+
+[id="breaking-changes-1-18_{context}"]
+== Breaking changes
+
+* With this release, {tekton-results} no longer supports forwarding of logs by the {tekton-results} watcher to storage in a persistent volume (PV), an S3 bucket, or a GCS bucket.
+
+* Before this update, older versioned tasks and step actions were installed in the `openshift-pipelines` namespace. With this update, these older versions are removed, and only the latest two minor versions of tasks and step actions are installed. For example, in {pipelines-shortname} 1.18, the installed versioned tasks and step actions are `pass:[*]-1-17-0` and `pass:[*]-1-18-0`.
+
+[id="known-issues-1-18_{context}"]
+== Known issues
+
+* If you add or change any parameters in the `result:` section of the `TektonConfig` CR, the changes do not apply automatically. To apply the changes, restart the deployment or pod of the Results API server in the `openshift-pipelines` namespace.
+
+[id="fixed-issues-1-18_{context}"]
+== Fixed issues
+
+* Before this update, if you defined a task that included both regular parameters and `matrix` parameters, the `tekton-pipelines-controller` component crashed and logged a segmentation fault message. If the task was not removed, the component continued to crash and did not run any pipelines. With this update, the controller no longer crashes in such cases.
+
+* Before this update, when a user tried to rerun a resolver-based `PipelineRun` resource by using the {OCP} web console, the attempt resulted in an error with the `Invalid PipelineRun configuration, unable to start Pipeline.` message. With this update, the rerun no longer causes an error and works as expected.
+
+* Before this update, when the `PipelineRun` resource failed, the *Output* tab of the `PipelineRun` resource in the {OCP} web console displayed an error message instead of available results. With this update, the web console correctly shows the results.
+
+* Before this update, the `buildah` task from the `openshift-pipelines` namespace failed when values for `CONTEXT` and `DOCKERFILE` parameters pointed to different directories. With this update, the issue is fixed.
+
+* Before this update, referencing parameters as default values in step actions caused the `TaskRun` resource referencing that step action to fail. With this release, the issue is fixed.
++
+.Example of using a parameter as a value
+[source,yaml]
+----
+apiVersion: tekton.dev/v1alpha1
+kind: StepAction
+metadata:
+  name: simple-step-action
+# ...
+spec:
+  params:
+    - name: param1 # This parameter is required
+      type: string
+    - name: param2 # This parameter uses the value of `param1` as default value
+      type: string
+      default: $(params.param1)
+# ...
+----
+
+* Before this update, when you created a `PipelineRun` resource that referenced a remote Git repository that contained a symlink pointing outside of that repository, the `PipelineRun` would fail. With this release, the `PipelineRun` no longer fails even if the symlink is invalid.
+
+* Before this update, the resource requests for memory and ephemeral storage could sometimes exceed the defined limits. With this release, the issue is fixed.
+
+* Before this update, running pipelines in a cluster that uses injected sidecars sometimes did not affect the {pipelines-shortname} controller. This was caused by faulty minor Kubernetes version checking. With this update, the issue is fixed.
+
+* Before this update, when the list of results contained duplicate keys with an invalid result, the duplicates were removed and replaced with the last result for each key, which could change the order of the result list. With this release, when duplicate keys are removed, the order of the results is preserved, ensuring that the last valid result for each key is kept as the final result.
+
+* Before this update, when using {pac}, GitLab instances hosted under a relative path, for example, `\https://example.servehttp.com/gitlab`, failed to correctly update status for merge requests. Although the initial event updates worked correctly, subsequent updates, for example, marking the pipeline run as `Finished`, did not appear in GitLab, leaving the status in the `Running` state. With this update, the status updates work correctly.
+
+* Before this update, when using {pac}, if you passed the `onEvent` or `onTargetBranch` annotations in a `PipelineRun` resource with an empty `[]` value, it prevented matching of any `PipelineRun` resources. With this update, passing the annotations with an empty value returns an error.
+
+* Before this update, when using {pac}, you could create the `Repository` custom resource (CR) without a URL or with an invalid URL. With this update, you can only create the `Repository` CR if you provide a valid URL. You can still create the `Repository` CR in the `openshift-pipelines` namespace without a URL to provide default settings for all repositories.
+
+* Before this update, when using {pac}, if a pull request was raised through a forked repository in GitLab, the `PipelineRun` resource was created successfully, but its final status was not reported in the GitLab UI. With this update, the issue is fixed.
+
+* Before this update, when using {pac}, GitLab displayed check names for pipeline runs as a single entry for a pipeline. This caused issues when multiple pipeline runs were running simultaneously and one of them failed. If the other pipeline run succeeded, it would override the failed status and the pipeline would appear as successful. With this update, every check name shows separately for each pipeline run. Therefore, the status of pipelines shows correctly as failed if any of the pipeline runs fail.
+
+* Before this update, when using {pac}, if you used the `{{ trigger_comment }}` variable in the `PipelineRun` resource definition and then submitted a multiline comment in GitHub, {pac} could repost YAML validation errors for the pipeline run. With this update, the issue is fixed.
+
+* Before this update, when using {pac}, a `/test branch:<branch>` command where a branch name contained parts that could be interepreted as other commands did not work properly. For example, in the command `/test branch:a/testbranch` the branch branch name contains `/test`, and this command would fail. With this update, only the first `/test` substring in a comment is considered a command to prevent any malfunction.
+
+* Before this update, when using {pac}, if an unauthorized user sent `/test`, `/retest`, or other GitOps commands on pushed commits in GitHub, `PipelineRun` resources were triggered, even though the user was not authorized to trigger them. With this update, an additional user authorization check is added, preventing the `PipelineRun` resources from being triggered without proper verification.
+
+* Before this update, when using {pac}, if an unauthorized user raised a pull request and the repository administrator sent the `/ok-to-test` command, a pending check was created, even if there was no matching `PipelineRun` resource for the pull request event. With this update, no pending checks are created if there is no matching `PipelineRun` resource. Instead, a neutral check is created describing that there is no matching `PipelineRun`.
+
+* Before this update, when using {pac} with Bitbucket Data Center, in a push event users could not reference all fields of event payload in the `PipelineRun` resource, for example, the `body.changes` object. This update fixes the issue.
++
+.Example of using the {{ body.changes }} dynamic variable
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+# ...
+spec:
+    params:
+      - name: ref_id
+        value: "{{ body.changes[0].ref.id }}"
+# ...
+----
+
+* Before this update, when using {pac}, if you used the `generateName` field in a `PipelineRun` resource to match the resource to the `incoming` webhook, the match would not work correctly. With this update, the issue is fixed.
+
+* Before this update, when using {pac}, the `on-cel-expression` annotation was not working on push events in Bitbucket Data Center. With this update, the issue is fixed.
+
+[id="release-notes-1-18-1_{context}"]
+== Release notes for {pipelines-title} 1.18.1
+
+With this update, {pipelines-title} General Availability (GA) 1.18.1 is available on {OCP} 4.15 and later versions.
+
+[id="fixed-issues-1-18-1_{context}"]
+== Fixed issues
+
+* Before this update, when you set configuration options for  {tekton-results} in the `TektonConfig` custom resource (CR), they were not propagated to the `TektonResult` CR and were not applied to the {tekton-results} component. With this update, configuration options from the `TektonConfig` CR are correctly propagated to the `TektonResult` CR and applied to the {tekton-results} component.
+
+* Before this update, if {pac} started a pipeline run without the `cancel-in-progress` annotation because of a pull request (PR) and that PR was closed, the pipeline run was automatically canceled. With this update, {pac} does not cancel the pipeline run unless the `cancel-in-progress` annotation is explicitly specified.
+
+* Before this update, the {pac} controller sometimes stopped working and logged an `index out of range` error. With this update, this issue is resolved and the {pac} controller does not stop working.
+
+* Before this update, the web console for a `PipelineRun` object displayed duplicate `TaskRun` objects and incorrect step completion status based on archived data. With this update, the console displays only the `TaskRun` objects that belong to the current pipeline run and the status bar in the console shows the status of the current task tun.
+
+* Before this update, if you used the `cancel-in-progress` annotation in a {pac} pipeline run and specified the `generateName` field for this pipeline run, {pac} could not cancel this pipeline run when another copy of the pipeline run started. With this update, {pac} cancels the pipeline run normally.
+
+* Before this update, when you used `skopeo` or a similar tool to inspect the {pipelines-title} Operator bundle, an incorrect name, `serverless-operator`, was displayed. With this update, the issue is resolved and the correct name, `openshift-pipelines-operator-rh`, is displayed.
+
+* Before this update, when using {pac}, adding a label to a pull request could unintentionally trigger a pipeline run. With this update, a `PipelineRun` resource is triggered only after you add a label to a pull request.

--- a/modules/op-release-notes-1-19-1.adoc
+++ b/modules/op-release-notes-1-19-1.adoc
@@ -1,0 +1,15 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-19.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-19-1_{context}"]
+= Release notes for {pipelines-title} 1.19.1
+
+With this update, {pipelines-title} General Availability (GA) 1.19.1 is available on {OCP} 4.15 and later versions.
+
+[id="fixed-issues-1-19-1_{context}"]
+== Fixed issues
+
+* Before this update, installing the {pipelines-title} 1.19 displayed the Tekton Pruner API in the console. With this update, this issue is fixed and the API is no longer displayed.
+
+* Before this update, installing {pipelines-shortname} on a FIPS-enabled cluster caused the Tekton entrypoint binary to display an error with the `FIPS mode is enabled, but this binary is not compiled with FIPS compliant mode enabled` message. With this update, this issue is fixed. {pipelines-shortname} functions correctly on FIPS-enabled clusters, and the {pipelines-title} Operator is designed and validated for use on FIPS enabled clusters.

--- a/modules/op-release-notes-1-19-2.adoc
+++ b/modules/op-release-notes-1-19-2.adoc
@@ -1,0 +1,25 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-19.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-19-2_{context}"]
+= Release notes for {pipelines-title} 1.19.2
+
+With this update, {pipelines-title} General Availability (GA) 1.19.2 is available on {OCP} 4.15 and later versions.
+
+[id="fixed-issues-1-19-2_{context}"]
+== Fixed issues
+
+* Before this update, when you installed the {pipelines-shortname} Operator 1.19.0 by using the web console, the `Tekton Pruner` API was incorrectly visible in the _Details_ section. With this update, the `Tekton Pruner`` API is no longer visible in the web console, as intended by the pruner design.
+
+* Before this update, there were only limited tasks fetched from ArtifactHUB in the pipeline builder page, and on search for a task, if the task was not available in the first fetched list, then that task was not displayed. With this update, UI makes an API call to ArtifactHub to search for a task in Pipeline builder quick search and lists them to install.
+
+* Before this update, the Pipeline Builder page only fetched a limited number of tasks from Artifact Hub. If a searched task was not included in that initial list, it would not appear in the results. With this update, the UI now makes a direct API call to Artifact Hub during quick search, allowing users to find and list additional tasks for installation.
+
+* Before this update, the _Events_ tab for a `PipelineRun` did not display any events. With this update, the tab now correctly shows events, allowing you to view relevant activity for each `PipelineRun`.
+
+* Before this update, `onError` variable substitution did not work with the `v1beta1` API. With this update, the issue has been fixed. 
+
+* Before this update, the Git resolver did not use the provided `gitToken` and `gitTokenKey` for remote authentication, which caused HTTP token-based authentication to fail. With this update, all Git resolver operations now use the provided `gitToken` for remote authentication.
+
+

--- a/modules/op-release-notes-1-19-3.adoc
+++ b/modules/op-release-notes-1-19-3.adoc
@@ -1,0 +1,21 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-19.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-19-3_{context}"]
+= Release notes for {pipelines-title} 1.19.3
+
+With this update, {pipelines-title} General Availability (GA) 1.19.3 is available on {OCP} 4.15 and later versions.
+
+[id="fixed-issues-1-19-3_{context}"]
+== Fixed issues
+
+* Before this update, upgrading to version 1.19.0 of the {pipelines-title} Operator could cause the Operator pod to crash. This issue was caused by an empty pointer reference at startup when the `spec.tektonpruner.disabled` field in the `tektonconfig` custom resource (CR) was `nil`. With this update, the issue is fixed.
+
+* Before this update, the `tekton_pipelines_controller_running_pipelineruns` metric included pending `PipelineRun` objects in its count, causing inaccurate reporting. With this update, the metric counts only actively running `PipelineRun` objects, excluding those in a pending state, improving monitoring accuracy.
+
+* Before this update, the default {tekton-results} TLS secret was mistakenly deleted during pre-upgrade steps on the {OCP}. This deletion caused the {tekton-results} API to fail during the upgrade process. With this update, {pipelines-shortname} prevents the deletion of the TLS secret, ensuring the {tekton-results} API remains operational throughout the upgrade.
+
+* Before this update, a recent regression caused the git resolver to bypass the `Proxy` custom-configured public key infrastructure (PKI), which could prevent it from resolving references to self-hosted Git providers. With this update, the git resolver trusts the full CA bundle configured in the `Proxy`, including any certificates in your custom PKI, restoring secure connectivity to self-hosted Git providers.
+
+* Before this update, if a `TaskRun` object failed to create a PersistentVolumeClaim (PVC) due to a `ResourceQuota` conflict, such as a concurrent update or exhausted quota, the `TaskRun` was immediately marked as `Failed`. With this update, when a `TaskRun` encounters a PVC creation failure caused by a `ResourceQuota` issue, it remains in a pending state and retries PVC creation instead of failing immediately.

--- a/modules/op-release-notes-1-19.adoc
+++ b/modules/op-release-notes-1-19.adoc
@@ -1,0 +1,593 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-19.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes_{context}"]
+= Release notes for {pipelines-title} 1.19
+
+With this update, {pipelines-title} General Availability (GA) 1.19 is available on {OCP} 4.15 and later versions.
+
+[id="new-features-1-19_{context}"]
+== New features
+
+In addition to fixes and stability improvements, the following sections highlight what is new in {pipelines-title} 1.19:
+
+[id="pipelines-new-features-1-19_{context}"]
+=== Pipelines
+
+* With this update, you can now specify custom `securityContext` settings in the `EventListener` resource. When you enable a custom `securityContext`, user-defined values override the default configuration. Otherwise, the default `securityContext` settings are applied automatically.
++
+.Example `securityContext` configuration in the `EventListener` resource
+[source,yaml]
+----
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: listener-securitycontext
+spec:
+  serviceAccountName: pipeline
+  resources:
+    kubernetesResource:
+      spec:
+        template:
+          spec:
+            securityContext:
+              runAsNonRoot: true
+            containers:
+              - resources:
+                  requests:
+                    memory: "64Mi"
+                    cpu: "250m"
+                  limits:
+                    memory: "128Mi"
+                    cpu: "500m"
+                securityContext:
+                  readOnlyRootFilesystem: true
+  triggers:
+    - name: foo-trig
+      bindings:
+        - ref: pipeline-binding
+        - ref: message-binding
+      template:
+        ref: pipeline-template
+# ...
+----
+
+[id="tekton-results-new-features-1-19_{context}"]
+=== {tekton-results}
+
+* With this update, you can configure custom database credentials for {tekton-results} by using the `TektonConfig` custom resource (CR). This eliminates the need to rely on the default PostgreSQL secrets that use default usernames and passwords.
++
+.Example for adding custom database credentials for {tekton-results}
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonResult
+metadata:
+  name: result
+spec:
+  db_secret_name: # optional: custom database secret name
+  db_secret_user_key: # optional
+  db_secret_password_key: # optional
+...
+----
+
+* With this update, the {tekton-results} API supports response field filtering or partial responses to reduce payload size and improve network efficiency. You can specify what fields to include in API responses, which benefits `List` operations by preventing the retrieval of entire objects, thus optimizing response latency and I/O performance.
+
+* With this update, you can configure retry timings for OCI bundle lookups, such as initial retry delay, backoff factor, and maximum retry duration, in the `config-resolver-bundle` config map under `bundle.resolver.backoff`. This helps reduce load on busy registries by preventing aggressive retry behavior.
++
+.Example for configuring retry timings
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bundleresolver-config
+  namespace: tekton-pipelines-resolvers
+  labels:
+    app.kubernetes.io/component: resolvers
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-pipelines
+data:
+  # The initial duration for a backoff.
+  backoff-duration: "500ms"
+  # The factor by which the sleep duration increases every step
+  backoff-factor: "2.5"
+  # A random amount of additional sleep between 0 and duration * jitter.
+  backoff-jitter: "0.1"
+  # The number of backoffs to attempt.
+  backoff-steps: "3"
+  # The maxumum backoff duration. If reached, remaining steps are zeroed.
+  backoff-cap: "10s"
+  # The default layer kind in the bundle image.
+  default-kind: "task"
+----
+
+* With this update, the Git resolver can now use personal access tokens to authenticate with GitHub or GitLab, avoiding rate limits associated with anonymous `git clone` API usage. To enable this feature, add a `gitToken:` field to your git resolver parameter specification. Tekton automatically injects the token as an HTTP header during resolution to reduce the risk of quota-related errors during remote resolution.
++
+.Example for configuring the `gitToken:` field
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: git-clone-demo-pr
+spec:
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/tektoncd/catalog.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: pipeline/simple/0.1/simple.yaml
+    - name: gitToken
+      value: "secret-with-token"
+    - name: gitTokenKey (optional, defaults to "token")
+      value: "token"
+  params:
+  - name: name
+    value: Ranni
+----
+
+* With this update, the default log level for SQL in {tekton-results} has been set to `warn`. You can override this setting by specifying the `SQL_LOG_LEVEL` environment variable in the {tekton-results} deployment.
++
+.Example for enabling the `SQL_LOG_LEVEL` environment variable
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+  options:
+    deployments:
+       tekton-results-api:
+         spec:
+           template:
+             spec:
+               containers:
+               - name: api
+                 env:
+                 - name: SQL_LOG_LEVEL
+                   value: debug
+# ...
+----
+
+* With this update, the {tekton-results} watcher retries reconciliation before removing the finalizer, until the `storedDeadline` duration is reached. This reduces the risk of missing `TaskRun` or `PipelineRun` storage.
+
+* With this update, {tekton-results} users can retrieve logs from Splunk that were forwarded by OpenShift Logging. To enable this functionality, set the following environment variables in the {tekton-results} API deployment:
+
+** SPLUNK\_SEARCH\_TOKEN, LOGGING\_PLUGIN\_QUERY\_PARAMS
+** LOGGING\_PLUGIN\_API\_URL
++
+.Example for retrieving forwarded logs by OpenShift Logging
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+  options:
+    deployments:
+       tekton-results-api:
+         spec:
+           template:
+             spec:
+               containers:
+               - name: api
+                 env:
+----
++
+[NOTE]
+====
+* The `LOGGING\_PLUGIN\_API\_URL` variable must be configured with the Splunk endpoint and port number.
+====
+
+* With this update, the {tekton-results} watcher uses `StatefulSet` ordinals to improve high availability and workload distribution as an alternative to the leader election mechanism.
++
+--
+.Example for enabling `StatefulSet` ordinals for the {tekton-results} watcher
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+# ...
+  result:
+    performance:
+      disable-ha: false
+      buckets: 4
+      replicas: 4
+      statefulset-ordinals: true
+# ...
+----
+
+:FeatureName: Using `StatefulSet` ordinals for high availability
+include::snippets/technology-preview.adoc[]
+--
+
+[id="pac-new-features-and-enhancements-1-19_{context}"]
+=== {pac}
+
+* With this update, {pac} no longer creates a `Pending` status on GitHub pull requests when an unauthorized bot user attempts to trigger a `PipelineRun`. Instead of generating a blocking status check, such requests are now silently disallowed.
+
+* With this update, a new `pipelines_as_code_git_provider_api_request_count` metric tracks the number of API calls made by {pac} to Git providers, such as GitHub, GitLab, and Gitea. The metric also helps monitor API rate limit usage per Git provider, namespace, event type, and repository.
+
+* With this update, URLs in the `Repository` CR are now validated during creation to ensure they are properly formatted and use valid schemes, such as http or https. This enhancement helps prevent configuration errors and runtime errors.
+
+* With this update, `PipelineRun` status comments now render correctly in markdown on Bitbucket Data Center and Bitbucket Cloud, instead of appearing as raw strings in the pull request UI.
+
+[id="Operator-new-features-1-19_{context}"]
+=== Operator
+
+* With this update, you can generate the `cosign` key pair by setting the `generateSigningSecret` field in the `TektonConfig` custom resource (CR) to `true`. The {pipelines-title} Operator generates a `cosign` key pair, a `cosign.key` private key and a `cosign.pub` public key.
++
+.Example of enabling `cosign` key pairs
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  chain:
+    disabled: false
+    generateSigningSecret: true
+# ...
+----
+
+* With this update, the `/ok-to-test` memory feature is disabled by default. This precaution helps mitigate the risk of malicious code execution within testing environments.
+
+* With this update, dynamic variables can be expanded from remote pipeline definitions. This enhancement improves pipeline composition capabilities.
+
+* With this update, the Git resolver included in the remote resolution feature now uses the native git binary instead of the pure Go `go-git` library. This change reduces memory consumption and improves clone performance, especially for large repositories. This enhancement uses shallow-clone flags, for example `--depth 1`, to reduce resource usage. No changes to pipeline manifests are required.
+
+* With this update, the `onError` field in {pipelines-title} supports Tekton parameter substitution. Previously, the `onError` field only accepted the literal values `stopAndFail` and `continue`. You can use the `$(params.strategy)` substitution token to dynamically determine failure handling behavior at runtime. This allows a single Pipeline definition to adapt its `onError` policy based on parameters, context, or results.
+
+* With this release, `StepAction` definitions are updated from alpha to stable and are now enabled by default. The  `enable-step-actions` flag used in the earlier versions is no longer used and will be removed in a future release.
+
+* With this update, the Pipeline scheduler now correctly evaluates result references in fan-out/fan-in patterns. Previously, such pipelines could fail unpredictably when matrix tasks relied on result refs.
+
+* With this update, the `remember-ok-to-test` value in the `TektonConfig` CR is set to `false` by default to reduce the risk of running untrusted code in test environments.
+
+[id="tekton-cache-new-features-1-19_{context}"]
+=== Tekton Cache
+
+* With this update, parameter naming conventions across the `StepAction` feature are unified for consistency. The casing of `cache-fetch` and `cache-upload` step actions is now consistent with that of `git-clone`.
+
+* With this update, the `tekton-caches` tool can push to and retrieve from Google Cloud Storage (GCS) buckets, in addition to existing OCI registry support. To enable this, set the cache backend to a `gs://bucket/path` URI.
+
+* With this update, you can store cache archives in any S3 compatible bucket, including on-premises solutions such as MinIO or cloud providers such as AWS. To use this feature, specify a URL, such as `s3://my-bucket/cache` as the cache backend.
+
+* With this update, cache archives are compressed using `Gzip` before being uploaded. This reduces object storage costs and speeds up data transfer, especially for large caches such as `Go` modules.
+
+* With this update, restored caches default to `0777` permission, ensuring that executable scripts and other permission-sensitive files function correctly. Previously, restored files defaulted to `0600` permissions, which could prevent scripts from running as expected.
+
+* With this update, running on Google Kubernetes Engine (GKE) with Workload Identity Federation (WIF) no longer requires embedding key files in tasks. Instead, you can now mount projected volume tokens, eliminating the need for long-lived credentials and improving security.
+
+* With this update, the code paths for GCS and S3 backends are unified using the `gocloud.dev` library. This abstraction simplifies support of additional storage providers, such as Azure Blob Storage or local filesystems.
+
+* With this update, the `fetch` command is improved to automatically create the destination folder if it does not exist in a new workspace. Previously, the command would fail in such cases, requiring you to create a directory manually.
+
+* With this update, registry authentication is no longer limited to the `/tekton/home/.docker/config.json` default path. You can now mount any Docker configuration file and specify its location by using the `dockerConfig` parameter in your `Task` resource. However, the custom location for `DOCKER_CONFIG` must include a valid `config.json` file.
++
+.Example for enabling the `dockerConfig` parameter in a task
+[source,yaml]
+----
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-task
+spec:
+  workspaces:
+    - name: source
+    - name: cred
+  params:
+    - name: cachePatterns
+      default: $(params.cachePatterns)
+  steps:
+    - name: cache-fetch
+      ref:
+        resolver: cluster
+        params:
+          - name: name
+            value: cache-fetch
+          - name: namespace
+            value: openshift-pipelines
+          - name: kind
+            value: stepaction
+      params:
+        - name: PATTERNS
+          value: $(params.cachePatterns)
+        - name: SOURCE
+          value: oci://$(params.registry)/cache-go:{{hash}}
+        - name: CACHE_PATH
+          value: $(workspaces.source.path)/cache
+        - name: WORKING_DIR
+          value: $(workspaces.source.path)/repo
+        - name: DOCKER_CONFIG
+          value: $(workspaces.cred.path)/
+    - name: cache-upload
+      ref:
+        resolver: cluster
+        params:
+          - name: name
+            value: cache-upload
+          - name: namespace
+            value: openshift-pipelines
+          - name: kind
+            value: stepaction
+      params:
+        - name: PATTERNS
+          value: $(params.cachePatterns)
+        - name: TARGET
+          value: oci://$(params.registry)/cache-go:{{hash}}
+        - name: CACHE_PATH
+          value: $(workspaces.source.path)/cache
+        - name: WORKING_DIR
+          value: $(workspaces.source.path)/repo
+        - name: DOCKER_CONFIG
+          value: $(workspaces.cred.path)/
+			...
+# ...
+----
+
+[id="tekton-chains-new-features-1-19_{context}"]
+=== {tekton-chains}
+
+* With this update, the {tekton-chains} controller uses `StatefulSet` ordinals to improve high availability and workload distribution as an alternative to the leader election mechanism.
++
+--
+.Example of enabling the StatefulSet ordinals for the the `Chains` controller
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonChains
+metadata:
+  name: chain
+spec:
+  chain:
+    performance:
+      disable-ha: false
+      buckets: 4
+      replicas: 4
+      statefulset-ordinals: true
+----
+:FeatureName: Using `StatefulSet` ordinals for high availability
+include::snippets/technology-preview.adoc[]
+--
+
+[id="pac-new-features-1-19_{context}"]
+=== {pac}
+
+* With this release, {pac} introduces the `pipelines_as_code_git_provider_api_request_count` metric. This metric tracks the number of API requests made by {pac} to a Git provider in response to an event.
+
+* With this release, the `TektonConfig` custom resource provides support for two new fields to enable the `cancel-in-progress` feature for pipeline runs in {pac} globally:
+** `enable-cancel-in-progress-on-pull-requests`
+** `enable-cancel-in-progress-on-push`
++
+When set to `true`, these fields automatically cancel any in-progress pipeline run triggered by pull request or push events when there is a new commit. By default, both these fields are set to false.
++
+[NOTE]
+====
+If a `PipelineRun` resource includes the `pipelinesascode.tekton.dev/cancel-in-progress` annotation, it overrides the corresponding `TektonConfig` setting.
+====
++
+.Example enabling auto-cancel on pull requests and push events with `TektonConfig` CR
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+# ...
+platforms:
+    openshift:
+      pipelinesAsCode:
+        # ...
+        settings:
+          # ...
+          enable-cancel-in-progress-on-pull-requests: "false"
+          enable-cancel-in-progress-on-push: "false"
+        # ...
+----
+
+* With this release, {pac} supports the `git_tag` dynamic variable. This variable is used during tag push events and reflects the value of the Git tag. For example, if the tag `v1.0` is pushed to the `Repository` CR, the `git_tag` variable holds the value `v1.0`.
++
+.Example configuration for git_tag
+[source,yaml]
+----
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pull-pr-3
+  annotations:
+    pipelinesascode.tekton.dev/on-event: ["push"]
+    pipelinesascode.tekton.dev/on-target-branch: ["refs/tags/*"]
+spec:
+  params:
+    - name: tag
+      value: "{{ git_tag }}"
+  pipelineSpec:
+    tasks:
+        # ...
+    tasks:
+        ...
+        taskSpec:
+          steps:
+            ...
+              script: |
+----
+
+* With this release, the `TektonConfig` CR includes the  `skip-push-event-for-pr-commits` field. When enabled, {pac} does not trigger pipeline runs for push events if the commit SHA is included in an open pull request. This prevents duplicate pipeline runs for the same commit. By default, this field is set to `true`.
++
+.Example configuration for `skip-push-event-for-pr-commits` in `TektonConfig`
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+# ...
+platforms:
+  openshift:
+    pipelinesAsCode:
+      additionalPACControllers:
+        <controllerName>:
+          enable: true
+          configMapName:
+          secretName:
+          settings:
+      enable: true
+        # ...
+        settings:
+          # ...
+          hub-url: https://api.hub.tekton.dev/v1
+          skip-push-event-for-pr-commits: "true"
+          remote-tasks: "true"
+          secret-auto-create: "true"
+          # ...
+----
+
+* With this release, an OpenAPI schema is now integrated into {pac} for the Repository CR. This schema enables IDE autocompletion for Repository CR writing and allows repository explanations via the `oc explain` command.
+
+* With this update, when you set the `on-cel-expression`, `on-event`, or `on-target-branch` annotations in a repository, the `on-cel-expression` annotation takes precedence. The `on-event` and `on-target-branch` annotations are ignored in this case. To alert users, a warning log and Kubernetes event are generated to indicate this behavior.
+
+[id="pruner-new-features-1-19_{context}"]
+=== Event-based Pruner
+
+:FeatureName: The Pruner component
+include::snippets/technology-preview.adoc[]
+
+* With this update, the `Pruner` component introduces automated cleanup of `PipelineRun` and `TaskRun` resources in {pipelines-title}. It supports the following features:
+
+** Time-based pruning (TTL). This feature automatically deletes completed `PipelineRun` and `TaskRun` resources after a specified duration. This is controlled through the `ttlSecondsAfterFinished` setting.
+
+** History-based pruning. This feature retains a limited number of successful and failed runs. it is configured  through the following parameters:
+
+*** `successfulHistoryLimit`
+*** `failedHistoryLimit`
+*** `historyLimit`
+
+** Flexible configuration levels. There are two configurable levels:
+
+*** Global. This option applies to all namespaces except those prefixed with `kube-` and `openshift-`. 
+*** Namespace. This option applies to all resources in a specific namespace
++
+[NOTE]
+====
+In this release, only `Global` and `Namespace` configurations are available.
+====
+
+* With this update, you can disable or enable the event-based pruner in the `TektonConfig` CR by setting `spec.tektonpruner.disabled` to `true` or `false`. Fine-grained configuration is not yet supported in the `TektonConfig` CR and must be managed through config maps.
++
+[NOTE]
+====
+The existing job-based pruner must be disabled before enabling the event-based pruner.
+====
+
+[id="breaking-changes-1-19_{context}"]
+== Breaking changes
+
+* With this release, the `hub clustertask` command is removed from the CLI because the `ClusterTask` functionality is no longer available on {tekton-hub}.
+
+* With this release, support for `ClusterTask` objects is removed. As a result, the `tkn clustertask` and `tkn task create` commands are no longer available.
+
+* With this release, the `opc results list` command is replaced with the `opc results result list` command.
+
+* With this update, the `disable-affinity-assistant` flag is removed from the {pipelines-title} Operator. This flag is deprecated in {pipelines-title} v1.13 and does not have any effect in {pipelines-title} v1.19. The `disable-affinity-assistant flag is still available in the `TektonConfig` custom resource (CR) for backward compatibility, but it does not impact the behavior of the {pipelines-title} Operator. To maintain the same behavior, set the `coschedule` feature flag to `disabled`.
+
+[id="known-issues-1-19_{context}"]
+== Known issues
+
+* Currently, the event-based pruner does not strictly validate the contents of the `tekton-pruner-default-spec` config map. If invalid configuration keys or malformed values with incorrect field names are provided, the configuration is ignored. As a result, the pruner might fall back to default behavior or skip pruning altogether.
+
+[id="fixed-issues-1-19_{context}"]
+== Fixed issues
+
+* Before this update, the `s2i-java` task failed with an error message, `/usr/libexec/s2i/assemble: No such file or directory`. This error occurred due to incorrect script path references. With this update, the default script path for the `s2i-java` task is modified to `/usr/local/s2i`. Other S2I tasks, such as those for Go or .NET, continue to use the `/usr/libexec/s2i/assemble` script path.
+
+* Before this update, YAML syntax errors in `PipelineRun` were only reported in logs and Kubernetes events, making them difficult to detect and troubleshoot. With this update, {pac} comments directly on pull requests when `PipelineRun` YAML validation errors occur. This improves error visibility and simplifies troubleshooting on GitHub, GitLab, and Gitea providers.
+
+* Before this update, in the GitLab integration, {pac} posted comments on merge requests at the start and end of each `PipelineRun`. This behavior led to excessive comments appearing on merge requests when multiple pipelineruns were triggered. With this update, you can now disable all GitLab comments by setting `disable_all` to `true` in the `Repository` custom resource (CR).
++
+.Example of enabling the Repository CR
+[source,yaml]
+----
+---
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: test-pac
+spec:
+  # other fields 
+  settings:
+    gitlab:
+      comment_strategy: "disable_all"
+----
+
+* Before this update, logs retrieved from the Amazon Web Services (AWS) S3 bucket were displayed in a random order, making debugging and troubleshooting difficult. With this update, logs from AWS S3 are now correctly ordered chronologically, improving readability and the overall debugging experience.
+
+* Before this update, {pac} required all custom parameters defined in a `Repository` CR to include predefined values. With this update, custom parameters can now be defined without specifying default values in the `Repository` CR. This change enables values to be supplied through webhook payloads and preserves backward compatibility.
+
+* Before this update, when using the `github-push` `ClusterTriggerBinding`, the `git-clone` command could fail with `HTTP 403` errors. This issue occurred because the `$(body.repository.url)` parameter pointed to the GitHub API URL instead of a valid Git clone URL. With this update, a new `git-repo-clone-url` parameter uses `$(body.repository.html_url)` to ensure that the cloning uses the correct repository URL.
+
+* Before this update, the `buildah` task failed to process build arguments that contained spaces when used with the cluster resolver. This issue affected users migrating from the deprecated `ClusterTask` custom resource (CR). With this update, the `BUILD_ARGS` parameter in the `buildah` task now correctly supports arguments with spaces, for example, `EXAMPLE="abc def"`, restoring compatibility with previous functionality.
+
+* Before this update, the *PipelineRun details* page in the {OCP} web console failed to load correctly, preventing users from viewing pipeline run details. With this update, the web console displays the `PipelineRun` information correctly.
+
+* Before this update, the console plugin styling was outdated due to the upgrade to PatternFly 6 and the removal of deprecated `co-` classes. This caused alignment and spacing issues in the *Pipelines* section of the {OCP} web console. With this update, the console plugin styling is updated to use the appropriate PatternFly equivalent classes, ensuring consistent alignment and visual integration with the current {OCP} web console design standards
+
+* Before this update, the {pipelines-shortname} console plugin failed due to a default {tekton-results} TLS secret creation issue in {pipelines-shortname} 1.18. This caused the console to be inaccessible, making pipeline details unviewable. With this release, the default {tekton-results} TLS secret creation is skipped in {pipelines-shortname} 1.18, resolving the issue.
+
+* Before this update, links for `PipelineRun` in the {OCP} web console incorrectly pointed to the deprecated `v1beta1` {pipelines-title} APIs instead of the current `v1` APIs. With this update, the links point to the appropriate `v1` APIs.
+
+* Before this update, {pipelines-title} and {tekton-results} incorrectly displayed `TaskRun` resources from previous `PipelineRun` resource that shared the same name. This led to confusion about which `TaskRun` resources were associated with the current execution. With this update, {tekton-results} now correctly isolates and displays only the `TaskRun` resources associated with the current `PipelineRun` resource, preventing the mixing of archived and active execution data.
+
+* Before this update, end-to-end (E2E) tests were unstable due to GitOps comments being incorrectly associated with cancelled pipeline runs. This behavior caused intermittent test failures and reduced reliability in CI/CD pipelines. With this update, GitOps comments are no longer mixed with cancelled pipeline runs, resulting in stable and predictable E2E tests.
+
+* Before this update, the `tekton-caches` `tarit` tool did not keep file permissions when compressing cached directories. As a result, executable files and scripts sometimes stopped working after being unpacked. This caused problems especially when artifacts were used by different users or SELinux-enforcing base images. With this update, file permissions are kept correctly during caching and files work as expected in all user environments.
+
+* Before this update, when a `TaskRun` failed due to `ImagePullBackOff` errors, the `PipelineRun` log snippet displayed unclear messages, such as “pods not found,” after switching between tabs in the *Pipelines* section of the {OCP} web console. With this update, errors include clear error messages, such as `TaskRunImagePullFailed` or `failing to pull image`, to improve the troubleshooting experience.
+
+* Before this update, certain elements within the {pipelines-title} *Start* interface in the {OCP} web console, such as `deployment-name`, `Hr`,  `Min`, and `Sec`, always showed in English, no matter the user’s regional settings. With this update, all interface elements are fully localized and now display according to the user’s selected region.
+
+* Before this update, the Tekton pruner job encountered `ImagePullBackOff` errors during Helm-based installation due to missing `SHA256 digests` in image tags. With this update, image tag includes the required `SHA256 digests` and the error no longer occurs.
+
+* Before this update, the {pac} controller could crash with an `index out of range` error during push events from Bitbucket Data Center. This behavior occurred when the changes array in the event payload was empty. With this update, {pac} now handles empty changes arrays gracefully, preventing the controller from crashing.
+
+* Before this update, adding labels to pull requests would unintentionally trigger a `PipelineRun`. With this update, this issue is resolved.
+
+* Before this update, closing a pull request would cancel ongoing `PipelineRun` even if the `cancel-in-progress` annotation was not set. With this update, pipeline runs are only canceled on pull request closure when you configure the `cancel-in-progress` annotation.
+
+* Before this update, the GitLab integration in {pac} encountered API call failures caused by an incorrect API URL. With this update, this issue is fixed by introducing URL validation, which prevents such misconfigurations and ensures successful API communication.
+
+* Before this update, {pac} did not cancel a `PipelineRun` created with the `generateName` field, even when the `cancel-in-progress` annotation was set. With this update, {pac} correctly cancels an in-progress `PipelineRun` that contains the `generateName` field.
+
+* Before this update, when provenance was configured in GitLab, {pac} retrieved an incorrect `PipelineRun` template from the Git repository. With this update, {pac} correctly identifies and retrieves the intended template in GitLab provenance setups.
+
+* Before this update, if you used the `/ok-to-test` GitOps command in a push commit comment, it triggered a pipeline run. With this update, the `/ok-to-test` command no longer triggers a pipeline run when used outside of pull requests.
+
+* Before this update, `TaskRun` and `PipelineRun` resources failed with the `kind param must be task or pipeline` error when referencing `StepAction` definitions by the Artifact Hub resolver. This happened because the `StepAction` definition was not recognized as a valid resource type. With this update, the Artifact Hub resolver supports `StepAction` references, allowing users to include remote step actions in their tasks and pipelines.
+
+* Before this update, `PipelineRun` failed with the error `failed to create subPath directory for volumeMount`, even though {OCP} would eventually recover and create the required pod. This led to unnecessary `PipelineRun` failures and a poor user experience, often requiring manual restarts. With this update, `PipelineRun` implements a grace period and retry mechanism for `subPath` directory creation errors. This allows {OCP} time to resolve the issue automatically, reducing false failures and improving reliability.
+
+* Before this update, the {tekton-results} API server encountered an error when a log query was made for a non-existent `TaskRun` or `PipelineRun`. With this update, the issue is fixed.
+
+* Before this update, users had to wrap the CLI in separate `Task` resources to back up or restore build caches. With this update, `StepAction` definitions support `fetch` and `upload`, so you can handle cache operations with a single step inside any `Task` or `Pipeline`.
+
+* Before this update, pushing a cache to a registry with a self-signed certificate failed due to TLS errors. With this update, the CLI and `Task` resource support new `--insecure` flag, which enables those pushes and makes it easier to work with air-gapped development clusters and local registries.
+
+* Before this update, in GitLab, pipeline runs for Merge Requests (MRs) were automatically re-triggered when non-code changes occurred in {pac}, such as updating the MR description or modifying reviewers. This behavior caused unnecessary pipeline executions. With this update, this issue is fixed, and pipeline runs are only triggered by new commits.
+
+* Before this update, in {pac}, a push `PipelineRun` with the `on-path-change` annotation was not triggered on pull request merge events, even when the merged pull request modified the specified paths. With this update, this issue is fixed by ensuring that the pipeline is correctly triggered when relevant path changes are introduced through a pull request merge.
+
+* Before this update, {pac} attempted to parse and validate every YAML file in the `.tekton directory`, resulting in false errors for unrelated or invalid non-Tekton resources. With this update, {pac} validates only explicitly defined Tekton resources, reducing noise in pull request feedback and improving the accuracy of CI validation.
+
+* Before this update, a non-domain-qualified finalizer name was used, leading to warnings in the {pac} watcher from the Kubernetes API. This issue is now resolved by using a domain-qualified finalizer name that aligns with Kubernetes conventions.
+
+* Before this update, the {pac} controller terminated unexpectedly when validating GitHub webhook secrets with an invalid or expired token. With this update, this issue is fixed. The controller logs a clear error message and continues running, ensuring webhook functionality and controller availability are not disrupted.

--- a/modules/op-release-notes-1-20-0.adoc
+++ b/modules/op-release-notes-1-20-0.adoc
@@ -184,7 +184,7 @@ $ oc patch configmap pipelines-as-code -n openshift-pipelines --type=json -p='[{
 * Using `opc pr logs` in the OpenShift namespace may fail with repeated `Failed to list objects from openshift namespace` errors for both admin and non-admin users. 
 
 .{tekton-cache}
-* On IBM P environments, the `cache-fetch` step may fail with the error `failed to change ownership: operation not permitted`. This typically occurs because of filesystem permission restrictions on the underlying storage.
+* On IBM P and IBM Z environments, the `cache-fetch` step might fail with the `failed to change ownership: operation not permitted` error message. This issue occurs due to filesystem permission restrictions on the underlying storage.
 
 .{tekton-chains}
 * Pod anti-affinity rules are not applied to `tekton-chains-controller` replicas.
@@ -236,7 +236,7 @@ data:
 
 * Before this update, the `git-clone` task failed with a `No such remote 'origin'` error messgae if the `origin` remote was missing from the repository. With this update, the task automatically adds the `origin` remote to the repository configuration, ensuring correct setup and successful cloning.
 
-* Before this update, {pac} failed immediately when resource quotas were exceeded, canceling the run and interrupting user workflows. With this update, the controllers retry and automatically rerun if resources become available, reducing unnecessary cancellations and improving pipeline reliability.
+* Before this update, the `pipeline` controller failed immediately when resource quotas were exceeded, canceling the run and interrupting user workflows. With this update, the controller retries and automatically reruns if resources become available, reducing unnecessary cancellations and improving pipeline reliability.
 
 * Before this update, the pipeline builder UI failed to save a pipeline when the `buildah` task `BUILD_ARGS` parameter had the default value `[""]`. The validation incorrectly rejected empty strings in arrays, even though the task could run successfully.
 With this update, the issue is fixed, allowing pipelines with default `BUILD_ARGS` parameter to be saved correctly.

--- a/release_notes/op-release-notes-1-18.adoc
+++ b/release_notes/op-release-notes-1-18.adoc
@@ -1,0 +1,34 @@
+:_mod-docs-content-type: ASSEMBLY
+//OpenShift Pipelines Release Notes
+include::_attributes/common-attributes.adoc[]
+[id="op-release-notes"]
+= {pipelines-title} release notes
+:context: op-release-notes
+
+toc::[]
+
+[NOTE]
+====
+For additional information about the {pipelines-shortname} lifecycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] and link:https://access.redhat.com/support/policy/updates/openshift[Red{nbsp}Hat {OCP} Life Cycle Policy].
+====
+
+Release notes contain information about new and deprecated features, breaking changes, and known issues. The following release notes apply for the most recent {pipelines-shortname} releases on {OCP}.
+
+{pipelines-title} is a cloud-native CI/CD experience based on the Tekton project which provides:
+
+* Standard Kubernetes-native pipeline definitions (CRDs).
+* Serverless pipelines with no CI server management overhead.
+* Extensibility to build images using any Kubernetes tool, such as S2I, Buildah, JIB, and Kaniko.
+* Portability across any Kubernetes distribution.
+* Powerful CLI for interacting with pipelines.
+* Integrated user experience with the *Developer* perspective of the {OCP} web console.
+
+For an overview of {pipelines-title}, see xref:../about/understanding-openshift-pipelines.adoc#understanding-openshift-pipelines[Understanding {pipelines-shortname}].
+
+// Compatibility and support matrix
+include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
+
+
+// Release notes for Red Hat OpenShift Pipelines 1.18.0 
+include::modules/op-release-notes-1-18.adoc[leveloffset=+1]
+

--- a/release_notes/op-release-notes-1-19.adoc
+++ b/release_notes/op-release-notes-1-19.adoc
@@ -1,0 +1,41 @@
+:_mod-docs-content-type: ASSEMBLY
+//OpenShift Pipelines Release Notes
+include::_attributes/common-attributes.adoc[]
+[id="op-release-notes"]
+= {pipelines-title} release notes
+:context: op-release-notes
+
+toc::[]
+
+[NOTE]
+====
+For additional information about the {pipelines-shortname} lifecycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[OpenShift Operator Life Cycles] and link:https://access.redhat.com/support/policy/updates/openshift[Red{nbsp}Hat {OCP} Life Cycle Policy].
+====
+
+Release notes contain information about new and deprecated features, breaking changes, and known issues. The following release notes apply for the most recent {pipelines-shortname} releases on {OCP}.
+
+{pipelines-title} is a cloud-native CI/CD experience based on the Tekton project which provides:
+
+* Standard Kubernetes-native pipeline definitions (CRDs).
+* Serverless pipelines with no CI server management overhead.
+* Extensibility to build images using any Kubernetes tool, such as S2I, Buildah, JIB, and Kaniko.
+* Portability across any Kubernetes distribution.
+* Powerful CLI for interacting with pipelines.
+* Integrated user experience with the *Developer* perspective of the {OCP} web console, up to {OCP} version 4.19.
+
+For an overview of {pipelines-title}, see xref:../about/understanding-openshift-pipelines.adoc#understanding-openshift-pipelines[Understanding {pipelines-shortname}].
+
+// Compatibility and support matrix
+include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
+
+// Release notes for Red Hat OpenShift Pipelines 1.19.0 
+include::modules/op-release-notes-1-19.adoc[leveloffset=+1]
+
+// Release notes for Red Hat OpenShift Pipelines 1.19.1 
+include::modules/op-release-notes-1-19-1.adoc[leveloffset=+1]
+
+// Release notes for Red Hat OpenShift Pipelines 1.19.2 
+include::modules/op-release-notes-1-19-2.adoc[leveloffset=+1]
+
+// Release notes for Red Hat OpenShift Pipelines 1.19.3 
+include::modules/op-release-notes-1-19-3.adoc[leveloffset=+1]

--- a/release_notes/op-release-notes-1-20.adoc
+++ b/release_notes/op-release-notes-1-20.adoc
@@ -34,7 +34,7 @@ include::modules/op-release-notes-1-20-0.adoc[leveloffset=+1]
 //Additional resources 1.20
 .Additional resources
 * xref:../secure/using-buildah-ns-tekton-task.adoc#op-differences-between-buildah-buildah-ns-tasks_using-buildah-ns-tekton-task[Differences between `buildah` and `buildah-ns` tasks]
-* xref:../install_config/customizing-configurations-in-the-tektonconfig-cr.adoc#op-configuration-rbac-trusted-ca-flags_customizing-configurations-in-the-tektonconfig-cr[Configuration of RBAC and Trusted CA flags].  
+//* xref:../install_config/customizing-configurations-in-the-tektonconfig-cr.adoc#op-configuration-rbac-trusted-ca-flags_customizing-configurations-in-the-tektonconfig-cr[Configuration of RBAC and Trusted CA flags].  
 * xref:../install_config/customizing-configurations-in-the-tektonconfig-cr.adoc#event-pruner-configuration_customizing-configurations-in-the-tektonconfig-cr[Enabling the event-based pruner]
 * xref:../pac/install-config-pipelines-as-code.adoc#customizing-pipelines-as-code-configuration_install-config-pipelines-as-code[Customizing {pac} configuration]
 * xref:../pac/creating-pipeline-runs-pac.adoc#op-parameters-pipeline-run-using-pipelines-as-code_creating-pipeline-runs-pac[Commit and URL Information]


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.21

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6816

Link to docs preview:
- [Release notes are now up to date for 1.20](https://100386--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-20.html)
- rest of the issues included here are already present in the latest docs but were not in main

QE review:
- [ ] QE has approved this change.

Additional information:
_Quick repo cross-replacement to check for files not included in `pipielines-docs-main`._