### PR TITLE
ROX-31378: Update docs with configurable CRS

### DIFF
--- a/modules/roxctl-central-crs-generate.adoc
+++ b/modules/roxctl-central-crs-generate.adoc
@@ -14,4 +14,22 @@ Generate a cluster registration secret (CRS) that allows communication between C
 $ roxctl central crs generate <crs name> [flags]
 ----
 
-For available flags, see "roxctl central command options inherited from the parent command".
+.Flags
+[cols="2,2",options="header"]
+|===
+|Flag |Description
+
+|-o, --output
+|File to be used for storing the newly generated CRS. Use `-` for `stdout`.
+
+|--valid-for
+|Specify the validity duration for the new CRS, for example, `10m`, `1d`.
+
+|--valid-until
+|Specify the validity as an RFC 3339 timestamp for the new CRS.
+
+|===
+
+If you do not specify the validity for the new CRS, `24h` is selected as a default value.
+
+For information about additional flags, see "roxctl central command options inherited from the parent command".


### PR DESCRIPTION
Version(s):
4.9

[Issue](https://issues.redhat.com/browse/ROX-31378)

Link to docs preview: https://100966--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/command-reference/roxctl-central.html#roxctl-central-crs-generate_roxctl-central

QE review:
- [x] QE has approved this change. **ACS has no QE, approved by SME**
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
