### PR TITLE
OCPBUGS#63359: Removed TNA acronym in the arbiter docs

### DIFF
--- a/installing/installing_two_node_cluster/about-two-node-arbiter-installation.adoc
+++ b/installing/installing_two_node_cluster/about-two-node-arbiter-installation.adoc
@@ -3,13 +3,13 @@
 = Two-Node with Arbiter
 :context: about-two-node-arbiter-installation
 
-A Two-Node OpenShift with Arbiter (TNA) cluster is a compact, cost-effective {product-title} topology. The topology consists of two control plane nodes and a lightweight arbiter node. The arbiter node stores the full etcd data, maintaining an etcd quorum and preventing split brain. The arbiter node does not run the additional control plane components `kube-apiserver` and `kube-controller-manager`, nor does it run workloads.
+An {product-title} cluster with two control plane nodes and one local arbiter node is a compact, cost-effective {product-title} topology. The arbiter node stores the full etcd data, maintaining an etcd quorum and preventing split brain. The arbiter node does not run the additional control plane components `kube-apiserver` and `kube-controller-manager`, nor does it run workloads.
 
-To install a Two-Node OpenShift with Arbiter cluster, assign an arbiter role to at least one of the nodes and set the control plane node count for the cluster to 2. Although {product-title} does not currently impose a limit on the number of arbiter nodes, the typical deployment includes only one to minimize the use of hardware resources.
+To install a cluster with two control plane nodes and one local arbiter node, assign an arbiter role to at least one of the nodes and set the control plane node count for the cluster to 2. Although {product-title} does not currently impose a limit on the number of arbiter nodes, the typical deployment includes only one to minimize the use of hardware resources.
 
-After installation, you can add additional arbiter nodes to a Two-Node OpenShift with Arbiter cluster but not to a standard multi-node cluster. It is also not possible to convert between a Two-Node OpenShift with Arbiter and standard topology.
+After installation, you can add additional arbiter nodes to a cluster with two control plane nodes and one local arbiter node but not to a standard multi-node cluster. It is also not possible to convert between a two-node OpenShift cluster with a local node arbiter and standard topology.
 
-You can install a Two-Node Arbiter cluster by using one of the following methods:
+You can install a cluster with two control plane nodes and one local arbiter node by using one of the following methods:
 
 * Installing on bare metal: xref:../installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#ipi-install-config-local-arbiter-node_ipi-install-installation-workflow[Configuring a local arbiter node]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-63359](https://issues.redhat.com/browse/OCPBUGS-63359)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Two-Node with Arbiter](https://100874--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/about-two-node-arbiter-installation.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
