### PR TITLE
OSDOCS 16556 Linux User Namespace ID-mapped mount information RN

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -2454,6 +2454,17 @@ In the following tables, features are marked with the following statuses:
 +
 There is no supported workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-57440[OCPBUGS-57440])
 
+* When running a pod in an isolated user namespace, the UID/GID inside a pod container no longer matches the UID/GID on the host. For file system ownership to work correctly, the Linux kernel uses ID-mapped mounts, which translate user IDs between the container and the host at the virtual file system (VFS) layer.
++
+However, not all file systems currently support ID-mapped mounts, such as Network File Systems (NFS) and other network or distributed file systems. Because such file systems do not support ID-mapped mounts, pods running within user namespaces can fail to access mounted NFS volumes. This behavior is not specific to {product-title}. It applies to all Kubernetes distributions from Kubernetes v1.33 and later.
++
+When upgrading to {product-title} 4.20, clusters are unaffected until you opt in to user namespaces. After enabling user namespaces, any pod that is using an NFS-backed persistent volume from a vendor that does not support ID-mapped mounts might experience access or permission issues when running in a user namespace. For more information about enabling user namespaces, see xref:../nodes/pods/nodes-pods-user-namespaces.adoc#nodes-pods-user-namespaces-configuring_nodes-pods-user-namespaces[Configuring Linux user namespace support].
++
+[NOTE]
+====
+Existing {product-title} 4.19 clusters are unaffected until you explicitly enable user namespaces, which is a Technology Preview feature in {product-title} 4.19. 
+====
+
 * When installing a cluster on {azure-short}, if you set any of the `compute.platform.azure.identity.type`, `controlplane.platform.azure.identity.type`, or `platform.azure.defaultMachinePlatform.identity.type` field values to `None`, your cluster is unable to pull images from the Azure Container Registry.
 You can avoid this issue by providing a user-assigned identity or by leaving the identity field blank.
 In both cases, the installation program generates a user-assigned identity.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16556

From [thread in Slack](https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1760112414435929).

Link to docs preview:
[Linux User Namespace support and ID-mapped mount requirements for NFS/remote file systems](https://100434--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-known-issues_release-notes) -- New Known Issue.

SME review:
- [x] Per Matt Werner, Peter Hunt has approved this change.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
