### PR TITLE
PR for SRVCOM-3983: Update the Serverless & Serverless Logic 1.37 release notes

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -29,6 +29,9 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 // Release notes included, most to least recent
 
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-37-0.adoc[leveloffset=+1]
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-36-1.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-36-0.adoc[leveloffset=+1]
 

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -14,23 +14,23 @@ For the most recent list of major functionality deprecated and removed within {S
 [cols="3,1,1,1,1,1,1",options="header"]
 |====
 |Feature 
-|1.31
 |1.32
 |1.33
 |1.34
 |1.35
 |1.36
+|1.37
 
 |Knative client `https://mirror.openshift.com/pub/openshift-v4/clients/serverless/` URL
 |-
 |-
 |-
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 
 |EventTypes `v1beta1` API
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
@@ -38,7 +38,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |Deprecated
 
 |`domain-mapping` and `domain-mapping-webhook` deployments
-|-
+|Removed
 |Removed
 |Removed
 |Removed
@@ -46,7 +46,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |Removed
 
 |{SMProductName} with {ServerlessProductShortName} when Kourier is enabled
-|-
+|Deprecated
 |Deprecated
 |Deprecated
 |Deprecated
@@ -76,6 +76,7 @@ For the most recent list of major functionality deprecated and removed within {S
 |Removed
 |Removed
 |Removed
+
 
 |`kn func emit` (`kn func invoke` in 1.21+)
 |Removed

--- a/modules/serverless-rn-1-37-0.adoc
+++ b/modules/serverless-rn-1-37-0.adoc
@@ -1,0 +1,94 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-37-0_{context}"]
+= Red{nbsp}Hat {ServerlessProductName} 1.37
+
+[role="_abstract"]
+{ServerlessProductName} 1.37 is now available. New features, updates, fixed issues, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="new-features-1-37-0_{context}"]
+== New features
+
+[id="new-features-eventing-1-37-0_{context}"]
+=== {ServerlessProductName} Eventing
+
+* {ServerlessProductName} now uses Knative Eventing 1.17.
+
+* {ServerlessProductName} now uses Knative for Apache Kafka 1.17.
+
+* Knative Eventing now supports the ability to define authorization policies that restrict which entities can send events to Eventing custom resources. This enables greater control and security within event-driven architectures. This functionality is now available as a Technology Preview feature.
+
+[id="new-features-serving-1-37-0_{context}"]
+=== {ServerlessProductName} Serving
+
+* {ServerlessProductName} now uses Knative Serving 1.17.
+
+* {ServerlessProductName} now uses Kourier 1.17.
+
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.17.
+
+* Integration with {SMProductName} 3.x is now available as a Technology Preview feature.
+
+[id="new-features-functions-1-37-0_{context}"]
+=== {ServerlessProductName} Functions
+
+* The `kn func` CLI plugin now uses `func` 1.17.
+
+* Python runtime for {ServerlessProductName} Functions are now Generally Available (GA).
+
+* The Func MCP server is now available as a Developer Preview feature.
+
+[id="fixed-issues-1-37-0_{context}"]
+== Fixed issues
+
+[id="fixed-issues-eventing-1-37-0_{context}"]
+=== {ServerlessProductName} Eventing
+
+* Before this update, the `KafkaSource` dispatcher stopped committing offsets when the offsets of produced events were not consecutive integers, for example, when events were produced within a Kafka transaction. This behavior caused the dispatcher to stall and prevented subsequent events from being processed.
++
+With this update, the `KafkaSource` dispatcher has been fixed to handle such empty offsets correctly. Additionally, the default Kafka consumer configuration for `KafkaSource` has been updated to `isolation.level=read_committed`. When Kafka transactions are used to produce events into a Kafka topic, the `KafkaSource` now processes only the events from committed transactions.
+
+[id="known-issues-1-37-0_{context}"]
+== Known issues
+
+[id="known-issues-eventing-1-37-0_{context}"]
+=== {ServerlessProductName} Eventing
+
+* The `EventTransform` custom resource definition (CRD) is currently not compatible with {SMProductName}. The `EventTransform` resource does not provide a way to configure Istio-specific labels or annotations required for integration with {SMProductName}. As a result, the `EventTransform` component cannot function properly in environments where {SMProductName} is enabled.
+
+[id="known-issues-serving-1-37-0_{context}"]
+=== {ServerlessProductName} Serving
+
+* In some cases, cluster-scoped resources such as webhook configurations are not removed during the uninstallation, reinstallation, or upgrade of the `KnativeServing` or Serverless Operator components. When this occurs, the reconciliation of `KnativeServing` fails, and the installation process becomes stuck with an error similar to the following example:
++
+[source,text]
+----
+failed to apply non rbac manifest: Internal error occurred: failed calling webhook "webhook.serving.knative.dev": failed to call webhook: Post "https://webhook.knative-serving.svc:443/?timeout=10s": no endpoints available for service "webhook"
+----
+
+* When the `serving.knative.openshift.io/disableRoute=true` annotation is applied to a Knative Service, the service displays an invalid URL in the `.status.url` field. The URL shown does not resolve to the Knative Service and can be misleading. Additionally, both the OpenShift Console UI and the Knative client (`kn`) CLI display this invalid address in multiple locations. The corresponding Knative Route is also created, and its `.status.url` field contains the same invalid URL.
+
+[id="known-issues-functions-1-37-0_{context}"]
+=== {ServerlessProductName} Functions
+
+* Some operations of the {ServerlessProductName} Function MCP server, such as build and deploy, fail when triggered from the Cursor IDE using its built-in agent. When invoking these operations, the Cursor agent sends a malformed request for any optional parameters. Although the parameter values appear correctly formatted, for example, `"quay.io/myuser"`, the {ServerlessProductName} Function MCP API returns the following error message:
++
+[source,text]
+----
+Error calling tool: Parameter 'optionalStr' must be of type null,string, got string
+----
+
+[id="known-issues-knative-cli-1-37-0_{context}"]
+=== Knative client (`kn`) CLI
+
+* As of {ServerlessProductName} 1.37 release, the `kn` client is built with {op-system-base} 9 dependencies and cannot run on {op-system-base} 8. Attempting to run the binary on {op-system-base} 8 displays an error similar to the following:
++
+[source,text]
+----
+kn: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by kn)
+----
+
+* As of {ServerlessProductName} 1.37 release, the `kn` client binary downloaded from the *Command Line Tools* page in the {ocp-product-title} web console is not signed with the Red{nbsp}Hat certificate for macOS and Windows platforms. This issue affects the binaries available directly through the {ocp-product-title} console. To obtain properly signed binaries, download them from the link:https://mirror.openshift.com/pub/cgw/serverless/[Official OpenShift Serverless downloads mirror] instead.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -14,29 +14,38 @@ The following table provides information about which {ServerlessProductName} fea
 [cols="2,1,1,1",options="header"]
 |====
 |Feature 
