### PR TITLE
OCP 4.13 - OADP-6692: artesca support

### DIFF
--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+// * backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="oadp-s3-compatible-backup-storage-providers_{context}"]
@@ -25,8 +26,8 @@ The following AWS S3 compatible object storage providers are fully supported by 
 * Ceph RADOS Gateway (Ceph Object Gateway)
 * Red Hat Container Storage
 * {odf-full}
-* {gcp-first}
-* {azure-first}
+* NetApp ONTAP S3 Object Storage
+* link:https://downloads.scality.com/artesca-ova/doc/general_introduction.html#[Scality ARTESCA S3 object storage]
 
 [NOTE]
 ====
@@ -38,7 +39,6 @@ The following AWS S3 compatible object storage providers are fully supported by 
 
 The following AWS S3 compatible object storage providers, are known to work with Velero through the AWS plugin, for use as backup storage locations, however, they are unsupported and have not been tested by Red Hat:
 
-* IBM Cloud
 * Oracle Cloud
 * DigitalOcean
 * NooBaa, unless installed using Multicloud Object Gateway (MCG)


### PR DESCRIPTION
### Cherry pick

Cherry Picked from 17969c5824c1ae4187e0d1409ea1a8719e06a970 xref: https://github.com/openshift/openshift-docs/pull/101221

### JIRA

* [OADP-6692](https://issues.redhat.com/browse/OADP-6692)

### Version(s):

* OCP 4.13 → branch/enterprise-4.13

### Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
* [OADP S3 supported](https://101239--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#oadp-s3-compatible-backup-storage-providers_about-installing-oadp)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
