### PR TITLE
ROX-30956: Fix incorrect proxy yaml info

### DIFF
--- a/configuration/configure-proxy.adoc
+++ b/configuration/configure-proxy.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="configure-proxy"]
 = Configuring a proxy for external network access
 include::modules/common-attributes.adoc[]

--- a/modules/configure-proxy-during-installation.adoc
+++ b/modules/configure-proxy-during-installation.adoc
@@ -28,20 +28,20 @@ metadata:
   name: proxy-config
 type: Opaque
 stringData:
-  config.yaml: |- <4>
+  config.yaml: |-
     # # NOTE: Both central and scanner should be restarted if this secret is changed.
     # # While it is possible that some components will pick up the new proxy configuration
     # # without a restart, it cannot be guaranteed that this will apply to every possible
     # # integration etc.
-    # url: http://proxy.name:port <2>
-    # username: username <1>
-    # password: password <1>
+    # url: http://proxy.name:port
+    # username: username
+    # password: password
     # # If the following value is set to true, the proxy wil NOT be excluded for the default hosts:
     # # - *.stackrox, *.stackrox.svc
     # # - localhost, localhost.localdomain, 127.0.0.0/8, ::1
     # # - *.local
     # omitDefaultExcludes: false
-    # excludes:  # hostnames (may include * components) for which you do not <3>
+    # excludes:  # hostnames (may include * components) for which you do not
     # # want to use a proxy, like in-cluster repositories.
     # - some.domain
     # # The following configuration sections allow specifying a different proxy to be used for HTTP(S) connections.
@@ -49,22 +49,22 @@ stringData:
     # # If only the `http` section is given, it will be used for HTTPS connections as well.
     # # Note: in most cases, a single, global proxy configuration is sufficient.
     # http:
-    #   url: http://http-proxy.name:port <2>
-    #   username: username <1>
-    #   password: password <1>
+    #   url: http://http-proxy.name:port
+    #   username: username
+    #   password: password
     # https:
-    #   url: http://https-proxy.name:port <2>
-    #   username: username <1>
-    #   password: password <1>
+    #   url: http://https-proxy.name:port
+    #   username: username
+    #   password: password
 ----
-<1>  Adding a `username` and a `password` is optional, both at the beginning and in the `http` and `https` sections.
-<2> The `url` option supports the following URL schemes:
-*** `http://` for an HTTP proxy.
-*** `https://` for a TLS-enabled HTTP proxy.
-*** `socks5://` for a SOCKS5 proxy.
-<3> The `excludes` list can contain DNS names (with or without `*` wildcards), IP addresses, or IP blocks in CIDR notation (for example, `10.0.0.0/8`).
+* `username` and `password` are optional, both at the beginning and in the `http` and `https` sections.
+* `url` supports the following URL schemes:
+** `http://` for an HTTP proxy
+** `https://` for a TLS-enabled HTTP proxy
+** `socks5://` for a SOCKS5 proxy
+* `excludes` is a list that can contain DNS names, with or without `*` wildcards, IP addresses, or IP blocks in CIDR notation, for example, `10.0.0.0/8`.
 The values in this list are applied to all outgoing connections, regardless of protocol.
-<4> The `|-` line in the `stringData` section indicates the start of the configuration data.
+* `|-` in the `stringData` section indicates the start of the configuration data.
 +
 [NOTE]
 ====

--- a/modules/configure-proxy-on-an-existing-deployment.adoc
+++ b/modules/configure-proxy-on-an-existing-deployment.adoc
@@ -11,7 +11,7 @@ To configure a proxy in an existing deployment, you must export the `proxy-confi
 ====
 If you have configured a global proxy on your {ocp} cluster, the Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. However, you can also configure installed Operators to override the global proxy or inject a custom certificate authority (CA) certificate.
 
-For more information, see link:https://docs.openshift.com/container-platform/4.11/operators/admin/olm-configuring-proxy-support.html[Configuring proxy support in Operator Lifecycle Manager].
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/administrator-tasks#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager].
 ====
 
 .Procedure
@@ -24,8 +24,38 @@ $ oc -n stackrox get secret proxy-config \
   -o go-template='{{index .data "config.yaml" | \
   base64decode}}{{"\n"}}' > /tmp/proxy-config.yaml
 ----
-. Edit the fields you want to modify in the YAML configuration file, as specified in the Configure proxy during installation section.
-//TODO Link to Configure proxy during installation section
+. Edit the fields you want to modify in the YAML configuration file, for example:
++
+[source,yaml]
+----
+    # # NOTE: Both central and scanner should be restarted if this secret is changed.
+    # # While it is possible that some components will pick up the new proxy configuration
+    # # without a restart, it cannot be guaranteed that this will apply to every possible
+    # # integration etc.
+    # url: http://proxy.name:port
+    # username: username
+    # password: password
+    # # If the following value is set to true, the proxy wil NOT be excluded for the default hosts:
+    # # - *.stackrox, *.stackrox.svc
+    # # - localhost, localhost.localdomain, 127.0.0.0/8, ::1
+    # # - *.local
+    # omitDefaultExcludes: false
+    # excludes:  # hostnames (may include * components) for which you do not
+    # # want to use a proxy, like in-cluster repositories.
+    # - some.domain
+    # # The following configuration sections allow specifying a different proxy to be used for HTTP(S) connections.
+    # # If they are omitted, the above configuration is used for HTTP(S) connections as well as TCP connections.
+    # # If only the `http` section is given, it will be used for HTTPS connections as well.
+    # # Note: in most cases, a single, global proxy configuration is sufficient.
+    # http:
+    #   url: http://http-proxy.name:port 
+    #   username: username
+    #   password: password
+    # https:
+    #   url: http://https-proxy.name:port 
+    #   username: username 
+    #   password: password 
+----
 . After you save the changes, run the following command to replace the secret:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s): 4.7+

[Issue](https://issues.redhat.com/browse/ROX-30956)

[Link to docs preview
](https://101153--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/configure-proxy.html)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

* Removed/reformatted callouts for migration prep
* Added missing content type

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