-|1.34
 |1.35
 |1.36
+|1.37
+
+|Authorization policies for Knative Eventing
+|-
+|TP
+|TP
+
+|{SMProductShortName} 3.x integration
+|-
+|-
+|TP
 
 |`EventTransform` API for JSON event transformation
 |-
-|-
+|TP
 |TP
 
 |Automatic `EventType` registration
 |-
-|-
 |TP
-
+|TP
 
 |`IntegrationSource` and `IntegrationSink`
 |-
-|-
+|TP
 |TP
 
 |Eventing Transport encryption
 |TP
-|TP
+|GA
 |GA
 
 |Serving Transport encryption
@@ -44,14 +53,9 @@ The following table provides information about which {ServerlessProductName} fea
 |TP
 |TP
 
-|OpenShift Serverless Logic
-|GA
-|GA
-|GA
-
 |ARM64 support
 |TP
-|TP
+|GA
 |GA
 
 |Custom Metrics Autoscaler Operator (KEDA)
@@ -61,7 +65,7 @@ The following table provides information about which {ServerlessProductName} fea
 
 |kn event plugin
 |TP
-|TP
+|GA
 |GA
 
 |Pipelines-as-code
@@ -71,11 +75,11 @@ The following table provides information about which {ServerlessProductName} fea
 
 |Advanced trigger filters
 |TP
-|TP
+|GA
 |GA
 
 |Go function using S2I builder
-|TP
+|GA
 |GA
 |GA
 
@@ -117,7 +121,7 @@ The following table provides information about which {ServerlessProductName} fea
 |Python functions
 |TP
 |TP
-|TP
+|GA
 
 |Service Mesh mTLS
 |GA


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.37`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-3983

**Doc preview:**

- [Serverless 1.37 release notes](https://101425--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-37-0_serverless-release-notes)
- [Deprecated and removed features](https://101425--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-deprecated-removed-features_serverless-release-notes)
- [Generally Available and Technology Preview features](https://101425--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-tech-preview-features_serverless-release-notes)

**Reviews:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] Peer has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->