### PR TITLE
[enterprise-4.14] Adding missing content types for core OCP snippets

### DIFF
--- a/snippets/audit-logs-default.adoc
+++ b/snippets/audit-logs-default.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // Module included in the following assemblies and modules:
 //
 // * observability/logging/log_collection_forwarding/configuring-log-forwarding.adoc

--- a/snippets/deprecated-feature.adoc
+++ b/snippets/deprecated-feature.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // When including this file, ensure that {FeatureName} is set immediately before
 // the include. Otherwise it will result in an incorrect replacement.
 

--- a/snippets/developer-preview.adoc
+++ b/snippets/developer-preview.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // DO NOT USE THIS SNIPPET. DEVELOPER PREVIEW FEATURES ARE NOT DOCUMENTED IN CORE OPENSHIFT DOCS.
 
 // When including this file, ensure that {FeatureName} is set immediately before the include. Otherwise it will result in an incorrect replacement.

--- a/snippets/operator-not-available.adoc
+++ b/snippets/operator-not-available.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // When including this file, ensure that {operator-name} is set immediately before
 // the include. Otherwise it will result in an incorrect replacement.
 

--- a/snippets/technology-preview.adoc
+++ b/snippets/technology-preview.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // When including this file, ensure that {FeatureName} is set immediately before
 // the include. Otherwise it will result in an incorrect replacement.
 


### PR DESCRIPTION
Manual CP of #101094