### PR TITLE
OSDOCS-16617-417: modularizes 4.17 relnotes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -6,252 +6,47 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 {product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate a single-node in low-resource edge environments.
 
-{microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
+include::modules/microshift-4-17-about-this-release.adoc[leveloffset=+1]
 
-[id="microshift-4-17-about-this-release_{context}"]
-== About this release
-Version 4.17 of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+include::modules/microshift-4-17-new-features-and-enhancements.adoc[leveloffset=+1]
 
-You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
+include::modules/microshift-4-17-tech-preview.adoc[leveloffset=+1]
 
-{microshift-short} {product-version} is supported on {op-system-base-full} 9.4.
+include::modules/microshift-4-17-doc-enhancements.adoc[leveloffset=+1]
 
-For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
+include::modules/microshift-4-17-asynchronous-errata-updates.adoc[leveloffset=+1]
 
-[id="microshift-4-17-new-features-and-enhancements_{context}"]
-== New features and enhancements
+include::modules/microshift-4-17-1-dp.adoc[leveloffset=+2]
 
-This release adds improvements related to the following components and concepts.
+include::modules/microshift-4-17-2-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-rhel_{context}"]
-=== {op-system-base-full}
-* {microshift-short} {product-version} runs on {op-system-base-full} 9.4.
+include::modules/microshift-4-17-3-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-updating_{context}"]
-=== Updating
-Updating two minor versions in a single step is not supported in 4.17. Updates for both single-version minor releases and patch releases are supported.
+include::modules/microshift-4-17-4-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-networking_{context}"]
-=== Networking
+include::modules/microshift-4-17-5-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-IPv6_{context}"]
-==== IPv6 single and dual-stack IPv6 networking now available
-With this release, you can run {microshift-short} and your workloads with either IPv6 only or IPv4 and IPv6 dual-stack networking protocols. Ingress and egress traffic can be on either IPv4 or IPv6 traffic, mixed or parallel. See xref:../microshift_configuring/microshift-nw-ipv6-config.adoc#microshift-nw-ipv6-config[Configuring IPv6 networking].
+include::modules/microshift-4-17-6-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-storage_{context}"]
-=== Storage
+include::modules/microshift-4-17-7-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-LVMS-resource-footprint-reduction_{context}"]
-==== Resource footprint reduction for LVM storage driver now available
-With this release, the resource footprint of the LVM storage driver is significantly reduced, particularly in terms of memory consumption.
+include::modules/microshift-4-17-8-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-LVMS-volume-snapshot-deployment-optional_{context}"]
-==== Disabling and uninstalling LVM Storage CSI provider and CSI snapshot deployments now available
-With this release, {microshift-short} can now be configured to disable and uninstall the container storage interface (CSI) provider or the CSI snapshot capabilities which can reduce the use of runtime resources such as RAM, CPU, and storage. See xref:../microshift_storage/microshift-storage-plugin-overview.adoc#microshift-disabling-uninstalling-lvms-csi-snapshot_microshift-storage-plugin-overview[Disabling and uninstalling LVMS CSI provider and CSI snapshot deployments].
+include::modules/microshift-4-17-9-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-running-apps_{context}"]
-=== Running applications
+include::modules/microshift-4-17-10-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-low-latency_{context}"]
-====  Low-latency performance for applications now available
-You can now run a {microshift-short} node with low-latency response rates. Using a low-latency {microshift-short} configuration with operating system tuning results in reduced application response times and can include deterministic performance. Using workload partitioning is also recommended. See xref:../microshift_configuring/microshift_low_latency/microshift-low-latency.adoc#microshift-low-latency[Configuring low latency] for more information.
+include::modules/microshift-4-17-11-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-workload-partitioning_{context}"]
-==== Support for workload partitioning
-With this release, workload partitioning is supported in {microshift-short}. See xref:../microshift_configuring/microshift_low_latency/microshift-workload-partitioning.adoc#microshift-workload-partitioning[Workload partitioning] for more information.
+include::modules/microshift-4-17-12-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-doc-enhancements_{context}"]
-=== Documentation enhancements
+include::modules/microshift-4-17-14-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-data-cleanup_{context}"]
-==== Data cleanup now documented
-With this release, the `microshift-cleanup-data` script is documented. See xref:../microshift_troubleshooting/microshift-cleanup-data.adoc#microshift-cleanup-data[Data cleanup] for more information.
+include::modules/microshift-4-17-27-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-install-topics-reorg_{context}"]
-==== Installation topics are reorganized
-With this release, system requirements, installation types, and information about installing add-ons are reorganized into discrete topics so that they are easier to use.
+include::modules/microshift-4-17-35-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-17-tech-preview_{context}"]
-== Technology Preview feature
-
-One feature in this release is currently in Technology Preview. This experimental feature is not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for this feature:
-
-link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
-
-[id="microshift-4-17-rhel-image-mode_{context}"]
-=== {op-system-base-full} image mode Technology Preview feature
-* You can now install {microshift-short} using a `bootc` container image. Image mode for {op-system-base} is a Technology Preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
-
-See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.
-
-[id="microshift-4-17-asynchronous-errata-updates_{context}"]
-== Asynchronous errata updates
-
-Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
-
-Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
-
-[NOTE]
-====
-Red Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
-====
-
-This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
-
-[id="microshift-4-17-1-dp_{context}"]
-=== RHBA-2024:7924 - {microshift-short} 4.17.1 Generally Available release advisory
-
-Issued: 15 October 2024
-
-{product-title} release 4.17.1 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:7924[RHBA-2024:7924] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:7922[RHSA-2024:7922] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-2-dp_{context}"]
-=== RHBA-2024:8231 - {microshift-short} 4.17.2 bug fix and enhancement update advisory
-
-Issued: 23 October 2024
-
-{product-title} release 4.17.2 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:8231[RHBA-2024:8231] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:8229[RHSA-2024:8229] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-3-dp_{context}"]
-=== RHBA-2024:8436 - {microshift-short} 4.17.3 bug fix and enhancement update advisory
-
-Issued: 29 October 2024
-
-{product-title} release 4.17.3 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:8436[RHBA-2024:8436] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:8434[RHSA-2024:8434] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-4-dp_{context}"]
-=== RHBA-2024:8983 - {microshift-short} 4.17.4 bug fix and enhancement update advisory
-
-Issued: 13 November 2024
-
-{product-title} release 4.17.4 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:8983[RHBA-2024:8983] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:8981[RHSA-2024:8981] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-5-dp_{context}"]
-=== RHBA-2024:9612 - {microshift-short} 4.17.5 bug fix and enhancement update advisory
-
-Issued: 19 November 2024
-
-{product-title} release 4.17.5 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:9612[RHBA-2024:9612] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:9610[RHSA-2024:9610] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-6-dp_{context}"]
-=== RHBA-2024:10139 - {microshift-short} 4.17.6 bug fix and enhancement update advisory
-
-Issued: 26 November 2024
-
-{product-title} release 4.17.6 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:10139[RHBA-2024:10139] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:10137[RHBA-2024:10137] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-7-dp_{context}"]
-=== RHSA-2024:10520 - {microshift-short} 4.17.7 security and bug fix update advisory
-
-Issued: 3 December 2024
-
-{product-title} release 4.17.7 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHSA-2024:10520[RHSA-2024:10520] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:10518[RHSA-2024:10518] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-8-dp_{context}"]
-=== RHBA-2024:10820 - {microshift-short} 4.17.8 bug fix and enhancement advisory
-
-Issued: 11 December 2024
-
-{product-title} release 4.17.8 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:10820[RHBA-2024:10820] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:10818[RHSA-2024:10818] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-9-dp_{context}"]
-=== RHBA-2024:11012 - {microshift-short} 4.17.9 bug fix and enhancement advisory
-
-Issued: 19 December 2024
-
-{product-title} release 4.17.9 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:11012[RHBA-2024:11012] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:11010[RHBA-2024:11010] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-10-dp_{context}"]
-=== RHBA-2024:11524 - {microshift-short} 4.17.10 bug fix and enhancement advisory
-
-Issued: 2 January 2025
-
-{product-title} release 4.17.10 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:11524[RHBA-2024:11524] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:11522[RHBA-2024:11522] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-11-dp_{context}"]
-=== RHBA-2025:0025 - {microshift-short} 4.17.11 bug fix and enhancement advisory
-
-Issued: 8 January 2025
-
-{product-title} release 4.17.11 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0025[RHBA-2025:0025] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:0023[RHBA-2025:0023] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-12-dp_{context}"]
-=== RHBA-2025:0117 - {microshift-short} 4.17.12 bug fix and enhancement advisory
-
-Issued: 14 January 2025
-
-{product-title} release 4.17.12 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0117[RHBA-2025:0117] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:0115[RHSA-2025:0115] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-14-dp_{context}"]
-=== RHBA-2025:0682 - {microshift-short} 4.17.14 bug fix and enhancement advisory
-
-Issued: 28 January 2025
-
-{product-title} release 4.17.14 is now available. With this release, {microshift-short} introduces a priority-based release cadence to provide the most important updates with the least disruption.
-
-Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0682[RHBA-2025:0682] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:0654[RHSA-2025:0654] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-27-dp_{context}"]
-=== RHBA-2025:0682 - {microshift-short} 4.17.27 bug fix and enhancement advisory
-
-Issued: 30 April 2025
-
-{product-title} release 4.17.27 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4217[RHBA-2025:4217] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:4204[RHSA-2025:4204] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="ocp-4-17-27-bug-fixes_{context}"]
-==== Bug fixes
-
-* Previously, an IPv6 configuration for {microshift-short} was created in the system at first start when an IP address was not configured. This was caused by an erroneous retrieval of the default node IP address because of the order in which the interfaces were listed. Consequentially, the misconfiguration resulted in the {microshift-short} service being unreachable. With this release, the correct node IP address is retrieved first. (link:https://issues.redhat.com/browse/OCPBUGS-52861[OCPBUGS-52861])
-
-[id="microshift-4-17-35-dp_{context}"]
-=== RHBA-2025:10331 - {microshift-short} 4.17.35 security advisory
-
-Issued: 9 July 2025
-
-{product-title} release 4.17.35 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:10331[RHBA-2025:10331] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:10294[RHSA-2025:10294] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-37-dp_{context}"]
-=== RHBA-2025:12508 - {microshift-short} 4.17.37 bug fix and enhancement update
-
-Issued: 7 Aug 2025
-
-{product-title} release 4.17.37 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:12508[RHBA-2025:12508] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:12437[RHSA-2025:12437] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-17-37-bug-fixes_{context}"]
-==== Bug fix
-
-* Before this update, {microshift-short} 4.17 used OpenVSwitch (OVS) 3.4. With this release, {microshift-short} now uses OVS 3.5, keeping OVS synchronized with OVN-Kubernetes. (link:https://issues.redhat.com/browse/OCPBUGS-58384[OCPBUGS-58384])
+include::modules/microshift-4-17-37-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-17-1-dp.adoc
+++ b/modules/microshift-4-17-1-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-1-dp_{context}"]
+= RHBA-2024:7924 - {microshift-short} 4.17.1 Generally Available release advisory
+
+[role="_abstract"]
+Issued: 15 October 2024
+
+{product-title} release 4.17.1 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:7924[RHBA-2024:7924] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:7922[RHSA-2024:7922] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-10-dp.adoc
+++ b/modules/microshift-4-17-10-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-10-dp_{context}"]
+= RHBA-2024:11524 - {microshift-short} 4.17.10 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 2 January 2025
+
+{product-title} release 4.17.10 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:11524[RHBA-2024:11524] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:11522[RHBA-2024:11522] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-11-dp.adoc
+++ b/modules/microshift-4-17-11-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-11-dp_{context}"]
+= RHBA-2025:0025 - {microshift-short} 4.17.11 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 8 January 2025
+
+{product-title} release 4.17.11 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0025[RHBA-2025:0025] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:0023[RHBA-2025:0023] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-12-dp.adoc
+++ b/modules/microshift-4-17-12-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-12-dp_{context}"]
+= RHBA-2025:0117 - {microshift-short} 4.17.12 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 14 January 2025
+
+{product-title} release 4.17.12 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0117[RHBA-2025:0117] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:0115[RHSA-2025:0115] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-14-dp.adoc
+++ b/modules/microshift-4-17-14-dp.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-14-dp_{context}"]
+= RHBA-2025:0682 - {microshift-short} 4.17.14 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 28 January 2025
+
+{product-title} release 4.17.14 is now available. With this release, {microshift-short} introduces a priority-based release cadence to provide the most important updates with the least disruption.
+
+Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2025:0682[RHBA-2025:0682] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:0654[RHSA-2025:0654] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-2-dp.adoc
+++ b/modules/microshift-4-17-2-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-2-dp_{context}"]
+= RHBA-2024:8231 - {microshift-short} 4.17.2 bug fix and enhancement update advisory
+
+[role="_abstract"]
+Issued: 23 October 2024
+
+{product-title} release 4.17.2 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:8231[RHBA-2024:8231] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:8229[RHSA-2024:8229] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-27-dp.adoc
+++ b/modules/microshift-4-17-27-dp.adoc
@@ -1,0 +1,20 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-27-dp_{context}"]
+= RHBA-2025:0682 - {microshift-short} 4.17.27 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 30 April 2025
+
+{product-title} release 4.17.27 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:4217[RHBA-2025:4217] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:4204[RHSA-2025:4204] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="ocp-4-17-27-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, an IPv6 configuration for {microshift-short} was created in the system at first start when an IP address was not configured. This was caused by an erroneous retrieval of the default node IP address because of the order in which the interfaces were listed. Consequentially, the misconfiguration resulted in the {microshift-short} service being unreachable. With this release, the correct node IP address is retrieved first. (link:https://issues.redhat.com/browse/OCPBUGS-52861[OCPBUGS-52861])

--- a/modules/microshift-4-17-3-dp.adoc
+++ b/modules/microshift-4-17-3-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-3-dp_{context}"]
+= RHBA-2024:8436 - {microshift-short} 4.17.3 bug fix and enhancement update advisory
+
+[role="_abstract"]
+Issued: 29 October 2024
+
+{product-title} release 4.17.3 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:8436[RHBA-2024:8436] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:8434[RHSA-2024:8434] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-35-dp.adoc
+++ b/modules/microshift-4-17-35-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-35-dp_{context}"]
+= RHBA-2025:10331 - {microshift-short} 4.17.35 security advisory
+
+[role="_abstract"]
+Issued: 9 July 2025
+
+{product-title} release 4.17.35 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:10331[RHBA-2025:10331] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:10294[RHSA-2025:10294] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-37-dp.adoc
+++ b/modules/microshift-4-17-37-dp.adoc
@@ -1,0 +1,20 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-37-dp_{context}"]
+= RHBA-2025:12508 - {microshift-short} 4.17.37 bug fix and enhancement update
+
+[role="_abstract"]
+Issued: 7 Aug 2025
+
+{product-title} release 4.17.37 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:12508[RHBA-2025:12508] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:12437[RHSA-2025:12437] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-17-37-bug-fixes_{context}"]
+== Bug fix
+
+* Before this update, {microshift-short} 4.17 used OpenVSwitch (OVS) 3.4. With this release, {microshift-short} now uses OVS 3.5, keeping OVS synchronized with OVN-Kubernetes. (link:https://issues.redhat.com/browse/OCPBUGS-58384[OCPBUGS-58384])

--- a/modules/microshift-4-17-4-dp.adoc
+++ b/modules/microshift-4-17-4-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-4-dp_{context}"]
+= RHBA-2024:8983 - {microshift-short} 4.17.4 bug fix and enhancement update advisory
+
+[role="_abstract"]
+Issued: 13 November 2024
+
+{product-title} release 4.17.4 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:8983[RHBA-2024:8983] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:8981[RHSA-2024:8981] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-5-dp.adoc
+++ b/modules/microshift-4-17-5-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-5-dp_{context}"]
+= RHBA-2024:9612 - {microshift-short} 4.17.5 bug fix and enhancement update advisory
+
+[role="_abstract"]
+Issued: 19 November 2024
+
+{product-title} release 4.17.5 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:9612[RHBA-2024:9612] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:9610[RHSA-2024:9610] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-6-dp.adoc
+++ b/modules/microshift-4-17-6-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-6-dp_{context}"]
+= RHBA-2024:10139 - {microshift-short} 4.17.6 bug fix and enhancement update advisory
+
+[role="_abstract"]
+Issued: 26 November 2024
+
+{product-title} release 4.17.6 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:10139[RHBA-2024:10139] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:10137[RHBA-2024:10137] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-7-dp.adoc
+++ b/modules/microshift-4-17-7-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-7-dp_{context}"]
+= RHSA-2024:10520 - {microshift-short} 4.17.7 security and bug fix update advisory
+
+[role="_abstract"]
+Issued: 3 December 2024
+
+{product-title} release 4.17.7 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHSA-2024:10520[RHSA-2024:10520] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:10518[RHSA-2024:10518] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-8-dp.adoc
+++ b/modules/microshift-4-17-8-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-8-dp_{context}"]
+= RHBA-2024:10820 - {microshift-short} 4.17.8 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 11 December 2024
+
+{product-title} release 4.17.8 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:10820[RHBA-2024:10820] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2024:10818[RHSA-2024:10818] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-9-dp.adoc
+++ b/modules/microshift-4-17-9-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-9-dp_{context}"]
+= RHBA-2024:11012 - {microshift-short} 4.17.9 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 19 December 2024
+
+{product-title} release 4.17.9 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHBA-2024:11012[RHBA-2024:11012] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2024:11010[RHBA-2024:11010] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-17-about-this-release.adoc
+++ b/modules/microshift-4-17-about-this-release.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-17-about-this-release_{context}"]
+= About this release
+
+[role="_abstract"]
+{microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
+
+Version 4.17 of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+
+You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
+
+{microshift-short} {product-version} is supported on {op-system-base-full} 9.4.
+
+For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
+
+Updating two minor versions in a single step is not supported in 4.17. Updates for both single-version minor releases and patch releases are supported.

--- a/modules/microshift-4-17-asynchronous-errata-updates.adoc
+++ b/modules/microshift-4-17-asynchronous-errata-updates.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-17-asynchronous-errata-updates_{context}"]
+= Asynchronous errata updates
+
+[role="_abstract"]
+Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
+
+Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
+
+[NOTE]
+====
+Red Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
+====
+
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.

--- a/modules/microshift-4-17-doc-enhancements.adoc
+++ b/modules/microshift-4-17-doc-enhancements.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-17-doc-enhancements_{context}"]
+= Documentation enhancements
+
+[role="_abstract"]
+You can also benefit by using the following documentation enhancements.
+
+[id="microshift-4-17-data-cleanup_{context}"]
+== Data cleanup now documented
+
+With this release, the `microshift-cleanup-data` script is documented. See xref:../microshift_troubleshooting/microshift-cleanup-data.adoc#microshift-cleanup-data[Data cleanup] for more information.
+
+[id="microshift-4-17-install-topics-reorg_{context}"]
+== Installation topics are reorganized
+
+With this release, system requirements, installation types, and information about installing add-ons are reorganized into discrete topics so that they are easier to use.

--- a/modules/microshift-4-17-new-features-and-enhancements.adoc
+++ b/modules/microshift-4-17-new-features-and-enhancements.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-17-new-features-and-enhancements_{context}"]
+= New features and enhancements
+
+[role="_abstract"]
+This release adds improvements related to the following components and concepts.
+
+[id="microshift-4-17-rhel_{context}"]
+== {op-system-base-full}
+
+* {microshift-short} {product-version} runs on {op-system-base-full} 9.4.
+
+[id="microshift-4-17-IPv6_{context}"]
+== IPv6 single and dual-stack IPv6 networking now available
+
+With this release, you can run {microshift-short} and your workloads with either IPv6 only or IPv4 and IPv6 dual-stack networking protocols. Ingress and egress traffic can be on either IPv4 or IPv6 traffic, mixed or parallel. See xref:../microshift_configuring/microshift-nw-ipv6-config.adoc#microshift-nw-ipv6-config[Configuring IPv6 networking].
+
+[id="microshift-4-17-LVMS-resource-footprint-reduction_{context}"]
+== Resource footprint reduction for LVM storage driver now available
+
+With this release, the resource footprint of the LVM storage driver is significantly reduced, particularly in terms of memory consumption.
+
+[id="microshift-4-17-LVMS-volume-snapshot-deployment-optional_{context}"]
+== Disabling and uninstalling LVM Storage CSI provider and CSI snapshot deployments now available
+
+With this release, {microshift-short} can now be configured to disable and uninstall the container storage interface (CSI) provider or the CSI snapshot capabilities which can reduce the use of runtime resources such as RAM, CPU, and storage. See xref:../microshift_storage/microshift-storage-plugin-overview.adoc#microshift-disabling-uninstalling-lvms-csi-snapshot_microshift-storage-plugin-overview[Disabling and uninstalling LVMS CSI provider and CSI snapshot deployments].
+
+[id="microshift-4-17-low-latency_{context}"]
+==  Low-latency performance for applications now available
+
+You can now run a {microshift-short} node with low-latency response rates. Using a low-latency {microshift-short} configuration with operating system tuning results in reduced application response times and can include deterministic performance. Using workload partitioning is also recommended. See xref:../microshift_configuring/microshift_low_latency/microshift-low-latency.adoc#microshift-low-latency[Configuring low latency] for more information.
+
+[id="microshift-4-17-workload-partitioning_{context}"]
+== Support for workload partitioning
+
+With this release, workload partitioning is supported in {microshift-short}. See xref:../microshift_configuring/microshift_low_latency/microshift-workload-partitioning.adoc#microshift-workload-partitioning[Workload partitioning] for more information.

--- a/modules/microshift-4-17-tech-preview.adoc
+++ b/modules/microshift-4-17-tech-preview.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-17-tech-preview_{context}"]
+= Technology Preview feature
+
+[role="_abstract"]
+One feature in this release is currently in Technology Preview. This experimental feature is not intended for production use. Note the following scope of support on the Red{nbsp}Hat Customer Portal for this feature:
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+[id="microshift-4-17-rhel-image-mode_{context}"]
+== {op-system-base-full} image mode Technology Preview feature
+
+* You can now install {microshift-short} using a `bootc` container image. Image mode for {op-system-base} is a Technology Preview deployment method that uses a container-native approach to build, deploy and manage the operating system as a bootc container image.
+
+See xref:../microshift_install_bootc/microshift-install-rhel-image-mode.adoc#microshift-install-rhel-image-mode[Using image mode for RHEL with {microshift-short}] for more information.


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-16617](https://issues.redhat.com/browse/OSDOCS-16617)

Link to docs preview:
https://101478--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html

QE review:
N/A, migration work only

Additional info:
This PR modularizes the release notes for DITA compatibility. It does not update content.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
