### PR TITLE
OSDOCS Update modules O-Q 4.21

### DIFF
--- a/modules/pod-using-a-different-service-account.adoc
+++ b/modules/pod-using-a-different-service-account.adoc
@@ -2,6 +2,7 @@
 //
 // * orphaned
 
+:_mod-docs-content-type: PROCEDURE
 [id="pod-using-a-different-service-account_{context}"]
 = Running a pod with a different service account
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16697

Follow up to https://github.com/openshift/openshift-docs/pull/101178 and https://github.com/openshift/openshift-docs/pull/101203.

After merging the full PR to add `:_mod-docs-content-type:` to all branches, we need to check each branch individually. Files starting in `op-` and `ossm` are aligned products done in their own PRs.