### PR TITLE
OSDOCS#16599: Docs for OSSO 1.1.5

### DIFF
--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -12,6 +12,33 @@ These release notes track the development of the {secondary-scheduler-operator-f
 
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
 
+[id="secondary-scheduler-operator-release-notes-1.1.5"]
+== Release notes for {secondary-scheduler-operator-full} 1.1.5
+
+Issued: 5 November 2025
+
+The following advisory is available for the {secondary-scheduler-operator-full} 1.1.5:
+
+* link:https://access.redhat.com/errata/RHBA-2025:19779[RHBA-2025:19779]
+
+[id="secondary-scheduler-operator-1.1.5-new-features-and-enhancements"]
+=== New features and enhancements
+
+* This release rebuilds the base image for the {secondary-scheduler-operator} to improve its image grade.
+
+////
+// No bug fixes in this release
+[id="secondary-scheduler-1.1.5-bug-fixes"]
+=== Bug fixes
+
+// * This release of the {secondary-scheduler-operator} addresses Common Vulnerabilities and Exposures (CVEs).
+////
+
+[id="secondary-scheduler-operator-1.1.5-known-issues"]
+=== Known issues
+
+* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])
+
 [id="secondary-scheduler-operator-release-notes-1.1.4"]
 == Release notes for {secondary-scheduler-operator-full} 1.1.4
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12 and 4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-16599

Link to docs preview:
https://101451--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html#secondary-scheduler-operator-release-notes-1.1.5

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Even though we don't normally originate changes on 4.13, I think this probably still should go out there, since engineering noted that it will be released on 4.13 too.

Also note that the advisory link will be updated on the day of the release