### PR TITLE
OSDOCS Update modules O-Q part 2 (P,Q)

### DIFF
--- a/modules/persistent-storage-cinder-provisioning.adoc
+++ b/modules/persistent-storage-cinder-provisioning.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/persistent_storage/persistent_storage-cinder.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="persistent-storage-cinder-provisioning_{context}"]
 = Manual provisioning with Cinder
 

--- a/modules/persistent-storage-cinder-pv-format.adoc
+++ b/modules/persistent-storage-cinder-pv-format.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/persistent_storage/persistent_storage-cinder.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="persistent-storage-cinder-pv-format_{context}"]
 = Persistent volume formatting
 

--- a/modules/persistent-storage-csi-architecture.adoc
+++ b/modules/persistent-storage-csi-architecture.adoc
@@ -3,7 +3,7 @@
 // * storage/container_storage_interface/persistent_storage-csi.adoc
 // * microshift_storage/container_storage_interface_microshift/microshift-persistent-storage-csi.adoc
 
-
+:_mod-docs-content-type: REFERENCE
 [id="persistent-storage-csi-architecture_{context}"]
 = CSI architecture
 

--- a/modules/persistent-storage-csi-driver-daemonset.adoc
+++ b/modules/persistent-storage-csi-driver-daemonset.adoc
@@ -3,7 +3,7 @@
 // * storage/container_storage_interface/persistent_storage-csi.adoc
 // * microshift_storage/container_storage_interface_microshift/microshift-persistent-storage-csi.adoc
 
-
+:_mod-docs-content-type: REFERENCE
 [id="csi-driver-daemonset_{context}"]
 = CSI driver daemon set
 

--- a/modules/persistent-storage-csi-efs-security.adoc
+++ b/modules/persistent-storage-csi-efs-security.adoc
@@ -4,6 +4,7 @@
 // * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
 // * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="efs-security_{context}"]
 = Amazon Elastic File Storage security
 

--- a/modules/persistent-storage-csi-efs-troubleshooting.adoc
+++ b/modules/persistent-storage-csi-efs-troubleshooting.adoc
@@ -4,6 +4,7 @@
 // * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
 // * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="efs-troubleshooting_{context}"]
 = Amazon Elastic File Storage troubleshooting
 

--- a/modules/persistent-storage-csi-external-controllers.adoc
+++ b/modules/persistent-storage-csi-external-controllers.adoc
@@ -3,7 +3,7 @@
 // * storage/container_storage_interface/persistent_storage-csi.adoc
 // * microshift_storage/container_storage_interface_microshift/microshift-persistent-storage-csi.adoc
 
-
+:_mod-docs-content-type: REFERENCE
 [id="external-csi-contollers_{context}"]
 = External CSI controllers
 

--- a/modules/persistent-storage-csi-snapshots-controller-sidecar.adoc
+++ b/modules/persistent-storage-csi-snapshots-controller-sidecar.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/container_storage_interface/persistent-storage-csi-snapshots.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="persistent-storage-csi-snapshots-controller-sidecar_{context}"]
 = CSI snapshot controller and sidecar
 

--- a/modules/persistent-storage-csi-snapshots-provision.adoc
+++ b/modules/persistent-storage-csi-snapshots-provision.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/container_storage_interface/persistent-storage-csi-snapshots.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="persistent-storage-csi-snapshots-provision_{context}"]
 = Volume snapshot provisioning
 

--- a/modules/persistent-storage-csi-vsphere-rwx.adoc
+++ b/modules/persistent-storage-csi-vsphere-rwx.adoc
@@ -3,6 +3,7 @@
 // storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
 //
 
+:_mod-docs-content-type: CONCEPT
 [id="persistent-storage-csi-vsphere-rwx_{context}"]
 = ReadWriteMany vSphere volume support
 

--- a/modules/persistent-storage-csi-vsphere-stor-policy.adoc
+++ b/modules/persistent-storage-csi-vsphere-stor-policy.adoc
@@ -3,6 +3,7 @@
 // persistent-storage-csi-vsphere.adoc
 //
 
+:_mod-docs-content-type: CONCEPT
 [id="persistent-storage-csi-vsphere-stor-policy_{context}"]
 = vSphere storage policy
 

--- a/modules/persistent-storage-fibre-disk-quotas.adoc
+++ b/modules/persistent-storage-fibre-disk-quotas.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/persitent-storage/persistent_storage-fibre.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="enforcing-disk-quota_{context}"]
 = Enforcing disk quotas
 Use LUN partitions to enforce disk quotas and size constraints.

--- a/modules/persistent-storage-fibre-volume-security.adoc
+++ b/modules/persistent-storage-fibre-volume-security.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/persistent_storage/persistent-storage-fibre.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="fibre-volume-security_{context}"]
 = Fibre Channel volume security
 Users request storage with a persistent volume claim. This claim only lives in

--- a/modules/persistent-storage-flexvolume-driver-example.adoc
+++ b/modules/persistent-storage-flexvolume-driver-example.adoc
@@ -2,6 +2,7 @@
 //
 // storage/persistent_storage/persistent-storage-flexvolume.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="flexvolume-driver-example_{context}"]
 = FlexVolume driver example
 

--- a/modules/persistent-storage-vsphere-formatting.adoc
+++ b/modules/persistent-storage-vsphere-formatting.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/persistent_storage/persistent-storage-vsphere.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="vsphere-formatting-volumes_{context}"]
 = Formatting VMware vSphere volumes
 

--- a/modules/policy-change-management.adoc
+++ b/modules/policy-change-management.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_architecture/osd_policy/policy-process-security.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="policy-change-management_{context}"]
 = Change management
 

--- a/modules/policy-customer-responsibility.adoc
+++ b/modules/policy-customer-responsibility.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_architecture/osd_policy/policy-responsibility-matrix.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="policy-customer-responsibility_{context}"]
 = Customer responsibilities for data and applications
 

--- a/modules/policy-disaster-recovery.adoc
+++ b/modules/policy-disaster-recovery.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_architecture/osd_policy/policy-process-security.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="policy-disaster-recovery_{context}"]
 = Disaster recovery
 

--- a/modules/policy-failure-points.adoc
+++ b/modules/policy-failure-points.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_architecture/osd_policy/policy-understand-availability.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="policy-failure-points_{context}"]
 = Potential points of failure
 

--- a/modules/private-clusters-about-aws.adoc
+++ b/modules/private-clusters-about-aws.adoc
@@ -5,6 +5,7 @@
 // * installing/installing_aws/installing-aws-private.adoc
 // * post_installation_configuration/node-tasks.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="private-clusters-about-aws_{context}"]
 = Private clusters in AWS
 

--- a/modules/private-clusters-about-azure.adoc
+++ b/modules/private-clusters-about-azure.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_azure/installing-azure-government-region.adoc
 // * installing/installing_azure/installing-azure-private.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="private-clusters-about-azure_{context}"]
 = Private clusters in Azure
 

--- a/modules/private-clusters-about-gcp.adoc
+++ b/modules/private-clusters-about-gcp.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/installing_gcp/installing-gcp-private.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="private-clusters-about-gcp_{context}"]
 = Private clusters in GCP
 

--- a/modules/pruning-basic-operations.adoc
+++ b/modules/pruning-basic-operations.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/pruning-objects.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="pruning-basic-operations_{context}"]
 = Basic pruning operations
 

--- a/modules/pruning-cronjobs.adoc
+++ b/modules/pruning-cronjobs.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/pruning-objects.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="pruning-cronjobs_{context}"]
 = Pruning cron jobs
 

--- a/modules/quick-start-components.adoc
+++ b/modules/quick-start-components.adoc
@@ -2,6 +2,7 @@
 //
 // * web_console/creating-quick-start-tutorials.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="quick-start-components_{context}"]
 = Quick start components
 

--- a/modules/quick-start-content-guidelines.adoc
+++ b/modules/quick-start-content-guidelines.adoc
@@ -2,6 +2,7 @@
 //
 // * web_console/creating-quick-start-tutorials.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="quick-start-content-guidelines_{context}"]
 = Quick start content guidelines
 

--- a/modules/quick-start-limiting-access.adoc
+++ b/modules/quick-start-limiting-access.adoc
@@ -2,6 +2,7 @@
 //
 // * web_console/creating-quick-start-tutorials.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="limiting-access-to-quick-starts_{context}"]
 = Limiting access to a quick start
 

--- a/modules/quick-start-user-workflow.adoc
+++ b/modules/quick-start-user-workflow.adoc
@@ -2,6 +2,7 @@
 //
 // * web_console/creating-quick-start-tutorials.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="quick-start-user-workflow_{context}"]
 = Quick start user workflow
 

--- a/modules/quick-starts-accessing-and-executing-code-snippets.adoc
+++ b/modules/quick-starts-accessing-and-executing-code-snippets.adoc
@@ -2,6 +2,7 @@
 //
 // * web_console/creating-quick-start-tutorials.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="quick-starts-accessing-and-executing-code-snippets_{context}"]
 = Code snippet markdown reference
 

--- a/modules/quick-starts-highlighting-reference.adoc
+++ b/modules/quick-starts-highlighting-reference.adoc
@@ -2,6 +2,7 @@
 //
 // * web_console/creating-quick-start-tutorials.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="quick-start-highlighting-reference_{context}"]
 = Quick start highlighting markdown reference
 

--- a/modules/quick-starts-supported-tags.adoc
+++ b/modules/quick-starts-supported-tags.adoc
@@ -2,6 +2,7 @@
 //
 // * web_console/creating-quick-start-tutorials.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="supported-tags-for-quick-starts_{context}"]
 = Supported tags for quick starts
 

--- a/modules/quotas-enforcement.adoc
+++ b/modules/quotas-enforcement.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/quotas/quotas-setting-per-project.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="quota-enforcement_{context}"]
 = Quota enforcement
 

--- a/modules/quotas-requests-vs-limits.adoc
+++ b/modules/quotas-requests-vs-limits.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/quotas/quotas-setting-per-project.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="quotas-requests-vs-limits_{context}"]
 = Requests versus limits
 

--- a/modules/quotas-resources-managed.adoc
+++ b/modules/quotas-resources-managed.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/quotas/quotas-setting-per-project.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="quotas-resources-managed_{context}"]
 = Resources managed by quotas
 

--- a/modules/quotas-sample-resource-quotas-def.adoc
+++ b/modules/quotas-sample-resource-quotas-def.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/quotas/quotas-setting-per-project.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="quotas-sample-resource-quota-definitions_{context}"]
 = Sample resource quota definitions
 

--- a/modules/quotas-scopes.adoc
+++ b/modules/quotas-scopes.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/quotas/quotas-setting-per-project.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="quotas-scopes_{context}"]
 = Quota scopes
 

--- a/modules/quotas-selection-granularity.adoc
+++ b/modules/quotas-selection-granularity.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/quotas/quotas-setting-across-multiple-projects.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="quotas-selection-granularity_{context}"]
 = Selection granularity
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16697

Adding the `:_mod-docs-content-type:` metadata to modules starting with P and Q. 

Did not alter the modules starting with the following:

`psap-` None 
`ptp-` None

