### PR TITLE
OSDOCS-16617-418: modularizes 4.18 relnotes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -1,208 +1,35 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-4-18-release-notes"]
-= {product-title} {product-version} release notes
 include::_attributes/attributes-microshift.adoc[]
+= {product-title} {product-version} release notes
+
 :context: release-notes
 
 toc::[]
 
+[role="_abstract"]
 {product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate single-nodes in low-resource edge environments.
 
-{microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
+include::modules/microshift-4-18-about-this-release.adoc[leveloffset=+1]
 
-[id="microshift-4-18-about-this-release_{context}"]
-== About this release
-Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {ocp-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+include::modules/microshift-4-18-new-features-and-enhancements.adoc[leveloffset=+1]
 
-You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
+include::modules/microshift-4-18-tech-preview.adoc[leveloffset=+1]
 
-{microshift-short} {product-version} is supported on {op-system-base-full} 9.4.
+include::modules/microshift-4-18-doc-enhancements.adoc[leveloffset=+1]
 
-For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
+include::modules/microshift-4-18-deprecated-and-removed-features.adoc[leveloffset=+1]
 
-[id="microshift-4-18-new-features-and-enhancements_{context}"]
-== New features and enhancements
+include::modules/microshift-4-18-bug-fixes.adoc[leveloffset=+1]
 
-This release adds improvements related to the following components and concepts.
+include::modules/microshift-4-18-additional-release-notes.adoc[leveloffset=+1]
 
-[id="microshift-4-18-updating_{context}"]
-=== Updating
-Updating two minor EUS versions in a single step is supported in 4.18. Updates for both single-version minor releases and patch releases are also supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
+include::modules/microshift-4-18-asynch-errata-updates.adoc[leveloffset=+1]
 
-[id="microshift-4-18-configuring_{context}"]
-=== Configuring
+include::modules/microshift-4-18-1-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-18-drop-in-config_{context}"]
-==== Drop-in configuration snippets now available
-With this release, make configuring your {microshift-short} instances easier by using drop-in configuration snippets. See xref:../microshift_configuring/microshift-using-config-yaml.adoc#microshift-config-snippets_microshift-configuring[Using configuration snippets] for details.
+include::modules/microshift-4-18-2-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-18-ingress-controller-config_{context}"]
-==== Control ingress for your use case with additional parameters
-With this update, you have greater control over ingress to your {microshift-short} node by configuring more parameters. You can use these parameters to define secure connections and the number of connections per pod, plus more. See xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller_microshift-configuring[Using ingress control for a {microshift-short} node] for details.
+include::modules/microshift-4-18-11-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-18-running-apps_{context}"]
-=== Running applications
-
-[id="microshift-4-18-deleting-resource-manifest_{context}"]
-==== Deleting or updating Kustomize manifest resources now documented
-With this release, you can delete or upgrade the Kustomize manifest resources. For more information, see xref:../microshift_running_apps/microshift-deleting-resource-manifests.adoc#microshift-deleting-resource-manifests[Deleting or updating Kustomize manifest resources].
-
-[id="microshift-4-18-greenboot-workload-scripts-by-os_{context}"]
-==== Greenboot example outputs for image mode for RHEL available
-With this release, you can see detailed explanations and example outputs to check whether greenboot workload scripts are running properly. For more information, see xref:../microshift_running_apps/microshift-greenboot-workload-scripts.adoc#microshift-greenboot-test-workload-health-check-script_microshift-greenboot-workload-scripts[Testing a workload health check script].
-
-[id="microshift-4-18-backup_and_restore_{context}"]
-=== Backup and restore
-
-[id="microshift-4-18-autorecovery-from-manual-backup_{context}"]
-==== Automated recovery from manual backups
-With this release, you can automatically restore data from manual backups when {microshift-short} fails to start by using the `auto-recovery` feature. For more information, see xref:../microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc#microshift-auto-recover-manual-backup[Automated recovery from manual backups].
-
-[id="microshift-4-18-doc-enhancements_{context}"]
-=== Documentation enhancements
-
-[id="microshift-4-18-install-with-rhel-image-mode_{context}"]
-==== Updated content in the {op-system-base} image mode section
-With this release, the contents of the "Installing with {op-system-base} image mode" section, which were previously developer-focused, are now updated to be {microshift-short} administrator-focused. For more information, see xref:../microshift_install_bootc/microshift-about-rhel-image-mode.adoc#microshift-about-rhel-image-mode[Understanding image mode for RHEL with {microshift-short}].
-
-[id="microshift-4-18-tech-preview_{context}"]
-== Technology Preview features
-
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
-
-link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
-
-[id="microshift-4-18-rhel-image-mode_{context}"]
-=== {op-system-base-full} image mode Technology Preview feature
-* You can install {microshift-short} using a `bootc` container image. Image mode for {op-system-base} is a Technology Preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
-+
-See xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-publish-bootc-image[Using image mode for RHEL with {microshift-short}] for more information.
-
-[id="microshift-4-18-rhel-image-mode-image_{context}"]
-==== Image mode for RHEL image added for use with {microshift-short}
-* New for 20 March 2025: A `microshift-bootc` image is now available at the Red{nbsp}Hat Ecosystem catalog. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-publish-bootc-image[Installing and publishing a bootc image to a registry].
-
-[id="microshift-4-18-deprecated-and-removed-features_{context}"]
-== Deprecated and removed features
-With this release, the CSI snapshot webhook feature available in previous releases is removed. The webhook is replaced by CEL validation rules for snapshot objects.
-
-//NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
-[id="microshift-4-18-bug-fixes_{context}"]
-== Bug fixes
-
-[id="microshift-4-18-installation-bug-fixes"]
-=== Installation
-Previously, the greenboot health check marked some healthy Image mode for {op-system-base} systems as unhealthy due to a 300-second timeout, which was insufficient for systems with slow networks. Beginning in {product-title} 4.18, the default greenboot wait timeout has been extended to 600 seconds to provide more time to download images and ensure accurate system checks. (https://issues.redhat.com/browse/OCPBUGS-47463[OCPBUGS-47463])
-
-[id="microshift-4-18-additional-release-notes_{context}"]
-== Additional release notes
-Release notes for related components and products are available in the following documentation:
-
-[NOTE]
-====
-The following release notes are for downstream Red{nbsp}Hat products only; upstream or community release notes for related products are not included.
-====
-
-[id="microshift-4-18-additional-release-notes-gitops_{context}"]
-=== GitOps release notes
-See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/latest/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package, link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
-
-[id="microshift-4-18-additional-release-notes-ocp_{context}"]
-=== {OCP} release notes
-See the https://docs.openshift.com/container-platform/4.18/release_notes/ocp-4-18-release-notes.html[{OCP} Release Notes] for information about the Operator Lifecycle Manager and other components. Not all of the changes to {OCP} apply to {microshift-short}. See the specific {microshift-short} implementation of an Operator or function for more information.
-
-[id="microshift-4-18-additional-release-notes-rhel_{context}"]
-=== {op-system-base-full} release notes
-See the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.4_release_notes/index[Release Notes for Red{nbsp}Hat Enterprise Linux 9.4] for more information about {op-system-base}.
-
-[id="microshift-4-18-asynchronous-errata-updates_{context}"]
-== Asynchronous errata updates
-
-Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red{nbsp}Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
-
-Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
-
-[NOTE]
-====
-Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
-====
-
-This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections. {microshift-short} uses a priority-based release cadence to provide the most important updates with the least disruption.
-
-[IMPORTANT]
-====
-For any {product-title} release, always review the xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] documentation before proceeding with an update.
-====
-
-[id="microshift-4-18-1-dp_{context}"]
-=== RHEA-2024:6124 - {microshift-short} 4.18.1 bug fix and security update advisory
-
-Issued: 25 February 2025
-
-{product-title} release 4.18.1 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:6124[RHEA-2024:6124] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:6122[RHSA-2024:6122] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-18-1-known-issue_{context}"]
-==== Known issue
-
-* A failed greenboot health check flag does not clear when an RPM-install-based {microshift-short} service is updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. (link:https://issues.redhat.com/browse/OCPBUGS-51198[OCPBUGS-51198])
-
-[id="microshift-4-18-2-dp_{context}"]
-=== RHBA-2025:1953 - {microshift-short} 4.18.2 bug fix and enhancement advisory
-
-Issued: 4 March 2025
-
-{product-title} release 4.18.2 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:1953[RHBA-2025:1953] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:1904[RHBA-2025:1904] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-18-2-bugs_{context}"]
-==== Bug fix
-
-* Previously, a failed greenboot health check flag did not clear when an RPM-install-based {microshift-short} service was updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. With this release, the primary {microshift-short} greenboot health check clears the condition that causes optional component health checks to continue to fail. (link:https://issues.redhat.com/browse/OCPBUGS-51198[OCPBUGS-51198])
-
-[id="microshift-4-18-11-dp_{context}"]
-=== RHBA-2025:4249 - {microshift-short} 4.18.11 bug fix and enhancement advisory
-
-Issued: 1 May 2025
-
-{product-title} release 4.18.11 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4249[RHBA-2025:4249] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:4211[RHSA-2025:4211] advisory.
-
-See the latest images included with {microshift-short} by using the following instructions:
-
-* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
-* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
-
-[id="microshift-4-18-11-bugs_{context}"]
-==== Bug fixes
-
-* Previously, {microshift-short} could fail to start on a host without the hostname RPM package installed. With this release, the hostname RPM package is pulled as a dependency during installation. This change means that the hostname RPM package is now required when building the {microshift-short} system, preventing this type of startup failure.  (link:https://issues.redhat.com/browse/OCPBUGS-54448[OCPBUGS-54448])
-
-* In some cases, {microshift-short} did not start when using the default configuration file shipped in the {microshift-short} RPM because certain required values were missing. These values are now added to the default `config.yaml` file to avoid this problem and {microshift-short} starts as expected. (link:https://issues.redhat.com/browse/OCPBUGS-53026[OCPBUGS-53026])
-
-* Previously, when embedding container images during a bootc build procedure, extended attributes were discarded, preventing the router pod from connecting to default `haproxy` ports. With this release, extended attributes are kept for container layers that are embedded into container images. As a result, the bootc container router pod starts normally. (link:https://issues.redhat.com/browse/OCPBUGS-42010[OCPBUGS-42010])
-
-[id="microshift-4-18-26-dp_{context}"]
-=== RHBA-2025:17912 - {microshift-short} 4.18.26 bug fix and enhancement advisory
-
-Issued: 16 October 2026
-
-{product-title} release 4.18.26 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:17912[RHBA-2025:17912] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:17657[RHSA-2025:17657] advisory.
-
-See the latest images included with {microshift-short} by using the following instructions:
-
-* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
-* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
-
-[id="microshift-4-18-26-bugs_{context}"]
-==== Bug fix
-
-* Before this update, embedding container images into a bootc build could fail because HTTP proxy environment variables were defined in the bootc image. Proxy errors occurred during container image embedding and prevented successful builds. With this release, the bootc image no longer sets HTTP proxy environment variables, thereby eliminating the issue. As a result, you can now embed container images without encountering proxy errors. (link:https://issues.redhat.com/browse/OCPBUGS-61433[OCPBUGS-61433])
-
-[id="microshift-4-18-26-enhancements_{context}"]
-==== Enhancements
-
-* With this release, {microshift-short} uses OpenVSwitch (OVS) 3.5, keeping OVS synchronized with OVN-Kubernetes. (link:https://issues.redhat.com/browse/OCPBUGS-58139[OCPBUGS-58139])
-
-* With this release, the `microshift-release-info` RPM now incudes example {op-system-base} Kickstart files for RPM, {op-system-ostree} and {op-system-image} installation types. You can use the Kickstart immediately for a faster installation, or customize it with your requirements. (link:https://issues.redhat.com/browse/OCPBUGS-42864[OCPBUGS-42864])
+include::modules/microshift-4-18-26-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-18-1-dp.adoc
+++ b/modules/microshift-4-18-1-dp.adoc
@@ -1,0 +1,20 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-18-1-dp_{context}"]
+= RHEA-2024:6124 - {microshift-short} 4.18.1 bug fix and security update advisory
+
+[role="_abstract"]
+Issued: 25 February 2025
+
+{product-title} release 4.18.1 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2024:6124[RHEA-2024:6124] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:6122[RHSA-2024:6122] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-18-1-known-issue_{context}"]
+== Known issue
+
+* A failed greenboot health check flag does not clear when an RPM-install-based {microshift-short} service is updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. (link:https://issues.redhat.com/browse/OCPBUGS-51198[OCPBUGS-51198])

--- a/modules/microshift-4-18-11-dp.adoc
+++ b/modules/microshift-4-18-11-dp.adoc
@@ -1,0 +1,27 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-18-11-dp_{context}"]
+= RHBA-2025:4249 - {microshift-short} 4.18.11 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 1 May 2025
+
+{product-title} release 4.18.11 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4249[RHBA-2025:4249] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:4211[RHSA-2025:4211] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-18-11-bugs_{context}"]
+== Bug fixes
+
+* Previously, {microshift-short} could fail to start on a host without the hostname RPM package installed. With this release, the hostname RPM package is pulled as a dependency during installation. This change means that the hostname RPM package is now required when building the {microshift-short} system, preventing this type of startup failure.  (link:https://issues.redhat.com/browse/OCPBUGS-54448[OCPBUGS-54448])
+
+* In some cases, {microshift-short} did not start when using the default configuration file shipped in the {microshift-short} RPM because certain required values were missing. These values are now added to the default `config.yaml` file to avoid this problem and {microshift-short} starts as expected. (link:https://issues.redhat.com/browse/OCPBUGS-53026[OCPBUGS-53026])
+
+* Previously, when embedding container images during a bootc build procedure, extended attributes were discarded, preventing the router pod from connecting to default `haproxy` ports. With this release, extended attributes are kept for container layers that are embedded into container images. As a result, the bootc container router pod starts normally. (link:https://issues.redhat.com/browse/OCPBUGS-42010[OCPBUGS-42010])

--- a/modules/microshift-4-18-2-dp.adoc
+++ b/modules/microshift-4-18-2-dp.adoc
@@ -1,0 +1,20 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-18-2-dp_{context}"]
+= RHBA-2025:1953 - {microshift-short} 4.18.2 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 4 March 2025
+
+{product-title} release 4.18.2 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:1953[RHBA-2025:1953] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:1904[RHBA-2025:1904] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-18-2-bugs_{context}"]
+== Bug fix
+
+* Previously, a failed greenboot health check flag did not clear when an RPM-install-based {microshift-short} service was updated without rebooting the system. As a consequence, greenboot health checks for optional components continue to fail because the `systemctl restart greenboot-healthcheck.service` command fails while the flag is present. With this release, the primary {microshift-short} greenboot health check clears the condition that causes optional component health checks to continue to fail. (link:https://issues.redhat.com/browse/OCPBUGS-51198[OCPBUGS-51198])

--- a/modules/microshift-4-18-26-dp.adoc
+++ b/modules/microshift-4-18-26-dp.adoc
@@ -1,0 +1,30 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-18-26-dp_{context}"]
+= RHBA-2025:17912 - {microshift-short} 4.18.26 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 16 October 2026
+
+{product-title} release 4.18.26 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:17912[RHBA-2025:17912] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:17657[RHSA-2025:17657] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-18-26-bugs_{context}"]
+== Bug fix
+
+* Before this update, embedding container images into a bootc build could fail because HTTP proxy environment variables were defined in the bootc image. Proxy errors occurred during container image embedding and prevented successful builds. With this release, the bootc image no longer sets HTTP proxy environment variables, thereby eliminating the issue. As a result, you can now embed container images without encountering proxy errors. (link:https://issues.redhat.com/browse/OCPBUGS-61433[OCPBUGS-61433])
+
+[id="microshift-4-18-26-enhancements_{context}"]
+== Enhancements
+
+* With this release, {microshift-short} uses OpenVSwitch (OVS) 3.5, keeping OVS synchronized with OVN-Kubernetes. (link:https://issues.redhat.com/browse/OCPBUGS-58139[OCPBUGS-58139])
+
+* With this release, the `microshift-release-info` RPM now incudes example {op-system-base} Kickstart files for RPM, {op-system-ostree} and {op-system-image} installation types. You can use the Kickstart immediately for a faster installation, or customize it with your requirements. (link:https://issues.redhat.com/browse/OCPBUGS-42864[OCPBUGS-42864])

--- a/modules/microshift-4-18-about-this-release.adoc
+++ b/modules/microshift-4-18-about-this-release.adoc
@@ -1,0 +1,19 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-18-about-this-release_{context}"]
+= About this release
+
+[role="_abstract"]
+{microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
+
+Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {ocp-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+
+You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
+
+{microshift-short} {product-version} is supported on {op-system-base-full} 9.4.
+
+For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].

--- a/modules/microshift-4-18-additional-release-notes.adoc
+++ b/modules/microshift-4-18-additional-release-notes.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-18-additional-release-notes_{context}"]
+= Additional release notes
+
+[role="_abstract"]
+Release notes for related components and products are available in the following documentation:
+
+[NOTE]
+====
+The following release notes are for downstream Red{nbsp}Hat products only; upstream or community release notes for related products are not included.
+====
+
+[id="microshift-4-18-additional-release-notes-gitops_{context}"]
+== GitOps release notes
+
+See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/latest/html/release_notes/index[Red{nbsp}Hat OpenShift GitOps: Highlights of what is new and what has changed with this OpenShift GitOps release] for more information. You can also go to the Red{nbsp}Hat package download page and search for "gitops" if you just need the latest package, link:https://access.redhat.com/downloads/content/package-browser[Red{nbsp}Hat packages].
+
+[id="microshift-4-18-additional-release-notes-ocp_{context}"]
+== {OCP} release notes
+
+See the https://docs.openshift.com/container-platform/4.18/release_notes/ocp-4-18-release-notes.html[{OCP} Release Notes] for information about the Operator Lifecycle Manager and other components. Not all of the changes to {OCP} apply to {microshift-short}. See the specific {microshift-short} implementation of an Operator or function for more information.
+
+[id="microshift-4-18-additional-release-notes-rhel_{context}"]
+== {op-system-base-full} release notes
+
+See the link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/9.4_release_notes/index[Release Notes for Red{nbsp}Hat Enterprise Linux 9.4] for more information about {op-system-base}.

--- a/modules/microshift-4-18-asynch-errata-updates.adoc
+++ b/modules/microshift-4-18-asynch-errata-updates.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-18-asynch-errata-updates_{context}"]
+= Asynchronous errata updates
+
+[role="_abstract"]
+Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red{nbsp}Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
+
+Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
+
+[NOTE]
+====
+Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
+====
+
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections. {microshift-short} uses a priority-based release cadence to provide the most important updates with the least disruption.
+
+[IMPORTANT]
+====
+For any {product-title} release, always review the xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] documentation before proceeding with an update.
+====

--- a/modules/microshift-4-18-bug-fixes.adoc
+++ b/modules/microshift-4-18-bug-fixes.adoc
@@ -1,0 +1,13 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-18-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+Learn about the bug fixes included in this release.
+
+* Previously, the greenboot health check marked some healthy Image mode for {op-system-base} systems as unhealthy due to a 300-second timeout, which was insufficient for systems with slow networks. Beginning in {product-title} 4.18, the default greenboot wait timeout has been extended to 600 seconds to provide more time to download images and ensure accurate system checks. (https://issues.redhat.com/browse/OCPBUGS-47463[OCPBUGS-47463])

--- a/modules/microshift-4-18-deprecated-and-removed-features.adoc
+++ b/modules/microshift-4-18-deprecated-and-removed-features.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-18-deprecated-and-removed-features_{context}"]
+= Deprecated and removed features
+
+[role="_abstract"]
+Learn about deprecated and removed features in {microshift-short} {product-version}.
+
+[id="microshift-4-18-csi-webhook-removed_{context}"]
+== CSI snapshot webhook removed
+
+With this release, the CSI snapshot webhook feature available in previous releases is removed. The webhook is replaced by CEL validation rules for snapshot objects.

--- a/modules/microshift-4-18-doc-enhancements.adoc
+++ b/modules/microshift-4-18-doc-enhancements.adoc
@@ -1,0 +1,16 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-18-doc-enhancements_{context}"]
+= Documentation enhancements
+
+[role="_abstract"]
+You can also benefit by using the following documentation enhancements.
+
+[id="microshift-4-18-install-with-rhel-image-mode_{context}"]
+== Updated content in the {op-system-base} image mode section
+
+With this release, the contents of the "Installing with {op-system-base} image mode" section, which were previously developer-focused, are now updated to be {microshift-short} administrator-focused. For more information, see xref:../microshift_install_bootc/microshift-about-rhel-image-mode.adoc#microshift-about-rhel-image-mode[Understanding image mode for RHEL with {microshift-short}].

--- a/modules/microshift-4-18-new-features-and-enhancements.adoc
+++ b/modules/microshift-4-18-new-features-and-enhancements.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-18-new-features-and-enhancements_{context}"]
+= New features and enhancements
+
+[role="_abstract"]
+This release adds improvements related to the following components and concepts.
+
+[id="microshift-4-18-updating_{context}"]
+== Updating
+
+Updating two minor EUS versions in a single step is supported in 4.18. Updates for both single-version minor releases and patch releases are also supported. See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
+
+[id="microshift-4-18-drop-in-config_{context}"]
+== Drop-in configuration snippets now available
+
+With this release, make configuring your {microshift-short} instances easier by using drop-in configuration snippets. See xref:../microshift_configuring/microshift-using-config-yaml.adoc#microshift-config-snippets_microshift-configuring[Using configuration snippets] for details.
+
+[id="microshift-4-18-ingress-controller-config_{context}"]
+== Control ingress for your use case with additional parameters
+
+With this update, you have greater control over ingress to your {microshift-short} node by configuring more parameters. You can use these parameters to define secure connections and the number of connections per pod, plus more. See xref:../microshift_configuring/microshift-ingress-controller.adoc#microshift-ingress-controller_microshift-configuring[Using ingress control for a {microshift-short} node] for details.
+
+[id="microshift-4-18-deleting-resource-manifest_{context}"]
+== Deleting or updating Kustomize manifest resources now documented
+
+With this release, you can delete or upgrade the Kustomize manifest resources. For more information, see xref:../microshift_running_apps/microshift-deleting-resource-manifests.adoc#microshift-deleting-resource-manifests[Deleting or updating Kustomize manifest resources].
+
+[id="microshift-4-18-greenboot-workload-scripts-by-os_{context}"]
+== Greenboot example outputs for image mode for RHEL available
+
+With this release, you can see detailed explanations and example outputs to check whether greenboot workload scripts are running properly. For more information, see xref:../microshift_running_apps/microshift-greenboot-workload-scripts.adoc#microshift-greenboot-test-workload-health-check-script_microshift-greenboot-workload-scripts[Testing a workload health check script].
+
+[id="microshift-4-18-autorecovery-from-manual-backup_{context}"]
+== Automated recovery from manual backups
+
+With this release, you can automatically restore data from manual backups when {microshift-short} fails to start by using the `auto-recovery` feature. For more information, see xref:../microshift_backup_and_restore/microshift-auto-recover-manual-backup.adoc#microshift-auto-recover-manual-backup[Automated recovery from manual backups].

--- a/modules/microshift-4-18-tech-preview.adoc
+++ b/modules/microshift-4-18-tech-preview.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-18-tech-preview_{context}"]
+= Technology Preview features
+
+[role="_abstract"]
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for these features:
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+[id="microshift-4-18-rhel-image-mode_{context}"]
+== {op-system-base-full} image mode Technology Preview feature
+
+* You can install {microshift-short} using a `bootc` container image. Image mode for {op-system-base} is a Technology Preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
++
+See xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-publish-bootc-image[Using image mode for RHEL with {microshift-short}] for more information.
+
+[id="microshift-4-18-rhel-image-mode-image_{context}"]
+== Image mode for RHEL image added for use with {microshift-short}
+
+* New for 20 March 2025: A `microshift-bootc` image is now available at the Red{nbsp}Hat Ecosystem catalog. For more information, see xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-publish-bootc-image[Installing and publishing a bootc image to a registry].


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-16617](https://issues.redhat.com/browse/OSDOCS-16617)

Link to docs preview:
https://101454--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html

QE review:
N/A, migration work only

Additional info:
This PR modularizes the release notes for DITA compatibility. It does not update content.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
