### PR TITLE
[OBSDOCS-2680] Fix formatting in AWS logging configuration documentation

### DIFF
--- a/modules/logging-loki-storage-aws.adoc
+++ b/modules/logging-loki-storage-aws.adoc
@@ -26,7 +26,7 @@ $ oc create secret generic logging-loki-aws \ #<1>
   --from-literal=endpoint="<aws_bucket_endpoint>" \
   --from-literal=access_key_id="<aws_access_key_id>" \
   --from-literal=access_key_secret="<aws_access_key_secret>" \
-  --from-literal=region="<aws_region_of_your_bucket>"
+  --from-literal=region="<aws_region_of_your_bucket>" \
   --from-literal=forcepathstyle="true" # <2>
 ----
 <1> `logging-loki-aws` is the name of the secret.


### PR DESCRIPTION
- backslash () is missing from AWS object storage secret creation command 
- Here is the documentation link:
https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage-aws_configuring-the-log-store  

- The backslash () must be set at the end of a line, as it is a line continuation character. 

Here is the current look:

- Create an object storage secret with the name logging-loki-aws by running the following command:
~~~
$ oc create secret generic logging-loki-aws \  1 
  --from-literal=bucketnames="<bucket_name>" \
  --from-literal=endpoint="<aws_bucket_endpoint>" \
  --from-literal=access_key_id="<aws_access_key_id>" \
  --from-literal=access_key_secret="<aws_access_key_secret>" \
  --from-literal=region="<aws_region_of_your_bucket>"
  --from-literal=forcepathstyle="true" 
~~~ 

- The backslash ()  is missing from line no. 6
- As backslash is a line continuation character,  so we need to add it to the command. 
- So it will complete the command.

Here is the updated look:

- Create an object storage secret with the name logging-loki-aws by running the following command: 
~~~
$ oc create secret generic logging-loki-aws \  1 
  --from-literal=bucketnames="<bucket_name>" \
  --from-literal=endpoint="<aws_bucket_endpoint>" \
  --from-literal=access_key_id="<aws_access_key_id>" \
  --from-literal=access_key_secret="<aws_access_key_secret>" \
  --from-literal=region="<aws_region_of_your_bucket>" \
  --from-literal=forcepathstyle="true" 
  ~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Logging 6.4, Logging 6.3, Logging 6.2, Logging 6.1, Logging 6.0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-2680

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://101346--ocpdocs-pr.netlify.app/
https://101346--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-the-log-store.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
