### PR TITLE
OSDOCS-15556:Update RHDE page for MicroShift 4.21

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,28 +1,14 @@
-StylesPath = .vale/styles
+StylesPath = ../.vale/styles
 
 MinAlertLevel = suggestion
 
-Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc
-
-# Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
 [[!.]*.adoc]
-BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
-
-# Disabling rules (NO)
-RedHat.ReleaseNotes = NO
+BasedOnStyles = OpenShiftAsciiDoc, AsciiDoc, RedHat
 
 # Use local OpenShiftDocs Vocab terms
 Vale.Terms = YES
 Vale.Avoid = YES
 
-# Disable module specific rules
-OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO
-OpenShiftAsciiDoc.NoNestingInModules = NO
-OpenShiftAsciiDoc.NoXrefInModules = NO
-OpenShiftAsciiDoc.IdHasContextVariable = NO
-OpenShiftAsciiDoc.NoTocInModules = NO
-
-# Optional: pass doc attributes to asciidoctor before linting
 # Temp values are used for Prow CI comment linting only
 [asciidoctor]
 temp-ifdef = YES

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -7,15 +7,17 @@
 :OCP: OpenShift Container Platform
 :rhel-major: rhel-9
 :op-system-first: Red{nbsp}Hat Enterprise Linux (RHEL)
+:op-system-base-full: Red{nbsp}Hat Enterprise Linux (RHEL)
 :op-system-base: RHEL
 :op-system-ostree-first: Red{nbsp}Hat Enterprise Linux (RHEL) for Edge
 :op-system-ostree: RHEL for Edge
 :op-system-bootc: image mode for RHEL
 :op-system-version: 9.6
 :op-system-version-major: 9
+:op-system-bundle: Red{nbsp}Hat Device Edge
 :microshift-first: Red{nbsp}Hat build of MicroShift (MicroShift)
 :microshift-short: MicroShift
-:microshift-version: 4.20
+:microshift-version: 4.21
 :rhde: Red{nbsp}Hat Device Edge
 :ansible: Red{nbsp}Hat Ansible Automation Platform
 :ansible-version: 2.5

--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -6,6 +6,7 @@
 [id="about-rhde_{context}"]
 = About {product-title}
 
+[role="_abstract"]
 {product-title} is for organizations that need small-form-factor edge devices and support for bare metal, virtualized, or containerized applications. {product-title} is a solution for large-scale computing at the device edge that combines {microshift-short} and an edge-optimized {op-system-first} operating system. {microshift-short} is a Kubernetes orchestration in a smaller, lighter-weight footprint. Together, these components of {product-title} provide all of the benefits of containers deployed to the edge. You can manage {product-title} by using {ansible}.
 
 .{product-title} components
@@ -30,68 +31,3 @@ The latest release notes for each product that is part of {product-title} are av
 * link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/9.6_release_notes/index[{op-system-first}] 9.6 release notes.
 
 * link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{ansible-version}/html/red_hat_ansible_automation_platform_release_notes/index[{ansible} Release Notes]
-
-[id="device-edge-compatibility_{context}"]
-== {product-title} product release compatibility matrix
-
-{op-system-base} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. For example, an update of {microshift-short} from 4.18 to 4.20 requires a {op-system-base} update. Supported configurations of {product-title} use verified releases for each together as listed in the following table:
-
-[%header,cols="3",cols="1,1,2"]
-|===
-^|*{op-system-base} Version(s)*
-^|*{microshift-short} Version*
-^|*Supported {microshift-short} Version{nbsp}&#8594;{nbsp}Version Updates*
-
-^|9.6
-^|4.20
-^|4.20.0{nbsp}&#8594;{nbsp}4.20.z
-
-^|9.6
-^|4.19
-^|4.19.0{nbsp}&#8594;{nbsp}4.19.z; 4.19{nbsp}&#8594;{nbsp}4.20
-
-^|9.4
-^|4.18
-^|4.18.0{nbsp}&#8594;{nbsp}4.18.z, 4.18{nbsp}&#8594;{nbsp}4.20 on {op-system-base} 9.6
-
-^|9.4
-^|4.17
-^|4.17.1{nbsp}&#8594;{nbsp}4.17.z, 4.17{nbsp}&#8594;{nbsp}4.18
-
-^|9.4
-^|4.16
-^|4.16.0{nbsp}&#8594;{nbsp}4.16.z, 4.16{nbsp}&#8594;{nbsp}4.17, 4.16{nbsp}&#8594;{nbsp}4.18
-
-^|9.2
-^|4.15
-^|4.15.0{nbsp}&#8594;{nbsp}4.15.z, 4.15{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
-
-^|9.2
-^|4.14
-^|4.14.0{nbsp}&#8594;{nbsp}4.14.z, 4.14{nbsp}&#8594;{nbsp}4.15, 4.14{nbsp}&#8594;{nbsp}4.16 on {op-system-base} 9.4
-|===
-
-[id="device-edge-compatibility-ansible_{context}"]
-== {ansible} compatibility
-
-* When {ansible} is used to manage {product-title} deployments, you can use any supported version listed here: link:https://access.redhat.com/support/policy/updates/ansible-automation-platform#dates[{ansible} Life Cycle].
-
-* To manage an older version of {op-system-first} with {ansible}, see the link:https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix[`ansible-core` support matrix] page.
-
-[id="prod-docs-rhde_{context}"]
-== {product-title} documentation
-
-For more information about the {product-title} products, see the following documentation:
-
-* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{microshift-version}[Red Hat build of MicroShift]
-
-* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
-
-* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{ansible-version}[Product Documentation for {ansible}]
-
-[id="upgrade-paths-rhde_{context}"]
-== Upgrade paths
-
-For details about {microshift-short} upgrade paths, see the following documentation:
-
-* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{microshift-version}/html/updating/microshift-update-options#red-hat-device-edge-updates_microshift-update-options[{rhde} updates]

