### PR TITLE
OSDOCS-16585 created doc for config network policy for operand

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1256,6 +1256,8 @@ Topics:
     File: external-secrets-operator-release-notes
   - Name: Installing the External Secrets Operator
     File: external-secrets-operator-install
+  - Name: Configuring Network Policy for the Operand
+    File: external-secrets-operator-config-net-policy
   - Name: Uninstalling the External Secrets Operator
     File: external-secrets-operator-uninstall
   - Name: External Secrets Operator APIs

--- a/modules/external-secrets-operator-egress-allow-all-traffic.adoc
+++ b/modules/external-secrets-operator-egress-allow-all-traffic.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-egress-allow-all-traffic_{context}"]
+= Adding a custom network policy to allow egress to all external providers
+
+You must configure custom policies through the `ExternalSecretsConfig` custom resource to allow all egress to all external providers.
+
+.Prerequisites
+
+* An `ExternalSecretsConfig` must be predefined.
+
+* You must be able to define specific egress rules, including desitination ports and protocols
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the policy by editing the `networkPolicies` section:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    networkPolicies:
+      - name: allow-external-secrets-egress
+        componentName: CoreController
+        egress: # Allow all egress traffic
+----

--- a/modules/external-secrets-operator-egress-specific-provider.adoc
+++ b/modules/external-secrets-operator-egress-specific-provider.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-egress-specific-provider_{context}"]
+= Adding a custom network policy to allow egress to a specific provider
+
+You must configure custom policies through the `ExternalSecretsConfig` custom resource to allow all egress to a specific provider.
+
+.Prerequisites
+
+* An `ExternalSecretsConfig` must be predefined.
+
+* You must be able to define specific egress rules, including desitination ports and protocols
+
+.Procedure
+
+. Edit the `ExternalSecretsConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Set the policy by editing the `networkPolicies` section. The following example shows how to allow egress to {aws-first} endpoints.
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+metadata:
+  name: cluster
+spec:
+  controllerConfig:
+    networkPolicies:
+      - componentName: ExternalSecretsCoreController
+        egress:
+          # Allow egress to Kubernetes API server, AWS endpoints, and DNS
+          - ports:
+              - port: 443   # HTTPS (AWS Secrets Manager)
+                protocol: TCP
+      - name: allow-external-secrets-egress
+----
+
+componentName:: name for the core controller specified as `ExternalSecretsCoreController`.
+
+Egress rules must include the necessary ports, such as Transmission Control Protocol (TCP) port 443 for services like the {aws-short} Secrets Manager.
+

--- a/modules/external-secrets-operator-ingress-egress-rules.adoc
+++ b/modules/external-secrets-operator-ingress-egress-rules.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-ingress-egress-rules_{context}"]
+= Default ingress and egress rules
+
+The following table summarizes the default ingress and egress rules.
+
+[cols="1,1,1,1",options="header"]
+|===
+| Component
+| Ingress ports
+| Egress ports
+| Description
+
+| `external-secrets`
+| 8080
+| 6443
+| Allows retrieving metrics and interacting with the API server
+
+| `external-secrets-webhook`
+| 8080/10250
+| 6443
+| Allows retrieving metrics, handling webhook requests, and interacting with the API server
+
+| `external-secrets-cert-controller`
+| 8080
+| 6443
+| Allows retrieving metrics and interacting with the API server
+
+| `external-secrets-bitwarden-server`
+| 9998
+| 6443
+| Handles Bitwarden server connections and interacts with the API server
+
+| `external-secrets-allow-dns`
+|
+| 5353
+| Enables DNS lookups to find external secret providers.
+|===

--- a/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
@@ -1,0 +1,20 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-config-net-policy"]
+= Configuring network policy for the operand
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-uninstall
+
+toc::[]
+
+The {external-secrets-operator} includes pre-defined `NetworkPolicies` for security, but you must configure additonal, custom policies through the `ExternalSecretsConfig` custom resource to set the external-secrets controller egress allow policies to communicate with external providers. These configurable policies are set via the `ExternalSecretsConfig` custom resource to establish the egress allow policy.
+
+// Adding network policy to connect to permit all egress traffic
+include::modules/external-secrets-operator-egress-allow-all-traffic.adoc[leveloffset=+1]
+
+// Adding network policy to connect to a specific provider
+include::modules/external-secrets-operator-egress-specific-provider.adoc[leveloffset=+1]
+
+// Default ingress and egress rules
+include::modules/external-secrets-operator-ingress-egress-rules.adoc[leveloffset=+1]
+
+


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16585

Link to docs preview:
https://100980--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-config-net-policy.html


QE review:
- [ ] QE has approved this change.


Additional information:

