### PR TITLE
OCPBUGS-51113: Remove known issue from 4.20 RN

### DIFF
--- a/virt/release_notes/virt-4-20-release-notes.adoc
+++ b/virt/release_notes/virt-4-20-release-notes.adoc
@@ -62,7 +62,7 @@ This release adds new features and enhancements related to the following compone
 === Installation and update
 
 //CNV-62403 direct z-stream updates
-* You can now directly update {VirtProductName} to a later z-stream (x.y.z) release without applying each intermediate z-stream version. 
+* You can now directly update {VirtProductName} to a later z-stream (x.y.z) release without applying each intermediate z-stream version.
 +
 [NOTE]
 ====
@@ -251,12 +251,6 @@ ifdef::openshift-enterprise[]
 include::snippets/technology-preview.adoc[]
 :!FeatureName:
 endif::[]
-
-// ocpbugs-51113 - ballooning call traces
-* When you create a VM by using {op-system-base-full} container disk images for s390x architecture, call traces referencing `virtio_balloon` free page reporting print to the VM console. This is due to a kernel bug. (link:https://issues.redhat.com/browse/OCPBUGS-51113[OCPBUGS-51113])
-** As a workaround, disable memory ballooning for the VM by adding the following parameter to the VM YAML configuration: `spec.domain.devices.autoattachMemBalloon: false`.
-+
-You can also disable free page reporting of memory ballooning for all new VMs. To do so, edit the `HyperConverged` CR and add the parameter `spec.virtualMachineOptions.disableFreePageReporting: true`.
 
 // CNV-56889: Matan indicated this will remain in 4.20 but is targeted for 4.21
 * VMs based on s390x architecture can only use the *IPL* boot mode. However, in the {product-title} web console, the *Boot mode* list for s390x VMs incorrectly includes *BIOS*, *UEFI*, and *UEFI (secure)* boot modes. If you select one of these modes for an s390x-based VM, the operation fails. (link:https://issues.redhat.com/browse/CNV-56889[CNV-56889])


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OCPBUGS-51113

Link to docs preview:
https://101018--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-20-release-notes.html#virt-4-20-ki-ibm-z_virt-4-20-release-notes

QE review:
- [x] QE has approved this change. (see Jira)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
