### PR TITLE
OSDOCS Update modules O-Q 4.20

### DIFF
--- a/modules/olm-architecture.adoc
+++ b/modules/olm-architecture.adoc
@@ -3,6 +3,7 @@
 // * operators/understanding/olm/olm-understanding-olm.adoc
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-architecture_{context}"]
 ifeval::["{context}" != "operator-reference"]
 = Component responsibilities

--- a/modules/olm-bundle-format.adoc
+++ b/modules/olm-bundle-format.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/understanding/olm-packaging-format.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-bundle-format_{context}"]
 = Bundle format
 

--- a/modules/olm-catalogsource-image-template.adoc
+++ b/modules/olm-catalogsource-image-template.adoc
@@ -9,6 +9,7 @@ ifndef::openshift-origin[]
 :global_ns: openshift-marketplace
 endif::[]
 
+:_mod-docs-content-type: REFERENCE
 [id="olm-catalogsource-image-template_{context}"]
 = Image template for custom catalog sources
 

--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -9,6 +9,7 @@ ifndef::openshift-origin[]
 :global_ns: openshift-marketplace
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-catalogsource_{context}"]
 = Catalog source
 

--- a/modules/persistent-storage-csi-cloning-using.adoc
+++ b/modules/persistent-storage-csi-cloning-using.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/container_storage_interface/persistent-storage-csi-cloning.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="persistent-storage-csi-cloning-using_{context}"]
 = Using a cloned PVC as a storage volume
 

--- a/modules/pod-using-a-different-service-account.adoc
+++ b/modules/pod-using-a-different-service-account.adoc
@@ -2,6 +2,7 @@
 //
 // * orphaned
 
+:_mod-docs-content-type: PROCEDURE
 [id="pod-using-a-different-service-account_{context}"]
 = Running a pod with a different service account
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16697

Follow up to https://github.com/openshift/openshift-docs/pull/101178 and https://github.com/openshift/openshift-docs/pull/101203.

After merging the full PR to add `:_mod-docs-content-type:` to all branches, we need to check each branch individually. Files starting in `op-` and `ossm` are aligned products done in their own PRs.