### PR TITLE
OCPBUGS-61221-63545# Ensure new keypairs are not generated and public-key-file flag is used where appropriate

### DIFF
--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -22,6 +22,23 @@ On AWS clusters, some `ccoctl` commands make AWS API calls to create or modify A
 
 .Procedure
 
+. Create the output directory if it does not already exist by running the following command:
++
+[source,terminal]
+----
+$ mkdir -p <path_to_ccoctl_output_dir>
+----
+
+. Extract the bound service account signing key from the cluster and save it to the output directory by running the following command:
++
+[source,terminal]
+----
+$ oc get secret bound-service-account-signing-key \
+  -n openshift-kube-apiserver \
+  -ojsonpath='{ .data.service-account\.pub }' | base64 \
+  -d > <path_to_ccoctl_output_dir>/serviceaccount-signer.public
+----
+
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the command for your cloud provider. The following commands process `CredentialsRequest` objects:
 +
 .Amazon Web Services (AWS)
@@ -34,14 +51,16 @@ $ ccoctl aws create-all \// <1>
   --region=<aws_region> \// <3>
   --credentials-requests-dir=<path_to_credentials_requests_directory> \// <4>
   --output-dir=<path_to_ccoctl_output_dir> \// <5>
-  --create-private-s3-bucket <6>
+  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public \// <6>
+  --create-private-s3-bucket <7>
 ----
 <1> To create the AWS resources individually, use the "Creating AWS resources individually" procedure in the "Installing a cluster on AWS with customizations" content. This option might be useful if you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization.
 <2> Specify the name used to tag any cloud resources that are created for tracking.
 <3> Specify the AWS region in which cloud resources will be created.
 <4> Specify the directory containing the files for the component `CredentialsRequest` objects.
-<5> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
-<6> Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
+<5> Specify the path to the output directory.
+<6> Specify the path to the `serviceaccount-signer.public` file that you extracted from the cluster.
+<7> Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
 ====
 +
 .{gcp-first}
@@ -54,13 +73,15 @@ $ ccoctl gcp create-all \
   --region=<gcp_region> \// <2>
   --project=<gcp_project_id> \// <3>
   --credentials-requests-dir=<path_to_credentials_requests_directory> \// <4>
-  --output-dir=<path_to_ccoctl_output_dir> <5>
+  --output-dir=<path_to_ccoctl_output_dir> \// <5>
+  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public \// <6>
 ----
 <1> Specify the user-defined name for all created {gcp-short} resources used for tracking.
 <2> Specify the {gcp-short} region in which cloud resources will be created.
 <3> Specify the {gcp-short} project ID in which cloud resources will be created.
 <4> Specify the directory containing the files of `CredentialsRequest` manifests to create {gcp-short} service accounts.
-<5> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+<5> Specify the path to the output directory.
+<6> Specify the path to the `serviceaccount-signer.public` file that you extracted from the cluster.
 ====
 +
 .{ibm-cloud-title}
@@ -87,19 +108,21 @@ $ ccoctl ibmcloud create-service-id \
 ----
 $ ccoctl azure create-managed-identities \
   --name <azure_infra_name> \// <1>
-  --output-dir ./output_dir \
-  --region <azure_region> \// <2>
-  --subscription-id <azure_subscription_id> \// <3>
-  --credentials-requests-dir <path_to_directory_for_credentials_requests> \
-  --issuer-url "${OIDC_ISSUER_URL}" \// <4>
-  --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name> \// <5>
-  --installation-resource-group-name "${AZURE_INSTALL_RG}" <6>
+  --output-dir=<path_to_ccoctl_output_dir> \// <2>
+  --region <azure_region> \// <3>
+  --subscription-id <azure_subscription_id> \// <4>
+  --credentials-requests-dir <path_to_directory_for_credentials_requests> \// <5>
+  --issuer-url "${OIDC_ISSUER_URL}" \// <6>
+  --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name> \// <7>
+  --installation-resource-group-name "${AZURE_INSTALL_RG}" <8>
 ----
 <1> The value of the `name` parameter is used to create an Azure resource group.
 To use an existing Azure resource group instead of creating a new one, specify the `--oidc-resource-group-name` argument with the existing group name as its value.
-<2> Specify the region of the existing cluster.
-<3> Specify the subscription ID of the existing cluster.
-<4> Specify the OIDC issuer URL from the existing cluster.
+<2> Specify the path to the output directory.
+<3> Specify the region of the existing cluster.
+<4> Specify the subscription ID of the existing cluster.
+<5> Specify the directory containing the files for the component `CredentialsRequest` objects.
+<6> Specify the OIDC issuer URL from the existing cluster.
 You can obtain this value by running the following command:
 +
 [source,terminal]
