### PR TITLE
[OSDOCS-16594]: Hiding HCP TOC and xrefs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2514,129 +2514,129 @@ Topics:
 # - Name: Scaling a cluster to 4 or 5 control-plane nodes
 #  File: etcd-4-5-node
 ---
-Name: Hosted control planes
-Dir: hosted_control_planes
-Distros: openshift-enterprise, openshift-origin
-Topics:
-- Name: Hosted control planes release notes
-  File: hosted-control-planes-release-notes
-- Name: Hosted control planes overview
-  File: index
-- Name: Preparing to deploy hosted control planes
-  Dir: hcp-prepare
-  Topics:
-  - Name: Requirements for hosted control planes
-    File: hcp-requirements
-  - Name: Sizing guidance for hosted control planes
-    File: hcp-sizing-guidance
-  - Name: Overriding resouce utilization measurements
-    File: hcp-override-resource-util
-  - Name: Installing the hosted control plane command-line interface
-    File: hcp-cli
-  - Name: Distributing hosted cluster workloads
-    File: hcp-distribute-workloads
-  - Name: Enabling or disabling the hosted control planes feature
-    File: hcp-enable-disable
-- Name: Deploying hosted control planes
-  Dir: hcp-deploy
-  Topics:
-  - Name: Deploying hosted control planes on AWS
-    File: hcp-deploy-aws
-  - Name: Deploying hosted control planes on bare metal
-    File: hcp-deploy-bm
-  - Name: Deploying hosted control planes on OpenShift Virtualization
-    File: hcp-deploy-virt
-  - Name: Deploying hosted control planes on non-bare-metal agent machines
-    File: hcp-deploy-non-bm
-  - Name: Deploying hosted control planes on IBM Z
-    File: hcp-deploy-ibmz
-  - Name: Deploying hosted control planes on IBM Power
-    File: hcp-deploy-ibm-power
-  - Name: Deploying hosted control planes on OpenStack
-    File: hcp-deploy-openstack
-- Name: Managing hosted control planes
-  Dir: hcp-manage
-  Topics:
-  - Name: Managing hosted control planes on AWS
-    File: hcp-manage-aws
-  - Name: Managing hosted control planes on bare metal
-    File: hcp-manage-bm
-  - Name: Managing hosted control planes on OpenShift Virtualization
-    File: hcp-manage-virt
-  - Name: Managing hosted control planes on non-bare-metal agent machines
-    File: hcp-manage-non-bm
-  - Name: Managing hosted control planes on IBM Power
-    File: hcp-manage-ibm-power
-  - Name: Managing hosted control planes on OpenStack
-    File: hcp-manage-openstack
-- Name: Deploying hosted control planes in a disconnected environment
-  Dir: hcp-disconnected
-  Topics:
-  - Name: Introduction to hosted control planes in a disconnected environment
-    File: hcp-deploy-dc
-  - Name: Deploying hosted control planes on OpenShift Virtualization in a disconnected environment
-    File: hcp-deploy-dc-virt
-  - Name: Deploying hosted control planes on bare metal in a disconnected environment
-    File: hcp-deploy-dc-bm
-  - Name: Deploying hosted control planes on IBM Z in a disconnected environment
-    File: disconnected-install-ibmz-hcp
-  - Name: Monitoring user workload in a disconnected environment
-    File: hcp-dc-monitor
-- Name: Configuring certificates for hosted control planes
-  File: hcp-certificates
-- Name: Updating hosted control planes
-  File: hcp-updating
-- Name: High availability for hosted control planes
-  Dir: hcp_high_availability
-  Topics:
-  - Name: About high availability for hosted control planes
-    File: about-hcp-ha
-  - Name: Recovering a failing etcd cluster
-    File: hcp-recovering-etcd-cluster
-  - Name: Backing up and restoring etcd in an on-premise environment
-    File: hcp-backup-restore-on-premise
-  - Name: Backing up and restoring etcd on AWS
-    File: hcp-backup-restore-aws
-  - Name: Backing up and restoring a hosted cluster on OpenShift Virtualization
-    File: hcp-backup-restore-virt
-  - Name: Disaster recovery for a hosted cluster in AWS
-    File: hcp-disaster-recovery-aws
-  - Name: Disaster recovery for a hosted cluster by using OADP
-    File: hcp-disaster-recovery-oadp
-  - Name: Automated disaster recovery for a hosted cluster by using OADP
-    File: hcp-disaster-recovery-oadp-auto
-- Name: Authentication and authorization for hosted control planes
-  File: hcp-authentication-authorization
-- Name: Handling machine configuration for hosted control planes
-  File: hcp-machine-config
-- Name: Using feature gates in a hosted cluster
-  File: hcp-using-feature-gates
-- Name: Observability for hosted control planes
-  File: hcp-observability
-- Name: Networking for hosted control planes
-  File: hcp-networking
-- Name: Troubleshooting hosted control planes
-  File: hcp-troubleshooting
-- Name: Destroying a hosted cluster
-  Dir: hcp-destroy
-  Topics:
-  - Name: Destroying a hosted cluster on AWS
-    File: hcp-destroy-aws
-  - Name: Destroying a hosted cluster on bare metal
-    File: hcp-destroy-bm
-  - Name: Destroying a hosted cluster on OpenShift Virtualization
-    File: hcp-destroy-virt
-  - Name: Destroying a hosted cluster on IBM Z
-    File: hcp-destroy-ibmz
-  - Name: Destroying a hosted cluster on IBM Power
-    File: hcp-destroy-ibm-power
-  - Name: Destroying a hosted cluster on OpenStack
-    File: hcp-destroy-openstack
-  - Name: Destroying a hosted cluster on non-bare-metal agent machines
-    File: hcp-destroy-non-bm
-- Name: Manually importing a hosted cluster
-  File: hcp-import
----
+# Name: Hosted control planes
+# Dir: hosted_control_planes
+# Distros: openshift-enterprise, openshift-origin
+# Topics:
+# - Name: Hosted control planes release notes
+#   File: hosted-control-planes-release-notes
+# - Name: Hosted control planes overview
+#   File: index
+# - Name: Preparing to deploy hosted control planes
+#   Dir: hcp-prepare
+#   Topics:
+#   - Name: Requirements for hosted control planes
+#     File: hcp-requirements
+#   - Name: Sizing guidance for hosted control planes
+#     File: hcp-sizing-guidance
+#   - Name: Overriding resouce utilization measurements
+#     File: hcp-override-resource-util
+#   - Name: Installing the hosted control plane command-line interface
+#     File: hcp-cli
+#   - Name: Distributing hosted cluster workloads
+#     File: hcp-distribute-workloads
+#   - Name: Enabling or disabling the hosted control planes feature
+#     File: hcp-enable-disable
+# - Name: Deploying hosted control planes
+#   Dir: hcp-deploy
+#   Topics:
+#   - Name: Deploying hosted control planes on AWS
+#     File: hcp-deploy-aws
+#   - Name: Deploying hosted control planes on bare metal
+#     File: hcp-deploy-bm
+#   - Name: Deploying hosted control planes on OpenShift Virtualization
+#     File: hcp-deploy-virt
+#   - Name: Deploying hosted control planes on non-bare-metal agent machines
+#     File: hcp-deploy-non-bm
+#   - Name: Deploying hosted control planes on IBM Z
+#     File: hcp-deploy-ibmz
+#   - Name: Deploying hosted control planes on IBM Power
+#     File: hcp-deploy-ibm-power
+#   - Name: Deploying hosted control planes on OpenStack
+#     File: hcp-deploy-openstack
+# - Name: Managing hosted control planes
+#   Dir: hcp-manage
+#   Topics:
+#   - Name: Managing hosted control planes on AWS
+#     File: hcp-manage-aws
+#   - Name: Managing hosted control planes on bare metal
+#     File: hcp-manage-bm
+#   - Name: Managing hosted control planes on OpenShift Virtualization
+#     File: hcp-manage-virt
+#   - Name: Managing hosted control planes on non-bare-metal agent machines
+#     File: hcp-manage-non-bm
+#   - Name: Managing hosted control planes on IBM Power
+#     File: hcp-manage-ibm-power
+#   - Name: Managing hosted control planes on OpenStack
+#     File: hcp-manage-openstack
+# - Name: Deploying hosted control planes in a disconnected environment
+#   Dir: hcp-disconnected
+#   Topics:
+#   - Name: Introduction to hosted control planes in a disconnected environment
+#     File: hcp-deploy-dc
+#   - Name: Deploying hosted control planes on OpenShift Virtualization in a disconnected environment
+#     File: hcp-deploy-dc-virt
+#   - Name: Deploying hosted control planes on bare metal in a disconnected environment
+#     File: hcp-deploy-dc-bm
+#   - Name: Deploying hosted control planes on IBM Z in a disconnected environment
+#     File: disconnected-install-ibmz-hcp
+#   - Name: Monitoring user workload in a disconnected environment
+#     File: hcp-dc-monitor
+# - Name: Configuring certificates for hosted control planes
+#   File: hcp-certificates
+# - Name: Updating hosted control planes
+#   File: hcp-updating
+# - Name: High availability for hosted control planes
+#   Dir: hcp_high_availability
+#   Topics:
+#   - Name: About high availability for hosted control planes
+#     File: about-hcp-ha
+#   - Name: Recovering a failing etcd cluster
+#     File: hcp-recovering-etcd-cluster
+#   - Name: Backing up and restoring etcd in an on-premise environment
+#     File: hcp-backup-restore-on-premise
+#   - Name: Backing up and restoring etcd on AWS
+#     File: hcp-backup-restore-aws
+#   - Name: Backing up and restoring a hosted cluster on OpenShift Virtualization
+#     File: hcp-backup-restore-virt
+#   - Name: Disaster recovery for a hosted cluster in AWS
+#     File: hcp-disaster-recovery-aws
+#   - Name: Disaster recovery for a hosted cluster by using OADP
+#     File: hcp-disaster-recovery-oadp
+#   - Name: Automated disaster recovery for a hosted cluster by using OADP
+#     File: hcp-disaster-recovery-oadp-auto
+# - Name: Authentication and authorization for hosted control planes
+#   File: hcp-authentication-authorization
+# - Name: Handling machine configuration for hosted control planes
+#   File: hcp-machine-config
+# - Name: Using feature gates in a hosted cluster
+#   File: hcp-using-feature-gates
+# - Name: Observability for hosted control planes
+#   File: hcp-observability
+# - Name: Networking for hosted control planes
+#   File: hcp-networking
+# - Name: Troubleshooting hosted control planes
+#   File: hcp-troubleshooting
+# - Name: Destroying a hosted cluster
+#   Dir: hcp-destroy
+#   Topics:
+#   - Name: Destroying a hosted cluster on AWS
+#     File: hcp-destroy-aws
+#   - Name: Destroying a hosted cluster on bare metal
+#     File: hcp-destroy-bm
+#   - Name: Destroying a hosted cluster on OpenShift Virtualization
+#     File: hcp-destroy-virt
+#   - Name: Destroying a hosted cluster on IBM Z
+#     File: hcp-destroy-ibmz
+#   - Name: Destroying a hosted cluster on IBM Power
+#     File: hcp-destroy-ibm-power
+#   - Name: Destroying a hosted cluster on OpenStack
+#     File: hcp-destroy-openstack
+#   - Name: Destroying a hosted cluster on non-bare-metal agent machines
+#     File: hcp-destroy-non-bm
+# - Name: Manually importing a hosted cluster
+#   File: hcp-import
+# ---
 Name: Nodes
 Dir: nodes
 Distros: openshift-enterprise,openshift-origin

