### PR TITLE
OSDOCS#16652:  Update the z-stream RN for 4.16.51

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3391,6 +3391,31 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.51
+[id="ocp-4-16-51_{context}"]
+=== RHSA-2025:19017 - {product-title} {product-version}.51 bug fix and security update
+
+Issued: 29 October 2025
+
+{product-title} release {product-version}.51 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:19017[RHSA-2025:19017] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.51 --pullspecs
+----
+
+[id="ocp-4-16-51-bug-fixes_{context}"]
+==== Bug fixes
+
+There are no notable bug fixes in this release.
+
+[id="ocp-4-16-51-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.50
 [id="ocp-4-16-50_{context}"]
 === RHSA-2025:17690 - {product-title} {product-version}.50 bug fix and security update


### PR DESCRIPTION
Version(s):
[4.16.51](https://101104--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-51_release-notes)

Issue:
[OSDOCS-16652](https://issues.redhat.com//browse/OSDOCS-16652)

Link to docs preview:
[4.16.51](https://101104--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-51_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
4.16.51 shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/190/diffs#1881eea20d4e8069b48888b371fc0257b59944a1)
ART [dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16) for `rpm` and `rhcos` advisories
