### PR TITLE
[power-monitoring-docs-0.5] Fix assembly metadata

### DIFF
--- a/about/about-power-monitoring.adoc
+++ b/about/about-power-monitoring.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+
 [id="about-power-monitoring"]
 = About {PM-shortname}
-include::_attributes/common-attributes.adoc[]
+
 :context: about-power-monitoring
 
 toc::[]

--- a/configuring/configuring-power-monitoring.adoc
+++ b/configuring/configuring-power-monitoring.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+
 [id="configuring-power-monitoring"]
 = Configuring {PM-shortname}
-include::_attributes/common-attributes.adoc[]
+
 :context: configuring-power-monitoring
 
 toc::[]

--- a/installing/installing-power-monitoring.adoc
+++ b/installing/installing-power-monitoring.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+
 [id="installing-power-monitoring"]
 = Installing {PM-title}
-include::_attributes/common-attributes.adoc[]
+
 :context: installing-power-monitoring
 
 toc::[]

--- a/reference/power-monitoring-api-reference.adoc
+++ b/reference/power-monitoring-api-reference.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="power-monitoring-api-reference"]
 = Power monitoring API reference
+
 include::_attributes/common-attributes.adoc[]
+
 :context: power-monitoring-kepler-power-attribution-guide
 
 toc::[]

--- a/reference/power-monitoring-references.adoc
+++ b/reference/power-monitoring-references.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="power-monitoring-references"]
 = Power monitoring references
+
 include::_attributes/common-attributes.adoc[]
+
 :context: power-monitoring-references
 
 toc::[]

--- a/release_notes/power-monitoring-release-notes-tp-0-5.adoc
+++ b/release_notes/power-monitoring-release-notes-tp-0-5.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="power-monitoring-assembly-tp-0-5-release-notes_{context}"]
 include::_attributes/common-attributes.adoc[]
+
+[id="power-monitoring-assembly-tp-0-5-release-notes"]
 = {PM-title-c} 0.5 (Technology Preview) release notes
+
 :context: power-monitoring-release-notes
 
 toc::[]

--- a/uninstalling/uninstalling-power-monitoring.adoc
+++ b/uninstalling/uninstalling-power-monitoring.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+
 [id="uninstalling-power-monitoring"]
 = Uninstalling {PM-shortname}
-include::_attributes/common-attributes.adoc[]
+
 :context: uninstalling-power-monitoring
 
 toc::[]

--- a/visualizing/visualizing-power-monitoring-metrics.adoc
+++ b/visualizing/visualizing-power-monitoring-metrics.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+
 [id="visualizing-power-monitoring-metrics"]
 = Visualizing power monitoring metrics
-include::_attributes/common-attributes.adoc[]
+
 :context: visualizing-power-monitoring-metrics
 
 toc::[]


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/100993 to 0.5 (needed manual cherry-pick due to release notes assembly)