### PR TITLE
OSDOCS-16214:Reintroduce limits and scalability sections to ROSA Classic docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -230,10 +230,8 @@ Topics:
   File: rosa-sts-aws-prereqs
 - Name: ROSA Classic IAM role resources
   File: rosa-sts-ocm-role
-##### NOTE: THE BELOW IS REMOVED AS PART OF OSDOCS-13310
-# - Name: Limits and scalability
-#   File: rosa-limits-scalability
-##### NOTE: THE ABOVE IS REMOVED AS PART OF OSDOCS-13310F
+- Name: Limits and scalability
+  File: rosa-limits-scalability
 - Name: Planning your environment
   File: rosa-planning-environment
 - Name: Required AWS service quotas


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16214

Link to docs preview:
[Limits and scalability](https://100713--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-limits-scalability)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