--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -34,11 +34,11 @@ endif::openshift-dedicated,openshift-rosa[]
 include::modules/architecture-machine-roles.adoc[leveloffset=+1]
 
 // This additional resource does not apply to OSD/ROSA
-ifndef::openshift-dedicated,openshift-rosa[]
-[role="_additional-resources"]
-.Additional resources
-* xref:../hosted_control_planes/index.adoc#hcp-overview[{hcp-capital} overview]
-endif::openshift-dedicated,openshift-rosa[]
+// ifndef::openshift-dedicated,openshift-rosa[]
+// [role="_additional-resources"]
+// .Additional resources
+// * xref:../hosted_control_planes/index.adoc#hcp-overview[{hcp-capital} overview]
+// endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/operators-overview.adoc[leveloffset=+1]
 

--- a/architecture/index.adoc
+++ b/architecture/index.adoc
@@ -60,12 +60,12 @@ Operators are important components in {product-title} because they provide the f
 * Manage over-the-air updates
 * Ensure applications stay in the specified state
 
-ifndef::openshift-dedicated,openshift-rosa[]
-[role="_additional-resources"]
-.Additional resources
+// ifndef::openshift-dedicated,openshift-rosa[]
+// [role="_additional-resources"]
+// .Additional resources
 
-* xref:../hosted_control_planes/index.adoc#hcp-overview[{hcp-capital} overview]
-endif::openshift-dedicated,openshift-rosa[]
+// * xref:../hosted_control_planes/index.adoc#hcp-overview[{hcp-capital} overview]
+// endif::openshift-dedicated,openshift-rosa[]
 
 [id="about-containerized-applications-for-developers"]
 == About containerized applications for developers

--- a/architecture/mce-overview-ocp.adoc
+++ b/architecture/mce-overview-ocp.adoc
@@ -16,7 +16,7 @@ One of the challenges of scaling Kubernetes environments is managing the lifecyc
 
 When you enable multicluster engine on {product-title}, you gain the following capabilities:
 
-* xref:../hosted_control_planes/index.adoc#hcp-overview[{hcp-capital}], which is a feature that is based on the HyperShift project. With a centralized hosted control plane, you can operate {product-title} clusters in a hyperscale manner.
+* {hcp-capital}, which is a feature that is based on the HyperShift project. With a centralized hosted control plane, you can operate {product-title} clusters in a hyperscale manner.
 * Hive, which provisions self-managed {product-title} clusters to the hub and completes the initial configurations for those clusters.
 * klusterlet agent, which registers managed clusters to the hub.
 * Infrastructure Operator, which manages the deployment of the Assisted Service to orchestrate on-premise bare metal and vSphere installations of {product-title}, such as {sno} on bare metal. The Infrastructure Operator includes xref:../edge_computing/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-challenges-of-far-edge-deployments_ztp-deploying-far-edge-clusters-at-scale[{ztp-first}], which fully automates cluster creation on bare metal and vSphere provisioning with GitOps workflows to manage deployments and configuration changes.

--- a/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
@@ -26,10 +26,10 @@ After you have an etcd backup, you can xref:../../backup_and_restore/control_pla
 // Backing up etcd data
 include::modules/backup-etcd.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-[id="additional-resources_backup-etcd"]
-== Additional resources
-* xref:../../hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc#hcp-recovering-etcd-cluster[Recovering an unhealthy etcd cluster]
+// [role="_additional-resources"]
+// [id="additional-resources_backup-etcd"]
+// == Additional resources
+// * xref:../../hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc#hcp-recovering-etcd-cluster[Recovering an unhealthy etcd cluster]
 
 // Creating automated etcd backups
 include::modules/etcd-creating-automated-backups.adoc[leveloffset=+1]

