### PR TITLE
[OSDOCS-16594]: Add note that HCP docs are not available for OCP 4.20 yet

### DIFF
--- a/hosted_control_planes/hcp-authentication-authorization.adoc
+++ b/hosted_control_planes/hcp-authentication-authorization.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 The {product-title} control plane includes a built-in OAuth server. You can obtain OAuth access tokens to authenticate to the {product-title} API. After you create your hosted cluster, you can configure OAuth by specifying an identity provider.
 
 include::modules/hcp-configuring-oauth.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-certificates.adoc
+++ b/hosted_control_planes/hcp-certificates.adoc
@@ -6,7 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-With {hcp}, the steps to configure certificates differ from those of standalone {product-title}.  
+include::snippets/hcp-snippet.adoc[]
+
+With {hcp}, the steps to configure certificates differ from those of standalone {product-title}.
 
 include::modules/hcp-custom-cert.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 A _hosted cluster_ is an {product-title} cluster with its API endpoint and control plane that are hosted on the management cluster. The hosted cluster includes the control plane and its corresponding data plane. To configure {hcp} on premises, you must install {mce} in a management cluster. By deploying the HyperShift Operator on an existing managed cluster by using the `hypershift-addon` managed cluster add-on, you can enable that cluster as a management cluster and start to create the hosted cluster. The `hypershift-addon` managed cluster add-on is enabled by default for the `local-cluster` managed cluster.
 
 You can use the {mce-short} console or the hosted control plane command-line interface (CLI), `hcp`, to create a hosted cluster. The hosted cluster is automatically imported as a managed cluster. However, you can xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[disable this automatic import feature into {mce-short}].

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can deploy {hcp} by configuring a cluster to function as a management cluster. The management cluster is the {product-title} cluster where the control planes are hosted. In some contexts, the management cluster is also known as the _hosting_ cluster.
 
 [NOTE]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can deploy {hcp} by configuring a cluster to function as a hosting cluster. This configuration provides an efficient and scalable solution for managing many clusters. The hosting cluster is an {product-title} cluster that hosts control planes. The hosting cluster is also known as the _management_ cluster.
 
 [NOTE]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can deploy {hcp} by configuring a cluster to function as a management cluster. The management cluster is the {product-title} cluster where the control planes are hosted. The management cluster is also known as the _hosting_ cluster.
 
 [NOTE]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can deploy {hcp} by configuring a cluster to function as a hosting cluster. The hosting cluster is an {product-title} cluster where the control planes are hosted. The hosting cluster is also known as the management cluster.
 
 :FeatureName: {hcp-capital} on non-bare-metal agent machines

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-openstack.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-openstack.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 :FeatureName: Deploying {hcp} clusters on {rh-openstack-first}
 include::snippets/technology-preview.adoc[]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 With {hcp} and {VirtProductName}, you can create {product-title} clusters with worker nodes that are hosted by KubeVirt virtual machines. {hcp-capital} on {VirtProductName} provides several benefits:
 
 * Enhances resource usage by packing {hcp} and hosted clusters in the same underlying bare-metal infrastructure

--- a/hosted_control_planes/hcp-destroy/hcp-destroy-aws.adoc
+++ b/hosted_control_planes/hcp-destroy/hcp-destroy-aws.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can destroy a hosted cluster and its managed cluster resource on {aws-first} by using the command-line interface (CLI).
 
 include::modules/hcp-destroy-aws-cli.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-destroy/hcp-destroy-bm.adoc
+++ b/hosted_control_planes/hcp-destroy/hcp-destroy-bm.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can destroy hosted clusters on bare metal by using the command-line interface (CLI) or the {mce-short} web console.
 
 include::modules/destroy-hc-bm-cli.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-destroy/hcp-destroy-ibm-power.adoc
+++ b/hosted_control_planes/hcp-destroy/hcp-destroy-ibm-power.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can destroy a hosted cluster on {ibm-power-title} by using the command-line interface (CLI).
 
 include::modules/destroy-hc-ibm-power-cli.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-destroy/hcp-destroy-ibmz.adoc
