### PR TITLE
OSDOCS-16559 [NETOBSERV] Add NETOBSERV-2451 to 1.10 Known Issues

### DIFF
--- a/modules/network-observability-operator-release-notes-1-10-known-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-10-known-issues.adoc
@@ -8,6 +8,69 @@
 [role="_abstract"]
 Review the following known issues and their recommended workarounds (where available) that might affect your use of the Network Observability Operator 1.10 release.
 
+[id="upgrading-to-1-10-fails-on-ocp-4-14-and-earlier_{context}"]
+== Upgrading to 1.10 fails on {product-title} 4.14 and earlier
+
+Upgrading to the Network Observability Operator 1.10 on {product-title} 4.14 and earlier can fail due to a `FlowCollector` custom resource definition (CRD) validation error in the software catalog.
+
+To workaround this problem, you must:
+
+. Uninstall both versions of the Network Observability Operator from the software catalog in the {product-title} web console.
+.. Keep the `FlowCollector` CRD installed so that it doesn't cause any disruption in the flow collection process.
+
+. Check the current name of the `FlowCollector` CRD by running the following command:
++
+[source,terminal]
+----
+$ oc get crd flowcollectors.flows.netobserv.io -o jsonpath='{.spec.versions[0].name}'
+----
++
+Expected output:
++
+[source,terminal]
+----
+v1beta1
+----
+
+. Check the current serving status of the `FlowCollector` CRD by running the following command:
++
+[source,terminal]
+----
+$ oc get crd flowcollectors.flows.netobserv.io -o jsonpath='{.spec.versions[0].served}'
+----
++
+Expected output:
++
+[source,terminal]
+----
+true
+----
+
+. Set the `served` flag for the `v1beta1` version to `false` by running the following command:
++
+[source,terminal]
+----
+$ oc patch crd flowcollectors.flows.netobserv.io --type='json' -p "[{'op': 'replace', 'path': '/spec/versions/0/served', 'value': false}]"
+----
+
+. Verify that the `served` flag is set to `false` by running the following command:
++
+[source,terminal]
+----
+$ oc get crd flowcollectors.flows.netobserv.io -o jsonpath='{.spec.versions[0].served}'
+----
++
+Expected output:
++
+[source,terminal]
+----
+false
+----
+
+. Install Network Observability Operator 1.10.
+
+link:https://issues.redhat.com/browse/OCPBUGS-63208[OCPBUGS-63208], link:https://issues.redhat.com/browse/NETOBSERV-2451[NETOBSERV-2451]
+
 [id="eBPF-agent-compatibility-with-older-open-shift-versions_{context}"]
 == eBPF agent compatibility with older {product-title} versions
 The eBPF agent used in the Network Observability Command Line Interface (CLI) packet capture feature is incompatible with {product-title} versions 4.16 and older.
@@ -17,3 +80,21 @@ This limitation prevents the eBPF-based Packet Capture Agent (PCA) from function
 To work around this problem, you must manually configure PCA to use an older, compatible eBPF agent container image. For more information, see the Red Hat Knowledgebase Solution link:https://access.redhat.com/solutions/7132671[eBPF agent compatibility with older Openshift versions in Network Observability CLI 1.10+].
 
 link:https://issues.redhat.com/browse/NETOBSERV-2358[NETOBSERV-2358]
+
+[id="ebpf-agent-fail-to-send-flows-with-openshift-sdn-when-network-policy-enabled_{context}"]
+== eBPF Agent fails to send flows with OpenShiftSDN when NetworkPolicy is enabled
+
+When running Network Observability Operator 1.10 on {product-title} 4.14 clusters that use the `OpenShiftSDN` CNI plugin, the eBPF agent is unable to send flow records to the `flowlogs-pipeline` component. This occurs when the `FlowCollector` custom resource is created with `NetworkPolicy` enabled (`spec.networkPolicy.enable: true`).
+
+As a consequence, flow data is not processed by the `flowlogs-pipeline` component and does not appear in the *Network Traffic* dashboard or the configured storage (Loki). The eBPF agent pod logs show `i/o timeout` errors when attempting to connect to the collector:
+
+[source,terminal]
+----
+time="2025-10-17T13:53:44Z" level=error msg="couldn't send flow records to collector" collector="10.0.68.187:2055" component=exporter/GRPCProto error="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 10.0.68.187:2055: i/o timeout\""
+----
+
+To work around this problem, set `spec.networkPolicy.enable` to `false` to disable `NetworkPolicy` in the `FlowCollector` resource for Network Observability Operator 1.10.
+
+This will allow the eBPF agent to communicate with the `flowlogs-pipeline` component without interference from the automatically deployed network policy.
+
+link:https://issues.redhat.com/browse/NETOBSERV-2450[NETOBSERV-2450]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16559

[NETOBSERV] Add [NETOBSERV-2451](https://issues.redhat.com//browse/NETOBSERV-2451) to 1.10 Known Issues

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the no-1.10 branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the <no-.10> content just before its GA.

Note to self for integration: Applies to only OCP 4.14 and earlier.

Issue:
https://issues.redhat.com/browse/OSDOCS-16559

Link to docs preview:
* Upgrading to 1.10 fails on OpenShift Container Platform 4.14 and earlier: https://100809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes-1-10.html#upgrading-to-1-10-fails-on-ocp-4-14-and-earlier_network-observability-operator-release-notes-v1-10
* eBF Agent fails to send flows with OpenShiftSDN when NetworkPolicy is enabled:  https://100809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes-1-10.html#ebpf-agent-fail-to-send-flows-with-openshift-sdn-when-network-policy-enabled_network-observability-operator-release-notes-v1-10

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [NETOBSERV-2450](https://issues.redhat.com//browse/NETOBSERV-2450) added per engineering.
* eBPF agent compatibility with older {product-title} versions and all other release note entries have already been reviewed and merged into `no-1.10`. See by https://github.com/openshift/openshift-docs/commit/62d28d8975d4a416af26b56a71ac5f56ef9b959d 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
