### PR TITLE
OSDOCS 16556 Linux User Namespace ID-mapped mount information

### DIFF
--- a/nodes/pods/nodes-pods-user-namespaces.adoc
+++ b/nodes/pods/nodes-pods-user-namespaces.adoc
@@ -12,6 +12,13 @@ By default, a container runs in the host user namespace. Running a container in 
  
 Running containers in individual user namespaces can mitigate container breakouts and several other vulnerabilities that a compromised container can pose to other pods and the node itself. 
 
+When running a pod in an isolated user namespace, the UID/GID inside a pod container no longer matches the UID/GID on the host. In order for file system ownership to work correctly, the Linux kernel uses ID-mapped mounts, which translate user IDs between the container and the host at the virtual file system (VFS) layer.
+
+[IMPORTANT]
+====
+Not all file systems currently support ID-mapped mounts, such as Network File Systems (NFS) and other network/distributed file systems. Any pod that is using an NFS-backed persistent volume from a vendor that does not support ID-mapped mounts might experience access or permission issues when running in a user namespace. This behavior is not specific to {product-title}. It applies to all Kubernetes distributions from Kubernetes v1.33 onward.
+====
+
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16556

From [thread in Slack](https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1760112414435929).

Link to docs preview:
[Running pods in Linux user namespaces](https://100433--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-user-namespaces.html) -- New paragraph 4 and Note.

SME review:
- [x] Per Matt Werner, Peter Hunt has [approved this change in Slack](https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1760443671529539?thread_ts=1760112414.435929&cid=CK1AE4ZCK).

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

