### PR TITLE
OSDOCS-16549:Docs updates for GA Virt for OSD on Google Cloud

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1392,183 +1392,185 @@ Topics:
   Topics:
   - Name: Serverless overview
     File: about-serverless
-# ---
-# Name: Virtualization
-# Dir: virt
-# Distros: openshift-dedicated
-# Topics:
-# - Name: About
-#   Dir: about_virt
-#   Topics:
-#   - Name: About OpenShift Virtualization
-#     File: about-virt
-#     Distros: openshift-dedicated
-#   - Name: About OKD Virtualization
-#     File: about-virt
-#     Distros: openshift-origin
-#   - Name: Security policies
-#     File: virt-security-policies
-#   - Name: Architecture
-#     File: virt-architecture
-#     Distros: openshift-dedicated
-# #- Name: Release notes
-# #  Dir: release_notes
-# #  Topics:
-# #  - Name: OpenShift Virtualization release notes
-# #    File: virt-release-notes-placeholder
-# #    Distros: openshift-rosa
-# - Name: Getting started
-#   Dir: getting_started
-#   Topics:
-#   - Name: Getting started with OpenShift Virtualization
-#     File: virt-getting-started
-#     Distros: openshift-dedicated
-#   - Name: Getting started with OKD Virtualization
-#     File: virt-getting-started
-#     Distros: openshift-origin
-#   - Name: virtctl and libguestfs
-#     File: virt-using-the-cli-tools
-#     Distros: openshift-dedicated
-# - Name: Installing
-#   Dir: install
-#   Topics:
-#   - Name: Preparing your cluster
-#     File: preparing-cluster-for-virt
-#   - Name: Installing OpenShift Virtualization
-#     File: installing-virt
-#   - Name: Uninstalling OpenShift Virtualization
-#     File: uninstalling-virt
-# - Name: Post-installation configuration
-#   Dir: post_installation_configuration
-#   Topics:
-#   - Name: Post-installation configuration
-#     File: virt-post-install-config
-#   - Name: Node placement rules
-#     File: virt-node-placement-virt-components
-#   - Name: Network configuration
-#     File: virt-post-install-network-config
-#   - Name: Storage configuration
-#     File: virt-post-install-storage-config
-## Hiding in ROSA/OSD as Cluster checkup framework TP not supported
-##  - Name: Self validation checkups
-##    File: virt-self-validation-checkups
-# - Name: Updating
-#   Dir: updating
-#   Topics:
-#   - Name: Updating OpenShift Virtualization
-#     File: upgrading-virt
-#     Distros: openshift-dedicated
+---
+Name: Virtualization
+Dir: virt
+Distros: openshift-dedicated
+Topics:
+- Name: About
+  Dir: about_virt
+  Topics:
+   - Name: About OpenShift Virtualization
+     File: about-virt
+     Distros: openshift-dedicated
+   - Name: About OKD Virtualization
+     File: about-virt
+     Distros: openshift-origin
+   - Name: Security policies
+     File: virt-security-policies
+   - Name: Architecture
+     File: virt-architecture
+     Distros: openshift-dedicated
+- Name: Getting started
+  Dir: getting_started
+  Topics:
+  - Name: Getting started with OpenShift Virtualization
+    File: virt-getting-started
+    Distros: openshift-dedicated
+  - Name: Getting started with OKD Virtualization
+    File: virt-getting-started
+    Distros: openshift-origin
+  - Name: virtctl and libguestfs
+    File: virt-using-the-cli-tools
+    Distros: openshift-dedicated
+- Name: Installing
+  Dir: install
+  Topics:
+  - Name: Preparing your cluster
+    File: preparing-cluster-for-virt
+  - Name: Installing OpenShift Virtualization
+    File: installing-virt
+    Distros: openshift-dedicated
+  - Name: Uninstalling OpenShift Virtualization
+    File: uninstalling-virt
+- Name: Post-installation configuration
+  Dir: post_installation_configuration
+  Topics:
+  - Name: Post-installation configuration
+    File: virt-post-install-config
+  - Name: Node placement rules
+    File: virt-node-placement-virt-components
+  - Name: Network configuration
+    File: virt-post-install-network-config
+  - Name: Storage configuration
+    File: virt-post-install-storage-config
+  - Name: Configuring certificate rotation
+    File: virt-configuring-certificate-rotation
+- Name: Updating
+  Dir: updating
+  Topics:
+  - Name: Updating OpenShift Virtualization
+    File: upgrading-virt
+    Distros: openshift-dedicated
 # - Name: Virtual machines
 #   Dir: virtual_machines
 #   Topics:
-#   - Name: Creating a virtual machine
-#     Dir: creating_vm
-#     Topics:
+- Name: Creating a virtual machine
+  Dir: creating_vm
+  Topics:
 #     - Name: Overview
 #       File: virt-vm-overview
