### PR TITLE
[RHDEVDOCS-6885] Release notes for Pipelines 1.20.1

### DIFF
--- a/modules/op-release-notes-1-20-1.adoc
+++ b/modules/op-release-notes-1-20-1.adoc
@@ -1,0 +1,33 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-20.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-20-1_{context}"]
+= Release notes for {pipelines-title} 1.20.1
+
+With this update, {pipelines-title} General Availability (GA) 1.20.1 is available on {OCP} 4.15 and later versions.
+
+[id="fixed-issues-1-20-1_{context}"]
+== Fixed issues
+
+.Operator 
+
+Webhook validation no longer disrupts unrelated cluster components::
+* Before this update, the `tekton-operator-proxy-webhook` admission webhook validated all namespaces, including control-plane namespaces (`kube-\*`, `openshift-*`). This behavior could cause webhook certificate issues to affect unrelated system components, such as the Network Operator, during namespace reconciliation. With this update, the webhook excludes control-plane namespaces from validation. This change prevents certificate issues from impacting other cluster operators, keeps the existing certificate renewal logic intact, and improves isolation between Tekton and system components.
+
+.{pac}
+
+GitLab PipelineRun custom resource no longer fails or shows incorrect commit status for forked projects::
+* Before this update, commit status handling and pipeline execution for GitLab forks could fail unexpectedly. {pac} fell back to posting comments for status updates when permissions were restricted on forked projects. Execution of `PipelineRun` custom resources (CR) could fail when the configured token lacked read access to the source repository.
+With this update, {pac} attempts to set commit status on both the source (fork) and target (upstream) projects. A status comment is posted only if both attempts fail. Additionally, {pac} attempts to proactively verify that the configured token includes the `read_repository` scope before executing a `PipelineRun` CR, failing early with a clear error message in the `controller-logs` output if access is insufficient.
+
+revision variable no longer returns incorrect commit SHA::
+* Before this update, the {pac} dynamic variable `revision` returned the SHA of the original commit instead of the latest HEAD merge commit after upgrading to {pipelines-shortname} 1.19. With this update, the changes introduced in 1.19 are reverted and the `revision` variable always fetches the SHA of the HEAD merge commit as expected.
+
+hub-catalog-name no longer defaults to deprecated Tekton Hub catalog::
+* Before this update, when upgrading to 1.20.0, the `hub-catalog-name` field in the {pac} config map was set to the deprecated {tekton-hub} catalog name `tekton`. With this update, the field defaults to the {artifact-hub} catalog name, and you can override it with a custom value.
+
+.User interface
+
+Navigation tab no longer disappears and installation UI no longer crashes after {OCP} upgrade::
+* Before this update, after upgrading {OCP} to 4.19.15 or greater, the *Navigation* tab intermittently disappeared, and the Pipeline Operator installation UI could crash after creating a `PipelineRun` CR on Sandbox clusters. These issues were caused by a race condition introduced by new flags in {OCP}. With this update, the race condition is resolved on {OCP} 4.19.18.

--- a/release_notes/op-release-notes-1-20.adoc
+++ b/release_notes/op-release-notes-1-20.adoc
@@ -31,6 +31,10 @@ include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=
 // Release notes for Red Hat OpenShift Pipelines 1.20.0 
 include::modules/op-release-notes-1-20-0.adoc[leveloffset=+1]
 
+// Release notes for Red Hat OpenShift Pipelines 1.20.1 
+include::modules/op-release-notes-1-20-1.adoc[leveloffset=+1]
+
+
 //Additional resources 1.20
 .Additional resources
 * xref:../secure/using-buildah-ns-tekton-task.adoc#op-differences-between-buildah-buildah-ns-tasks_using-buildah-ns-tekton-task[Differences between `buildah` and `buildah-ns` tasks]


### PR DESCRIPTION
Version(s):
- none for cherry-picking

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-6885

Link to docs preview:
 - [Release notes for Pipelines 1.20.1](https://100998--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-20.html#op-release-notes-1-20-1_op-release-notes-1-20)

QE review:
- [ ] QE has approved this change.
