### PR TITLE
OSDOCS Update modules O-Q part 1 (O)

### DIFF
--- a/modules/oauth-default-clients.adoc
+++ b/modules/oauth-default-clients.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/configuring-oauth-clients.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="oauth-default-clients_{context}"]
 = Default OAuth clients
 

--- a/modules/oauth-internal-options.adoc
+++ b/modules/oauth-internal-options.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/configuring-internal-oauth.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="oauth-internal-options_{context}"]
 = Options for the internal OAuth server
 

--- a/modules/oauth-troubleshooting-api-events.adoc
+++ b/modules/oauth-troubleshooting-api-events.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/configuring-internal-oauth.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="oauth-troubleshooting-api-events_{context}"]
 = Troubleshooting OAuth API events
 

--- a/modules/ocm-insightsadvisor-tab.adoc
+++ b/modules/ocm-insightsadvisor-tab.adoc
@@ -2,6 +2,7 @@
 //
 // ocm/ocm-overview.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="ocm-insightsadvisor-tab_{context}"]
 = Insights Advisor tab
 

--- a/modules/odc-deleting-applications-using-developer-perspective.adoc
+++ b/modules/odc-deleting-applications-using-developer-perspective.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * applications/odc-deleting-applications.adoc
+
+:_mod-docs-content-type: PROCEDURE
 [id="odc-deleting-applications-using-developer-perspective_{context}"]
 = Deleting applications using the Developer perspective
 

--- a/modules/odc-interacting-with-applications-and-components.adoc
+++ b/modules/odc-interacting-with-applications-and-components.adoc
@@ -2,6 +2,7 @@
 //
 // * /applications/odc-viewing-application-composition-using-topology-view.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="odc-interacting-with-applications-and-components_{context}"]
 = Interacting with applications and components
 

--- a/modules/odc-labels-and-annotations-used-for-topology-view.adoc
+++ b/modules/odc-labels-and-annotations-used-for-topology-view.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * applications/odc-viewing-application-composition-using-topology-view.adoc
+
+:_mod-docs-content-type: CONCEPT
 [id="odc-labels-and-annotations-used-for-topology-view_{context}"]
 = Labels and annotations used for the Topology view
 

--- a/modules/odc-monitoring-application-health-using-developer-perspective.adoc
+++ b/modules/odc-monitoring-application-health-using-developer-perspective.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies:
 //
-// applications/application-health
+// * applications/application-health
 
+:_mod-docs-content-type: CONCEPT
 [id="odc-monitoring-application-health-using-developer-perspective_{context}"]
 = Monitoring application health using the Developer perspective
 

--- a/modules/odc-scaling-application-pods-and-checking-builds-and-routes.adoc
+++ b/modules/odc-scaling-application-pods-and-checking-builds-and-routes.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies:
 //
-// * //applications/odc-viewing-application-composition-using-topology-view.adoc
+// * applications/odc-viewing-application-composition-using-topology-view.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="odc-scaling-application-pods-and-checking-builds-and-routes_{context}"]
 = Scaling application pods and checking builds and routes
 

--- a/modules/olm-arch-catalog-operator.adoc
+++ b/modules/olm-arch-catalog-operator.adoc
@@ -3,6 +3,7 @@
 // * operators/understanding/olm/olm-arch.adoc
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-arch-catalog-operator_{context}"]
 = Catalog Operator
 

--- a/modules/olm-arch-catalog-registry.adoc
+++ b/modules/olm-arch-catalog-registry.adoc
@@ -3,6 +3,7 @@
 // * operators/understanding/olm/olm-arch.adoc
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-arch-catalog-registry_{context}"]
 = Catalog Registry
 

--- a/modules/olm-arch-olm-operator.adoc
+++ b/modules/olm-arch-olm-operator.adoc
@@ -3,6 +3,7 @@
 // * operators/understanding/olm/olm-arch.adoc
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-arch-olm-operator_{context}"]
 = OLM Operator
 

--- a/modules/olm-bundle-schema.adoc
+++ b/modules/olm-bundle-schema.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-bundle-schema_{context}"]
 = olm.bundle schema
 

