### PR TITLE
OSDOCS#16699# Adding mod-docs-content-type older branches for snippets

### DIFF
--- a/snippets/microshift-upload-cont2-mirror-script.adoc
+++ b/snippets/microshift-upload-cont2-mirror-script.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: SNIPPET
+
 [source,terminal]
 ----
 image_tag=mirror-$(date +%y%m%d%H%M%S)


### PR DESCRIPTION
Version(s):
4.14-4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-16699

Link to docs preview:
No visible changes to preview

QE review:
No QE required - metadata change only