### PR TITLE
TELCODOCS-2100-RN: Release note for unassisted holder for PTP

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -794,6 +794,17 @@ For more information, see xref:../networking/hardware_networks/configure-lacp-fo
 ==== Network policies for additional namespaces
 With this release, {product-title} deploys Kubernetes network policies to additional system namespaces to control ingress and egress traffic. It is anticipated that future releases might include network policies for additional system namespaces and Red{nbsp}Hat Operators.
 
+[id="ocp-4-20-ptp-holdover_{context}"]
+==== Unassisted holdover for PTP devices (Technology Preview)
+With this release, the PTP Operator provides unassisted holdover as a Technology Preview feature. When the upstream timing signal is lost, the PTP Operator automatically places PTP devices configured as either a boundary clock or a time slave clock into holdover mode. Automatic placement into holdover mode helps to maintain a continuous and stable time source for cluster nodes, minimizing time synchronization disruptions.
+
+[NOTE]
+====
+This feature is available only for nodes with Intel E810-XXVDA4T network interface cards.
+====
+
+For more information, see xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#configuring-ptp[Configuring PTP devices].
+
 [id="ocp-release-notes-nodes_{context}"]
 === Nodes
 
@@ -2273,13 +2284,18 @@ In the following tables, features are marked with the following statuses:
 |PF Status Relay Operator for high availability with SR-IOV networks
 |Not Avaialable
 |Not Available
-|Technology preview
-
+|Technology Preview
 
 |Preconfigured user-defined network end points using {mtv-short}
 |Not Available
 |Not Available
 |Technology Preview
+
+|Unassisted holdover for PTP devices
+|Not Available
+|Not Available
+|Technology Preview
+
 |====
 
 


### PR DESCRIPTION
[TELCODOCS-2100](https://issues.redhat.com//browse/TELCODOCS-2100)-RN: Release note for unassisted holder for PTP

Version(s):
4.20

Issue:
https://issues.redhat.com/browse/TELCODOCS-2100

Link to docs preview:
https://100722--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-ptp-holdover_release-notes
