### PR TITLE
[enterprise-4.14] OCPBUGS-62278: Updated the Platform support table for EgressIp addresses

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -10,14 +10,14 @@ ifeval::["{context}" == "configuring-egress-ips-ovn"]
 :ovn:
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="nw-egress-ips-about_{context}"]
 = Egress IP address architectural design and implementation
 
-The {product-title} egress IP address functionality allows you to ensure that the traffic from one or more pods in one or more namespaces has a consistent source IP address for services outside the cluster network.
+By using the {product-title} egress IP address functionality, you can ensure that the traffic from one or more pods in one or more namespaces has a consistent source IP address for services outside the cluster network.
 
 For example, you might have a pod that periodically queries a database that is hosted on a server outside of your cluster. To enforce access requirements for the server, a packet filtering device is configured to allow traffic only from specific IP addresses.
 To ensure that you can reliably allow access to the server from only that specific pod, you can configure a specific egress IP address for the pod that makes the requests to the server.
-
 
 An egress IP address assigned to a namespace is different from an egress router, which is used to send traffic to specific destinations.
 
@@ -44,11 +44,10 @@ ifndef::openshift-rosa[]
 [id="nw-egress-ips-platform-support_{context}"]
 == Platform support
 
-Support for the egress IP address functionality on various platforms is summarized in the following table:
+The Egress IP address feature that runs on a primary host network is supported on the following platforms:
 
 [cols="1,1",options="header"]
 |===
-
 | Platform | Supported
 
 | Bare metal | Yes
@@ -61,7 +60,16 @@ Support for the egress IP address functionality on various platforms is summariz
 | {ibm-z-name} and {ibm-linuxone-name} for {op-system-base-full} KVM | Yes
 | {ibm-power-name} | Yes
 | Nutanix | Yes
+|===
 
+// If platform support increases, ensure to update the lead-in sentence to the plural form.
+The Egress IP address feature that runs on secondary host networks is supported on the following platform:
+
+[cols="1,1",options="header"]
+|===
+| Platform | Supported
+
+| Bare metal | Yes
 |===
 endif::openshift-rosa[]
 


### PR DESCRIPTION
Cherry pick of #100029 with commit ID ca8c0b938ff76a5653d1fa56aa93bd394465a121

Version(s):
4.14

Issue:
[OCPBUGS-62278](https://issues.redhat.com/browse/OCPBUGS-62278)
