### PR TITLE
OSDOCS-15028: Bug batch 4.20 oc mirror RNs

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1565,12 +1565,21 @@ As a result, the controller handles errors during migration better.
 
 [id="ocp-release-note-oc-mirror-bug-fixes_{context}"]
 === oc-mirror
+* Before this update, the incorrect count of mirrored Helm images in `oc-mirror` caused a failure to note all mirrored Helm images. As a consequence, an incorrect Helm image count was displayed. With this release, the incorrect Helm image count in `oc-mirror` is fixed, and correctly mirrors all Helm images. As a result, the total mirrored images count for Helm charts in `oc-mirror` is accurate. (link:https://issues.redhat.com/browse/OCPBUGS-59949[OCPBUGS-59949])
 
+* Before this update, the `--parallel-images` flag accepted invalid input, with a minimum value that was less than 1 or greater than the total number of images. As a consequence, parallel image copy failed with 0 or 100 `--parallel-images` flag, and limited the number of images that could be mirrored. With this release, the issue with invalid `--parallel-images` flags is fixed, and values between 1 and the total number of images are accepted. As a result, users can set the `--parallel-images` flag for any value in the valid range. (link:https://issues.redhat.com/browse/OCPBUGS-58467[OCPBUGS-58467])
 
+* Before this update, high `oc-mirror v2` concurrency defaults caused registry overload and led to request rejections. As a consequence, high concurrency defaults caused registry rejections, and failed container image pushes failed. With this release, concurrency defaults for `oc-mirror v2` are reduced to avoid registry rejections, and the image push success rate is improved. (link:https://issues.redhat.com/browse/OCPBUGS-57370[OCPBUGS-57370])
 
+* Before this update, a bug occurred due to a mismatch between image digests and blocked image tags in the `ImageSetConfig` parameter. This bug caused users to see images from various cloud providers in a mirrored set, although they were blocked. With this release, the `ImageSetConfig` parameter is updated to support regular expression in the `blockedImages` list for more flexible image exclusion, and allows the exclusion of images that match a regular expression pattern in the `blockedImages` list. (link:https://issues.redhat.com/browse/OCPBUGS-56117[OCPBUGS-56117])
 
+* Before this update, the system umask value was set to `0077` for Security Technical Implementation Guide (STIG) compliance, and caused the `disk2mirror` parameter to stop uploading {product-title} release images. As a consequence, users could not upload {product-title} release images due to the umask command restriction. With this release, `oc-mirror` handles the faulty umask value and alerts the user. The {product-title} release images are uploaded correctly when the system umask is set to `0077`. (link:https://issues.redhat.com/browse/OCPBUGS-55374[OCPBUGS-55374])
 
+* Before this update, an invalid Helm chart was incorrectly included in an Internet Systems Consortium (ISC) guideline, and caused an error message while running the `m2d`workflow. With this release, the error message for invalid Helm charts in `m2d` workflows is updated, and error message clarity is improved.  (link:https://issues.redhat.com/browse/OCPBUGS-54473[OCPBUGS-54473])
 
+* Before this update, multiple release collections occurred due to duplicate channel selection. As a consequence, duplicate release images were collected, and caused unnecessary storage usage. With this release, duplicate release collection is fixed, and each release is collected once. As a result, the duplicate release collection is eliminated, and ensures efficient storage with faster access. (link:https://issues.redhat.com/browse/OCPBUGS-52562[OCPBUGS-52562])
+
+* Before this update, `oc-mirror` did not check the availability of the specific {product-title} version, and caused it to continue with non-existent versions. As a consequence, users assumed that the mirroring was successful because no error messages were received. With this release, `oc-mirror` returns an error when a non-existent {product-title} version is specified, in addition to a reason for the issue. As a result, users are aware of unavailable versions and can take appropriate action. (link:https://issues.redhat.com/browse/OCPBUGS-51157[OCPBUGS-51157])
 
 [id="ocp-release-note-oc-cli-bug-fixes_{context}"]
 === OpenShift CLI (oc)


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-15028](https://issues.redhat.com//browse/OSDOCS-15028)

Link to docs preview:
[oc mirror](https://100698--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-oc-mirror-bug-fixes_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for bug batch