--- a/modules/olm-crds.adoc
+++ b/modules/olm-crds.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-understanding-olm.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-resources_{context}"]
 = OLM resources
 

--- a/modules/olm-dependencies-best-practices.adoc
+++ b/modules/olm-dependencies-best-practices.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-understanding-dependency-resolution.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-dependency-best-practices_{context}"]
 = Dependency best practices
 

--- a/modules/olm-dependencies-caveats.adoc
+++ b/modules/olm-dependencies-caveats.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-understanding-dependency-resolution.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-dependency-caveats_{context}"]
 = Dependency caveats
 

--- a/modules/olm-dependency-resolution-crd-upgrades.adoc
+++ b/modules/olm-dependency-resolution-crd-upgrades.adoc
@@ -3,6 +3,7 @@
 // * operators/understanding/olm/olm-understanding-dependency-resolution.adoc
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-dependency-resolution-crd-upgrades_{context}"]
 = CRD upgrades
 

--- a/modules/olm-fb-catalogs-automation.adoc
+++ b/modules/olm-fb-catalogs-automation.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-fb-catalogs-automation_{context}"]
 = Automation
 

--- a/modules/olm-fb-catalogs-example.adoc
+++ b/modules/olm-fb-catalogs-example.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-fb-catalogs-example_{context}"]
 = Example catalog
 

--- a/modules/olm-fb-catalogs-prop.adoc
+++ b/modules/olm-fb-catalogs-prop.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-fb-catalogs-prop_{context}"]
 = Properties
 

--- a/modules/olm-fb-catalogs-schemas.adoc
+++ b/modules/olm-fb-catalogs-schemas.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-fb-catalogs-schemas_{context}"]
 = Schemas
 

--- a/modules/olm-fb-catalogs-structure.adoc
+++ b/modules/olm-fb-catalogs-structure.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-fb-catalogs-structure_{context}"]
 = Directory structure
 

--- a/modules/olm-installplan.adoc
+++ b/modules/olm-installplan.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-understanding-olm.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-installplan_{context}"]
 = Install plan
 

--- a/modules/olm-metrics.adoc
+++ b/modules/olm-metrics.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-understanding-olm.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-metrics_{context}"]
 = Exposed metrics
 

--- a/modules/olm-mirroring-catalog-extracting.adoc
+++ b/modules/olm-mirroring-catalog-extracting.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/disconnected_install/installing-mirroring-installation-images.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-mirror-catalog-extracting_{context}"]
 = Extracting and mirroring catalog contents
 

--- a/modules/olm-mirroring-catalog-manifests.adoc
+++ b/modules/olm-mirroring-catalog-manifests.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/disconnected_install/installing-mirroring-installation-images.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-mirror-catalog-manifests_{context}"]
 = Generated manifests
 

--- a/modules/olm-operatorgroups-copied-csvs.adoc
+++ b/modules/olm-operatorgroups-copied-csvs.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-understanding-operatorgroups.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-operatorgroups-copied-csvs_{context}"]
 = Copied CSVs
 

--- a/modules/olm-operatorgroups-csv-annotations.adoc
+++ b/modules/olm-operatorgroups-csv-annotations.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-understanding-operatorgroups.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-operatorgroups-csv-annotations_{context}"]
 = Operator group CSV annotations
 

--- a/modules/olm-operatorgroups-membership.adoc
+++ b/modules/olm-operatorgroups-membership.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-understanding-operatorgroups.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-operatorgroups-membership_{context}"]
 = Operator group membership
 

--- a/modules/olm-operatorgroups-static.adoc
+++ b/modules/olm-operatorgroups-static.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-understanding-operatorgroups.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-operatorgroups-static_{context}"]
 = Static Operator groups
 

--- a/modules/olm-operatorgroups-target-namespace.adoc
+++ b/modules/olm-operatorgroups-target-namespace.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-understanding-operatorgroups.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-operatorgroups-target-namespace_{context}"]
 = Target namespace selection
 

