### PR TITLE
OSDOCS-16617-419: modularizes 4.19 relnotes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-19-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-19-release-notes.adoc
@@ -1,219 +1,33 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-4-19-release-notes"]
-= {product-title} {product-version} release notes
 include::_attributes/attributes-microshift.adoc[]
+= {product-title} {product-version} release notes
+
 :context: release-notes
 
 toc::[]
 
+[role="_abstract"]
 {product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate a single node in low-resource edge environments.
 
-{microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
+include::modules/microshift-4-19-about-this-release.adoc[leveloffset=+1]
 
-[id="microshift-4-19-about-this-release_{context}"]
-== About this release
-Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {ocp-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+include::modules/microshift-4-19-new-features-and-enhancements.adoc[leveloffset=+1]
 
-You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
+include::modules/microshift-4-19-notable-technical-changes.adoc[leveloffset=+1]
 
-{microshift-short} {product-version} is supported on {op-system-base-full} 9.6.
+include::modules/microshift-4-19-tech-preview.adoc[leveloffset=+1]
 
-For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
+include::modules/microshift-4-19-deprecated-and-removed-features.adoc[leveloffset=+1]
 
-[id="microshift-4-19-new-features-and-enhancements_{context}"]
-== New features and enhancements
+include::modules/microshift-4-19-bug-fixes.adoc[leveloffset=+1]
 
-This release adds improvements related to the following components and concepts.
+include::modules/microshift-4-19-known-issues.adoc[leveloffset=+1]
 
-//L3 major categories with features in each as L4s
-//[id="microshift-4-19-rhel_{context}"]
-=== {op-system-base-full}
+include::modules/microshift-4-19-additional-release-notes.adoc[leveloffset=+1]
 
-[id="microshift-4-19-rhel-image-mode_{context}"]
-==== {op-system-base} image mode (Generally Available)
-Installing {microshift-short} by using a bootc container image is now generally available. Previously available as a Technology Preview feature, {op-system-image} is a deployment method that uses a container-native approach to build, deploy, and manage the operating system as a `rhel-bootc` container image. See xref:../microshift_install_bootc/microshift-about-rhel-image-mode.adoc#microshift-about-rhel-image-mode[Understanding image mode for RHEL with {microshift-short}] for more information.
+include::modules/microshift-4-19-asynchronous-errata-updates.adoc[leveloffset=+1]
 
-//4.19 is not an EUS release
-[id="microshift-4-19-updating_{context}"]
-=== Updating
-Updates for both single-version minor releases and patch releases are supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
+include::modules/microshift-4-19-0-dp.adoc[leveloffset=+2]
 
-//TODO add new features and enhancements as needed, follow doc TOC titles as L3s, then add L4 headings for each feature
-
-[id="microshift-4-19-configuring_{context}"]
-=== Configuring
-
-[id="microshift-4-19-ingress-controller-two-config_{context}"]
-==== Control ingress for your use case with additional parameters
-
-With this release, the `ingress.certificate.Secret`,`ingress.clientTLS`, `ingress.routeAdmissionPolicy`, and `ingress.tlsSecurityProfile` parameters are added to the YAML configuration file for {microshift-short}. These parameters specify security settings for the ingress controller. For more information, see xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} node].
-
-[id="microshift-4-19-tls-config_{context}"]
-==== {microshift-short} control plane enhanced with TLS
-
-With this release, configurable transport layer security (TLS) protocols on internal control plane components are enabled to help prevent known insecure protocols, ciphers, or algorithms from accessing the applications you run on {microshift-short}. You use either the TLS 1.2 or TLS 1.3 with {microshift-short}. For more information, see xref:../microshift_configuring/microshift_auth_security/microshift-tls-config.adoc#microshift-tls-config[Configuring TLS security profiles].
-
-[id="microshift-4-19-running-apps_{context}"]
-=== Running applications
-
-[id="microshift-4-19-greenboot-updated_{context}"]
-==== Check application health with the {microshift-short} healthcheck command
-
-With this release, you can use the `microshift healthcheck` command with various options to run a basic health check on your applications. For more information, see xref:../microshift_running_apps/microshift-greenboot-workload-health-checks.adoc#microshift-greenboot-workload-health-checks[Greenboot workload health checks].
-
-[id="microshift-4-19-observability-metrics_{context}"]
-==== Collecting metrics using the {microshift-short} Observability service
-
-With this release, you can configure the {microshift-short} Observability service to collect performance and usage metrics for monitoring resources. The following predefined configurations differ in the amount of data collected:
-
-* Small
-* Medium
-* Large (default)
-
-For more information, see xref:../microshift_running_apps/microshift-observability-service.adoc#microshift-observability-service[Using {microshift-short}] Observability.
-
-[id="microshift-4-19-support_{context}"]
-=== Support
-
-[id="microshift-4-19-telemetry_{context}"]
-==== Telemetry now available
-With this release, {microshift-short} adds the Telemeter API. Lightweight attributes can be sent from a connected node to Red{nbsp}Hat to monitor the health of the node. To opt-out of Telemetry, see xref:../microshift_support/microshift-remote-node-monitoring.adoc#microshift-remote-node-monitoring[Remote health monitoring with a connected node].
-
-[id="microshift-4-19-notable-technical-changes_{context}"]
-== Notable technical changes
-
-[id="microshift-4-19-multus-standard-install_{context}"]
-=== Multus CNI manifests included in the {microshift-short} RPM
-
-With this release, the {microshift-short} RPM includes the {microshift-short} multiple networking plug-in. To deploy the Multus container network interface (CNI), you can either set the value in the {microshift-short} configuration file, or install the `microshift-multus` RPM, which contains a configuration snippet. For more information, see xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-cni-multus[About using multiple networks].
-
-[id="microshift-4-19-tech-preview_{context}"]
-== Technology Preview features
-
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
-
-link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
-
-[id="microshift-4-19-ai_{context}"]
-=== Red{nbsp}Hat OpenShift AI with {microshift-short}
-
-[id="microshift-4-19-example-ra-feature_{context}"]
-==== Serve your trained models on edge deployments
-
-With this release, a streamlined version of Red{nbsp}Hat OpenShift AI (RHOAI) can be used to serve artificial intelligence or machine learning (AI/ML) models on {microshift-short}. Develop and train your AI models in the data center or cloud, then deploy them to the edge where these models can make decisions without a human user. For more information, see xref:../microshift_ai/microshift-rhoai.adoc#microshift-rhoai[Using Red{nbsp}Hat OpenShift AI with {microshift-short}].
-
-[id="microshift-4-19-deprecated-and-removed-features_{context}"]
-== Deprecated and removed features
-
-Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in and continues to be supported, but will be removed in a future release. Deprecated features and functionality are not recommended for new deployments.
-
-[id="microshift-4-19-app-greenboot-script-deprecated_{context}"]
-=== Greenboot application health check script functions deprecated
-
-The following functions related to checking workload health in the `/usr/share/microshift/functions/greenboot.sh` script are deprecated:
-
-* `wait_for`
-* `namespace_images_downloaded`
-* `namespace_deployment_ready`
-* `namespace_daemonset_ready`
-* `namespace_pods_ready`
-* `namespace_pods_not_restarting`
-* `print_failure_logs`
-* `log_failure_cmd`
-* `log_script_exit`
-* `lvmsDriverShouldExist`
-* `csiComponentShouldBeDeploy`
-
-//NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
-[id="microshift-4-19-bug-fixes_{context}"]
-== Bug fixes
-
-* Before this update, using `microshift-gitops` in a disconnected environment failed because its manifests had the `imagePullPolicy` set to `Always`. In these cases, GitOps tried to pull images over a non-existent network and failed with an `ImagePullBackoff` error. With this update, the `imagePullPolicy` is set to `IfNotPresent`, which means that GitOps uses a local image and can start normally. (link:https://issues.redhat.com/browse/OCPBUGS-37938[OCPBUGS-37938])
-
-* Previously, specific cipher suites required by {microshift-short} etcd when using TLS 1.2 were not included in the {microshift-short} startup configuration file. As a result, {microshift-short} failed to start when using TLS 1.2. With this release, the required cipher suites are in the configuration file by default and {microshift-short} can start normally when using TLS 1.2. (link:https://issues.redhat.com/browse/OCPBUGS-48735[OCPBUGS-48735])
-
-* Previously, a `.nodename` file that holds the last hostname was created by MicroShift on startup non-atomically. When MicroShift's startup was interrupted, the `.nodename` file was left behind empty. This `.nodename` file was used on the next MicroShift startup, causing the node name to stored as an empty string. This caused the API Server to reject the kubelet's calls and the start up failed. With this release, the `.nodename` file is created atomically with each MicroShift start up, preventing the error. (link:https://issues.redhat.com/browse/OCPBUGS-48163[OCPBUGS-48163])
-
-* By default, the {microshift-short} Logical Volume Manager Storage (LVMS) image copied the manifest list for four platforms because of automatic digest preservation. This action caused unnecessary usage of disk and network space. With this release, the manifest list is replaced with images specific to each architecture. Now, the {microshift-short} LVMS images only contain supported platform images, saving on disk space and network bandwidth. (link:https://issues.redhat.com/browse/OCPBUGS-51329[OCPBUGS-51329])
-
-* Previously, the `kustomizer` sub-service was blocking `microshift.service` readiness by adding a manifest that required a webhook for a Custom Resource (CR) before {microshift-short} had started. This resulted `kustomizer` failing, causing {microshift-short} to fail. With this release, {microshift-short} is no longer dependent on the `kustomizer` sub-service, and can start even if a manifest is malformed by `kustomizer`. (link:https://issues.redhat.com/browse/OCPBUGS-51365[OCPBUGS-51365])
-
-* In previous versions of {microshift-short} and {op-system-base}, the {microshift-short} container-image-embedding procedure used the default container storage directory, which prevented proper image updates. With this release, the recommended image-embedding procedure was changed to use a dedicated directory for each image and a systemd service copying those embedded images into the default container storage. As a result, updates for {op-system-image} are applied as expected with {microshift-short} and embedded containers. (link:https://issues.redhat.com/browse/OCPBUGS-52420[OCPBUGS-52420])
-
-[id="microshift-4-19-known-issues_{context}"]
-== Known issues
-
-* The maximum transmission unit (MTU) value in {microshift-short} OVN-K overlay networking must be 100 bytes smaller than the MTU value of the base network. {microshift-short} automatically configures the value using the MTU value of the default gateway of the host. If the auto-configuration does not work correctly, the MTU value must be configured manually. For more information, see xref:../microshift_networking/microshift-cni.adoc#microshift-network-topology_microshift-about-ovn-k-plugin[Network topology].
-
-[id="microshift-4-19-additional-release-notes_{context}"]
-== Additional release notes
-Release notes for related components and products are available in the following documentation:
-
-[NOTE]
-====
-The following release notes are for downstream Red{nbsp}Hat products only; upstream or community release notes for related products are not included.
-====
-
-//TODO check the latest gitops release version
-[id="microshift-4-19-additional-release-notes-gitops_{context}"]
-=== GitOps release notes
-See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/latest/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package, link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
-
-[id="microshift-4-19-additional-release-notes-ocp_{context}"]
-=== {OCP} release notes
-See the https://docs.openshift.com/container-platform/4.19/release_notes/ocp-4-19-release-notes.html[{OCP} Release Notes] for information about the Operator Lifecycle Manager and other components. Not all of the changes to {OCP} apply to {microshift-short}. See the specific {microshift-short} implementation of an Operator or function for more information.
-
-[id="microshift-4-19-additional-release-notes-rhel_{context}"]
-=== {op-system-base-full} release notes
-See the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.6_release_notes/index[Release Notes for Red{nbsp}Hat Enterprise Linux 9.6] for more information about {op-system-base}.
-//Use the latest compatible RHEL, expected to be 9.6
-
-[id="microshift-4-19-additional-release-notes-rhoai_{context}"]
-=== {rhoai} release notes
-See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/release_notes/index[Release notes] for more information about {rhoai}.
-//TODO rhoai has a faster release cadence than OCP; get `latest` tag working
-
-[id="microshift-4-19-asynchronous-errata-updates_{context}"]
-== Asynchronous errata updates
-
-Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red{nbsp}Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
-
-Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
-
-[NOTE]
-====
-Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
-====
-
-This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
-
-[id="microshift-4-19-0-dp_{context}"]
-=== RHEA-2024:11040 - {microshift-short} 4.19.0 bug fix and security update advisory
-
-Issued: 17 June 2025
-
-{product-title} release 4.19.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:11040[RHEA-2024:11040] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:11038[RHSA-2024:11038] advisory.
-
-See the latest images included with {microshift-short} by using the following instructions:
-
-* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
-* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
-
-[id="microshift-4-19-7-dp_{context}"]
-=== RHBA-2025:12745 - {microshift-short} 4.19.7 bug fix and update advisory
-
-Issued: 11 August 2025
-
-{product-title} release 4.19.7 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:12745[RHBA-2025:12745] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:12341[RHSA-2025:12341] advisory.
-
-See the latest images included with {microshift-short} by using the following instructions:
-
-* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
-* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
-
-[id="microshift-4-19-7-dp-bug-fixes_{context}"]
-==== Bug fixes
-
-* Before this update, a bare-metal node reboot caused the deployment progress deadline to be surpassed. This resulted in the greenboot health check failing with a false-positive error. With this release, the full timeout duration is provided for the deployment to become ready, reducing false-positive greenboot health check errors. (https://issues.redhat.com/browse/OCPBUGS-59301[OCPBUGS-59301])
-
-* Before this update, the excessive polling frequency for the cloud pull secret in node telemetry caused telemetry failure messages to flood journald logs. The log flooding negatively impacted system performance. With this release, the telemetry collection interval is updated from 1 second to 30 seconds. As a result, log flooding has been minimized and no longer impacts system performance. (https://issues.redhat.com/browse/OCPBUGS-59240[OCPBUGS-59240])
+include::modules/microshift-4-19-7-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-19-0-dp.adoc
+++ b/modules/microshift-4-19-0-dp.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-0-dp_{context}"]
+= RHEA-2024:11040 - {microshift-short} 4.19.0 bug fix and security update advisory
+
+[role="_abstract"]
+Issued: 17 June 2025
+
+{product-title} release 4.19.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:11040[RHEA-2024:11040] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:11038[RHSA-2024:11038] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]

--- a/modules/microshift-4-19-7-dp.adoc
+++ b/modules/microshift-4-19-7-dp.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-7-dp_{context}"]
+= RHBA-2025:12745 - {microshift-short} 4.19.7 bug fix and update advisory
+
+[role="_abstract"]
+Issued: 11 August 2025
+
+{product-title} release 4.19.7 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:12745[RHBA-2025:12745] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:12341[RHSA-2025:12341] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-19-7-dp-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, a bare-metal node reboot caused the deployment progress deadline to be surpassed. This resulted in the greenboot health check failing with a false-positive error. With this release, the full timeout duration is provided for the deployment to become ready, reducing false-positive greenboot health check errors. (https://issues.redhat.com/browse/OCPBUGS-59301[OCPBUGS-59301])
+
+* Before this update, the excessive polling frequency for the cloud pull secret in node telemetry caused telemetry failure messages to flood journald logs. The log flooding negatively impacted system performance. With this release, the telemetry collection interval is updated from 1 second to 30 seconds. As a result, log flooding has been minimized and no longer impacts system performance. (https://issues.redhat.com/browse/OCPBUGS-59240[OCPBUGS-59240])

--- a/modules/microshift-4-19-about-this-release.adoc
+++ b/modules/microshift-4-19-about-this-release.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-about-this-release_{context}"]
+= About this release
+
+[role="_abstract"]
+{microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
+
+Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {ocp-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+
+You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
+
+{microshift-short} {product-version} is supported on {op-system-base-full} 9.6.
+
+Updates for both single-version minor releases and patch releases are supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
+
+For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].

--- a/modules/microshift-4-19-additional-release-notes.adoc
+++ b/modules/microshift-4-19-additional-release-notes.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-additional-release-notes_{context}"]
+= Additional release notes
+
+[role="_abstract"]
+Release notes for related components and products are available in the following documentation:
+
+[NOTE]
+====
+The following release notes are for downstream Red{nbsp}Hat products only; upstream or community release notes for related products are not included.
+====
+
+//TODO check the latest gitops release version
+[id="microshift-4-19-additional-release-notes-gitops_{context}"]
+== GitOps release notes
+See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/latest/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package, link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
+
+[id="microshift-4-19-additional-release-notes-ocp_{context}"]
+== {OCP} release notes
+See the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/release_notes/index[{OCP} Release Notes] for information about the Operator Lifecycle Manager and other components. Not all of the changes to {OCP} apply to {microshift-short}. See the specific {microshift-short} implementation of an Operator or function for more information.
+
+[id="microshift-4-19-additional-release-notes-rhel_{context}"]
+== {op-system-base-full} release notes
+See the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.6_release_notes/index[Release Notes for Red{nbsp}Hat Enterprise Linux 9.6] for more information about {op-system-base}.
+//Use the latest compatible RHEL, expected to be 9.6
+
+[id="microshift-4-19-additional-release-notes-rhoai_{context}"]
+== {rhoai} release notes
+See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/release_notes/index[Release notes] for more information about {rhoai}.

--- a/modules/microshift-4-19-asynchronous-errata-updates.adoc
+++ b/modules/microshift-4-19-asynchronous-errata-updates.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-asynchronous-errata-updates_{context}"]
+= Asynchronous errata updates
+
+[role="_abstract"]
+Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red{nbsp}Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
+
+Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
+
+[NOTE]
+====
+Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
+====
+
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.

--- a/modules/microshift-4-19-bug-fixes.adoc
+++ b/modules/microshift-4-19-bug-fixes.adoc
@@ -1,0 +1,23 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+This release includes many fixes for bugs.
+
+* Before this update, using `microshift-gitops` in a disconnected environment failed because its manifests had the `imagePullPolicy` set to `Always`. In these cases, GitOps tried to pull images over a non-existent network and failed with an `ImagePullBackoff` error. With this update, the `imagePullPolicy` is set to `IfNotPresent`, which means that GitOps uses a local image and can start normally. (link:https://issues.redhat.com/browse/OCPBUGS-37938[OCPBUGS-37938])
+
+* Previously, specific cipher suites required by {microshift-short} etcd when using TLS 1.2 were not included in the {microshift-short} startup configuration file. As a result, {microshift-short} failed to start when using TLS 1.2. With this release, the required cipher suites are in the configuration file by default and {microshift-short} can start normally when using TLS 1.2. (link:https://issues.redhat.com/browse/OCPBUGS-48735[OCPBUGS-48735])
+
+* Previously, a `.nodename` file that holds the last hostname was created by MicroShift on startup non-atomically. When MicroShift's startup was interrupted, the `.nodename` file was left behind empty. This `.nodename` file was used on the next MicroShift startup, causing the node name to stored as an empty string. This caused the API Server to reject the kubelet's calls and the start up failed. With this release, the `.nodename` file is created atomically with each MicroShift start up, preventing the error. (link:https://issues.redhat.com/browse/OCPBUGS-48163[OCPBUGS-48163])
+
+* By default, the {microshift-short} Logical Volume Manager Storage (LVMS) image copied the manifest list for four platforms because of automatic digest preservation. This action caused unnecessary usage of disk and network space. With this release, the manifest list is replaced with images specific to each architecture. Now, the {microshift-short} LVMS images only contain supported platform images, saving on disk space and network bandwidth. (link:https://issues.redhat.com/browse/OCPBUGS-51329[OCPBUGS-51329])
+
+* Previously, the `kustomizer` sub-service was blocking `microshift.service` readiness by adding a manifest that required a webhook for a Custom Resource (CR) before {microshift-short} had started. This resulted `kustomizer` failing, causing {microshift-short} to fail. With this release, {microshift-short} is no longer dependent on the `kustomizer` sub-service, and can start even if a manifest is malformed by `kustomizer`. (link:https://issues.redhat.com/browse/OCPBUGS-51365[OCPBUGS-51365])
+
+* In previous versions of {microshift-short} and {op-system-base}, the {microshift-short} container-image-embedding procedure used the default container storage directory, which prevented proper image updates. With this release, the recommended image-embedding procedure was changed to use a dedicated directory for each image and a systemd service copying those embedded images into the default container storage. As a result, updates for {op-system-image} are applied as expected with {microshift-short} and embedded containers. (link:https://issues.redhat.com/browse/OCPBUGS-52420[OCPBUGS-52420])

--- a/modules/microshift-4-19-deprecated-and-removed-features.adoc
+++ b/modules/microshift-4-19-deprecated-and-removed-features.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-deprecated-and-removed-features_{context}"]
+= Deprecated and removed features
+
+[role="_abstract"]
+Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in and continues to be supported, but will be removed in a future release. Deprecated features and functionality are not recommended for new deployments.
+
+[id="microshift-4-19-app-greenboot-script-deprecated_{context}"]
+== Greenboot application health check script functions deprecated
+
+The following functions related to checking workload health in the `/usr/share/microshift/functions/greenboot.sh` script are deprecated:
+
+* `wait_for`
+* `namespace_images_downloaded`
+* `namespace_deployment_ready`
+* `namespace_daemonset_ready`
+* `namespace_pods_ready`
+* `namespace_pods_not_restarting`
+* `print_failure_logs`
+* `log_failure_cmd`
+* `log_script_exit`
+* `lvmsDriverShouldExist`
+* `csiComponentShouldBeDeploy`

--- a/modules/microshift-4-19-known-issues.adoc
+++ b/modules/microshift-4-19-known-issues.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-known-issues_{context}"]
+= Known issues
+
+[role="_abstract"]
+Understand the known issues that impact your {microshift-short} development and deployments.
+
+* The maximum transmission unit (MTU) value in {microshift-short} OVN-K overlay networking must be 100 bytes smaller than the MTU value of the base network. {microshift-short} automatically configures the value using the MTU value of the default gateway of the host. If the auto-configuration does not work correctly, the MTU value must be configured manually. For more information, see xref:../microshift_networking/microshift-cni.adoc#microshift-network-topology_microshift-about-ovn-k-plugin[Network topology].

--- a/modules/microshift-4-19-new-features-and-enhancements.adoc
+++ b/modules/microshift-4-19-new-features-and-enhancements.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-new-features-and-enhancements_{context}"]
+= New features and enhancements
+
+[role="_abstract"]
+This release adds improvements related to the following components and concepts.
+
+[id="microshift-4-19-rhel-image-mode_{context}"]
+== {op-system-base} image mode (Generally Available)
+
+Installing {microshift-short} by using a bootc container image is now generally available. Previously available as a Technology Preview feature, {op-system-image} is a deployment method that uses a container-native approach to build, deploy, and manage the operating system as a `rhel-bootc` container image. See xref:../microshift_install_bootc/microshift-about-rhel-image-mode.adoc#microshift-about-rhel-image-mode[Understanding image mode for RHEL with {microshift-short}] for more information.
+
+[id="microshift-4-19-ingress-controller-two-config_{context}"]
+== Control ingress for your use case with additional parameters
+
+With this release, the `ingress.certificate.Secret`,`ingress.clientTLS`, `ingress.routeAdmissionPolicy`, and `ingress.tlsSecurityProfile` parameters are added to the YAML configuration file for {microshift-short}. These parameters specify security settings for the ingress controller. For more information, see xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} node].
+
+[id="microshift-4-19-tls-config_{context}"]
+== {microshift-short} control plane enhanced with TLS
+
+With this release, configurable transport layer security (TLS) protocols on internal control plane components are enabled to help prevent known insecure protocols, ciphers, or algorithms from accessing the applications you run on {microshift-short}. You use either the TLS 1.2 or TLS 1.3 with {microshift-short}. For more information, see xref:../microshift_configuring/microshift_auth_security/microshift-tls-config.adoc#microshift-tls-config[Configuring TLS security profiles].
+
+[id="microshift-4-19-greenboot-updated_{context}"]
+== Check application health with the {microshift-short} healthcheck command
+
+With this release, you can use the `microshift healthcheck` command with various options to run a basic health check on your applications. For more information, see xref:../microshift_running_apps/microshift-greenboot-workload-health-checks.adoc#microshift-greenboot-workload-health-checks[Greenboot workload health checks].
+
+[id="microshift-4-19-observability-metrics_{context}"]
+== Collecting metrics using the {microshift-short} Observability service
+
+With this release, you can configure the {microshift-short} Observability service to collect performance and usage metrics for monitoring resources. The following predefined configurations differ in the amount of data collected:
+
+* Small
+* Medium
+* Large (default)
+
+For more information, see xref:../microshift_running_apps/microshift-observability-service.adoc#microshift-observability-service[Using {microshift-short}] Observability.
+
+[id="microshift-4-19-telemetry_{context}"]
+== Telemetry now available
+With this release, {microshift-short} adds the Telemeter API. Lightweight attributes can be sent from a connected node to Red{nbsp}Hat to monitor the health of the node. To opt-out of Telemetry, see xref:../microshift_support/microshift-remote-node-monitoring.adoc#microshift-remote-node-monitoring[Remote health monitoring with a connected node].

--- a/modules/microshift-4-19-notable-technical-changes.adoc
+++ b/modules/microshift-4-19-notable-technical-changes.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-notable-technical-changes_{context}"]
+= Notable technical changes
+
+[role="_abstract"]
+Learn about technical changes that include enhancements or changes in your workflow.
+
+[id="microshift-4-19-multus-standard-install_{context}"]
+== Multus CNI manifests included in the {microshift-short} RPM
+
+With this release, the {microshift-short} RPM includes the {microshift-short} multiple networking plug-in. To deploy the Multus container network interface (CNI), you can either set the value in the {microshift-short} configuration file, or install the `microshift-multus` RPM, which contains a configuration snippet. For more information, see xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-cni-multus[About using multiple networks].

--- a/modules/microshift-4-19-release-notes.adoc
+++ b/modules/microshift-4-19-release-notes.adoc
@@ -1,0 +1,33 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-4-19-release-notes"]
+include::_attributes/attributes-microshift.adoc[]
+= {product-title} {product-version} release notes
+
+:context: release-notes
+
+toc::[]
+
+[role="_abstract"]
+{product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate a single node in low-resource edge environments.
+
+include::modules/microshift-4-19-about-this-release.adoc[levelsoffset=+1]
+
+include::modules/microshift-4-19-new-features-and-enhancements.adoc[levelsoffset=+1]
+
+include::modules/microshift-4-19-notable-technical-changes.adoc[levelsoffset=+1]
+
+include::modules/microshift-4-19-tech-preview.adoc[levelsoffset=+1]
+
+include::modules/microshift-4-19-deprecated-and-removed-features.adoc[levelsoffset=+1]
+
+include::modules/microshift-4-19-bug-fixes.adoc[levelsoffset=+1]
+
+include::modules/microshift-4-19-known-issues.adoc[levelsoffset=+1]
+
+include::modules/microshift-4-19-additional-release-notes.adoc[levelsoffset=+1]
+
+include::modules/microshift-4-19-asynchronous-errata-updates.adoc[levelsoffset=+1]
+
+include::modules/microshift-4-19-0-dp.adoc[levelsoffset=+1]
+
+include::modules/microshift-4-19-7-dp.adoc[levelsoffset=+1]

--- a/modules/microshift-4-19-tech-preview.adoc
+++ b/modules/microshift-4-19-tech-preview.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-19-tech-preview_{context}"]
+= Technology Preview features
+
+[role="_abstract"]
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+[id="microshift-4-19-ai_{context}"]
+== Red{nbsp}Hat OpenShift AI with {microshift-short}
+
+With this release, a streamlined version of Red{nbsp}Hat OpenShift AI (RHOAI) can be used to serve artificial intelligence or machine learning (AI/ML) models on {microshift-short}. Develop and train your AI models in the data center or cloud, then deploy them to the edge where these models can make decisions without a human user. For more information, see xref:../microshift_ai/microshift-rhoai.adoc#microshift-rhoai[Using Red{nbsp}Hat OpenShift AI with {microshift-short}].


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-16617](https://issues.redhat.com/browse/OSDOCS-16617)

Link to docs preview:
https://101345--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-19-release-notes.html

QE review:
- N/A, migration work only

Additional info:
This PR modularizes the release notes for DITA compatibility. It does not update content.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
