### PR TITLE
OSDOCS#16684:Add a stub file in 'main' for the 4.21 RNs

### DIFF
--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -1,0 +1,11 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ocp-4-21-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/common-attributes.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch that they are relevant for.
+
+Release note changes should be added or edited in their own PR.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-16684](https://issues.redhat.com//browse/OSDOCS-16684)

Link to docs preview:
[4.21 RN stub doc](https://101122--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-release-notes)

QE review:
- [ ] QE has approved this change.
N/A for adding RN stub file to 4.21.
