### PR TITLE
OCPBUGS-63196: Added MTU change as DAY-2 note to hcp-virt-prereqs.adoc

### DIFF
--- a/modules/hcp-virt-prereqs.adoc
+++ b/modules/hcp-virt-prereqs.adoc
@@ -29,9 +29,17 @@ $ oc patch storageclass ocs-storagecluster-ceph-rbd \
 ----
 
 * You have a valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see "Install OpenShift on any x86_64 platform with user-provisioned infrastructure".
+
 * You have installed the hosted control plane command-line interface.
+
 * You have configured a load balancer. For more information, see "Configuring MetalLB".
+
 * For optimal network performance, you are using a network maximum transmission unit (MTU) of 9000 or greater on the {product-title} cluster that hosts the KubeVirt virtual machines. If you use a lower MTU setting, network latency and the throughput of the hosted pods are affected. Enable multiqueue on node pools only when the MTU is 9000 or greater.
++
+[IMPORTANT]
+====
+You cannot change the MTU value for your cluster as a postinstallation task.
+====
 
 * The {mce-short} has at least one managed {product-title} cluster. The `local-cluster` is automatically imported. For more information about the `local-cluster`, see "Advanced configuration" in the {mce-short} documentation. You can check the status of your hub cluster by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OCPBUGS-63196](https://issues.redhat.com/browse/OCPBUGS-63196)

Link to docs preview:
* [Prerequisites](https://100642--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-virt.html#hcp-virt-prereqs_hcp-deploy-virt)

- [x] SME has approved this change.
- [x] QE has approved this change.

Add info for finding reviewers:

https://github.com/openshift/openshift-docs/pull/84924
