### PR TITLE
CNV-61645: RN for disk hotplug with virtio-blk devices

### DIFF
--- a/virt/release_notes/virt-4-20-release-notes.adoc
+++ b/virt/release_notes/virt-4-20-release-notes.adoc
@@ -92,6 +92,8 @@ This release adds new features and enhancements related to the following compone
 
 //CNV-63497
 * When performing live migration of a VM, you can now xref:../../virt/live_migration/virt-initiating-live-migration.adoc#virt-initiating-vm-migration-web_virt-initiating-live-migration[specify the particular node for the VM to migrate to.]
+//CNV-61645
+* The procedure for hot plugging disks now includes an optional step for selecting a bus type. You can select the `virtio-blk` or the `virtio-scsi` bus type. The `virtio-blk` type is the default. For more information, see xref:../../virt/managing_vms/virtual_disks/virt-hot-plugging-virtual-disks.adoc#virt-hot-plugging-virtual-disks[Hot plugging VM disks].
 
 [id="virt-4-20-monitoring_{context}"]
 === Monitoring
@@ -104,9 +106,10 @@ The guest agent ping probe is now generally available (GA). Previously, this fea
 //[id="virt-4-20-documentation_{context}"]
 //=== Documentation improvements
 
-//[id="virt-4-20-notable-technical-changes_{context}"]
-//=== Notable technical changes
-
+[id="virt-4-20-notable-technical-changes_{context}"]
+=== Notable technical changes
+//CNV-61645
+* Before this update, only the `virtio-scsi` bus type could be used for hot plugging disks. With this update, the `virtio-blk` bus type is supported as well.
 
 [id="virt-4-20-deprecated-removed_{context}"]
 == Deprecated and removed features
@@ -118,6 +121,7 @@ The guest agent ping probe is now generally available (GA). Previously, this fea
 Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
 
 * The `OperatorConditionsUnhealthy` alert is deprecated. You can safely xref:../../observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc#silencing-alerts-adm_managing-alerts-as-an-administrator[silence] it.
+* All hot plugged disks are persistent by default. The use of non-persistent hot plugged disks is deprecated. They will not be supported in future releases.
 
 [id="virt-4-20-removed_{context}"]
 === Removed features


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/CNV-61645

CNV 4.20
OCP 4.20

Preview:
https://100533--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-20-release-notes.html#virt-4-20-web_virt-4-20-release-notes
https://100533--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-20-release-notes.html#virt-4-20-deprecated_virt-4-20-release-notes
https://100533--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-20-release-notes.html#virt-4-20-notable-technical-changes_virt-4-20-release-notes