### PR TITLE
OLS-2207: Update task for troubleshooting alerts

### DIFF
--- a/modules/ols-using-lightspeed-to-troubleshoot-alerts.adoc
+++ b/modules/ols-using-lightspeed-to-troubleshoot-alerts.adoc
@@ -9,21 +9,19 @@ This procedure shows how to use {ols-long} to troubleshoot alerts.
 
 .Procedure
 
-. In the {ocp-product-title} web console, select the Administrator perspective.
+. In the {ocp-product-title} web console, select *Observe* -> *Alerting*.
 
-. Click *Observe* -> *Alerting*.
+. Click to expand an alert row.
 
-. Click the *AlertmanagerReceiversNotConfigured* alert.
-
-. Copy the title and text of the warning.
+. Click the alert to present it on the screen and view details.
 
 . Click the {ols-official} icon in the lower-right corner of the screen.
+
+. Click *Attach context* and select *Alert*.
 
 . In the {ols-official} user interface, enter the following text:
 +
 What should I do about this alert?
-
-. Paste the title and text associated with the alert.
 
 . Click the *Submit* button.
 +


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2207

Link to docs preview:
https://101303--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/operate/ols-using-openshift-lightspeed.html#ols-using-lightspeed-to-troubleshoot-alerts_ols-using-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
