### PR TITLE
OLS-2239: Run vale checks on tshooting assembly

### DIFF
--- a/modules/ols-502-bad-gateway-errors.adoc
+++ b/modules/ols-502-bad-gateway-errors.adoc
@@ -1,10 +1,11 @@
 // This module is used in the following assemblies:
 // troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="ols-502-bad-gateway-errors_{context}"]
 = 502 Bad Gateway Errors in the interface
 
-If you try to start using {ols-long} before the internal components have stabilized, 502 Bad Gateway errors can occur. While all the pods might be running, there can be other console and internal {ocp-product-title} system components that are not ready. 
+[role="_abstract"]
+Avoid 502 Bad Gateway errors by waiting for all internal {ols-long} and {ocp-product-title} system components to stabilize after deployment.
 
 Wait a few minutes and try using {ols-long} again.

--- a/modules/ols-operator-missing-from-operatorhub-list.adoc
+++ b/modules/ols-operator-missing-from-operatorhub-list.adoc
@@ -1,10 +1,11 @@
 // This module is used in the following assemblies:
 // troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="ols-operator-missing-from-operatorhub-list_{context}"]
 = Operator Missing from the Operator Hub list
 
+[role="_abstract"] 
 If you are not running your {ocp-product-title} cluster on an x86 architecture, for example OpenShift Local on M1 Mac, you will not see the {ols-long} Operator in Operator Hub due to the way the Operator Hub filters architectures. 
 
 {ols-long} is only supported on x86 architecture.

--- a/modules/ols-thinking-model-generates-delineator-prompt.adoc
+++ b/modules/ols-thinking-model-generates-delineator-prompt.adoc
@@ -1,10 +1,11 @@
 // This module is used in the following assemblies:
 // troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="ols-thinking-model-generates-delineator-prompt_{context}"]
 = Thinking model generates delineator prompt
 
+[role="_abstract"]
 In some cases, thinking or reasoning models produce output that has delineators, such as `THOUGHT` or `reasoning`, to separate the thinking process from the model output that the {ols-long} Service uses to answer your question. 
 
 The {ols-long} Service does not configure the delineator behavior or produce the delineators in the output. The delineator feature is a model configuration setting. Typically, you can disable the feature using one of the following methods:

--- a/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+++ b/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
@@ -1,12 +1,14 @@
 :_content-type: ASSEMBLY
 [id="ols-troubleshooting-openshift-lightspeed"]
 = Troubleshooting OpenShift Lightspeed
+
 include::_attributes/common-attributes.adoc[]
 :context: ols-troubleshooting-openshift-lightspeed
 
 toc::[]
 
-The following topics provide information to help troubleshoot {ols-long}.
+[role="_abstract"]
+Find solutions and workarounds for common issues encountered when using and configuring the {ols-long} Operator and Service.
 
 include::modules/ols-502-bad-gateway-errors.adoc[leveloffset=+1]
 include::modules/ols-operator-missing-from-operatorhub-list.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2239

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