--- a/etcd/etcd-backup-restore/etcd-backup.adoc
+++ b/etcd/etcd-backup-restore/etcd-backup.adoc
@@ -26,9 +26,9 @@ After you have an etcd backup, you can xref:../../backup_and_restore/control_pla
 // Backing up etcd data
 include::modules/backup-etcd.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../../hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc#hcp-recovering-etcd-cluster[Recovering an unhealthy etcd cluster]
+// [role="_additional-resources"]
+// .Additional resources
+// * xref:../../hosted_control_planes/hcp_high_availability/hcp-recovering-etcd-cluster.adoc#hcp-recovering-etcd-cluster[Recovering an unhealthy etcd cluster]
 
 // Creating automated etcd backups
 include::modules/etcd-creating-automated-backups.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc
@@ -25,9 +25,9 @@ include::modules/hcp-access-hc-aws-hcpcli.adoc[leveloffset=+1]
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
 
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
 
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]
 
 * xref:../../networking/networking_operators/sr-iov-operator/configuring-sriov-operator.adoc#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for {hcp}]
 
@@ -53,9 +53,9 @@ include::modules/hcp-custom-dns.adoc[leveloffset=+2]
 
 include::modules/hcp-aws-deploy-hc.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc#hcp-enable-arm-amd_hcp-deploy-aws[Running hosted clusters on an ARM64 architecture]
+// [role="_additional-resources"]
+// .Additional resources
+// * xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc#hcp-enable-arm-amd_hcp-deploy-aws[Running hosted clusters on an ARM64 architecture]
 
 include::modules/hcp-access-hc-aws.adoc[leveloffset=+2]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc
@@ -47,8 +47,8 @@ include::modules/hcp-bm-infra-reqs.adoc[leveloffset=+2]
 
 * xref:../../etcd/etcd-practices.adoc#recommended-etcd-practices[Recommended etcd practices]
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc[Persistent storage using {lvms}]
-* xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
+// * xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
 
 include::modules/hcp-bm-dns.adoc[leveloffset=+1]
@@ -78,11 +78,11 @@ You can create a hosted cluster on bare metal by using the command-line interfac
 
 include::modules/hcp-bm-hc.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* xref:../../hosted_control_planes/hcp-import.adoc[Manually importing a hosted cluster]
-* xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
+// * xref:../../hosted_control_planes/hcp-import.adoc[Manually importing a hosted cluster]
+// * xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
 
 include::modules/hcp-bm-hc-console.adoc[leveloffset=+2]
 
@@ -95,7 +95,7 @@ include::modules/hcp-bm-hc-mirror.adoc[leveloffset=+2]
 .Next steps
 
 * To create credentials that you can reuse when you create a hosted cluster with the console, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment].
-* To access a hosted cluster, see xref:../../hosted_control_planes/hcp-manage/hcp-manage-bm.adoc#hcp-bm-access_hcp-manage-bm[Accessing the hosted cluster].
+// * To access a hosted cluster, see xref:../../hosted_control_planes/hcp-manage/hcp-manage-bm.adoc#hcp-bm-access_hcp-manage-bm[Accessing the hosted cluster].
 * To add hosts to the host inventory by using the Discovery Image, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#add-host-host-inventory[Adding hosts to the host inventory by using the Discovery Image].
 * To extract the {product-title} release image digest, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#configure-hosted-disconnected-digest-image[Extracting the {product-title} release image digest].
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc
@@ -31,9 +31,9 @@ include::modules/hcp-ibm-power-prereqs.adoc[leveloffset=+1]
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli-terminal_hcp-cli[Installing the hosted control plane command-line interface]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli-terminal_hcp-cli[Installing the hosted control plane command-line interface]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]
 
 // IBM Power infrastructure requirements
 include::modules/hcp-ibm-power-infra-reqs.adoc[leveloffset=+1]
@@ -47,13 +47,13 @@ include::modules/hcp-custom-dns.adoc[leveloffset=+2]
 // Creating a hosted cluster by using the CLI
 include::modules/hcp-bm-hc.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* xref:../../hosted_control_planes/hcp-prepare/hcp-requirements.adoc[Requirements for hosted control planes]
-* xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-bm-dns_hcp-deploy-bm[DNS configurations on bare metal]
-* xref:../../hosted_control_planes/hcp-import.adoc[Manually importing a hosted cluster]
-* xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-requirements.adoc[Requirements for hosted control planes]
+// * xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-bm-dns_hcp-deploy-bm[DNS configurations on bare metal]
+// * xref:../../hosted_control_planes/hcp-import.adoc[Manually importing a hosted cluster]
+// * xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
 
 // About creating heterogeneous node pools on agent hosted clusters
 include::modules/hcp-ibm-power-create-heterogeneous-nodepools-agent-hc-con.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc
@@ -32,26 +32,26 @@ include::modules/hcp-ibm-z-prereqs.adoc[leveloffset=+1]
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#enable-cim[Enabling the central infrastructure management service]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli-terminal_hcp-cli[Installing the {hcp} command-line interface]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli-terminal_hcp-cli[Installing the {hcp} command-line interface]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
 
 include::modules/hcp-ibm-z-infra-reqs.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
 
 include::modules/hcp-ibm-z-dns.adoc[leveloffset=+1]
 include::modules/hcp-custom-dns.adoc[leveloffset=+2]
 
 include::modules/hcp-bm-hc.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../../hosted_control_planes/hcp-import.adoc[Manually importing a hosted cluster]
-* xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
-* xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-bm-hc-console_hcp-deploy-bm[Creating a hosted cluster on bare metal by using the console]
+// [role="_additional-resources"]
+// .Additional resources
+// * xref:../../hosted_control_planes/hcp-import.adoc[Manually importing a hosted cluster]
+// * xref:../../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-dc-extract_hcp-deploy-dc-bm[Extracting the release image digest]
+// * xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-bm-hc-console_hcp-deploy-bm[Creating a hosted cluster on bare metal by using the console]
 
 include::modules/hcp-ibm-z-infraenv.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc
@@ -48,11 +48,11 @@ include::modules/hcp-non-bm-infra-reqs.adoc[leveloffset=+2]
 
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#persistent-storage-using-lvms_logical-volume-manager-storage[Persistent storage using logical volume manager storage]
 
-* xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
+// * xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
 
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-manual_hcp-enable-disable[Manually enabling the {hcp} feature]
 
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-disable_hcp-enable-disable[Disabling the {hcp} feature]
 
 * link:4/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
 
@@ -62,10 +62,10 @@ include::modules/hcp-custom-dns.adoc[leveloffset=+2]
 
 include::modules/hcp-non-bm-hc.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-manual_hcp-import[Manually importing a hosted cluster]
+// * xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-manual_hcp-import[Manually importing a hosted cluster]
 
 include::modules/hcp-non-bm-hc-console.adoc[leveloffset=+2]
 
@@ -79,7 +79,7 @@ include::modules/hcp-non-bm-hc-mirror.adoc[leveloffset=+2]
 
 * To create credentials that you can reuse when you create a hosted cluster with the console, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment].
 
-* To access a hosted cluster, see xref:../../hosted_control_planes/hcp-manage/hcp-manage-bm.adoc#hcp-bm-access_hcp-manage-bm[Accessing the hosted cluster].
+// * To access a hosted cluster, see xref:../../hosted_control_planes/hcp-manage/hcp-manage-bm.adoc#hcp-bm-access_hcp-manage-bm[Accessing the hosted cluster].
 
 * To add hosts to the host inventory by using the Discovery Image, see link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#add-host-host-inventory[Adding hosts to the host inventory by using the Discovery Image].
 

