### PR TITLE
[OBSDOCS-2682] Fix command formatting for creating logging-loki-odf secret

### DIFF
--- a/modules/logging-loki-storage-odf.adoc
+++ b/modules/logging-loki-storage-odf.adoc
@@ -56,7 +56,7 @@ $ oc create -n openshift-logging secret generic logging-loki-odf \ #<1>
   --from-literal=access_key_id="<access_key_id>" \
   --from-literal=access_key_secret="<secret_access_key>" \
   --from-literal=bucketnames="<bucket_name>" \
-  --from-literal=endpoint="https://<bucket_host>:<bucket_port>"
+  --from-literal=endpoint="https://<bucket_host>:<bucket_port>" \
   --from-literal=forcepathstyle="true" # <2>
 ----
 <1> `logging-loki-odf` is the name of the secret.


### PR DESCRIPTION
- New line continuation character () is missing from ODF Object Store secret creation command 
- Here is the documentation link:
https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage-odf_configuring-the-log-store  

- The backslash () must be set at the end of a line, as it is a line continuation character. 

Here is the current look:

- Create an object storage secret with the name logging-loki-odf by running the following command: 
~~~
$ oc create -n openshift-logging secret generic logging-loki-odf \  1 
  --from-literal=access_key_id="<access_key_id>" \
  --from-literal=access_key_secret="<secret_access_key>" \
  --from-literal=bucketnames="<bucket_name>" \
  --from-literal=endpoint="https://<bucket_host>:<bucket_port>"
  --from-literal=forcepathstyle="true"  2
~~~

- The backslash ()  is missing from line no. 5
- As backslash is a line continuation character,  so we need to add it to the command. 
- So it will complete the command.

Here is the updated look:

- Create an object storage secret with the name logging-loki-odf by running the following command: 
~~~
$ oc create -n openshift-logging secret generic logging-loki-odf \  1 
  --from-literal=access_key_id="<access_key_id>" \
  --from-literal=access_key_secret="<secret_access_key>" \
  --from-literal=bucketnames="<bucket_name>" \
  --from-literal=endpoint="https://<bucket_host>:<bucket_port>" \
  --from-literal=forcepathstyle="true"  2
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Logging 6.4, Logging 6.3, Logging 6.2, Logging 6.1, Logging 6.0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-2682

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://101365--ocpdocs-pr.netlify.app/
https://101365--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-the-log-store.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
