### PR TITLE
OSDOCS-13908-sync: manual CP

### DIFF
--- a/microshift_updating/microshift-update-options.adoc
+++ b/microshift_updating/microshift-update-options.adoc
@@ -8,7 +8,7 @@ include::_attributes/attributes-microshift.adoc[]
 toc::[]
 
 [role="_abstract"]
-To update {op-system-bundle}, you can update both {product-title} and {op-system-full}, or each part by itself without updating the other. You must keep the parts in a supported configuration. Consider the following options when planning updates to your current deployments.
+To update {op-system-bundle}, you can update both {product-title} and {op-system-base-full}, or each part by itself without updating the other. You must keep the parts in a supported configuration. Consider the following options when planning updates to your current deployments.
 
 include::modules/microshift-rhde-updates.adoc[leveloffset=+1]
 
@@ -34,4 +34,3 @@ include::modules/microshift-migrate-rhel-edge-to-image-mode.adoc[leveloffset=+1]
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/index[Composing a customized RHEL system image]
 * xref:../microshift_install_get_ready/microshift-greenboot.adoc#microshift-greenboot[The greenboot system health check]
 * xref:../microshift_running_apps/microshift-greenboot-workload-health-checks.adoc#microshift-greenboot-workload-health-checks[Greenboot workload health checks]
-

--- a/modules/microshift-manual-rpm-updates.adoc
+++ b/modules/microshift-manual-rpm-updates.adoc
@@ -13,4 +13,4 @@ You can update {microshift-short} manually on {op-system-base-full} by updating 
 * Use manual processes to ensure system health and complete additional system backups.
 * To begin a manual RPM update, use the procedures in the following documentation:
 
-* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{product-version}/html/updating/microshift-update-rpms-manually[About updating MicroShift RPMs manually]
+* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/updating/microshift-update-rpms-manually[About updating MicroShift RPMs manually]

--- a/modules/microshift-updating-rpms-y.adoc
+++ b/modules/microshift-updating-rpms-y.adoc
@@ -7,7 +7,7 @@
 = Applying minor-version updates with RPMs
 
 [role="_abstract"]
-Updating a {microshift-short} minor version on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to update from 4.16 to 4.18.
+Updating a {microshift-short} minor version on non `rpm-ostree` systems such as {op-system-base-full} requires downloading then updating the RPMs. For example, use the following procedure to update from 4.18 to 4.19.
 
 include::snippets/microshift-unsupported-config-warn.adoc[leveloffset=+1]
 

--- a/snippets/microshift-rhde-compatibility-table-snip.adoc
+++ b/snippets/microshift-rhde-compatibility-table-snip.adoc
@@ -7,7 +7,7 @@
 
 .{op-system-bundle} release compatibility matrix
 
-{op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.18 to 4.20 requires a {op-system-base-full} update. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
+{op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
 
 [%header,cols="3",cols="1,1,2"]
 |===


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-13908](https://issues.redhat.com/browse/OSDOCS-13908)

Link to docs preview:
https://100486--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-options.html
https://100486--ocpdocs-pr.netlify.app/microshift/latest/microshift_updating/microshift-update-rpms-manually.html

QE review:
- N/A

Additional information:
Backports fix to `4.19` from https://github.com/openshift/openshift-docs/pull/100412.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