--- a/modules/olm-package-schema.adoc
+++ b/modules/olm-package-schema.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-package-schema_{context}"]
 = olm.package schema
 

--- a/modules/olm-pod-placement.adoc
+++ b/modules/olm-pod-placement.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/admin/olm-adding-operators-to-cluster.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-pod-placement_{context}"]
 = Pod placement of Operator workloads
 

--- a/modules/olm-policy-fine-grained-permissions.adoc
+++ b/modules/olm-policy-fine-grained-permissions.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/admin/olm-creating-policy.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-policy-fine-grained-permissions_{context}"]
 = Fine-grained permissions
 

--- a/modules/olm-policy-scenarios.adoc
+++ b/modules/olm-policy-scenarios.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/admin/olm-creating-policy.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-policy-scenarios_{context}"]
 = Installation scenarios
 

--- a/modules/olm-policy-workflow.adoc
+++ b/modules/olm-policy-workflow.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/admin/olm-creating-policy.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-policy-workflow_{context}"]
 = Installation workflow
 

--- a/modules/olm-status-conditions.adoc
+++ b/modules/olm-status-conditions.adoc
@@ -3,6 +3,7 @@
 // * operators/admin/olm-status.adoc
 // * support/troubleshooting/troubleshooting-operator-issues.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-status-conditions_{context}"]
 = Operator subscription condition types
 

--- a/modules/olm-subscription.adoc
+++ b/modules/olm-subscription.adoc
@@ -9,6 +9,7 @@ ifndef::openshift-origin[]
 :global_ns: openshift-marketplace
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-subscription_{context}"]
 = Subscription
 

--- a/modules/olm-supported-operatorconditions.adoc
+++ b/modules/olm-supported-operatorconditions.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-operatorconditions.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-supported-operatorconditions_{context}"]
 = Supported conditions
 

--- a/modules/olm-updating-use-operatorconditions.adoc
+++ b/modules/olm-updating-use-operatorconditions.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/admin/olm-managing-operatorconditions.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-updating-use-operatorconditions_{context}"]
 = Updating your Operator to use Operator conditions
 

--- a/modules/olm-upgrades.adoc
+++ b/modules/olm-upgrades.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm/olm-workflow.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-upgrades_{context}"]
 = Operator installation and upgrade workflow in OLM
 

--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -2,6 +2,7 @@
 //
 // * scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-maximums-environment_{context}"]
 = {product-title} environment and configuration on which the cluster maximums are tested
 

--- a/modules/opm-cli-ref-init.adoc
+++ b/modules/opm-cli-ref-init.adoc
@@ -2,6 +2,7 @@
 //
 // * cli_reference/opm/cli-opm-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="opm-cli-ref-init_{context}"]
 = init
 

--- a/modules/opm-cli-ref-migrate.adoc
+++ b/modules/opm-cli-ref-migrate.adoc
@@ -2,6 +2,7 @@
 //
 // * cli_reference/opm/cli-opm-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="opm-cli-ref-migrate_{context}"]
 = migrate
 

--- a/modules/opm-cli-ref-render.adoc
+++ b/modules/opm-cli-ref-render.adoc
@@ -2,6 +2,7 @@
 //
 // * cli_reference/opm/cli-opm-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="opm-cli-ref-render_{context}"]
 = render
 

--- a/modules/opm-cli-ref-serve.adoc
+++ b/modules/opm-cli-ref-serve.adoc
@@ -2,6 +2,7 @@
 //
 // * cli_reference/opm/cli-opm-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="opm-cli-ref-server_{context}"]
 = serve
 

--- a/modules/opm-cli-ref-validate.adoc
+++ b/modules/opm-cli-ref-validate.adoc
@@ -2,6 +2,7 @@
 //
 // * cli_reference/opm/cli-opm-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="opm-cli-ref-validate_{context}"]
 = validate
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16697

Adding the `:_mod-docs-content-type:` metadata to modules starting with O. 

Did not alter the modules starting with the following:

`oadp-` None
`odc-` 5 files 
`op-`  Multiple files
`osd-` None
`ossm-` Multiple files 

