### PR TITLE
OSDOCS-16215_v1 replaced all instances of Build.21 with in a future r…

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -817,9 +817,9 @@ The command is not currently supported on Hosted Control Plane (HCP) clusters.
 For more information, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#update-upgrading-cli[Updating a cluster by using the CLI].
 
 [id="ocp-release-notes-openshift-cli-mirror-environment-var-imagepaths_{context}"]
-==== oc-mirror v2 mirrors container images in environment variables of deployment templates 
+==== oc-mirror v2 mirrors container images in environment variables of deployment templates
 
-Operand images, dynamically deployed by Operator controllers at runtime, are typically referenced by environment variables within the controller’s deployment template. 
+Operand images, dynamically deployed by Operator controllers at runtime, are typically referenced by environment variables within the controller’s deployment template.
 
 Before {product-title} 4.20, while `oc-mirror` plugin v2 could access these environment variables, it attempted to mirror all values, including non-image references, for example, log levels, leading to failures. With this update, {product-title} identifies and mirrors only the container images referenced in these environment variables.
 
@@ -1244,6 +1244,10 @@ This prevents users from discovering certain problems only after the cache is po
 The use of Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV) on {gcp-first} has been deprecated and might be removed in a future release.
 
 You can use AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP) instead.
+[id="ocp-4-20-docker-v2-registries-removed_{context}"]
+==== Docker v2 registries deprecated
+
+Support for Docker v2 registries is deprecated and is planned for removal in a future release. A registry that supports the Open Container Initiative (OCI) specification will be required for all mirroring operations in a future release. Additionally, `oc-mirror` v2 now only generates custom catalog images in the OCI format, whereas the deprecated `oc-mirror` v1 still supports the Docker v2 format.
 
 [id="ocp-release-removed-features_{context}"]
 === Removed features
@@ -1278,14 +1282,6 @@ You can use AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SN
 |`admissionregistration.k8s.io/v1`
 |link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#webhook-resources-v122[Yes]
 |===
-
-[id="ocp-4-20-deprecated-features_{context}"]
-=== Deprecated features
-
-[id="ocp-4-20-docker-v2-registries-removed_{context}"]
-==== Docker v2 registries deprecated
-
-Support for Docker v2 registries is deprecated and will be removed in {product-title} {product-version}.21. A registry that supports the Open Container Initiative (OCI) specification will be required for all mirroring operations as of {product-title} {product-version}.21. Additionally, `oc-mirror` v2 now only generates custom catalog images in the OCI format, whereas the deprecated `oc-mirror` v1 still supports the Docker v2 format.
 
 [id="ocp-release-bug-fixes_{context}"]
 == Bug fixes


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-16215

Link to docs preview:
https://100531--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-deprecated-features_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:

