### PR TITLE
OSDOCS-14809: Adding a live link to Capacity Reservations

### DIFF
--- a/modules/creating-a-machine-pool-cli-capres.adoc
+++ b/modules/creating-a-machine-pool-cli-capres.adoc
@@ -65,6 +65,7 @@ The following example creates a machine pool called `mymachinepool` that uses th
 $ rosa create machinepool --cluster=mycluster --name=mymachinepool --replicas 1 --capacity-reservation-id <capacity_reservation_id> --subnet <subnet_id> --instance-type c5.xlarge
 ----
 
+
 [source,terminal]
 ----
 I: Checking available instance types for machine pool 'mymachinepool'

--- a/modules/creating-a-machine-pool-cli.adoc
+++ b/modules/creating-a-machine-pool-cli.adoc
@@ -10,9 +10,8 @@ You can create additional machine pools for your {product-title} cluster by usin
 
 [NOTE]
 ====
-To add a pre-purchased Capacity Reservation to a machine pool, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#creating_machine_pools_cli_rosa-managing-worker-nodes[Creating a machine pool with Capacity Reservations].
+To add a pre-purchased Capacity Reservation to a machine pool, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#creating_machine_pools_cli_capres_rosa-managing-worker-nodes[Creating a machine pool with Capacity Reservations].
 ====
-//Commenting out the not-yet-published link that breaks the build: https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#creating_machine_pools_cli_capres_rosa-managing-worker-nodes Will have to add it here after the new Cap Res module is merged and published.
 
 .Prerequisites
 


### PR DESCRIPTION
OSDOCS#14809: A follow-up PR: the original PR https://github.com/openshift/openshift-docs/pull/100445 was breaking because of a link to a not yet published new module. The new module is life now so the link can be added.

Version(s):
4.20+
The original PR said 4.19+ but it probably doesn't matter.

Issue:
https://issues.redhat.com/browse/OSDOCS-14809

Link to docs preview:
Updated link is in the Note: https://101037--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes#creating_machine_pools_cli_rosa-managing-worker-nodes

QE review:
N/A

Additional information:
