### PR TITLE
OSDOCS-16456: adds 4.21 relnotes build file MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -33,8 +33,8 @@ Name: Red Hat build of MicroShift release notes
 Dir: microshift_release_notes
 Distros: microshift
 Topics:
-- Name: Red Hat build of MicroShift 4.20 release notes
-  File: microshift-4-20-release-notes
+- Name: Red Hat build of MicroShift 4.21 release notes
+  File: microshift-4-21-release-notes
 ---
 Name: Getting ready to install MicroShift
 Dir: microshift_install_get_ready

--- a/microshift_release_notes/microshift-4-21-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-21-release-notes.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-4-21-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/attributes-microshift.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch that they are relevant for.
+
+Release note changes should be added/edited in their own PR.
+
+This file is here to allow builds to work.

--- a/microshift_welcome/index.adoc
+++ b/microshift_welcome/index.adoc
@@ -20,7 +20,7 @@ To browse the {microshift-short} {product-version} documentation, use one of the
 
 To get started with {microshift-short}, use the following links:
 
-* xref:../microshift_release_notes/microshift-4-20-release-notes.adoc#microshift-4-20-release-notes[{product-title} release notes]
+//* xref:../microshift_release_notes/microshift-4-20-release-notes.adoc#microshift-4-20-release-notes[{product-title} release notes]
 * xref:../microshift_install_get_ready/microshift-install-get-ready.adoc#microshift-install-get-ready[Getting ready to install MicroShift]
 
 For related information, use the following links:


### PR DESCRIPTION
Version(s):
main only; no cherry-pick

Issue:
[OSDOCS-16456](https://issues.redhat.com/browse/OSDOCS-16456)

Link to docs preview:
N/A release notes build file only
(https://100839--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html)

QE review:
N/A release notes build file only

Additional info:
Release notes branch file added in https://github.com/openshift/openshift-docs/pull/100845
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