--- a/modules/microshift-rhde-compatibility-table-ref.adoc
+++ b/modules/microshift-rhde-compatibility-table-ref.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// rhde-overview.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="compatibility-table_{context}"]
+= Compatibility table
+
+[role="_abstract"]
+You must pair a supported version of {op-system-base} with the {microshift-short} version you are using as described in the following compatibility table.
+
+== {op-system-bundle} release compatibility matrix
+
+{op-system-base-full} and {microshift-short} work together as a single solution for device-edge computing. You can update each component separately, but the product versions must be compatible. Supported configurations of {op-system-bundle} use verified releases for each together as listed in the following table:
+
+[NOTE]
+====
+Be sure to check the support status of a release on the product lifecycle page.
+====
+
+[%header,cols="3",cols="1,1,2"]
+|===
+^|*{op-system-base} Version(s)*
+^|*{microshift-short} Version*
+^|*Supported {microshift-short} Version{nbsp}->{nbsp}Version Updates*
+
+^|10.0
+^|4.21
+^|4.21.0{nbsp}->{nbsp}4.21.z (Technology Preview)
+
+^|9.6
+^|4.21
+^|4.21.0{nbsp}->{nbsp}4.21.z
+
+^|9.6
+^|4.20
+^|4.20.0{nbsp}->{nbsp}4.20.z, 4.20{nbsp}->{nbsp}4.21
+
+^|9.6
+^|4.19
+^|4.19.0{nbsp}->{nbsp}4.19.z, 4.19{nbsp}->{nbsp}4.20
+
+^|9.4
+^|4.18
+^|4.18.0{nbsp}->4.18.z, 4.18{nbsp}->{nbsp}4.20 on {op-system-base} 9.6
+
+^|9.4
+^|4.17
+^|4.17.1{nbsp}->{nbsp}4.17.z, 4.17{nbsp}->{nbsp}4.18
+
+^|9.4
+^|4.16
+^|4.16.0{nbsp}->{nbsp}4.16.z, 4.16{nbsp}->4.17, 4.16{nbsp}->{nbsp}4.18
+
+^|9.2
+^|4.14
+^|4.14.0{nbsp}->{nbsp}4.14.z, 4.14{nbsp}->{nbsp}4.16 on {op-system-base} 9.4
+|===

--- a/overview/rhde-overview.adoc
+++ b/overview/rhde-overview.adoc
@@ -3,6 +3,27 @@
 include::_attributes/common-attributes.adoc[]
 :context: device-edge-overview
 
+:_mod-docs-content-type: ASSEMBLY
+[id="rhde-overview_{context}"]
+[role="_abstract"]
 {product-title} delivers an enterprise-ready distribution of the Red Hat-led open source community project {microshift-first} with {op-system-first} and {ansible}.
 
 include::modules/about-rhde.adoc[leveloffset=+1]
+
+include::modules/microshift-rhde-compatibility-table-ref.adoc[leveloffset=+1]
+
+[id="additional-resources_{context}"]
+[role="_additional-resources"]
+== Additional resources
+
+* link:https://access.redhat.com/support/policy/updates/ansible-automation-platform#dates[Red Hat Ansible Life Cycle]
+
+* link:https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix[`ansible-core` matrix page]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{microshift-version}[Red Hat build of MicroShift]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/{op-system-version-major}/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/{ansible-version}[Product Documentation for Red Hat Ansible]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{microshift-version}/html/updating/microshift-update-options#red-hat-device-edge-updates_microshift-update-options[Red Hat Device Edge updates]


### PR DESCRIPTION
Version(s):
RHDE 4

Issue:
https://issues.redhat.com/browse/OSDOCS-15556

Link to docs preview:
https://101107--ocpdocs-pr.netlify.app/openshift-rhde/latest/overview/rhde-overview.html

QE review:
- [x] QE has approved this change.

Additional information:
After the PR is approved for merging, do NOT sync and publish until 4.21 is released.