### PR TITLE
OCPBUGS-30975: Added note about calc max no of nodes with subnet figu…

### DIFF
--- a/networking/networking_overview/cidr-range-definitions.adoc
+++ b/networking/networking_overview/cidr-range-definitions.adoc
@@ -13,16 +13,15 @@ If your cluster uses OVN-Kubernetes, you must specify non-overlapping ranges for
 
 [IMPORTANT]
 ====
-For {product-title} 4.17 and later versions, clusters use `169.254.0.0/17` for IPv4 and `fd69::/112` for IPv6 as the default masquerade subnet. These ranges should also be avoided by users. For upgraded clusters, there is no change to the default masquerade subnet.
+For {product-title} 4.17 and later versions, clusters use `169.254.0.0/17` for IPv4 and `fd69::/112` for IPv6 as the default masquerade subnet. Users must avoid these ranges. For upgraded clusters, there is no change to the default masquerade subnet.
 ====
 
 [TIP]
 ====
-You can use the link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator] to determine your networking needs prior to setting CIDR range during cluster creation. 
+You can use the link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator] to decide your networking needs before setting CIDR range during cluster creation. 
 
 You must have a Red Hat account to use the calculator.
 ====
-
 
 The following subnet types and are mandatory for a cluster that uses OVN-Kubernetes:
 
@@ -32,7 +31,7 @@ The following subnet types and are mandatory for a cluster that uses OVN-Kuberne
 
 [NOTE]
 ====
-You can change the join, masquerade, and transit CIDR ranges for your cluster as a post-installation task.
+You can change the join, masquerade, and transit CIDR ranges for your cluster as a postinstallation task.
 ====
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
@@ -51,7 +50,7 @@ OVN-Kubernetes, the default network provider in {product-title} 4.14 and later v
 
 [IMPORTANT]
 ====
-The previous list includes join, transit, and masquerade IPv4 and IPv6 address subnets. If your cluster uses OVN-Kubernetes, do not include any of these IP address subnet ranges in any other CIDR definitions in your cluster or infrastructure.
+The earlier list includes join, transit, and masquerade IPv4 and IPv6 address subnets. If your cluster uses OVN-Kubernetes, do not include any of these IP address subnet ranges in any other CIDR definitions in your cluster or infrastructure.
 ====
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
@@ -68,7 +67,7 @@ In the Machine classless inter-domain routing (CIDR) field, you must specify the
 
 [NOTE]
 ====
-Machine CIDR ranges cannot be changed after creating your cluster.
+You cannot change Machine CIDR ranges after you created your cluster.
 ====
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
@@ -122,16 +121,26 @@ You can expand the range after cluster installation.
 endif::openshift-enterprise[]
 
 [id="host-prefix-description"]
-== Host Prefix
-In the Host Prefix field, you must specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine.
+== Host prefix
+
+In the `hostPrefix` parameter, you must specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine.
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 512 cluster nodes, and 512 pods per node (both of which are beyond our maximum supported).
+For example, if you set the `hostPrefix` parameter to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 512 cluster nodes, and 512 pods per node (both of which are beyond our maximum supported).
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 510 cluster nodes, and 510 pod IP addresses per node.
-endif::openshift-enterprise[]
 
+Consider another example where you set the `clusterNetwork.cidr` parameter to `10.128.0.0/16`, you define the complete address space for the cluster. This assigns a pool of 65536 IP addresses to your cluster. If you then set the `hostPrefix` parameter to `/23`, you define a subnet slice to each node in the cluster, where the `/23` slice becomes a subnet of the `/16` subnet network. This assigns 512 IP addresses to each node, where 2 IP addresses get reserved for networking and broadcasting purposes. The following example calculation uses these IP address figures to determine the maximum number of nodes that you can create for your cluster:
 
+[source,text]
+----
+65536 / 512 = 128
+----
+
+You can use the link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator] to calculate the maximum number of nodes for your cluster.
+endif::openshift-enterprise,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+
+// CIDR ranges for HCP
 include::modules/hcp-cidr-ranges.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-30975](https://issues.redhat.com/browse/OCPBUGS-30975)

Link to docs preview:
* [CIDR range definitions - core](https://100822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/cidr-range-definitions.html#host-prefix-description)
* [CIDR range defs - ROSA Classic](https://100822--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/networking_overview/cidr-range-definitions.html#host-prefix-description)
* [CIDR range defs - ROSA](https://100822--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/networking_overview/cidr-range-definitions.html#host-prefix-description)
* [CIDR range defs - Dedicated](https://100822--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/networking_overview/cidr-range-definitions.html#host-prefix-description)

- [x] SME has approved this change (David C.).
- [x] QE has approved this change (Anurag Saxena).

