### PR TITLE
TELCODOCS-2039 release note

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -759,6 +759,17 @@ You can use the `spec.interface` field of the BGP peer custom resource to config
 
 For more information, see xref:../networking/ingress_load_balancing/metallb/metallb-frr-k8s.adoc#nw-metallb-frrconfiguration-crd-interface[Configuring the integration of MetalLB and FRR-K8s ].
 
+[id="ocp-4-20-networking-pfrs-operator_{context}"]
+==== High-availability for pod-level bonding on SR-IOV networks (Technology Preview)
+
+This Technology Preview feature introduces the PF Status Relay Operator. The Operator uses Link Aggregation Control Protocol (LACP) as a health check to detect upstream switch failures, enabling high availability for workloads that use pod-level bonding with SR-IOV network virtual functions (VF).
+
+Without this feature, an upstream switch can fail while the underlying physical function (PF) still reports an `up` state. VFs attached to the PF also remain up, causing pods to send traffic to a dead endpoint and leading to packet loss.
+
+The PF Status Relay Operator prevents this by monitoring the LACP status of the PF. When a failure is detected, the Operator forces the link state of the attached VFs down, triggering the pod's bond to fail over to a backup path. This ensures the workload remains available and minimizes packet loss.
+
+For more information, see xref:../networking/hardware_networks/configure-lacp-for-sriov.adoc#sriov-lacp-sriov[High availability for pod-level bonds on SR-IOV networks].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 
@@ -1919,6 +1930,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 
 |Load balancing across the aggregated bonded interface with xmitHashPolicy
+|Not Available
+|Not Available
+|Technology Preview
+
+|PF Status Relay Operator for high availability with SR-IOV networks
 |Not Available
 |Not Available
 |Technology Preview


### PR DESCRIPTION
[TELCODOCS-2039](https://issues.redhat.com//browse/TELCODOCS-2039): Release note to add PF Status Relay Operator.

Version(s):
4.20

Issue:
https://issues.redhat.com/browse/TELCODOCS-2039

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


