### PR TITLE
OBSDOCS-2380: Logging Z-Stream Release Notes - 5.9.16

### DIFF
--- a/modules/logging-release-notes-5-9-16.adoc
+++ b/modules/logging-release-notes-5-9-16.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-5-9-16_{context}"]
+= Logging 5.9.16
+
+This release includes link:https://access.redhat.com/errata/RHBA-2025:18144[RHBA-2025:18144].
+
+[id="logging-release-notes-5-9-16-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, log forwarding failed when the cluster-wide proxy configuration included a URL with a username containing an encoded `@` symbol, for example, `user%40name`.
+This update adds the correct support for URL-encoded values in proxy configurations and resolves the issue.
+link:https://issues.redhat.com/browse/LOG-6963[LOG-6963]
+
+* Before this update, Vector sent a single message twice to syslog after reading it due to an issue in the log forwarding configuration.
+As a consequence, duplicate syslog messages were sent, causing increased network usage and resource consumption.
+With this update, Vector sends a single message to syslog, reducing network usage and improving server performance.
+link:https://issues.redhat.com/browse/LOG-7008[LOG-7008]
+
+* Before this update, Vector overwrote the defined log type when writing to syslog if the log message included a `log_type` field.
+With this update, the `.message` field is replaced only if it contains a valid JSON string. This ensures that structured data is handled correctly and nested fields are preserved during syslog encoding.
+As a result, the defined log type is preserved.
+link:https://issues.redhat.com/browse/LOG-7009[LOG-7009]
+
+* Before this update, Vector duplicated fields inside a log message when forwarding logs to syslog.
+This led to redundant data in the output.
+With this update, the `.message` field is replaced only if it contains a valid JSON string, ensuring that structured data is handled correctly and preventing field duplication during syslog encoding. 
+link:https://issues.redhat.com/browse/LOG-7010[LOG-7010]
+
+* Before this update, `ClusterLoggingForwarder` spec validation failed with a nil pointer runtime error when the `outputRef` field in a pipeline did not have a corresponding output defined or had an output with no name.
+With this update, the validation function has been fixed, preventing the Operator from crashing and ensuring continuous logging service.
+link:https://issues.redhat.com/browse/LOG-7191[LOG-7191]
+
+* Before this update, parsing the `.message` field as JSON could generate logs at the `error` level even when the issue was not critical.
+With this update, the messages are logged at the `debug` level, reducing log noise and still allowing for debugging when needed.
+link:https://issues.redhat.com/browse/LOG-7232[LOG-7232]
+
+* Before this update, the histogram in the *Observe > Logs* page did not update its time range even after being manually refreshed.
+With this update, the correct time range is set and the histogram shows updated data when refreshed.
+link:https://issues.redhat.com/browse/LOG-7413[LOG-7413]
+
+[id="known-issues-5-9-16_{context}"]
+== Known issues
+
+* When you forward logs to a syslog output, the produced message format is inconsistent between Fluentd and Vector log collectors. Vector messages are within quotation marks; Fluentd messages are not. As a consequence, when migrating from Fluentd to Vector, users might experience issues with their tool integrations.  (link:https://issues.redhat.com/browse/LOG-7007[LOG-7007])

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -10,6 +10,8 @@ Logging is provided as an installable component, with a distinct release cycle f
 
 include::snippets/logging-stable-updates-snip.adoc[leveloffset=+1]
 
+include::modules/logging-release-notes-5-9-16.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-5-9-15.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-5-9-14.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16, 4.15, 4.14, 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OBSDOCS-2380](https://issues.redhat.com/browse/OBSDOCS-2380)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://100392--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
