### PR TITLE
OCPBUGS-57484: Documented support for migrating a configured br-ex br…

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -659,6 +659,11 @@ With route advertisements enabled, the OVN-Kubernetes network plugin supports th
 
 For more information, see xref:../networking/advanced_networking/route_advertisements/about-route-advertisements.adoc#about-route-advertisements[About route advertisements].
 
+[id="ocp-4-20-migration-configure-ovs-nmstate_{context}"]
+==== Support for migrating a configured br-ex bridge to NMState
+
+If you used the `configure-ovs.sh` shell script to set a `br-ex` bridge during cluster installation, you can migrate the `br-ex` bridge to NMState as a postinstallation task. For more information, see xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#migrating-br-ex-bridge-nmstate_bare-metal-postinstallation-configuration[Migrating a configured br-ex bridge to NMState].
+
 [id="ocp-release-notes-ptp-logging-config_{context}"]
 ==== Configuring enhanced PTP logging
 


### PR DESCRIPTION
Bug was pre-approved on the Jira as the feature was treated like an OCPBUGS.

Version(s):
4.20

Issue:
[OCPBUGS-57484](https://issues.redhat.com/browse/OCPBUGS-57484)

Link to docs preview:
* [Support for migrating a configured br-ex bridge to NMState](https://100464--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-migration-configure-ovs-nmstate_release-notes)