-#     - Name: Creating VMs from instance types
-#       File: virt-creating-vms-from-instance-types
-#     - Name: Creating VMs from templates
-#       File: virt-creating-vms-from-templates
-# - Name: Advanced VM creation
-#   Dir: creating_vms_advanced
-#   Topics:
-#  - Name: Creating VMs in the web console
-#    Dir: creating_vms_advanced_web
-#    Topics:
-#    - Name: Creating VMs from Red Hat images
-#      File: virt-creating-vms-from-rh-images-overview
-#    - Name: Creating VMs by importing images from web pages
-#      File: virt-creating-vms-from-web-images
-#    - Name: Creating VMs by uploading images
-#      File: virt-creating-vms-uploading-images
-#    - Name: Cloning VMs
-#      File: virt-cloning-vms
-#  - Name: Creating VMs using the CLI
-#    Dir: creating_vms_cli
-#    Topics:
-#    - Name: Creating VMs using a VirtualMachine manifest
-#      File: virt-create-vm-manifest-virtctl
-#    - Name: Creating VMs by using container disks
-#      File: virt-creating-vms-from-container-disks
-#    - Name: Creating VMs by cloning PVCs
-#      File: virt-creating-vms-by-cloning-pvcs
-#- Name: Managing VMs
-#  Dir: managing_vms
-#  Topics:
-#  - Name: Installing the QEMU guest agent and VirtIO drivers
-#    File: virt-installing-qemu-guest-agent
-#  - Name: Connecting to VM consoles
-#    File: virt-accessing-vm-consoles
-#  - Name: Configuring SSH access to VMs
-#    File: virt-accessing-vm-ssh
-#  - Name: Editing virtual machines
-#    File: virt-edit-vms
-#  - Name: Editing boot order
-#    File: virt-edit-boot-order
-#  - Name: Deleting virtual machines
-#    File: virt-delete-vms
-#  - Name: Exporting virtual machines
-#    File: virt-exporting-vms
-#  - Name: Managing virtual machine instances
-#    File: virt-manage-vmis
-#  - Name: Controlling virtual machine states
-#    File: virt-controlling-vm-states
-#  - Name: Using virtual Trusted Platform Module devices
-#    File: virt-using-vtpm-devices
-#  - Name: Managing virtual machines with OpenShift Pipelines
-#    File: virt-managing-vms-openshift-pipelines
-#  - Name: Advanced virtual machine management
-#    Dir: advanced_vm_management
-#    Topics:
-#    - Name: Working with resource quotas for virtual machines
-#      File: virt-working-with-resource-quotas-for-vms
-#    - Name: Specifying nodes for virtual machines
-#      File: virt-specifying-nodes-for-vms
-#    - Name: Configuring the default CPU model
-#      File: virt-configuring-default-cpu-model
-#    - Name: UEFI mode for virtual machines
-#      File: virt-uefi-mode-for-vms
-#    - Name: Configuring PXE booting for virtual machines
-#      File: virt-configuring-pxe-booting
-#    - Name: Using huge pages with virtual machines
-#      File: virt-using-huge-pages-with-vms
+  - Name: Creating VMs from instance types
+    File: virt-creating-vms-from-instance-types
+  - Name: Creating VMs from templates
+    File: virt-creating-vms-from-templates
+- Name: Advanced VM creation
+  Dir: creating_vms_advanced
+  Topics:
+  - Name: Creating VMs in the web console
+    Dir: creating_vms_advanced_web
+    Topics:
+    - Name: Creating VMs from Red Hat images
+      File: virt-creating-vms-from-rh-images-overview
+    - Name: Creating VMs by importing images from web pages
+      File: virt-creating-vms-from-web-images
+    - Name: Creating VMs by uploading images
+      File: virt-creating-vms-uploading-images
+    - Name: Cloning VMs
+      File: virt-cloning-vms
+  - Name: Creating VMs using the CLI
+    Dir: creating_vms_cli
+    Topics:
+    - Name: Creating virtual machines from the command line
+      File: virt-creating-vms-from-cli
+    - Name: Creating VMs by using container disks
+      File: virt-creating-vms-from-container-disks
+    - Name: Creating VMs by cloning PVCs
+      File: virt-creating-vms-by-cloning-pvcs
+- Name: Managing VMs
+  Dir: managing_vms
+  Topics:
+  - Name: Installing the QEMU guest agent and VirtIO drivers
+    File: virt-installing-qemu-guest-agent
+  - Name: Connecting to VM consoles
+    File: virt-accessing-vm-consoles
+  - Name: Configuring SSH access to VMs
+    File: virt-accessing-vm-ssh
+  - Name: Editing virtual machines
+    File: virt-edit-vms
+  - Name: Editing boot order
+    File: virt-edit-boot-order
+  - Name: Deleting virtual machines
+    File: virt-delete-vms
+  - Name: Exporting virtual machines
+    File: virt-exporting-vms
+  - Name: Managing virtual machine instances
+    File: virt-manage-vmis
+  - Name: Controlling virtual machine states
+    File: virt-controlling-vm-states
+  - Name: Using virtual Trusted Platform Module devices
+    File: virt-using-vtpm-devices
+  - Name: Managing virtual machines with OpenShift Pipelines
+    File: virt-managing-vms-openshift-pipelines
+  - Name: Advanced virtual machine management
+    Dir: advanced_vm_management
+    Topics:
+    - Name: Working with resource quotas for virtual machines
+      File: virt-working-with-resource-quotas-for-vms
+    - Name: Specifying nodes for virtual machines
+      File: virt-specifying-nodes-for-vms
+    - Name: Configuring the default CPU model
+      File: virt-configuring-default-cpu-model
+    - Name: UEFI mode for virtual machines
+      File: virt-uefi-mode-for-vms
+    - Name: Configuring PXE booting for virtual machines
+      File: virt-configuring-pxe-booting
+    - Name: Using huge pages with virtual machines
+      File: virt-using-huge-pages-with-vms
+# CPU Manager not supported in ROSA- leaving commented out of OSD for now
 #    - Name: Enabling dedicated resources for a virtual machine
 #      File: virt-dedicated-resources-vm
-#    - Name: Scheduling virtual machines
-#      File: virt-schedule-vms
+    - Name: Scheduling virtual machines
+      File: virt-schedule-vms
+# Cannot create required machine config in ROSA- leaving commented out of OSD for now
 #    - Name: Configuring PCI passthrough
 #      File: virt-configuring-pci-passthrough
+# Cannot create required machine config in ROSA as required- leaving commented out of OSD for now
 #    - Name: Configuring virtual GPUs
 #      File: virt-configuring-virtual-gpus
+# Feature is TP, thus not supported in ROSA/OSD
 #    - Name: Enabling descheduler evictions on virtual machines
 #      File: virt-enabling-descheduler-evictions
-#    - Name: About high availability for virtual machines
-#      File: virt-high-availability-for-vms
-#    - Name: Control plane tuning
-#      File: virt-vm-control-plane-tuning
+    - Name: About high availability for virtual machines
+      File: virt-high-availability-for-vms
+    - Name: Control plane tuning
+      File: virt-vm-control-plane-tuning
+# Need to review following are supported:
 #    - Name: Assigning compute resources
 #      File: virt-assigning-compute-resources
 #    - Name: About multi-queue functionality
 #      File: virt-about-multi-queue
-#  - Name: VM disks
-#    Dir: virtual_disks
-#    Topics:
-#    - Name: Hot-plugging VM disks
-#      File: virt-hot-plugging-virtual-disks
-#    - Name: Expanding VM disks
-#      File: virt-expanding-vm-disks
+  - Name: VM disks
+    Dir: virtual_disks
+    Topics:
+    - Name: Hot-plugging VM disks
+      File: virt-hot-plugging-virtual-disks
+    - Name: Expanding VM disks
+      File: virt-expanding-vm-disks
+# Need to check if supported:
 #    - Name: Configuring shared volumes
 #      File: virt-configuring-shared-volumes-for-vms
-# - Name: Networking
-#   Dir: vm_networking
-#   Topics:
-#   - Name: Networking configuration overview
-#     File: virt-networking-overview
-#   - Name: Connecting a VM to the default pod network
-#     File: virt-connecting-vm-to-default-pod-network
-#   - Name: Exposing a VM by using a service
-#     File: virt-exposing-vm-with-service
+- Name: Networking
+  Dir: vm_networking
+  Topics:
+  - Name: Networking configuration overview
+    File: virt-networking-overview
+  - Name: Connecting a VM to the default pod network
+    File: virt-connecting-vm-to-default-pod-network
+  - Name: Connecting a VM to a primary user-defined network
+    File: virt-connecting-vm-to-primary-udn
+  - Name: Exposing a VM by using a service
+    File: virt-exposing-vm-with-service
 # # Not supported in ROSA/OSD
 # #  - Name: Connecting a VM to a Linux bridge network
 # #    File: virt-connecting-vm-to-linux-bridge
