### PR TITLE
OSDOCS#15779: Network policies for the SSCSI Operator

### DIFF
--- a/modules/persistent-storage-csi-secrets-store-network-policies.adoc
+++ b/modules/persistent-storage-csi-secrets-store-network-policies.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+//
+
+:_mod-docs-content-type: CONCEPT
+[id="persistent-storage-csi-secrets-store-network-policies_{context}"]
+= Support for network policies
+
+The {secrets-store-operator} includes pre-defined `NetworkPolicies` resources for enhanced security. These policies govern the ingress and egress traffic for both the SS-CSI Operator and its associated driver.
+
+The following table summarizes the default ingress and egress rules:
+
+[cols="1,1,1,1", options="header"]
+|===
+| Component | Ingress ports | Egress ports | Description
+
+| {secrets-store-operator}
+| `8443`
+| `6443`
+| Accesses metrics and communicates with the API server
+
+| {secrets-store-driver}
+| `8095`
+| `6443`
+| Accesses metrics and communicates with the API server
+|===

--- a/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="persistent-storage-csi-secrets-store"]
-= {secrets-store-driver}
+= Secrets Store Container Storage Interface Driver Operator
 include::_attributes/common-attributes.adoc[]
 :context: persistent-storage-csi-secrets-store
 
@@ -23,6 +23,8 @@ include::modules/persistent-storage-csi-secrets-store-disconnect-environment.ado
 ====
 For more information about disconnected environments, see xref:../../disconnected/about.adoc#about[About disconnected environments].
 ====
+
+include::modules/persistent-storage-csi-secrets-store-network-policies.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-secrets-store-driver-install.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-15779](https://issues.redhat.com/browse/OSDOCS-15779)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Support for network policies](https://100287--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-secrets-store.html#persistent-storage-csi-secrets-store-network-policies_persistent-storage-csi-secrets-store)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Cherry-picked from: 0b54f15f2b27353e5da473632eb18ebbbe2d0742
xref: https://github.com/openshift/openshift-docs/pull/100287