### PR TITLE
OSDOCS WMCO 10.20 RN add link to errata

### DIFF
--- a/modules/windows-containers-release-notes-10-20-0.adoc
+++ b/modules/windows-containers-release-notes-10-20-0.adoc
@@ -8,7 +8,7 @@
 
 Issued: 21 October 2025
 
-// The components of the Red Hat Windows Machine Config Operator (WMCO) 10.20.0 were released in TBD.
+The components of the Red Hat Windows Machine Config Operator (WMCO) 10.20.0 were released in link:https://access.redhat.com/errata/RHBA-2025:18930[RHBA-2025:18930].
 
 [id="wmco-10-20-0-new-features"]
 == New features and improvements


### PR DESCRIPTION
I published the WMCO 10.20.0 release notes without the errata link, as the errata was not available at GA. This PR adds the link. 

Preview
[Release notes for Red Hat Windows Machine Config Operator 10.20.0](https://101073--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/wmco_rn/windows-containers-release-notes.html#windows-containers-release-notes-10-20-0_windows-containers-release-notes)
