### PR TITLE
OSDOCS-15083 updating AMI list for 4.21

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -7,7 +7,8 @@
 [id="installation-aws-user-infra-rhcos-ami_{context}"]
 = {op-system} AMIs for the AWS infrastructure
 
-Red Hat provides {op-system-first} AMIs that are valid for the various AWS regions and instance architectures that you can manually specify for your {product-title} nodes.
+[role="_abstract"]
+Red{nbsp}Hat provides {op-system-first} AMIs that are valid for the various AWS regions and instance architectures that you can manually specify for your {product-title} nodes.
 
 [NOTE]
 ====
@@ -24,109 +25,112 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-03ec26381f6a347be`
+|`ami-0a3b22174319ad66e`
 
 |`ap-east-1`
-|`ami-04332931a972c8398`
+|`ami-09cde51703738523d`
 
 |`ap-east-2`
-|`ami-0ac916d2813a7b18a`
+|`ami-05478426f756db81c`
 
 |`ap-northeast-1`
-|`ami-0a3254abafd41cbda`
+|`ami-0d6f0c1a044b6848f`
 
 |`ap-northeast-2`
-|`ami-001d35f0b7a38999e`
+|`ami-0d19d79e52ad365c8`
 
 |`ap-northeast-3`
-|`ami-012a97b7293096c47`
+|`ami-0a0391de700b812ae`
 
 |`ap-south-1`
-|`ami-021b5ab76f755886f`
+|`ami-097ffb6f644b7bad1`
 
 |`ap-south-2`
-|`ami-038f598890a52f3c9`
+|`ami-08f1c0c6caafcf2c5`
 
 |`ap-southeast-1`
-|`ami-0d191a1bffd735ebe`
+|`ami-09b223a7c699ecde8`
 
 |`ap-southeast-2`
-|`ami-007439e088223214a`
+|`ami-0a44bb6d4903a93a1`
 
 |`ap-southeast-3`
-|`ami-0e024a0bbbdf621da`
+|`ami-01469b817e364700f`
 
 |`ap-southeast-4`
-|`ami-0929268b6d28ba1e9`
+|`ami-086cc002b6d450301`
 
 |`ap-southeast-5`
-|`ami-0a9461ac20d4691fe`
+|`ami-0b5b9be3ea6fc17de`
+
+|`ap-southeast-6`
+|`ami-03a6ddee59246ab62`
 
 |`ap-southeast-7`
-|`ami-0ae438f9ab8af4459`
+|`ami-03ce4d4bb4f67e777`
 
 |`ca-central-1`
-|`ami-07079826624ddc0d3`
+|`ami-0b23054e68ef5ec3b`
 
 |`ca-west-1`
-|`ami-0e0a89efe9e4aebd8`
+|`ami-0541a60892c677593`
 
 |`eu-central-1`
-|`ami-0b9392304b25a1be6`
+|`ami-006a33223c87af648`
 
 |`eu-central-2`
-|`ami-004899c1b1392a416`
+|`ami-05ddf59e283155ea1`
 
 |`eu-north-1`
-|`ami-04db8de6d2660d477`
+|`ami-054f384036093db98`
 
 |`eu-south-1`
-|`ami-03f6525889efe953b`
+|`ami-0a1cc6a65238669f3`
 
 |`eu-south-2`
-|`ami-0214e803d8564e890`
+|`ami-0fe02b801fea5edf6`
 
 |`eu-west-1`
-|`ami-04ca111133e8458c6`
+|`ami-0632ffa330e30aea1`
 
 |`eu-west-2`
-|`ami-089d8892ef8f88156`
+|`ami-05829d8d5c031e4a8`
 
 |`eu-west-3`
-|`ami-0cebb38e071808759`
+|`ami-00be64f508df27900`
 
 |`il-central-1`
-|`ami-08ff4ee35db1e8b29`
+|`ami-0eeea15b1c070e051`
 
 |`me-central-1`
-|`ami-0467b2b1a131cb070`
+|`ami-090084b481adf23e9`
 
 |`me-south-1`
-|`ami-09fe6bcfb3cab07a7`
+|`ami-0569abe19529c8b10`
 
 |`mx-central-1`
-|`ami-0a7e97cb28cbb8354`
+|`ami-05ab0cf33b0e946a7`
 
 |`sa-east-1`
-|`ami-0ff7e5fea2302529b`
+|`ami-04dd4c56b43a23fb5`
 
 |`us-east-1`
-|`ami-09d23adad19cdb25c`
+|`ami-04018496b0a1da2d2`
 
 |`us-east-2`
-|`ami-082a55a580d5538ed`
+|`ami-0b264801b0e00009c`
 
 |`us-gov-east-1`
-|`ami-06eb65026809257f2`
+|`ami-042feba6717887157`
 
 |`us-gov-west-1`
-|`ami-02d89c98e7cb51709`
+|`ami-0b05862564ac8353d`
 
 |`us-west-1`
-|`ami-0788e768db7ced74d`
+|`ami-08f548f5be577ce2d`
 
 |`us-west-2`
-|`ami-000b42519a25cacc5`
+|`ami-04941543f3e575579`
 
 |===
 
@@ -139,109 +143,112 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-0148286cf26e84d1d`
+|`ami-0265ec024c31e7603`
 
 |`ap-east-1`
