### PR TITLE
TELCODOCS-2327 - TELCO RAN RDS updates for 4.20

### DIFF
--- a/modules/telco-ran-crs-cluster-tuning.adoc
+++ b/modules/telco-ran-crs-cluster-tuning.adoc
@@ -11,12 +11,12 @@
 |====
 Component,Reference CR,Description,Optional
 Cluster capabilities,`example-sno.yaml`,Representative SiteConfig CR to install single-node OpenShift with the RAN DU profile,No
-Console disable,`ConsoleOperatorDisable.yaml`,Disables the Console Operator.,No
-Disconnected registry,`09-openshift-marketplace-ns.yaml`,Defines a dedicated namespace for managing the OpenShift Operator Marketplace.,No
-Disconnected registry,`DefaultCatsrc.yaml`,Configures the catalog source for the disconnected registry.,No
-Disconnected registry,`DisableOLMPprof.yaml`,Disables performance profiling for OLM.,No
-Disconnected registry,`DisconnectedIDMS.yaml`,Configures disconnected registry image content source policy.,No
-Disconnected registry,`OperatorHub.yaml`,"Optional, for multi-node clusters only. Configures the OperatorHub in OpenShift, disabling all default Operator sources. Not required for single-node OpenShift installs with marketplace capability disabled.",No
-Monitoring configuration,`ReduceMonitoringFootprint.yaml`,"Reduces the monitoring footprint by disabling Alertmanager and Telemeter, and sets Prometheus retention to 24 hours",No
-Network diagnostics disable,`DisableSnoNetworkDiag.yaml`,Configures the cluster network settings to disable built-in network troubleshooting and diagnostic features.,No
+Console disable,`cluster-tuning/console-disable/ConsoleOperatorDisable.yaml`,Disables the Console Operator.,No
+Disconnected registry,`extra-manifest/09-openshift-marketplace-ns.yaml`,Defines a dedicated namespace for managing the OpenShift Operator Marketplace.,No
+Disconnected registry,`disconnected-registry/DefaultCatsrc.yaml`,Configures the catalog source for the disconnected registry.,No
+Disconnected registry,`cluster-tuning/DisableOLMPprof.yaml`,Disables performance profiling for OLM.,No
+Disconnected registry,`disconnected-registry/DisconnectedIDMS.yaml`,Configures disconnected registry image content source policy.,No
+Disconnected registry,`cluster-tuning/operator-hub/OperatorHub.yaml`,"Optional, for multi-node clusters only. Configures the OperatorHub in OpenShift, disabling all default Operator sources. Not required for single-node OpenShift installs with marketplace capability disabled.",No
+Monitoring configuration,`cluster-tuning/monitoring-configuration/ReduceMonitoringFootprint.yaml`,"Reduces the monitoring footprint by disabling Alertmanager and Telemeter, and sets Prometheus retention to 24 hours",No
+Network diagnostics disable,`cluster-tuning/disabling-network-diagnostics/DisableSnoNetworkDiag.yaml`,Configures the cluster network settings to disable built-in network troubleshooting and diagnostic features.,No
 |====

--- a/modules/telco-ran-crs-day-2-operators.adoc
+++ b/modules/telco-ran-crs-day-2-operators.adoc
@@ -10,55 +10,57 @@
 [cols="4*", options="header", format=csv]
 |====
 Component,Reference CR,Description,Optional