@@ -1576,103 +1578,102 @@ Topics:
 # #    File: virt-connecting-vm-to-sriov
 # #  - Name: Using DPDK with SR-IOV
 # #    File: virt-using-dpdk-with-sriov
-#   - Name: Connecting a VM to an OVN-Kubernetes secondary network
-#     File: virt-connecting-vm-to-ovn-secondary-network
-# # Tecp preview not supported ROSA/OSD
-# #  - Name: Hot plugging secondary network interfaces
-# #    File: virt-hot-plugging-network-interfaces
-#   - Name: Connecting a VM to a service mesh
-#     File: virt-connecting-vm-to-service-mesh
-#   - Name: Configuring a dedicated network for live migration
-#     File: virt-dedicated-network-live-migration
-#   - Name: Configuring and viewing IP addresses
-#     File: virt-configuring-viewing-ips-for-vms
+  - Name: Connecting a VM to an OVN-Kubernetes secondary network
+    File: virt-connecting-vm-to-ovn-secondary-network
+  - Name: Hot plugging secondary network interfaces
+    File: virt-hot-plugging-network-interfaces
+  - Name: Connecting a VM to a service mesh
+    File: virt-connecting-vm-to-service-mesh
+  - Name: Configuring a dedicated network for live migration
+    File: virt-dedicated-network-live-migration
+  - Name: Configuring and viewing IP addresses
+    File: virt-configuring-viewing-ips-for-vms
 # # Tech Preview features not supported in ROSA/OSD
 # #  - Name: Accessing a VM by using the cluster FQDN
 # #    File: virt-accessing-vm-secondary-network-fqdn
-#   - Name: Managing MAC address pools for network interfaces
-#     File: virt-using-mac-address-pool-for-vms
-# - Name: Storage
-#   Dir: storage
-#   Topics:
-#   - Name: Storage configuration overview
-#     File: virt-storage-config-overview
-#   - Name: Configuring storage profiles
-#     File: virt-configuring-storage-profile
-#   - Name: Managing automatic boot source updates
-#     File: virt-automatic-bootsource-updates
-#   - Name: Reserving PVC space for file system overhead
-#     File: virt-reserving-pvc-space-fs-overhead
-#   - Name: Configuring local storage by using HPP
-#     File: virt-configuring-local-storage-with-hpp
-#   - Name: Enabling user permissions to clone data volumes across namespaces
-#     File: virt-enabling-user-permissions-to-clone-datavolumes
-#   - Name: Configuring CDI to override CPU and memory quotas
-#     File: virt-configuring-cdi-for-namespace-resourcequota
-#   - Name: Preparing CDI scratch space
-#     File: virt-preparing-cdi-scratch-space
-#   - Name: Using preallocation for data volumes
-#     File: virt-using-preallocation-for-datavolumes
-#   - Name: Managing data volume annotations
-#     File: virt-managing-data-volume-annotations
+  - Name: Managing MAC address pools for network interfaces
+    File: virt-using-mac-address-pool-for-vms
+- Name: Storage
+  Dir: storage
+  Topics:
+  - Name: Storage configuration overview
+    File: virt-storage-config-overview
+  - Name: Configuring storage profiles
+    File: virt-configuring-storage-profile
+  - Name: Managing automatic boot source updates
+    File: virt-automatic-bootsource-updates
+  - Name: Reserving PVC space for file system overhead
+    File: virt-reserving-pvc-space-fs-overhead
+  - Name: Configuring local storage by using HPP
+    File: virt-configuring-local-storage-with-hpp
+  - Name: Enabling user permissions to clone data volumes across namespaces
+    File: virt-enabling-user-permissions-to-clone-datavolumes
+  - Name: Configuring CDI to override CPU and memory quotas
+    File: virt-configuring-cdi-for-namespace-resourcequota
+  - Name: Preparing CDI scratch space
+    File: virt-preparing-cdi-scratch-space
+  - Name: Using preallocation for data volumes
+    File: virt-using-preallocation-for-datavolumes
+  - Name: Managing data volume annotations
+    File: virt-managing-data-volume-annotations
 # # Virtual machine live migration
-# - Name: Live migration
-#   Dir: live_migration
-#   Topics:
-#   - Name: About live migration
-#     File: virt-about-live-migration
-#   - Name: Configuring live migration
-#     File: virt-configuring-live-migration
-#   - Name: Initiating and canceling live migration
-#     File: virt-initiating-live-migration
+- Name: Live migration
+  Dir: live_migration
+  Topics:
+  - Name: About live migration
+    File: virt-about-live-migration
+  - Name: Configuring live migration
+    File: virt-configuring-live-migration
+  - Name: Initiating and canceling live migration
+    File: virt-initiating-live-migration
 # # Node maintenance mode
-# - Name: Nodes
-#   Dir: nodes
-#   Topics:
-#   - Name: Node maintenance
-#     File: virt-node-maintenance
-#   - Name: Managing node labeling for obsolete CPU models
-#     File: virt-managing-node-labeling-obsolete-cpu-models
-#   - Name: Preventing node reconciliation
-#     File: virt-preventing-node-reconciliation
+- Name: Nodes
+  Dir: nodes
+  Topics:
+  - Name: Node maintenance
+    File: virt-node-maintenance
+  - Name: Managing node labeling for obsolete CPU models
+    File: virt-managing-node-labeling-obsolete-cpu-models
+  - Name: Preventing node reconciliation
+    File: virt-preventing-node-reconciliation
 # # Hiding in ROSA/OSD as user cannot cordon and drain nodes
 # #  - Name: Deleting a failed node to trigger VM failover
 # #    File: virt-triggering-vm-failover-resolving-failed-node
-# - Name: Monitoring
-#   Dir: monitoring
-#   Topics:
-#   - Name: Monitoring overview
-#     File: virt-monitoring-overview
+- Name: Monitoring
+  Dir: monitoring
+  Topics:
+  - Name: Monitoring overview
+    File: virt-monitoring-overview
 ## Hiding in ROSA/OSD as TP not supported
 ##  - Name: Cluster checkup framework
 ##    File: virt-running-cluster-checkups
 ##  - Name: Storage checkups
 ##    File: virt-storage-checkups
