### PR TITLE
OSDOCS-16038_v1 created doc for egress proxy and proxy considerations

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1258,6 +1258,8 @@ Topics:
     File: external-secrets-operator-install
   - Name: Configuring Network Policy for the Operand
     File: external-secrets-operator-config-net-policy
+  - Name: Configuring the egress proxy
+    File: external-secrets-operator-proxy
   - Name: Uninstalling the External Secrets Operator
     File: external-secrets-operator-uninstall
   - Name: External Secrets Operator APIs

--- a/modules/external-secrets-operator-configure-proxy.adoc
+++ b/modules/external-secrets-operator-configure-proxy.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-proxy.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-configure-proxy_{context}"]
+= Configuring the egress proxy for the {external-secrets-operator}
+
+The egress proxy can be configured in the `ExternalSecretsConfig` or the `ExternalSecretsManager` custom resource (CR). The Operator and the operand make use of the {product-title} supported certificate authority (CA) bundle for the proxy validations.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have created the `ExternalSecretsConfig` custom CR.
+
+.Procedure
+
+* To set the proxy in the `ExternalSecretsConfig` resource, perform the following steps:
+
+. Edit the `ExternalSecretsConfig` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsconfigs.operator.openshift.io cluster
+----
+
+. Edit the `spec.appConfig.proxy` section to set the proxy values as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsConfig
+...
+spec:
+  appConfig:
+    proxy:
+      httpProxy: <http_proxy>
+      httpsProxy: <https_proxy>
+      noProxy: <no_proxy>
+----
+
+where:
+
+<http_proxy>:: Specifies the proxy URL for the http requests.
+
+<https_proxy>:: Proxy URL for the https requests.
+
+<no_proxy>:: Comma-separated list of hostnames, CIDRs, IPs or a combination of these, for which the proxy should not be used.
+
+* To set the proxy in the `ExternalSecretsManager` CR, perform the following steps.
+
+. Edit the `ExternalSecretsManager` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit externalsecretsmanagers.operator.openshift.io cluster
+----
+
+. Edit the `spec.globalConfig.proxy` section to set the proxy values as follows:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: ExternalSecretsManager
+...
+spec:
+  globalConfig:
+    proxy:
+      httpProxy: <http_proxy>
+      httpsProxy: <https_proxy>
+      noProxy: <no_proxy>
+----
+
+where:
+
+<http_proxy>:: Specifies the proxy URL for the http requests.
+
+<https_proxy>:: Proxy URL for the https requests.
+
+<no_proxy>:: Comma-separated list of hostnames, CIDRs, IPs or a combination of these for which the proxy should not be used.
+

--- a/modules/external-secrets-operator-proxy-considerations.adoc
+++ b/modules/external-secrets-operator-proxy-considerations.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/index.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="external-secrets-operator-proxy-considerations_{context}"]
+= Security considerations
+
+When using the {external-secrets-operator}, there are some security concerns you should consider:
+
+* The `external-secrets` operand fetches the secrets from the configured external providers and stores it in a Kubernetes native `Secrets` resource. This results in a secret zero problem. It is recommended to secure the secret objects using additional encryption. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.9/html/planning_your_deployment/security-considerations_rhodf#data-encryption-options_rhodf[Data encryption options].
+
+* When configuring `SecretStore` and `ClusterSecretStore` resources, consider using short-term credential-based authorization. This approach enhances security by limiting the window of opportunity for unauthorized access, even if credentials are compromised.
+
+* To enhance the security of the {external-secrets-operator}, it is crucial to implement role-based access controls (RBACs). These RBACs should define and limit access to the custom resources provided by the {external-secrets-operator-short}.

--- a/security/external_secrets_operator/external-secrets-operator-proxy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-proxy.adoc
@@ -1,0 +1,18 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="external-secrets-operator-proxy"]
+= About the egress proxy for the {external-secrets-operator}
+include::_attributes/common-attributes.adoc[]
+:context: external-secrets-operator-proxy
+
+toc::[]
+
+If a cluster-wide egress proxy is configured in {product-title}, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. OLM automatically updates all of the Operator’s deployments with the `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.
+
+// Configure egress proxy
+include::modules/external-secrets-operator-configure-proxy.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="external-resources-operator-proxy_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]

--- a/security/external_secrets_operator/index.adoc
+++ b/security/external_secrets_operator/index.adoc
@@ -20,6 +20,9 @@ include::modules/external-secrets-test-coverage.adoc[leveloffset=+1]
 //FIPS compliant support
 include::modules/external-secrets-fips-support.adoc[leveloffset=+1]
 
+//egress proxy security considerations
+include::modules/external-secrets-operator-proxy-considerations.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="external-secrets-operator-about_additional-resources"]
 == Additional resources
@@ -28,3 +31,5 @@ include::modules/external-secrets-fips-support.adoc[leveloffset=+1]
 * xref:../../security/container_security/security-compliance.adoc#security-compliance[Understanding compliance]
 * xref:../../installing/overview/installing-fips.adoc#installing-fips-mode_installing-fips[Installing a cluster in FIPS mode]
 * xref:../../installing/overview/installing-preparing.adoc#installing-preparing-security[Do you need extra security for your cluster?]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.19/html/planning_your_deployment/security-considerations_rhodf[Security considerations]
+* link:https://external-secrets.io/latest/guides/security-best-practices/[Security Best Practices]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16038

Link to docs preview:
https://101072--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-proxy.html
https://101072--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/index.html


QE review:
- [x] QE has approved this change.


Additional information:

