### PR TITLE
TELCODOCS-2529: In IBI and IBU, IPv6/4 now both possible as primary address fam in dual-stack networking

### DIFF
--- a/modules/ibi-create-config-iso.adoc
+++ b/modules/ibi-create-config-iso.adoc
@@ -213,7 +213,7 @@ spec:
 <3> Specify the name of the `ClusterDeployment` resource that you want to use for the image-based installation of the target host.
 <4> Specify the hostname for the cluster.
 <5> Specify the name of the `ClusterImageSet` resource you used to define the container release images to use for deployment.
-<6> Specify the public Classless Inter-Domain Routing (CIDR) of the external network. For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format. Regardless of the list order, the IPv4 family becomes the primary address family.
+<6> Specify the public Classless Inter-Domain Routing (CIDR) of the external network. For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format. The first CIDR in the list is the primary address family and must match the primary address family of the seed cluster.
 <7> Optional: Specify a proxy to use for the cluster deployment.
 +
 [IMPORTANT]

--- a/modules/ibi-create-standalone-config-iso.adoc
+++ b/modules/ibi-create-standalone-config-iso.adoc
@@ -67,7 +67,7 @@ cpuPartitioningMode: "AllNodes"
 pullSecret: '{"auths":{"<your_pull_secret>"}}}'
 sshKey: 'ssh-rsa <your_ssh_pub_key>'
 ----
-<1> For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format. You must specify the IPv4 family as the primary address family by defining the IPv4 address as the first item in the list.
+<1> For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format. The first CIDR in the list is the primary address family and must match the primary address family of the seed cluster.
 
 [IMPORTANT]
 ====

--- a/modules/ibi-image-cluster-install-api-spec.adoc
+++ b/modules/ibi-image-cluster-install-api-spec.adoc
@@ -45,7 +45,7 @@ imageDigestSources:
 
 |`bareMetalHostRef`|`string`| Specify the `bareMetalHost` resource to use for the cluster deployment
 
-|`machineNetwork`|`string`| Specify the public Classless Inter-Domain Routing (CIDR) of the external network. For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format. Regardless of the list order, the IPv4 family becomes the primary address family.
+|`machineNetworks`|`string`| Specify the public Classless Inter-Domain Routing (CIDR) of the external network. For dual-stack networking, you can specify both IPv4 and IPv6 CIDRs using a list format. The first CIDR in the list is the primary address family and must match the primary address family of the seed cluster.
 
 |`proxy`|`string`|Specifies proxy settings for the cluster, for example:
 [source,yaml]


### PR DESCRIPTION
[TELCODOCS-2529](https://issues.redhat.com//browse/TELCODOCS-2529): In IBI and IBU, IPv6/4 now both possible as primary address fam in dual-stack networking

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/TELCODOCS-2529

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
