### PR TITLE
chore: fix reference to image signature policy field

### DIFF
--- a/modules/use-signature-verification.adoc
+++ b/modules/use-signature-verification.adoc
@@ -5,7 +5,7 @@
 [id="use-signature-verification_{context}"]
 = Using signature verification in a policy
 
-When creating custom security policies, you can use the *Trusted image signers* policy criteria to verify image signatures.
+When creating custom security policies, you can use the *Require image signature* policy criteria to verify image signatures.
 
 .Prerequisites
 
@@ -13,6 +13,6 @@ When creating custom security policies, you can use the *Trusted image signers* 
 
 .Procedure
 
-. When creating or editing a policy, drag the *Not verified by trusted image signers* policy criteria in the policy field drop area for the *Policy criteria* section.
+. When creating or editing a policy, drag the *Require image signature* policy criteria in the policy field drop area for the *Policy criteria* section.
 . Click *Select*.
 . Select the trusted image signers from the list and click *Save*.


### PR DESCRIPTION
This PR fixes the references to an outdated name of the image signature policy field in section 14.3 "Using signature verification in a policy" [1]: it points to a criterion named "Trusted image signers"/"Not verified by trusted image signers", while the correct current name is "Require image signature".

[1] https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_security_for_kubernetes/4.8/html/operating/verify-image-signatures

Version(s): 4.10.0

Issue: none

Link to docs preview: https://101158--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/verify-image-signatures.html#use-signature-verification_verify-image-signatures
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: ACS does not have QE