-|`ami-020178428baa4d29d`
+|`ami-01d0891e1fa7c28fe`
 
 |`ap-east-2`
-|`ami-0dc346212bfae9a5a`
+|`ami-0de88496066d7428e`
 
 |`ap-northeast-1`
-|`ami-04cd61839a245df4e`
+|`ami-0d7c8859dc8f2ac02`
 
 |`ap-northeast-2`
-|`ami-09f756251f513af27`
+|`ami-00377959ff7cf0ed6`
 
 |`ap-northeast-3`
-|`ami-0d2f277e312013de9`
+|`ami-095386042a7673286`
 
 |`ap-south-1`
-|`ami-0bc01c2ad16fef268`
+|`ami-09f0f012b2c626f59`
 
 |`ap-south-2`
-|`ami-0961ddf05f99aa1ac`
+|`ami-01c8221c9a56e0c74`
 
 |`ap-southeast-1`
-|`ami-086c5fdb20edc12c7`
+|`ami-0c27520bfa297e78a`
 
 |`ap-southeast-2`
-|`ami-0cd7e64385588d5af`
+|`ami-0af72833671d615f1`
 
 |`ap-southeast-3`
-|`ami-09a4ec979ba4d8804`
+|`ami-085607af8f322e956`
 
 |`ap-southeast-4`
-|`ami-030445ba8507a3ec6`
+|`ami-03d8bfd58de713367`
 
 |`ap-southeast-5`
-|`ami-013bd53f7db86068d`
+|`ami-0f6479fb82d8108d1`
+
+|`ap-southeast-6`
+|`ami-0a6a284e74f2e9afd`
 
 |`ap-southeast-7`
-|`ami-026b8f665827ffda4`
+|`ami-054eb3c4286f4dbca`
 
 |`ca-central-1`
-|`ami-0dd67b8ff235b962c`
+|`ami-032e08fde31f0a6cc`
 
 |`ca-west-1`
-|`ami-09469dfe86edf2a39`
+|`ami-07d83e72beff3eb6c`
 
 |`eu-central-1`
-|`ami-00bd76511738f7c79`
+|`ami-0a62c879da82e8f99`
 
 |`eu-central-2`
-|`ami-0e72cf40ed8ca51f3`
+|`ami-09c91e670678ce2c1`
 
 |`eu-north-1`
-|`ami-06ce6706d18914e38`
+|`ami-0e896b8e4e7de42be`
 
 |`eu-south-1`
-|`ami-0d3c5dedab43b8daa`
+|`ami-01718000bd7650956`
 
 |`eu-south-2`
-|`ami-06c0dd7efd3688e89`
+|`ami-02c48b6c8488542b2`
 
 |`eu-west-1`
-|`ami-0ba6941055f037421`
+|`ami-06ea845fe728a8891`
 
 |`eu-west-2`
-|`ami-0934f6e7344143299`
+|`ami-0e6c67a8674179e1b`
 
 |`eu-west-3`
-|`ami-0faeee552170fef71`
+|`ami-0c4cb83cc7e4ec057`
 
 |`il-central-1`
-|`ami-0f6dbbdd757912184`
+|`ami-00a88a6e634ac6676`
 
 |`me-central-1`
-|`ami-0f9afa7909fa8890b`
+|`ami-09aff5ac8bd25e9b8`
 
 |`me-south-1`
-|`ami-0f7e06ef6b630d78c`
+|`ami-043e9d5894e68426d`
 
 |`mx-central-1`
-|`ami-08956a7d43f06c11a`
+|`ami-00c0f1b2fc7ab92d4`
 
 |`sa-east-1`
-|`ami-0774d29f6ed96935b`
+|`ami-0af3988f6b0fbee7f`
 
 |`us-east-1`
-|`ami-05834415546b16278`
+|`ami-02ffd1d5ed7351ceb`
 
 |`us-east-2`
-|`ami-0c59bfd7b7a7cc3e7`
+|`ami-0d08ccc7bcf77433d`
 
 |`us-gov-east-1`
-|`ami-04c3ea90e1fec5a29`
+|`ami-0b183fafd7eeae965`
 
 |`us-gov-west-1`
-|`ami-05fce4dea56fdf75f`
+|`ami-0411a4dd8cbf726db`
 
 |`us-west-1`
-|`ami-0104db843a42a4455`
+|`ami-06149aec55f3e1d6c`
 
 |`us-west-2`
-|`ami-0b745e03468dc48d2`
+|`ami-0c2bafedf2fc1dfc3`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-15083

Link to docs preview:
https://101437--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/upi/installing-aws-user-infra.html#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra

QE review:
- [x] SME has approved this change.