-Cluster Logging Operator,`ClusterLogForwarder.yaml`,Configures log forwarding for the cluster.,No
-Cluster Logging Operator,`ClusterLogNS.yaml`,Configures the namespace for cluster logging.,No
-Cluster Logging Operator,`ClusterLogOperGroup.yaml`,Configures Operator group for cluster logging.,No
-Cluster Logging Operator,`ClusterLogServiceAccount.yaml`,Configures the cluster logging service account.,No
-Cluster Logging Operator,`ClusterLogServiceAccountAuditBinding.yaml`,Configures the cluster logging service account.,No
-Cluster Logging Operator,`ClusterLogServiceAccountInfrastructureBinding.yaml`,Configures the cluster logging service account.,No
-Cluster Logging Operator,`ClusterLogSubscription.yaml`,Manages installation and updates for the Cluster Logging Operator.,No
-Lifecycle Agent,`ImageBasedUpgrade.yaml`,Manage the image-based upgrade process in OpenShift.,Yes
-Lifecycle Agent,`LcaSubscription.yaml`,Manages installation and updates for the LCA Operator.,Yes
-Lifecycle Agent,`LcaSubscriptionNS.yaml`,Configures namespace for LCA subscription.,Yes
-Lifecycle Agent,`LcaSubscriptionOperGroup.yaml`,Configures the Operator group for the LCA subscription.,Yes
-Local Storage Operator,`StorageClass.yaml`,Defines a storage class with a Delete reclaim policy and no dynamic provisioning in the cluster.,No
-Local Storage Operator,`StorageLV.yaml`,"Configures local storage devices for the example-storage-class in the openshift-local-storage namespace, specifying device paths and filesystem type.",No
-Local Storage Operator,`StorageNS.yaml`,Creates the namespace with annotations for workload management and the deployment wave for the Local Storage Operator.,No
-Local Storage Operator,`StorageOperGroup.yaml`,Creates the Operator group for the Local Storage Operator.,No
-Local Storage Operator,`StorageSubscription.yaml`,Creates the namespace for the Local Storage Operator with annotations for workload management and deployment wave.,No
-LVM Operator,`LVMOperatorStatus.yaml`,Verifies the installation or upgrade of the LVM Storage Operator.,Yes
-LVM Operator,`StorageLVMCluster.yaml`,"Defines an LVM cluster configuration, with placeholders for storage device classes and volume group settings. Optional substitute for the Local Storage Operator.",No
-LVM Operator,`StorageLVMSubscription.yaml`,Manages installation and updates of the LVMS Operator. Optional substitute for the Local Storage Operator.,No
-LVM Operator,`StorageLVMSubscriptionNS.yaml`,Creates the namespace for the LVMS Operator with labels and annotations for cluster monitoring and workload management. Optional substitute for the Local Storage Operator.,No
-LVM Operator,`StorageLVMSubscriptionOperGroup.yaml`,Defines the target namespace for the LVMS Operator. Optional substitute for the Local Storage Operator.,No
-Node Tuning Operator,`PerformanceProfile.yaml`,"Configures node performance settings in an OpenShift cluster, optimizing for low latency and real-time workloads.",No
-Node Tuning Operator,`TunedPerformancePatch.yaml`,"Applies performance tuning settings, including scheduler groups and service configurations for nodes in the specific namespace.",No
-PTP fast event notifications,`PtpConfigBoundaryForEvent.yaml`,Configures PTP settings for PTP boundary clocks with additional options for event synchronization. Dependent on cluster role.,No
-PTP fast event notifications,`PtpConfigForHAForEvent.yaml`,Configures PTP for highly available boundary clocks with additional PTP fast event settings. Dependent on cluster role.,No
-PTP fast event notifications,`PtpConfigMasterForEvent.yaml`,Configures PTP for PTP grandmaster clocks with additional PTP fast event settings. Dependent on cluster role.,No
-PTP fast event notifications,`PtpConfigSlaveForEvent.yaml`,Configures PTP for PTP ordinary clocks with additional PTP fast event settings. Dependent on cluster role.,No
-PTP fast event notifications,`PtpOperatorConfigForEvent.yaml`,Overrides the default OperatorConfig. Configures the PTP Operator specifying node selection criteria for running PTP daemons in the openshift-ptp namespace.,No
-PTP Operator,`PtpConfigBoundary.yaml`,Configures PTP settings for PTP boundary clocks. Dependent on cluster role.,No
-PTP Operator,`PtpConfigDualCardGmWpc.yaml`,Configures PTP grandmaster clock settings for hosts that have dual NICs. Dependent on cluster role.,No
-PTP Operator,`PtpConfigThreeCardGmWpc.yaml`,Configures PTP grandmaster clock settings for hosts that have 3 NICs. Dependent on cluster role.,No
-PTP Operator,`PtpConfigGmWpc.yaml`,Configures PTP grandmaster clock settings for hosts that have a single NIC. Dependent on cluster role.,No
-PTP Operator,`PtpConfigSlave.yaml`,Configures PTP settings for a PTP ordinary clock. Dependent on cluster role.,No
-PTP Operator,`PtpConfigDualFollower.yaml`,Configures PTP settings for a PTP ordinary clock with 2 interfaces in an active/standby configuration. Dependent on cluster role.,No
-PTP Operator,`PtpOperatorConfig.yaml`,"Configures the PTP Operator settings, specifying node selection criteria for running PTP daemons in the openshift-ptp namespace.",No
-PTP Operator,`PtpSubscription.yaml`,Manages installation and updates of the PTP Operator in the openshift-ptp namespace.,No
-PTP Operator,`PtpSubscriptionNS.yaml`,Configures the namespace for the PTP Operator.,No
-PTP Operator,`PtpSubscriptionOperGroup.yaml`,Configures the Operator group for the PTP Operator.,No
-PTP Operator (high availability),`PtpConfigBoundary.yaml`,Configures PTP settings for highly available PTP boundary clocks.,No
-PTP Operator (high availability),`PtpConfigForHA.yaml`,Configures PTP settings for highly available PTP boundary clocks.,No
-SR-IOV FEC Operator,`AcceleratorsNS.yaml`,Configures namespace for the VRAN Acceleration Operator. Optional part of application workload.,Yes
-SR-IOV FEC Operator,`AcceleratorsOperGroup.yaml`,Configures the Operator group for the VRAN Acceleration Operator. Optional part of application workload.,Yes
-SR-IOV FEC Operator,`AcceleratorsSubscription.yaml`,Manages installation and updates for the VRAN Acceleration Operator. Optional part of application workload.,Yes
-SR-IOV FEC Operator,`SriovFecClusterConfig.yaml`,"Configures SR-IOV FPGA Ethernet Controller (FEC) settings for nodes, specifying drivers, VF amount, and node selection.",Yes
-SR-IOV Operator,`SriovNetwork.yaml`,"Defines an SR-IOV network configuration, with placeholders for various network settings.",No
-SR-IOV Operator,`SriovNetworkNodePolicy.yaml`,"Configures SR-IOV network settings for specific nodes, including device type, RDMA support, physical function names, and the number of virtual functions.",No
-SR-IOV Operator,`SriovOperatorConfig.yaml`,"Configures SR-IOV Network Operator settings, including node selection, injector, and webhook options.",No
-SR-IOV Operator,`SriovOperatorConfigForSNO.yaml`,"Configures the SR-IOV Network Operator settings for Single Node OpenShift (SNO), including node selection, injector, webhook options, and disabling node drain, in the openshift-sriov-network-operator namespace.",No
-SR-IOV Operator,`SriovSubscription.yaml`,Manages the installation and updates of the SR-IOV Network Operator.,No
-SR-IOV Operator,`SriovSubscriptionNS.yaml`,Creates the namespace for the SR-IOV Network Operator with specific annotations for workload management and deployment waves.,No
-SR-IOV Operator,`SriovSubscriptionOperGroup.yaml`,"Defines the target namespace for the SR-IOV Network Operators, enabling their management and deployment within this namespace.",No
+Cluster Logging Operator,`cluster-logging/ClusterLogForwarder.yaml`,Configures log forwarding for the cluster.,No
+Cluster Logging Operator,`cluster-logging/ClusterLogNS.yaml`,Configures the namespace for cluster logging.,No
+Cluster Logging Operator,`cluster-logging/ClusterLogOperGroup.yaml`,Configures Operator group for cluster logging.,No
+Cluster Logging Operator,`cluster-logging/ClusterLogServiceAccount.yaml`,New in 4.18. Configures the cluster logging service account.,No
+Cluster Logging Operator,`cluster-logging/ClusterLogServiceAccountAuditBinding.yaml`,New in 4.18. Configures the cluster logging service account.,No
+Cluster Logging Operator,`cluster-logging/ClusterLogServiceAccountInfrastructureBinding.yaml`,New in 4.18. Configures the cluster logging service account.,No
+Cluster Logging Operator,`cluster-logging/ClusterLogSubscription.yaml`,Manages installation and updates for the Cluster Logging Operator.,No
+Lifecycle Agent,`ibu/ImageBasedUpgrade.yaml`,Manage the image-based upgrade process in OpenShift.,Yes
+Lifecycle Agent,`lca/LcaSubscription.yaml`,Manages installation and updates for the LCA Operator.,Yes
+Lifecycle Agent,`lca/LcaSubscriptionNS.yaml`,Configures namespace for LCA subscription.,Yes
+Lifecycle Agent,`lca/LcaSubscriptionOperGroup.yaml`,Configures the Operator group for the LCA subscription.,Yes
+Local Storage Operator,`storage-lso/StorageClass.yaml`,Defines a storage class with a Delete reclaim policy and no dynamic provisioning in the cluster.,No
+Local Storage Operator,`storage/StorageLV.yaml`,"Configures local storage devices for the example-storage-class in the openshift-local-storage namespace, specifying device paths and filesystem type.",No
+Local Storage Operator,`storage-lso/StorageNS.yaml`,Creates the namespace with annotations for workload management and the deployment wave for the Local Storage Operator.,No
+Local Storage Operator,`storage-lso/StorageOperGroup.yaml`,Creates the Operator group for the Local Storage Operator.,No
+Local Storage Operator,`storage-lso/StorageSubscription.yaml`,Creates the namespace for the Local Storage Operator with annotations for workload management and deployment wave.,No
+LVM Operator,`storage-lvm/LVMOperatorStatus.yaml`,Verifies the installation or upgrade of the LVM Storage Operator.,Yes
+LVM Operator,`storage-lvm/StorageLVMCluster.yaml`,"Defines an LVM cluster configuration, with placeholders for storage device classes and volume group settings. Optional substitute for the Local Storage Operator.",No
+LVM Operator,`storage-lvm/StorageLVMSubscription.yaml`,Manages installation and updates of the LVMS Operator. Optional substitute for the Local Storage Operator.,No
+LVM Operator,`storage-lvm/StorageLVMSubscriptionNS.yaml`,Creates the namespace for the LVMS Operator with labels and annotations for cluster monitoring and workload management. Optional substitute for the Local Storage Operator.,No
+LVM Operator,`storage-lvm/StorageLVMSubscriptionOperGroup.yaml`,Defines the target namespace for the LVMS Operator. Optional substitute for the Local Storage Operator.,No
+Node Tuning Operator,`node-tuning-operator/aarch64/PerformanceProfile.yaml`,"Configures node performance settings in an OpenShift cluster, optimizing for low latency and real-time workloads for aarch64 CPUs.",No
+Node Tuning Operator,`node-tuning-operator/x86_64/PerformanceProfile.yaml`,"Configures node performance settings in an OpenShift cluster, optimizing for low latency and real-time workloads for x86_64 CPUs.",No
+Node Tuning Operator,`node-tuning-operator/TunedPerformancePatch.yaml`,"Applies performance tuning settings, including scheduler groups and service configurations for nodes in the specific namespace.",No
+Node Tuning Operator,`node-tuning-operator/TunedPowerCustom.yaml`,"Applies additional powersave mode tuning as an overlay on top of TunedPerformancePatch.",No
+PTP fast event notifications,`ptp-operator/configuration/PtpConfigBoundaryForEvent.yaml`,Configures PTP settings for PTP boundary clocks with additional options for event synchronization. Dependent on cluster role.,No
+PTP fast event notifications,`ptp-operator/configuration/PtpConfigForHAForEvent.yaml`,Configures PTP for highly available boundary clocks with additional PTP fast event settings. Dependent on cluster role.,No
+PTP fast event notifications,`ptp-operator/configuration/PtpConfigMasterForEvent.yaml`,Configures PTP for PTP grandmaster clocks with additional PTP fast event settings. Dependent on cluster role.,No
+PTP fast event notifications,`ptp-operator/configuration/PtpConfigSlaveForEvent.yaml`,Configures PTP for PTP ordinary clocks with additional PTP fast event settings. Dependent on cluster role.,No
+PTP fast event notifications,`ptp-operator/PtpOperatorConfigForEvent.yaml`,Overrides the default OperatorConfig. Configures the PTP Operator specifying node selection criteria for running PTP daemons in the openshift-ptp namespace.,No
+PTP Operator,`ptp-operator/configuration/PtpConfigBoundary.yaml`,Configures PTP settings for PTP boundary clocks. Dependent on cluster role.,No
+PTP Operator,`ptp-operator/configuration/PtpConfigDualCardGmWpc.yaml`,Configures PTP grandmaster clock settings for hosts that have dual NICs. Dependent on cluster role.,No
+PTP Operator,`ptp-operator/configuration/PtpConfigThreeCardGmWpc.yaml`,Configures PTP grandmaster clock settings for hosts that have 3 NICs. Dependent on cluster role.,No
+PTP Operator,`ptp-operator/configuration/PtpConfigGmWpc.yaml`,Configures PTP grandmaster clock settings for hosts that have a single NIC. Dependent on cluster role.,No
+PTP Operator,`ptp-operator/configuration/PtpConfigSlave.yaml`,Configures PTP settings for a PTP ordinary clock. Dependent on cluster role.,No
+PTP Operator,`ptp-operator/configuration/PtpConfigDualFollower.yaml`,Configures PTP settings for a PTP ordinary clock with 2 interfaces in an active/standby configuration. Dependent on cluster role.,No
+PTP Operator,`ptp-operator/PtpOperatorConfig.yaml`,"Configures the PTP Operator settings, specifying node selection criteria for running PTP daemons in the openshift-ptp namespace.",No
+PTP Operator,`ptp-operator/PtpSubscription.yaml`,Manages installation and updates of the PTP Operator in the openshift-ptp namespace.,No
+PTP Operator,`ptp-operator/PtpSubscriptionNS.yaml`,Configures the namespace for the PTP Operator.,No
+PTP Operator,`ptp-operator/PtpSubscriptionOperGroup.yaml`,Configures the Operator group for the PTP Operator.,No
+PTP Operator (high availability),`ptp-operator/configuration/PtpConfigBoundary.yaml`,Configures PTP settings for highly available PTP boundary clocks.,No
+PTP Operator (high availability),`ptp-operator/configuration/PtpConfigForHA.yaml`,Configures PTP settings for highly available PTP boundary clocks.,No
+SR-IOV FEC Operator,`sriov-fec-operator/AcceleratorsNS.yaml`,Configures namespace for the VRAN Acceleration Operator. Optional part of application workload.,Yes
+SR-IOV FEC Operator,`sriov-fec-operator/AcceleratorsOperGroup.yaml`,Configures the Operator group for the VRAN Acceleration Operator. Optional part of application workload.,Yes
+SR-IOV FEC Operator,`sriov-fec-operator/AcceleratorsSubscription.yaml`,Manages installation and updates for the VRAN Acceleration Operator. Optional part of application workload.,Yes
+SR-IOV FEC Operator,`sriov-fec-operator/SriovFecClusterConfig.yaml`,"Configures SR-IOV FPGA Ethernet Controller (FEC) settings for nodes, specifying drivers, VF amount, and node selection.",Yes
+SR-IOV Operator,`sriov-operator/SriovNetwork.yaml`,"Defines an SR-IOV network configuration, with placeholders for various network settings.",No
+SR-IOV Operator,`sriov-operator/SriovNetworkNodePolicy.yaml`,"Configures SR-IOV network settings for specific nodes, including device type, RDMA support, physical function names, and the number of virtual functions.",No
+SR-IOV Operator,`sriov-operator/SriovOperatorConfig.yaml`,"Configures SR-IOV Network Operator settings, including node selection, injector, and webhook options.",No
+SR-IOV Operator,`sriov-operator/SriovOperatorConfigForSNO.yaml`,"Configures the SR-IOV Network Operator settings for Single Node OpenShift (SNO), including node selection, injector, webhook options, and disabling node drain, in the openshift-sriov-network-operator namespace.",No
+SR-IOV Operator,`sriov-operator/SriovSubscription.yaml`,Manages the installation and updates of the SR-IOV Network Operator.,No
+SR-IOV Operator,`sriov-operator/SriovSubscriptionNS.yaml`,Creates the namespace for the SR-IOV Network Operator with specific annotations for workload management and deployment waves.,No
+SR-IOV Operator,`sriov-operator/SriovSubscriptionOperGroup.yaml`,"Defines the target namespace for the SR-IOV Network Operators, enabling their management and deployment within this namespace.",No
 |====

