### PR TITLE
provide ResourceClaim example instead of ResourceClaimTemplate

### DIFF
--- a/modules/nodes-pods-allocate-dra-configure-about.adoc
+++ b/modules/nodes-pods-allocate-dra-configure-about.adoc
@@ -62,34 +62,33 @@ The following example resource claim template uses CEL expressions to request sp
 [source,yaml]
 ----
 apiVersion: resource.k8s.io/v1beta1
-kind: ResourceClaimTemplate
+kind: ResourceClaim
 metadata:
   namespace: gpu-claim
   name: gpu-devices
 spec:
-  spec:
-    devices:
-      requests:
-      - name: 1g-5gb
-        deviceClassName: example-device-class
-        selectors:
-        - cel:
-            expression: "device.attributes['driver.example.com'].profile == '1g.5gb'"
-      - name: 1g-5gb-2
-        deviceClassName: example-device-class
-        selectors:
-        - cel:
-            expression: "device.attributes['driver.example.com'].profile == '1g.5gb'"
-      - name: 2g-10gb
-        deviceClassName: example-device-class
-        selectors:
-        - cel:
-            expression: "device.attributes['driver.example.com'].profile == '2g.10gb'"
-      - name: 3g-20gb
-        deviceClassName: example-device-class
-        selectors:
-        - cel:
-            expression: "device.attributes['driver.example.com'].profile == '3g.20gb'"
+  devices:
+    requests:
+    - name: 1g-5gb
+      deviceClassName: example-device-class
+      selectors:
+      - cel:
+          expression: "device.attributes['driver.example.com'].profile == '1g.5gb'"
+    - name: 1g-5gb-2
+      deviceClassName: example-device-class
+      selectors:
+      - cel:
+          expression: "device.attributes['driver.example.com'].profile == '1g.5gb'"
+    - name: 2g-10gb
+      deviceClassName: example-device-class
+      selectors:
+      - cel:
+          expression: "device.attributes['driver.example.com'].profile == '2g.10gb'"
+    - name: 3g-20gb
+      deviceClassName: example-device-class
+      selectors:
+      - cel:
+          expression: "device.attributes['driver.example.com'].profile == '3g.20gb'"
 ----
 
 For more information on configuring resource claims, resource claim templates, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/["Dynamic Resource Allocation"] (Kubernetes documentation).


### PR DESCRIPTION
Version:
4.20+

Issue:
https://issues.redhat.com/browse/OCPBUGS-63552

The https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/nodes/working-with-pods#nodes-pods-allocate-dra-configure-about_nodes-pods-allocate-dra section, the example under ResourceClaim is actually a ResourceClaimTemplate one, instead of the desired ResourceClaim one    

This PR changed the kind type, removed a `spec` level, and moved the parameters up one level.

Link to docs preview:
[2.15.2. About GPU allocation objects](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/nodes/working-with-pods#nodes-pods-allocate-dra-configure-about_nodes-pods-allocate-dra) -- Updated the _Example resource claim object_ code example. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->