### PR TITLE
[enterprise-4.16] OSDOCS#16699: Adding missing mod-docs-content-types for assemblies fo…

### DIFF
--- a/authentication/index.adoc
+++ b/authentication/index.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="overview-of-authentication-authorization"]
 = Overview of authentication and authorization
 include::_attributes/common-attributes.adoc[]

--- a/storage/container_storage_interface/persistent-storage-csi-azure-file.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-azure-file.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="persistent-storage-csi-azure-file"]
 = Azure File CSI Driver Operator
 include::_attributes/common-attributes.adoc[]

--- a/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-google-cloud-file.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="persistent-storage-csi-google-cloud-file"]
 = Google Compute Platform Filestore CSI Driver Operator
 include::_attributes/common-attributes.adoc[]


### PR DESCRIPTION
Manual CP of #101159