### PR TITLE
OSDOCS-15028 created storage release notes

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1723,10 +1723,9 @@ As a result, the controller handles errors during migration better.
 [id="ocp-release-note-storage-bug-fixes_{context}"]
 === Storage
 
+* Before this update, resizing or cloning small {gcp-first} Hyperdisk volumes (e.g., from 4Gi to 5Gi) would fail due to an Input/Output Operations Per Second (IOPS) validation error from the {gcp-full} API. This occurred because the Container Storage Interface (CSI) driver did not automatically adjust the provisioned IOPS to meet the minimum requirements of the new volume size. With this release, the driver has been updated to correctly calculate and provide the required IOPS during volume expansion operations. Users can now successfully resize and clone these smaller Hyperdisk volumes. (link:https://issues.redhat.com/browse/OCPBUGS-62117[OCPBUGS-62117])
 
-
-
-
+* Before this update, a race condition would sometimes cause an intermittent failure, or _flake_, when a Persistent Volume Claim (PVC) was resized too quickly after being created. This resulted in an error where the system would incorrectly report that the bound Persistent Volume (PV) could not be found. With this release, the timing issue was fixed, so resizing a PVC right after its creation works. (link:https://issues.redhat.com/browse/OCPBUGS-61546[OCPBUGS-61546])
 
 
 [id="ocp-release-note-rhcos-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.20

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://100723--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-storage-bug-fixes_release-notes


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
