### PR TITLE
OSDOCS-15903-17-re: Updated the cipher suites release note

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -1620,7 +1620,7 @@ In {product-title} 4.16, Patternfly 4 and React Router 5 were deprecated. The de
 [id="ocp-4-17-tls-1-2-ciphers_{context}"]
 ==== Removed support for TLS 1.2 custom profile ciphers
 
-{product-title} no longer supports the following Transport Layer Security (TLS) 1.2 cipher suites that formed part of the custom TLS profile. Including these cipher suites as a part of a custom TLS profile for TLS v1.2 does not give you the results that you expect.
+{product-title} no longer supports the following Transport Layer Security (TLS) 1.2 cipher suites. Including these cipher suites as a part of a custom TLS profile for TLS v1.2 does not give you the results that you expect.
 
 * `TLS_RSA_WITH_AES_128_GCM_SHA256`
 * `TLS_RSA_WITH_AES_256_GCM_SHA384`


### PR DESCRIPTION
Slight modification to the [note](https://github.com/openshift/openshift-docs/pull/98317#discussion_r2360545925) that was recently merged. 

Version(s):
4.17

Issue:
[OSDOCS-15903](https://issues.redhat.com/browse/OSDOCS-15903)

Link to docs preview:
* [Removed support for TLS 1.2 custom profile ciphers](https://100796--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-tls-1-2-ciphers_release-notes)

- [x] SME has approved this change (Candace Holman).