-#   - Name: Prometheus queries for virtual resources
-#     File: virt-prometheus-queries
-#   - Name: Virtual machine custom metrics
-#     File: virt-exposing-custom-metrics-for-vms
-#   - Name: Virtual machine health checks
-#     File: virt-monitoring-vm-health
-#   - Name: Runbooks
-#     File: virt-runbooks
-# - Name: Support
-#   Dir: support
-#   Topics:
-#   - Name: Support overview
-#     File: virt-support-overview
-#   - Name: Collecting data for Red Hat Support
-#     File: virt-collecting-virt-data
-#     Distros: openshift-dedicated
-#   - Name: Troubleshooting
-#     File: virt-troubleshooting
-# - Name: Backup and restore
-#   Dir: backup_restore
-#   Topics:
-#   - Name: Backup and restore by using VM snapshots
-#     File: virt-backup-restore-snapshots
-#   - Name: Backing up and restoring virtual machines
-#     File: virt-backup-restore-overview
+  - Name: Prometheus queries for virtual resources
+    File: virt-prometheus-queries
+  - Name: Virtual machine custom metrics
+    File: virt-exposing-custom-metrics-for-vms
+  - Name: Virtual machine health checks
+    File: virt-monitoring-vm-health
+  - Name: Runbooks
+    File: virt-runbooks
+- Name: Support
+  Dir: support
+  Topics:
+  - Name: Support overview
+    File: virt-support-overview
+  - Name: Collecting data for Red Hat Support
+    File: virt-collecting-virt-data
+    Distros: openshift-dedicated
+  - Name: Troubleshooting
+    File: virt-troubleshooting
+- Name: Backup and restore
+  Dir: backup_restore
+  Topics:
+  - Name: Backup and restore by using VM snapshots
+    File: virt-backup-restore-snapshots
+  - Name: Backing up and restoring virtual machines
+    File: virt-backup-restore-overview
 # #  - Name: Collecting OKD Virtualization data for community report
 # #    File: virt-collecting-virt-data
 # #    Distros: openshift-origin

--- a/modules/osd-release-notes-Q1-2026.adoc
+++ b/modules/osd-release-notes-Q1-2026.adoc
@@ -8,6 +8,11 @@
 [role="_abstract"]
 The following items were added during the first quarter of 2026.
 
+*  **Virtualization support for {product-title} on {GCP}.** {product-title} on {GCP} version 4.21.5 now supports running virtualized workloads using the {VirtProductName} Operator version 4.21.1, leveraging {GCP} C3 bare-metal instances and {GCP} Hyperdisk. This enables you to migrate and modernize virtual machines (VMs) from existing platforms directly onto {product-title}, managing them alongside containerized workloads on a single, unified application platform.
++
+For more information about using {VirtProductName} on {product-title} on {gcp}, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/virtualization/index[Virtualization].
+//link to Virtualization 4.21.z release note documentation to be added when available
+
 * **{product-title} now available in {GCP} console.**
 {product-title} is now available directly within the link:https://console.cloud.google.com/redhat-openshift/landing[{GCP} console], making it easier to find and deploy alongside native {GCP} services. This integration simplifies the initial setup by allowing you to validate environment prerequisites for {product-title} cluster deployment.
 +

--- a/modules/virt-about-services.adoc
+++ b/modules/virt-about-services.adoc
@@ -23,9 +23,9 @@ For on-premise clusters, you can configure a load-balancing service by deploying
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 For {product-rosa}, you must use `externalTrafficPolicy: Cluster` when configuring a load-balancing service, to minimize the network downtime during live migration.
 ====
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+endif::openshift-rosa,openshift-rosa-hcp[]

--- a/modules/virt-about-storage-volumes-for-vm-disks.adoc
+++ b/modules/virt-about-storage-volumes-for-vm-disks.adoc
@@ -10,13 +10,22 @@
 [role="_abstract"]
 If you use the storage API with known storage providers, the volume and access modes are selected automatically. However, if you use a storage class that does not have a storage profile, you must configure the volume and access mode.
 
-For a list of known storage providers for {VirtProductName}, see link:https://catalog.redhat.com/search?searchType=software&badges_and_features=OpenShift+Virtualization&subcategories=Storage[the Red Hat Ecosystem Catalog].
+For a list of known storage providers for {VirtProductName}, see the link:https://catalog.redhat.com/search?searchType=software&badges_and_features=OpenShift+Virtualization&subcategories=Storage[ Red Hat Ecosystem Catalog].
 
+ifdef::openshift-dedicated[]
+For best results, use the `Block` volume mode. This is important for the following reasons:
+
+* Shared storage that supports live migration is required to migrate virtual machines between nodes.
+
+* The `Block` volume mode performs significantly better than the `Filesystem` volume mode. This is because the `Filesystem` volume mode uses more storage layers, including a file system layer and a disk image file. These layers are not necessary for VM disk storage.
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
 For best results, use the `ReadWriteMany` (RWX) access mode and the `Block` volume mode. This is important for the following reasons:
 
 * `ReadWriteMany` (RWX) access mode is required for live migration.
 
 * The `Block` volume mode performs significantly better than the `Filesystem` volume mode. This is because the `Filesystem` volume mode uses more storage layers, including a file system layer and a disk image file. These layers are not necessary for VM disk storage.
+endif::openshift-dedicated[]
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 +
 For example, if you use {rh-storage-first}, Ceph RBD volumes are preferable to CephFS volumes.

--- a/modules/virt-about-upgrading-virt.adoc
+++ b/modules/virt-about-upgrading-virt.adoc
@@ -47,14 +47,14 @@ If you have virtual machines running that use hostpath provisioner storage, they
 As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster update. Set the `evictionStrategy` field to `None` and the `runStrategy` field to `Always`.
 ====
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 If you have virtual machines running that use AWS Elastic Block Store (EBS) storage, they cannot be live migrated and might block an {product-title} cluster update.
 
 As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster update. Set the `evictionStrategy` field to `None` and the `runStrategy` field to `Always`.
 ====
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 [id="how-updates-work_{context}"]
 == How updates work

--- a/modules/virt-aws-bm.adoc
+++ b/modules/virt-aws-bm.adoc
@@ -19,59 +19,89 @@ ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 :_mod-docs-content-type: CONCEPT
 [id="virt-aws-bm_{context}"]
 = {VirtProductName} on {product-title}
-
+[role="_abstract"]
+You can run {VirtProductName} on
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-You can run {VirtProductName} on a {product-title} cluster.
+a
 endif::openshift-rosa,openshift-rosa-hcp[]
 ifdef::openshift-dedicated[]
-You can run {VirtProductName} on an {product-title} cluster.
+an
 endif::openshift-dedicated[]
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+ {product-title} cluster.
 
