### PR TITLE
OSDOCS#16699# Adding mod-docs-content-type older branches for snippets

### DIFF
--- a/snippets/microshift-tech-preview-snip.adoc
+++ b/snippets/microshift-tech-preview-snip.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 //used in both install assemblies
 
 [IMPORTANT]

--- a/snippets/microshift-upload-cont2-mirror-script.adoc
+++ b/snippets/microshift-upload-cont2-mirror-script.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 [source,terminal]
 ----
 image_tag=mirror-$(date +%y%m%d%H%M%S)


### PR DESCRIPTION
Version(s):
4.19-4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-16699

Link to docs preview:
No visible changes to preview

QE review:
No QE required - metadata change only

Additional information:

Note to reviewer: Yes this does need to go into 4.21 directly (not main). These files don't exist in main for some reason. So I'm making the update here and CPing back as far as it will go.
