### PR TITLE
OSDOCS WMCO unhiding Windows Troubleshooting

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -863,8 +863,8 @@ Topics:
     File: troubleshooting-s2i
   - Name: Troubleshooting storage issues
     File: troubleshooting-storage-issues
-#  - Name: Troubleshooting Windows container workload issues
-#    File: troubleshooting-windows-container-workload-issues
+  - Name: Troubleshooting Windows container workload issues
+    File: troubleshooting-windows-container-workload-issues
   - Name: Investigating monitoring issues
     File: investigating-monitoring-issues
   - Name: Diagnosing OpenShift CLI (oc) issues


### PR DESCRIPTION
Neglected to clear a comment mark for the Windows Troubleshooting assembly. Also applies to [4.21](https://github.com/openshift/openshift-docs/blob/enterprise-4.21/_topic_maps/_topic_map.yml#L866), but not [main](https://github.com/openshift/openshift-docs/blob/main/_topic_maps/_topic_map.yml#L867).

Link to docs preview:
[Troubleshooting Windows container workload issues](https://100921--ocpdocs-pr.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-windows-container-workload-issues) -- Activated this assembly. In the [current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/support/troubleshooting#troubleshooting-storage-issues), the assembly is not present between the storage and monitoring assemblies.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