--- a/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
+++ b/hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc
@@ -22,8 +22,8 @@ You can use the hosted control plane command-line interface, `hcp`, to create an
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
+// * xref:../../hosted_control_planes/hcp-import.adoc#hcp-import-disable_hcp-import[Disabling the automatic import of hosted clusters into {mce-short}]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc[Enabling or disabling the {hcp} feature]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#ansible-config-hosted-cluster[Configuring Ansible Automation Platform jobs to run on hosted clusters]
 
 include::modules/hcp-virt-reqs.adoc[leveloffset=+1]
@@ -42,7 +42,7 @@ include::modules/hcp-virt-prereqs.adoc[leveloffset=+2]
 * xref:../../virt/install/installing-virt.adoc#installing-virt-web[Installing OpenShift Virtualization using the web console]
 * xref:../../post_installation_configuration/post-install-storage-configuration.adoc#post-install-storage-configuration[Postinstallation storage configuration]
 * link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure]
-* xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc#hcp-metallb_hcp-deploy-virt[Configuring MetalLB]
+// * xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc#hcp-metallb_hcp-deploy-virt[Configuring MetalLB]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#advanced-config-engine[Advanced configuration]
 
 include::modules/hcp-virt-firewall-port.adoc[leveloffset=+2]
@@ -63,7 +63,7 @@ include::modules/hcp-virt-create-hc-console.adoc[leveloffset=+2]
 
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment]
 
-* xref:../../hosted_control_planes/hcp-manage/hcp-manage-virt.adoc#hcp-virt-access_hcp-manage-virt[Accessing the hosted cluster]
+// * xref:../../hosted_control_planes/hcp-manage/hcp-manage-virt.adoc#hcp-virt-access_hcp-manage-virt[Accessing the hosted cluster]
 
 include::modules/hcp-virt-ingress-dns.adoc[leveloffset=+1]
 include::modules/hcp-custom-dns.adoc[leveloffset=+2]

--- a/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc
+++ b/hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc
@@ -20,7 +20,7 @@ include::modules/hcp-dc-mgmt-cluster.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.html#hcp-enable-manual-addon_hcp-enable-disable[Manually enabling the hypershift-addon managed cluster add-on for local-cluster]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-enable-disable.html#hcp-enable-manual-addon_hcp-enable-disable[Manually enabling the hypershift-addon managed cluster add-on for local-cluster]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with multicluster engine operator]
 
 include::modules/hcp-dc-web-server.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-import.adoc
+++ b/hosted_control_planes/hcp-import.adoc
@@ -15,8 +15,8 @@ include::modules/hcp-import-limitations.adoc[leveloffset=+1]
 [role="_additional-resources_{context}"]
 == Additional resources
 
-* xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]
-* xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-ocp-hc_hcp-updating[Updating a control plane in a hosted cluster]
+// * xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]
+// * xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-ocp-hc_hcp-updating[Updating a control plane in a hosted cluster]
 * link:https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.11/html/clusters/cluster_mce_overview#discover-hosted-acm[Discovering {mce} hosted clusters in {rh-rhacm-title}]
 
 include::modules/hcp-import-manual.adoc[leveloffset=+1]

--- a/hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-bm.adoc
@@ -16,10 +16,10 @@ include::modules/hcp-bm-add-np.adoc[leveloffset=+2]
 include::modules/hcp-bm-autoscale.adoc[leveloffset=+2]
 include::modules/hcp-bm-autoscale-disable.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* xref:../../hosted_control_planes/hcp-troubleshooting.adoc#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero]
+// * xref:../../hosted_control_planes/hcp-troubleshooting.adoc#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero]
 
 include::modules/hcp-bm-ingress.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-manage/hcp-manage-ibm-power.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-ibm-power.adoc
@@ -20,4 +20,4 @@ include::modules/hcp-ibm-power-scale-np.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../../installing/installing_ibm_power/installing-ibm-power.adoc#installation-operators-config[Initial Operator configuration]
-* xref:../../hosted_control_planes/hcp-troubleshooting.adoc#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero]
+// * xref:../../hosted_control_planes/hcp-troubleshooting.adoc#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero]

--- a/hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
+++ b/hosted_control_planes/hcp-manage/hcp-manage-non-bm.adoc
@@ -16,10 +16,10 @@ include::modules/hcp-bm-add-np.adoc[leveloffset=+2]
 include::modules/hcp-bm-autoscale.adoc[leveloffset=+2]
 include::modules/hcp-bm-autoscale-disable.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* xref:../../hosted_control_planes/hcp-troubleshooting.adoc#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero]
+// * xref:../../hosted_control_planes/hcp-troubleshooting.adoc#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero]
 
 include::modules/hcp-bm-ingress.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-requirements.adoc
@@ -31,7 +31,7 @@ include::modules/hcp-fips.adoc[leveloffset=+1]
 .Additional resources
 * link:https://access.redhat.com/articles/7120837[The {mce} 2.9 support matrix]
 * link:https://access.redhat.com/labs/ocpouic/?operator=multicluster-engine&&upgrade_path=4.14%20to%204.16[Red{nbsp}Hat {product-title} Operator Update Information Checker]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc#hcp-shared-infra_hcp-sizing-guidance[Shared infrastructure between hosted and standalone control planes]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc#hcp-shared-infra_hcp-sizing-guidance[Shared infrastructure between hosted and standalone control planes]
 
 include::modules/hcp-cidr-ranges.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc
+++ b/hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc
@@ -19,11 +19,11 @@ See the following highly available {hcp} requirements, which were tested with {p
 * Minimum vCPU: approximately 5.5 cores
 * Minimum memory: approximately 19 GiB
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* xref:../../hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc#hcp-override-resource-util[Overriding resource utilization measurements]
-* xref:../../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-distribute-workloads[Distributing hosted cluster workloads]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc#hcp-override-resource-util[Overriding resource utilization measurements]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-distribute-workloads[Distributing hosted cluster workloads]
 
 include::modules/hcp-pod-limits.adoc[leveloffset=+1]
 
@@ -37,7 +37,7 @@ include::modules/hcp-load-based-limit.adoc[leveloffset=+1]
 include::modules/hcp-sizing-calculation.adoc[leveloffset=+1]
 include::modules/hcp-shared-infra.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* xref:../../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc[Sizing guidance for {hcp}]
+// * xref:../../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc[Sizing guidance for {hcp}]

--- a/hosted_control_planes/hcp-troubleshooting.adoc
+++ b/hosted_control_planes/hcp-troubleshooting.adoc
@@ -12,9 +12,9 @@ If you encounter issues with {hcp}, see the following information to guide you t
 
 include::modules/hosted-control-planes-troubleshooting.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../hosted_control_planes/hcp-prepare/hcp-cli.adoc[Installing the {hcp} command-line interface]
+// [role="_additional-resources"]
+// .Additional resources
+// * xref:../hosted_control_planes/hcp-prepare/hcp-cli.adoc[Installing the {hcp} command-line interface]
 
 [id="hcp-must-gather-day-2"]
 == Gathering {product-title} data for a hosted cluster

--- a/hosted_control_planes/hcp-updating.adoc
+++ b/hosted_control_planes/hcp-updating.adoc
@@ -18,8 +18,8 @@ include::modules/hcp-updating-requirements.adoc[leveloffset=+1]
 * xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[Updating a cluster using the web console]
 * xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI]
 * xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators]
-* xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-ocp-hc_hcp-updating[Updating a control plane in a hosted cluster]
-* xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]
+// * xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-ocp-hc_hcp-updating[Updating a control plane in a hosted cluster]
+// * xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]
 
 include::modules/hcp-get-ocp-channel.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/hosted-control-planes-release-notes.adoc
+++ b/hosted_control_planes/hosted-control-planes-release-notes.adoc
@@ -10,107 +10,21 @@ include::snippets/hcp-snippet.adoc[]
 
 Release notes contain information about new and deprecated features, changes, and known issues.
 
