### PR TITLE
OSDOCS-16617-420: modularizes 4.20 relnotes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-20-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-20-release-notes.adoc
@@ -1,153 +1,27 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-4-20-release-notes"]
-= {product-title} {product-version} release notes
 include::_attributes/attributes-microshift.adoc[]
+= {product-title} {product-version} release notes
+
 :context: release-notes
 
 toc::[]
 
+[role="_abstract"]
 {product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate a single node in low-resource edge environments.
 
-{microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
+include::modules/microshift-4-20-about-this-release.adoc[leveloffset=+1]
 
-[id="microshift-4-20-about-this-release_{context}"]
-== About this release
+include::modules/microshift-4-20-new-features-and-enhancements.adoc[leveloffset=+1]
 
-Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {ocp-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+include::modules/microshift-4-20-tech-preview.adoc[leveloffset=+1]
 
-You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
+include::modules/microshift-4-20-doc-enhancements.adoc[leveloffset=+1]
 
-{microshift-short} {product-version} is supported on {op-system-base-full} {op-system-version}.
+include::modules/microshift-4-20-known-issues.adoc[leveloffset=+1]
 
-For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
+include::modules/microshift-4-20-additional-release-notes.adoc[leveloffset=+1]
 
-[id="microshift-4-20-new-features-and-enhancements_{context}"]
-== New features and enhancements
+include::modules/microshift-4-20-asynchronous-updates.adoc[leveloffset=+1]
 
-This release adds improvements related to the following components and concepts.
-
-//4.20 is an EUS release, so two minor version updates are supported
-[id="microshift-4-20-updating_{context}"]
-=== Updating
-
-Updating two minor EUS versions in a single step is supported in {product-version}. Updates for both single-version minor releases and patch releases are also supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
-
-//TODO add new features and enhancements as needed, follow doc TOC titles as L3s, then add L4 headings for each feature
-[id="microshift-4-20-configuring_{context}"]
-=== Configuring {microshift-short}
-
-[id="microshift-4-20-ingress-controller-three-config_{context}"]
-==== Inspect ingress for your use case with additional logging parameters
-
-With this release, you can configure custom error code pages and logging parameters in the router, and you can capture HTTP headers and cookies in the ingress controller access logs. For more information, see xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} node].
-
-[id="microshift-4-20-running-apps_{context}"]
-=== Running applications
-
-[id="microshift-4-20-install-cert-manager_{context}"]
-==== The cert manager Operator is now available with {microshift-short}
-
-With this release, {microshift-short} users can securely manage certificates for their components by using the cert-manager Operator. This enhancement automates the issuance and renewal of SSL/TLS certificates, enhancing data protection and ensuring regulatory compliance. It enables standardized certificate management, enhances node security, and results in more secure and standardized communication within and between user services. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift[cert-manager Operator for Red Hat OpenShift].
-
-[id="microshift-4-20-doc-enhancements_{context}"]
-=== Documentation enhancements
-
-[id="microshift-4-20-uninstall_{context}"]
-==== Instructions for uninstalling {microshift-short} now available
-* With this release, instructions on uninstalling {microshift-short} are now included. For more information, see xref:../microshift_install_rpm/microshift-uninstall-rpm.adoc#microshift-uninstall-rpm[Uninstalling {microshift-short}].
-
-[id="microshift-4-20-bootc-doc-updates_{context}"]
-==== Additional documentation for {op-system-image}
-* With this release, prerequisites and instructions for installing image mode for RHEL for {microshift-short} are updated. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-image[Installing and publishing a bootc image to a registry].
-
-* With this release, information about physically-bound container images for fully self-contained bootc images is now included. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-physically-bound.adoc#microshift-install-bootc-physically-bound[Creating a fully self-contained bootc image].
-
-[id="microshift-4-20-encrypt-etcd_{context}"]
-==== Information about encrypting etcd is added to installation planning
-* With this release, instructions on encrypting etcd data are now included. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/getting_ready_to_install_microshift/microshift-install-get-ready#microshift-encrypt-etcd-data_microshift-install-get-ready[Encrypt etcd data].
-
-
-[id="microshift-4-20-tech-preview_{context}"]
-== Technology Preview features
-
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
-
-link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
-
-[id="microshift-4-20-Generic-Device-Plugin_{context}"]
-=== Generic Device Plugin feature
-
-The Generic Device Plugin (GDP) is a Kubernetes device plugin that enables applications running in pods to access host devices such as serial ports, cameras, and sound cards securely. This Technology Preview capability is especially important for edge and IoT environments where direct hardware interaction is a common requirement. The GDP integrates with the kubelet to advertise available devices to the node and facilitate their allocation to pods without requiring elevated privileges within the container itself.
-
-[id="microshift-4-20-ai_{context}"]
-=== Red{nbsp}Hat OpenShift AI with {microshift-short}
-
-With this release, you can access the most recent updates and improvements to supported Red Hat OpenShift AI (RHOAI) model-serving releases. The latest RHOAI release improves compatibility with the new Hugging Face Model Detector and Variable Length Language Model (VLLM) runtimes.
-
-//NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
-[id="microshift-4-20-bug-fixes_{context}"]
-== Bug fixes
-
-* Before this update, embedding container images into a bootc build could fail because HTTP proxy environment variables were defined in the bootc image. Proxy errors occurred during container image embedding and prevented successful builds. With this release, the bootc image no longer sets HTTP proxy environment variables, thereby eliminating the issue. As a result, you can now embed container images without encountering proxy errors. (link:https://issues.redhat.com/browse/OCPBUGS-61433[OCPBUGS-61433])
-
-* Before this update, a bare-metal node reboot caused the deployment progress deadline to be surpassed. This resulted in the greenboot health check failing with a false-positive error. With this release, the `ProgressDeadlineExceeded` condition for deployments is removed to allow time for reboots that exceed the default time limit. Now, the full timeout duration is provided for the deployment to become ready, reducing false-positive greenboot health check errors. (link:https://issues.redhat.com/browse/OCPBUGS-59175[OCPBUGS-59175])
-
-* Before this update, duplicated dependencies and firewall configurations were included in blueprints. This update streamlines blueprint installation by eliminating unnecessary packages and firewall configurations, enhancing efficiency. (link:https://issues.redhat.com/browse/OCPBUGS-55818[OCPBUGS-55818])
-
-* Before this update, the ROUTER_ENABLE_EXTERNAL_CERTIFICATE environment variable was not set by default, despite the Route `ExternalCertificate` feature being supported in {microshift-short}. Because of this, you could not configure routes with third-party certificate management solutions by using the `.spec.tls.externalCertificate` field of the route API. With this release, the environment variable value is set to `True` and the Route `ExternalCertificate` feature is enabled. You can reference externally managed TLS certificates through secrets, eliminating the need for manual certificate management. (link:https://issues.redhat.com/browse/OCPBUGS-58357[OCPBUGS-58357])
-** For more information, see also https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/ingress_and_load_balancing/configuring-routes#nw-ingress-route-secret-load-external-cert_secured-routes[Creating a route with externally managed certificates].
-
-* Before this update, the lack of an {OCP} pull-secret caused excessive telemetry collection failure logs. As a consequence, telemetry errors flooded the journald logs With this release, the telemetry pull secret error rate is reduced. As a result, telemetry collection messages no longer flood the logs. (link:https://issues.redhat.com/browse/OCPBUGS-57777[OCPBUGS-57777])
-
-* In this release, the backend implementation of the observability YAML file is streamlined to prevent accidental overwriting of custom observability configuration when you update {microshift-short}. (link:https://issues.redhat.com/browse/OCPBUGS-56157[OCPBUGS-56157])
-
-[id="microshift-4-20-known-issues_{context}"]
-== Known issues
-
-* The maximum transmission unit (MTU) value in {microshift-short} OVN-K overlay networking must be 100 bytes smaller than the MTU value of the base network. {microshift-short} automatically configures the value using the MTU value of the default gateway of the host. If the auto-configuration does not work correctly, you must configure the the MTU value manually. For more information, see xref:../microshift_networking/microshift-cni.adoc#microshift-network-topology_microshift-about-ovn-k-plugin[Network topology].
-
-[id="microshift-4-20-additional-release-notes_{context}"]
-== Additional release notes
-Release notes for related components and products are available in the following documentation:
-
-=== GitOps release notes
-See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/latest/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the following Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package: link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
-
-[id="microshift-4-20-additional-release-notes-ocp_{context}"]
-=== {OCP} release notes
-See the link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/release_notes/index[{OCP} Release Notes] for information about the Operator Lifecycle Manager and other components. Not all of the changes to {OCP} apply to {microshift-short}. See the specific {microshift-short} implementation of an Operator or function for more information.
-
-[id="microshift-4-20-additional-release-notes-rhel_{context}"]
-=== {op-system-base-full} release notes
-See the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.6_release_notes/index[Release Notes for Red{nbsp}Hat Enterprise Linux 9.6] for more information about {op-system-base}.
-//Use the latest compatible RHEL, expected to be 9.6
-
-[id="microshift-4-20-additional-release-notes-rhoai_{context}"]
-=== {rhoai} release notes
-See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/release_notes/index[Release notes] for more information about {rhoai}.
-
-[id="microshift-4-20-asynchronous-updates_{context}"]
-== Asynchronous updates
-
-Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released asynchronously through the Red{nbsp}Hat Network. All {microshift-short} {product-version} updates are https://access.redhat.com/downloads/content/290/[available on the Red{nbsp}Hat Customer Portal]. For more information about asynchronous updates, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
-
-Red{nbsp}Hat Customer Portal users can enable update notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When notifications are enabled, you are notified through email whenever new updates relevant to your registered systems are released.
-
-[NOTE]
-====
-Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} update notification emails to generate.
-====
-
-This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
-
-[id="microshift-4-20-0-dp_{context}"]
-=== RHEA-2025:10667 - {microshift-short} 4.20.0 bug fix and enhancement update
-
-Issued: 21 October 2025
-
-{product-title} release 4.20.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2025:10667[RHEA-2025:10667] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:9562[RHBA-2025:9562] advisory.
-
-See the latest images included with {microshift-short} by using the following instructions:
-
-* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
-* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]
+include::modules/microshift-4-20-0-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-20-0-dp.adoc
+++ b/modules/microshift-4-20-0-dp.adoc
@@ -1,0 +1,18 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-0-dp_{context}"]
+= RHEA-2025:10667 - {microshift-short} 4.20.0 bug fix and enhancement update
+
+[role="_abstract"]
+Issued: 21 October 2025
+
+{product-title} release 4.20.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2025:10667[RHEA-2025:10667] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:9562[RHBA-2025:9562] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]

--- a/modules/microshift-4-20-about-this-release.adoc
+++ b/modules/microshift-4-20-about-this-release.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-about-this-release_{context}"]
+= About this release
+
+[role="_abstract"]
+{microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
+
+Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {ocp-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+
+You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
+
+{microshift-short} {product-version} is supported on {op-system-base-full} {op-system-version}.
+
+For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
+
+//4.20 is an EUS release, so two minor version updates are supported
+[id="microshift-4-20-updating_{context}"]
+== Updating
+
+Updating two minor EUS versions in a single step is supported in {product-version}. Updates for both single-version minor releases and patch releases are also supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.

--- a/modules/microshift-4-20-additional-release-notes.adoc
+++ b/modules/microshift-4-20-additional-release-notes.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-additional-release-notes_{context}"]
+= Additional release notes
+
+[role="_abstract"]
+Release notes for related components and products are available in the following documentation:
+
+== GitOps release notes
+
+See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/latest/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the following Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package: link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
+
+[id="microshift-4-20-additional-release-notes-ocp_{context}"]
+== {OCP} release notes
+
+See the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/release_notes/index[{OCP} Release Notes] for information about the Operator Lifecycle Manager and other components. Not all of the changes to {OCP} apply to {microshift-short}. See the specific {microshift-short} implementation of an Operator or function for more information.
+
+[id="microshift-4-20-additional-release-notes-rhel_{context}"]
+== {op-system-base-full} release notes
+
+See the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.6_release_notes/index[Release Notes for Red{nbsp}Hat Enterprise Linux 9.6] for more information about {op-system-base}.
+
+[id="microshift-4-20-additional-release-notes-rhoai_{context}"]
+== {rhoai} release notes
+
+See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/release_notes/index[Release notes] for more information about {rhoai}.

--- a/modules/microshift-4-20-asynchronous-updates.adoc
+++ b/modules/microshift-4-20-asynchronous-updates.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-asynchronous-updates_{context}"]
+= Asynchronous updates
+
+[role="_abstract"]
+Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released asynchronously through the Red{nbsp}Hat Network. All {microshift-short} {product-version} updates are https://access.redhat.com/downloads/content/290/[available on the Red{nbsp}Hat Customer Portal]. For more information about asynchronous updates, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
+
+Red{nbsp}Hat Customer Portal users can enable update notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When notifications are enabled, you are notified through email whenever new updates relevant to your registered systems are released.
+
+[NOTE]
+====
+Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} update notification emails to generate.
+====
+
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.

--- a/modules/microshift-4-20-bug-fixes.adoc
+++ b/modules/microshift-4-20-bug-fixes.adoc
@@ -1,0 +1,25 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+This release includes many fixes for bugs.
+
+* Before this update, embedding container images into a bootc build could fail because HTTP proxy environment variables were defined in the bootc image. Proxy errors occurred during container image embedding and prevented successful builds. With this release, the bootc image no longer sets HTTP proxy environment variables, thereby eliminating the issue. As a result, you can now embed container images without encountering proxy errors. (link:https://issues.redhat.com/browse/OCPBUGS-61433[OCPBUGS-61433])
+
+* Before this update, a bare-metal node reboot caused the deployment progress deadline to be surpassed. This resulted in the greenboot health check failing with a false-positive error. With this release, the `ProgressDeadlineExceeded` condition for deployments is removed to allow time for reboots that exceed the default time limit. Now, the full timeout duration is provided for the deployment to become ready, reducing false-positive greenboot health check errors. (link:https://issues.redhat.com/browse/OCPBUGS-59175[OCPBUGS-59175])
+
+* Before this update, duplicated dependencies and firewall configurations were included in blueprints. This update streamlines blueprint installation by eliminating unnecessary packages and firewall configurations, enhancing efficiency. (link:https://issues.redhat.com/browse/OCPBUGS-55818[OCPBUGS-55818])
+
+* Before this update, the ROUTER_ENABLE_EXTERNAL_CERTIFICATE environment variable was not set by default, despite the Route `ExternalCertificate` feature being supported in {microshift-short}. Because of this, you could not configure routes with third-party certificate management solutions by using the `.spec.tls.externalCertificate` field of the route API. With this release, the environment variable value is set to `True` and the Route `ExternalCertificate` feature is enabled. You can reference externally managed TLS certificates through secrets, eliminating the need for manual certificate management. (link:https://issues.redhat.com/browse/OCPBUGS-58357[OCPBUGS-58357])
+
+** For more information, see also https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ingress_and_load_balancing/configuring-routes#nw-ingress-route-secret-load-external-cert_secured-routes[Creating a route with externally managed certificates].
+
+* Before this update, the lack of an {OCP} pull-secret caused excessive telemetry collection failure logs. As a consequence, telemetry errors flooded the journald logs With this release, the telemetry pull secret error rate is reduced. As a result, telemetry collection messages no longer flood the logs. (link:https://issues.redhat.com/browse/OCPBUGS-57777[OCPBUGS-57777])
+
+* In this release, the backend implementation of the observability YAML file is streamlined to prevent accidental overwriting of custom observability configuration when you update {microshift-short}. (link:https://issues.redhat.com/browse/OCPBUGS-56157[OCPBUGS-56157])

--- a/modules/microshift-4-20-doc-enhancements.adoc
+++ b/modules/microshift-4-20-doc-enhancements.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-doc-enhancements_{context}"]
+= Documentation enhancements
+
+[role="_abstract"]
+You can also benefit by using the following documentation enhancements.
+
+[id="microshift-4-20-uninstall_{context}"]
+== Instructions for uninstalling {microshift-short} now available
+
+* With this release, instructions on uninstalling {microshift-short} are now included. For more information, see xref:../microshift_install_rpm/microshift-uninstall-rpm.adoc#microshift-uninstall-rpm[Uninstalling {microshift-short}].
+
+[id="microshift-4-20-bootc-doc-updates_{context}"]
+== Additional documentation for {op-system-image}
+
+* With this release, prerequisites and instructions for installing image mode for RHEL for {microshift-short} are updated. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-image[Installing and publishing a bootc image to a registry].
+
+* With this release, information about physically-bound container images for fully self-contained bootc images is now included. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-physically-bound.adoc#microshift-install-bootc-physically-bound[Creating a fully self-contained bootc image].
+
+[id="microshift-4-20-encrypt-etcd_{context}"]
+== Information about encrypting etcd is added to installation planning
+
+* With this release, instructions on encrypting etcd data are now included. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/getting_ready_to_install_microshift/microshift-install-get-ready#microshift-encrypt-etcd-data_microshift-install-get-ready[Encrypt etcd data].

--- a/modules/microshift-4-20-known-issues.adoc
+++ b/modules/microshift-4-20-known-issues.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-known-issues_{context}"]
+= Known issues
+
+[role="_abstract"]
+Understand the known issues that impact your {microshift-short} development and deployments.
+
+* The maximum transmission unit (MTU) value in {microshift-short} OVN-K overlay networking must be 100 bytes smaller than the MTU value of the base network. {microshift-short} automatically configures the value using the MTU value of the default gateway of the host. If the auto-configuration does not work correctly, you must configure the the MTU value manually. For more information, see xref:../microshift_networking/microshift-cni.adoc#microshift-network-topology_microshift-about-ovn-k-plugin[Network topology].

--- a/modules/microshift-4-20-new-features-and-enhancements.adoc
+++ b/modules/microshift-4-20-new-features-and-enhancements.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-new-features-and-enhancements_{context}"]
+= New features and enhancements
+
+[role="_abstract"]
+This release adds improvements related to the following components and concepts.
+
+[id="microshift-4-20-ingress-controller-three-config_{context}"]
+== Inspect ingress for your use case with additional logging parameters
+
+With this release, you can configure custom error code pages and logging parameters in the router, and you can capture HTTP headers and cookies in the ingress controller access logs. For more information, see xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller[Using ingress control for a {microshift-short} node].
+
+[id="microshift-4-20-install-cert-manager_{context}"]
+== The cert manager Operator is now available with {microshift-short}
+
+With this release, {microshift-short} users can securely manage certificates for their components by using the cert-manager Operator. This enhancement automates the issuance and renewal of SSL/TLS certificates, enhancing data protection and ensuring regulatory compliance. It enables standardized certificate management, enhances node security, and results in more secure and standardized communication within and between user services. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/security_and_compliance/cert-manager-operator-for-red-hat-openshift[cert-manager Operator for Red Hat OpenShift].

--- a/modules/microshift-4-20-tech-preview.adoc
+++ b/modules/microshift-4-20-tech-preview.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-tech-preview_{context}"]
+= Technology Preview features
+
+[role="_abstract"]
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+[id="microshift-4-20-Generic-Device-Plugin_{context}"]
+== Generic Device Plugin feature
+
+The Generic Device Plugin (GDP) is a Kubernetes device plugin that enables applications running in pods to access host devices such as serial ports, cameras, and sound cards securely. This Technology Preview capability is especially important for edge and IoT environments where direct hardware interaction is a common requirement. The GDP integrates with the kubelet to advertise available devices to the node and facilitate their allocation to pods without requiring elevated privileges within the container itself.
+
+[id="microshift-4-20-ai_{context}"]
+== Red{nbsp}Hat OpenShift AI with {microshift-short}
+
+With this release, you can access the most recent updates and improvements to supported Red Hat OpenShift AI (RHOAI) model-serving releases. The latest RHOAI release improves compatibility with the new Hugging Face Model Detector and Variable Length Language Model (VLLM) runtimes.


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-16617](https://issues.redhat.com/browse/OSDOCS-16617)

Link to docs preview:
https://101450--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-20-release-notes.html

QE review:
N/A, migration work only

Additional info:
This PR modularizes the release notes for DITA compatibility. It does not update content. XREFS are allowed in these modules only per DPM.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
