### PR TITLE
OSDOCS Update modules O-Q 4.14 to 4.18

### DIFF
--- a/modules/ocm-settings-tab.adoc
+++ b/modules/ocm-settings-tab.adoc
@@ -2,6 +2,7 @@
 //
 // ocm/ocm-overview.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="ocm-settings-tab_{context}"]
 = Settings tab
 

--- a/modules/ocm-support-tab.adoc
+++ b/modules/ocm-support-tab.adoc
@@ -2,6 +2,7 @@
 //
 // ocm/ocm-overview.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="ocm-support-tab_{context}"]
 = Support tab
 

--- a/modules/olm-arch-os-support.adoc
+++ b/modules/olm-arch-os-support.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-arch-os-support_{context}"]
 = Architecture and operating system support for Operators
 

--- a/modules/olm-architecture.adoc
+++ b/modules/olm-architecture.adoc
@@ -3,6 +3,7 @@
 // * operators/understanding/olm/olm-understanding-olm.adoc
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-architecture_{context}"]
 ifeval::["{context}" != "operator-reference"]
 = Component responsibilities

--- a/modules/olm-bundle-format.adoc
+++ b/modules/olm-bundle-format.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-bundle-format_{context}"]
 = Bundle format
 

--- a/modules/olm-catalogsource-image-template.adoc
+++ b/modules/olm-catalogsource-image-template.adoc
@@ -9,6 +9,7 @@ ifndef::openshift-origin[]
 :global_ns: openshift-marketplace
 endif::[]
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-catalogsource-image-template_{context}"]
 = Image template for custom catalog sources
 

--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -9,6 +9,7 @@ ifndef::openshift-origin[]
 :global_ns: openshift-marketplace
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-catalogsource_{context}"]
 = Catalog source
 

--- a/modules/olm-operatorhub-architecture.adoc
+++ b/modules/olm-operatorhub-architecture.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-understanding-operatorhub.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-operatorhub-arch_{context}"]
 = OperatorHub architecture
 

--- a/modules/olm-overview.adoc
+++ b/modules/olm-overview.adoc
@@ -3,6 +3,7 @@
 // * operators/understanding/olm/olm-understanding-olm.adoc
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-overview_{context}"]
 = What is Operator Lifecycle Manager?
 

--- a/modules/olm-webhook-considerations.adoc
+++ b/modules/olm-webhook-considerations.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-webhook-considerations_{context}"]
 = Webhook considerations for OLM
 

--- a/modules/osdk-ansible-custom-resource-files.adoc
+++ b/modules/osdk-ansible-custom-resource-files.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/ansible/osdk-ansible-support.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-ansible-custom-resource-files_{context}"]
 = Custom resource files
 

--- a/modules/osdk-ansible-extra-variables.adoc
+++ b/modules/osdk-ansible-extra-variables.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/ansible/osdk-ansible-support.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-ansible-extra-variables_{context}"]
 = Extra variables sent to Ansible
 

--- a/modules/osdk-ansible-inside-operator-logs.adoc
+++ b/modules/osdk-ansible-inside-operator-logs.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/ansible/osdk-ansible-inside-operator.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-ansible-inside-operator-logs_{context}"]
 = Ansible logs
 

--- a/modules/osdk-ansible-project-layout.adoc
+++ b/modules/osdk-ansible-project-layout.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/ansible/osdk-ansible-project-layout.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-ansible-project-layout_{context}"]
 = Ansible-based project layout
 

--- a/modules/osdk-ansible-runner-directory.adoc
+++ b/modules/osdk-ansible-runner-directory.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/ansible/osdk-ansible-support.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-ansible-runner-directory_{context}"]
 = Ansible Runner directory
 

--- a/modules/osdk-ansible-watches-file.adoc
+++ b/modules/osdk-ansible-watches-file.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/ansible/osdk-ansible-support.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-ansible-watches-file_{context}"]
 = watches.yaml file
 

--- a/modules/osdk-building-helm-operator.adoc
+++ b/modules/osdk-building-helm-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-helm.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="osdk-building-helm-operator_{context}"]
 = Building a Helm-based Operator using the Operator SDK
 

--- a/modules/osdk-cli-ref-bundle.adoc
+++ b/modules/osdk-cli-ref-bundle.adoc
@@ -3,6 +3,7 @@
 // * cli_reference/osdk/cli-osdk-ref.adoc
 // * operators/operator_sdk/osdk-cli-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-cli-ref-bundle_{context}"]
 = bundle
 

--- a/modules/osdk-cli-ref-completion.adoc
+++ b/modules/osdk-cli-ref-completion.adoc
@@ -3,6 +3,7 @@
 // * cli_reference/osdk/cli-osdk-ref.adoc
 // * operators/operator_sdk/osdk-cli-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-cli-ref-completion_{context}"]
 = completion
 

--- a/modules/osdk-cli-ref-create.adoc
+++ b/modules/osdk-cli-ref-create.adoc
@@ -3,6 +3,7 @@
 // * cli_reference/osdk/cli-osdk-ref.adoc
 // * operators/operator_sdk/osdk-cli-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-cli-ref-create_{context}"]
 = create
 

--- a/modules/osdk-cli-ref-generate-bundle.adoc
+++ b/modules/osdk-cli-ref-generate-bundle.adoc
@@ -3,6 +3,7 @@
 // * cli_reference/osdk/cli-osdk-ref.adoc
 // * operators/operator_sdk/osdk-cli-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-cli-ref-generate-bundle_{context}"]
 = bundle
 

--- a/modules/osdk-cli-ref-generate-kustomize.adoc
+++ b/modules/osdk-cli-ref-generate-kustomize.adoc
@@ -3,6 +3,7 @@
 // * cli_reference/osdk/cli-osdk-ref.adoc
 // * operators/operator_sdk/osdk-cli-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-cli-ref-generate-kustomize_{context}"]
 = kustomize
 

--- a/modules/osdk-cli-ref-generate.adoc
+++ b/modules/osdk-cli-ref-generate.adoc
@@ -3,6 +3,7 @@
 // * cli_reference/osdk/cli-osdk-ref.adoc
 // * operators/operator_sdk/osdk-cli-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-cli-ref-generate_{context}"]
 = generate
 

--- a/modules/osdk-cli-ref-init.adoc
+++ b/modules/osdk-cli-ref-init.adoc
@@ -3,6 +3,7 @@
 // * cli_reference/osdk/cli-osdk-ref.adoc
 // * operators/operator_sdk/osdk-cli-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-cli-ref-init_{context}"]
 = init
 

--- a/modules/osdk-cli-ref-run.adoc
+++ b/modules/osdk-cli-ref-run.adoc
@@ -3,6 +3,7 @@
 // * cli_reference/osdk/cli-osdk-ref.adoc
 // * operators/operator_sdk/osdk-cli-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-cli-ref-run_{context}"]
 = run
 

--- a/modules/osdk-cli-ref-scorecard.adoc
+++ b/modules/osdk-cli-ref-scorecard.adoc
@@ -3,6 +3,7 @@
 // * cli_reference/osdk/cli-osdk-ref.adoc
 // * operators/operator_sdk/osdk-cli-ref.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-cli-ref-scorecard_{context}"]
 = scorecard
 

--- a/modules/osdk-common-prereqs.adoc
+++ b/modules/osdk-common-prereqs.adoc
@@ -30,6 +30,7 @@ ifeval::["{context}" == "osdk-java-tutorial"]
 :java:
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-common-prereqs_{context}"]
 = Prerequisites
 

--- a/modules/osdk-crd-templates.adoc
+++ b/modules/osdk-crd-templates.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-crds-templates_{context}"]
 = CRD templates
 

--- a/modules/osdk-csv-annotations-dep.adoc
+++ b/modules/osdk-csv-annotations-dep.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-csv-manual-annotations-deprecated_{context}"]
 = Deprecated infrastructure feature annotations
 

--- a/modules/osdk-csv-annotations-other.adoc
+++ b/modules/osdk-csv-annotations-other.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-csv-annotations-other_{context}"]
 = Other optional annotations
 

--- a/modules/osdk-csv-bundle-files.adoc
+++ b/modules/osdk-csv-bundle-files.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-csv-bundle-files_{context}"]
 = Generated files and resources
 

--- a/modules/osdk-csv-composition-configuration.adoc
+++ b/modules/osdk-csv-composition-configuration.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-configuring-csv-composition_{context}"]
 = CSV composition configuration
 

--- a/modules/osdk-csv-manual-annotations.adoc
+++ b/modules/osdk-csv-manual-annotations.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-csv-manual-annotations_{context}"]
 = Operator metadata annotations
 

--- a/modules/osdk-csv-ver.adoc
+++ b/modules/osdk-csv-ver.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-csv-ver_{context}"]
 = Version management
 

--- a/modules/osdk-generating-a-csv.adoc
+++ b/modules/osdk-generating-a-csv.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="osdk-generating-a-csv_{context}"]
 = Generating a CSV
 

--- a/modules/osdk-golang-controller-configs.adoc
+++ b/modules/osdk-golang-controller-configs.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/golang/osdk-golang-tutorial.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-golang-controller-configs_{context}"]
 = Controller configurations
 

--- a/modules/osdk-golang-controller-rbac-markers.adoc
+++ b/modules/osdk-golang-controller-rbac-markers.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/golang/osdk-golang-tutorial.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-golang-controller-rbac-markers_{context}"]
 = Permissions and RBAC manifests
 

--- a/modules/osdk-golang-controller-reconcile-loop.adoc
+++ b/modules/osdk-golang-controller-reconcile-loop.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/golang/osdk-golang-tutorial.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-golang-controller-reconcile-loop_{context}"]
 = Reconcile loop
 

--- a/modules/osdk-golang-controller-resources.adoc
+++ b/modules/osdk-golang-controller-resources.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/golang/osdk-golang-tutorial.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-golang-controller-resources_{context}"]
 = Resources watched by the controller
 

