### PR TITLE
OCPBUGS 60994 ImageDigestMirrorSet documentation clarifications

### DIFF
--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -65,6 +65,18 @@ Each of these custom resource objects identify the following information:
 requested from the source repository.
 --
 
+Note the following actions and how they affect node drain behavior:
+
+* If you create an IDMS or ICSP CR object, the MCO does not drain or reboot the node. 
+* If you create an ITMS CR object, the MCO drains and reboots the node. 
+* If you delete an ITMS, IDMS, or ICSP CR object, the MCO drains and reboots the node.  
+* If you modify an ITMS, IDMS, or ICSP CR object, the MCO drains and reboots the node.
++
+[IMPORTANT]
+====
+include::snippets/node-icsp-no-drain.adoc[]
+====
+
 ifndef::winc[]
 For new clusters, you can use IDMS, ITMS, and ICSP CRs objects as desired. However, using IDMS and ITMS is recommended.
 

--- a/snippets/node-icsp-no-drain.adoc
+++ b/snippets/node-icsp-no-drain.adoc
@@ -2,10 +2,9 @@
 //
 // * modules/understanding-machine-config-operator.adoc
 // * modules/troubleshooting-disabling-autoreboot-mco.adoc
+// * modules/images-configuration-registry-mirror.adoc
 
 :_mod-docs-content-type: SNIPPET
-
-The following modifications do not trigger a node reboot:
 
 * When the MCO detects any of the following changes, it applies the update without draining or rebooting the node:
 
@@ -13,7 +12,8 @@ The following modifications do not trigger a node reboot:
 ** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
 ** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
 
-* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageDigestMirrorSet`, `ImageTagMirrorSet`, or `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes. The node drain does not happen for the following changes:
+* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as editing an `ImageDigestMirrorSet`, `ImageTagMirrorSet`, or `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes. The node drain does not happen for the following changes:
+
 ** The addition of a registry with the `pull-from-mirror = "digest-only"` parameter set for each mirror.
 ** The addition of a mirror with the `pull-from-mirror = "digest-only"` parameter set in a registry.
 ** The addition of items to the `unqualified-search-registries` list.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-60994

Link to docs preview:
Image configuration resources -> [Understanding image registry repository mirroring](https://100697--ocpdocs-pr.netlify.app/openshift-dedicated/latest/openshift_images/image-configuration.html#images-configuration-registry-mirror_image-configuration) -- Added bullet list "Note the following actions..." and updated admonition (snippet).
Updating a cluster in a disconnected environment -> [Understanding image registry repository mirroring](https://100697--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/updating/disconnected-update.html#images-configuration-registry-mirror_updating-disconnected-cluster) -- Added bullet list "Note the following actions..." and updated admonition (snippet).
Enabling Windows container workloads -> [Understanding image registry repository mirroring](https://100697--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html#images-configuration-registry-mirror_enabling-windows-container-workloads) -- Added bullet list "Note the following actions..." and updated admonition (snippet).


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->