### PR TITLE
OLS-2196: Update Google Cloud attribute

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -83,10 +83,8 @@
 :ibm-z-title: IBM Z
 :ibm-linuxone-name: IBM(R) LinuxONE
 :ibm-linuxone-title: IBM LinuxONE
-//GCP
-:gcp-first: Google Cloud Platform (GCP)
-:gcp-full: Google Cloud Platform
-:gcp-short: GCP
+//Google Cloud
+:gc: Google Cloud
 //Product titles
 :pipelines-title: Red Hat OpenShift Pipelines
 :gitops-title: Red Hat OpenShift GitOps


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OLS-2196
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
