### PR TITLE
OSDOCS 16556 Linux User Namespace ID-mapped mount information fixes

### DIFF
--- a/nodes/pods/nodes-pods-user-namespaces.adoc
+++ b/nodes/pods/nodes-pods-user-namespaces.adoc
@@ -12,11 +12,11 @@ By default, a container runs in the host user namespace. Running a container in 
  
 Running containers in individual user namespaces can mitigate container breakouts and several other vulnerabilities that a compromised container can pose to other pods and the node itself. 
 
-When running a pod in an isolated user namespace, the UID/GID inside a pod container no longer matches the UID/GID on the host. In order for file system ownership to work correctly, the Linux kernel uses ID-mapped mounts, which translate user IDs between the container and the host at the virtual file system (VFS) layer.
+When running a pod in an isolated user namespace, the UID/GID inside a pod container no longer matches the UID/GID on the host. For file system ownership to work correctly, the Linux kernel uses ID-mapped mounts, which translate user IDs between the container and the host at the virtual file system (VFS) layer.
 
 [IMPORTANT]
 ====
-Not all file systems currently support ID-mapped mounts, such as Network File Systems (NFS) and other network/distributed file systems. Any pod that is using an NFS-backed persistent volume from a vendor that does not support ID-mapped mounts might experience access or permission issues when running in a user namespace. This behavior is not specific to {product-title}. It applies to all Kubernetes distributions from Kubernetes v1.33 onward.
+Not all file systems currently support ID-mapped mounts, such as Network File Systems (NFS) and other network/distributed file systems. Any pod that is using an NFS-backed persistent volume from a vendor that does not support ID-mapped mounts might experience access or permission issues when running in a user namespace. This behavior is not specific to {product-title}. It applies to all Kubernetes distributions from Kubernetes v1.33 and later.
 ====
 
 // The following include statements pull in the module files that comprise


### PR DESCRIPTION
Implementing changes that Lisa P suggested in the release note for this change. I added the info to the user namespace docs and the 4.20 release notes. The text is largely the same in both places. 

* https://github.com/openshift/openshift-docs/pull/100434#discussion_r2440072674
* https://github.com/openshift/openshift-docs/pull/100434#discussion_r2440075017