### PR TITLE
OCPBUGS#48746 Removing unneeded firewall rule

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -318,7 +318,7 @@ Operators require route access to perform health checks. Specifically, the authe
 that is specified in the `spec.route.hostname` field of the
 `consoles.operator/cluster` object if the field is not empty.
 
-. Allowlist the following URLs for optional third-party content:
+. Allowlist the following URL for optional third-party content:
 +
 [cols="3,2,4",options="header"]
 |===
@@ -327,14 +327,6 @@ that is specified in the `spec.route.hostname` field of the
 |`registry.connect.redhat.com`
 |443
 |Required for all third-party images and certified operators.
-
-|`rhc4tp-prod-z8cxf-image-registry-us-east-1-evenkyleffocxqvofrk.s3.dualstack.us-east-1.amazonaws.com`
-|443
-|Provides access to container images hosted on `registry.connect.redhat.com`
-
-|`oso-rhc4tp-docker-registry.s3-us-west-2.amazonaws.com`
-|443
-|Required for Sonatype Nexus, F5 Big IP operators.
 |===
 +
 . If you use a default Red Hat Network Time Protocol (NTP) server allow the following URLs:


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-48746

Link to docs preview:
https://100840--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html#configuring-firewall_configuring-firewall

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
