### PR TITLE
OSDOCS#13616: RN for etcd cluster latency requirements 

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -993,6 +993,11 @@ With this release, you can use the `PerformanceProfile` custom resource to confi
 
 This new feature enhances TLS certificate rotations in {product-title}, ensuring 95% expected cluster availability. It is particularly beneficial for high-transaction-rate clusters and {sno} deployments, ensuring seamless operation even under heavy loads.
 
+[id="ocp-release-notes-additional-cluster-requirements-for-etcd_{context}"]
+==== Additional cluster latency requirements for etcd
+
+With this update, the etcd product documentation is updated to include additional requirements for reducing {product-title} cluster latency. This update clarifies the prerequisites and setup procedures for using etcd, resulting in an improved user experience. As a result, this feature introduces support for Transport Layer Security (TLS) 1.3 in etcd, which enhances security and performance for data transmission, and enables etcd to comply with the latest security standards, reducing potential vulnerabilities. The improved encryption ensures more secure communication between etcd and its clients. For more information, see xref:../etcd/etcd-practices.adoc#recommended-cluster-latency-etcd_etcd-practices[Cluster latency requirements for etcd].
+
 [id="ocp-release-notes-security_{context}"]
 === Security
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-13616](https://100706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-additional-cluster-requirements-for-etcd_release-notes)

Link to docs preview:
[etcd cluster latency requirements

QE review:
- [x] QE has approved this change.

Additional information:
This PR replaces the original one. The content is the same.
