### PR TITLE
OCPBUGS-51298: Added VPC note to manually-create-iam-ibm-cloud.adoc

### DIFF
--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -53,33 +53,43 @@ You can use the Cloud Credential Operator (CCO) utility (`ccoctl`) to create the
 
 .Procedure
 
-. Edit the `install-config.yaml` configuration file so that it contains the `credentialsMode` parameter set to `Manual`.
+. Edit the `install-config.yaml` configuration file so that the file includes the `credentialsMode` parameter set to `Manual`.
 +
+ifdef::ibm-vpc[]
 .Example `install-config.yaml` configuration file
-[source,yaml]
+[source,yaml,subs="+quotes"]
 ----
 apiVersion: v1
 baseDomain: cluster1.example.com
-credentialsMode: Manual <1>
+credentialsMode: Manual
 compute:
-ifdef::ibm-vpc[]
 - architecture: amd64
-endif::ibm-vpc[]
-ifdef::ibm-power-vs[]
-- architecture: ppc64le
-endif::ibm-power-vs[]
   hyperthreading: Enabled
 ----
-<1> This line is added to set the `credentialsMode` parameter to `Manual`.
+endif::ibm-vpc[]
+ifdef::ibm-power-vs[]
+.Example `install-config.yaml` configuration file
+[source,yaml,subs="+quotes"]
+----
+apiVersion: v1
+baseDomain: cluster1.example.com
+credentialsMode: Manual
+compute:
+- architecture: ppc64le
+  hyperthreading: Enabled
+----
+endif::ibm-power-vs[]
 
-. To generate the manifests, run the following command from the directory that contains the installation program:
+* `credentialsMode`: Set the `credentialsMode` parameter to `Manual`.
+
+. To generate the manifests, run the following command from the directory that includes the installation program:
 +
 [source,terminal]
 ----
 $ ./openshift-install create manifests --dir <installation_directory>
 ----
 
-. From the directory that contains the installation program, set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
+. From the directory that includes the installation program, set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
 +
 [source,terminal]
 ----
@@ -93,13 +103,13 @@ $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}'
 $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
-  --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+  --include \
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \
+  --to=<path_to_directory_for_credentials_requests>
 ----
-<1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+* `--included`: Includes only the manifests that your specific cluster configuration requires.
+* `<path_to_directory_with_installation_configuration>`: Specify the location of the `install-config.yaml` file.
+* `<path_to_directory_for_credentials_requests>`: Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 This command creates a YAML file for each `CredentialsRequest` object.
 +
@@ -143,22 +153,22 @@ This command creates a YAML file for each `CredentialsRequest` object.
 [source,terminal]
 ----
 $ ccoctl ibmcloud create-service-id \
-  --credentials-requests-dir=<path_to_credential_requests_directory> \// <1>
-  --name=<cluster_name> \// <2>
-  --output-dir=<installation_directory> \// <3>
-  --resource-group-name=<resource_group_name> <4>
+  --credentials-requests-dir=<path_to_credential_requests_directory> \
+  --name=<cluster_name> \
+  --output-dir=<installation_directory> \
+  --resource-group-name=<resource_group_name>
 ----
-<1> Specify the directory containing the files for the component `CredentialsRequest` objects.
-<2> Specify the name of the {product-title} cluster.
-<3> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
-<4> Optional: Specify the name of the resource group used for scoping the access policies.
+* `<path_to_credential_requests_directory>`: Specify the directory containing the files for the `CredentialsRequest` objects.
+* `<cluster_name>`: Specify the name of the {product-title} cluster.
+* `<installation_directory>`: Optional parameter. Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which you run the commands.
+* `<resource_group_name>`: Optional parameter. Specify the name of the resource group used for scoping the access policies.
 +
 --
 [NOTE]
 ====
-If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
+If you enabled Technology Preview features by using the `TechPreviewNoUpgrade` feature set for your cluster, you must include the `--enable-tech-preview` parameter in the configuration for the `CredentialsRequest` object.
 
-If an incorrect resource group name is provided, the installation fails during the bootstrap phase. To find the correct resource group name, run the following command:
+If you provided a wrong resource group name, the installation fails during the bootstrap phase. To find the correct resource group name, run the following command:
 
 ifdef::ibm-vpc[]
 [source,terminal]
@@ -177,7 +187,7 @@ endif::ibm-power-vs[]
 
 .Verification
 
