### PR TITLE
OCPBUGS-58291-18: Added SR-IOV Op support on arm RN tables

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -2634,10 +2634,10 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
-| Live migration to OVN-Kubernetes from OpenShift SDN
-| Not Available
-| General Availability
-| Not Available
+|Live migration to OVN-Kubernetes from OpenShift SDN
+|Not Available
+|General Availability
+|Not Available
 
 |User defined network segmentation
 |Not Available
@@ -2653,6 +2653,11 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Not Available
 |Technology Preview
+
+|SR-IOV Network Operator support on ARM architecture
+|Not Available
+|Not Available
+|General Availability
 
 |====
 


### PR DESCRIPTION
CM not needed as a release note already exists in the 4.18 release notes. The table was an internal addition that should have been added in the 4.18 to 4.20 TP tabbles section of the release notes document.


Version(s):
4.18

Issue:
[OCPBUGS-61690](https://issues.redhat.com/browse/OCPBUGS-61690)

Link to docs preview:
* [Networking Technology Preview features](https://101431--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-release-notes-networking-tech-preview_release-notes)

- [x] SME has approved this change.
- [x] QE has approved this change.

