### PR TITLE
OLS-2203: Create release notes for OLS 1.0.7

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -95,3 +95,11 @@
 :cluster-management-title: Red Hat Advanced Cluster Management for Kubernetes
 :codeready-title: Red Hat CodeReady Workspaces
 :quay-title: Red Hat Quay
+//Initial version of OLM that shipped with OCP 4, aka "v0" and f/k/a "existing" during OLM v1's pre-4.18 TP phase
+:olmv0: OLM (Classic)
+:olmv0-caps: OLM (Classic)
+:olmv0-first: Operator Lifecycle Manager (OLM) Classic
+:olmv0-first-caps: Operator Lifecycle Manager (OLM) Classic
+//Next-gen (OCP 4.14+) Operator Lifecycle Manager, f/k/a "1.0"
+:olmv1: OLM v1
+:olmv1-first: Operator Lifecycle Manager (OLM) v1

--- a/modules/ols-1-0-7-fixed-issues.adoc
+++ b/modules/ols-1-0-7-fixed-issues.adoc
@@ -1,0 +1,12 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-7-fixed-issues_{context}"]
+= Fixed issues
+
+{ols-official} 1.0.7 fixes the following issues:
+
+* Previously, an invalid model reference in the `OLSConfig` custom resource (CR) caused the {ols-long} installation to fail. Now, the `OLSConfig` CR health check ensures that the model exists before use, providing error details in the console. This results in improved server health checks, providing more precise status information to the web console, improving the user experience. https://issues.redhat.com/browse/OLS-1949[OLS-1949]
+

--- a/modules/ols-1-0-7-release-notes.adoc
+++ b/modules/ols-1-0-7-release-notes.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+// release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-1-7-release-notes_{context}"]
+= {ols-long} version 1.0.7
+
+{ols-official} 1.0.7 is now available on {ocp-product-title} 4.16 and later.
+
+[id="ols-1-0-7-enhancements_{context}"]
+== Enhancements
+
+The following enhancements have been made with {ols-official} 1.0.7:
+
+* Beginning in this release, clusters deployed with {ocp-product-title} 4.19 and later use PatternFly 6 styling and components from the PatternFly Chatbot extension. This change provides a more consistent user experience across Red{nbsp}Hat Artificial Intelligence (AI) products.
+
+* With this release, the Red{nbsp}Hat-provided Operator catalogs have moved from OperatorHub to the software catalog and the *Operators* navigation item is renamed to *Ecosystem* in the console. The unified software catalog presents Operators, Helm charts, and other installable content in the same console view.
+
+** To access the Red{nbsp}Hat-provided Operator catalogs in the console, select *Ecosystem* -> *Software Catalog*.
+** To manage, update, and remove installed Operators, select *Ecosystem* -> *Installed Operators*.
++
+[NOTE]
+====
+Currently, the console only supports managing Operators by using {olmv0-first}. If you want to use {olmv1} to install and manage cluster extensions, such as Operators, you must use the CLI.
+====
++
+To manage the default or custom catalog sources, you still interact with OperatorHub custom resource (CR) in the console or CLI.
+
+* Beginning in this release, the Service CA Operator automatically adds the {ols-long} default cluster CA certificate to the {ols-long} service trust store. This change simplifies the configuration process for Red Hat OpenShift Application Integration. This enhancement eliminates the need for additional configuration, reducing potential errors due to manual management and ensuring a smoother user experience during deployment.
+
+* Beginning in this release, specifying a header for an MCP server requires creating a secret to hold the header value. Then, you must reference the secret by name in the `OLSConfig` custom resource, setting the secret name as the `value` in the `MCPServer.MCPServerStreamableHTTPTransport.Headers` field where `key` is the header name. To specify a Kubernetes token as the header, enter the string `kubernetes` instead of the `Secret` name. This is a breaking change that addresses a security breach that occurs when you specify a header value in the CR `MCPServer.MCPServerStreamableHTTPTransport.Headers` field that is visible in the `OLSConfig` config map.
+
+* With this release, it is possible to attach `VirtualMachine` details from the *VirtualMachine* details page to your {ols-long} prompt on the Red{nbsp}Hat Advanced Cluster Management for Kubernetes User Interface.
+
+* This release introduces the ability to copy the entire {ols-long} conversation to the clipboard.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -13,6 +13,8 @@ The release notes highlight what is new and what has changed with each {ols-offi
 {ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
 ====
 
+include::modules/ols-1-0-7-release-notes.adoc[leveloffset=+1]
+include::modules/ols-1-0-7-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-6-release-notes.adoc[leveloffset=+1]
 include::modules/ols-1-0-6-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-5-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2203

Link to docs preview:
https://101089--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