-Before you set up your cluster, review the following summary of supported features and limitations:
 
 Installing::
---
-*  You can install the cluster by using installer-provisioned infrastructure, ensuring that you specify bare-metal instance types for the worker nodes. For example, you can use the `c5n.metal` type value for a machine based on x86_64 architecture.
-ifndef::openshift-rosa,openshift-rosa-hcp[]
-You specify bare-metal instance types by editing the `install-config.yaml` file.
-endif::openshift-rosa,openshift-rosa-hcp[]
-+
-For more information, see the {product-title} documentation about installing on AWS.
---
 
+*  You can install the cluster by using installer-provisioned infrastructure, ensuring that you specify bare-metal instance types for the worker nodes.
+For example, you can use the
+ifndef::openshift-dedicated[]
+`c5n.metal`
+endif::openshift-dedicated[]
+ifdef::openshift-dedicated[]
+`c3-standard-192-metal`
+endif::openshift-dedicated[]
+type value for a machine based on x86_64 architecture.
+ifdef::openshift-dedicated[]
+[NOTE]
+====
+{VirtProductName} on {gcp-short} requires {product-title} 4.21.5 and {VirtProductName} Operator 4.21.1 or later.
+====
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
+You specify bare-metal instance types by editing the `install-config.yaml` file.
+
+For more information, see the {product-title} documentation about installing on AWS.
+
+endif::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
 Accessing virtual machines (VMs)::
---
+
 * There is no change to how you access VMs by using the `virtctl` CLI tool or the {product-title} web console.
 * You can expose VMs by using a `NodePort` or `LoadBalancer` service.
 +
 [NOTE]
 ====
-The load balancer approach is preferable because {product-title} automatically creates the load balancer in AWS and manages its lifecycle. A security group is also created for the load balancer, and you can use annotations to attach existing security groups. When you remove the service, {product-title} removes the load balancer and its associated resources.
+The load balancer approach is preferable because {product-title} automatically creates the load balancer in
+ifndef::openshift-dedicated[]
+AWS
+endif::openshift-dedicated[]
+ifdef::openshift-dedicated[]
+Google Cloud
+endif::openshift-dedicated[]
+and manages its lifecycle. A security group is also created for the load balancer, and you can use annotations to attach existing security groups. When you remove the service, {product-title} removes the load balancer and its associated resources.
 ====
---
 
-Networking::
+
 // Hiding the following in ROSA/OSD because SR-IOV is not supported.
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
---
+Networking::
+
 * You cannot use Single Root I/O Virtualization (SR-IOV) or bridge Container Network Interface (CNI) networks, including virtual LAN (VLAN). If your application requires a flat layer 2 network or control over the IP pool, consider using OVN-Kubernetes secondary overlay networks.
---
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
---
+
 * If your application requires a flat layer 2 network that does not need egress traffic, consider using OVN-Kubernetes secondary overlay networks with a `Layer2` topology.
---
+
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 Storage::
---
+ifndef::openshift-dedicated[]
 * You can use any storage solution that is certified by the storage vendor to work with the underlying platform.
+endif::openshift-dedicated[]
+ifdef::openshift-dedicated[]
+* You can use {gcp-short} Hyperdisk storage with {VirtProductName} on {product-title} on {gcp-short}. {gcp-short} Hyperdisk storage provides high performance and flexibility for VM workloads. For more information about using Hyperdisk storage, see link:https://access.redhat.com/articles/7139046[Storage configuration for OpenShift Virtualization 4.21.x on Google Cloud].
+* In {product-title} on {gcp-short}, you must ensure your StorageClass uses the GCP PD CSI driver or {gcp-short} Filestore CSI driver.
 +
+[NOTE]
+====
+For more information about configuring {VirtProductName} on {product-title} on {gcp-short}, see link:https://access.redhat.com/articles/7139682[OpenShift Virtualization on Google Cloud: Known Issues and Limitations].
+====
+endif::openshift-dedicated[]
++
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 [IMPORTANT]
 ====
 AWS bare metal, Red Hat OpenShift Service on AWS, and Red Hat OpenShift Service on AWS classic architecture clusters might have different supported storage solutions. Ensure that you confirm support with your storage vendor.
 ====
+endif::openshift-rosa,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 * Using Amazon Elastic File System (EFS) or Amazon Elastic Block Store (EBS) with {VirtProductName} might cause performance and functionality limitations as shown in the following table:
 +
 .EFS and EBS performance and functionality limitations
@@ -109,11 +139,16 @@ AWS bare metal, Red Hat OpenShift Service on AWS, and Red Hat OpenShift Service 
 |===
 +
 Consider using CSI storage, which supports ReadWriteMany (RWX), cloning, and snapshots to enable live migration, fast VM creation, and VM snapshots capabilities.
---
 
+endif::openshift-rosa,openshift-rosa-hcp[]
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 Hosted control planes (HCPs)::
---
+
 * HCPs for {VirtProductName} are not currently supported on AWS infrastructure.
---
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+
+endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+
+
+
+

--- a/modules/virt-creating-linux-bridge-nad-web.adoc
+++ b/modules/virt-creating-linux-bridge-nad-web.adoc
@@ -30,11 +30,13 @@ The network attachment definition must be in the same namespace as the pod or vi
 . Select *CNV Linux bridge* from the *Network Type* list.
 . Enter the name of the bridge in the *Bridge Name* field.
 . Optional: If the resource has VLAN IDs configured, enter the ID numbers in the *VLAN Tag Number* field.
+ifndef::openshift-dedicated[]
 +
 [NOTE]
 ====
 OSA interfaces on {ibm-z-name} do not support VLAN filtering and VLAN-tagged traffic is dropped. Avoid using VLAN-tagged NADs with OSA interfaces.
 ====
 +
+endif::openshift-dedicated[]
 . Optional: Select *MAC Spoof Check* to enable MAC spoof filtering. This feature provides security against a MAC spoofing attack by allowing only a single MAC address to exit the pod.
 . Click *Create*.

--- a/modules/virt-creating-linux-bridge-nncp.adoc
+++ b/modules/virt-creating-linux-bridge-nncp.adoc
@@ -49,6 +49,7 @@ spec:
 ** `spec.desiredState.interfaces.bridge.options.stp.enabled` defines whether STP is active. Setting this to `false` disables STP on this bridge.
 ** `spec.desiredState.interfaces.bridge.port.name` defines the node NIC to which the bridge is attached.
 +
+ifndef::openshift-dedicated[]
 [NOTE]
 ====
 To create the NNCP manifest for a Linux bridge using OSA with {ibm-z-name}, you must disable VLAN filtering by the setting the `rx-vlan-filter` to `false` in the `NodeNetworkConfigurationPolicy` manifest.
