### PR TITLE
[OBSDOCS-2663] Modify access key secret and bucket name in docs

### DIFF
--- a/modules/installing-loki-operator-cli.adoc
+++ b/modules/installing-loki-operator-cli.adoc
@@ -119,8 +119,8 @@ metadata:
   namespace: openshift-logging
 stringData: # <2>
   access_key_id: <access_key_id>
-  access_key_secret: <access_secret>
-  bucketnames: s3-bucket-name
+  access_key_secret: <secret_access_key>
+  bucketnames: <s3_bucket_name>
   endpoint: https://s3.eu-central-1.amazonaws.com
   region: eu-central-1
 ----


### PR DESCRIPTION
- AWS secret code needs to be corrected
- Here is the documentation link:
https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html/installing_logging/installing-logging#install-loki-operator-cli_installing-logging:~:text=Create%20a%20secret%20with%20the%20credentials%20to%20access%20the%20object%20storage.%20For%20example%2C%20create%20a%20secret%20to%20access%20Amazon%20Web%20Services%20(AWS)%20s3.  

Here is the current look:

9. Create a secret with the credentials to access the object storage. For example, create a secret to access Amazon Web Services (AWS) s3.
~~~
apiVersion: v1
kind: Secret
metadata:
  name: logging-loki-s3  1 
  namespace: openshift-logging
stringData:  2 
  access_key_id: <access_key_id>
  access_key_secret: <access_secret>
  bucketnames: s3-bucket-name
  endpoint: https://s3.eu-central-1.amazonaws.com
  region: eu-central-1
~~~

- `access_key_secret` value is wrongly mentioned.
- It needs to be corrected. The correct value is `secret_access_key` 
- Also change the s3-bucket-name to `<s3_bucket_name>`.

Here is the updated look:

9. Create a secret with the credentials to access the object storage. For example, create a secret to access Amazon Web Services (AWS) s3.
~~~
apiVersion: v1
kind: Secret
metadata:
  name: logging-loki-s3  1 
  namespace: openshift-logging
stringData:  2 
  access_key_id: <access_key_id>
  access_key_secret: <secret_access_key>
  bucketnames: <s3_bucket_name>
  endpoint: https://s3.eu-central-1.amazonaws.com
  region: eu-central-1
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Logging 6.4, Logging 6.3, Logging 6.2, Logging 6.1, Logging 6.0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-2663

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://101390--ocpdocs-pr.netlify.app/openshift-logging/latest/installing/installing-logging.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
