### PR TITLE
OSDOCS#16699: Adding missing mod-docs-content-types for assemblies fo…

### DIFF
--- a/authentication/index.adoc
+++ b/authentication/index.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="overview-of-authentication-authorization"]
 = Overview of authentication and authorization
 include::_attributes/common-attributes.adoc[]

--- a/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/ipi/installing-azure-stack-hub-network-customizations.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="installing-azure-stack-hub-network-customizations"]
 = Installing a cluster on Azure Stack Hub with network customizations
 include::_attributes/common-attributes.adoc[]

--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="microshift-4-12-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/attributes-microshift.adoc[]

--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="microshift-4-13-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/attributes-microshift.adoc[]

--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="microshift-4-14-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/attributes-microshift.adoc[]

--- a/networking/networking/networking_operators/ingress-operator.adoc
+++ b/networking/networking/networking_operators/ingress-operator.adoc
@@ -1,0 +1,2 @@
+:_mod-docs-content-type: ASSEMBLY
+

--- a/release_notes/ocp-4-1-release-notes.adoc
+++ b/release_notes/ocp-4-1-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-1-release-notes"]
 = {product-title} 4.1 release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-10-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-11-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-12-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-13-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-14-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-2-release-notes.adoc
+++ b/release_notes/ocp-4-2-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-2-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-3-release-notes.adoc
+++ b/release_notes/ocp-4-3-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-3-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-4-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-5-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-6-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-7-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-8-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="ocp-4-9-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]

--- a/storage/container_storage_interface/persistent-storage-csi-azure-file.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-azure-file.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="persistent-storage-csi-azure-file"]
 = Azure File CSI Driver Operator
 include::_attributes/common-attributes.adoc[]

--- a/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="persistent-storage-csi-google-cloud-file"]
 = Google Compute Platform Filestore CSI Driver Operator
 include::_attributes/common-attributes.adoc[]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-16699

Link to docs preview:
No visible changes to preview

QE review:
No QE required - metadata change only
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