@@ -60,3 +61,4 @@ Alternatively, if you have SSH access to the node, you can disable VLAN filterin
 $ sudo ethtool -K <osa-interface-name> rx-vlan-filter off
 ----
 ====
+endif::openshift-dedicated[]

--- a/modules/virt-creating-vm-instancetype.adoc
+++ b/modules/virt-creating-vm-instancetype.adoc
@@ -48,12 +48,13 @@ endif::[]
 . In the web console, navigate to *Virtualization* -> *Catalog*.
 +
 The *InstanceTypes* tab opens by default.
+ifndef::openshift-dedicated[]
 +
 [NOTE]
 ====
 When configuring a downward-metrics device on an {ibm-z-name} system that uses a VM preference, set the `spec.preference.name` value to `rhel.9.s390x` or another available preference with the format `*.s390x`.
 ====
-
+endif::openshift-dedicated[]
 . Heterogeneous clusters only: To filter the bootable volumes using the options provided, click *Architecture*.
 
 . Select either of the following options:

--- a/modules/virt-defining-watchdog-device-vm.adoc
+++ b/modules/virt-defining-watchdog-device-vm.adoc
@@ -58,12 +58,10 @@ $ oc apply -f <file_name>.yaml
 
 .Verification
 
---
 [IMPORTANT]
 ====
 This procedure is provided for testing watchdog functionality only and must not be run on production machines.
 ====
---
 
 . Run the following command to verify that the VM is connected to the watchdog device:
 +

--- a/modules/virt-enabling-persistent-efi.adoc
+++ b/modules/virt-enabling-persistent-efi.adoc
@@ -7,12 +7,22 @@
 = Enabling persistent EFI
 
 [role="_abstract"]
+ifdef::openshift-dedicated[]
+You can enable EFI persistence in a VM by configuring a suitable storage class at the cluster level and adjusting the settings in the EFI section of the VM.
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
 You can enable EFI persistence in a VM by configuring an RWX storage class at the cluster level and adjusting the settings in the EFI section of the VM.
+endif::openshift-dedicated[]
 
 .Prerequisites
 
 * You must have cluster administrator privileges.
+ifdef::openshift-dedicated[]
+* You must have a storage class that supports filesystem (`FS`) volume mode and the access mode required for persistent EFI state.
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
 * You must have a storage class that supports RWX access mode and FS volume mode.
+endif::openshift-dedicated[]
 * You have installed the {oc-first}.
 
 .Procedure

--- a/modules/virt-expanding-vm-disk-pvc-cli.adoc
+++ b/modules/virt-expanding-vm-disk-pvc-cli.adoc
@@ -37,7 +37,12 @@ metadata:
    name: vm-disk-expand
 spec:
   accessModes:
+ifdef::openshift-dedicated[]
+     - ReadWriteOnce
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
      - ReadWriteMany
+endif::openshift-dedicated[]
   resources:
     requests:
        storage: 3Gi

--- a/modules/virt-installing-watchdog-agent.adoc
+++ b/modules/virt-installing-watchdog-agent.adoc
@@ -12,14 +12,14 @@ You can install the watchdog agent on the guest and start the `watchdog` service
 .Procedure
 
 . Log in to the virtual machine as root user.
-
+ifndef::openshift-dedicated[]
 . This step is only required when installing on {ibm-z-name} (`s390x`). Enable `watchdog` by running the following command:
 +
 [source,terminal]
 ----
 # modprobe diag288_wdt
 ----
-
+endif::openshift-dedicated[]
 . Verify that the `/dev/watchdog` file path is present in the VM by running the following command:
 +
 [source,terminal]

--- a/modules/virt-planning-bare-metal-cluster-for-ocp-virt.adoc
+++ b/modules/virt-planning-bare-metal-cluster-for-ocp-virt.adoc
@@ -33,7 +33,6 @@ You can install {VirtProductName} on a single-node cluster, but {sno} does not s
 ====
 You can install {VirtProductName} on a single-node cluster, but {sno} does not support live migration.
 ====
-
 * Live migration requires shared storage. Storage for {VirtProductName} must support and use the ReadWriteMany (RWX) access mode.
 
 [id="virt-planning-bare-metal-cluster-for-ocp-virt-SR-IOV_{context}"]

--- a/modules/virt-storage-wizard-fields-web.adoc
+++ b/modules/virt-storage-wizard-fields-web.adoc
@@ -68,16 +68,25 @@ If you do not specify these parameters, the system uses the default storage prof
 |Block
 |Stores the virtual disk directly on the block volume. Only use `Block` if the underlying storage supports it.
 
+ifndef::openshift-dedicated[]
 .3+|Access Mode
-
 |ReadWriteOnce (RWO)
 |Volume can be mounted as read-write by a single node.
 |ReadWriteMany (RWX)
 |Volume can be mounted as read-write by many nodes at one time.
-[NOTE]
-====
-This mode is required for live migration.
-====
 |ReadOnlyMany (ROX)
 |Volume can be mounted as read only by many nodes.
+
+[NOTE]
+====
+`ReadWriteMany` access mode is required for live migration.
+====
+endif::openshift-dedicated[]
+ifdef::openshift-dedicated[]
+.2+|Access Mode
+|ReadWriteOnce (RWO)
+|Volume can be mounted as read-write by a single node.
+|ReadOnlyMany (ROX)
+|Volume can be mounted as read only by many nodes.
+endif::openshift-dedicated[]
 |===

--- a/modules/virt-supported-cluster-version.adoc
+++ b/modules/virt-supported-cluster-version.adoc
@@ -8,9 +8,14 @@
 = Supported cluster versions for {VirtProductName}
 
 [role="_abstract"]
+ifdef::openshift-dedicated[]
+{VirtProductName} on {product-title} on {gcp-short} requires {product-title} 4.21.5 or later and {VirtProductName} Operator 4.21.1 or later.
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
 {VirtProductName} {VirtVersion} is supported for use on {product-title} {product-version} clusters. To use the latest z-stream release of {VirtProductName}, you must first upgrade to the latest version of {product-title}.
-
+endif::openshift-dedicated[]
 The latest stable release of {VirtProductName} {VirtVersion} is {HCOVersion}.
+
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 [NOTE]

--- a/modules/virt-viewing-automatically-created-storage-profiles.adoc
+++ b/modules/virt-viewing-automatically-created-storage-profiles.adoc
@@ -59,9 +59,11 @@ Metadata:
 Spec:
 Status:
   Claim Property Sets:
+ifndef::openshift-dedicated[]
     accessModes:
       ReadWriteMany
     volumeMode:  Block
