### PR TITLE
[RHDEVDOCS-6910] Remove TP note from Console plugin

### DIFF
--- a/modules/op-console-statistics.adoc
+++ b/modules/op-console-statistics.adoc
@@ -13,6 +13,3 @@ To view the statistic information, you must complete the following steps:
 * Enable the {pipelines-shortname} console plugin.
 
 Statistic information is available for all pipelines together and for each individual pipeline.
-
-:FeatureName: The {pipelines-shortname} Pipelines console plugin
-include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
Versions:
- pipelines-docs-1.21
- pipelines-docs-1.20
- pipelines-docs-1.19

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6910

Link to docs preview:
- [Section with the removed TP notice](https://101285--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/working-with-pipelines-web-console.html#op-console-statistics_working-with-pipelines-web-console)

QE review:
- [x] QE has approved this change - 

Additional info:
_Requested by the team as a response to a support case, console plugin is GA: 
https://redhat-internal.slack.com/archives/CSPS1077U/p1761731868371799?thread_ts=1760954740.581669&cid=CSPS1077U_  