--- a/modules/telco-ran-crs-machine-configuration.adoc
+++ b/modules/telco-ran-crs-machine-configuration.adoc
@@ -10,20 +10,20 @@
 [cols="4*", options="header", format=csv]
 |====
 Component,Reference CR,Description,Optional
-Container runtime (crun),`enable-crun-master.yaml`,Configures the container runtime (crun) for control plane nodes.,No
-Container runtime (crun),`enable-crun-worker.yaml`,Configures the container runtime (crun) for worker nodes.,No
-CRI-O wipe disable,`99-crio-disable-wipe-master.yaml`,Disables automatic CRI-O cache wipe following a reboot for on control plane nodes.,No
-CRI-O wipe disable,`99-crio-disable-wipe-worker.yaml`,Disables automatic CRI-O cache wipe following a reboot for on worker nodes.,No
-Kdump enable,`06-kdump-master.yaml`,Configures kdump crash reporting on control plane nodes.,No
-Kdump enable,`06-kdump-worker.yaml`,Configures kdump crash reporting on worker nodes.,No
-Kubelet configuration and container mount hiding,`01-container-mount-ns-and-kubelet-conf-master.yaml`,Configures a mount namespace for sharing container-specific mounts between kubelet and CRI-O on control plane nodes.,No
-Kubelet configuration and container mount hiding,`01-container-mount-ns-and-kubelet-conf-worker.yaml`,Configures a mount namespace for sharing container-specific mounts between kubelet and CRI-O on worker nodes.,No
-One-shot time sync,`99-sync-time-once-master.yaml`,Synchronizes time once on control plane nodes.,No
-One-shot time sync,`99-sync-time-once-worker.yaml`,Synchronizes time once on worker nodes.,No
-SCTP,`03-sctp-machine-config-master.yaml`,Loads the SCTP kernel module on control plane nodes.,Yes
-SCTP,`03-sctp-machine-config-worker.yaml`,Loads the SCTP kernel module on worker nodes.,Yes
-Set RCU normal,`08-set-rcu-normal-master.yaml`,Disables rcu_expedited by setting rcu_normal after the control plane node has booted.,No
-Set RCU normal,`08-set-rcu-normal-worker.yaml`,Disables rcu_expedited by setting rcu_normal after the worker node has booted.,No
-SRIOV-related kernel arguments,`07-sriov-related-kernel-args-master.yaml`,Enables SR-IOV support on control plane nodes.,No
-SRIOV-related kernel arguments,`07-sriov-related-kernel-args-worker.yaml`,Enables SR-IOV support on worker nodes.,No
+Container runtime (crun),`optional-extra-manifest/enable-crun-master.yaml`,Configures the container runtime (crun) for control plane nodes.,No
+Container runtime (crun),`optional-extra-manifest/enable-crun-worker.yaml`,Configures the container runtime (crun) for worker nodes.,No
+CRI-O wipe disable,`extra-manifest/99-crio-disable-wipe-master.yaml`,Disables automatic CRI-O cache wipe following a reboot for on control plane nodes.,No
+CRI-O wipe disable,`extra-manifest/99-crio-disable-wipe-worker.yaml`,Disables automatic CRI-O cache wipe following a reboot for on worker nodes.,No
+Kdump enable,`extra-manifest/06-kdump-master.yaml`,Configures kdump crash reporting on master nodes.,No
+Kdump enable,`extra-manifest/06-kdump-worker.yaml`,Configures kdump crash reporting on worker nodes.,No
+Kubelet configuration and container mount hiding,`extra-manifest/01-container-mount-ns-and-kubelet-conf-master.yaml`,Configures a mount namespace for sharing container-specific mounts between kubelet and CRI-O on control plane nodes.,No
+Kubelet configuration and container mount hiding,`extra-manifest/01-container-mount-ns-and-kubelet-conf-worker.yaml`,Configures a mount namespace for sharing container-specific mounts between kubelet and CRI-O on worker nodes.,No
+One-shot time sync,`extra-manifest/99-sync-time-once-master.yaml`,Synchronizes time once on master nodes.,No
+One-shot time sync,`extra-manifest/99-sync-time-once-worker.yaml`,Synchronizes time once on worker nodes.,No
+SCTP,`extra-manifest/03-sctp-machine-config-master.yaml`,Loads the SCTP kernel module on master nodes.,Yes
+SCTP,`extra-manifest/03-sctp-machine-config-worker.yaml`,Loads the SCTP kernel module on worker nodes.,Yes
+Set RCU normal,`extra-manifest/08-set-rcu-normal-master.yaml`,Disables rcu_expedited by setting rcu_normal after the control plane node has booted.,No
+Set RCU normal,`extra-manifest/08-set-rcu-normal-worker.yaml`,Disables rcu_expedited by setting rcu_normal after the worker node has booted.,No
+SRIOV-related kernel arguments,`extra-manifest/07-sriov-related-kernel-args-master.yaml`,Enables SR-IOV support on master nodes.,No
+SRIOV-related kernel arguments,`extra-manifest/07-sriov-related-kernel-args-worker.yaml`,Enables SR-IOV support on worker nodes.,No
 |====

--- a/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
+++ b/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
@@ -41,7 +41,7 @@ Workloads::
 
 
 Resources::
-The maximum number of running pods in the system, inclusive of application workload and {product-title} pods, is 120.
+The maximum number of running pods in the system, inclusive of application workload and {product-title} pods, is 160.
 
 Resource utilization::
 +
@@ -70,10 +70,10 @@ You might need to allocate additional cluster resources to meet these requiremen
 --
 
 Reference application workload characteristics::
-. Uses 15 pods and 30 containers for the vRAN application including its management and control functions
-. Uses an average of 2 `ConfigMap` and 4 `Secret` CRs per pod
-. Uses a maximum of 10 exec probes with a frequency of not less than 10 seconds
-. Incremental application load on the kube-apiserver is less than or equal to 10% of the cluster platform usage
+. Uses 75 pods across 5 namespaces with 4 containers per pod for the vRAN application including its management and control functions
+. Creates 30 `ConfigMap` CRs and 30 `Secret` CRs per namespace
+. Uses no exec probes
+. Uses a secondary network
 +
 [NOTE]
 ====
@@ -85,7 +85,7 @@ $ query=avg_over_time(pod:container_cpu_usage:sum{namespace="openshift-kube-apis
 ----
 ====
 . Application logs are not collected by the platform log collector.
-. Aggregate traffic on the primary CNI is less than 8 Mbps
+. Aggregate traffic on the primary CNI is up to 30 Mbps and up to 5 Gbps on the secondary network
 
 Hub cluster management characteristics::
 +

--- a/modules/telco-ran-gitops-operator-and-ztp-plugins.adoc
+++ b/modules/telco-ran-gitops-operator-and-ztp-plugins.adoc
@@ -8,7 +8,7 @@
 = GitOps Operator and {ztp}
 
 New in this release::
-* https://issues.redhat.com/browse/CNF-9183[GA support for ACM PolicyGenerator with gitops/ZTP (as recommended reference)]
+* No reference design updates in this release
 
 Description::
 +

--- a/modules/telco-ran-ptp-operator.adoc
+++ b/modules/telco-ran-ptp-operator.adoc
@@ -20,7 +20,9 @@ Limits and requirements::
 * Limited to 3 Westport channel NIC configurations for T-GM
 
 Engineering considerations::
-* RAN DU RDS configurations are provided for ordinary clocks, boundary clocks, grandmaster clocks, and highly available dual NIC boundary clocks.
+* * Example RAN DU RDS configurations are provided for:
+** T-GM, T-BC, and T-TSC
+** Variations with and without HA
 * PTP fast event notifications use `ConfigMap` CRs to persist subscriber details.
 * Hierarchical event subscription as described in the O-RAN specification is not supported for PTP events.
 * The PTP fast events REST API v1 is end of life.

--- a/modules/telco-ran-red-hat-advanced-cluster-management-rhacm.adoc
+++ b/modules/telco-ran-red-hat-advanced-cluster-management-rhacm.adoc
@@ -23,7 +23,7 @@ You manage cluster configuration and upgrades declaratively by applying `Policy`
 
 The recommended method for {sno} cluster installation is the image-based installation approach, available in MCE, using the `ClusterInstance` CR for cluster definition.
 
-The recommended method for {sno} cluster upgrade is the image-based upgrade method.
+Image-based upgrade is the recommended method for {sno} cluster upgrade.
 --
 
 Limits and requirements::

--- a/modules/telco-ran-sr-iov-operator.adoc
+++ b/modules/telco-ran-sr-iov-operator.adoc
@@ -7,7 +7,7 @@
 = SR-IOV Operator
 
 New in this release::
-* https://issues.redhat.com/browse/CNF-12813[Support moving failed policy in resource injector to failed for SR-IOV operator]
+* No reference design updates in this release
 
 Description::
 The SR-IOV Operator provisions and configures the SR-IOV CNI and device plugins.

--- a/modules/telco-ref-design-overview.adoc
+++ b/modules/telco-ref-design-overview.adoc
@@ -18,13 +18,6 @@ Following the RDS minimizes high severity escalations and improves application s
 5G use cases are evolving and your workloads are continually changing.
 Red Hat is committed to iterating over the telco core and RAN DU RDS to support evolving requirements based on customer and partner feedback.
 
-[NOTE]
-====
-Support for an ARM based platform is currently a Developer Preview feature for {product-title} 4.19.
-All information is subject to change on release.
-For more details, see the following Red Hat knowledge base article : https://access.redhat.com/articles/7118870[How to use ARM platform hardware in OpenShift 4.19 Telco RDS (Developer Preview)]
-====
-
 The reference configuration includes the configuration of the far edge clusters and hub cluster components.
 
 The reference configurations in this document are deployed using a centrally managed hub cluster infrastructure as shown in the following image.

--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -18,24 +18,23 @@ The Red Hat telco RAN DU {product-version} solution has been validated using the
 |4.19
 
 |Cluster Logging Operator
-|6.2^1^
+|6.2
 
 |Local Storage Operator
-|4.19
+|4.20
 
 |OpenShift API for Data Protection (OADP)
 |1.5
 
 |PTP Operator
-|4.19
+|4.20
 
 |SR-IOV Operator
-|4.19
+|4.20
 
 |SRIOV-FEC Operator
 |2.11
 
 |Lifecycle Agent
-|4.19
+|4.20
 |====
-[1] This table will be updated when the aligned Cluster Logging Operator version 6.3 is released.

--- a/scalability_and_performance/telco-ran-du-rds.adoc
+++ b/scalability_and_performance/telco-ran-du-rds.adoc
@@ -176,6 +176,6 @@ include::modules/using-cluster-compare-telco-ran.adoc[leveloffset=+1]
 
 include::modules/ztp-telco-ran-software-versions.adoc[leveloffset=+1]
 
-include::modules/ztp-telco-hub-cluster-software-versions.adoc[leveloffset=+1]
+//include::modules/ztp-telco-hub-cluster-software-versions.adoc[leveloffset=+1]
 
 :!telco-ran:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[TELCODOCS-2327](https://issues.redhat.com//browse/TELCODOCS-2327) - TELCO RAN RDS updates for 4.20 
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2327
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- [Reference design specifications for telco RAN DU 5G deployments](https://100501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#telco-ref-design-overview_telco-ran-du)
- [Engineering considerations for the RAN DU use model](https://100501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#telco-ran-engineering-considerations-for-the-ran-du-use-model_telco-ran-du)
- [PTP Operator](https://100501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#telco-ran-ptp-operator_telco-ran-du)
- [Red Hat Advanced Cluster Management](https://100501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#telco-ran-red-hat-advanced-cluster-management-rhacm_telco-ran-du)
- [Cluster tuning reference CRs](https://100501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#cluster-tuning-crs_telco-ran-du)
- [Day 2 Operators reference CRs](https://100501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#day-2-operators-crs_telco-ran-du)
- [Machine configuration reference CRs](https://100501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#machine-configuration-crs_telco-ran-du)
- [Telco RAN DU Branch Build validated software components](https://100501--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#ztp-telco-ran-software-versions_telco-ran-du)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
