### PR TITLE
[RHDEVDOCS-6246] Event-based pruner TP for 1.19

### DIFF
--- a/install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
+++ b/install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
@@ -55,6 +55,10 @@ include::modules/op-default-pruner-configuration.adoc[leveloffset=+2]
 
 include::modules/op-annotations-for-automatic-pruning-taskruns-pipelineruns.adoc[leveloffset=+2]
 
+include::modules/op-event-pruner-configuration.adoc[leveloffset=+2]
+
+include::modules/op-event-pruner-reference.adoc[leveloffset=+2]
+
 include::modules/op-additional-options-webhooks.adoc[leveloffset=+1]
 
 

--- a/modules/op-event-pruner-configuration.adoc
+++ b/modules/op-event-pruner-configuration.adoc
@@ -1,0 +1,96 @@
+// This module is included in the following assemblies:
+// * install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="event-pruner-configuration_{context}"]
+= Enabling the event-based pruner
+
+:FeatureName: The event-based pruner
+include::snippets/technology-preview.adoc[]
+
+You can use the event-based `tektonpruner` controller to automatically delete completed resources, such as `PipelineRuns` and `TaskRuns`, based on configurable policies. Unlike the default job-based pruner, the event-based pruner listens for resource events and prunes resources in near real time.
+
+You can use the event-based pruner together with the following:
+
+Resource annotations
+{tekton-results}
+{PAC}
+
+[NOTE]
+====
+The Operator does not restrict the use of these features with the event-based pruner. However, future releases might introduce validation if conflicts are detected.
+====
+
+[IMPORTANT]
+====
+You must disable the default pruner in the `TektonConfig` custom resource (CR) before enabling the event-based pruner. If both pruner types are enabled, the deployment readiness status changes to `False` and the following error message is displayed in the output:
+
+[source,terminal]
+----
+Components not in ready state: Invalid Pruner Configuration!! Both pruners, tektonpruner(event based) and pruner(job based) cannot be enabled simultaneously. Please disable one of them.
+----
+====
+
+.Procedure
+
+. In your TektonConfig CR, disable the default pruner by setting the `spec.pruner.disabled` field to `true` and enable the event-based pruner by setting the `spec.tektonpruner.disabled` field to `false`.  
++
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+ name: config
+spec:
+  # ...
+  pruner:
+    disabled: true
+  # ...
+  tektonpruner:
+    disabled: false
+    options: {}
+  # ...
+----
++
+After you apply the updated CR, the Operator deploys the `tekton-pruner-controller` pod in the `openshift-pipelines` namespace.
+
+. Verify that the following config maps are displayed in the `openshift-pipelines` namespace:
++
+[cols="1,3",options="header"]
+|===
+|ConfigMap 
+|Purpose
+
+|`tekton-pruner-default-spec`
+|Define default pruning behavior
+
+|`pruner-info`
+|Store internal runtime data used by the controller
+
+|`config-logging-tekton-pruner`
+|Configure logging settings for the pruner
+
+|`config-observability-tekton-pruner`
+|Enable observability features such as metrics and tracing
+|===
+
+[IMPORTANT]
+====
+Unlike the default pruner, you can only enable or disable the event-based pruner by modifying the `TektonConfig` CR. Configure all other pruning behavior by modifying the tekton-pruner-default-spec config map.
+====
+
+.Verification
+
+. To verify that the `tekton-pruner-controller` pod is running, run the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-pipelines
+----
+
+. Verify that the output includes a `tekton-pruner-controller` pod in the `Running` state. Example output:
++
+[source,terminal]
+----
+$ tekton-pruner-controller-<id>    Running
+----

--- a/modules/op-event-pruner-reference.adoc
+++ b/modules/op-event-pruner-reference.adoc
@@ -1,0 +1,74 @@
+// This module is included in the following assemblies:
+// * install_config/customizing-configurations-in-the-tektonconfig-cr.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="event-pruner-reference_{context}"]
+= Configuration of the event-based pruner
+
+:FeatureName: The event-based pruner
+include::snippets/technology-preview.adoc[]
+
+You can configure the pruning behavior for the event-based pruner by modifying the `tekton-pruner-default-spec` config map in the `openshift-pipelines` namespace. This config map supports both global pruning policies and optional namespace-specific overrides.
+
+The following example shows a default `tekton-pruner-default-spec` config map that uses global pruning rules:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-default-spec
+  namespace: openshift-pipelines
+data:
+  global-config: |
+    enforcedConfigLevel: global
+    ttlSecondsAfterFinished: 300
+    successfulHistoryLimit: 3
+    failedHistoryLimit: 3
+    historyLimit: 5
+# ...
+----
+* `ttlSecondsAfterFinished: 300`: Delete resources 300 seconds (5 minutes) after completion.
+* `successfulHistoryLimit: 3`: Retain 3 successful runs.
+* `failedHistoryLimit: 3`: Retain 3 failed runs.
+* `historyLimit: 5`: Limit retention to 5 runs. This setting is used if status-specific limits are not defined. 
+
+You can define pruning rules for individual namespaces by setting `enforcedConfigLevel` to `namespace` and configuring policies under the `namespaces` section. In the following example, a 60 second time to live (TTL) is applied to resources in the `dev-project` namespace:
+
+[source,yaml]
+----
+# ...
+data:
+  global-config: |
+    enforcedConfigLevel: namespace
+    ttlSecondsAfterFinished: 300
+    namespaces:
+      dev-project:
+        ttlSecondsAfterFinished: 60
+# ...
+----
+
+You can use the following parameters in the `global-config` section of the `tekton-pruner-default-spec` config map:
+
+[cols="1,3",options="header"]
+|===
+|Parameter |Description
+
+|`ttlSecondsAfterFinished`
+|Delete resources after a fixed number of seconds following completion.
+
+|`successfulHistoryLimit`
+|Retain the specified number of most recent successful runs, and delete older successful runs.
+
+|`failedHistoryLimit`
+|Retain the specified number of most recent failed runs, and delete older failed runs.
+
+|`historyLimit`
+|Apply a generic history limit when status-specific limits are not defined.
+
+|`enforcedConfigLevel`
+|Specify the level at which the pruner applies the configuration. Accepted values: `global` or `namespace`.
+
+|`namespaces`
+|Define per-namespace pruning rules.
+|===


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6246?src=confmacro

Link to docs preview:
- [Enabling the event-based pruner](https://101002--ocpdocs-pr.netlify.app/openshift-pipelines/latest/install_config/customizing-configurations-in-the-tektonconfig-cr.html#event-pruner-configuration_customizing-configurations-in-the-tektonconfig-cr)

- [Configuration of the event-based pruner](https://101002--ocpdocs-pr.netlify.app/openshift-pipelines/latest/install_config/customizing-configurations-in-the-tektonconfig-cr.html#event-pruner-reference_customizing-configurations-in-the-tektonconfig-cr)

QE review:
- [x] QE has approved this change.

Additional info: 
This is an older commit that didn't get merged. 
-> QE and peer reviews completed as a part of the original PR: https://github.com/openshift/openshift-docs/pull/97970