### PR TITLE
[RHDEVDOCS-6458] GitLab support for GitOps comment on pushed commits

### DIFF
--- a/modules/op-restarting-or-canceling-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-restarting-or-canceling-pipeline-run-using-pipelines-as-code.adoc
@@ -5,13 +5,13 @@
 [id="restarting-or-canceling-pipeline-run-using-pipelines-as-code_{context}"]
 = Restarting or canceling a pipeline run using {pac}
 
-You can restart or cancel a pipeline run with no events, such as sending a new commit to your branch or raising a pull request. To restart all pipeline runs, use the *Re-run all checks* feature in the GitHub App.
+You can restart or cancel a pipeline run without triggering an event, such as sending a new commit to a branch or creating a pull request. To restart all pipeline runs, use the *Re-run all checks* feature in the GitHub App.
 
 To restart all or specific pipeline runs, use the following comments:
 
-* The `/test` and `/retest` comment restarts all pipeline runs.
+* The `/test` and `/retest` comments restart all pipeline runs.
 
-* The `/test <pipeline_run_name>` and `/retest <pipeline_run_name>` comment starts or restarts a specific pipeline run. You can use this command to start any {pac} pipeline run on the repository, whether or not it was triggered by an event for this pipeline run.
+* The `/test <pipeline_run_name>` and `/retest <pipeline_run_name>` comments start or restart a specific pipeline run. You can use these commands to start any {pac} pipeline run on the repository, whether or not it was triggered by an event for this pipeline run.
 
 To cancel all or specific pipeline runs, use the following comments:
 
@@ -25,7 +25,7 @@ The comment starts, restarts, or cancels any pipeline runs only if the comment a
 
 * The author is the owner of the repository.
 * The author is a collaborator on the repository.
-* The author is a public member on the organization of the repository.
+* The author is a public member of the organization that owns the repository.
 * The comment author is listed in the `approvers` or `reviewers` section of the `OWNERS` file in the root of the repository, as defined in the https://www.kubernetes.dev/docs/guide/owners/[Kubernetes documentation]. {pac} supports the specification for the `OWNERS` and `OWNERS_ALIASES` files. If the `OWNERS` file includes a https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#filters[filters] section, {pac} matches approvers and reviewers only against the `.*` filter.
 
 :FeatureName: Using a comment to start a pipeline run that does not match an event
@@ -49,18 +49,17 @@ This is a comment inside a pull request.
 +
 [NOTE]
 ====
-This feature is supported for the GitHub provider only.
+This feature is supported for the GitHub and GitLab providers only.
 ====
 
-.. Go to your GitHub repository.
+.. Go to your GitHub or GitLab repository.
 
-.. Click the *Commits* section.
+.. In GitHub, click the *Commits* section. In GitLab, click the *History* section.
 
 .. Click the commit where you want to restart a pipeline run.
 
-.. Click on the line number where you want to add a comment.
+.. Click on the line number where you want to add a comment. The following example shows a comment that starts or restarts a specific pipeline run:
 +
-.Example comment that starts or restarts a specific pipeline run
 [source]
 ----
 This is a comment inside a commit.


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.21

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6458

Link to docs preview:
- [Procedure of "Restarting or canceling a pipeline run using Pipelines as Code"](https://100799--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/managing-pipeline-runs-pac.html#restarting-or-canceling-pipeline-run-using-pipelines-as-code_managing-pipeline-runs-pac)

QE review ([requested](https://redhat-internal.slack.com/archives/CG5GV6CJD/p1763980168561999)):
- [x] QE has approved this change.
