### PR TITLE
OSDOCS-16512: Update Machine management TP tracker for CAPI 4.15

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2547,6 +2547,16 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
+|Managing machines with the Cluster API for {ibm-power-server-name}
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Managing machines with the Cluster API for {rh-openstack}
+|Not Available
+|Not Available
+|Technology Preview
+
 |Defining a vSphere failure domain for a control plane machine set
 |Not Available
 |Not Available


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-16512](https://issues.redhat.com//browse/OSDOCS-16512)

Link to docs preview:
[Machine management Technology Preview features](https://100439--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-release-notes-machine-management-tech-preview_release-notes)

QE review:
- [x] QE has approved this change.

Additional information: