### PR TITLE
OSDOCS-16215 added deprecated features for 4.20

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -701,10 +701,10 @@ Previously, creating an SR-IOV network required a cluster administrator to confi
 For more information, see xref:../networking/hardware_networks/configuring-namespaced-sriov-resources.html#configuring-namespaced-sriov-resources[Configuring namespaced SR-IOV resources].
 
 [id="ocp-4-20-unnumbered-bgp-peering_{context}"]
-==== Unnumbered BGP peering 
+==== Unnumbered BGP peering
 
 With this release, {product-title} includes unnumbered BGP peering.
-This was previously available as a Technology Preview feature. 
+This was previously available as a Technology Preview feature.
 You can use the `spec.interface` field of the BGP peer custom resource to configure unnumbered BGP peering.
 
 For more information, see xref:../networking/ingress_load_balancing/metallb/metallb-frr-k8s.adoc#nw-metallb-frrconfiguration-crd-interface[Configuring the integration of MetalLB and FRR-K8s ].
@@ -972,6 +972,11 @@ This prevents users from discovering certain problems only after the cache is po
 |Deprecated
 |Deprecated
 |Deprecated
+
+|Docker v2 registries
+|General Availability
+|General Availability
+|Deprecated
 |====
 
 
@@ -1119,6 +1124,14 @@ This prevents users from discovering certain problems only after the cache is po
 |
 
 |===
+
+[id="ocp-4-20-deprecated-features_{context}"]
+=== Deprecated features
+
+[id="ocp-4-20-docker-v2-registries-removed_{context}"]
+==== Docker v2 registries deprecated
+
+Support for Docker v2 registries is deprecated and will be removed in {product-title} {product-version}.21. A registry that supports the Open Container Initiative (OCI) specification will be required for all mirroring operations as of {product-title} {product-version}.21. Additionally, `oc-mirror` v2 now only generates custom catalog images in the OCI format, whereas the deprecated `oc-mirror` v1 still supports the Docker v2 format.
 
 [id="ocp-release-bug-fixes_{context}"]
 == Bug fixes


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-16215

Link to docs preview:
https://100463--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-cli-dep-rem_release-notes

https://100463--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-deprecated-features_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:

