### PR TITLE
[service-mesh-docs-3.0] OSSM-11202 Doc update; OSSM 3.0.6 (At Stage): Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.0.5
+:SMProductVersion: 3.0.6
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.10

--- a/modules/ossm-release-notes-3-0-6.adoc
+++ b/modules/ossm-release-notes-3-0-6.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-0-6_{context}"]
+= {SMProductName} version 3.0.6
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.0.6 and is supported on {ocp-product-title} 4.16 and later. This release addresses enhancements and Common Vulnerabilities and Exposures (CVEs). For supported component versions for 3.0.6, see "Service Mesh version support tables".
+
+[id="ossm-enhancements-3-0-6_{context}"]
+== Enhancements
+
+* This enhancement updates Kiali server to version 2.4.10.
+
+* This enhancement updates Kiali Operator to version 2.11.4.

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -6,10 +6,41 @@
 [id="ossm-release-notes-supported-versions_{context}"]
 = {SMProduct} supported versions
 
+[role="_abstract"]
+See the following table for information about {SMProduct} 3.0.6 supported versions.
+
+== {SMProduct} 3.0.6 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.0.6
+
+|{SMProduct} `Istio` control plane resource
+|1.24.6
+
+|{ocp-product-title}
+|4.16 and later
+
+| Envoy proxy
+| 1.32.11
+
+| `IstioCNI` resource
+| 1.24.6 
+
+|Kiali Operator
+|2.11.4
+
+|Kiali control plane resource
+|2.4.10
+
+|===
+
 See the following table for information about {SMProduct} 3.0.5 supported versions.
 
 == {SMProduct} 3.0.5 supported versions
-
 [cols="1,1"]
 |===
 | Feature | Supported versions
@@ -40,7 +71,6 @@ See the following table for information about {SMProduct} 3.0.5 supported versio
 See the following table for information about {SMProduct} 3.0.4 supported versions.
 
 == {SMProduct} 3.0.4 supported versions
-
 [cols="1,1"]
 |===
 | Feature | Supported versions
@@ -68,7 +98,6 @@ See the following table for information about {SMProduct} 3.0.4 supported versio
 See the following table for information about {SMProduct} 3.0.3 supported versions.
 
 == {SMProduct} 3.0.3 supported versions
-
 [cols="1,1"]
 |===
 | Feature | Supported versions
@@ -98,7 +127,6 @@ See the following table for information about {SMProduct} 3.0.3 supported versio
 See the following table for information about {SMProduct} 3.0.2 supported versions.
 
 == {SMProduct} 3.0.2 supported versions
-
 [cols="1,1"]
 |===
 | Feature | Supported versions
@@ -122,7 +150,6 @@ See the following table for information about {SMProduct} 3.0.2 supported versio
 See the following table for information about {SMProduct} 3.0.1 supported versions.
 
 == {SMProduct} 3.0.1 supported versions
-
 [cols="1,1"]
 |===
 | Feature | Supported versions
@@ -146,7 +173,6 @@ See the following table for information about {SMProduct} 3.0.1 supported versio
 See the following table for information about {SMProduct} 3 supported versions.
 
 == {SMProduct} 3.0 supported versions
-
 [cols="1,1"]
 |===
 | Feature | Supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -13,6 +13,8 @@ The {SMProductName} release notes provide details about new features and enhance
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[{ocp-short-name} Operator Life Cycles].
 ====
 
+include::modules/ossm-release-notes-3-0-6.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-5.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-0-4.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 3.0.6 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-11202

Fix Version: [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Previews:

Release notes: https://100504--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes#ossm-release-3-0-6_ossm-release-notes

Version support table: https://100504--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-0-6-supported-versions

QE Review: @ctartici @mkralik3 
Peer Review: @eromanova97 