### PR TITLE
OSDOCS#16127: Add deprecated notice for Red Hat Marketplace

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1272,6 +1272,11 @@ You can use AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SN
 
 Support for Docker v2 registries is deprecated and is planned for removal in a future release. A registry that supports the Open Container Initiative (OCI) specification will be required for all mirroring operations in a future release. Additionally, `oc-mirror` v2 now only generates custom catalog images in the OCI format, whereas the deprecated `oc-mirror` v1 still supports the Docker v2 format.
 
+[id="ocp-4-20-sunset-redhat-marketplace_{context}"]
+==== Red{nbsp}Hat Marketplace is deprecated
+
+The Red{nbsp}Hat Marketplace is deprecated. Customers who use the partner software from the Marketplace should contact the software vendor about how to migrate from the Marketplace Operator to an Operator in the Red{nbsp}Hat Ecosystem Catalog. It is expected that the Marketplace index will be removed in {product-title} 4.21. For more information, see link:https://access.redhat.com/articles/7130828[Sunset of the Red Hat Marketplace, operated by IBM].
+
 [id="ocp-release-removed-features_{context}"]
 === Removed features
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-16127](https://issues.redhat.com//browse/OSDOCS-16127)

Link to docs preview:
[Red Hat Marketplace is deprecated](https://100495--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-sunset-redhat-marketplace_release-notes)

QE review:
- [ ] QE has approved this change.
(The 2 primary SMEs reviewed and acked)