--- a/modules/osdk-golang-project-layout.adoc
+++ b/modules/osdk-golang-project-layout.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/golang/osdk-golang-project-layout.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-golang-project-layout_{context}"]
 = Go-based project layout
 

--- a/modules/osdk-ha-sno-api-examples.adoc
+++ b/modules/osdk-ha-sno-api-examples.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-ha-sno.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-ha-sno-api-examples_{context}"]
 = Example API usage in Operator projects
 

--- a/modules/osdk-helm-charts.adoc
+++ b/modules/osdk-helm-charts.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/helm/osdk-helm-support.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-helm-charts_{context}"]
 = Helm charts
 

--- a/modules/osdk-helm-existing-chart.adoc
+++ b/modules/osdk-helm-existing-chart.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/helm/osdk-helm-tutorial.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-helm-existing-chart_{context}"]
 = Existing Helm charts
 

--- a/modules/osdk-helm-project-layout.adoc
+++ b/modules/osdk-helm-project-layout.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/helm/osdk-helm-project-layout.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-helm-project-layout_{context}"]
 = Helm-based project layout
 

--- a/modules/osdk-helm-sample-chart.adoc
+++ b/modules/osdk-helm-sample-chart.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/helm/osdk-helm-tutorial.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-helm-sample-chart_{context}"]
 = Sample Helm chart
 

--- a/modules/osdk-how-csv-gen-works.adoc
+++ b/modules/osdk-how-csv-gen-works.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-how-csv-gen-works_{context}"]
 = How CSV generation works
 

--- a/modules/osdk-leader-election-types.adoc
+++ b/modules/osdk-leader-election-types.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-leader-election.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-leader-election-types_{context}"]
 = Operator leader election examples
 

--- a/modules/osdk-manager-file.adoc
+++ b/modules/osdk-manager-file.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/golang/osdk-golang-tutorial.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-manager-file_{context}"]
 = Manager file
 

--- a/modules/osdk-manually-defined-csv-fields.adoc
+++ b/modules/osdk-manually-defined-csv-fields.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-manually-defined-csv-fields_{context}"]
 = Manually-defined CSV fields
 

--- a/modules/osdk-monitoring-prometheus-operator-support.adoc
+++ b/modules/osdk-monitoring-prometheus-operator-support.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-monitoring-prometheus.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-monitoring-prometheus-operator-support_{context}"]
 = Prometheus Operator support
 

--- a/modules/osdk-owned-crds.adoc
+++ b/modules/osdk-owned-crds.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-crds-owned_{context}"]
 = Owned CRDs
 

--- a/modules/osdk-project-file.adoc
+++ b/modules/osdk-project-file.adoc
@@ -26,6 +26,7 @@ ifeval::["{context}" == "osdk-java-tutorial"]
 :app: memcached
 endif::[]
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-project-file_{context}"]
 = PROJECT file
 

--- a/modules/osdk-required-crds.adoc
+++ b/modules/osdk-required-crds.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-crds-required_{context}"]
 = Required CRDs
 

--- a/modules/osdk-run-operator.adoc
+++ b/modules/osdk-run-operator.adoc
@@ -18,6 +18,7 @@ ifeval::["{context}" == "osdk-java-tutorial"]
 :java:
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="osdk-run-operator_{context}"]
 = Running the Operator
 

--- a/modules/osdk-scorecard-config.adoc
+++ b/modules/osdk-scorecard-config.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-scorecard-config_{context}"]
 = Scorecard configuration
 

--- a/modules/osdk-scorecard-custom-tests.adoc
+++ b/modules/osdk-scorecard-custom-tests.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-scorecard-custom-tests_{context}"]
 = Custom scorecard tests
 

--- a/modules/osdk-scorecard-output.adoc
+++ b/modules/osdk-scorecard-output.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-scorecard-output_{context}"]
 = Scorecard output
 

--- a/modules/osdk-scorecard-tests.adoc
+++ b/modules/osdk-scorecard-tests.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-scorecard-tests_{context}"]
 = Built-in scorecard tests
 

--- a/modules/osdk-workflow.adoc
+++ b/modules/osdk-workflow.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator_sdk/osdk-about.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="osdk-workflow_{context}"]
 = Development workflow
 

--- a/modules/pod-using-a-different-service-account.adoc
+++ b/modules/pod-using-a-different-service-account.adoc
@@ -2,6 +2,7 @@
 //
 // * orphaned
 
+:_mod-docs-content-type: PROCEDURE
 [id="pod-using-a-different-service-account_{context}"]
 = Running a pod with a different service account
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16697

Follow up to https://github.com/openshift/openshift-docs/pull/101178 and https://github.com/openshift/openshift-docs/pull/101203. 

After merging the full PR to add `:_mod-docs-content-type:` to all branches, we need to check each branch individually.  Files starting in `op-` and `ossm` are aligned products done in their own PRs.

Merge to 4.14 and cherrypick up to 4.18.

**MERGE REVIEW.** I can perform the merge and CP if you don't want to. I'm not sure how the CPs will go. 