+++ b/hosted_control_planes/hcp-destroy/hcp-destroy-ibmz.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can destroy a hosted cluster on `x86` bare metal with {ibm-z-title} compute nodes and its managed cluster resource by using the command-line interface (CLI).
 
 include::modules/destroy-hc-ibm-z-cli.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-destroy/hcp-destroy-non-bm.adoc
+++ b/hosted_control_planes/hcp-destroy/hcp-destroy-non-bm.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can destroy hosted clusters on non-bare-metal agent machines by using the command-line interface (CLI) or the {mce-short} web console.
 
 include::modules/destroy-hc-non-bm-cli.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-destroy/hcp-destroy-openstack.adoc
+++ b/hosted_control_planes/hcp-destroy/hcp-destroy-openstack.adoc
@@ -6,4 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 include::modules/hosted-clusters-openstack-destroy.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-destroy/hcp-destroy-virt.adoc
+++ b/hosted_control_planes/hcp-destroy/hcp-destroy-virt.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can destroy a hosted cluster and its managed cluster resource on {VirtProductName} by using the command-line interface (CLI).
 
 include::modules/destroy-hc-virt-cli.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-disconnected/disconnected-install-ibmz-hcp.adoc
+++ b/hosted_control_planes/hcp-disconnected/disconnected-install-ibmz-hcp.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 {hcp-capital} deployments in disconnected environments function differently than in a standalone {product-title}.
 
 {hcp-capital} involves two distinct environments:

--- a/hosted_control_planes/hcp-disconnected/hcp-dc-monitor.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-dc-monitor.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 The `hypershift-addon` managed cluster add-on enables the `--enable-uwm-telemetry-remote-write` option in the HyperShift Operator. By enabling that option, you ensure that user workload monitoring is enabled and that it can remotely write telemetry metrics from control planes. 
 
 include::modules/hcp-dc-usr-wkld.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 When you provision {hcp} on bare metal, you use the Agent platform. The Agent platform and {mce} work together to enable disconnected deployments. The Agent platform uses the central infrastructure management service to add worker nodes to a hosted cluster. For an introduction to the central infrastructure management service, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service].
 
 include::modules/hcp-dc-bm-arch.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 When you deploy {hcp} in a disconnected environment, some of the steps differ depending on the platform you use. The following procedures are specific to deployments on {VirtProductName}.
 
 [id="prerequisites_{context}"]

--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 In the context of {hcp}, a disconnected environment is an {product-title} deployment that is not connected to the internet and that uses {hcp} as a base. You can deploy {hcp} in a disconnected environment on bare metal or {VirtProductName}.
 
 {hcp-capital} in disconnected environments function differently than in standalone {product-title}:

--- a/hosted_control_planes/hcp-import.adoc
+++ b/hosted_control_planes/hcp-import.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 Hosted clusters are automatically imported into {mce-short} after the hosted control plane becomes available.
 
 include::modules/hcp-import-limitations.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-machine-config.adoc
+++ b/hosted_control_planes/hcp-machine-config.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 In a standalone {product-title} cluster, a machine config pool manages a set of nodes. You can handle a machine configuration by using the `MachineConfigPool` custom resource (CR).
 
 [TIP]

--- a/hosted_control_planes/hcp-manage/hcp-manage-aws.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-aws.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 When you use {hcp} for {product-title} on {aws-first}, the infrastructure requirements vary based on your setup.
 
 include::modules/hcp-manage-aws-prereq.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 After you deploy {hcp} on bare metal, you can manage a hosted cluster by completing the following tasks.
 
 include::modules/hcp-bm-access.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-manage/hcp-manage-ibm-power.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-ibm-power.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 After you deploy {hcp} on {ibm-power-title}, you can manage a hosted cluster by completing the following tasks.
 
 include::modules/hcp-ibm-power-infraenv.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 After you deploy {hcp} on non-bare-metal agent machines, you can manage a hosted cluster by completing the following tasks.
 
 include::modules/hcp-bm-access.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-manage/hcp-manage-openstack.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-openstack.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 After you deploy {hcp} on {rh-openstack-first} agent machines, you can manage a hosted cluster by completing the
 following tasks.
 

