### PR TITLE
OSDOCS-16187: Add release note for network policies

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -775,6 +775,10 @@ The PF Status Relay Operator prevents this by monitoring the LACP status of the 
 
 For more information, see xref:../networking/hardware_networks/configure-lacp-for-sriov.adoc#sriov-lacp-sriov[High availability for pod-level bonds on SR-IOV networks].
 
+[id="ocp-4-20-network-policies_{context}"]
+==== Network policies for additional namespaces
+With this release, {product-title} deploys Kubernetes network policies to additional system namespaces to control ingress and egress traffic. It is anticipated that future releases might include network policies for additional system namespaces and Red{nbsp}Hat Operators.
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 


### PR DESCRIPTION
[OSDOCS-16187](https://issues.redhat.com/browse/OSDOCS-16187):  Release note for network policies

Version(s): enterprise-4.20 only

Issue:
https://issues.redhat.com/browse/OSDOCS-16187

Link to docs preview:
https://100457--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-network-policies_release-notes

QE review:
N/A
