### PR TITLE
ROX-30965: Rename image signature policy field

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -72,7 +72,7 @@ AND, OR
 *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Image Signature
+| Require image signature
 | The list of signature integrations you can use to verify an image's signature. Create alerts on images that either do not have a signature or their signature is not verifiable by at least one of the provided signature integrations.
 | Image Signature Verified By
 | A valid ID of an already configured image signature integration


### PR DESCRIPTION
Note that only the first word is capitalized to match the name actually presented in the UI [1].

[1] https://github.com/stackrox/stackrox/blob/e8a7f4a5b80903d26e01317593b916888d1d11ae/ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx#L360

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10.0

Issue: https://issues.redhat.com/browse/ROX-30965

Link to docs preview: https://101154--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/security-policy-reference.html#reference-image-criteria_security-policy-reference

QE review: ACS does not have QE

