### PR TITLE
OCPBUGS-63362: Address EgressIP for sec interface consideration to nw…

### DIFF
--- a/modules/nw-egress-ips-multi-nic-considerations.adoc
+++ b/modules/nw-egress-ips-multi-nic-considerations.adoc
@@ -28,12 +28,16 @@ You can determine which other network interfaces might support egress IP address
 OVN-Kubernetes provides a mechanism to control and direct outbound network traffic from specific namespaces and pods. This ensures that it exits the cluster through a particular network interface and with a specific egress IP address.
 ====
 
-For users who want an egress IP address and traffic to be routed over a particular interface that is not the primary network interface, the following conditions must be met:
+As an administrator who wants an egress IP address and traffic to route over a particular interface that is not the primary network interface, you must meet the following conditions:
 
 * {product-title} is installed on a bare-metal cluster. This feature is disabled within a cloud or a hypervisor environment.
 
 * Your {product-title} pods are not configured as _host-networked_.
 
-* If a network interface is removed or if the IP address and subnet mask which allows the egress IP address to be hosted on the interface is removed, the egress IP address is reconfigured. Consequently, the egress IP address could be assigned to another node and interface.
+* You understand that if a network interface is removed or if the IP address and subnet mask which allows the egress IP address to be hosted on the interface is removed, reconfiguration of the egress IP address occurs. Consequently, the egress IP address might get assigned to another node and interface.
 
 * If you use an Egress IP address on a secondary network interface card (NIC), you must use the Node Tuning Operator to enable IP forwarding on the secondary NIC.
+
+* You configured a NIC with routes by ensuring a gateway exists in the main routing table. As a postinstallation task, Red Hat does not support configuring a NIC on a cluster that uses OVN-Kubernetes.
+
+* Routes associated with an egress interface get copied from the main routing table to the routing table that was created to support the Egress IP object. 


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OCPBUGS-63362](https://issues.redhat.com/browse/OCPBUGS-63362)

Link to docs preview:
* [Considerations for using an egress IP address on additional network interfaces](https://100872--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-multi-nic-considerations_configuring-egress-ips-ovn)
* [Configuring an egress IP address - ROSA -Link generated but section never existed in ROSA docs](https://100872--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-node-architecture_configuring-egress-ips-ovn)

- [x] SME has approved this change (Miheer S).
- [x] QE has approved this change (Jean Chen).

