### PR TITLE
OCPBUGS-58291-20: Added SR-IOV Op support on arm RN tables

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -2496,6 +2496,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
+|SR-IOV Network Operator support on ARM architecture
+|General Availability
+|General Availability
+|General Availability
+
 |Gateway API and Istio for Ingress management
 |Technology Preview
 |General Availability


### PR DESCRIPTION
CM not needed as a release note already exists in the 4.18 release notes. The table was an internal addition that should have been added in the 4.18 to 4.20 TP tabbles section of the release notes document.

Version(s):
4.20

Issue:
[OCPBUGS-61690](https://issues.redhat.com/browse/OCPBUGS-61690)

Link to docs preview:
* [Networking Technology Preview features](https://101429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-networking-tech-preview_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.

