### PR TITLE
OSDOCS-16520: Corrected the release notes for DITA compliance

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-whats-new"]
 = What's new for {product-title}
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-whats-new

--- a/rosa_release_notes/whats-new-template.adoc
+++ b/rosa_release_notes/whats-new-template.adoc
@@ -1,6 +1,0 @@
-// Text snippet included in the following modules:
-//
-// * rosa_release_notes/rosa-release-notes.adoc
-
-:_mod-docs-content-type: SNIPPET
-* With {product-title} <release-version>, {product-title} does <something>. This functionality offers <benefits>. For more information, see link:<link-to-relevant-docs>[Documentation].


### PR DESCRIPTION
Version(s):
`enterprise-4.20+`

Issue:
**[OSDOCS-16520](https://issues.redhat.com/browse/OSDOCS-16520)**

Link to docs preview:
- ROSA release notes (no visible changes)

Additional information:
This PR corrects some of the Vale errors to ensure DITA compliance.