### PR TITLE
OSDOCS#62055 - Docs for VM storage latency

### DIFF
--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -37,18 +37,23 @@ This delay appears to the virtual machine as _steal time_, which is CPU time los
 Type: Counter.
 
 *Example vCPU delay query*
+
+The following query returns the average per-second delay over a 5-minute period. A high value may indicate CPU overcommitment or contention on the node:
+
 [source,promql]
 ----
-irate(kubevirt_vmi_vcpu_delay_seconds_total[5m]) > 0.05 <1>
+irate(kubevirt_vmi_vcpu_delay_seconds_total[5m]) > 0.05
 ----
-<1> This query returns the average per-second delay over a 5-minute period. A high value may indicate CPU overcommitment or contention on the node.
+
 
 *Example vCPU wait time query*
+
+The following query returns the top 3 VMs waiting for I/O at every given moment over a six-minute time period:
+
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (rate(kubevirt_vmi_vcpu_wait_seconds_total[6m]))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_vcpu_wait_seconds_total[6m]))) > 0
 ----
-<1> This query returns the top 3 VMs waiting for I/O at every given moment over a six-minute time period.
 endif::openshift-rosa,openshift-dedicated[]
 
 [id="virt-promql-network-metrics_{context}"]
@@ -63,11 +68,13 @@ Returns the total amount of traffic received (in bytes) on the virtual machine's
 Returns the total amount of traffic transmitted (in bytes) on the virtual machine's network. Type: Counter.
 
 *Example network traffic query*
+
+The following query returns the top 3 VMs transmitting the most network traffic at every given moment over a six-minute time period:
+
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (rate(kubevirt_vmi_network_receive_bytes_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_network_transmit_bytes_total[6m]))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_network_receive_bytes_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_network_transmit_bytes_total[6m]))) > 0
 ----
-<1> This query returns the top 3 VMs transmitting the most network traffic at every given moment over a six-minute time period.
 
 [id="virt-promql-storage-metrics_{context}"]
 == Storage metrics
@@ -84,13 +91,21 @@ Returns the total amount (in bytes) of the virtual machine's storage-related tra
 Returns the total amount of storage writes (in bytes) of the virtual machine's storage-related traffic. Type: Counter.
 --
 
-*Example storage-related traffic query*
+*Example storage-related traffic queries*
+
+* The following query returns the top 3 VMs performing the most storage traffic at every given moment over a six-minute time period:
++
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_read_traffic_bytes_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_storage_write_traffic_bytes_total[6m]))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_read_traffic_bytes_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_storage_write_traffic_bytes_total[6m]))) > 0
 ----
 
-<1> This query returns the top 3 VMs performing the most storage traffic at every given moment over a six-minute time period.
+* The following query returns the top 3 VMs with the highest average read latency at every given moment over a six-minute time period:
++
+[source,promql]
+----
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_read_times_seconds_total{name='${name}',namespace='${namespace}'${clusterFilter}}[6m]) / rate(kubevirt_vmi_storage_iops_read_total{name='${name}',namespace='${namespace}'${clusterFilter}}[6m]) > 0)) > 0
+----
 
 [id="virt-storage-snapshot-data_{context}"]
 === Storage snapshot data
@@ -102,17 +117,21 @@ Returns the total number of virtual machine disks restored from the source virtu
 Returns the amount of space in bytes restored from the source virtual machine. Type: Gauge.
 
 *Examples of storage snapshot data queries*
-[source,promql]
-----
-kubevirt_vmsnapshot_disks_restored_from_source{vm_name="simple-vm", vm_namespace="default"} <1>
-----
-<1> This query returns the total number of virtual machine disks restored from the source virtual machine.
 
+* The following query returns the total number of virtual machine disks restored from the source virtual machine:
++
 [source,promql]
 ----
-kubevirt_vmsnapshot_disks_restored_from_source_bytes{vm_name="simple-vm", vm_namespace="default"} <1>
+kubevirt_vmsnapshot_disks_restored_from_source{vm_name="simple-vm", vm_namespace="default"}
 ----
-<1> This query returns the amount of space in bytes restored from the source virtual machine.
+
+* The following query returns the amount of space in bytes restored from the source virtual machine:
++
+[source,promql]
+----
+kubevirt_vmsnapshot_disks_restored_from_source_bytes{vm_name="simple-vm", vm_namespace="default"}
+----
+
 
 [id="virt-iops_{context}"]
 === I/O performance
@@ -126,11 +145,13 @@ Returns the amount of write I/O operations the virtual machine is performing per
 Returns the amount of read I/O operations the virtual machine is performing per second. Type: Counter.
 
 *Example I/O performance query*
+
+The following query returns the top 3 VMs performing the most I/O operations per second at every given moment over a six-minute time period:
+
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_iops_read_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_storage_iops_write_total[6m]))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_iops_read_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_storage_iops_write_total[6m]))) > 0
 ----
-<1> This query returns the top 3 VMs performing the most I/O operations per second at every given moment over a six-minute time period.
 
 [id="virt-promql-guest-memory-metrics_{context}"]
 == Guest memory swapping metrics
@@ -144,12 +165,14 @@ Returns the total amount (in bytes) of memory the virtual guest is swapping in. 
 Returns the total amount (in bytes) of memory the virtual guest is swapping out. Type: Gauge.
 
 *Example memory swapping query*
+
+The following query returns the top 3 VMs where the guest is performing the most memory swapping at every given moment over a six-minute time period:
+
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_in_traffic_bytes[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_out_traffic_bytes[6m]))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_in_traffic_bytes[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_out_traffic_bytes[6m]))) > 0
 +
 ----
-<1> This query returns the top 3 VMs where the guest is performing the most memory swapping at every given moment over a six-minute time period.
 
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/CNV-62055

Link to docs preview:
https://100651--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-prometheus-queries.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
