### PR TITLE
OSDOCS-16522: adds 4.20.1 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-20-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-20-release-notes.adoc
@@ -151,3 +151,16 @@ See the latest images included with {microshift-short} by using the following in
 
 * xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
 * xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]
+
+
+[id="microshift-4-20-1-dp_{context}"]
+=== RHSA-2025:xxxxx - {microshift-short} 4.20.1 bug fix and enhancement update
+
+Issued: 28 October 2025
+
+{product-title} release 4.20.1 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHSA-2025:xxxxx[RHSA-2025:xxxxx] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:19003[RHSA-2025:19003] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-16522](https://issues.redhat.com/browse/OSDOCS-16522)

Link to docs preview:
[microshift-4-20-1-dp_release-notes](https://101105--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-20-release-notes.html#microshift-4-20-1-dp_release-notes)

QE review:
- N/A stock text


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
