### PR TITLE
OSDOCS-17018 [NETOBSERV] enterprise-4.12 update xref for monitoring

### DIFF
--- a/modules/network-observability-enabling-alerts.adoc
+++ b/modules/network-observability-enabling-alerts.adoc
@@ -26,7 +26,5 @@ spec:
         EXPERIMENTAL_ALERTS_HEALTH: "true"
 ----
 
-You can still use the existing method for creating alerts. For more information, see "Creating alerts".
-
 //for NetObserv 1.10, specific to new alerts functionality and new health dashboard as a Technology Preview feature. This may or may not be needed when the feature GA's.
 //Kept the ID generic but the title specific to Technology Preview, just in case this needs to be updated for GA, then only the title will change and not the URL or ID, so xrefs should still function.

--- a/observability/network_observability/network-observability-alerts.adoc
+++ b/observability/network_observability/network-observability-alerts.adoc
@@ -27,15 +27,11 @@ include::modules/network-observability-creating-custom-alert-rules.adoc[leveloff
 
 include::modules/network-observability-disabling-predefined-alerts.adoc[leveloffset=+2]
 
-////
-New content so xrefs break builds. Update/uncomment after content is merged into main
 [role="_additional-resources"]
 .Additional resources
-//* xref:../../network_observability/index#metrics-dashboards-alerts.adoc[Metrics and alerts dashboard]
-// xref:../../network_observability/network-observability-alerts.adoc#network-observability-default-alerts_network-observability-alerts[List of default alerts]
-//* xref:../../../network_observability/metrics-alerts-dashboards.adoc#metrics-alerts-dashboards#network-observability-netobserv-dashboard-high-traffic-alert_metrics-dashboards-alerts[Creating alerts]
-* xref: ../../monitoring/about-ocp-monitoring/monitoring-stack-architecture.adoc#default-monitoring-components_monitoring-stack-architecture[Monitoring stack architecture]
+* xref:../../observability/network_observability/network-observability-alerts.adoc#network-observability-default-alert-templates_network-observability-alerts[List of default alerts]
+* xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-viewing-dashboards_metrics-dashboards-alerts[Viewing network observability metrics dashboards]
+* xref:../../observability/monitoring/monitoring-overview.adoc#understanding-the-monitoring-stack_monitoring-overview[Understanding the monitoring stack]
 
 //file name for Creating alerts: network-observability-includelist-example.adoc
 //URL for Creating alerts: https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/network_observability/metrics-dashboards-alerts#network-observability-netobserv-dashboard-high-traffic-alert_metrics-dashboards-alerts
-////


### PR DESCRIPTION
[OSDOCS-17018](https://issues.redhat.com//browse/OSDOCS-17018) [NETOBSERV] enterprise-4.12 update xref for monitoring

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-17018

Link to docs preview:
* Additional resources: https://101442--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-alerts.html#network-observability-disabling-predefined-alerts_network-observability-alerts 

QE review:
QE is not required for this PR.

Additional information:
* Build failed due to "Creating alerts" xref. After checking, confirmed existing "Creating alerts" is not documented until enterprise-4.14 so also removed xref and sentence referencing existing "Creating alerts" content.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
