### PR TITLE
chore: Use sentence case in policy criteria names

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -50,7 +50,7 @@ AND, OR
 *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Image Name
+| Image name
 | The full name of the image in registry, for example `library/nginx`.
 | Image Remote
 | String
@@ -61,7 +61,7 @@ AND, OR
 *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Image Tag
+| Image tag
 | Identifier for an image.
 | Image Tag
 | String
@@ -345,7 +345,7 @@ AND, OR
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Container CPU Request
+| Container CPU request
 | Check for the number of cores reserved for a given resource.
 | Container CPU Request
 | <, >, <=, >= or nothing (which implies equal to) +
@@ -369,7 +369,7 @@ Examples: +
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Container Memory Request
+| Container memory request
 | Number, including fraction, of MB requested.
 // Do we convert the K8s resource into MB (including convert MiB to MB) ? If so, the documentation should explain this conversion .
 | Container Memory Request
@@ -378,7 +378,7 @@ Examples: +
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Container Memory Limit
+| Container memory limit
 | Check for the maximum amount of memory a resource is allowed to use.
 | Container Memory Limit
 | (Same as Container CPU Request)
@@ -402,7 +402,7 @@ Examples: +
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Seccomp Profile Type
+| Seccomp profile type
 | The type of `seccomp` profile defined for the deployment. If `seccomp` options are provided at both the pod and container level, the container options override the pod options. See link:https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1[Security Context].
 | Seccomp Profile Type
 | One of: +
@@ -422,7 +422,7 @@ LOCALHOST
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Drop Capabilities
+| Drop capabilities
 | Linux capabilities that must be dropped from the container. Provides alerts when the specified capabilities are not dropped.
 For example, if configured with `SYS_ADMIN` AND `SYS_BOOT`, and the deployment drops only _one_ or _neither_ of these two capabilities, the alert occurs.
 | Drop Capabilities +
@@ -472,7 +472,7 @@ WAKE_ALARM +
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Add Capabilities
+| Add capabilities
 | Linux capabilities that must not be added to the container, such as the ability to send raw packets or override file permissions. Provides alerts when the specified capabilities are added. For example, if configured with `NET_ADMIN` or `NET_RAW`, and the deployment manifest YAML file includes at least one of these two capabilities, the alert occurs.
 | Add Capabilities
 |
@@ -517,7 +517,7 @@ WAKE_ALARM +
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Container Name
+| Container name
 | The name of the container.
 | Container Name
 | String
@@ -527,7 +527,7 @@ AND, OR
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| AppArmor Profile
+| AppArmor profile
 | The Application Armor ("AppArmor") profile used in the container.
 | AppArmor Profile
 | String
@@ -537,7 +537,7 @@ AND, OR
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Liveness Probe
+| Liveness probe
 | Whether the container defines a liveness probe.
 | Liveness Probe
 | Boolean
@@ -545,7 +545,7 @@ AND, OR
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
-| Readiness Probe
+| Readiness probe
 | Whether the container defines a readiness probe.
 | Readiness Probe
 | Boolean
@@ -856,7 +856,7 @@ Process activity::
 |===
 | *Attribute* | *Description* | *JSON Attribute* | *Allowed Values* | *Regex*, *NOT*, *AND, OR* | *Phase*
 
-| Process Name
+| Process name
 | Name of the process executed in a deployment.
 | Process Name
 | String
@@ -980,7 +980,7 @@ UPDATE +
 | ! `OR` only
 | *Runtime* ONLY - Audit Log
 
-| Kubernetes Resource Type
+| Kubernetes resource type
 | Type of the accessed Kubernetes resource.
 | Kubernetes Resource
 | One of: +


### PR DESCRIPTION
This PR fixes a mismatch between docs and UI, where in the UI all policy field names use sentence case but in the docs some field names are written with title case.

    $ grep shortName ui/apps/platform/src/Containers/Policies/Wizard/Step3/policyCriteriaDescriptors.tsx
        shortName: required string for title of rule criterion in group of form and tree of modal
        shortName: string;
            shortName: 'Image registry',
            shortName: 'Image name',
            shortName: 'Image tag',
            shortName: 'Require image signature',
            shortName: 'Image age',
            shortName: 'Image scan age',
            shortName: 'Image user',
            shortName: 'Dockerfile line',
            shortName: 'Image scan status',
            shortName: 'CVSS',
            shortName: 'NVD CVSS',
            shortName: 'Severity',
            shortName: 'Fixable',
            shortName: 'Fixed by',
            shortName: 'CVE',
            shortName: 'Days since CVE was published',
            shortName: 'Days since CVE was first discovered in image',
            shortName: 'Days since CVE was first discovered in system',
            shortName: 'Image component',
            shortName: 'Image OS',
            shortName: 'Environment variable',
            shortName: 'Disallowed annotation',
            shortName: 'Required label',
            shortName: 'Required annotation',
            shortName: 'Runtime class',
            shortName: 'Volume name',
            shortName: 'Volume source path',
            shortName: 'Volume destination path',
            shortName: 'Volume type',
            shortName: 'Mounted volume writability',
            shortName: 'Mount propagation',
            shortName: 'Exposed port protocol',
            shortName: 'Exposed node port',
            shortName: 'Exposed port',
            shortName: 'Port exposure method',
            shortName: 'Ingress network policy',
            shortName: 'Egress network policy',
            shortName: 'Container CPU request',
            shortName: 'Container CPU limit',
            shortName: 'Container memory request',
            shortName: 'Container memory limit',
            shortName: 'Privileged container',
            shortName: 'Root filesystem writeability',
            shortName: 'Seccomp profile type',
            shortName: 'Privilege escalation',
            shortName: 'Host network',
            shortName: 'Host PID',
            shortName: 'Host IPC',
            shortName: 'Drop capabilities',
            shortName: 'Add capabilities',
            shortName: 'Process name',
            shortName: 'Process ancestor',
            shortName: 'Process arguments',
            shortName: 'Process UID',
            shortName: 'Unexpected network flow detected',
            shortName: 'Unexpected process executed',
            shortName: 'Host mount writability',
            shortName: 'Service account',
            shortName: 'Automount service account token',
            shortName: 'Minimum RBAC permissions',
            shortName: 'Require image label',
            shortName: 'Disallow image label',
            shortName: 'Namespace',
            shortName: 'Container name',
            shortName: 'AppArmor profile',
            shortName: 'Kubernetes action',
            shortName: 'Kubernetes user name',
            shortName: 'Kubernetes user groups',
            shortName: 'Replicas',
            shortName: 'Liveness probe',
            shortName: 'Readiness probe',
            shortName: 'Kubernetes API verb',
            shortName: 'Kubernetes resource type',
            shortName: 'Kubernetes resource name',
            shortName: 'Kubernetes user name',
            shortName: 'Kubernetes user groups',
            shortName: 'User agent',
            shortName: 'Source IP address',
            shortName: 'Is impersonated user',

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Link to docs preview: https://101160--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/security-policy-reference.html#reference-image-criteria_security-policy-reference

QE review: ACS does not have QE
