### PR TITLE
Add 4.20 to CMA Supported Versions table

### DIFF
--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -27,6 +27,10 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |General availability
 
 |2.17.2
+|4.20
+|General availability
+
+|2.17.2
 |4.19
 |General availability
 


### PR DESCRIPTION
Missed adding 4.20 to the Custom Metrics Autoscaler Supported Versions table in the release notes. This PR corrects that ommision.

Link to docs preview:
[Supported versions](https://101077--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-versions_nodes-cma-autoscaling-custom-rn)
