### PR TITLE
OCPBUGS-63351: Hardcoding 4.19 in once instance in Hub cluster RDS until eng validates 4.20 RDS resources

### DIFF
--- a/modules/telco-hub-software-stack.adoc
+++ b/modules/telco-hub-software-stack.adoc
@@ -7,7 +7,7 @@
 [id="telco-hub-software-stack_{context}"]
 = Telco hub reference configuration software specifications
 
-The telco hub {product-version} solution has been validated using the following Red{nbsp}Hat software products for {product-title} clusters.
+The telco hub 4.19 solution has been validated using the following Red{nbsp}Hat software products for {product-title} clusters.
 
 .Telco hub cluster validated software components
 [cols=2*, width="80%", options="header"]


### PR DESCRIPTION
OCPBUGS-63351: Hardcoding 4.19 in once instance in Hub cluster RDS until eng validates 4.20 RDS resources

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OCPBUGS-63351

Link to docs preview:

Typo, no QE required, this is just mirroring the 4.19 docs temporarily.