### PR TITLE
OSDOCS-13103: adds 4.18.26 release note MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -173,7 +173,6 @@ See the latest images included with {microshift-short} by using the following in
 
 * xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
 * xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
-//addition of this bullet requires notification-only change management; bootc bullet carries forward to all 4.18 async releases
 
 [id="microshift-4-18-11-bugs_{context}"]
 ==== Bug fixes
@@ -183,3 +182,27 @@ See the latest images included with {microshift-short} by using the following in
 * In some cases, {microshift-short} did not start when using the default configuration file shipped in the {microshift-short} RPM because certain required values were missing. These values are now added to the default `config.yaml` file to avoid this problem and {microshift-short} starts as expected. (link:https://issues.redhat.com/browse/OCPBUGS-53026[OCPBUGS-53026])
 
 * Previously, when embedding container images during a bootc build procedure, extended attributes were discarded, preventing the router pod from connecting to default `haproxy` ports. With this release, extended attributes are kept for container layers that are embedded into container images. As a result, the bootc container router pod starts normally. (link:https://issues.redhat.com/browse/OCPBUGS-42010[OCPBUGS-42010])
+
+[id="microshift-4-18-26-dp_{context}"]
+=== RHBA-2025:17912 - {microshift-short} 4.18.26 bug fix and enhancement advisory
+
+Issued: 16 October 2026
+
+{product-title} release 4.18.26 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:17912[RHBA-2025:17912] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:17657[RHSA-2025:17657] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-18-26-bugs_{context}"]
+==== Bug fix
+
+* Before this update, embedding container images into a bootc build could fail because HTTP proxy environment variables were defined in the bootc image. Proxy errors occurred during container image embedding and prevented successful builds. With this release, the bootc image no longer sets HTTP proxy environment variables, thereby eliminating the issue. As a result, you can now embed container images without encountering proxy errors. (link:https://issues.redhat.com/browse/OCPBUGS-61433[OCPBUGS-61433])
+
+[id="microshift-4-18-26-enhancements_{context}"]
+==== Enhancements
+
+* With this release, {microshift-short} uses OpenVSwitch (OVS) 3.5, keeping OVS synchronized with OVN-Kubernetes. (link:https://issues.redhat.com/browse/OCPBUGS-58139[OCPBUGS-58139])
+
+* With this release, the `microshift-release-info` RPM now incudes example {op-system-base} Kickstart files for RPM, {op-system-ostree} and {op-system-image} installation types. You can use the Kickstart immediately for a faster installation, or customize it with your requirements. (link:https://issues.redhat.com/browse/OCPBUGS-42864[OCPBUGS-42864])


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.18

Issue:
[OSDOCS-13103](https://issues.redhat.com/browse/OSDOCS-13103)

Link to docs preview:
[microshift-4-18-26-dp_release-notes](https://100426--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-26-dp_release-notes)

QE review:
- [x] QE has approved this change (_in previous release notes/bugs and enhancements are ported from 4.17, 4.19, and 4.20_)

Additional info: Reviewers, please ack, but do not merge. Release is scheduled for a future date.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
