### PR TITLE
[OBSDOCS-2661] Update loki-create-object-storage-secret-cli.adoc

### DIFF
--- a/modules/loki-create-object-storage-secret-cli.adoc
+++ b/modules/loki-create-object-storage-secret-cli.adoc
@@ -21,11 +21,11 @@ To configure Loki object storage, you must create a secret. You can do this by u
 [source,terminal]
 ----
 $ oc create secret generic -n openshift-logging <your_secret_name> \
- --from-file=tls.key=<your_key_file>
- --from-file=tls.crt=<your_crt_file>
- --from-file=ca-bundle.crt=<your_bundle_file>
- --from-literal=username=<your_username>
- --from-literal=password=<your_password>
+  --from-file=tls.key=<your_key_file>
+  --from-file=tls.crt=<your_crt_file>
+  --from-file=ca-bundle.crt=<your_bundle_file>
+  --from-literal=username=<your_username>
+  --from-literal=password=<your_password>
 ----
 
 [NOTE]
@@ -39,5 +39,5 @@ Use generic or opaque secrets for best results.
 +
 [source,terminal]
 ----
-$ oc get secrets
+$ oc get secret -n openshift-logging
 ----


### PR DESCRIPTION
- Command structure needs to be corrected in Loki Object Storage documentation. 
- Here is the documentation link: https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html/configuring_logging/configuring-lokistack-storage#loki-create-object-storage-secret-cli_configuring-the-log-store  Current Status:

Create a secret in the directory that contains your certificate and key files by running the following command: 
~~~
$ oc create secret generic -n openshift-logging <your_secret_name> \
 --from-file=tls.key=<your_key_file>
 --from-file=tls.crt=<your_crt_file>
 --from-file=ca-bundle.crt=<your_bundle_file>
 --from-literal=username=<your_username>
 --from-literal=password=<your_password> 
~~~

- In the above commands, the "- -" signs are incorrectly placed below the "$" symbol. 
- However, they should be aligned parallel to the "oc" command, where the command begins. 
- Here is the updated look for all these commands:

Create a secret in the directory that contains your certificate and key files by running the following command: 
~~~
$ oc create secret generic -n openshift-logging <your_secret_name> \
  --from-file=tls.key=<your_key_file>
  --from-file=tls.crt=<your_crt_file>
  --from-file=ca-bundle.crt=<your_bundle_file>
  --from-literal=username=<your_username>
  --from-literal=password=<your_password>
~~~

Verify that a secret was created by running the following command:
~~~
$ oc get secret -n openshift-logging
~~~

The commands will work as it is, but the structure is incorrect.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Logging 6.4, Logging 6.3, Logging 6.2, Logging 6.1, Logging 6.0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-2661

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://101114--ocpdocs-pr.netlify.app/
https://101114--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-the-log-store.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