-* Ensure that the appropriate secrets were generated in your cluster's `manifests` directory.
+* Check that the appropriate secrets exist in the `manifests` directory of your cluster.
 
 ifeval::["{context}" == "installing-ibm-cloud-customizations"]
 :!ibm-vpc:

--- a/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
@@ -6,51 +6,59 @@
 [id="minimum-required-permissions-ipi-gcp-xpn_{context}"]
 = Required {gcp-short} permissions for shared VPC installations
 
-When you are installing a cluster to a link:https://cloud.google.com/vpc/docs/shared-vpc[shared VPC], you must configure the service account for both the host project and the service project. If you are not installing to a shared VPC, you can skip this section.
-
-You must apply the minimum roles required for a standard installation as listed above, to the service project.
+When you are installing a cluster to a link:https://cloud.google.com/vpc/docs/shared-vpc[shared VPC], you must configure the service account for both the host project and the service project.
 
 [IMPORTANT]
 ====
-You can use granular permissions for a Cloud Credential Operator that operates in either manual or mint credentials mode. You cannot use granular permissions in passthrough credentials mode.
+You can use granular permissions for a Cloud Credential Operator that operates in either Manual or Mint credentials mode. For more information about the minimum permissions required for a standard installation that is configured with either of these credentials modes, see "Required Google Cloud permissions for installer-provisioned infrastructure".
+
+You cannot use granular permissions in Passthrough credentials mode. For more information about the minimum roles required, see "Required Google Cloud roles".
+====
+
+If you are not installing to a shared Virtual Private Cloud (VPC), you can skip the procedure.
+
+[IMPORTANT]
+====
+When installing a cluster on shared Virtual Private Cloud (VPC) infrastructure and you want to manually create credentials, grant the `compute.subnetworks.use` permission on the host project to the credentials that the Machine API Operator uses.
 ====
 
 Ensure that the host project applies one of the following configurations to the service account:
 
 .Required permissions for creating firewalls in the host project
-[%collapsible]
-====
+[source,text]
+----
 * `projects/<host-project>/roles/dns.networks.bindPrivateDNSZone`
 * `roles/compute.networkAdmin`
 * `roles/compute.securityAdmin`
-====
+----
 
 .Required permissions for deleting firewalls in the host project
-[%collapsible]
-====
+[source,text]
+----
 * `compute.firewalls.delete`
 * `compute.networks.updatePolicy`
-====
+----
 
 .Required minimal permissions
-[%collapsible]
-====
+[source,text]
+----
 * `projects/<host-project>/roles/dns.networks.bindPrivateDNSZone`
 * `roles/compute.networkUser`
-====
+----
 
-If you do not supply a service account for control plane nodes in the `install-config.yaml` file, please grant the following permissions to the service account in the host project. If you do not supply a service account for compute nodes in the `install-config.yaml` file, please grant the following permissions to the service account in the host project for cluster destruction. If you do supply service accounts for control plane and compute nodes, you do not need to grant the following permissions.
+If you do not supply a service account for control plane nodes in the `install-config.yaml` file, grant the following permissions to the service account in the host project. If you do not supply a service account for compute nodes in the `install-config.yaml` file, grant the following permissions to the service account in the host project for cluster destruction. If you do supply service accounts for control plane and compute nodes, you do not need to grant the following permissions.
 
-[%collapsible]
-====
+[source,text]
+----
 * `resourcemanager.projects.getIamPolicy`
 * `resourcemanager.projects.setIamPolicy`
-====
+----
 
 The following permissions are required when you select a separate project for the location of the DNS zone or zones. These permissions are also required when the DNS zone or zones are located in a third project.
 
 .Required minimal permissions for provisioning DNS resources in a separate project
-====
+[source,text]
+----
 * `dns.changes.create`
 * `dns.changes.get`
 * `dns.managedZones.create`
@@ -61,4 +69,4 @@ The following permissions are required when you select a separate project for th
 * `dns.resourceRecordSets.create`
 * `dns.resourceRecordSets.delete`
 * `dns.resourceRecordSets.list`
-====
+----


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OCPBUGS-51298](https://issues.redhat.com/browse/OCPBUGS-51298)

Link to docs preview:
* [Required GCP permissions for shared VPC installations](https://100820--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#minimum-required-permissions-ipi-gcp-xpn_installing-gcp-account)
* [Manually creating IAM](https://100820--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/installing-ibm-cloud-customizations.html#manually-create-iam-ibm-cloud_installing-ibm-cloud-customizations)


- [x] SME has approved this change (Patrick Dillon).
- [x] QE has approved this change (Jianli Wei).

