### PR TITLE
Updating Google Cloud attribute

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -282,10 +282,11 @@ endif::[]
 :aws-first: Amazon Web Services (AWS)
 :aws-full: Amazon Web Services
 :aws-short: AWS
-// Google Cloud Platform (GCP)
-:gcp-first: Google Cloud Platform (GCP)
-:gcp-full: Google Cloud Platform
-:gcp-short: GCP
+// Google Cloud
+//as of Oct 15 2025, the only acceptable name is Google Cloud
+:gcp-first: Google Cloud
+:gcp-full: Google Cloud
+:gcp-short: Google Cloud
 // IBM general
 :ibm-name: IBM(R)
 :ibm-title: IBM


### PR DESCRIPTION
Version(s):
4.12+

Per google, GCP is now Google Cloud, with no abbreviation/acronym to be used.