### PR TITLE
OSDOCS-16509 [NETOBSERV] Update xrefs in new alert content

### DIFF
--- a/observability/network_observability/network-observability-alerts.adoc
+++ b/observability/network_observability/network-observability-alerts.adoc
@@ -27,15 +27,13 @@ include::modules/network-observability-creating-custom-alert-rules.adoc[leveloff
 
 include::modules/network-observability-disabling-predefined-alerts.adoc[leveloffset=+2]
 
-////
-New content so xrefs break builds. Update/uncomment after content is merged into main
+
 [role="_additional-resources"]
 .Additional resources
-//* xref:../../network_observability/index#metrics-dashboards-alerts.adoc[Metrics and alerts dashboard]
-// xref:../../network_observability/network-observability-alerts.adoc#network-observability-default-alerts_network-observability-alerts[List of default alerts]
-//* xref:../../../network_observability/metrics-alerts-dashboards.adoc#metrics-alerts-dashboards#network-observability-netobserv-dashboard-high-traffic-alert_metrics-dashboards-alerts[Creating alerts]
-* xref: ../../monitoring/about-ocp-monitoring/monitoring-stack-architecture.adoc#default-monitoring-components_monitoring-stack-architecture[Monitoring stack architecture]
+* xref:../../observability/network_observability/network-observability-alerts.adoc#network-observability-default-alert-templates_network-observability-alerts[List of default alerts]
+* xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-viewing-dashboards_metrics-dashboards-alerts[Viewing network observability metrics dashboards]
+* xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-netobserv-dashboard-high-traffic-alert_metrics-dashboards-alerts[Creating alerts]
+* xref:../../observability/monitoring/about-ocp-monitoring/monitoring-stack-architecture.adoc#monitoring-stack-architecture[Monitoring stack architecture]
 
 //file name for Creating alerts: network-observability-includelist-example.adoc
 //URL for Creating alerts: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/network_observability/metrics-dashboards-alerts#network-observability-netobserv-dashboard-high-traffic-alert_metrics-dashboards-alerts
-////


### PR DESCRIPTION
[OSDOCS-16509](https://issues.redhat.com//browse/OSDOCS-16509) [NETOBSERV] Update xrefs in new alert content

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-16509

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
QE review is not required for this PR.

Additional information:
* Additional resources section: https://101325--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-alerts.html#network-observability-disabling-predefined-alerts_network-observability-alerts
* xref: List of default alert templates: https://101325--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-alerts#network-observability-default-alert-templates_network-observability-alerts
* xref: Viewing network observability metrics dashboards: https://101325--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards#network-observability-viewing-dashboards_metrics-dashboards-alerts
* xref: Creating alerts: https://101325--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards#network-observability-netobserv-dashboard-high-traffic-alert_metrics-dashboards-alerts
* xref: Monitoring stack architecture: https://101325--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/monitoring/about-ocp-monitoring/monitoring-stack-architecture#monitoring-stack-architecture

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
