### PR TITLE
OLS-2197: NotebookLM checks on tshooting assembly and modules

### DIFF
--- a/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+++ b/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following topics provide information to help troubleshoot {ols-long}.
+The following topics provide information to help Platform Engineers and System Administrators troubleshoot {ols-long}.
 
 include::modules/ols-502-bad-gateway-errors.adoc[leveloffset=+1]
 include::modules/ols-operator-missing-from-operatorhub-list.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2197

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
