### PR TITLE
node-role.kubernetes.io/control-plane is not added automatically in existing OpenShift Container Platform - Cluster

### DIFF
--- a/modules/nodes-nodes-working-updating.adoc
+++ b/modules/nodes-nodes-working-updating.adoc
@@ -65,5 +65,5 @@ $ oc label pods --all status=unhealthy
 ====
 In {product-title} 4.12 and later, newly installed clusters include both the `node-role.kubernetes.io/control-plane` and `node-role.kubernetes.io/master` labels on control plane nodes by default.
 
-In {product-title} versions earlier than 4.12, the `node-role.kubernetes.io/control-plane` label is not added by default. Therefore, you must manually add the `node-role.kubernetes.io/control-plane` label to control plane nodes in clusters upgraded from earlier versions.
+In {product-title} versions earlier than 4.12, the `node-role.kubernetes.io/control-plane` label is not added by default. You can manually add the `node-role.kubernetes.io/control-plane` label to control plane nodes in clusters upgraded from earlier versions, as needed.
 ====


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-17709

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
