### PR TITLE
OSDOCS-16550: Updated the comment on images-update-global-pull-secret

### DIFF
--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -34,17 +34,16 @@ endif::image-pull-secrets[]
 * You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
+
 . Optional: To append a new pull secret to the existing pull secret, complete the following steps:
 +
 .. Enter the following command to download the pull secret:
 +
 [source,terminal]
 ----
-$ oc get secret/pull-secret -n openshift-config \
-  --template='{{index .data ".dockerconfigjson" | base64decode}}' \
-  <pull_secret_location> <1>
+$ oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > <pull_secret_location> <1>
 ----
-<1> Include the path to the pull secret file.
+<1> `<pull_secret_location>`: Include the path to the pull secret file.
 +
 .. Enter the following command to add the new pull secret:
 +
@@ -54,9 +53,9 @@ $ oc registry login --registry="<registry>" \ <1>
 --auth-basic="<username>:<password>" \ <2>
 --to=<pull_secret_location> <3>
 ----
-<1> Include the new registry. You can include many repositories within the same registry, for example: `--registry="<registry/my-namespace/my-repository>"`.
-<2> Include the credentials of the new registry.
-<3> Include the path to the pull secret file.
+<1> `<registry>`: Include the new registry. You can include many repositories within the same registry, for example: `--registry="<registry/my-namespace/my-repository>`.
+<2> `<username>:<password>`: Include the credentials of the new registry.
+<3> `<pull_secret_location>`: Include the path to the pull secret file.
 +
 You can also perform a manual update to the pull secret file.
 
@@ -67,7 +66,7 @@ You can also perform a manual update to the pull secret file.
 $ oc set data secret/pull-secret -n openshift-config \
   --from-file=.dockerconfigjson=<pull_secret_location> <1>
 ----
-<1> Include the path to the new pull secret file.
+<1> `<pull_secret_location>`: Include the path to the new pull secret file.
 +
 This update rolls out to all nodes, which can take some time depending on the size of your cluster.
 +


### PR DESCRIPTION
Module not in ROSA or OKD docs, but links were generated from the build.

Version(s):
4.12+

Issue:
[OSDOCS-16550](https://issues.redhat.com/browse/OSDOCS-16550)

Link to docs preview:
* [Updating the global cluster pull secret](https://100801--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/remote-health-reporting.html#images-update-global-pull-secret_remote-health-reporting)
* [Updating the global cluster pull secret - Disconnected environment](https://100801--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/updating/disconnected-update-osus.html#images-update-global-pull-secret_updating-disconnected-cluster-osus)
* [Updating the global cluster pull secret - Managing Images](https://100801--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets)

- [x] SME has approved this change (Isaac Jimeno/Ondrej Pokorny).
- [x] QE has approved this change (baiyang zhou).