-[id="hcp-4-19-release-notes_{context}"]
-== {hcp-capital} release notes for {product-title} 4.19
+[id="hcp-4-20-release-notes_{context}"]
+== {hcp-capital} release notes for {product-title} 4.20
 
-With this release, {hcp} for {product-title} 4.19 is available. {hcp-capital} for {product-title} 4.19 supports {mce} version 2.9.
+With this release, {hcp} for {product-title} 4.20 is available. {hcp-capital} for {product-title} 4.20 supports {mce} version 2.10.
 
-[id="hcp-4-19-new-features-and-enhancements_{context}"]
+[id="hcp-4-20-new-features-and-enhancements_{context}"]
 === New features and enhancements
 
-[id="hcp-4-19-custom-dns_{context}"]
-==== Defining a custom DNS name
 
-Cluster administrators can now define a custom DNS name for a hosted cluster to provide for more flexibility in how DNS names are managed and used. For more information, see xref:../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-custom-dns_hcp-deploy-bm[Defining a custom DNS name].
-
-[id="hcp-4-19-aws-tags_{context}"]
-==== Adding or updating {aws-short} tags for hosted clusters
-
-Cluster administrators can add or update {aws-first} tags for several different types of resources. For more information, see xref:../hosted_control_planes/hcp-manage/hcp-manage-aws.adoc#hcp-aws-tags_hcp-managing-aws[Adding or updating {aws-short} tags for a hosted cluster].
-
-[id="hcp-4-19-auto-dr-oadp_{context}"]
-==== Automated disaster recovery for a hosted cluster by using {oadp-short}
-
-On bare metal or {aws-first} platforms, you can automate disaster recovery for a hosted cluster by using {oadp-first}. For more information, see xref:../hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp-auto.adoc#hcp-disaster-recovery-oadp-auto[Automated disaster recovery for a hosted cluster by using OADP].
-
-[id="hcp-4-19-dr-agent_{context}"]
-==== Disaster recovery for a hosted cluster on a bare-metal platform
-
-For hosted clusters on a bare-metal platform, you can complete disaster recovery tasks by using {oadp-short}, including backing up the data plane and control plane workloads and restoring either to the same management cluster or to a new management cluster. For more information, see xref:../hosted_control_planes/hcp_high_availability/hcp-disaster-recovery-oadp.adoc#hcp-disaster-recovery-oadp[Disaster recovery for a hosted cluster by using OADP].
-
-[id="hcp-4-19-openstack_{context}"]
-==== {hcp-capital} on {rh-openstack-first} 17.1 (Technology Preview)
-
-{hcp-capital} on {rh-openstack} 17.1 is now supported as a Technology Preview feature.
-
-For more information, see xref:../hosted_control_planes/hcp-deploy/hcp-deploy-openstack.adoc#hosted-clusters-openstack-prerequisites_hcp-deploy-openstack[Deploying {hcp} on OpenStack].
-
-[id="hcp-4-19-np-capacity-blocks_{context}"]
-==== Configuring node pool capacity blocks on {aws-short}
-
-You can now configure node pool capacity blocks for {hcp} on {aws-first}. For more information, see xref:../hosted_control_planes/hcp-manage/hcp-manage-aws.adoc#hcp-np-capacity-blocks_hcp-managing-aws[Configuring node pool capacity blocks on {aws-short}].
-
-[id="bug-fixes-hcp-rn-4-19_{context}"]
+[id="bug-fixes-hcp-rn-4-20_{context}"]
 === Bug fixes
 
