### PR TITLE
OBSDOCS-2650-4.19 Fix broken COO stub in OCP docs

### DIFF
--- a/observability/cluster_observability_operator/cluster-observability-operator-overview.adoc
+++ b/observability/cluster_observability_operator/cluster-observability-operator-overview.adoc
@@ -1,7 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cluster-observability-operator-overview"]
-= {coo-full} overview
 include::_attributes/common-attributes.adoc[]
+= {coo-full} overview
+
 :context: cluster_observability_operator_overview
 
 toc::[]


### PR DESCRIPTION

Version(s):
4.19 and back to 4.12

Issue:
[OBSDOCS-2650](https://issues.redhat.com//browse/OBSDOCS-2650)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
