### PR TITLE
OSDOCS#15028: 4.20 bug batching for kube-apiserver 

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -61,6 +61,19 @@ Before this update, deleting an `istag` resource with the `--dry-run=server` opt
 //[id="ocp-release-notes-auth_{context}"]
 //=== Authentication and authorization
 
+[id="ocp-release-notes-service-interruptions_{context}"]
+==== No service interruptions for certificate-related issues
+
+With this update, self-signed loopback certificates in API servers are prevented from expiring, and ensures a stable and secure connection within Kubernetes 4.16.z. This enhancement backports a solution from a newer version, cherry-picks a specific pull request and applies it to the selected version. This reduces the likelihood of service interruptions due to certificate-related issues, providing a more reliable user experience in Kubernetes 4.16.z deployments.
+
+[id="ocp-release-notes-communication-flows_{context}"]
+==== Enhanced communication matrix for TCP ports
+
+With this update, the communication flows matrix for {product-title} is enhanced. The feature automatically generates services for open ports 17697 (TCP) and 6080 (TCP) on the primary node, and ensures that all open ports have corresponding endpoint slices. This results in accurate and up-to-date communication flows matrixes, improves the overall security and efficiency of the communication matrix, and provides a more comprehensive and reliable communication matrix for users.
+
+[id="ocp-release-notes-auth_{context}"]
+=== Authentication and authorization
+
 //[id="ocp-release-notes-documentation_{context}"]
 //=== Documentation
 
@@ -1511,7 +1524,7 @@ The Red{nbsp}Hat Marketplace is deprecated. Customers who use the partner softwa
 
 * Previously, in certain configurations, the kubelet `podresources` API might have reported memory that was assigned to both active and terminated pods, instead of reporting memory assigned to active pods only. As a consequence, this inaccurate reporting might have affected workload placement by the NUMA-aware scheduler.
 +
-With this release, kubelet no longer reports resources for terminated pods, which results in accurate workload placement by the NUMA-aware scheduler. (link:https://issues.redhat.com/browse/OCPBUGS-56785[OCPBUGS-56785)
+With this release, kubelet no longer reports resources for terminated pods, which results in accurate workload placement by the NUMA-aware scheduler. (link:https://issues.redhat.com/browse/OCPBUGS-56785[OCPBUGS-56785])
 
 //Telco Edge / TALO
 //Telco Edge / ZTP
@@ -1520,6 +1533,21 @@ With this release, kubelet no longer reports resources for terminated pods, whic
 //[id="ocp-release-note-api-auth-bug-fixes_{context}"]
 //=== API Server and Authentication
 
+* Before this update, concurrent map iteration and kube-apiserver validation caused crashes. As a consequence, API server disruptions and `list watch` storms occurred. With this release, the concurrent map iteration and validation issue is resolved. As a result, API server crashes are prevented, and cluster stability is improved. (link:https://issues.redhat.com/browse/OCPBUGS-61347[OCPBUGS-61347])
+
+* Before this update, the resource quantity and `IntOrString` fields validation cost were incorrectly calculated due to improper consideration of maximum field length in the Common Expression Language (CEL) validation. As a consequence, users encountered validation errors due to incorrect string length consideration in CEL validation. With this release, CEL validation correctly accounts for the maximum length of `IntOrString fields`. As a result, users can submit valid resource requests without CEL validation errors. (link:https://issues.redhat.com/browse/OCPBUGS-59756[OCPBUGS-59756])
+
+* Before this update, the `node-system-admin-signer` validity was limited to one year and was not extended or refreshed at 2.5 years. This issue prevented issuing the `node-system-admin-client` for two years. With this release, the `node-system-admin-signer` validity is extended to three years, and issuing the `node-system-admin-client` for a two-year period is enabled. (link:https://issues.redhat.com/browse/OCPBUGS-59527[OCPBUGS-59527])
+
+* Before this update, a cluster installation failure occurred on {ibm-title} and {azure-first} systems due to incompatibility with the `ShortCertRotation` feature gate. As a consequence, the cluster installation failed, and caused nodes to remain offline. With this release, the fix removes the `ShortCertRotation`  feature gate during a cluster installation on {ibm-title} and {azure-first} systems. As a result, cluster installations are successful on these platforms. (link:https://issues.redhat.com/browse/OCPBUGS-57202[OCPBUGS-57202])
+
+* Before this update, the `admissionregistration.k8s.io/v1beta1` API was served incorrectly in {product-title} version 4.17, despite being intended for deprecation and removal. This led to dependency issues for users. With this release, the deprecated API filter is registered for a phased removal, and requires administrative acknowledgment for upgrades. As a result, users do not encounter deprecated API errors in {product-title} version 4.20, and the system stability is improved. (link:https://issues.redhat.com/browse/OCPBUGS-55465[OCPBUGS-55465])
+
+* Before this update, the certificate rotation controller copied and rewrote all of their changes, and caused excessive event spamming. As a consequence, users experienced excessive event spamming and potential etcd overload. With this release, the certificate rotation controller conflict is resolved, and reduces excessive event spamming. As a result, excessive event spamming in the certificate rotation controller is resolved, reduces the load on etcd, and improves the system stability.(link:https://issues.redhat.com/browse/OCPBUGS-55217[OCPBUGS-55217]) 
+
+* Before this update, user secrets were logged in audit logs after enabling `WriteRequestBodies` profile settings. As a consequence, sensitive data was visible in the audit log. With this release, the `MachineConfig` object is removed from the audit log response, and prevents user secrets from being logged. As a result, secrets and credentials do not appear in audit logs. (link:https://issues.redhat.com/browse/OCPBUGS-52466[OCPBUGS-52466])
+
+* Before this update, testing Operator conditions using synthesized methods instead of deploying and scheduling pods by using the deployment controller caused incorrect test results. As a consequence, users experienced test failures due to the incorrect use of synthesized conditions instead of real pod creation. With this release, the Kubernetes deployment controller is used for testing Operator conditions, and improves pod deployment reliability. (link:https://issues.redhat.com/browse/OCPBUGS-43777[OCPBUGS-43777])
 
 [id="ocp-release-note-bare-metal-hardware-bug-fixes_{context}"]
 === Bare Metal Hardware Provisioning


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-15028](https://issues.redhat.com//browse/OSDOCS-15028)

Link to docs preview:
[API server](https://100786--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-api_release-notes)
[API server and authentication](https://100786--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-api_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for 4.20 bug batching