### PR TITLE
OCPDOCS MCO Add extensions module to assembly

### DIFF
--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -198,14 +198,11 @@ include::modules/coreos-layering-configuring-on-modifying.adoc[leveloffset=+2]
 .Additional resources
 * xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine config pools]
 
-////
-Hiding extensions, not in 4.18. Maybe 4.19?
 include::modules/coreos-layering-configuring-on-extensions.adoc[leveloffset=+2]
 
 .Additional resources
 * xref:../machine_configuration/machine-configs-configure.html#rhcos-add-extensions_machine-configs-configure[Adding extensions to RHCOS]
 * xref:../updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools[Pausing the machine config pools]
-////
 
 include::modules/coreos-layering-configuring-on-rebuild.adoc[leveloffset=+2]
 

--- a/modules/coreos-layering-configuring-on-extensions.adoc
+++ b/modules/coreos-layering-configuring-on-extensions.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// * machine_configuration/coreos-layering.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="coreos-layering-configuring-on-extensions_{context}"]
+= Installing extensions into an on-cluster custom layered image
+
+You can install {op-system-first} extensions into your on-cluster custom layered image by creating a machine config that lists the extensions that you want to install. The Machine Config Operator (MCO) installs the extensions onto the nodes associated with a specific machine config pool (MCP).
+
+For a list of the currently supported extensions, see "Adding extensions to RHCOS."
+
+After you make the change, the MCO reboots the nodes associated with the specified machine config pool.
+
+[NOTE]
+====
+include::snippets/coreos-layering-configuring-on-pause.adoc[]
+====
+
+.Prerequisites
+
+* You have opted in to {image-mode-os-on-lower} by creating a `MachineOSConfig` object.
+
+.Procedure
+
+. Create a YAML file for the machine config similar to the following example: 
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1 <1>
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker <2>
+  name: 80-worker-extensions
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+  extensions: <3>
+    - usbguard
+    - kerberos
+----
+<1> Specifies the `machineconfiguration.openshift.io/v1` API that is required for `MachineConfig` CRs.
+<2> Specifies the machine config pool to apply the `MachineConfig` object to.
+<3> Lists the {op-system-first} extensions that you want to install.
+
+. Create the MCP object:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
+
+.Verification
+
+. You can watch the build progress by using the following command:
++
+[source,terminal]
+----
+$ oc get machineosbuilds
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                       PREPARED   BUILDING   SUCCEEDED   INTERRUPTED   FAILED
+layered-f8ab2d03a2f87a2acd449177ceda805d   False      True       False       False         False <1>
+----
+<1> The value `True` in the `BUILDING` column indicates that the `MachineOSBuild` object is building. When the `SUCCEEDED` column reports `TRUE`, the build is complete. 
+
+. You can watch as the new machine config is rolled out to the nodes by using the following command:
++
+[source,terminal]
+----
+$ oc get machineconfigpools
+----
++
+.Example output
+[source,terminal]
+----
+NAME      CONFIG                                              UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
+master    rendered-master-a0b404d061a6183cc36d302363422aba    True      False      False      3              3                   3                     0                      3h38m
+worker    rendered-worker-221507009cbcdec0eec8ab3ccd789d18    False     True       False      2              2                   2                     0                      3h38m <1>
+----
+<1> The value `FALSE` in the `UPDATED` column indicates that the `MachineOSBuild` object is building. When the `UPDATED` column reports `FALSE`, the new custom layered image has rolled out to the nodes.
+
+. When the associated machine config pool is updated, check that the extensions were installed:
+
+.. Open an `oc debug` session to the node by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+.. Set `/host` as the root directory within the debug shell by running the following command:
++
+[source,terminal]
+----
+sh-5.1# chroot /host
+----
+
+.. Use an appropriate command to verify that the extensions were installed. The following example shows that the usbguard extension was installed:
++
+[source,terminal]
+----
+sh-5.1# rpm -qa |grep usbguard
+----
++
+.Example output
+[source,terminal]
+----
+usbguard-selinux-1.0.0-15.el9.noarch
+usbguard-1.0.0-15.el9.x86_64
+----


### PR DESCRIPTION
I created this module for the OCP 4.18 release, but was told [the feature was removed](https://github.com/openshift/openshift-docs/pull/87730#issuecomment-2672191534). Hang on to this PR in case the feature is implemented. 

For history:
This PR [added the module initially](https://github.com/openshift/openshift-docs/pull/87730/files#diff-a74b1cfb5de47553efe02a5bf9f9a2eeb1e0251431ecedbb6d40e4ae42d4cd0eR194).
This PR [hid the module](https://github.com/openshift/openshift-docs/pull/88993/files#diff-a74b1cfb5de47553efe02a5bf9f9a2eeb1e0251431ecedbb6d40e4ae42d4cd0eR194-R201).
This current PR unhides the module. 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


