### PR TITLE
[OBSDOCS-2667] Update cluster-logging-collector-limits.adoc

### DIFF
--- a/modules/cluster-logging-collector-limits.adoc
+++ b/modules/cluster-logging-collector-limits.adoc
@@ -14,7 +14,7 @@ You can adjust both the CPU and memory limits for the log collector by editing t
 +
 [source,terminal]
 ----
-$ oc -n openshift-logging edit ClusterLogging instance
+$ oc -n openshift-logging edit clusterlogforwarder.observability.openshift.io <clf_name> 
 ----
 +
 [source,yaml]


### PR DESCRIPTION
- Wrong command in logging 6 documentation
- Here is the documentation link:
 https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html/configuring_logging/cluster-logging-collector#cluster-logging-collector-limits_cluster-logging-collector 

Current Look:

- Edit the ClusterLogForwarder CR in the openshift-logging project: 
~~~
$ oc -n openshift-logging edit ClusterLogging instance  
~~~

- This is a command referencing the `ClusterLogging` instance 
- But here we are editing the ClusterLogForwarder CR in the openshift-logging project. 
- Hence, it needs to be changed with ClusterLogForwarder or obsclf. 

Updated Look:

- Edit the ClusterLogForwarder CR in the openshift-logging project: 
~~~
$ oc -n openshift-logging edit clusterlogforwarder.observability.openshift.io <clf_name>  
~~~

This is the correct format.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Logging 6.4, Logging 6.3, Logging 6.2, Logging 6.1, Logging 6.0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-2667

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://101296--ocpdocs-pr.netlify.app/
https://101296--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/cluster-logging-collector.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
