### PR TITLE
OCP 4.15: OADP-6456: Release Notes for OADP 1.4.6

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -39,9 +39,9 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.4.5
+:oadp-version: 1.4.6
 :oadp-version-1-3: 1.3.7
-:oadp-version-1-4: 1.4.5
+:oadp-version-1-4: 1.4.6
 :oadp-bsl-api: backupstoragelocations.velero.io
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -14,6 +14,7 @@ The release notes for {oadp-first} describe new features and enhancements, depre
 For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
 ====
 
+include::modules/oadp-1-4-6-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-5-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-4-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-3-release-notes.adoc[leveloffset=+1]
@@ -28,12 +29,9 @@ include::modules/oadp-1-4-0-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+3]
 include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+3]
 
-// TODO: Include this xref when the Operators book is added to the ROSA HCP docs.
-ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
-endif::openshift-rosa-hcp[]
 
 [id="oadp-converting-dpa-to-new-version-1-4-0_{context}"]
 === Converting DPA to the new version

--- a/modules/oadp-1-4-6-release-notes.adoc
+++ b/modules/oadp-1-4-6-release-notes.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-6-release-notes_{context}"]
+= {oadp-short} 1.4.6 release notes
+
+{oadp-first} 1.4.6 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.5.


### PR DESCRIPTION
### Cherry pick

Cherry Picked from 34258a494840c10d498ba604d5e0d13486e94c43 xref: https://github.com/openshift/openshift-docs/pull/100299

### JIRA

* [OADP-6456](https://issues.redhat.com/browse/OADP-6456)

### VERSION

* OCP 4.15 → branch/enterprise-4.15

### PREVIEW

* [OADP 1.4.6 release notes](https://100574--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes#oadp-1-4-6-release-notes_oadp-1-4-release-notes)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
