### PR TITLE
OSDOCS-16127: Correcting the removal info for Marketplace

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1489,7 +1489,7 @@ Support for Docker v2 registries is deprecated and is planned for removal in a f
 [id="ocp-4-20-sunset-redhat-marketplace_{context}"]
 ==== Red{nbsp}Hat Marketplace is deprecated
 
-The Red{nbsp}Hat Marketplace is deprecated. Customers who use the partner software from the Marketplace should contact the software vendor about how to migrate from the Marketplace Operator to an Operator in the Red{nbsp}Hat Ecosystem Catalog. It is expected that the Marketplace index will be removed in {product-title} 4.21. For more information, see link:https://access.redhat.com/articles/7130828[Sunset of the Red Hat Marketplace, operated by IBM].
+The Red{nbsp}Hat Marketplace is deprecated. Customers who use the partner software from the Marketplace should contact the software vendor about how to migrate from the Marketplace Operator to an Operator in the Red{nbsp}Hat Ecosystem Catalog. It is expected that the Marketplace index will be removed in an upcoming {product-title} release. For more information, see link:https://access.redhat.com/articles/7130828[Sunset of the Red Hat Marketplace, operated by IBM].
 
 [id="ocp-release-removed-features_{context}"]
 === Removed features


### PR DESCRIPTION
[OSDOCS-16127](https://issues.redhat.com/browse/OSDOCS-16127): Correcting the removal info for Marketplace to address https://github.com/openshift/openshift-docs/pull/100495#issuecomment-3412706622


Version(s): enterprise-4.20 only

Issue:
https://issues.redhat.com/browse/OSDOCS-16127

Link to docs preview:
https://100918--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-sunset-redhat-marketplace_release-notes

QE review:
N/A