### PR TITLE
OSDOCS-15028: Created RNs for management console

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1437,11 +1437,7 @@ As a result, compute machine sets successfully transition from the Cluster API t
 With this release, the CRD documents the default value.
 (link:https://issues.redhat.com/browse/OCPBUGS-61314[OCPBUGS-61314])
 
-* Before this update, it was possible to specify the use of the `CapacityReservationsOnly` capacity reservation behavior and Spot Instances in the same machine template.
-As a consequence, machines with these two incompatible settings were created.
-With this release, validation of machine templates ensures that these two incompatible settings do not co-occur.
-As a result, machines with these two incompatible settings cannot be created.
-(link:https://issues.redhat.com/browse/OCPBUGS-60943[OCPBUGS-60943])
+* Before this update, it was possible to specify the use of the `CapacityReservationsOnly` capacity reservation behavior and `SpotInstances` in the same machine template. As a consequence, machines with these two incompatible settings were created. With this release, validation of machine templates ensures that these two incompatible settings are not set at this time. As a result, machines with these two incompatible settings cannot be created. (link:https://issues.redhat.com/browse/OCPBUGS-60943[OCPBUGS-60943])
 
 * Before this update, on clusters that support migrating Machine API resources to Cluster API resources, deleting a nonauthoritative machine did not delete the corresponding authoritative machine.
 As a consequence, orphaned machines that should have been cleaned up remained on the cluster and could cause a resource leak.
@@ -1586,12 +1582,90 @@ As a result, the controller handles errors during migration better.
 [id="ocp-release-note-management-console-bug-fixes_{context}"]
 === Management Console
 
+* Before this update, the YAML editor in the web console would default to indenting YAML files with 4 spaces. With this release, the default indentation has changed to 2 spaces to align with recommendations. (link:https://issues.redhat.com/browse/OCPBUGS-61990[OCPBUGS-61990])
+
+* Before this update, expanding the terminal in the web console caused the session to close because the {product-title} logo and header overlapped the terminal view. With this release, the terminal layout is fixed so that it expands correctly. As a result, you can expand or collapse the terminal without connection loss or input interruption. (link:https://issues.redhat.com/browse/OCPBUGS-61819[OCPBUGS-61819])
+
+* Before this update, visiting the `/auth/error` page without the required state cookie showed a blank page and prevented error details from displaying. With this release, error handling is improved in the front-end code. As a result, the `/auth/error` page displays error content, making it easier to diagnose and resolve problems. (link:https://issues.redhat.com/browse/OCPBUGS-60912[OCPBUGS-60912])
+
+* Before this update, the order of items in the **PersistentVolumeClaim** action menu was not defined, causing the **Delete PersistentVolumeClaim** option to display in the middle of the list. With this release, the option is reordered so it now displays last in the menu. As a result, the action list is consistent and easier to navigate. (link:https://issues.redhat.com/browse/OCPBUGS-60756[OCPBUGS-60756])
+
+* Before this update, clicking **Download log** on the Build logs page added `undefined` to the downloaded file name, and clicking **Raw logs** did not open the raw log in a new tab. With this release, the file name is corrected ensuring that clicking **Raw logs** opens the raw log as expected. (link:https://issues.redhat.com/browse/OCPBUGS-60753[OCPBUGS-60753])
+
+* Before this update, entering a wrong value in an OpenShift console form field caused multiple exclamation icons to display. With this release, only one icon displays when a field value is invalid. As a result, error messages in all fields now display clearly. (link:https://issues.redhat.com/browse/OCPBUGS-60428[OCPBUGS-60428])
+
+* Before this update, some entries on the Quick Starts page displayed duplicate link buttons. With this release, the duplicates are removed, and links now display as intended, resulting in a cleaner and clearer page layout. (link:https://issues.redhat.com/browse/OCPBUGS-60373[OCPBUGS-60373])
+
+* Before this update, the console included an outdated security instruction `X-XSS-Protection` when sending pages to your browser. With this release, the instruction is removed. As a result, the console runs securely in modern browsers. (link:https://issues.redhat.com/browse/OCPBUGS-60130[OCPBUGS-60130])
+
+* Before this update, the error message in the **events page** would erroneously show the placeholder "{ error }" instead of an error message. With this release, the error message is shown. (link:https://issues.redhat.com/browse/OCPBUGS-60010[OCPBUGS-60010])
+
+* Before this update, the console displayed the **Registry poll interval** drop-down menu for managed `CatalogSource` objects, but any change you made was automatically reverted. With this release, the drop-down menu is hidden for managed sources. As a result, the console no longer shows a menu option that cannot be applied. (link:https://issues.redhat.com/browse/OCPBUGS-59725[OCPBUGS-59725])
+
+* Before this update, selecting the **Resource** menu on the Deploy from image page caused the view to jump to the top due to improper focus handling. With this release, the focus behavior is corrected so the page stays in place when you open the menu. As a result, your scroll position is preserved during selection. (link:https://issues.redhat.com/browse/OCPBUGS-59586[OCPBUGS-59586])
+
+* Before this update, the **Get started** message occupied too much space when you did not have a project, preventing the **No resources found** message from fully displaying. This update reduces the space used by the **Get started** message. As a result, all messages now display completely on the page. (link:https://issues.redhat.com/browse/OCPBUGS-59483[OCPBUGS-59483])
+
+* Before this update, improperly nested `flags` within `properties` in `console-crontab-plugin.json` caused the plugin to break. With this release, the nesting in the JSON file is fixed, resolving the conflict with OCPBUGS-58858. As a result, the plugin now loads and displays the `CronTabs` correctly. (link:https://issues.redhat.com/browse/OCPBUGS-59418[OCPBUGS-59418])
+
+* Before this update, starting a job from the console always reset its `backoffLimit` to 6, overriding your configured value. With this release, the configured `backoffLimit` is preserved when you start a job in the console. As a result, jobs behave consistently between the console and the CLI. (link:https://issues.redhat.com/browse/OCPBUGS-59382[OCPBUGS-59382])
+
+* Before this update, the YAML editor component did not handle some edge cases where the content could not be parsed into a JavaScript object, which caused errors in some situations. With this release, the component was updated to handle these edge cases reliably and the errors no longer occur. (link:https://issues.redhat.com/browse/OCPBUGS-59196[OCPBUGS-59196])
+
+* Before this update, the **Namespace** column displayed on the MachineSets list page even when you viewed a single project, because the code did not correctly scope the columns. With this release, the column logic is fixed. As a result, the MachineSets list no longer shows the **Namespace** column for project-scoped views. (link:https://issues.redhat.com/browse/OCPBUGS-58334[OCPBUGS-58334])
+
+* Before this update, navigating to a storage class page with multiple path elements in the `href` displayed a blank tab. With this release, the plugin is fixed so that the tab content displays correctly after switching. As a result, storage class pages no longer show blank tabs. (link:https://issues.redhat.com/browse/OCPBUGS-58258[OCPBUGS-58258])
+
+* Before this update, editing a `HorizontalPodAutoscaler` (HPA) with a `ContainerResource` type caused a runtime error because the code did not define the `e.resource` variable. With this release, the `e.resource` is defined and the runtime error is fixed in the form editor. As a result, editing an HPA with the `ContainerResource` type no longer fails. (link:https://issues.redhat.com/browse/OCPBUGS-58208[OCPBUGS-58208])
+
+* Before this update, the `TELEMETER_CLIENT_DISABLED` setting in the `ConsoleConfig` ConfigMap caused gaps in the telemetry, which limited troubleshooting. With this release, the telemetry client is temporarily disable to resolve "Too Many Requests" errors. As a result, telemetry data is collected reliably, removing limits on troubleshooting. (link:https://issues.redhat.com/browse/OCPBUGS-58094[OCPBUGS-58094])
+
+* Before this update, clicking **Configure** in `AlertmanagerReceiversNotConfigured` failed with the error `navigate is not a function` because the code did not handle the configuration correctly. With this release, the issue is fixed. As a result, `AlertmanagerReceiversNotConfigured` now opens as expected. (link:https://issues.redhat.com/browse/OCPBUGS-56986[OCPBUGS-56986])
+
+* Before this update, the **CronTab** list page returned an error when a `CronTab` resource was missing optional entries in its `spec` because the console did not validate them properly. with this release, the necessary validation is added. As a result, the **CronTab** list page loads correctly even when some `spec` fields are not defined. (link:https://issues.redhat.com/browse/OCPBUGS-56830[OCPBUGS-56830])
+
+* Before this update, users without a project saw only part of the Roles list because of insufficient role-based access control (RBAC) permissions. With this release, the access logic is fixed. As a result, these users can no longer open the Roles page, keeping sensitive data secure. (link:https://issues.redhat.com/browse/OCPBUGS-56707[OCPBUGS-56707])
+
+* Before this release, when there were no Quick Starts in the **Quick Starts** page, a plain text message was shown. With this release, cluster administrators are given actions to add or manage Quick Starts. (link:https://issues.redhat.com/browse/OCPBUGS-56629[OCPBUGS-56629)])
+
+* Before this update, the generated console dynamic plugin API documentation used the wrong `k8s` utility function names, such as `k8sGetResource` instead of `k8sGet`. With this update, the documentation uses the correct function names with their export name aliases. As a result, the API documentation is clearer for console dynamic plugin developers working with `k8s` utility functions. (link:https://issues.redhat.com/browse/OCPBUGS-56248[OCPBUGS-56248])
+
+* Before this update, unused code in the deployment and deployment configuration menus caused unnecessary menu items to display. With this release, the unused menu item definitions are removed, improving code maintainability and reducing potential issues in future updates. (link:https://issues.redhat.com/browse/OCPBUGS-56245[OCPBUGS-56245])
 
 
+* Before this update, the `/metrics` endpoint was not correctly parsing a bearer token from the authorization header on internal Prometheus scrape requests, which caused `TokenReviews` to fail and all of these requests to be denied with a 401 response. This triggered a `TargetDown` alert for the console metrics endpoint. With this release, the metrics endpoint handler was updated to correctly parse a bearer token from the authorization header for `TokenReview`. This made the `TokenReview` step behave as expected, and resolved the `TargetDown` alert. (link:https://issues.redhat.com/browse/OCPBUGS-56148[OCPBUGS-56148])
 
+* Before this update, creating a node without a disk triggered a JavaScript `TypeError` when you accessed nodes in the console. With this release, the filter property initializes correctly. As a result, the node list displays without errors. (link:https://issues.redhat.com/browse/OCPBUGS-56050[OCPBUGS-56050])
 
+* Before this update, the `VirtualizedTable` hid the `Started` column on smaller screens, which broke default sorting and disrupted the `PipelineRun` list. With this release, the default sorted column adjusts based on screen size, preventing the table from breaking. As a result, the `PipelineRun` list page remains stable and displays correctly on smaller screens. (link:https://issues.redhat.com/browse/OCPBUGS-56044[OCPBUGS-56044])
 
+* Before this update, the cluster switcher allowed users to access {rh-rhacm-first} by choosing the **All Clusters** option. With this release, the {rh-rhacm} is accessed from the perspective selector by choosing the **Fleet Management** perspective. (link:https://issues.redhat.com/browse/OCPBUGS-55946[OCPBUGS-55946])
 
+* Before this update, the web console displayed an outdated message about a 60-day update limit in versions 4.16 and later, even though the limit was removed. With this update, the outdated message is removed. As a result, the web console shows only current updated information. (link:https://issues.redhat.com/browse/OCPBUGS-55919[OCPBUGS-55919])
+
+* Before this update, the web console home page showed the wrong icon for `Info` alerts, which caused a mismatch in alert severity. With this release, the severity icons are fixed so they match correctly. As a result, the console shows alert severity clearly. (link:https://issues.redhat.com/browse/OCPBUGS-55806[OCPBUGS-55806])
+
+* Before this update, a dependency issue prevented the Console Operator from including the required `FeatureGate` resource for Cloud Service Provider (CSP) APIs. With this release, the missing `FeatureGate` resource is added to the `openshift/api` dependency. As a result, CSP APIs now work as expected in the console. (link:https://issues.redhat.com/browse/OCPBUGS-55698[OCPBUGS-55698])
+
+* Before this update, clicking the accordian in the **Critical alerts** section of the notification drawer did nothing, so the section stayed expanded. With this release, the accordian is fixed. As a result, you can now collapse the section when critical alerts are present. (link:https://issues.redhat.com/browse/OCPBUGS-55633[OCPBUGS-55633])
+
+* Before this update, additional HTTP client configurations increased the plugin initial loading time, which slowed overall {product-title} performance. With this update, the client configuration is fixed, reducing plugin load time and improving page load speed. (link:https://issues.redhat.com/browse/OCPBUGS-55514[OCPBUGS-55514])
+
+* Before this update, the custom masthead logo replaced the default OpenShift logo in all themes, even when the light theme was set to use the default. With this release, the correct behavior is restored so the default OpenShift logo displays in the light theme when no custom logo is set. As a result, logos now display correctly in both light and dark themes, improving visual consistency. (link:https://issues.redhat.com/browse/OCPBUGS-55208[OCPBUGS-55208])
+
+* Before this update, changing or removing a custom logo in the Console Operator configuration left outdated `ConfigMaps` in the `openshift-console` namespace due to delayed synchronization. With this release, the console operator removes these outdated `ConfigMaps` when the custom logo configuration changes. As a result, `ConfigMaps` in the `openshift-console` namespace remain accurate and up-to-date. (link:https://issues.redhat.com/browse/OCPBUGS-54780[OCPBUGS-54780])
+
+* Before this update, the **Raw logs** page decoded Chinese log messages incorrectly, making them unreadable. With this release, the decoding is corrected. As a result, the page now displays Chinese log messages correctly. (link:https://issues.redhat.com/browse/OCPBUGS-52165[OCPBUGS-52165])
+
+* Before this update, opening a modal on a Networking page caused some web console plugin panels, such as the **OpenShift Lightspeed UI** or the **Troubleshooting** panel, to disappear. With this release, the conflict is resolved between networking modals and web console plugins. As a result, modals on the Networking pages no longer hide other console panels. (link:https://issues.redhat.com/browse/OCPBUGS-49709[OCPBUGS-49709])
+
+* Before this update, the console server did not handle Content Security Policy (CSP) directives correctly when run locally with JSON input because it did not support the `MultiValue` type. With this release, the console accepts CSP directives as `MultiValue` instead of JSON for local use. As a result, you can now pass separate CSP directives more easily during console development. (link:https://issues.redhat.com/browse/OCPBUGS-49291[OCPBUGS-49291])
+
+* Before this update, importing multiple files in the YAML editor copied the existing content and appended the new file, creating duplicates. With this release, the import behavior is fixed. As a result, the YAML editor displays only the new file content without duplication. (link:https://issues.redhat.com/browse/OCPBUGS-45297[OCPBUGS-45297])
+
+* Before this update, only one plugin using the `CreateProjectModal` extension could display its modal, causing conflicts when multiple plugins used the same extension point. As a result, there was no way to control which plugin extension was rendered. With this release, the plugin extensions resolve in the same order as their definitions in the cluster console Operator configuration. As a result, administrators can control which `CreateProjectModal` extension displays in the console by reordering the list. (link:https://issues.redhat.com/browse/OCPBUGS-43792[OCPBUGS-43792])
+
+* Before this update, the console did not display the header defined by the `ResourceYAMLEditor` property, so the YAML view opened without it. With this release, the property is fixed. As a result, headers such as **Simple pod** now display correctly. (link:https://issues.redhat.com/browse/OCPBUGS-32157[OCPBUGS-32157])
 
 [id="ocp-release-note-monitoring-bug-fixes_{context}"]
 === Monitoring


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-15028

Link to docs preview:
https://100668--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-cloud-compute-bug-fixes_release-notes
https://100668--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-management-console-bug-fixes_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:

