### PR TITLE
Update OCP documentation links to latest versions

### DIFF
--- a/microshift_networking/microshift-configuring-routes.adoc
+++ b/microshift_networking/microshift-configuring-routes.adoc
@@ -58,6 +58,6 @@ include::modules/nw-ingress-reencrypt-route-custom-cert.adoc[leveloffset=+1]
 
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/{ocp-version}/html/networking/configuring-routes#nw-ingress-creating-a-reencrypt-route-with-a-custom-certificate_secured-routes[Creating a re-encrypt route with a custom certificate]
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/networking/configuring-routes#nw-ingress-creating-an-edge-route-with-a-custom-certificate_secured-routes[Creating an edge route with a custom certificate]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking/configuring-routes#nw-ingress-creating-an-edge-route-with-a-custom-certificate_secured-routes[Creating an edge route with a custom certificate]
 
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/networking/configuring-routes#nw-ingress-creating-a-passthrough-route_secured-routes[Creating a passthrough route]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/networking/configuring-routes#nw-ingress-creating-a-passthrough-route_secured-routes[Creating a passthrough route]

--- a/modules/microshift-rhoai-export-metrics-otel.adoc
+++ b/modules/microshift-rhoai-export-metrics-otel.adoc
@@ -20,7 +20,7 @@ You can alternatively get the Prometheus-format metrics of the model server by m
 * You have root user access to your machine.
 * The {oc-first} is installed.
 * You installed the `microshift-observability` RPM.
-* Your {microshift-short} Open Telemetry configuration includes the Prometheus Receiver. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/red_hat_build_of_opentelemetry/configuring-the-collector#prometheus-receiver_otel-collector-receivers[Prometheus Receiver].
+* Your {microshift-short} Open Telemetry configuration includes the Prometheus Receiver. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/red_hat_build_of_opentelemetry/configuring-the-collector#prometheus-receiver_otel-collector-receivers[Prometheus Receiver].
 
 .Procedure
 

--- a/rest_api/operator_apis/console-operator-openshift-io-v1.adoc
+++ b/rest_api/operator_apis/console-operator-openshift-io-v1.adoc
@@ -650,7 +650,7 @@ You can create it with a command like:
 The ConfigMap key must include the file extension so that the console serves the file with the correct MIME type.
 The recommended file format for the Masthead and Favicon logos is SVG, but other file formats are allowed if supported by the browser.
 The logo image size must be less than 1 MB due to constraints on the ConfigMap size.
-For more information, see the documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/web_console/customizing-web-console#customizing-web-console
+For more information, see the documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/web_console/customizing-web-console#customizing-web-console
 
 |===
 === .spec.customization.logos[].themes[].source
@@ -664,7 +664,7 @@ You can create it with a command like:
 The ConfigMap key must include the file extension so that the console serves the file with the correct MIME type.
 The recommended file format for the Masthead and Favicon logos is SVG, but other file formats are allowed if supported by the browser.
 The logo image size must be less than 1 MB due to constraints on the ConfigMap size.
-For more information, see the documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/web_console/customizing-web-console#customizing-web-console
+For more information, see the documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/web_console/customizing-web-console#customizing-web-console
 --
 
 Type::


### PR DESCRIPTION
This PR updates OpenShift Container Platform documentation URLs to point to the latest available versions.

## Changes
- Automatically updated OCP documentation links using [ocp-doc-checker](https://github.com/sebrandon1/ocp-doc-checker)
- All documentation URLs now point to current versions

## Tool Information
This PR was created automatically by scanning the repository with `ocp-doc-checker`, which identifies and updates outdated OpenShift documentation links.

Repository: https://github.com/sebrandon1/ocp-doc-checker

---

**Tracking Issue:** https://github.com/sebrandon1/ocp-doc-checker/issues/18