### PR TITLE
ROX-31096: Update policy description for low-sev policy

### DIFF
--- a/modules/low-sev-security-policies.adoc
+++ b/modules/low-sev-security-policies.adoc
@@ -19,7 +19,7 @@ The following table lists the default security policies in {product-title} that 
 |====
 |Life cycle stage |Name |Description | Status
 |Build or Deploy |90-Day Image Age |Alerts when a deployment has not been updated in 90 days. |Enabled
-|Build or Deploy |ADD Command used instead of COPY |Alerts when a deployment uses an ADD command. |Disabled
+|Build or Deploy |ADD Command used instead of COPY |Alerts when an image was built by using an `ADD` command. |Disabled
 |Build or Deploy |Alpine Linux Package Manager (apk) in Image |Alerts when a deployment includes the Alpine Linux package manager (apk). |Enabled
 |Build or Deploy |Curl in Image |Alerts when a deployment includes curl. |Disabled
 |Build or Deploy |Docker CIS 4.1: Ensure That a User for the Container Has Been Created |Ensures that containers are running as non-root users. |Enabled


### PR DESCRIPTION
Version(s): 4.7+

[Issue](https://issues.redhat.com/browse/ROX-31096)

[Link to docs preview
](https://101449--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage_security_policies/security-policy-reference.html#low-sev-security-policies_security-policy-reference)

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
