### PR TITLE
OBSDOCS-2651 COO 1.3 GA Release Notes

### DIFF
--- a/release-notes/cluster-observability-operator-release-notes.adoc
+++ b/release-notes/cluster-observability-operator-release-notes.adoc
@@ -26,6 +26,41 @@ The following table provides information about which features are available depe
 
 include::snippets/unified-perspective-web-console.adoc[]
 
+
+[id="cluster-observability-operator-release-notes-1-3_{context}"]
+== {coo-full} 1.3
+
+The following advisory is available for {coo-full} 1.3:
+
+//* link:https://access.redhat.com/errata/RHBA-2025:XXXX[RHBA-2025:XXXX {coo-full} 1.3]
+
+[id="cluster-observability-operator-1-3-new-features-enhancements_{context}"]
+=== New features and enhancements
+
+
+[id="cluster-observability-operator-1-3-bug-fixes_{context}"]
+=== Bug fixes
+
+Troubleshooting panel handles {product-title} 4.19 alert URLs correctly::
+Before this update, {product-title} 4.19 introduced changes to alert URL formatting where some URLs contained only console-internal numeric IDs without alert names. As a consequence, the korrel8r troubleshooting panel failed to process these URLs correctly and could not correlate alerts with related resources.
++
+With this release, korrel8r correctly handles alert URLs from {product-title} 4.19, including URLs that contain only numeric identifiers. As a result, the troubleshooting panel works correctly with all alert types on {product-title} 4.19 clusters.
++
+link:https://issues.redhat.com/browse/COO-1145[COO-1145]
+
+Troubleshooting panel generates valid LogQL queries for Loki logs::
+Before this update, the troubleshooting panel generated malformed LogQL queries when accessing Loki logs through the korrel8r graph. The panel omitted label names from query expressions, producing invalid syntax such as `{ :"value" }` instead of `{label="value"}`. As a consequence, users could not open Loki logs from the korrel8r graph in the {product-title} console and encountered parsing errors from the Observatorium API.
++
+With this release, the troubleshooting panel correctly generates valid LogQL queries with proper label matcher syntax. As a result, users can successfully navigate from the korrel8r graph to corresponding Loki logs for detailed investigation.
++
+link:https://issues.redhat.com/browse/COO-1271[COO-1271]
+
+
+[id="cluster-observability-operator-1-3-known-issues_{context}"]
+=== Known issues
+
+
+
 [id="cluster-observability-operator-release-notes-1-2-2_{context}"]
 == {coo-full} 1.2.2
 


### PR DESCRIPTION
Version(s):
standalone-coo-docs-1-latest

Issue:
[OBSDOCS-2651](https://issues.redhat.com//browse/OBSDOCS-2651)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
