### PR TITLE
OSDOCS WMCO remove docker references fix metadata

### DIFF
--- a/modules/collecting-windows-application-event-logs.adoc
+++ b/modules/collecting-windows-application-event-logs.adoc
@@ -2,6 +2,7 @@
 //
 // * support/troubleshooting/troubleshooting-windows-container-workload-issues.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="collecting-windows-application-event-logs_{context}"]
 = Collecting Windows application event logs
 


### PR DESCRIPTION
The https://github.com/openshift/openshift-docs/pull/100278 PR removed some metadata from this file. This PR fixes this. 