### PR TITLE
OSDOCS-16651:Update the z-stream RNs for 4.18.27

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3054,6 +3054,40 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.27
+[id="ocp-4-18-27_{context}"]
+=== RHSA-2025:19047 - {product-title} {product-version}.27 bug fix and security update
+
+Issued: 29 October 2025
+
+{product-title} release {product-version}.27 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:19047[RHSA-2025:19047] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:19045[RHBA-2025:19045] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.27 --pullspecs
+----
+
+[id="ocp-4-18-27-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, if the OVN-Kubernetes controller was not processing updates from the Kubernetes API server and configuring the open virtual network (OVN) databases on each node, then the OVN-Controller, which consumed this database, might have connected to the database before the OVN-Kubernetes controller had configured them. As a consequence, the OVN-Controller synced with a stale OVN database, consumed source network address translations (SNATs) that were configured to support the egress IP, and proceeded to the gratuitous address resolution protocol (GARP) for the associated IP even though that IP might have moved to another node. With this release, these GARPs are blocked when the OVN-Kubernetes controller is not processing updates.  (link:https://issues.redhat.com/browse/OCPBUGS-62671[OCPBUGS-62671])
+
+* Before this update, the Cluster Version Operator (CVO) in 4.19.9 and 4.18.23 started to require bearer token authentication in metrics requests. As a consequence, {hcp} clusters were broken because the metrics scraper did not provide client authentication. With this release, the CVO does not require client authentication for metrics requests. As a result, access to CVO metrics scraping is recovered on {hcp} clusters. (link:https://issues.redhat.com/browse/OCPBUGS-62869[OCPBUGS-62869])
+
+* Before this update, the linked URL was in the developer perspective, but the perspective was not switched when you clicked the link. As a consequence, a blank page was shown. With this release, the perspective changes when you click the link and the page is correctly shown. (link:https://issues.redhat.com/browse/OCPBUGS-63041[OCPBUGS-63041])
+
+* Before this update, users without a project saw only part of the *Roles* list because of insufficient role-based access control (RBAC) permissions. With this release, the access logic is fixed. As a result, these users cannot open the *Roles* page, which keeps sensitive data secure. (link:https://issues.redhat.com/browse/OCPBUGS-63247[OCPBUGS-63247])
+
+* Before this update, during an update from 4.18.21 to 4.19.6, the Machine Config Operator (MCO) failed due to multiple labels in the `capacity.cluster-autoscaler.kubernetes.io/labels` annotation in one or more machine sets. With this release, the MCO accepts multiple labels in the `capacity.cluster-autoscaler.kubernetes.io/labels` annotation. As result, the MCO does not fail during the update to 4.19.6. (link:https://issues.redhat.com/browse/OCPBUGS-63346[OCPBUGS-63346]) 
+
+[id="ocp-4-18-27-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.26
 [id="ocp-4-18-26_{context}"]
 === RHSA-2025:17657 - {product-title} {product-version}.26 bug fix and security update


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-16651

Link to docs preview:
https://101031--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-27_release-notes

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
4.18.27 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/192
4.18.27 ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
