### PR TITLE
OSDOCS-16650 created z-stream RNs for 4-20-1

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -2912,6 +2912,69 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.20.1
+[id="ocp-4-20-1_{context}"]
+=== RHSA-2025:19003 - {product-title} {product-version}.1 image release, bug fix, and security update advisory
+
+Issued: 28 Oct 2025
+
+{product-title} release {product-version}.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:19003[RHSA-2025:19003] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHEA-2025:19001[RHEA-2025:19001] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.1 --pullspecs
+----
+
+[id="ocp-4-20-1-known-issues_{context}"]
+==== Known issues
+
+* Starting with {product-title} 4.20, there is a decrease in the default maximum open files soft limit for containers. As a consequence, end users may experience application failures. To work around this problem, increase the container runtimes (CRI-O) ulimit configuration. (link:https://issues.redhat.com/browse/OCPBUGS-62095[OCPBUGS-62095])
+
+[id="ocp-4-20-1-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, iDRAC10 hardware provisioning was failing due to an incorrect data type for the Dell Original Equipment Manufacturer (OEM) `Target` property and the use of an incorrect virtual media slot. As a result, users were unable to provision Dell iDRAC10 servers. With this release, the Dell iDRAC10 can be provisioned. (link:https://issues.redhat.com/browse/OCPBUGS-52427[OCPBUGS-52427])
+
+* Before this release, two identical copies of the same controller were updating the same certificate authority (CA) bundle in a `configmap` causing them to receive different metadata inputs, rewrite each other's changes, and create duplicate events. With this release, the controllers use optimistic updating and server-side apply to avoid update events and handle update conflicts. As a result, metadata updates no longer trigger duplicate events, and the expected metadata is set correctly. (link:https://issues.redhat.com/browse/OCPBUGS-55217[OCPBUGS-55217])
+
+
+* Before this update, when installing a cluster on {ibm-power-server-title} you could only specify a name for an existing Transit Gateway or virtual private cloud (VPC). As the uniqueness of names was not guaranteed, this could cause conflicts and installation failures. With this release, you can use Universally Unique Identifiers (UUIDs) for a Transit Gateway and VPC. By using unique identifiers, the installation program can unambiguously identify the correct Transit Gateway or VPC. This prevents the naming conflicts and the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-59678[OCPBUGS-59678])
+
+* Before this update, the Cloud event proxy for the Precision Time Protocol (PTP) Operator incorrectly parsed BF3 Network Interface Card (NIC) names, causing the interface alias to be formatted incorrectly. As a consequence, the incorrect parsing caused end users to misinterpret cloud events. With this release, the Cloud event proxy has been updated to correctly parse BF3 NIC names in the PTP Operator. As a result, fix improves parsing of BF3 NIC names, ensuring correct event publication for the PTP Operator. (link:https://issues.redhat.com/browse/OCPBUGS-60466[OCPBUGS-60466])
+
+* Before this update, a pod with a secondary interface in an OVN-Kubernetes Localnet network (mapped to the br-ex bridge) could communicate with pods on the same node that used the default network for connectivity only if the Localnet IP addresses were within the same subnet as the host network. With this release, the localnet IP addresses can be drawn from any subnet; in this generalized case, an external router outside the cluster is expected to connect the localnet subnet to the host network. (link:https://issues.redhat.com/browse/OCPBUGS-61453[OCPBUGS-61453])
+
+* Before this update, the Precision Time Protocol (PTP) Operator wrongly parsed network interface controller (NIC) names. As a result, interface aliases were incorrectly formatted and this impacted identifying a PTP hardware clock (PHC) when using Mellaonox cards to send clock state events. With this release, the PTP now correctly parses the NIC names so that generated aliases align with Mellanox naming conventions. Mellanox cards can now accurately identify a PHC when sending clock state events.  (link:https://issues.redhat.com/browse/OCPBUGS-61581[OCPBUGS-61581])
+
+* Before this update, the `cluster in workload identity mode` warning was missing when only the `token-auth-azure` annotation was set, which could lead to misconfiguration. This update adds a check for the `token-auth-azure` annotation when showing the warning. As a result, clusters that use only Azure Workload Identity now show the “cluster in workload identity mode” warning as expected. (link:https://issues.redhat.com/browse/OCPBUGS-61861[OCPBUGS-61861])
+
+* Before this update, the YAML editor in the web console would default to indenting YAML files with 4 spaces. With this release, the default indentation has changed to 2 spaces to align with recommendations. (link:https://issues.redhat.com/browse/OCPBUGS-61990[OCPBUGS-61990])
+
+* Before this update, deploying hosted control planes in version 4.20 or later with user-supplied `ignition-server-serving-cert` and `ignition-server-ca-cert` secrets`, along with the `disable-pki-reconciliation annotation`, caused the system to remove the user supplied ignition secrets and the `ignition-server` pods to fail. With this release, the `ignition-server` secrets are preserved during reconciliation after removing the delete action for the `disable-pki-reconciliation` annotation ensuring ignition-server pods start. (link:https://issues.redhat.com/browse/OCPBUGS-62006[OCPBUGS-62006])
+
+* Before this update, if the `OVNKube-controller` on a node failed to process updates and configure its local OVN database, the `OVN-controller` could connect to this stale database. This caused the `OVN-controller` to consume outdated `EgressIP` configurations and send incorrect Gratuitous ARPs (GARPs) for an IP address that might have already moved to a different node. With this release, the `OVN-controller` is blocked from sending these GARPs during the time when the `OVNKube-controller` is not processing updates. As a result, network disruptions are prevented by ensuring GARPs are not sent based on stale database information. (link:https://issues.redhat.com/browse/OCPBUGS-62273[OCPBUGS-62273])
+
+* Before this update, upgrading a `ClusterExtension` could fail when unhandled Customer Resource Definition (CRD) changes produced a large JSON diff for the validation status. This diff often exceeded the Kubernetes 32 KB limit, causing the status update to fail and leaving users with no information about why the upgrade did not occur. With this release, the diff output is truncated and summarized for unhandled scenarios instead of including the full JSON diff. This ensures the status updates remain within size limits, allowing them to post successfully and provide users with clear, actionable error messages. (link:https://issues.redhat.com/browse/OCPBUGS-62722[OCPBUGS-62722])
+
+* Before this update, gRPC connection logs were set at a highly verbose log level. This generated an excessive number of messages, which caused the logs to overflow. With this release, the gRPC connection logs have been moved to the V(4) log level. Consequently, the logs no longer overflow, as these specific messages are now less verbose by default. (link:https://issues.redhat.com/browse/OCPBUGS-62844[OCPBUGS-62844])
+
+* Before this update, running `oc-mirror` without displaying its version caused delays in debugging, as the correct version with required fixes was not known. As a consequence, the user was unable to identify `oc-mirror` version, hindering efficient debugging. With this release, `oc-mirror` now displays its version in the output, aiding faster debugging and ensuring correct fix application. (link:https://issues.redhat.com/browse/OCPBUGS-62283[OCPBUGS-62283])
+
+* Before this update, a bug occurred when the `cluster-api-operator` kubeconfig controller tried to use a regenerated authentication token secret before the token value was fully populated. This caused users to experience recurring, transient reconciliation errors every 30 minutes, which briefly put the Operator into a degraded state. With this release, the controller now waits for the authentication token to be populated within the secret before proceeding, preventing the Operator from going into a degraded state and eliminates the recurring errors. (link:https://issues.redhat.com/browse/OCPBUGS-62755[OCPBUGS-62755])
+
+* Before this update, in {product-title] 4.19.9, the Cluster Version Operator began requiring bearer token authentication in metrics requests. As a consequence, this broke the metrics scraper on hosted control plane clusters because their scrapers provided no client authentication. With this release, the Cluster Version Operator no longer requires client authentication for metrics requests in hosted control plane clusters. (link:https://issues.redhat.com/browse/OCPBUGS-62867[OCPBUGS-62867])
+
+* Before this update, during failover, the system's duplicate address detection (DAD) could incorrectly disable the Egress IPv6 address if it was briefly present on both nodes, breaking the connection. With this release, the Egress IPv6 is configured to skip the DAD check during failover, guaranteeing uninterrupted egress IPv6 traffic after an Egress IP address successfully moves to a different node and ensuring greater network stability. (link:https://issues.redhat.com/browse/OCPBUGS-62913[OCPBUGS-62913])
+
+
+[id="ocp-4-20-1-updating_{context}"]
+==== Updating
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //Update with relevant advisory information
 [id="ocp-4-20-0-ga_{context}"]
 === RHSA-2025:9562 - {product-title} {product-version}.0 image release, bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-16650

Link to docs preview:
https://101081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-1_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:

To find the Image and RPM IDs, select the following links:

For the Image ID: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/189/diffs

For the RPM ID: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20

Must be on VPN to view these links.


