### PR TITLE
OSDOCS#16699: Adding mod-docs-content-type to API assemblies

### DIFF
--- a/rest_api/authorization_apis/tokenreview-oauth-openshift-io-v1.adoc
+++ b/rest_api/authorization_apis/tokenreview-oauth-openshift-io-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="tokenreview-oauth-openshift-io-v1"]
 = TokenReview [oauth.openshift.io/v1]
 ifdef::product-title[]

--- a/rest_api/metadata_apis/componentstatus-core-v1.adoc
+++ b/rest_api/metadata_apis/componentstatus-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="componentstatus-core-v1"]
 = ComponentStatus [core/v1]
 ifdef::product-title[]

--- a/rest_api/metadata_apis/configmap-core-v1.adoc
+++ b/rest_api/metadata_apis/configmap-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="configmap-core-v1"]
 = ConfigMap [core/v1]
 ifdef::product-title[]

--- a/rest_api/metadata_apis/event-core-v1.adoc
+++ b/rest_api/metadata_apis/event-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="event-core-v1"]
 = Event [core/v1]
 ifdef::product-title[]

--- a/rest_api/metadata_apis/namespace-core-v1.adoc
+++ b/rest_api/metadata_apis/namespace-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="namespace-core-v1"]
 = Namespace [core/v1]
 ifdef::product-title[]

--- a/rest_api/network_apis/endpoints-core-v1.adoc
+++ b/rest_api/network_apis/endpoints-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="endpoints-core-v1"]
 = Endpoints [core/v1]
 ifdef::product-title[]

--- a/rest_api/network_apis/endpointslice-discovery-k8s-io-v1beta1.adoc
+++ b/rest_api/network_apis/endpointslice-discovery-k8s-io-v1beta1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="endpointslice-discovery-k8s-io-v1beta1"]
 = EndpointSlice [discovery.k8s.io/v1beta1]
 ifdef::product-title[]

--- a/rest_api/network_apis/service-core-v1.adoc
+++ b/rest_api/network_apis/service-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="service-core-v1"]
 = Service [core/v1]
 ifdef::product-title[]

--- a/rest_api/node_apis/node-core-v1.adoc
+++ b/rest_api/node_apis/node-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="node-core-v1"]
 = Node [core/v1]
 ifdef::product-title[]

--- a/rest_api/operatorhub_apis/operatorcondition-operators-coreos-com-v1.adoc
+++ b/rest_api/operatorhub_apis/operatorcondition-operators-coreos-com-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="operatorcondition-operators-coreos-com-v1"]
 = OperatorCondition [operators.coreos.com/v1]
 ifdef::product-title[]

--- a/rest_api/policy_apis/poddisruptionbudget-policy-v1beta1.adoc
+++ b/rest_api/policy_apis/poddisruptionbudget-policy-v1beta1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="poddisruptionbudget-policy-v1beta1"]
 = PodDisruptionBudget [policy/v1beta1]
 ifdef::product-title[]

--- a/rest_api/schedule_and_quota_apis/flowschema-flowcontrol-apiserver-k8s-io-v1alpha1.adoc
+++ b/rest_api/schedule_and_quota_apis/flowschema-flowcontrol-apiserver-k8s-io-v1alpha1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="flowschema-flowcontrol-apiserver-k8s-io-v1alpha1"]
 = FlowSchema [flowcontrol.apiserver.k8s.io/v1alpha1]
 ifdef::product-title[]

--- a/rest_api/schedule_and_quota_apis/limitrange-core-v1.adoc
+++ b/rest_api/schedule_and_quota_apis/limitrange-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="limitrange-core-v1"]
 = LimitRange [core/v1]
 ifdef::product-title[]

--- a/rest_api/schedule_and_quota_apis/prioritylevelconfiguration-flowcontrol-apiserver-k8s-io-v1alpha1.adoc
+++ b/rest_api/schedule_and_quota_apis/prioritylevelconfiguration-flowcontrol-apiserver-k8s-io-v1alpha1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="prioritylevelconfiguration-flowcontrol-apiserver-k8s-io-v1alpha1"]
 = PriorityLevelConfiguration [flowcontrol.apiserver.k8s.io/v1alpha1]
 ifdef::product-title[]

--- a/rest_api/schedule_and_quota_apis/resourcequota-core-v1.adoc
+++ b/rest_api/schedule_and_quota_apis/resourcequota-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="resourcequota-core-v1"]
 = ResourceQuota [core/v1]
 ifdef::product-title[]

--- a/rest_api/security_apis/secret-core-v1.adoc
+++ b/rest_api/security_apis/secret-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="secret-core-v1"]
 = Secret [core/v1]
 ifdef::product-title[]

--- a/rest_api/security_apis/serviceaccount-core-v1.adoc
+++ b/rest_api/security_apis/serviceaccount-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="serviceaccount-core-v1"]
 = ServiceAccount [core/v1]
 ifdef::product-title[]

--- a/rest_api/storage_apis/persistentvolumeclaim-core-v1.adoc
+++ b/rest_api/storage_apis/persistentvolumeclaim-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="persistentvolumeclaim-core-v1"]
 = PersistentVolumeClaim [core/v1]
 ifdef::product-title[]

--- a/rest_api/template_apis/podtemplate-core-v1.adoc
+++ b/rest_api/template_apis/podtemplate-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="podtemplate-core-v1"]
 = PodTemplate [core/v1]
 ifdef::product-title[]

--- a/rest_api/workloads_apis/cronjob-batch-v1beta1.adoc
+++ b/rest_api/workloads_apis/cronjob-batch-v1beta1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="cronjob-batch-v1beta1"]
 = CronJob [batch/v1beta1]
 ifdef::product-title[]

--- a/rest_api/workloads_apis/persistentvolume-core-v1.adoc
+++ b/rest_api/workloads_apis/persistentvolume-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="persistentvolume-core-v1"]
 = PersistentVolume [core/v1]
 ifdef::product-title[]

--- a/rest_api/workloads_apis/pod-core-v1.adoc
+++ b/rest_api/workloads_apis/pod-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="pod-core-v1"]
 = Pod [core/v1]
 ifdef::product-title[]

--- a/rest_api/workloads_apis/replicationcontroller-core-v1.adoc
+++ b/rest_api/workloads_apis/replicationcontroller-core-v1.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="replicationcontroller-core-v1"]
 = ReplicationController [core/v1]
 ifdef::product-title[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-16699

Link to docs preview:
 No visible changes to preview

QE review:
 No QE required - metadata change only
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Note - yes this is updating an autogenerated file and that's okay this time (per @jab-rh). We will have a Jira going forward to continue making this manual update after the API docs are generated.