### PR TITLE
ROX-26100: Correct process baseline location for info

### DIFF
--- a/modules/configuring-network-baselining-timeframe.adoc
+++ b/modules/configuring-network-baselining-timeframe.adoc
@@ -3,34 +3,25 @@
 // * operating/manage-network-policies.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="configuring-network-baselining-timeframe_{context}"]
-= Configuring network baselining time frame
+= Configuring the network baseline observation time frame
 
-You can use the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` and the `ROX_BASELINE_GENERATION_DURATION` environment variables to configure the observation period and the network baseline generation duration.
+[role="_abstract"]
+You can configure the duration of the observation period that {product-title-short} uses when creating the network baseline.
 
 .Procedure
 
-. Set the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` environment variable by running the following command:
+* Set the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` environment variable by running the following command:
 +
 [source,terminal]
 ----
-$ oc -n stackrox set env deploy/central \// <1>
-  ROX_NETWORK_BASELINE_OBSERVATION_PERIOD=<value> <2>
+$ oc -n stackrox set env deploy/central \
+  ROX_NETWORK_BASELINE_OBSERVATION_PERIOD=<value> 
 ----
-+
---
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
-<2> Value must be time units, for example: `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us` or `µs`, `ms`, `s`, `m`, `h`.
---
-
-. Set the `ROX_BASELINE_GENERATION_DURATION` environment variable by running the following command:
-+
-[source,terminal]
-----
-$ oc -n stackrox set env deploy/central \// <1>
-  ROX_BASELINE_GENERATION_DURATION=<value> <2>
-----
-+
---
-<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
-<2> Value must be time units, for example: `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us` or `µs`, `ms`, `s`, `m`, `h`.
---
+** `oc`: If you use Kubernetes, enter `kubectl`.
+** `<value>`: Use time units, for example: `300ms`, `-1.5h`, or `2h45m`. Valid time units are:
+*** `ns`
+*** `us` or `µs`
+*** `ms`
+*** `s`
+*** `m`
+*** `h`

--- a/modules/configuring-process-baseline-generation-duration.adoc
+++ b/modules/configuring-process-baseline-generation-duration.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * operating/evaluate-security-risks.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-process-baseline-generation-duration_{context}"]
+= Configuring the observation period for the process baseline
+
+[role="_abstract"]
+You can configure the observation period for the process baseline by setting the `ROX_BASELINE_GENERATION_DURATION` environment variable.
+
+.Procedure
+
+* Set the `ROX_BASELINE_GENERATION_DURATION` environment variable by running the following command:
++
+[source,terminal]
+----
+$ oc -n stackrox set env deploy/central \
+  ROX_BASELINE_GENERATION_DURATION=<value>
+----
+** `oc`: If you use Kubernetes, enter `kubectl`.
+** `<value>`: Use time units, for example: `300ms`, `-1.5h`, or `2h45m`. Valid time units are:
+*** `ns`
+*** `us` or `µs`
+*** `ms`
+*** `s`
+*** `m`
+*** `h`

--- a/modules/use-process-baselines.adoc
+++ b/modules/use-process-baselines.adoc
@@ -9,13 +9,13 @@
 You can minimize risk by using process baselining for infrastructure security. With this approach, {product-title} first discovers existing processes and creates a baseline.
 Then it operates in the default deny-all mode and only allows processes listed in the baseline to run.
 
-== Process baselines
+Process baselines::
 
 When you install {product-title}, there is no default process baseline.
 As {product-title} discovers deployments, it creates a process baseline for every container type in a deployment.
 Then it adds all discovered processes to their own process baselines.
 
-== Process baseline states
+Process baseline states::
 
 During the process discovery phase, all baselines are in an unlocked state.
 
@@ -24,13 +24,18 @@ In an *unlocked* state:
 * When {product-title} discovers a new process, it adds that process to the process baseline.
 * Processes do not show up as risks and do not trigger any violations.
 
-After an hour from when {product-title} receives the first process indicator from a container in a deployment, it finishes the process discovery phase.
+After an hour from when {product-title} receives the first process indicator from a container in a deployment, it finishes the process discovery phase. For information about how to configure the duration of the discovery phase, see "Configuring the observation period for the process baseline".
+
 At this point:
 
 * {product-title} stops adding processes to the process baselines.
 * New processes that are not in the process baseline show up as risks, but they do not by default trigger any violations.
 
-To generate violations, you must either manually lock the process baseline, or enable process baseline auto-lock feature.
+To generate violations, you must either manually lock the process baseline, or enable process baseline auto-lock feature. 
+
+For more information about manually locking and unlocking process baselines, see "Locking and unlocking the process baselines". 
+
+For more information about automatically locking process baselines, see "Configuring auto-lock for process baselines".
 //See <<lock-and-unlock-process-baselines,Manually Lock and unlock process baselines>>  for more details about manually locking and unlocking process baselines.
 //See <<auto-lock-process-baselines,Auto-lock process baselines>> for more details about enabling the process baselines auto-lock feature.
 //See <<auto-lock-process-baselines-known-limitations,Auto-lock process baselines known limitations>> for information how enabling the process baselines auto-lock feature may degrade performance.

--- a/operating/evaluate-security-risks.adoc
+++ b/operating/evaluate-security-risks.adoc
@@ -42,6 +42,8 @@ include::modules/process-discovery-event-timeline.adoc[leveloffset=+2]
 
 include::modules/use-process-baselines.adoc[leveloffset=+1]
 
+include::modules/configuring-process-baseline-generation-duration.adoc[leveloffset=+2]
+
 include::modules/view-process-baselines.adoc[leveloffset=+2]
 
 include::modules/add-process-to-baseline.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):

4.7+

[Issue](https://issues.redhat.com/browse/ROX-26100)

Links to docs previews:

- https://101440--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/evaluate-security-risks.html
- https://101440--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-network-policies.html

QE review:
- [x] QE has approved this change. **ACS has no QE, approved by SME**
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

* Fixed bug where process baseline duration was incorrectly included with network baselining duration
* Added "for more info, see" sections
* Fixed a few things that will trip up migration

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
