### PR TITLE
OLS-2212: Update Operator installation doc 

### DIFF
--- a/install/ols-installing-openshift-lightspeed.adoc
+++ b/install/ols-installing-openshift-lightspeed.adoc
@@ -12,4 +12,14 @@ The installation process for {ols-official} consists of two main tasks: installi
 
 include::modules/ols-large-language-model-overview.adoc[leveloffset=+1]
 include::modules/ols-about-subscription-requirements.adoc[leveloffset=+1]
-include::modules/ols-installing-operator.adoc[leveloffset=+1]
+include::modules/ols-about-adding-operators-to-a-cluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/operators/administrator-tasks#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[About Operator installation with OperatorHub]
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/administrator-tasks#olm-installing-operators-from-software-catalog_olm-adding-operators-to-a-cluster[About Operator installation with software catalog]
+
+include::modules/ols-installing-operator-from-operatorhub.adoc[leveloffset=+2]
+include::modules/ols-installing-operator-from-software-catalog.adoc[leveloffset=+2]

--- a/modules/ols-about-adding-operators-to-a-cluster.adoc
+++ b/modules/ols-about-adding-operators-to-a-cluster.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/install/ols-installing-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ols-about-adding-operators-to-a-cluster_{context}"]
+
+= About adding Operators to a cluster
+
+Using Operator Lifecycle Manager (OLM), cluster administrators can install OLM-based Operators to an {ocp-product-title} cluster.
+
+As a cluster administrator, you can install an Operator by using the OperatorHub or the software catalog, depending on which {ocp-product-title} version is installed.

--- a/modules/ols-installing-operator-from-operatorhub.adoc
+++ b/modules/ols-installing-operator-from-operatorhub.adoc
@@ -2,29 +2,27 @@
 // * lightspeed-docs-main/install/ols-installing-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="ols-installing-operator_{context}"]
-= Installing the OpenShift Lightspeed Operator
+[id="ols-installing-operator-from-operatorhub_{context}"]
+= Installing the OpenShift Lightspeed Operator from the OperatorHub
 
 [role="_abstract"]
 Install the {ols-long} Operator so that you can configure the {ols-long} Service.
 
 .Prerequisites
 
-* You have deployed {ocp-product-title} 4.16 or later. The cluster must be connected to the Internet and have telemetry enabled.
+* You have deployed {ocp-product-title} 4.16 to 4.19. The cluster must be connected to the Internet and have telemetry enabled.
 
 * You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
 
-* You have access to the {ocp-short-name} CLI (oc).
-
-* You have successfully configured your Large Language Model (LLM) provider so that {ols-long} can communicate with it.
+* You have successfully configured your large language model (LLM) provider so that {ols-long} can communicate with it.
 
 .Procedure
 
 . In the {ocp-product-title} web console, navigate to the *Operators* -> *OperatorHub* page.
 
-. Search for Lightspeed.
+. Search for {ols-long}.
 
-. Locate the Lightspeed Operator, and click to select it.
+. Locate the {ols-long} Operator, and click to select it.
 
 . When the prompt that discusses the community operator appears, click *Continue*.
 
@@ -32,4 +30,4 @@ Install the {ols-long} Operator so that you can configure the {ols-long} Service
 
 . Use the default installation settings presented, and click *Install* to continue.
 
-. Click *Operators* -> *Installed Operators* to verify that the Lightspeed Operator is installed. `Succeeded` should appear in the *Status* column.
+. Click *Operators* -> *Installed Operators* to verify that the {ols-long} Operator is installed. `Succeeded` should appear in the *Status* column.

--- a/modules/ols-installing-operator-from-software-catalog.adoc
+++ b/modules/ols-installing-operator-from-software-catalog.adoc
@@ -1,0 +1,34 @@
+// This module is used in the following assemblies:
+// * install/ols-installing-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ols-installing-operator-from-software-catalog_{context}"]
+= Installing the OpenShift Lightspeed Operator from the software catalog
+
+.Prerequisites
+
+* You have deployed {ocp-product-title} 4.20 or later. The cluster must be connected to the Internet and have telemetry enabled.
+
+* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
+
+* You have successfully configured your large language model (LLM) provider so that {ols-long} can communicate with it.
+
+.Procedure
+
+. In the {ocp-product-title} web console, navigate to the *Ecosystem* -> *Software Catalog* page.
+
+. Click the *Project* drop-down list, and enable the toggle switch to show default projects.
+
+. Enter `openshift-marketplace` in the search field.
+
+. Click to select `openshift-marketplace`.
+
+. Search for {ols-long}.
+
+. Locate the {ols-long} Operator, and click to select it.
+
+. When the prompt that discusses the {ols-long} Operator appears, click *Install*.
+
+. Use the default installation settings presented, and click *Install* to continue.
+
+. Click *Ecosystem* -> *Installed Operators* to verify that the {ols-long} Operator was installed. `Succeeded` appears in the *Status* column.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2212

Link to docs preview:
https://100932--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/install/ols-installing-openshift-lightspeed.html#ols-about-adding-operators-to-a-cluster_ols-installing-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
