### PR TITLE
OSDOCS#16653:  Update the z-stream RNs for 4.14.58

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3426,6 +3426,33 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.14.58
+[id="ocp-4-14-58_{context}"]
+=== RHSA-2025:19058 - {product-title} 4.14.58 bug fix and security update
+
+Issued: 30 October 2025
+
+{product-title} release 4.14.58, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:19058[RHSA-2025:19058] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:19040[RHBA-2025:19040] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.58 --pullspecs
+----
+
+[id="ocp-4-14-58-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this release, the `properties.storageProfile.[osDiskImage/dataDiskImages].source.Id` field was supported for {azure-first}. With this release, use the `properties.storageProfile.osDiskImage.source.storageAccountId` field instead of the `properties.storageProfile.[osDiskImage/dataDiskImages].source.Id` field. (link:https://issues.redhat.com/browse/OCPBUGS-62814[OCPBUGS-62814])
+
+[id="ocp-4-14-58-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.14.57
 [id="ocp-4-14-57_{context}"]
 === RHSA-2025:16165 - {product-title} 4.14.57 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-16653](https://issues.redhat.com//browse/OSDOCS-16653)

Link to docs preview:
[4.14.58](https://101443--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-58_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
- Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/203)
- ART [dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.14)
<img width="877" height="246" alt="image" src="https://github.com/user-attachments/assets/d8680a74-93e7-4260-87a5-94f9f6826097" />

