### PR TITLE
OSDOCS-16508 [NETOBSERVE] Add advisory link in 1.10 rel notes

### DIFF
--- a/modules/network-observability-operator-release-notes-1-10-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-10-advisory.adoc
@@ -8,5 +8,5 @@
 [role="_abstract"]
 Review the advisory that is available for the Network Observability Operator 1.10:
 
-//* link:https://access.redhat.com/errata/<number>[<number> Network Observability Operator 1.10]
-// Likely to be updated just after release in separate PR.
+* link:https://access.redhat.com/errata/RHEA-2025:19153[RHEA-2025:19153 Network Observability Operator 1.10]
+


### PR DESCRIPTION
[OSDOCS-16508](https://issues.redhat.com//browse/OSDOCS-16508) [NETOBSERVE] Add advisory link in 1.10 rel notes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the no-1.10 branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the <no-.10> content just before its GA.

Note to self for integration: Applies to OCP 4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-16508

Link to docs preview:
https://101151--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes-1-10.html#network-observability-operator-release-notes-1-10-advisory_network-observability-operator-release-notes-v1-10

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* All other release note entries have already been reviewed and merged into no-1.10. See by https://github.com/openshift/openshift-docs/commit/62d28d8975d4a416af26b56a71ac5f56ef9b959d

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
