### PR TITLE
OSDOCS-16564:Updated prereqs for default OSD on GCP cluster.

### DIFF
--- a/modules/ccs-gcp-customer-procedure-wif.adoc
+++ b/modules/ccs-gcp-customer-procedure-wif.adoc
@@ -30,7 +30,7 @@ The following roles are only required when creating, updating, or deleting WIF c
 
 |Service Account Admin
 |`roles/iam.serviceAccountAdmin`
-|Required to pre-create the services account required by the OSD deployer, support and operators.
+|Required for the pre-creation of the service accounts used by the deployer, support, and Operators.
 
 |Workload Identity Pool Admin
 |`roles/iam.workloadIdentityPoolAdmin`

--- a/modules/ccs-gcp-provisioned.adoc
+++ b/modules/ccs-gcp-provisioned.adoc
@@ -13,14 +13,13 @@ This is an overview of the provisioned Google Cloud Platform (GCP) components on
 GCP compute instances are required to deploy the control plane and data plane functions of {product-title} in GCP. Instance types might vary for control plane and infrastructure nodes depending on worker node count.
 
 * Single availability zone
-** 2 infra nodes  (custom machine type: 4 vCPU and 32 GB RAM)
-** 3 control plane nodes  (custom machine type: 8 vCPU and 32 GB RAM)
-** 2 worker nodes (custom machine type: 4 vCPU and 16 GB RAM)
+** 2 infra nodes  (n2-highmem-4 machine type: 4 vCPU and 32 GB RAM)
+** 3 control plane nodes  (n2-standard-8 machine type: 8 vCPU and 32 GB RAM)
+** 2 worker nodes (default n2-standard-4 machine type: 4 vCPU and 16 GB RAM)
 * Multiple availability zones
-** 3 infra nodes  (custom machine type: 4 vCPU and 32 GB RAM)
-** 3 control plane nodes (custom machine type: 8 vCPU and 32 GB RAM)
-** 3 worker nodes (custom machine type: 4 vCPU and 16 GB RAM)
-
+** 3 infra nodes  (n2-highmem-4 machine type: 4 vCPU and 32 GB RAM)
+** 3 control plane nodes (n2-standard-8 machine type: 8 vCPU and 32 GB RAM)
+** 3 worker nodes (default n2-standard-4 machine type: 4 vCPU and 16 GB RAM)
 
 [id="gcp-policy-storage_{context}"]
 == Storage
@@ -38,7 +37,7 @@ GCP compute instances are required to deploy the control plane and data plane fu
 
 include::snippets/install-cluster-in-vpc.adoc[]
 
-* **Subnets:** One master subnet for the control plane workloads and one worker subnet for all others.
+* **Subnets:** One master subnet for the control plane workloads and one worker subnet for all others. An additional subnet is required for Google Private Service Connect (PSC) when a private cluster is deployed using PSC.
 * **Router tables:** One global route table per VPC.
 * **Internet gateways:** One internet gateway per cluster.
 * **NAT gateways:**  One master NAT gateway and one worker NAT gateway per cluster.
@@ -46,38 +45,4 @@ include::snippets/install-cluster-in-vpc.adoc[]
 [id="gcp-policy-services_{context}"]
 == Services
 
-The following services must be enabled on a GCP CCS cluster:
-
-* `deploymentmanager`
-* `compute`
-* `cloudapis`
-* `cloudresourcemanager`
-* `dns`
-* `iamcredentials`
-* `iam`
-* `servicemanagement`
-* `serviceusage`
-* `storage-api`
-* `storage-component`
-* `orgpolicy`
-* `networksecurity`
-
-//Commenting this section out for now. Once Workload Identity feature is implemented, this may need to be conditionalized for that, but does not apply to service account key authorization method.
-// [id="gcp-policy-permissions_{context}"]
-// == Permissions
-
-// The following roles must be added to the support service account:
-
-// * `compute.admin`
-// * `dns.admin`
-// * `orgpolicy.policyViewer`
-// * `servicemanagement.admin`
-// * `serviceusage.serviceUsageAdmin`
-// * `storage.admin`
-// * `compute.loadBalancerAdmin`
-// * `viewer`
-// * `iam.roleAdmin`
-// * `iam.securityAdmin`
-// * `iam.serviceAccountKeyAdmin`
-// * `iam.serviceAccountAdmin`
-// * `iam.serviceAccountUser`
+For a list of services that must be enabled on a GCP CCS cluster, see the _Required API services_ table.

--- a/modules/gcp-limits.adoc
+++ b/modules/gcp-limits.adoc
@@ -10,6 +10,15 @@ The {product-title} cluster uses a number of Google Cloud Platform (GCP) compone
 
 A standard {product-title} cluster uses the following resources. Note that some resources are required only during the bootstrap process and are removed after the cluster deploys.
 
+[NOTE]
+====
+3 subnets are required to deploy a private cluster with Private Service Connect (PSC). These subnets are a control plane subnet, a worker subnet, and a subnet used for the PSC service attachment with the purpose set to Private Service Connect.
+
+48 vCPUs for a default multi-AZ {product-title} cluster consists of 3 compute nodes (4 vCPUs each, one per availability zone), 3 infra nodes (4 vCPU each), and 3 control plane nodes (8 vCPU each).
+
+40 vCPUs for a default single-AZ {product-title} cluster consists of 2 compute nodes (4 vCPUs each), 2 infra nodes (4 vCPU each) and 3 control plane nodes (8 vCPU each).
+====
+
 .GCP resources used in a default cluster
 
 [cols="2a,2a,2a,2a,2a",options="header"]
@@ -31,10 +40,10 @@ A standard {product-title} cluster uses the following resources. Note that some 
 |Static IP addresses	|Compute	|Region	|4	|1
 |Routers	|Compute	|Global	|1	|0
 |Routes	|Compute	|Global	|2	|0
-|Subnetworks	|Compute	|Global	|2	|0
+|Subnetworks	|Compute	|Global	|3	|0
 |Target Pools	|Compute	|Global	|3	|0
-|CPUs	|Compute	|Region	|28	|4
-|Persistent Disk SSD (GB)	|Compute	|Region	|896	|128
+|CPUs	|Compute	|Region	|48	|4
+|Persistent Disk SSD (GB)	|Compute	|Region	|1060	|128
 
 |===
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16564

Link to docs preview:
[Customer Cloud Subscriptions on GCP](https://100797--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html#ccs-gcp-customer-procedure-wif_gcp-ccs)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
