### PR TITLE
TELCODOCS-2315: Document known issues Telco RAN

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -2456,10 +2456,15 @@ There is no supported workaround for this issue. (link:https://issues.redhat.com
 
 * When installing a cluster on {azure-short}, if you set any of the `compute.platform.azure.identity.type`, `controlplane.platform.azure.identity.type`, or `platform.azure.defaultMachinePlatform.identity.type` field values to `None`, your cluster is unable to pull images from the Azure Container Registry.
 You can avoid this issue by providing a user-assigned identity or by leaving the identity field blank.
-In both cases, the installation program generates a user-assigned identity.
-(link:https://issues.redhat.com/browse/OCPBUGS-56008[OCPBUGS-56008])
+In both cases, the installation program generates a user-assigned identity. (link:https://issues.redhat.com/browse/OCPBUGS-56008[OCPBUGS-56008])
 
 * There is a known issue in the unified software catalog view of the console. When you select *Ecosystem* -> *Software Catalog*, you must enter an existing project name or create a new project to view the software catalog. The project selection field does not effect how catalog content is installed on the cluster. As a workaround, enter any existing project name to view the software catalog. (link:https://issues.redhat.com/browse/OCPBUGS-61870[OCPBUGS-61870])
+
+* Starting with OCP 4.20, there is a decrease in the default maximum open files soft limit for containers. As a consequence, end users may experience application failures. To work around this problem, increase the container runtimes (CRI-O) ulimit configuration. (link:https://issues.redhat.com/browse/OCPBUGS-62095[OCPBUGS-62095])
+
+* Deleting and recreating test workloads with a BlueField-3 NIC causes clock jumps due to inconsistent PTP synchronization. This disrupts time synchronization in test workloads. The time synchronization stabilizes when the workloads are stable. (link:https://issues.redhat.com/browse/RHEL-93579[RHEL-93579])
+
+* Event logs for GNR-D interfaces are ambiguous due to identical three-letter prefixes ("eno"). As a consequence, affected interfaces are not clearly identified during state changes. To work around this problem, change interfaces used by ptp-operator to follow the "path" naming convention, ensuring per clock events are identified correctly based on interface names and clearly indicate which clock is affected by state changes. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/consistent-network-interface-device-naming_configuring-and-managing-networking#network-interface-naming-policies_consistent-network-interface-device-naming[Network interface naming policies]. (link:https://issues.redhat.com/browse/OCPBUGS-62817[OCPBUGS-62817])
 
 [id="ocp-telco-core-release-known-issues_{context}"]
 


### PR DESCRIPTION
**Fixes:** [TELCODOCS-2315](https://issues.redhat.com/browse/TELCODOCS-2315)

**For:** OCP TELCO RAN

[**Preview**](https://100482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-known-issues_release-notes)

**Approvals -** `/lgtm`:
- [x] Peer review (@lcavalle)

- [OCPBUGS-62095: "ulimit -n" just 1024 (instead of 1048576)](https://issues.redhat.com/browse/OCPBUGS-62095)
   - - [x] SME (@saschagrunert)

- [RHEL-93579: Inconsistent clock jumps observed when deleting and re-creating test workloads on SNO with BlueField-3 NIC](https://issues.redhat.com/browse/RHEL-93579)
   - - [x] SME (@vitus133)

- [OCPBUGS-62817: Events do not clearly differentiate all "eno" interfaces for GNR-D](https://issues.redhat.com/browse/OCPBUGS-62817)
   - - [x] SME