### PR TITLE
OSDOCS-15028 added monitoring release notes

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1527,6 +1527,30 @@ As a result, creating a Machine API machine that references a Capacity Reservati
 [id="ocp-release-note-monitoring-bug-fixes_{context}"]
 === Monitoring
 
+* Before this update, the `KubeNodeNotReady` and `KubeNodeReadinessFlapping` alerts did not filter out cordoned nodes. As a consequence, users received alerts for nodes under maintenance, resulting in false positives. With this release, cordoned nodes are filtered from alerts. As a result, the number of false positives during maintenance is reduced. link:https://issues.redhat.com/browse/OCPBUGS-60692[OCPBUGS-60692]
+
+* Before this update, the `KubeAggregatedAPIErrors` alert was based on the sum of errors across all instances of an API. As a consequence, users were more likely to get alerted as the number of instances grew. With this release, alerts are evaluated at the instance level, rather than the API level. As a result, this reduces the number of false alarms due to the API error threshold getting hit sooner due to being evaluated cluster-wise, rather than instance-wise. link:https://issues.redhat.com/browse/OCPBUGS-60691[OCPBUGS-60691]
+
+* Before this update, the `KubeStatefulSetReplicasMismatch` alert did not fire when the `StatefulSet` controller failed to create pods. As a consequence, users were not notified when the `StatefulSet` did not reach the desired number of replicas. With this release, the alert now fires correctly when the controller cannot create pods. As a result, users are alerted whenever the `StatefulSet` replicas do not match the configured amount. link:https://issues.redhat.com/browse/OCPBUGS-60689[OCPBUGS-60689]
+
+* Before this update, the Cluster Monitoring Operator logged warnings about insecure Transport Layer Security (TLS) ciphers, which could raise concerns about security. With this release, the secure TLS settings are configured, removing the cipher warnings from the logs and ensuring the Operator reports correct, secure TLS configurations. link:https://issues.redhat.com/browse/OCPBUGS-58475[OCPBUGS-58475]
+
+* Before this update, the monitoring dashboard in the {product-title} web console sometimes displayed large negative CPU utilization values due to incorrect assumptions about intermediate results. As a consequence, users could see negative CPU utilization in the web console. With this release, CPU utilization values are properly calculated and the web console no longer shows negative utilization values. link:https://issues.redhat.com/browse/OCPBUGS-57481[OCPBUGS-57481]
+
+* Before this update, when a new secret was created or updated in any namespace, `Alertmanager` was reconciling even if that secret was not referenced in the `AlertmanagerConfig` resource. As a consequence, the Prometheus Operator generated excessive API calls, causing increased CPU usage on control plane nodes. With this release, `Alertmanager` only reconciles secrets that the `AlertmanagerConfig` resource explicitly references. (link:https://issues.redhat.com/browse/OCPBUGS-56158[OCPBUGS-56158])
+
+* Before this update, Metrics Server logged the following warning even though functionality was not affected:
++
+[source,terminal]
+----
+setting componentGlobalsRegistry in SetFallback. We recommend calling componentGlobalsRegistry.Set() right after parsing flags to avoid using feature gates before their final values are set by the flags.
+----
++
+With this release, the warning message no longer appears in the `metrics-server` logs. link:https://issues.redhat.com/browse/OCPBUGS-41851[OCPBUGS-41851]
+
+* Before this update, the `KubeCPUOvercommit` alert would not trigger on multi-node clusters even after CPU-consuming spikes over the permitted limits. With this release, the alert expression is adjusted to correctly account for multi-node clusters. As a result, the `KubeCPUOvercommit` alert triggers correctly after such instances. link:https://issues.redhat.com/browse/OCPBUGS-35095[OCPBUGS-35095]
+
+* Before this update, users could set `prometheus`, `prometheus_replica`, or `cluster` as Prometheus external labels to the `cluster-monitoring-config` and `user-workload-monitoring-config` config maps. This was not recommended and could cause issues with the cluster. With this release, the config maps no longer accept these reserved external labels. link:https://issues.redhat.com/browse/OCPBUGS-18282[OCPBUGS-18282]
 
 
 


### PR DESCRIPTION
Version(s):
4.20

Issue:


Link to docs preview:
https://100689--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-monitoring-bug-fixes_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:

