### PR TITLE
[power-monitoring-docs-0.4] Fix assembly metadata

### DIFF
--- a/about/about-power-monitoring.adoc
+++ b/about/about-power-monitoring.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+
 [id="about-power-monitoring"]
 = About {PM-shortname}
-include::_attributes/common-attributes.adoc[]
+
 :context: about-power-monitoring
 
 toc::[]

--- a/configuring/configuring-power-monitoring.adoc
+++ b/configuring/configuring-power-monitoring.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+
 [id="configuring-power-monitoring"]
 = Configuring {PM-shortname}
-include::_attributes/common-attributes.adoc[]
+
 :context: configuring-power-monitoring
 
 toc::[]

--- a/installing/installing-power-monitoring.adoc
+++ b/installing/installing-power-monitoring.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+
 [id="installing-power-monitoring"]
 = Installing {PM-title}
-include::_attributes/common-attributes.adoc[]
+
 :context: installing-power-monitoring
 
 toc::[]

--- a/release_notes/power-monitoring-release-notes.adoc
+++ b/release_notes/power-monitoring-release-notes.adoc
@@ -1,7 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="power-monitoring-release-notes"]
 include::_attributes/common-attributes.adoc[]
+
+[id="power-monitoring-release-notes"]
+
 = {PM-title-c} release notes
+
 :context: power-monitoring-release-notes
 
 toc::[]

--- a/uninstalling/uninstalling-power-monitoring.adoc
+++ b/uninstalling/uninstalling-power-monitoring.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+
 [id="uninstalling-power-monitoring"]
 = Uninstalling {PM-shortname}
-include::_attributes/common-attributes.adoc[]
+
 :context: uninstalling-power-monitoring
 
 toc::[]

--- a/visualizing/visualizing-power-monitoring-metrics.adoc
+++ b/visualizing/visualizing-power-monitoring-metrics.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+
 [id="visualizing-power-monitoring-metrics"]
 = Visualizing power monitoring metrics
-include::_attributes/common-attributes.adoc[]
+
 :context: visualizing-power-monitoring-metrics
 
 toc::[]


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/100993 to 0.4