@@ -108,8 +131,8 @@ $ oc get authentication cluster \
   -o jsonpath \
   --template='{ .spec.serviceAccountIssuer }'
 ----
-<5> Specify the name of the resource group that contains the DNS zone.
-<6> Specify the {azure-short} resource group name.
+<7> Specify the name of the resource group that contains the DNS zone.
+<8> Specify the {azure-short} resource group name.
 You can obtain this value by running the following command:
 +
 [source,terminal]

--- a/modules/rotating-bound-service-keys.adoc
+++ b/modules/rotating-bound-service-keys.adoc
@@ -187,14 +187,16 @@ ifdef::rotate-aws[]
 [source,terminal]
 ----
 $ ccoctl aws create-identity-provider \
-  --dry-run \// <1> 
+  --dry-run \// <1>
   --output-dir ${TEMPDIR} \
-  --name fake \// <2>
-  --region us-east-1 <3>
+  --public-key-file=${TEMPDIR}/serviceaccount-signer.public \// <2>
+  --name fake \// <3>
+  --region us-east-1 <4>
 ----
 <1> The `--dry-run` option outputs files, including the new `keys.json` file, to the disk without making API calls.
-<2> Because the `--dry-run` option does not make any API calls, some parameters do not require real values.
-<3> Specify any valid {aws-short} region, such as `us-east-1`.
+<2> Specify the path to the public key that you downloaded in the previous step.
+<3> Because the `--dry-run` option does not make any API calls, some parameters do not require real values.
+<4> Specify any valid {aws-short} region, such as `us-east-1`.
 This value does not need to match the region the cluster is in.
 endif::rotate-aws[]
 ifdef::rotate-gcp[]
@@ -204,12 +206,14 @@ ifdef::rotate-gcp[]
 $ ccoctl gcp create-workload-identity-provider \
   --dry-run \// <1>
   --output-dir=${TEMPDIR} \
-  --name fake \// <2>
+  --public-key-file=${TEMPDIR}/serviceaccount-signer.public \// <2>
+  --name fake \// <3>
   --project fake \
   --workload-identity-pool fake
 ----
 <1> The `--dry-run` option outputs files, including the new `keys.json` file, to the disk without making API calls.
-<2> Because the `--dry-run` option does not make any API calls, some parameters do not require real values.
+<2> Specify the path to the public key that you downloaded in the previous step.
+<3> Because the `--dry-run` option does not make any API calls, some parameters do not require real values.
 endif::rotate-gcp[]
 ifdef::rotate-azure[]
 +
@@ -218,14 +222,16 @@ ifdef::rotate-azure[]
 $ ccoctl aws create-identity-provider \// <1>
   --dry-run \// <2>
   --output-dir ${TEMPDIR} \
-  --name fake \// <3>
-  --region us-east-1 <4>
+  --public-key-file=${TEMPDIR}/serviceaccount-signer.public \// <3>
+  --name fake \// <4>
+  --region us-east-1 <5>
 ----
 <1> The `ccoctl azure` command does not include a `--dry-run` option.
 To use the `--dry-run` option, you must specify `aws` for an {azure-short} cluster.
 <2> The `--dry-run` option outputs files, including the new `keys.json` file, to the disk without making API calls.
-<3> Because the `--dry-run` option does not make any API calls, some parameters do not require real values.
-<4> Specify any valid {aws-short} region, such as `us-east-1`.
+<3> Specify the path to the public key that you downloaded in the previous step.
+<4> Because the `--dry-run` option does not make any API calls, some parameters do not require real values.
+<5> Specify any valid {aws-short} region, such as `us-east-1`.
 This value does not need to match the region the cluster is in.
 endif::rotate-azure[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.16+

Issues:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-61221
https://issues.redhat.com/browse/OCPBUGS-63545

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
* Rotating AWS OIDC bound service account signer keys -- https://101095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration.html#rotating-bound-service-keys_key-rotation-aws
* Rotating Google Cloud bound service account signer keys --  https://101095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update.html#cco-ccoctl-upgrading_preparing-manual-creds-update
* Rotating Azure OIDC bound service account signer keys --  https://101095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/changing-cloud-credentials-configuration.html#rotating-bound-service-keys_key-rotation-azure
* Updating cloud provider resources with the Cloud Credential Operator utility -- https://101095--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update.html#cco-ccoctl-upgrading_preparing-manual-creds-update

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