+endif::openshift-dedicated[]
     accessModes:
       ReadWriteOnce
     volumeMode:  Block

--- a/modules/virt-vmware-comparison.adoc
+++ b/modules/virt-vmware-comparison.adoc
@@ -22,7 +22,12 @@ a|Persistent volume (PV)
 
 Persistent volume claim (PVC)
 
+ifdef::openshift-dedicated[]
+|Stores VM disks. A PV represents existing storage and is attached to a VM through a PVC. When configured for shared access, PVCs can be mounted by multiple VMs simultaneously.
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
 |Stores VM disks. A PV represents existing storage and is attached to a VM through a PVC. When created with the `ReadWriteMany` (RWX) access mode, PVCs can be mounted by multiple VMs simultaneously.
+endif::openshift-dedicated[]
 
 |Dynamic Resource Scheduling (DRS)
 a|Pod eviction policy
@@ -53,7 +58,12 @@ vRealize Operations
 
 |vMotion
 |Live migration
+ifdef::openshift-dedicated[]
+|Moves a running VM to another node without interruption. For live migration to be available, the PVC attached to the VM must use storage that supports live migration.
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
 |Moves a running VM to another node without interruption. For live migration to be available, the PVC attached to the VM must have the `ReadWriteMany` (RWX) access mode.
+endif::openshift-dedicated[]
 
 a|vSwitch
 

--- a/virt/creating_vm/virt-creating-vms-from-instance-types.adoc
+++ b/virt/creating_vm/virt-creating-vms-from-instance-types.adoc
@@ -10,12 +10,12 @@ toc::[]
 You can simplify virtual machine (VM) creation by using instance types, whether you use the {product-title} web console or the CLI to create VMs.
 
 // special TP note for ROSA only:
-ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+ifdef::openshift-rosa,openshift-rosa-hcp[]
 [NOTE]
 ====
 Creating a VM from an instance type in {VirtProductName} 4.15 and higher is supported on {product-title} clusters. In {VirtProductName} 4.14, creating a VM from an instance type is a Technology Preview feature and is not supported on {product-title} clusters.
 ====
-endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
+endif::openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/virt-about-instance-types.adoc[leveloffset=+1]
 

