### PR TITLE
OSDOCS-15028 added observability RNs

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1656,7 +1656,9 @@ As a result, the controller handles errors during migration better.
 [id="ocp-release-note-observability-bug-fixes_{context}"]
 === Observability
 
+* Before this update, the linked URL is in the developer perspective, but the perspective is not switched when you clicked the link. As a consequence, a blank page displayed. With this releae, the perspective changes when you click the link and the page displays correctly. (link:https://issues.redhat.com/browse/OCPBUGS-59215[OCPBUGS-59215])
 
+* Before this update, the **Troubleshooting** panel only worked in the admin perspective even though you could open the panel in all perspectives. As a consequence, when opening the panel in another perspective, the panel was non-operational. With this release, the **Troubleshooting** panel can only be opened from the admin perspective. (link:https://issues.redhat.com/browse/OCPBUGS-58166[OCPBUGS-58166])
 
 
 [id="ocp-release-note-oc-mirror-bug-fixes_{context}"]


### PR DESCRIPTION
Version(s):
4.20

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://100750--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-observability-bug-fixes_release-notes


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
