### PR TITLE
OSDOCS#16561: Update the z-stream RNs for 4.17.42

### DIFF
--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2928,6 +2928,34 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.17.42
+[id="ocp-4-17-42_{context}"]
+=== RHBA-2025:18235 - {product-title} {product-version}.42 bug fix update and security
+
+Issued: 22 October 2025
+
+{product-title} release {product-version}.42 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:18235[RHBA-2025:18235] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.42 --pullspecs
+----
+
+[id="ocp-4-17-42-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, multiple mirrors in the {hcp} payload caused image lookup failures, and led to {hcp} creation failures when multiple mirror images were handled. With this release, the {hcp} payload supports multiple mirrors, correctly handles unavailable mirrors, and results in a successful cluster creation. (link:https://issues.redhat.com/browse/OCPBUGS-57143[OCPBUGS-57143])
+
+* Before this update, a fixed upstream issue in {product-title} version 4.17 was not reproducible and was triggered by consuming the issue for downstream. This led to data inconsistency for users. With this release, the upstream issue in the `external-resizer` mechanism is fixed, and reduces potential consumption for downstream. As a result, users do not experience the issue in {product-title} version 4.17. (link:https://issues.redhat.com/browse/OCPBUGS-62466[OCPBUGS-62466])
+
+[id="ocp-4-17-42-updating_{context}"]
+==== Updating
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.17.41
 [id="ocp-4-17-41_{context}"]
 === RHSA-2025:17232 - {product-title} {product-version}.41 bug fix update and security

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2952,6 +2952,8 @@ $ oc adm release info 4.17.42 --pullspecs
 
 * Before this update, a fixed upstream issue in {product-title} version 4.17 was not reproducible and was triggered by consuming the issue for downstream. This led to data inconsistency for users. With this release, the upstream issue in the `external-resizer` mechanism is fixed, and reduces potential consumption for downstream. As a result, users do not experience the issue in {product-title} version 4.17. (link:https://issues.redhat.com/browse/OCPBUGS-62466[OCPBUGS-62466])
 
+* Before this update, the incorrect `hostPath` configuration for the `/etc/docker` directory caused {olmv1-first} pod issues. As a consequence, {olmv1} pods failed to work due to a `hostPath` type check error. With this release, the fix ensures the correct directory for `/etc/docker` in `hostPath`, and resolves {olmv1} pod issues. As a result, the {product-title} cluster operates smoothly. (link:https://issues.redhat.com/browse/OCPBUGS-62741[OCPBUGS-62741])
+
 [id="ocp-4-17-42-updating_{context}"]
 ==== Updating
 To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-16561](https://issues.redhat.com//browse/OSDOCS-16561)

Link to docs preview:
[4.17.42](https://100957--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#ocp-4-17-42_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/177)
