### PR TITLE
OSDOC@-15028 added kube controller RNs

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1560,11 +1560,12 @@ As a result, the controller handles errors during migration better.
 === Installer
 
 
+[id="ocp-release-note-kube-controller-manager-bug-fixes_{context}"]
+=== Kube Controller Manager
 
+* Before this update, the `cluster-policy-controller` was crashing when an invalid volume type was provided. With this release, the code no longer panics. As a result, the `cluster-policy-controller` logs an error to inform about invalidity of a volume type. (link:https://issues.redhat.com/browse/OCPBUGS-62053[OCPBUGS-62053])
 
-
-
-
+* Before this update, the `cluster-policy-controller` container was exposing the `10357` port for all networks (the bind address was set to 0.0.0.0). The port was exposed outside the node's host network because the KCM pod manifest set 'hostNetwork` to `true`. This port is used solely for the container's probe. With this enhancement, the bind address was updated to listen on the localhost only. As result, the node security is improved because the port is not exposed outside the node network. (link:https://issues.redhat.com/browse/OCPBUGS-53290[OCPBUGS-53290])
 
 
 [id="ocp-release-note-machine-config-operator-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.20

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://100730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-kube-controller-manager-bug-fixes_release-notes


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