-//FYI - OCPBUGS-56792 is a duplicate of this bug
-* Previously, when an IDMS or ICSP in the management OpenShift cluster defined a source that pointed to registry.redhat.io or registry.redhat.io/redhat, and the mirror registry did not contain the required OLM catalog images, provisioning for the `HostedCluster` resource stalled due to unauthorized image pulls. As a consequence, the `HostedCluster` resource was not deployed, and it remained blocked, where it could not pull essential catalog images from the mirrored registry.
-+
-With this release, if a required image cannot be pulled due to authorization errors, the provisioning now explicitly fails. The logic for registry override is improved to allow matches on the root of the registry, such as registry.redhat.io, for OLM CatalogSource image resolution. A fallback mechanism is also introduced to use the original `ImageReference` if the registry override does not yield a working image.
-+
-As a result, the `HostedCluster` resource can be deployed successfully, even in scenarios where the mirror registry lacks the required OLM catalog images, as the system correctly falls back to pulling from the original source when appropriate. (link:https://issues.redhat.com/browse/OCPBUGS-56492[OCPBUGS-56492])
 
-* Previously, the control plane controller did not properly select the correct CVO manifests for a feature set. As a consequence, the incorrect CVO manifests for a feature set might have been deployed for hosted clusters. In practice, CVO manifests never differed between feature sets, so this issue had no actual impact. With this release, the control plane controller properly selects the correct CVO manifests for a feature set. As a result, the correct CVO manifests for a feature set are deployed for the hosted cluster. (link:https://issues.redhat.com/browse/OCPBUGS-44438[OCPBUGS-44438])
 
-* Previously, when you set a secure proxy for a `HostedCluster` resource that served a certificate signed by a custom CA, that CA was not included in the initial ignition configuration for the node. As a result, the node did not boot due to failed ignition. This release fixes the issue by including the trusted CA for the proxy in the initial ignition configuration, which results in a successful node boot and ignition. (link:https://issues.redhat.com/browse/OCPBUGS-56896[OCPBUGS-56896])
-
-* Previously, the IDMS or ICSP resources from the management cluster were processed without considering that a user might specify only the root registry name as a mirror or source for image replacement. As a consequence, any IDMS or ICSP entries that used only the root registry name did not work as expected. With this release, the mirror replacement logic now correctly handles cases where only the root registry name is provided. As a result, the issue no longer occurs, and the root registry mirror replacements are now supported. (link:https://issues.redhat.com/browse/OCPBUGS-55693[OCPBUGS-55693])
-
-* Previously, the OADP plugin looked for the `DataUpload` object in the wrong namespace. As a consequence, the backup process was stalled indefinitely. In this release, the plugin uses the source namespace of the backup object, so this problem no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-55469[OCPBUGS-55469])
-
-* Previously, the SAN of the custom certificate that the user added to the `hc.spec.configuration.apiServer.servingCerts.namedCertificates` field conflicted with the hostname that was set in the `hc.spec.services.servicePublishingStrategy` field for the Kubernetes agent server (KAS). As a consequence, the KAS certificate was not added to the set of certificates to generate a new payload, and any new nodes that attempted to join the `HostedCluster` resource had issues with certificate validation. This release adds a validation step to fail earlier and warn the user about the issue, so that the problem no longer occurs. (link:https://issues.redhat.com/browse/OCPBUGS-53261[OCPBUGS-53261])
-
-* Previously, when you created a hosted cluster in a shared VPC, the private link controller sometimes failed to assume the shared VPC role to manage the VPC endpoints in the shared VPC. With this release, a client is created for every reconciliation in the private link controller so that you can recover from invalid clients. As a result, the hosted cluster endpoints and the hosted cluster are created successfully. (link:https://issues.redhat.com/browse/OCPBUGS-45184[*OCPBUGS-45184*])
-
-* Previously, ARM64 architecture was not allowed in the `NodePool` API on the Agent platform. As a consequence, you could not deploy heterogeneous clusters on the Agent platform. In this release, the API allows ARM64-based `NodePool` resources on the Agent platform. (link:https://issues.redhat.com/browse/OCPBUGS-46342[OCPBUGS-46342])
-
-* Previously, the HyperShift Operator always validated the subject alternative names (SANs) for the Kubernetes API server. With this release, the Operator validates the SANs only if PKI reconciliation is enabled. (link:https://issues.redhat.com/browse/OCPBUGS-56562[OCPBUGS-56562])
-
-* Previously, in a hosted cluster that existed for more than 1 year, when the internal serving certificates were renewed, the control plane workloads did not restart to pick up the renewed certificates. As a consequence, the control plane became degraded. With this release, when certificates are renewed, the control plane workloads are automatically restarted. As a result, the control plane remains stable. (link:https://issues.redhat.com/browse/OCPBUGS-52331[OCPBUGS-52331])
-
-* Previously, when you created a validating webhook on a resource that the OpenShift OAuth API server managed, such as a user or a group, the validating webhook was not executed. This release fixes the communication between the OpenShift OAuth API server and the data plane by adding a `Konnectivity` proxy sidecar. As a result, the process to validate webhooks on users and groups works as expected. (link:https://issues.redhat.com/browse/OCPBUGS-52190[OCPBUGS-52190])
-
-* Previously, when the `HostedCluster` resource was not available, the reason was not propagated correctly from `HostedControlPlane` resource in the condition. The `Status` and the `Message` information was propagated for the `Available` condition in the `HostedCluster` custom resource, but the `Resource` value was not propagated. In this release, the reason is also propagated, so you have more information to identify the root cause of unavailability. (link:https://issues.redhat.com/browse/OCPBUGS-50907[OCPBUGS-50907])
-
-* Previously, the `managed-trust-bundle` volume mount and the `trusted-ca-bundle-managed` config map were introduced as mandatory components. This requirement caused deployment failures if you used your own Public Key Infrastructure (PKI), because the OpenShift API server expected the presence of the `trusted-ca-bundle-managed` config map. To address this issue, these components are now optional, so that clusters can deploy successfully without the `trusted-ca-bundle-managed` config map when you are using a custom PKI. (link:https://issues.redhat.com/browse/OCPBUGS-52323[OCPBUGS-52323])
-
-* Previously, there was no way to verify that an `IBMPowerVSImage` resource was deleted, which led to unnecessary cluster retrieval attempts. As a consequence, hosted clusters on {ibm-power-server-title} were stuck in the destroy state. In this release, you can retrieve and process a cluster that is associated with an image only if the image is not in the process of being deleted. (link:https://issues.redhat.com/browse/OCPBUGS-46037[OCPBUGS-46037])
-
-* Previously, when you created a cluster with secure proxy enabled and set the certificate configuration to `configuration.proxy.trustCA`, the cluster installation failed. In addition, the OpenShift OAuth API server could not use the management cluster proxy to reach cloud APIs. This release introduces fixes to prevent these issues. (link:https://issues.redhat.com/browse/OCPBUGS-51050[OCPBUGS-51050])
-
-* Previously, both the `NodePool` controller and the cluster API controller set the `updatingConfig` status condition on the `NodePool` custom resource. As a consequence, the `updatingConfig` status was constantly changing. With this release, the logic to update the `updatingConfig` status is consolidated between the two controllers. As a result, the `updatingConfig` status is correctly set. (link:https://issues.redhat.com/browse/OCPBUGS-45322[OCPBUGS-45322])
-
-* Previously, the process to validate the container image architecture did not pass through the image metadata provider. As a consequence, image overrides did not take effect, and disconnected deployments failed. In this release, the methods for the image metadata provider are modified to allow multi-architecture validations, and are propagated through all components for image validation. As a result, the issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-44655[OCPBUGS-44655])
-
-* Previously, the `--goaway-chance` flag for the Kubernetes API Server was not configurable. The default value for the flag was `0`. With this release, you can change the value for the `--goaway-chance` flag by adding an annotation to the `HostedCluster` custom resource. (link:https://issues.redhat.com/browse/OCPBUGS-54863[OCPBUGS-54863])
-
-* Previously, on instances of Red{nbsp}Hat OpenShift on {ibm-cloud-title} that are based on {hcp}, in non-OVN clusters, the Cluster Network Operator could not patch service monitors and Prometheus rules in the `monitoring.coreos.com` API group. As a consequence, the Cluster Network Operator logs showed permissions errors and "could not apply" messages. With this release, permissions for service monitors and Prometheus rules are added in the Cluster Network Operator for non-OVN clusters. As a result, the Cluster Network Operator logs no longer show permissions errors. (link:https://issues.redhat.com/browse/OCPBUGS-54178[OCPBUGS-54178])
-
-* Previously, if you tried to use the {hcp} command-line interface (CLI) to create a disconnected cluster, the creation failed because the CLI could not access the payload. With this release, the release payload architecture check is skipped in disconnected environments because the registry where it is hosted is not usually accessible from the machine where the CLI runs. As a result, you can now use the CLI to create a disconnected cluster. (link:https://issues.redhat.com/browse/OCPBUGS-47715[OCPBUGS-47715])
-
-* Previously, when the Control Plane Operator checked API endpoint availability, the Operator did not honor the `_*PROXY` variables that were set. As a consequence, HTTP requests to validate the Kubernetes API Server failed when egress traffic was blocked, except through a proxy, and the hosted control plane and hosted cluster were not available. With this release, this issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-49913[OCPBUGS-49913])
-
-* Previously, when you used the {hcp} CLI (`hcp`) to create a hosted cluster, you could not configure the etcd storage size. As a consequence, the disk size was not sufficient for some larger clusters. With this release, you can set the etcd storage size by setting a flag in your `HostedCluster` resource. The flag was initially added to help the OpenShift performance team with testing higher `NodePool` resources on ROSA with HCP. As a result, you can now set the etcd storage size when you create a hosted cluster by using the `hcp` CLI. (link:https://issues.redhat.com/browse/OCPBUGS-52655[OCPBUGS-52655])
-
-* Previously, if you tried to update a hosted cluster that used in-place updates, the proxy variables were not honored and the update failed. With this release, the pod that performs in-place upgrades honors the cluster proxy settings. As a result, updates now work for hosted clusters that use in-place updates. (link:https://issues.redhat.com/browse/OCPBUGS-48540[OCPBUGS-48540])
-
-* Previously, the liveness and readiness probes that are associated with the OpenShift API server in {hcp} were misaligned with the probes that are used in installer-provisioned infrastructure. This release updates the liveness and readiness probes to use the `/livez` and `/readyz` endpoints instead of the `/healthz` endpoint. (link:https://issues.redhat.com/browse/OCPBUGS-54819[OCPBUGS-54819])
-
-* Previously, the Konnectivity agent on a hosted control plane did not have a readiness check. This release adds a readiness probe to the Konnectivity agent to indicate pod readiness when the connection to Konnectivity server drops. (link:https://issues.redhat.com/browse/OCPBUGS-49611[OCPBUGS-49611])
-
-* Previously, when the HyperShift Operator was scoped to a subset of hosted clusters and node pools, the Operator did not properly clean up token and user data secrets in control plane namespaces. As a consequence, secrets accumulated. With this release, the Operator properly cleans up secrets. (link:https://issues.redhat.com/browse/OCPBUGS-54272[OCPBUGS-54272])
-
-[id="known-issues-hcp-rn-4-19_{context}"]
+[id="known-issues-hcp-rn-4-20_{context}"]
 === Known issues
 
 * If the annotation and the `ManagedCluster` resource name do not match, the {mce} console displays the cluster as `Pending import`. The cluster cannot be used by the {mce-short}. The same issue happens when there is no annotation and the `ManagedCluster` name does not match the `Infra-ID` value of the `HostedCluster` resource.
@@ -165,30 +79,15 @@ For {ibm-power-title} and {ibm-z-title}, you must run the control plane on machi
 .{hcp-capital} GA and TP tracker
 [cols="4,1,1,1",options="header"]
 |===
-|Feature |4.17 |4.18 |4.19
+|Feature |4.18 |4.19 |4.20
 
 |{hcp-capital} for {product-title} using non-bare-metal agent machines
 |Technology Preview
 |Technology Preview
 |Technology Preview
 
-|{hcp-capital} for an ARM64 {product-title} cluster on {aws-full}
-|General Availability
-|General Availability
-|General Availability
-
-|{hcp-capital} for {product-title} on {ibm-power-title}
-|General Availability
-|General Availability
-|General Availability
-
-|{hcp-capital} for {product-title} on {ibm-z-title}
-|General Availability
-|General Availability
-|General Availability
-
 |{hcp-capital} for {product-title} on {rh-openstack}
 |Developer Preview
-|Developer Preview
+|Technology Preview
 |Technology Preview
 |===

--- a/observability/logging/api_reference/logging-5-7-reference.adoc
+++ b/observability/logging/api_reference/logging-5-7-reference.adoc
@@ -17,11 +17,11 @@ See the following highly available {hcp} requirements, which were tested with {p
 * Minimum vCPU: approximately 5.5 cores
 * Minimum memory: approximately 19 GiB
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* For more information about disabling the metric service monitoring, see xref:../../hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc#hcp-override-resource-util[Overriding resource utilization measurements].
-* For more information about highly available {hcp} topology, see xref:../../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-distribute-workloads[Distributing hosted cluster workloads].
+// * For more information about disabling the metric service monitoring, see xref:../../hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc#hcp-override-resource-util[Overriding resource utilization measurements].
+// * For more information about highly available {hcp} topology, see xref:../../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-distribute-workloads[Distributing hosted cluster workloads].
 
 include::modules/hcp-pod-limits.adoc[leveloffset=+1]
 

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -152,7 +152,9 @@ For more information, see xref:../extensions/ce/managing-ce.adoc#olmv1-supported
 [id="ocp-release-notes-hcp_{context}"]
 === Hosted control planes
 
-Because {hcp} releases asynchronously from {product-title}, it has its own release notes. For more information, see xref:../hosted_control_planes/hosted-control-planes-release-notes.adoc#hosted-control-planes-release-notes[{hcp-capital} release notes].
+include::snippets/hcp-snippet.adoc[]
+
+// Because {hcp} releases asynchronously from {product-title}, it has its own release notes. For more information, see xref:../hosted_control_planes/hosted-control-planes-release-notes.adoc#hosted-control-planes-release-notes[{hcp-capital} release notes].
 
 [id="ocp-release-notes-ibm-power_{context}"]
 === {ibm-power-title}

--- a/scalability_and_performance/cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile.adoc
+++ b/scalability_and_performance/cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile.adoc
@@ -30,7 +30,7 @@ include::modules/cnf-gathering-data-about-hosted-cluster-using-must-gather.adoc[
 
 * xref:../support/gathering-cluster-data.adoc#nodes-nodes-managing[Gathering data about your cluster] 
 
-* xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-must-gather-cli[Gathering data for a hosted cluster by using the CLI].
+// * xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-must-gather-cli[Gathering data for a hosted cluster by using the CLI].
 
 include::modules/cnf-running-the-performance-creator-profile-hosted.adoc[leveloffset=+2]
 

--- a/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+++ b/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
@@ -46,7 +46,7 @@ include::modules/cnf-gathering-data-about-cluster-using-must-gather.adoc[levelof
 
 * xref:../support/gathering-cluster-data.adoc#nodes-nodes-managing[Gathering data about your cluster]
 
-* xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-must-gather-cli[Gathering data for a hosted cluster by using the CLI]
+// * xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-must-gather-cli[Gathering data for a hosted cluster by using the CLI]
 
 include::modules/cnf-running-the-performance-creator-profile.adoc[leveloffset=+2]
 

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -35,6 +35,6 @@ include::modules/node-tuning-hosted-cluster.adoc[leveloffset=+1]
 
 include::modules/advanced-node-tuning-hosted-cluster.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../hosted_control_planes/index.adoc#hosted-control-planes-overview[{hcp-capital} overview]
+// [role="_additional-resources"]
+// .Additional resources
+// * xref:../hosted_control_planes/index.adoc#hosted-control-planes-overview[{hcp-capital} overview]

--- a/security/certificates/api-server.adoc
+++ b/security/certificates/api-server.adoc
@@ -13,7 +13,9 @@ by one that is issued by a CA that clients trust.
 
 [NOTE]
 ====
-In hosted control plane clusters, you can add as many custom certificates to your Kubernetes API Server as you need. However, do not add a certificate for the endpoint that worker nodes use to communicate with the control plane. For more information, see xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-custom-cert_hcp-deploy-bm[Configuring a custom API server certificate in a hosted cluster].
+In hosted control plane clusters, you can add as many custom certificates to your Kubernetes API Server as you need. However, do not add a certificate for the endpoint that worker nodes use to communicate with the control plane.
+
+// For more information, see xref:../../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-custom-cert_hcp-deploy-bm[Configuring a custom API server certificate in a hosted cluster].
 ====
 
 include::modules/customize-certificates-api-add-named.adoc[leveloffset=+1]

--- a/security/compliance_operator/co-management/compliance-operator-installation.adoc
+++ b/security/compliance_operator/co-management/compliance-operator-installation.adoc
@@ -51,7 +51,7 @@ include::modules/compliance-operator-hcp-install.adoc[leveloffset=+1]
 .Additional resources
 
 // 4.13+
-* xref:../../../hosted_control_planes/index.adoc#hcp-overview[{hcp-capital} overview]
+// * xref:../../../hosted_control_planes/index.adoc#hcp-overview[{hcp-capital} overview]
 //
 // 4.11-4.12, commenting out of 4.13-main
 //* xref:../../../architecture/control-plane.adoc#hosted-control-planes-overview_control-plane[Overview of {hcp} (Technology Preview)]

--- a/snippets/hcp-snippet.adoc
+++ b/snippets/hcp-snippet.adoc
@@ -6,5 +6,5 @@
 
 [IMPORTANT]
 ====
-{hcp-capital} is currently not available for {product-title} {product-version}. The feature is planned to be released in the near future.
+{hcp-capital} for {product-title} {product-version} is planned to be available with an upcoming release of {mce-short}. In the meantime, see the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/hosted_control_planes/hosted-control-planes-release-notes-1[{hcp} documentation for {product-title} 4.19].
 ====

--- a/storage/container_storage_interface/persistent-storage-csi-group-snapshots.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-group-snapshots.adoc
@@ -11,7 +11,7 @@ This document describes how to use volume group snapshots with supported Contain
 :FeatureName: CSI volume group snapshots
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-To use this Technology Preview feature, you must xref:../../hosted_control_planes/hcp-using-feature-gates.adoc#hcp-enable-feature-sets_hcp-using-feature-gates[enable it using feature gates].
+To use this Technology Preview feature, you must enable it using feature gates.
 
 include::modules/persistent-storage-csi-group-snapshots-overview.adoc[leveloffset=+1]
 
@@ -26,4 +26,4 @@ include::modules/persistent-storage-csi-group-snapshots-restore.adoc[leveloffset
 == Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi-snapshots.adoc#persistent-storage-csi-snapshots[CSI volume snapshots]
 
-* xref:../../hosted_control_planes/hcp-using-feature-gates.adoc#hcp-enable-feature-sets_hcp-using-feature-gates[Enabling features sets by using feature gates]
+// * xref:../../hosted_control_planes/hcp-using-feature-gates.adoc#hcp-enable-feature-sets_hcp-using-feature-gates[Enabling features sets by using feature gates]

--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -31,11 +31,11 @@ ifndef::openshift-origin[]
 include::modules/support-gather-data.adoc[leveloffset=+2]
 endif::openshift-origin[]
 
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-[role="_additional-resources"]
-.Additional resources
-* xref:../hosted_control_planes/hcp-troubleshooting.adoc#hosted-control-planes-troubleshooting_hcp-troubleshooting[Gathering information to troubleshoot {hcp}]
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+// ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+// [role="_additional-resources"]
+// .Additional resources
+// * xref:../hosted_control_planes/hcp-troubleshooting.adoc#hosted-control-planes-troubleshooting_hcp-troubleshooting[Gathering information to troubleshoot {hcp}]
+// endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 ifndef::openshift-origin[]
 // Table of must-gather flags

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -76,7 +76,9 @@ Version {product-version} of {product-title} requires VMware virtual hardware ve
 [id="updating-clusters-overview-hosted-control-planes"]
 == Updating {hcp}
 
-xref:../hosted_control_planes/hcp-updating.adoc#hcp-updating_hcp-updating[Updating {hcp}]: On {hcp} for {product-title}, updates are decoupled between the control plane and the nodes. Your service cluster provider, which is the user that hosts the cluster control planes, can manage the updates as needed. The hosted cluster handles control plane updates, and node pools handle node updates. For more information, see the following information:
+include::snippets/hcp-snippet.adoc[]
 
-* xref:../hosted_control_planes/hcp-updating.adoc#hcp-updates-hosted-cluster_hcp-updating[Updates for the hosted cluster]
-* xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]
+// xref:../hosted_control_planes/hcp-updating.adoc#hcp-updating_hcp-updating[Updating {hcp}]: On {hcp} for {product-title}, updates are decoupled between the control plane and the nodes. Your service cluster provider, which is the user that hosts the cluster control planes, can manage the updates as needed. The hosted cluster handles control plane updates, and node pools handle node updates. For more information, see the following information:
+
+// * xref:../hosted_control_planes/hcp-updating.adoc#hcp-updates-hosted-cluster_hcp-updating[Updates for the hosted cluster]
+// * xref:../hosted_control_planes/hcp-updating.adoc#hcp-update-node-pools_hcp-updating[Updating node pools in a hosted cluster]

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -291,38 +291,38 @@ a|* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-sched
 * xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets]
 |===
 
-[id="self-managed-hcp"]
-== {hcp-capital}
+// [id="self-managed-hcp"]
+// == {hcp-capital}
 
-[options="header",cols="2*",width="%autowidth.stretch"]
-|===
-|Learn about {hcp} |Optional additional resources
+// [options="header",cols="2*",width="%autowidth.stretch"]
+// |===
+// |Learn about {hcp} |Optional additional resources
 
-| xref:../hosted_control_planes/index.adoc#hosted-control-planes-overview[Hosted control planes overview]
-a|
-xref:../hosted_control_planes/index.adoc#hosted-control-planes-version-support_hcp-overview[Versioning for {hcp}]
+// | xref:../hosted_control_planes/index.adoc#hosted-control-planes-overview[Hosted control planes overview]
+// a|
+// xref:../hosted_control_planes/index.adoc#hosted-control-planes-version-support_hcp-overview[Versioning for {hcp}]
 
-| Preparing to deploy
-a| * xref:../hosted_control_planes/hcp-prepare/hcp-requirements.adoc#hcp-requirements[Requirements for {hcp}]
-* xref:../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc#hcp-sizing-guidance[Sizing guidance for {hcp}]
-* xref:../hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc#hcp-override-resource-util[Overriding resource utilization measurements]
-* xref:../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli[Installing the {hcp} command-line interface]
-* xref:../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-distribute-workloads[Distributing hosted cluster workloads]
-* xref:../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-disable[Enabling or disabling the {hcp} feature]
+// | Preparing to deploy
+// a| * xref:../hosted_control_planes/hcp-prepare/hcp-requirements.adoc#hcp-requirements[Requirements for {hcp}]
+// * xref:../hosted_control_planes/hcp-prepare/hcp-sizing-guidance.adoc#hcp-sizing-guidance[Sizing guidance for {hcp}]
+// * xref:../hosted_control_planes/hcp-prepare/hcp-override-resource-util.adoc#hcp-override-resource-util[Overriding resource utilization measurements]
+// * xref:../hosted_control_planes/hcp-prepare/hcp-cli.adoc#hcp-cli[Installing the {hcp} command-line interface]
+// * xref:../hosted_control_planes/hcp-prepare/hcp-distribute-workloads.adoc#hcp-distribute-workloads[Distributing hosted cluster workloads]
+// * xref:../hosted_control_planes/hcp-prepare/hcp-enable-disable.adoc#hcp-enable-disable[Enabling or disabling the {hcp} feature]
 
-| Deploying {hcp}
-a| * xref:../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc#hcp-deploy-virt[Deploying {hcp} on {VirtProductName}]
-* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc#hcp-deploy-aws[Deploying {hcp} on {aws-short}]
-* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-deploy-bm[Deploying {hcp} on bare metal]
-* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc#hcp-deploy-non-bm[Deploying {hcp} on non-bare-metal agent machines]
-* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc#hcp-deploy-ibmz[Deploying {hcp} on {ibm-z-title}]
-* xref:../hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc#hcp-deploy-ibm-power[Deploying {hcp} on {ibm-power-title}]
+// | Deploying {hcp}
+// a| * xref:../hosted_control_planes/hcp-deploy/hcp-deploy-virt.adoc#hcp-deploy-virt[Deploying {hcp} on {VirtProductName}]
+// * xref:../hosted_control_planes/hcp-deploy/hcp-deploy-aws.adoc#hcp-deploy-aws[Deploying {hcp} on {aws-short}]
+// * xref:../hosted_control_planes/hcp-deploy/hcp-deploy-bm.adoc#hcp-deploy-bm[Deploying {hcp} on bare metal]
+// * xref:../hosted_control_planes/hcp-deploy/hcp-deploy-non-bm.adoc#hcp-deploy-non-bm[Deploying {hcp} on non-bare-metal agent machines]
+// * xref:../hosted_control_planes/hcp-deploy/hcp-deploy-ibmz.adoc#hcp-deploy-ibmz[Deploying {hcp} on {ibm-z-title}]
+// * xref:../hosted_control_planes/hcp-deploy/hcp-deploy-ibm-power.adoc#hcp-deploy-ibm-power[Deploying {hcp} on {ibm-power-title}]
 
-| Deploying {hcp} in a disconnected environment
-a| * xref:../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-deploy-dc-bm[Deploying {hcp} on bare metal in a disconnected environment]
-* xref:../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc#hcp-deploy-dc-virt[Deploying {hcp} on {VirtProductName} in a disconnected environment]
+// | Deploying {hcp} in a disconnected environment
+// a| * xref:../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-bm.adoc#hcp-deploy-dc-bm[Deploying {hcp} on bare metal in a disconnected environment]
+// * xref:../hosted_control_planes/hcp-disconnected/hcp-deploy-dc-virt.adoc#hcp-deploy-dc-virt[Deploying {hcp} on {VirtProductName} in a disconnected environment]
 
-| xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-troubleshooting[Troubleshooting {hcp}]
-a| xref:../hosted_control_planes/hcp-troubleshooting.adoc#hosted-control-planes-troubleshooting_hcp-troubleshooting[Gathering information to troubleshoot {hcp}]
+// | xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-troubleshooting[Troubleshooting {hcp}]
+// a| xref:../hosted_control_planes/hcp-troubleshooting.adoc#hosted-control-planes-troubleshooting_hcp-troubleshooting[Gathering information to troubleshoot {hcp}]
 
-|===
+// |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-16594
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://101123--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes#ocp-release-notes-hcp_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR "hides" the hosted control planes documentation, except for two notes stating that HCP for OCP 4.20 will be available when the next MCE Operator release is available. The two notes are in the OCP release notes and the upgrading clusters sections.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
