### PR TITLE
OLS-2208: Remove text

### DIFF
--- a/operate/ols-using-openshift-lightspeed.adoc
+++ b/operate/ols-using-openshift-lightspeed.adoc
@@ -6,13 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-There are different ways you can access the {ols-official} user interface.
-
-* Clicking the {ols-official} chat window floating icon in the lower-right of the screen
-* Using the *Actions* dropdown list on specific resources in the {ocp-product-title} web console
-* Using the *Node options* icon from a list of resources in the {ocp-product-title} web console
-
-The following topics provide information about submitting questions to {ols-long}.
+The following topics provide information about submitting a question to {ols-long}, attaching resources to your question, and troubleshooting alerts.
 
 include::modules/ols-initiating-chat-using-chat-window.adoc[leveloffset=+1]
 include::modules/ols-about-lightspeed-conversations.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2208

Link to docs preview:
https://100955--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/operate/ols-using-openshift-lightspeed.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
