### PR TITLE
OSDOCS#16474: Update the z-stream RNs for 4.16.50

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3381,6 +3381,44 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.50
+[id="ocp-4-16-50_{context}"]
+=== RHSA-2025:17690 - {product-title} {product-version}.50 bug fix and security update
+
+Issued: 15 October 2025
+
+{product-title} release {product-version}.50 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:17690[RHSA-2025:17690] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.50 --pullspecs
+----
+
+[id="ocp-4-16-50-enhancements_{context}"]
+==== Enhancements
+
+* Previously, if you imported a virtual machine (VM) into an Azure Compute Gallery (ACG) image in the same subscription, read access was required on the VM. Also, to import a blob into an ACG image in the same subscription, write access was required on the storage account. Starting 8 October 2025, Microsoft requires write access on the source VM during VM image creation in the same subscription workflow. To prevent VM image version creation failures when importing VMs and blobs into an ACG image, users should use the `properties.storageProfile.source.virtualMachineId` property. If you use blobs as a source to create ACG image versions, use the `properties.storageProfile.osDiskImage.source.storageAccountId` property. (link:https://issues.redhat.com/browse/OCPBUGS-62653[OCPBUGS-62653])
+
+[id="ocp-4-16-50-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, setting the `routingViaHost` parameter to `true` on a single-stack IPv6 cluster that was connected by using a  proxy in {product-title} 4.x caused the cluster to stop during deployment. With this release, the issue is resolved because the `routingViaHost` parameter is not set to `true` on these clusters. As a result, the cluster deployment does not fail. (link:https://issues.redhat.com/browse/OCPBUGS-60079[OCPBUGS-60079])
+
+* Before this update, improper formatting in the provided YAML file before running `kubectl apply` caused deployment failure. As a consequence, user data loss occurred during pod rescheduling due to incorrect error handling. With this release, the pod scheduling issue with taints and tolerations has been fixed. As a result, end users no longer experience pod eviction due to incorrect resource allocation. (link:https://issues.redhat.com/browse/OCPBUGS-61582[OCPBUGS-61582])
+
+* Before this update, disabling the {product-registry} left legacy pull secret finalizer fields, and caused secret deletions to stop during namespace deletion. As a consequence, users could not delete `Dockercfg` secrets when disabling the {product-registry}. With this release, the remaining finalizer fields on legacy pull secrets are removed during registry deletion. As a result, registry deletions do not stop, and seamless secret cleanup is allowed. (link:https://issues.redhat.com/browse/OCPBUGS-61707[OCPBUGS-61707])
+
+* Before this update, NMState service failures occurred in baremetal deployments due to a dependency on the `NetworkManager-wait-online` service. This dependancy caused user deployment failures due to NMState service inactivity. With this release, the NMState dependency issue is resolved, and the `NetworkManager-wait-online` service is not required for a `br-ex` configuration. As a result, NMState service stability is improved in {product-title} deployments, reducing deployment failures. (link:https://issues.redhat.com/browse/OCPBUGS-61869[OCPBUGS-61869])
+
+* Before this update, using a fixed upstream issue in {product-title} version 4.16 triggered user data loss, due to an overflow in the error message buffer. With this release, the fixed upstream issue in the `external-resizer` process reduces potential consumption for downstream, and prevents user data loss. As a result, users do not experience the occasional issue that consumes fixed upstream resources. (link:https://issues.redhat.com/browse/OCPBUGS-62465[OCPBUGS-62465])
+
+[id="ocp-4-16-50-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.49
 [id="ocp-4-16-49_{context}"]
 === RHBA-2025:16726 - {product-title} {product-version}.49 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-16474](https://issues.redhat.com//browse/OSDOCS-16474)

Link to docs preview:
4.16.50

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
The errata URLs will return 404 until the go-live date of 10/15/25.
