### PR TITLE
OLS-2240: run vale checks on install assembly

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,30 +1,6 @@
 StylesPath = .vale/styles
+MinAlertLevel = warning
+Packages = https://github.com/jhradilek/asciidoctor-dita-vale/releases/latest/download/AsciiDocDITA.zip
 
-MinAlertLevel = suggestion
-
-Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc
-
-# Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
-[[!.]*.adoc]
-BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
-
-# Disabling rules (NO)
-RedHat.ReleaseNotes = NO
-
-# Use local OpenShiftDocs Vocab terms
-Vale.Terms = YES
-Vale.Avoid = YES
-
-# Disable module specific rules
-OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO
-OpenShiftAsciiDoc.NoNestingInModules = NO
-OpenShiftAsciiDoc.NoXrefInModules = NO
-OpenShiftAsciiDoc.IdHasContextVariable = NO
-OpenShiftAsciiDoc.NoTocInModules = NO
-
-# Optional: pass doc attributes to asciidoctor before linting
-# Temp values are used for Prow CI comment linting only
-[asciidoctor]
-temp-ifdef = YES
-temp-ifndef = NO
-temp-ifeval = temp
+[*.adoc]
+BasedOnStyles = AsciiDocDITA

--- a/install/ols-installing-openshift-lightspeed.adoc
+++ b/install/ols-installing-openshift-lightspeed.adoc
@@ -1,11 +1,13 @@
 :_content-type: ASSEMBLY
 [id="ols-installing-lightspeed"]
 = Installing OpenShift Lightspeed
+
 include::_attributes/common-attributes.adoc[]
 :context: ols-installing-openshift-lightspeed
 
 toc::[]
 
+[role="_abstract"]
 The installation process for {ols-official} consists of two main tasks: installing the {ols-long} Operator and configuring the {ols-long} Service to interact with the large language model (LLM) provider.
 
 include::modules/ols-large-language-model-overview.adoc[leveloffset=+1]

--- a/modules/ols-about-subscription-requirements.adoc
+++ b/modules/ols-about-subscription-requirements.adoc
@@ -5,7 +5,8 @@
 [id="about-subscription-requirements_{context}"]
 = About subscription requirements
 
-{ols-official} requires an active and valid subscription to one of the following products:
+[role="_abstract"]
+{ols-official} requires a valid and active subscription to one of the listed OpenShift products.
 
 * {oke-first}
 * {ove-first}

--- a/modules/ols-installing-operator.adoc
+++ b/modules/ols-installing-operator.adoc
@@ -1,6 +1,12 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/install/ols-installing-openshift-lightspeed.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="ols-installing-operator_{context}"]
 = Installing the OpenShift Lightspeed Operator
+
+[role="_abstract"]
+Install the {ols-long} Operator so that you can configure the {ols-long} Service.
 
 .Prerequisites
 

--- a/modules/ols-large-language-model-overview.adoc
+++ b/modules/ols-large-language-model-overview.adoc
@@ -6,6 +6,7 @@
 
 = Large Language Model (LLM) overview
 
+[role="_abstract"]
 A large language model (LLM) is a type of artificial intelligence program trained on vast quantities of data. The {ols-long} Service interacts with the LLM to generate answers to questions. 
 
 You can configure {rhelai} or {rhoai} as the LLM provider for the {ols-long} Service. Either LLM provider can use a server or inference service that processes inference queries. 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2240
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
