### PR TITLE
[OBSDOCS-2653] ClusterLogForwarder - Update creating-an-aws-role.adoc

### DIFF
--- a/modules/creating-an-aws-role.adoc
+++ b/modules/creating-an-aws-role.adoc
@@ -47,8 +47,8 @@ The following procedure demonstrates creating an {aws-short} IAM role by using t
 [source,terminal]
 ----
 aws iam create-policy \
-    --policy-name cluster-logging-allow \
-    --policy-document file://cw-iam-role-policy.json
+--policy-name cluster-logging-allow \
+--policy-document file://cw-iam-role-policy.json
 ----
 +
 Note the `Arn` value of the created policy.
@@ -93,9 +93,9 @@ Note the `Arn` value of the created role.
 +
 [source,terminal]
 ----
-$ aws iam put-role-policy \ 
-      --role-name openshift-logger --policy-name cluster-logging-allow \
-      --policy-document file://cw-role-policy.json
+$ aws iam attach-role-policy \ 
+  --role-name openshift-logger --policy-name cluster-logging-allow \
+  --policy-document file://cw-iam-role-policy.json
 ----
 
 .Verification


### PR DESCRIPTION
- IAM policy name needs to be corrected in the Creating an AWS IAM role docs.
- Wrong IAM policy referenced in step 4.
- Here is the documentation link:  https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html/configuring_logging/configuring-log-forwarding#creating-an-aws-role_configuring-log-forwarding

Here is updated changes:

ii. Create the IAM policy based on the previous policy definition by running the following command: 
~~~
$ aws iam create-policy \
  --policy-name cluster-logging-allow \
  --policy-document file://cw-iam-role-policy.json
~~~

4 Attach the policy to the role by running the following command: 
~~~
$ aws iam put-role-policy \
  --role-name openshift-logger --policy-name cluster-logging-allow \
  --policy-document file://cw-iam-role-policy.json
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Logging 6.4, Logging 6.3, Logging 6.2, Logging 6.1, Logging 6.0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-1837

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://101284--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-log-forwarding.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
