### PR TITLE
OSDOCS CMA 2.17.2-2 Release Notes

### DIFF
--- a/modules/nodes-pods-autoscaling-custom-rn-2151-4.adoc
+++ b/modules/nodes-pods-autoscaling-custom-rn-2151-4.adoc
@@ -2,7 +2,7 @@
 //
 // * nodes/pods/nodes-pods-user-namespaces.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="nodes-pods-autoscaling-custom-rn-2151-4_{context}"]
 = Custom Metrics Autoscaler Operator 2.15.1-4 release notes
 

--- a/modules/nodes-pods-autoscaling-custom-rn-2172-2.adoc
+++ b/modules/nodes-pods-autoscaling-custom-rn-2172-2.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-user-namespaces.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nodes-pods-autoscaling-custom-rn-2172-2_{context}"]
+= Custom Metrics Autoscaler Operator 2.17.2-2 release notes
+
+Issued: 21 October 2025
+
+This release of the Custom Metrics Autoscaler Operator 2.17.2-2 is a rebuild of the 2.17.2 version of the Custom Metrics Autoscaler Operator using a newer base image and Go compiler. There are no code changes to the Custom Metrics Autoscaler Operator. The following advisory is available for the Custom Metrics Autoscaler Operator:
+
+* link:https://access.redhat.com/errata/RHBA-2025:18914[RHBA-2025:18914]

--- a/modules/nodes-pods-autoscaling-custom-rn-2172.adoc
+++ b/modules/nodes-pods-autoscaling-custom-rn-2172.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-user-namespaces.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nodes-pods-autoscaling-custom-rn-2172_{context}"]
+= Custom Metrics Autoscaler Operator 2.17.2 release notes
+
+Issued: 25 September 2025
+
+This release of the Custom Metrics Autoscaler Operator 2.17.2 addresses Common Vulnerabilities and Exposures (CVEs). The following advisory is available for the Custom Metrics Autoscaler Operator:
+
+* link:https://access.redhat.com/errata/RHSA-2025:16124[RHSA-2025:16124]
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2172-new_{context}"]
+== New features and enhancements
+
+[id="nodes-pods-autoscaling-custom-rn-2172-new-controller_{context}"]
+=== The KEDA controller is automatically created during installation
+
+The KEDA controller is now automatically created when you install the Custom Metrics Autoscaler Operator. Previously, you needed to manually create the KEDA controller. You can edit the automatically-created KEDA controller, as needed. 
+
+[id="nodes-pods-autoscaling-custom-rn-2172-workload_{context}"]
+=== Support for the Kubernetes workload trigger
+
+The Cluster Metrics Autoscaler Operator now supports using the Kubernetes workload trigger to scale pods based on the number of pods matching a specific label selector.
+
+[id="nodes-pods-autoscaling-custom-rn-2172-new-tokens_{context}"]
+=== Support for bound service account tokens
+
+The Cluster Metrics Autoscaler Operator now supports bound service account tokens. Previously, the Operator supported only legacy service account tokens, which are being phased out in favor of bound service account tokens for security reasons.
+
+[id="nodes-pods-autoscaling-custom-rn-2172-bugs_{context}"]
+== Bug fixes
+
+* Previously, the KEDA controller did not support volume mounts. As a result, you could not use Kerberos with the Kafka scaler. With this fix, the KEDA controller now supports volume mounts. (link:https://issues.redhat.com/browse/OCPBUGS-42559[OCPBUGS-42559])
+* Previously, the KEDA version in the `keda-operator` deployment object log reported that the Custom Metrics Autoscaler Operator was based on an incorrect KEDA version. With this fix, the correct KEDA version is reported in the log. (link:https://issues.redhat.com/browse/OCPBUGS-58129[OCPBUGS-58129])

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -10,6 +10,14 @@ The following release notes are for previous versions of the Custom Metrics Auto
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
 
+include::modules/nodes-pods-autoscaling-custom-rn-2172.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../nodes/cma/nodes-cma-autoscaling-custom-install.adoc#nodes-cma-autoscaling-keda-controller-edit_nodes-cma-autoscaling-custom-install[Editing the Keda Controller CR]
+* xref:../../../nodes/cma/nodes-cma-autoscaling-custom-trigger#nodes-cma-autoscaling-custom-trigger-workload_nodes-cma-autoscaling-custom-trigger[Understanding the Kubernetes workload trigger]
+* xref:../../../nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc#nodes-cma-autoscaling-custom-trigger-auth[Understanding custom metrics autoscaler trigger authentications]
+
 include::modules/nodes-pods-autoscaling-custom-rn-2151-4.adoc[leveloffset=+1]
 
 [id="nodes-pods-autoscaling-custom-rn-2141-467_{context}"]
@@ -25,7 +33,7 @@ Before installing this version of the Custom Metrics Autoscaler Operator, remove
 [id="nodes-pods-autoscaling-custom-rn-2141-467-bugs_{context}"]
 === Bug fixes
 
-* Previously, the root file system of the Custom Metrics Autoscaler Operator pod was writable, which is unnecessary and could present security issues. This update makes the pod root file system read-only, which addresses the potential security issue. (link:https://issues.redhat.com/browse/OCPBUGS-37989[*OCPBUGS-37989*])
+* Previously, the root file system of the Custom Metrics Autoscaler Operator pod was writable, which is unnecessary and could present security issues. This update makes the pod root file system read-only, which addresses the potential security issue. (link:https://issues.redhat.com/browse/OCPBUGS-37989[OCPBUGS-37989])
 
 [id="nodes-pods-autoscaling-custom-rn-2141_{context}"]
 == Custom Metrics Autoscaler Operator 2.14.1-454 release notes
@@ -50,7 +58,7 @@ For more information, see xref:../../../nodes/cma/nodes-cma-autoscaling-custom-t
 [id="nodes-pods-autoscaling-custom-rn-2141-bugs_{context}"]
 === Bug fixes
 
-* Previously, if you made changes to audit configuration parameters in the `KedaController` custom resource, the `keda-metrics-server-audit-policy` config map would not get updated. As a consequence, you could not change the audit configuration parameters after the initial deployment of the Custom Metrics Autoscaler. With this fix, changes to the audit configuration now render properly in the config map, allowing you to change the audit configuration any time after installation. (link:https://issues.redhat.com/browse/OCPBUGS-32521[*OCPBUGS-32521*])
+* Previously, if you made changes to audit configuration parameters in the `KedaController` custom resource, the `keda-metrics-server-audit-policy` config map would not get updated. As a consequence, you could not change the audit configuration parameters after the initial deployment of the Custom Metrics Autoscaler. With this fix, changes to the audit configuration now render properly in the config map, allowing you to change the audit configuration any time after installation. (link:https://issues.redhat.com/browse/OCPBUGS-32521[OCPBUGS-32521])
 
 [id="nodes-pods-autoscaling-custom-rn-2131_{context}"]
 == Custom Metrics Autoscaler Operator 2.13.1 release notes
@@ -75,7 +83,7 @@ For more information, see xref:../../../nodes/cma/nodes-cma-autoscaling-custom.a
 [id="nodes-pods-autoscaling-custom-rn-2.13.1-bugs_{context}"]
 === Bug fixes
 
-* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images were missing time zone information. As a consequence, scaled objects with `cron` triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds are updated to include time zone information. As a result, scaled objects containing `cron` triggers now function properly. Scaled objects containing `cron` triggers are currently not supported for the custom metrics autoscaler. (link:https://issues.redhat.com/browse/OCPBUGS-34018[*OCPBUGS-34018*])
+* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images were missing time zone information. As a consequence, scaled objects with `cron` triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds are updated to include time zone information. As a result, scaled objects containing `cron` triggers now function properly. Scaled objects containing `cron` triggers are currently not supported for the custom metrics autoscaler. (link:https://issues.redhat.com/browse/OCPBUGS-34018[OCPBUGS-34018])
 
 
 [id="nodes-pods-autoscaling-custom-rn-2121-394_{context}"]
@@ -91,17 +99,17 @@ Before installing this version of the Custom Metrics Autoscaler Operator, remove
 [id="nodes-pods-autoscaling-custom-rn-2121-394-bugs_{context}"]
 === Bug fixes
 
-* Previously, the `protojson.Unmarshal` function entered into an infinite loop when unmarshaling certain forms of invalid JSON. This condition could occur when unmarshaling into a message that contains a `google.protobuf.Any` value or when the `UnmarshalOptions.DiscardUnknown` option is set. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30305[*OCPBUGS-30305*])
+* Previously, the `protojson.Unmarshal` function entered into an infinite loop when unmarshaling certain forms of invalid JSON. This condition could occur when unmarshaling into a message that contains a `google.protobuf.Any` value or when the `UnmarshalOptions.DiscardUnknown` option is set. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30305[OCPBUGS-30305])
 
-* Previously, when parsing a multipart form, either explicitly with the `Request.ParseMultipartForm` method or implicitly with the `Request.FormValue`, `Request.PostFormValue`, or `Request.FormFile` method, the limits on the total size of the parsed form were not applied to the memory consumed. This could cause memory exhaustion. With this fix, the parsing process now correctly limits the maximum size of form lines while reading a single form line. (link:https://issues.redhat.com/browse/OCPBUGS-30360[*OCPBUGS-30360*])
+* Previously, when parsing a multipart form, either explicitly with the `Request.ParseMultipartForm` method or implicitly with the `Request.FormValue`, `Request.PostFormValue`, or `Request.FormFile` method, the limits on the total size of the parsed form were not applied to the memory consumed. This could cause memory exhaustion. With this fix, the parsing process now correctly limits the maximum size of form lines while reading a single form line. (link:https://issues.redhat.com/browse/OCPBUGS-30360[OCPBUGS-30360])
 
-* Previously, when following an HTTP redirect to a domain that is not on a  matching subdomain or on an exact match of the initial domain, an HTTP client would not forward sensitive headers, such as `Authorization` or `Cookie`. For example, a redirect from `example.com` to `www.example.com` would forward the `Authorization` header, but a redirect to `www.example.org` would not forward the header. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30365[*OCPBUGS-30365*])
+* Previously, when following an HTTP redirect to a domain that is not on a  matching subdomain or on an exact match of the initial domain, an HTTP client would not forward sensitive headers, such as `Authorization` or `Cookie`. For example, a redirect from `example.com` to `www.example.com` would forward the `Authorization` header, but a redirect to `www.example.org` would not forward the header. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30365[OCPBUGS-30365])
 
-* Previously, verifying a certificate chain that contains a certificate with an unknown public key algorithm caused the certificate verification process to panic. This condition affected all crypto and  Transport Layer Security (TLS) clients and servers that set the `Config.ClientAuth` parameter to the `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert` value. The default behavior is for TLS servers to not verify client certificates. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30370[*OCPBUGS-30370*])
+* Previously, verifying a certificate chain that contains a certificate with an unknown public key algorithm caused the certificate verification process to panic. This condition affected all crypto and  Transport Layer Security (TLS) clients and servers that set the `Config.ClientAuth` parameter to the `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert` value. The default behavior is for TLS servers to not verify client certificates. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30370[OCPBUGS-30370])
 
-* Previously, if errors returned from the `MarshalJSON` method contained user-controlled data, an attacker could have used the data to break the contextual auto-escaping behavior of the HTML template package. This condition would allow for subsequent actions to inject unexpected content into the templates. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30397[*OCPBUGS-30397*])
+* Previously, if errors returned from the `MarshalJSON` method contained user-controlled data, an attacker could have used the data to break the contextual auto-escaping behavior of the HTML template package. This condition would allow for subsequent actions to inject unexpected content into the templates. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30397[OCPBUGS-30397])
 
-* Previously, the `net/http` and `golang.org/x/net/http2` Go packages did not limit the number of `CONTINUATION` frames for an HTTP/2 request. This condition could result in excessive CPU consumption. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30894[*OCPBUGS-30894*])
+* Previously, the `net/http` and `golang.org/x/net/http2` Go packages did not limit the number of `CONTINUATION` frames for an HTTP/2 request. This condition could result in excessive CPU consumption. This release fixes this issue. (link:https://issues.redhat.com/browse/OCPBUGS-30894[OCPBUGS-30894])
 
 [id="nodes-pods-autoscaling-custom-rn-2121-384_{context}"]
 == Custom Metrics Autoscaler Operator 2.12.1-384 release notes
@@ -116,7 +124,7 @@ Before installing this version of the Custom Metrics Autoscaler Operator, remove
 [id="nodes-pods-autoscaling-custom-rn-2121-384-bugs_{context}"]
 === Bug fixes
 
-* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images were missing time zone information. As a consequence, scaled objects with `cron` triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds are updated to include time zone information. As a result, scaled objects containing `cron` triggers now function properly. (link:https://issues.redhat.com/browse/OCPBUGS-32395[*OCPBUGS-32395*]) 
+* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images were missing time zone information. As a consequence, scaled objects with `cron` triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds are updated to include time zone information. As a result, scaled objects containing `cron` triggers now function properly. (link:https://issues.redhat.com/browse/OCPBUGS-32395[OCPBUGS-32395]) 
 
 [id="nodes-pods-autoscaling-custom-rn-2121-376_{context}"]
 == Custom Metrics Autoscaler Operator 2.12.1-376 release notes
@@ -131,9 +139,9 @@ Before installing this version of the Custom Metrics Autoscaler Operator, remove
 [id="nodes-pods-autoscaling-custom-rn-2121-376-bugs_{context}"]
 === Bug fixes
 
-* Previously, if invalid values such as nonexistent namespaces were specified in scaled object metadata, the underlying scaler clients would not free, or close, their client descriptors, resulting in a slow memory leak. This fix properly closes the underlying client descriptors when there are errors, preventing memory from leaking. (link:https://issues.redhat.com/browse/OCPBUGS-30145[*OCPBUGS-30145*])
+* Previously, if invalid values such as nonexistent namespaces were specified in scaled object metadata, the underlying scaler clients would not free, or close, their client descriptors, resulting in a slow memory leak. This fix properly closes the underlying client descriptors when there are errors, preventing memory from leaking. (link:https://issues.redhat.com/browse/OCPBUGS-30145[OCPBUGS-30145])
 
-* Previously the `ServiceMonitor` custom resource (CR) for the `keda-metrics-apiserver` pod was not functioning, because the CR referenced an incorrect metrics port name of `http`. This fix corrects the `ServiceMonitor` CR to reference the proper port name of `metrics`. As a result, the Service Monitor functions properly. (link:https://issues.redhat.com/browse/OCPBUGS-25806[*OCPBUGS-25806*])
+* Previously the `ServiceMonitor` custom resource (CR) for the `keda-metrics-apiserver` pod was not functioning, because the CR referenced an incorrect metrics port name of `http`. This fix corrects the `ServiceMonitor` CR to reference the proper port name of `metrics`. As a result, the Service Monitor functions properly. (link:https://issues.redhat.com/browse/OCPBUGS-25806[OCPBUGS-25806])
 
 [id="nodes-pods-autoscaling-custom-rn-2112-322_{context}"]
 == Custom Metrics Autoscaler Operator 2.11.2-322 release notes
@@ -148,7 +156,7 @@ Before installing this version of the Custom Metrics Autoscaler Operator, remove
 [id="nodes-pods-autoscaling-custom-rn-2112-332-bugs_{context}"]
 === Bug fixes
 
-* Because the Custom Metrics Autoscaler Operator version 3.11.2-311 was released without a required volume mount in the Operator deployment, the Custom Metrics Autoscaler Operator pod would restart every 15 minutes. This fix adds the required volume mount to the Operator deployment. As a result, the Operator no longer restarts every 15 minutes.  (link:https://issues.redhat.com/browse/OCPBUGS-22361[*OCPBUGS-22361*])
+* Because the Custom Metrics Autoscaler Operator version 3.11.2-311 was released without a required volume mount in the Operator deployment, the Custom Metrics Autoscaler Operator pod would restart every 15 minutes. This fix adds the required volume mount to the Operator deployment. As a result, the Operator no longer restarts every 15 minutes.  (link:https://issues.redhat.com/browse/OCPBUGS-22361[OCPBUGS-22361])
 
 [id="nodes-pods-autoscaling-custom-rn-2112_{context}"]
 == Custom Metrics Autoscaler Operator 2.11.2-311 release notes
@@ -171,9 +179,9 @@ The Custom Metrics Autoscaler Operator 2.11.2-311 can be installed on Red Hat Op
 [id="nodes-pods-autoscaling-custom-rn-2112-bugs_{context}"]
 === Bug fixes
 
-* Previously, if the Custom Metrics Autoscaler Operator was installed and configured, but not in use, the OpenShift CLI reported the `couldn't get resource list for external.metrics.k8s.io/v1beta1: Got empty response for: external.metrics.k8s.io/v1beta1` error after any `oc` command was entered. The message, although harmless, could have caused confusion. With this fix, the `Got empty response for: external.metrics...` error no longer appears inappropriately. (link:https://issues.redhat.com/browse/OCPBUGS-15779[*OCPBUGS-15779*])
+* Previously, if the Custom Metrics Autoscaler Operator was installed and configured, but not in use, the OpenShift CLI reported the `couldn't get resource list for external.metrics.k8s.io/v1beta1: Got empty response for: external.metrics.k8s.io/v1beta1` error after any `oc` command was entered. The message, although harmless, could have caused confusion. With this fix, the `Got empty response for: external.metrics...` error no longer appears inappropriately. (link:https://issues.redhat.com/browse/OCPBUGS-15779[OCPBUGS-15779])
 
-* Previously, any annotation or label change to objects managed by the Custom Metrics Autoscaler were reverted by Custom Metrics Autoscaler Operator any time the Keda Controller was modified, for example after a configuration change. This caused continuous changing of labels in your objects. The Custom Metrics Autoscaler now uses its own annotation to manage labels and annotations, and annotation or label are no longer inappropriately reverted. (link:https://issues.redhat.com/browse/OCPBUGS-15590[*OCPBUGS-15590*])
+* Previously, any annotation or label change to objects managed by the Custom Metrics Autoscaler were reverted by Custom Metrics Autoscaler Operator any time the Keda Controller was modified, for example after a configuration change. This caused continuous changing of labels in your objects. The Custom Metrics Autoscaler now uses its own annotation to manage labels and annotations, and annotation or label are no longer inappropriately reverted. (link:https://issues.redhat.com/browse/OCPBUGS-15590[OCPBUGS-15590])
 
 [id="nodes-pods-autoscaling-custom-rn-210-267_{context}"]
 == Custom Metrics Autoscaler Operator 2.10.1-267 release notes
@@ -188,13 +196,13 @@ Before installing this version of the Custom Metrics Autoscaler Operator, remove
 [id="nodes-pods-autoscaling-custom-rn-210-267-bugs_{context}"]
 === Bug fixes
 
-* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images did not contain time zone information. Because of this, scaled objects with cron triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds now include time zone information. As a result, scaled objects containing cron triggers now function properly. (link:https://issues.redhat.com/browse/OCPBUGS-15264[*OCPBUGS-15264*])
+* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images did not contain time zone information. Because of this, scaled objects with cron triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds now include time zone information. As a result, scaled objects containing cron triggers now function properly. (link:https://issues.redhat.com/browse/OCPBUGS-15264[OCPBUGS-15264])
 
-* Previously, the Custom Metrics Autoscaler Operator would attempt to take ownership of all managed objects, including objects in other namespaces and cluster-scoped objects. Because of this, the Custom Metrics Autoscaler Operator was unable to create the role binding for reading the credentials necessary to be an API server. This caused errors in the `kube-system` namespace. With this fix, the Custom Metrics Autoscaler Operator skips adding the `ownerReference` field to any object in another namespace or any cluster-scoped object. As a result, the role binding is now created without any errors. (link:https://issues.redhat.com/browse/OCPBUGS-15038[*OCPBUGS-15038*])
+* Previously, the Custom Metrics Autoscaler Operator would attempt to take ownership of all managed objects, including objects in other namespaces and cluster-scoped objects. Because of this, the Custom Metrics Autoscaler Operator was unable to create the role binding for reading the credentials necessary to be an API server. This caused errors in the `kube-system` namespace. With this fix, the Custom Metrics Autoscaler Operator skips adding the `ownerReference` field to any object in another namespace or any cluster-scoped object. As a result, the role binding is now created without any errors. (link:https://issues.redhat.com/browse/OCPBUGS-15038[OCPBUGS-15038])
 
-* Previously, the Custom Metrics Autoscaler Operator added an `ownerReferences` field to the `openshift-keda` namespace. While this did not cause functionality problems, the presence of this field could have caused confusion for cluster administrators. With this fix, the Custom Metrics Autoscaler Operator does not add the `ownerReference` field to the `openshift-keda` namespace. As a result, the `openshift-keda` namespace no longer has a superfluous `ownerReference` field. (link:https://issues.redhat.com/browse/OCPBUGS-15293[*OCPBUGS-15293*])
+* Previously, the Custom Metrics Autoscaler Operator added an `ownerReferences` field to the `openshift-keda` namespace. While this did not cause functionality problems, the presence of this field could have caused confusion for cluster administrators. With this fix, the Custom Metrics Autoscaler Operator does not add the `ownerReference` field to the `openshift-keda` namespace. As a result, the `openshift-keda` namespace no longer has a superfluous `ownerReference` field. (link:https://issues.redhat.com/browse/OCPBUGS-15293[OCPBUGS-15293])
 
-* Previously, if you used a Prometheus trigger configured with authentication method other than pod identity, and the `podIdentity` parameter was set to `none`, the trigger would fail to scale. With this fix, the Custom Metrics Autoscaler for OpenShift now properly handles the `none` pod identity provider type. As a result, a Prometheus trigger configured with authentication method other than pod identity, and the `podIdentity` parameter sset to `none` now properly scales. (link:https://issues.redhat.com/browse/OCPBUGS-15274[*OCPBUGS-15274*])
+* Previously, if you used a Prometheus trigger configured with authentication method other than pod identity, and the `podIdentity` parameter was set to `none`, the trigger would fail to scale. With this fix, the Custom Metrics Autoscaler for OpenShift now properly handles the `none` pod identity provider type. As a result, a Prometheus trigger configured with authentication method other than pod identity, and the `podIdentity` parameter sset to `none` now properly scales. (link:https://issues.redhat.com/browse/OCPBUGS-15274[OCPBUGS-15274])
 
 [id="nodes-pods-autoscaling-custom-rn-210_{context}"]
 == Custom Metrics Autoscaler Operator 2.10.1 release notes

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -26,78 +26,47 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |{product-title} version
 |General availability
 
-|2.17.2
+|2.17.2-2
 |4.20
 |General availability
 
-|2.17.2
+|2.17.2-2
 |4.19
 |General availability
 
-|2.17.2
+|2.17.2-2
 |4.18
 |General availability
 
 
-|2.17.2
+|2.17.2-2
 |4.17
 |General availability
 
-|2.17.2
+|2.17.2-2
 |4.16
 |General availability
 
-|2.17.2
+|2.17.2-2
 |4.15
 |General availability
 
-|2.17.2
+|2.17.2-2
 |4.14
 |General availability
 
-|2.17.2
+|2.17.2-2
 |4.13
 |General availability
 
-|2.17.2
+|2.17.2-2
 |4.12
 |General availability
 |===
 
-[id="nodes-pods-autoscaling-custom-rn-2172_{context}"]
-== Custom Metrics Autoscaler Operator 2.17.2 release notes
-
-Issued: 25 September 2025
-
-This release of the Custom Metrics Autoscaler Operator 2.17.2 addresses Common Vulnerabilities and Exposures (CVEs). The following advisory is available for the Custom Metrics Autoscaler Operator:
-
-* link:https://access.redhat.com/errata/RHSA-2025:16124[RHSA-2025:16124]
+include::modules/nodes-pods-autoscaling-custom-rn-2172-2.adoc[leveloffset=+1]
 
 [IMPORTANT]
 ====
 Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
 ====
-
-[id="nodes-pods-autoscaling-custom-rn-2172-new_{context}"]
-=== New features and enhancements
-
-[id="nodes-pods-autoscaling-custom-rn-2172-new-controller_{context}"]
-==== The KEDA controller is automatically created during installation
-
-The KEDA controller is now automatically created when you install the Custom Metrics Autoscaler Operator. Previously, you needed to manually create the KEDA controller. You can edit the automatically-created KEDA controller, as needed. For more information, see xref:../../../nodes/cma/nodes-cma-autoscaling-custom-install.adoc#nodes-cma-autoscaling-keda-controller-edit_nodes-cma-autoscaling-custom-install[Editing the Keda Controller CR].
-
-[id="nodes-pods-autoscaling-custom-rn-2172-workload_{context}"]
-==== Support for the Kubernetes workload trigger
-
-The Cluster Metrics Autoscaler Operator now supports using the Kubernetes workload trigger to scale pods based on the number of pods matching a specific label selector. For more information, see xref:../../../nodes/cma/nodes-cma-autoscaling-custom-trigger#nodes-cma-autoscaling-custom-trigger-workload_nodes-cma-autoscaling-custom-trigger[Understanding the Kubernetes workload trigger].
-
-[id="nodes-pods-autoscaling-custom-rn-2172-new-tokens_{context}"]
-==== Support for bound service account tokens
-
-The Cluster Metrics Autoscaler Operator now supports bound service account tokens. Previously, the Operator supported only legacy service account tokens, which are being phased out in favor of bound service account tokens for security reasons. For more information see xref:../../../nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc#nodes-cma-autoscaling-custom-trigger-auth[Understanding custom metrics autoscaler trigger authentications].
-
-[id="nodes-pods-autoscaling-custom-rn-2172-bugs_{context}"]
-=== Bug fixes
-
-* Previously, the KEDA controller did not support volume mounts. As a result, you could not use Kerberos with the Kafka scaler. With this fix, the KEDA controller now supports volume mounts. (link:https://issues.redhat.com/browse/OCPBUGS-42559[*OCPBUGS-42559*])
-* Previously, the KEDA version in the `keda-operator` deployment object log reported that the Custom Metrics Autoscaler Operator was based on an incorrect KEDA version. With this fix, the correct KEDA version is reported in the log. (link:https://issues.redhat.com/browse/OCPBUGS-58129[*OCPBUGS-58129*])


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16900

Link to docs preview:
CMA RN -> [Supported versions](https://101309--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn#nodes-pods-autoscaling-custom-rn-versions_nodes-cma-autoscaling-custom-rn) -- Updated version table.
CMA RN -> [Custom Metrics Autoscaler Operator 2.17.2-2 release notes](https://101309--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn#nodes-pods-autoscaling-custom-rn-2172-2_nodes-cma-autoscaling-custom-rn) -- New module, text based on the text in the errata.
CMA Past Releases -> [Custom Metrics Autoscaler Operator 2.17.2 release notes](https://101309--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past#nodes-pods-autoscaling-custom-rn-2172_nodes-cma-autoscaling-custom-rn-past) -- Moved from release notes to a new module in the past release notes assembly. Updated heading levels. **NO CHANGES TO THE TEXT. No need to review.**
CMA Past Releases -> [Custom Metrics Autoscaler Operator 2.15.1-4 release notes](https://github.com/openshift/openshift-docs/pull/101309/files#diff-33bf0ea57c5f61bb176d6f7f581fc448b03b31188352601e4c79c11639b84c16R5) -- Updated the mod-docs-content-type. No real preview.
