### PR TITLE
[service-mesh-docs-3.1] OSSM-11202 Doc update; OSSM 3.1.3 (At Stage): Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.1.2
+:SMProductVersion: 3.1.3
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.10

--- a/modules/ossm-release-notes-3-1-3.adoc
+++ b/modules/ossm-release-notes-3-1-3.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-1-3_{context}"]
+= {SMProductName} version 3.1.3
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.1.3 and is supported on {ocp-product-title} 4.16 and later. This release addresses enhancements, fixed issues, and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.1.3, see "Service Mesh version support tables".
+
+[id="ossm-enhancements-3-1-3_{context}"]
+== Enhancements
+
+* This enhancement updates Kiali Operator and Kiali server to version 2.11.4.
+
+[id="ossm-bug-fixes-3-1-3_{context}"]
+== Fixed issues
+
+* Before this update, images were incorrectly switched to use the newer manifest format, causing mirroring issues with older registries. As a consequence, the users experienced mirroring failures due to incompatible manifest formats. With this release, images now use the expected, older manifest format for mirroring to older registries. As a result, end users can now successfully mirror images to older registries.
+(link:https://issues.redhat.com/browse/OSSM-11139[OSSM-11139])

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -6,10 +6,40 @@
 [id="ossm-release-notes-supported-versions_{context}"]
 = {SMProduct} supported versions
 
+[role="_abstract"]
+See the following table for information about {SMProduct} 3.1.3 supported versions.
+
+== {SMProduct} 3.1.3 supported versions
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.1.3
+
+|{SMProduct} `Istio` control plane resource
+|1.26.4
+
+|{ocp-product-title}
+|4.16 and later
+
+| Envoy proxy
+| 1.34.6
+
+| `IstioCNI` resource
+| 1.26.4
+
+|Kiali Operator
+|2.11.4
+
+|Kiali control plane resource
+|2.11.4
+
+|===
+
 See the following table for information about {SMProduct} 3.1.2 supported versions.
 
 == {SMProduct} 3.1.2 supported versions
-
 [cols="1,1"]
 |===
 | Feature | Supported versions
@@ -40,7 +70,6 @@ See the following table for information about {SMProduct} 3.1.2 supported versio
 See the following table for information about {SMProduct} 3.1.1 supported versions.
 
 == {SMProduct} 3.1.1 supported versions
-
 [cols="1,1"]
 |===
 | Feature | Supported versions
@@ -68,7 +97,6 @@ See the following table for information about {SMProduct} 3.1.1 supported versio
 See the following table for information about {SMProduct} 3.1.0 supported versions.
 
 == {SMProduct} 3.1.0 supported versions
-
 [cols="1,1"]
 |===
 | Feature | Supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -13,6 +13,8 @@ The {SMProductName} release notes provide details about new features and enhance
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[{ocp-short-name} Operator Life Cycles].
 ====
 
+include::modules/ossm-release-notes-3-1-3.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-1-2.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-1-1.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 3.1.3 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-11202

Fix Version: [service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

Doc Previews:

Release notes: https://100509--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes#ossm-release-3-1-3_ossm-release-notes

Version support table: https://100509--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-1-3-supported-versions

QE Review: @ctartici @mkralik3 
Peer Review: @eromanova97 