### PR TITLE
OSDOCS-17030 created GA release notes

### DIFF
--- a/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-release-notes.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="external-secrets-operator-release-notes"]
-= {external-secrets-operator} release notes
 include::_attributes/common-attributes.adoc[]
 :context: external-secrets-operator-release-notes
+= {external-secrets-operator} release notes
 
 toc::[]
 
@@ -11,6 +11,59 @@ The {external-secrets-operator} is a cluster-wide service that provides lifecycl
 These release notes track the development of {external-secrets-operator-short}.
 
 For more information, see xref:../../security/external_secrets_operator/index.adoc#external-secrets-operator-about[{external-secrets-operator-short} overview].
+
+[id="external-secrets-operator-release-notes-1-0-0_{context}"]
+== Release notes for {external-secrets-operator} 1.0.0 (General Availability)
+
+Issued: 2025-11-03
+
+The following advisories are available for the {external-secrets-operator} 1.0.0:
+
+* link:https://access.redhat.com/errata/RHBA-2025:19416[RHBA-2025:19416]
+* link:https://access.redhat.com/errata/RHBA-2025:19417[RHBA-2025:19417]
+* link:https://access.redhat.com/errata/RHBA-2025:19418[RHBA-2025:19418]
+* link:https://access.redhat.com/errata/RHBA-2025:19463[RHBA-2025:19463]
+
+Version 1.0.0 of the {external-secrets-operator} is based on the upstream external-secrets project, version v0.19.0. For more information, see the link:https://github.com/external-secrets/external-secrets/releases/tag/v0.19.0[external-secrets project release notes for v0.19.0].
+
+[id="external-secrets-operator-1-0-0-bug-fixes_{context}"]
+=== Bug fixes
+
+* Before this release, many of the APIs listed in the console for the {external-secrets-operator} were missing descriptions. With this release, the API descriptions have been added. (link:https://issues.redhat.com/browse/OCPBUGS-61081[OCPBUGS-61081])
+
+
+[id="external-secrets-operator-1-0-0-features-enhancements_{context}"]
+=== New features and enhancements
+
+*Renaming and improvements on the Operator API*
+
+With this release, the Operator API, `externalsecrets.operator.openshift.io` has been renamed to `externalsecretsconfigs.operator.openshift.io` to avoid confusion with the external-secrets provided API that has the same name, but a different purpose. The external-secrets provided API has also been restructured and new features are added.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/security_and_compliance/index#external-secrets-operator-api[External Secrets Operator for Red Hat OpenShift APIs].
+
+*Support to collect metrics of {external-secrets-operator-short}*
+
+With this release, the {external-secrets-operator} supports collecting metrics for both the Operator and operands. This is optional and must be enabled.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/security_and_compliance/index#external-secrets-monitoring[Monitoring the External Secrets Operator for Red Hat OpenShift].
+
+
+*Support to configure proxy for {external-secrets-operator-short}*
+
+With this release, the {external-secrets-operator} supports configuring proxy for both the Operator and operand.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/security_and_compliance/index#external-secrets-operator-proxy[About the egress proxy for the External Secrets Operator for Red Hat OpenShift].
+
+*Root filesystem is read-only for {external-secrets-operator} containers*
+
+With this release, to improve security, the {external-secrets-operator} and all its operands have the `readOnlyRootFilesystem` security context set to true by default. This enhancement hardens the containers and prevents a potential attacker from modifying the contents of the container’s root file system.
+
+*Network policy hardening is now available for {external-secrets-operator-short} components*
+
+With this release, {external-secrets-operator} includes pre-defined `NetworkPolicy` resources designed for enhanced security by governing ingress and egress traffic for operand components. These policies cover essential internal traffic, such as ingress to the metrics and webhook servers, and egress to the OpenShift API server and DNS server. Note that deployment of the `NetworkPolicy` is enabled by default and egress allow policies must be explicitly defined in the `ExternalSecretsConfig` custom resource for the `external-secrets` component to fetch secrets from external providers.
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/security_and_compliance/index#external-secrets-operator-config-net-policy[Configuring network policy for the operand].
+
 
 [id="external-secrets-operator-release-notes-0-1-0_{context}"]
 == Release notes for {external-secrets-operator} 0.1.0 (Technology Preview)


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17030

Link to docs preview:
https://101444--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-release-notes.html

QE review:
- [x] QE has approved this change.


Additional information:
I just added links to the document which removed the /lgtm label. Doesn't need to be reviewed by QE again.
