### PR TITLE
OSDOCS#16699# Adding mod-docs-content-type older branches for snippets

### DIFF
--- a/snippets/osdk-deprecation.adoc
+++ b/snippets/osdk-deprecation.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 // Text snippet included in the following assemblies:
 // * cli_reference/osdk/cli-osdk-install.adoc
 // * cli_reference/osdk/cli-osdk-ref.adoc


### PR DESCRIPTION
Version(s):
4.16-4.18


Issue:
https://issues.redhat.com/browse/OSDOCS-16699

Link to docs preview:
No visible changes to preview

QE review:
No QE required - metadata change only