### PR TITLE
Adds OMR 2.0.8 to release notes

### DIFF
--- a/modules/mirror-registry-release-notes-2-0.adoc
+++ b/modules/mirror-registry-release-notes-2-0.adoc
@@ -8,6 +8,17 @@
 
 The following sections provide details for each 2.0 release of the mirror registry for Red{nbsp}Hat OpenShift.
 
+[id="mirror-registry-for-openshift-2-0-8_{context}"]
+== Mirror registry for Red{nbsp}Hat OpenShift 2.0.8
+
+Issued: 16 October 2025
+
+_Mirror registry for Red{nbsp}Hat OpenShift_ is now available with Red{nbsp}Hat Quay 3.12.12.
+
+The following advisory is available for the _mirror registry for Red{nbsp}Hat OpenShift_:
+
+* link:https://access.redhat.com/errata/RHBA-2025:17062[RHBA-2025:17062 - mirror registry for Red{nbsp}Hat OpenShift 2.0.8]
+
 [id="mirror-registry-for-openshift-2-0-7_{context}"]
 == Mirror registry for Red{nbsp}Hat OpenShift 2.0.7
 


### PR DESCRIPTION
Version(s):
4.14+

Based on https://errata.devel.redhat.com/advisory/152758 

Issue:
None. Release notes

Link to docs preview:
https://100666--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/installing-mirroring-creating-registry.html#mirror-registry-for-openshift-2-0-8_installing-mirroring-creating-registry

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
