### PR TITLE
OBSDOCS-235: Enable kube api-server Caching for Log Collection

### DIFF
--- a/configuring/cluster-logging-collector.adoc
+++ b/configuring/cluster-logging-collector.adoc
@@ -21,4 +21,6 @@ The {clo} deploys a service for each configured input receiver so that clients c
 include::modules/configuring-the-collector-to-receive-audit-logs-as-an-http-server.adoc[leveloffset=+2]
 include::modules/configuring-the-collector-to-listen-for-connections-as-a-syslog-server.adoc[leveloffset=+2]
 
+include::modules/configuring-pod-rollout-strategy.adoc[leveloffset=+1]
+
 //include::modules/cluster-logging-collector-tuning.adoc[leveloffset=+1]

--- a/modules/configuring-pod-rollout-strategy.adoc
+++ b/modules/configuring-pod-rollout-strategy.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * configuring/cluster-logging-collector.adoc
+
+
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-10-19
+:_mod-docs-content-type: PROCEDURE
+
+[id="configuring-pod-rollout-strategy_{context}"]
+= Configuring pod rollout strategy
+
+You can configure the collector pods rollout strategy so that the requests to the API server are minimized during upgrades and restarts.
+
+[NOTE]
+====
+Unlike in previous releases, API server kube-api caching is always enabled.
+==== 
+
+.Prerequisites
+* You have administrator permissions.
+* You installed the {oc-first}.
+* You installed and configured {clo}.
+* You have created a `ClusterLogForwarder` custom resource (CR).
+
+.Procedure
+
+. Update the `ClusterLogForwarder` CR:
++
+[source,yaml]
+----
+apiVersion: observability.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: my-forwarder
+  namespace: openshift-logging
+spec:
+  collector:
+    maxUnavailable: <value>
+----
++
+Where <value> can be a number or percentage. If you do not specify a value, the default value of `100%` is used for the `maxUnavailable` field.
+
+. Apply the `ClusterLogForwarder` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 6.4
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2354
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://100794--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/cluster-logging-collector.html#configuring-pod-rollout-strategy_cluster-logging-collector
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
