### PR TITLE
[enterprise-4.17] OSDOCS-16286: Added explanation for vlan: 0 in cnf-creating-an-additi…

### DIFF
--- a/modules/nw-sriov-network-object.adoc
+++ b/modules/nw-sriov-network-object.adoc
@@ -51,8 +51,8 @@ endif::ocp-sriov-net[]
 <1> A name for the object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with same name.
 <2> The namespace where the SR-IOV Network Operator is installed.
 <3> The value for the `spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
-<4> The target namespace for the `SriovNetwork` object. Only {object} in the target namespace can attach to the additional network.
-<5> Optional: A Virtual LAN (VLAN) ID for the additional network. The integer value must be from `0` to `4095`. The default value is `0`.
+<4> The target namespace for the SriovNetwork object. Only pods in the target namespace can attach to the additional network. When installing the SR-IOV Network Operator in a namespace other than `openshift-sriov-network-operator`, you must not configure this field.
+<5> Optional: Specifies the VLAN ID to assign to an additional network. The default value of `0` means that an additional network has no VLAN ID tag. Supported VLAN ID values range from `1` to `4094`.
 <6> Optional: The spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
 +
 [IMPORTANT]


### PR DESCRIPTION
Cherry pick of #100512 with commit f707ac8d537cf86889802c597e14a0265716b602.

Version(s):
4.17

Issue:
[OSDOCS-16286](https://issues.redhat.com/browse/OSDOCS-16286)

Link to docs preview:
