### PR TITLE
Fix navigation from OperatorHub to Software Catalog (no OSDOCS)

### DIFF
--- a/modules/lws-install-operator.adoc
+++ b/modules/lws-install-operator.adoc
@@ -21,7 +21,7 @@ You can use the web console to install the {lws-operator}.
 . Verify that the {cert-manager-operator} is installed.
 
 . Install the {lws-operator}.
-.. Navigate to *Operators* -> *OperatorHub*.
+.. Navigate to *Ecosystem* -> *Software Catalog*.
 .. Enter *{lws-operator}* into the filter box.
 .. Select the *{lws-operator}* and click *Install*.
 .. On the *Install Operator* page:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
N/A

Link to docs preview:
https://100858--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/leader_worker_set/lws-managing.html#lws-install-operator_lws-managing

QE review:
N/A - just navigation change

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