--- a/virt/getting_started/virt-using-the-cli-tools.adoc
+++ b/virt/getting_started/virt-using-the-cli-tools.adoc
@@ -50,5 +50,5 @@ include::modules/virt-about-libguestfs-tools-virtctl-guestfs.adoc[leveloffset=+2
 
 [id="using_ansible_{context}"]
 == Using Ansible
-To use the Ansible collection for {VirtProductName}, see link:https://console.redhat.com/ansible/automation-hub/repo/published/redhat/openshift_virtualization[Red{nbsp}Hat Ansible Automation Hub] ({hybrid-console}).
+To use the Ansible collection for {VirtProductName}, see link:https://console.redhat.com/ansible/automation-hub[Red{nbsp}Hat Ansible Automation Hub] ({hybrid-console}).
 

--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -111,11 +111,14 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/virt-aws-bm.adoc[leveloffset=+2]
 
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-connecting-vm-to-ovn-secondary-network[Connecting a virtual machine to an OVN-Kubernetes secondary network]
 * xref:../../virt/vm_networking/virt-exposing-vm-with-service.adoc#virt-exposing-vm-with-service[Exposing a virtual machine by using a service]
 
+//Hiding in OSD as not supported
+ifndef::openshift-dedicated[]
 [id="arm-compatibility_{context}"]
 === ARM64 compatibility
 
@@ -134,6 +137,7 @@ Live migration::
 VM creation::
 * {op-system-base} 10 supports instance types and preferences, but not templates.
 * {op-system-base} 9 supports templates, instance types, and preferences.
+endif::openshift-dedicated[]
 
 // Hiding in ROSA/OSD - todo: double check this
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
@@ -206,11 +210,9 @@ If you deploy {VirtProductName} with {rh-storage-first}, you must create a dedic
 IPv6::
 {VirtProductName} support for single-stack IPv6 clusters is limited to the OVN-Kubernetes localnet and Linux bridge Container Network Interface (CNI) plugins.
 +
---
 :FeatureName: Deploying {VirtProductName} on a single-stack IPv6 cluster
 include::snippets/technology-preview.adoc[]
 :!FeatureName:
---
 
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
@@ -285,7 +287,12 @@ include::modules/virt-about-storage-volumes-for-vm-disks.adoc[leveloffset=+3]
 [id="live-migration_preparing-cluster-for-virt"]
 == Live migration requirements
 
+ifdef::openshift-dedicated[]
+* Shared storage that supports live migration.
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
 * Shared storage with `ReadWriteMany` (RWX) access mode.
+endif::openshift-dedicated[]
 * Sufficient RAM and network bandwidth.
 +
 [NOTE]

--- a/virt/live_migration/virt-about-live-migration.adoc
+++ b/virt/live_migration/virt-about-live-migration.adoc
@@ -16,7 +16,12 @@ By default, live migration traffic is encrypted using Transport Layer Security (
 
 Live migration has the following requirements:
 
+ifdef::openshift-dedicated[]
+* The cluster must have shared storage that supports live migration.
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
 * The cluster must have shared storage with `ReadWriteMany` (RWX) access mode.
+endif::openshift-dedicated[]
 * The cluster must have sufficient RAM and network bandwidth.
 +
 [NOTE]

--- a/virt/nodes/virt-node-maintenance.adoc
+++ b/virt/nodes/virt-node-maintenance.adoc
@@ -17,7 +17,12 @@ For more information on remediation, fencing, and maintaining nodes, see the lin
 
 [IMPORTANT]
 ====
+ifdef::openshift-dedicated[]
+Virtual machines (VMs) must use persistent volume claims (PVCs) with storage that supports live migration to be live migrated.
+endif::openshift-dedicated[]
+ifndef::openshift-dedicated[]
 Virtual machines (VMs) must have a persistent volume claim (PVC) with a shared `ReadWriteMany` (RWX) access mode to be live migrated.
+endif::openshift-dedicated[]
 ====
 
 The Node Maintenance Operator watches for new or deleted `NodeMaintenance` CRs. When a new `NodeMaintenance` CR is detected, no new workloads are scheduled and the node is cordoned off from the rest of the cluster. All pods that can be evicted are evicted from the node. When a `NodeMaintenance` CR is deleted, the node that is referenced in the CR is made available for new workloads.

--- a/virt/support/virt-support-overview.adoc
+++ b/virt/support/virt-support-overview.adoc
@@ -26,8 +26,8 @@ It is helpful to collect debugging data to include with your support request.
 ==== Collecting data for Red{nbsp}Hat Support
 
 You can gather debugging information by performing the following steps:
-
-xref:../../virt/support/virt-collecting-virt-data.adoc#virt-collecting-data-about-your-environment_virt-collecting-virt-data[Collecting data about your environment]::
+//removing as xref is breaking build.
+//xref:../../virt/support/virt-collecting-virt-data.adoc#virt-collecting-data-about-your-environment[Collecting data about your environment]::
 Configure Prometheus and Alertmanager and collect `must-gather` data for {product-title} and {VirtProductName}.
 
 // must-gather not supported for ROSA/OSD, per Dustin Row

--- a/virt/support/virt-troubleshooting.adoc
+++ b/virt/support/virt-troubleshooting.adoc
@@ -99,3 +99,4 @@ You can check the `Conditions` and `Events` sections of the `DataVolume` object 
 include::modules/virt-about-dv-conditions-and-events.adoc[leveloffset=+2]
 
 include::modules/virt-analyzing-datavolume-conditions-and-events.adoc[leveloffset=+2]
+

--- a/virt/vm_networking/virt-connecting-vm-to-default-pod-network.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-default-pod-network.adoc
@@ -15,7 +15,10 @@ Traffic passing through network interfaces to the default pod network is interru
 
 include::modules/virt-configuring-masquerade-mode-cli.adoc[leveloffset=+1]
 
+// Masquerade mode with IPv4/IPv6 dual-stack is not documented for OpenShift Dedicated
+ifndef::openshift-dedicated[]
 include::modules/virt-configuring-masquerade-mode-dual-stack.adoc[leveloffset=+1]
+endif::openshift-dedicated[]
 
 // TO DO: This should be moved to an optimization section
 include::modules/virt-jumbo-frames-vm-pod-nw.adoc[leveloffset=+1]

--- a/virt/vm_networking/virt-exposing-vm-with-service.adoc
+++ b/virt/vm_networking/virt-exposing-vm-with-service.adoc
@@ -18,7 +18,10 @@ ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../networking/ingress_load_balancing/metallb/metallb-configure-services.adoc#metallb-configure-services[Configuring services to use MetalLB]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
+// Dual-stack (IPv4/IPv6) service configuration is not documented for OpenShift Dedicated
+ifndef::openshift-dedicated[]
 include::modules/virt-dual-stack-support-services.adoc[leveloffset=+1]
+endif::openshift-dedicated[]
 
 include::modules/virt-creating-service-cli.adoc[leveloffset=+1]
 

--- a/virt/vm_networking/virt-networking-overview.adoc
+++ b/virt/vm_networking/virt-networking-overview.adoc
@@ -9,10 +9,12 @@ toc::[]
 [role="_abstract"]
 To connect Virtual Machines (VMs) to cluster networks, configure default and user-defined networking options in {VirtProductName}.
 
+ifndef::openshift-dedicated[]
 {VirtProductName} support for single-stack IPv6 clusters is limited to the OVN-Kubernetes localnet and Linux bridge Container Network Interface (CNI) plugins.
 
 :FeatureName: Deploying {VirtProductName} on a single-stack IPv6 cluster
 include::snippets/technology-preview.adoc[]
+endif::openshift-dedicated[]
 
 The following figure illustrates the typical network setup of {VirtProductName}. Other configurations are also possible.
 
@@ -33,16 +35,17 @@ image:darkcircle-6.png[20,20] The machine network can be defined over a selected
 
 image:darkcircle-7.png[20,20] Secondary VM networks are typically bridged directly to a physical network, with or without VLAN encapsulation. It is also possible to create virtual overlay networks for secondary networks.
 
+ifndef::openshift-dedicated[]
 [IMPORTANT]
 ====
-Connecting VMs directly to the underlay network is not supported on {product-rosa}, {azure-short} for {product-title}, {gcp-first}, or {oci-first}.
+Connecting VMs directly to the underlay network is not supported on {product-rosa}, {azure-short},{dedicated}, {gcp-first}, or {oci-first}.
 ====
 
 [NOTE]
 ====
 Connecting VMs to user-defined networks with the `layer2` topology is recommended on public clouds.
 ====
-
+endif::openshift-dedicated[]
 image:darkcircle-8.png[20,20] Secondary VM networks can be defined on dedicated set of NICs, as shown in Figure 1, or they can use the machine network.
 
 include::modules/virt-networking-glossary.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR tracks the work involved in importing the OpenShift Virtualization book from the OCP docs and making it OSD and Google Cloud centric, similar to how it is done for the ROSA docs.

Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/OSDOCS-16549

Link to docs preview:

- [Virtualization](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/about_virt/about-virt)
   - [Comparing OpenShift Virtualization to VMware vSphere](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/about_virt/about-virt#virt-vmware-comparison_about-virt)
   - [Preparing your cluster for OpenShift Virtualization](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/install/preparing-cluster-for-virt)
   - [Node maintenance](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/nodes/virt-node-maintenance)
   - [Support overview](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/support/virt-support-overview)
   - [Connecting a virtual machine to the default pod network](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/vm_networking/virt-connecting-vm-to-default-pod-network)
   - [Exposing a virtual machine by using a service](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/vm_networking/virt-exposing-vm-with-service)
   - [Networking overview](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/vm_networking/virt-networking-overview)
   - [Creating virtual machines from instance types](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/creating_vm/virt-creating-vms-from-instance-types)
   - [Updating OpenShift Virtualization](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/updating/upgrading-virt)
   - [Enabling persistent EFI](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/managing_vms/advanced_vm_management/virt-uefi-mode-for-vms#virt-enabling-persistent-efi_virt-uefi-mode-for-vms)
   - [Expanding a VM disk PVC by using the CLI](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/managing_vms/virtual_disks/virt-expanding-vm-disks#virt-expanding-vm-disk-pvc-cli_virt-expanding-vm-disks)
   - [Installing the watchdog agent on the guest](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/monitoring/virt-monitoring-vm-health#virt-installing-watchdog-agent_virt-monitoring-vm-health)
   - [Configuring storage profiles](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/virt/storage/virt-configuring-storage-profile)
- [What's new](https://100665--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new)

Peer review:
- [ ] Peer reviewer has approved this change.

SME review:
- [ ] SME has approved this change.

**Note to peer reviewer:**
This is a content port of the Virt book from ROSA docs to OSD docs. It is a very large PR, but there are very little changes apart from making the content Google Cloud specific in places. Similar to the ROSA Virt docs, this is generic documentation for virtualization, briefly mentioning different supported platforms and linking out to KCS articles for specific details, such as storage configuration information and known Google Cloud limitations. The main areas for review are checking new links, the addition and removal of conditionals, and some small extra Google Cloud specific content.

