### PR TITLE
[enterprise-4.16] OSDOCS-16317# Doc update for removal of VMware 7.x and VCF 4.3 support.

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -7,12 +7,11 @@
 [id="installation-vsphere-infrastructure_{context}"]
 = VMware vSphere infrastructure requirements
 
-You must install an {product-title} cluster on one of the following versions of a VMware vSphere instance that meets the requirements for the components that you use:
+You must install an {product-title} cluster on a version of a {vmw-full} instance that meets the requirements for the components that you use:
 
-* Version 7.0 Update 2 or later, or VMware Cloud Foundation 4.3 or later
 * Version 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
 
-Both of these releases support Container Storage Interface (CSI) migration, which is enabled by default on {product-title} {product-version}.
+This release supports Container Storage Interface (CSI) migration, which is enabled by default on {product-title} {product-version}.
 
 You can host the VMware vSphere infrastructure on-premise or on a link:https://cloud.vmware.com/providers[VMware Cloud Verified provider] that meets the requirements outlined in the following tables:
 
@@ -21,8 +20,8 @@ You can host the VMware vSphere infrastructure on-premise or on a link:https://c
 |===
 |Virtual environment product |Required version
 |VMware virtual hardware | 15 or later
-|vSphere ESXi hosts | 7.0 Update 2 or later, or VMware Cloud Foundation 4.3 or later; 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
-|vCenter host | 7.0 Update 2 or later, or VMware Cloud Foundation 4.3 or later; 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
+|vSphere ESXi hosts | 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
+|vCenter host | 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
 |===
 
 [IMPORTANT]
@@ -35,11 +34,11 @@ You must ensure that the time on your ESXi hosts is synchronized before you inst
 |Component | Minimum supported versions |Description
 
 |Hypervisor
-|vSphere 7.0 Update 2 or later, or VMware Cloud Foundation 4.3 or later; vSphere 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later with virtual hardware version 15
+|vSphere 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later with virtual hardware version 15
 |This hypervisor version is the minimum version that {op-system-first} supports. For more information about supported hardware on the latest version of {op-system-base-full} that is compatible with {op-system}, see link:https://catalog.redhat.com/hardware/search[Hardware] on the Red Hat Customer Portal.
 
 |Optional: Networking (NSX-T)
-|vSphere 7.0 Update 2 or later, or VMware Cloud Foundation 4.3 or later; vSphere 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
+|vSphere 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
 |For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].
 
 |CPU micro-architecture

--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -69,15 +69,15 @@ ifndef::openshift-dedicated,openshift-rosa[]
 --
 1.
 
-* Requires vSphere version 7.0 Update 3 or later for both vCenter Server and ESXi.
+* Requires vSphere version 8.0 Update 1 or later for both vCenter Server and ESXi.
 
 * Does not support fileshare volumes.
 
 2.
 
-* Offline volume expansion: minimum required vSphere version is 6.7 Update 3 P06
+* Offline volume expansion: minimum required vSphere version is 8.0 Update 1.
 
-* Online volume expansion: minimum required vSphere version is 7.0 Update 2.
+* Online volume expansion: minimum required vSphere version is 8.0 Update 1.
 
 3.
 

--- a/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
@@ -16,7 +16,7 @@ Multiple compute nodes can be updated in parallel given workloads are tolerant o
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 7.0U2 or later.
+* Your vSphere ESXi hosts are version 8.0 Update 1 or later.
 
 .Procedure
 

--- a/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
@@ -11,7 +11,7 @@ To reduce the risk of downtime, it is recommended that control plane nodes be up
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 7.0U2 or later.
+* Your vSphere ESXi hosts are version 8.0 Update 1 or later.
 
 .Procedure
 

--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -9,7 +9,7 @@
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 7.0U2 or later.
+* Your vSphere ESXi hosts are version 8.0 Update 1 or later.
 
 .Procedure
 

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -10,8 +10,8 @@
 
 To install the vSphere Container Storage Interface (CSI) Driver Operator, the following requirements must be met:
 
-* VMware vSphere version: 7.0 Update 2 or later, or VMware Cloud Foundation 4.3 or later; 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
-* vCenter version: 7.0 Update 2 or later, or VMware Cloud Foundation 4.3 or later; 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
+* VMware vSphere version: 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
+* vCenter version: 8.0 Update 1 or later, or VMware Cloud Foundation 5.0 or later
 * Virtual machines of hardware version 15 or later
 * No third-party vSphere CSI driver already installed in the cluster
 

--- a/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc
+++ b/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc
@@ -20,7 +20,7 @@ You can update your virtual hardware immediately or schedule an update in vCente
 ====
 * Version {product-version} of {product-title} requires VMware virtual hardware version 15 or later.
 
-* Before upgrading OpenShift 4.12 to OpenShift 4.13, you must update vSphere to *v7.0.2 or later*; otherwise, the OpenShift 4.12 cluster is marked *un-upgradeable*.
+* Before upgrading OpenShift 4.12 to OpenShift 4.13, you must update vSphere to *v8.0 Update 1 or later*; otherwise, the OpenShift 4.12 cluster is marked *un-upgradeable*.
 ====
 
 [id="updating-virtual-hardware-on-vsphere_{context}"]


### PR DESCRIPTION
Cherry Picked from 89874e35fb1799f44daa81d378e17bebc44d11ce xref: https://github.com/openshift/openshift-docs/pull/99835
