### PR TITLE
OSDOCS-16512: Update Machine management TP tracker for CAPI 4.17

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2718,6 +2718,16 @@ To know the status of the {hcp} features on {product-title} 4.17, see xref:../ho
 |Technology Preview
 |Technology Preview
 
+|Managing machines with the Cluster API for {ibm-power-server-name}
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Managing machines with the Cluster API for {rh-openstack}
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
 |Managing machines with the Cluster API for {vmw-full}
 |Not Available
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-16512](https://issues.redhat.com//browse/OSDOCS-16512)

Link to docs preview:
[Machine management Technology Preview features](https://100437--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-release-notes-machine-management-tech-preview_release-notes)

QE review:
- [x] QE has approved this change.

Additional information: