### PR TITLE
tavery-ClusterAutoscaler:RN Bug Batch

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1454,9 +1454,9 @@ As a result, the controller handles errors during migration better.
 [id="ocp-release-note-cluster-autoscaler-bug-fixes_{context}"]
 === Cluster Autoscaler
 
+* Before this update, the cluster autoscaler attempted to include machine objects that were in a deleting state. As a consequence, the cluster autoscaler count of machines was inaccurate. This issue caused the cluster autoscaler to add additional taints that were not needed. With this release, the autoscaler accurately counts the machines. (link:https://issues.redhat.com/browse/OCPBUGS-60035[OCPBUGS-60035])
 
-
-
+* Before this update, when you created a cluster autoscaler object with the Cluster Autoscaler Operator enabled in the cluster, two `cluster-autoscaler-default` pods in the `openshift-machine-api` were sometimes created at the same time and one of the pods was immediately killed. With this release, only one pod is created. (link:https://issues.redhat.com/browse/OCPBUGS-57041[OCPBUGS-57041])
 
 [id="ocp-release-note-cluster-override-admin-operator-bug-fixes_{context}"]
 === Cluster Resource Override Admission Operator


### PR DESCRIPTION
Version(s):
4.20

Link to docs preview:
https://100659--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-cluster-autoscaler-bug-fixes_release-notes