### PR TITLE
OSDOCS#16699: Adding missing content types for core OCP snippets

### DIFF
--- a/snippets/audit-logs-default.adoc
+++ b/snippets/audit-logs-default.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // Module included in the following assemblies and modules:
 //
 // * observability/logging/log_collection_forwarding/configuring-log-forwarding.adoc

--- a/snippets/ccoctl-provider-permissions-requirements.adoc
+++ b/snippets/ccoctl-provider-permissions-requirements.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // Text snippet included in the following modules:
 //
 // * modules/cco-ccoctl-configuring.adoc (ifevals for aws-sts, azure-workload-id, google-cloud-platform)

--- a/snippets/deprecated-feature.adoc
+++ b/snippets/deprecated-feature.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // When including this file, ensure that {FeatureName} is set immediately before
 // the include. Otherwise it will result in an incorrect replacement.
 

--- a/snippets/developer-preview.adoc
+++ b/snippets/developer-preview.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // DO NOT USE THIS SNIPPET. DEVELOPER PREVIEW FEATURES ARE NOT DOCUMENTED IN CORE OPENSHIFT DOCS.
 
 // When including this file, ensure that {FeatureName} is set immediately before the include. Otherwise it will result in an incorrect replacement.

--- a/snippets/ibu-ImageBasedGroupUpgrade.adoc
+++ b/snippets/ibu-ImageBasedGroupUpgrade.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 [source,yaml]
 ----
 apiVersion: lcm.openshift.io/v1alpha1

--- a/snippets/machine-config-node-disruption-actions.adoc
+++ b/snippets/machine-config-node-disruption-actions.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // Text snippet included in the following modules:
 //
 // * modules/machine-config-node-disruption.adoc

--- a/snippets/operator-not-available.adoc
+++ b/snippets/operator-not-available.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // When including this file, ensure that {operator-name} is set immediately before
 // the include. Otherwise it will result in an incorrect replacement.
 

--- a/snippets/technology-preview.adoc
+++ b/snippets/technology-preview.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // When including this file, ensure that {FeatureName} is set immediately before
 // the include. Otherwise it will result in an incorrect replacement.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-16699

Link to docs preview:
No visible changes to preview

QE review:
No QE required - metadata change only
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
