### PR TITLE
OSDOCS-16286: Added explanation for vlan: 0 in cnf-creating-an-additi…

### DIFF
--- a/modules/nw-sriov-network-object.adoc
+++ b/modules/nw-sriov-network-object.adoc
@@ -52,7 +52,7 @@ endif::ocp-sriov-net[]
 <2> The namespace where the SR-IOV Network Operator is installed. You can also install the SR-IOV Network Operator in any namespace.
 <3> The value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
 <4> The target namespace for the SriovNetwork object. Only pods in the target namespace can attach to the additional network. When installing the SR-IOV Network Operator in a namespace other than `openshift-sriov-network-operator`, you must not configure this field..
-<5> Optional: A Virtual LAN (VLAN) ID for the additional network. The integer value must be from `0` to `4095`. The default value is `0`.
+<5> Optional: Specifies the VLAN ID to assign to an additional network. The default value of `0` means that an additional network has no VLAN ID tag. Supported VLAN ID values range from `1` to `4094`.
 <6> Optional: The spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
 +
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-16286](https://issues.redhat.com/browse/OSDOCS-16286)

Link to docs preview:
* [Ethernet device configuration object](https://100512--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-net-attach.html#nw-sriov-network-object_configuring-sriov-net-attach)


- [x] SME has approved this change (Sebastian Scienkman).
- [x] QE has approved this change (Evgen Levin).