--- a/hosted_control_planes/hcp-manage/hcp-manage-virt.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-virt.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 After you deploy a hosted cluster on {VirtProductName}, you can manage the cluster by completing the following procedures.
 
 include::modules/hcp-virt-access.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-networking.adoc
+++ b/hosted_control_planes/hcp-networking.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 For standalone {product-title}, proxy support is mainly about ensuring that workloads in the cluster are configured to use the HTTP or HTTPS proxy to access external services, honoring the `NO_PROXY` setting if one is configured, and accepting any trust bundle that is configured for the proxy.
 
 For {hcp}, proxy support involves the following additional use cases.

--- a/hosted_control_planes/hcp-observability.adoc
+++ b/hosted_control_planes/hcp-observability.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can gather metrics for {hcp} by configuring metrics sets. The HyperShift Operator can create or delete monitoring dashboards in the management cluster for each hosted cluster that it manages.
 
 include::modules/hosted-control-planes-metrics-sets.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-prepare/hcp-cli.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-cli.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 The {hcp} command-line interface, `hcp`, is a tool that you can use to get started with {hcp}. For Day 2 operations, such as management and configuration, use GitOps or your own automation tool.
 
 include::modules/hcp-cli-terminal.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 Before you get started with {hcp} for {product-title}, you must properly label nodes so that the pods of hosted clusters can be scheduled into infrastructure nodes. Node labeling is also important for the following reasons:
 
 * To ensure high availability and proper workload deployment. For example, to avoid having the control plane workload count toward your {product-title} subscription, you can set the `node-role.kubernetes.io/infra` label.

--- a/hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 The {hcp} feature, as well as the `hypershift-addon` managed cluster add-on, are enabled by default. If you want to disable the feature, or if you disabled it and want to manually enable it, see the following procedures.
 
 include::modules/hcp-enable-manual.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 The set of baseline measurements for resource utilization can vary in each hosted cluster.
 
 include::modules/hcp-override.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 In the context of {hcp}, a _management cluster_ is an {product-title} cluster where the HyperShift Operator is deployed and where the control planes for hosted clusters are hosted.
 
 The control plane is associated with a hosted cluster and runs as pods in a single namespace. When the cluster service consumer creates a hosted cluster, it creates a worker node that is independent of the control plane.

--- a/hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 Many factors, including hosted cluster workload and worker node count, affect how many {hcp} can fit within a certain number of worker nodes. Use this sizing guide to help with hosted cluster capacity planning. This guidance assumes a highly available {hcp} topology. The load-based sizing examples were measured on a bare-metal cluster. Cloud-based instances might have different limiting factors, such as memory size.
 
 You can override the following resource utilization sizing measurements and disable the metric service monitoring.

--- a/hosted_control_planes/hcp-troubleshooting.adoc
+++ b/hosted_control_planes/hcp-troubleshooting.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 If you encounter issues with {hcp}, see the following information to guide you through troubleshooting.
 
 include::modules/hosted-control-planes-troubleshooting.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-updating.adoc
+++ b/hosted_control_planes/hcp-updating.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 Updates for {hcp} involve updating the hosted cluster and the node pools. For a cluster to remain fully operational during an update process, you must meet the requirements of the link:https://kubernetes.io/releases/version-skew-policy/[Kubernetes version skew policy] while completing the control plane and node updates.
 
 include::modules/hcp-updating-requirements.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-using-feature-gates.adoc
