### PR TITLE
CNV - 64510: TP to GA boost on ARO

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="preparing-cluster-for-virt"]
 = Preparing your cluster for {VirtProductName}
-include::_attributes/common-attributes.adoc[]
 :context: preparing-cluster-for-virt
 :toclevels: 3
 
@@ -73,7 +73,7 @@ endif::[]
 * link:https://github.com/oracle-quickstart/oci-openshift/blob/main/docs/openshift-virtualization.md[Installing {VirtProductName} on OCI] in the `oracle-quickstart/oci-openshift` GitHub repository
 
 | Azure Red{nbsp}Hat OpenShift (ARO)
-| Technology Preview
+| GA
 | {odf-short}
 | * link:https://learn.microsoft.com/en-us/azure/openshift/howto-create-openshift-virtualization[{VirtProductName} for Azure Red Hat OpenShift (preview)] in the Microsoft documentation
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/CNV-64510

Link to docs preview:
https://100987--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html#compatible-platforms_preparing-cluster-for-virt

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

