### PR TITLE
Remove CCLM RNs

### DIFF
--- a/virt/release_notes/virt-4-20-release-notes.adoc
+++ b/virt/release_notes/virt-4-20-release-notes.adoc
@@ -129,7 +129,7 @@ Ensure that you update to the latest z-stream release of your current minor (x.y
 ** `HCOMultiArchGoldenImagesDisabled`
 --
 +
-For a complete list of virtualization metrics, see the link:https://github.com/openshift/runbooks/tree/master/alerts/openshift-virtualization-operator[openshift/runbooks] Git repository. 
+For a complete list of virtualization metrics, see the link:https://github.com/openshift/runbooks/tree/master/alerts/openshift-virtualization-operator[openshift/runbooks] Git repository.
 
 //CNV-67575
 The guest agent ping probe is now generally available (GA). Previously, this feature was provided as a Technology Preview. It has been fully tested and is now supported for production use.
@@ -175,11 +175,6 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 //CNV-62357
 * Golden image support for heterogeneous clusters is now available.
 
-//CNV-65204 Cross-cluster live migration (one note of two; related note added to Known issues)
-* Cross-cluster live migration is now available. By enabling cross-cluster live migration, you can move a virtual machine (VM) workload from one {product-title} cluster to another {product-title} cluster without disruption.
-+
-This feature currently requires installation of {VirtProductName} version 4.20 or later and a pre-release version of {mtv-first}.
-
 //CNV-52861
 * You can now use the Plug a Simple Socket Transport (passt) network binding plugin to connect a VM to a primary user-defined network (UDN). For more information, see xref:../../virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc#attaching-vm-to-primary-udn_virt-connecting-vm-to-primary-udn[Attaching a virtual machine to the primary user-defined network].
 
@@ -224,11 +219,8 @@ This feature currently requires installation of {VirtProductName} version 4.20 o
 //CNV-38543: According to Stu, this remains an issue in 4.20
 * Uninstalling {VirtProductName} does not remove the `feature.node.kubevirt.io` node labels created by {VirtProductName}. You must remove the labels manually. (link:https://issues.redhat.com/browse/CNV-38543[*CNV-38543*])
 
-[id="virt-4-20-ki-storage_{context}"]
-==== Storage
-
-//CNV-65204 Cross-cluster live migration (one note of two; related note added to TP)
-* When you create an {virtproductname} migration plan by using the {mtv-first} wizard to enable the cross-cluster live migration Technology Preview in the {product-title} web console, you are presented with a choice: *Cold migration* or *Live migration*. Choose *Live migration*. This step is missing in the cross-cluster live migration Technology Preview documentation.
+//[id="virt-4-20-ki-storage_{context}"]
+//==== Storage
 
 [id="virt-4-20-ki-virtualization_{context}"]
 === Virtualization


### PR DESCRIPTION
Version(s): 4.20
**NOTE:** Two RNs were merged in [this PR](https://github.com/openshift/openshift-docs/pull/100808) but are being removed as the feature will not be released as a TP in CNV 4.20.

Original issue: [CNV-65204](https://issues.redhat.com/browse/CNV-65204)

Link to docs preview:

QE review:
- [x] QE has approved this change.