+++ b/hosted_control_planes/hcp-using-feature-gates.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can use feature gates in a hosted cluster to enable features that are not part of the default set of features. You can enable the `TechPreviewNoUpgrade` feature set by using feature gates in your hosted cluster.
 
 include::modules/hcp-enable-feature-sets.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp_high_availability/about-hcp-ha.adoc
+++ b/hosted_control_planes/hcp_high_availability/about-hcp-ha.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can maintain high availability (HA) of {hcp} by implementing the following actions:
 
 * Recover etcd members for a hosted cluster.

--- a/hosted_control_planes/hcp_high_availability/hcp-backup-restore-aws.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-backup-restore-aws.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can back up and restore etcd on a hosted cluster on {aws-first} to fix failures.
 
 include::modules/backup-etcd-hosted-cluster.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp_high_availability/hcp-backup-restore-on-premise.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-backup-restore-on-premise.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can back up and restore etcd on a hosted cluster in an on-premise environment to fix failures.
 
 include::modules/hosted-cluster-etcd-backup-restore-on-premise.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp_high_availability/hcp-backup-restore-virt.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-backup-restore-virt.adoc
@@ -1,10 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="hcp-backup-restore-virt"]
-= Backing up and restoring a hosted cluster on {VirtProductName}
 include::_attributes/common-attributes.adoc[]
+= Backing up and restoring a hosted cluster on {VirtProductName}
 :context: hcp-backup-restore-virt
 
 toc::[]
+
+include::snippets/hcp-snippet.adoc[]
 
 You can back up and restore a hosted cluster on {VirtProductName} to fix failures.
 

--- a/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-aws.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-aws.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can recover a hosted cluster to the same region within {aws-first}. For example, you need disaster recovery when the upgrade of a management cluster fails and the hosted cluster is in a read-only state.
 
 The disaster recovery process involves the following steps:

--- a/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 In hosted clusters on bare-metal or {aws-first} platforms, you can automate some backup and restore steps by using the {oadp-first} Operator.
 
 The process involves the following steps:

--- a/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 You can use the {oadp-first} Operator to perform disaster recovery on {aws-first} and bare metal.
 
 The disaster recovery process with {oadp-first} involves the following steps:

--- a/hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc
+++ b/hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 In a highly available control plane, three etcd pods run as a part of a stateful set in an etcd cluster. To recover an etcd cluster, identify unhealthy etcd pods by checking the etcd cluster health.
 
 include::modules/hosted-cluster-etcd-status.adoc[leveloffset=+1]

--- a/hosted_control_planes/hosted-control-planes-release-notes.adoc
+++ b/hosted_control_planes/hosted-control-planes-release-notes.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/hcp-snippet.adoc[]
+
 Release notes contain information about new and deprecated features, changes, and known issues.
 
 [id="hcp-4-19-release-notes_{context}"]

--- a/hosted_control_planes/index.adoc
+++ b/hosted_control_planes/index.adoc
@@ -4,6 +4,8 @@ include::_attributes/common-attributes.adoc[]
 = {hcp-capital} overview
 :context: hcp-overview
 
+include::snippets/hcp-snippet.adoc[]
+
 You can deploy {product-title} clusters by using two different control plane configurations: standalone or {hcp}. The standalone configuration uses dedicated virtual machines or physical machines to host the control plane. With {hcp} for {product-title}, you create control planes as pods on a management cluster without the need for dedicated virtual or physical machines for each control plane.
 
 toc::[]

--- a/snippets/hcp-snippet.adoc
+++ b/snippets/hcp-snippet.adoc
@@ -1,0 +1,10 @@
+// Text snippet included in the following assemblies:
+//
+// * hosted-control-planes/index.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[IMPORTANT]
+====
+{hcp-capital} is currently not available for {product-title} {product-version}. The feature is planned to be released in the near future.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-16594
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://100841--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/index.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR adds a note to the HCP assemblies to let customers know that HCP for OCP 4.20 is not yet available. (HCP for OCP 4.20 depends on the release of the MCE Operator, which will GA in December)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
