### PR TITLE
ROX-28305: Customer requested update - enforcement

### DIFF
--- a/modules/custom-security-policies-about.adoc
+++ b/modules/custom-security-policies-about.adoc
@@ -8,10 +8,15 @@
 
 [role="_abstract"]
 
-{product-title-short} allows you to create custom security policies to provide security during the build, deploy, and run phases of development. You can create custom security policies by the following methods:
+With {product-title-short}, you can create custom security policies to provide security during the build, deploy, and run phases of development. You can create custom security policies by the following methods:
 
 * You can clone a default policy and then modify it to configure specific information for your environment
 * You can use the {product-title-short} portal to create and save a new policy.
 * With the policy as code feature, you can create and save policies as Kubernetes custom resources (CRs) and use a Kubernetes-native continuous delivery (CD) tool such as Argo CD to apply them to clusters.
 
 For more information, see "Creating and modifying custom security policies".
+
+[IMPORTANT]
+====
+Use caution when enforcing custom policies in the `openshift-*` namespaces and for default {ocp} pods. For example, a custom policy with enforcement configured can terminate pods with possible data loss if the policy is violated.
+==== 


### PR DESCRIPTION
Version(s): 4.9+
(module doesn't exist in 4.7 & 4.8)

[Issue
](https://issues.redhat.com/browse/ROX-28305)

[Link to docs preview
](https://100704--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/about-security-policies.html#custom-security-policies-about_about-security-policies)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
