### PR TITLE
OBSDOCS-2561 Fix OCP additional release notes 4.19

### DIFF
--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -24,7 +24,7 @@ link:https://docs.redhat.com/en/documentation/builds_for_red_hat_openshift/1.1/h
 C::
 xref:../security/cert_manager_operator/cert-manager-operator-release-notes.adoc#cert-manager-operator-release-notes[{cert-manager-operator}]
 +
-xref:../observability/cluster_observability_operator/cluster-observability-operator-release-notes.adoc#cluster-observability-operator-release-notes[{coo-first}]
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/1-latest/html/red_hat_openshift_cluster_observability_operator_release_notes/index[{coo-first}]
 +
 xref:../security/compliance_operator/compliance-operator-release-notes.adoc#compliance-operator-release-notes[Compliance Operator]
 +
@@ -52,7 +52,8 @@ xref:../ai_workloads/kueue/release-notes.adoc#release-notes[{kueue-name}]
 L::
 
 xref:../ai_workloads/leader_worker_set/lws-release-notes.adoc#lws-release-notes[{lws-operator}]
-
++
+link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging[{logging-uc}]
 ////
 * xref:../observability/logging/logging-6.2/log6x-release-notes-6.2.adoc#log6x-release-notes-6-2[{logging-uc}]
 ////


### PR DESCRIPTION

Version(s):
4.19 only

Issue:
[OBSDOCS-2561](https://issues.redhat.com//browse/OBSDOCS-2561) 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
