### PR TITLE
OSDOCS-16617-416: modularizes 4.16 relnotes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-16-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-16-release-notes.adoc
@@ -6,445 +6,79 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 {product-title} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate a single-node in low-resource edge environments.
 
-{microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
+include::modules/microshift-4-16-about-this-release.adoc[leveloffset=+1]
 
-[id="microshift-4-16-about-this-release_{context}"]
-== About this release
-Version 4.16 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+include::modules/microshift-4-16-new-features-and-enhancements.adoc[leveloffset=+1]
 
-You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
+include::modules/microshift-4-16-doc-enhancements.adoc[leveloffset=+1]
 
-{microshift-short} {product-version} is supported on {op-system-base-full} or {op-system-ostree-first} 9.4.
+include::modules/microshift-4-16-known-issues.adoc[leveloffset=+1]
 
-For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].
+include::modules/microshift-4-16-asynchronous-errata-updates.adoc[leveloffset=+1]
 
-[id="microshift-4-16-new-features-and-enhancements_{context}"]
-== New features and enhancements
+include::modules/microshift-4-16-0-dp.adoc[leveloffset=+2]
 
-This release adds improvements related to the following components and concepts.
+include::modules/microshift-4-16-1-dp.adoc[leveloffset=+2]
 
-//L3 major categories with features in each as L4s
-[id="microshift-4-16-rhel_{context}"]
-=== {op-system-base-full}
-* {microshift-short} {product-version} runs on {op-system-base-full} 9.4.
+include::modules/microshift-4-16-2-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-updating_{context}"]
-=== Updating
-Updating two minor versions in a single step is now supported. Updates for both single-version minor releases and patch releases are still supported.
+include::modules/microshift-4-16-3-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-updates-supported_{context}"]
-==== Update two minor versions in a single step
-See the following list for details:
+include::modules/microshift-4-16-4-dp.adoc[leveloffset=+2]
 
-* You can update from one long-life-cycle version of {microshift-short} directly to another, without applying the intermediate version. For example, you can update directly to 4.16 from 4.14. Updating 4.14 to 4.15 before updating to 4.16 is no longer required.
-* Now, you can focus on developing applications for your devices in remote locations and with limited bandwidth, rather than planning for updates.
-* {microshift-short} offers in-place updates on {op-system-ostree} systems with automatic system rollback capabilities and automatic back up and restore functions.
-* Updates of the RPMs on a non-OSTree system such as {op-system} are also supported.
-* See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
+include::modules/microshift-4-16-5-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-configuring_{context}"]
-=== Configuring
+include::modules/microshift-4-16-6-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-custom-cert-auths_{context}"]
-==== Customizable certificate authorities for the API server are supported
-With this release, you can configure a custom server certificate that has been issued by an external certificate authority (CA). The default API server certificate is issued by an internal {microshift-short} node CA. You can now replace this certificate with one that is issued by a CA that clients trust. See xref:../microshift_configuring/microshift_auth_security/microshift-custom-ca.adoc#microshift-custom-ca[Configuring custom certificate authorities].
+include::modules/microshift-4-16-7-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-audit-logging-config_{context}"]
-==== Configurable policies for log file rotation and retention
-You can now configure audit logging policies to manage the retention policies for log files, ensuring that edge devices with limited storage capacities are not hampered by accumulated logging data. To configure audit log policies, use settings such as a maximum file size limit and maximum retained files to set a limit on log storage size. You can also choose an audit policy profile to specify the data collected. See xref:../microshift_configuring/microshift_auth_security/microshift-audit-logs-config.adoc#microshift-audit-logs-config[Configuring audit logs].
+include::modules/microshift-4-16-8-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-certificates-cleaning_{context}"]
-==== Support for cleaning up certificates
-With this release, you can clean up custom certificates. For more information, see xref:../microshift_configuring/microshift_auth_security/microshift-custom-ca.adoc#microshift-custom-ca-certificates-cleaning_microshift-custom-ca[Cleaning up and recreating the custom certificates].
+include::modules/microshift-4-16-9-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-networking_{context}"]
-=== Networking
+include::modules/microshift-4-16-11-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-multus_{context}"]
-==== Multiple networks capability now available
-With this release, using multiple networks is supported with the {microshift-short} Multus plugin. If you have advanced networking requirements, you can attach additional networks to a pod for high-performance network configurations. After installing the {microshift-short} Multus RPM package, you can use the Bridge, MACVLAN, or IPVLAN plugins to create additional networks. See xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-multus-intro_microshift-cni-multus[Additional networks in {microshift-short}].
+include::modules/microshift-4-16-12-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-configure-ingress-router_{context}"]
-==== Custom configurations for the ingress router are supported
-You can now configure ingress routes to create access to multiple services inside your {microshift-short} node. You can use a variety of combinations to customize the endpoint configuration for your use case. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-nw-router-con_microshift-nw-router[About configuring the router].
+include::modules/microshift-4-16-13-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-configure-route-admission-policy_{context}"]
-==== Configuring the route admission policy now available
-You can now configure the route admission policy to allow routes to claim different paths of the same hostname across namespaces. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-configuring-route-admission_microshift-nw-router[Configuring the route admission policy].
+include::modules/microshift-4-16-14-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-running-apps_{context}"]
-=== Running applications
+include::modules/microshift-4-16-15-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-gitops_{context}"]
-==== GitOps with Argo CD now available
-With this release, you can use the GitOps with Argo CD agent derived from GitOps 1.12 with {microshift-short}. Using GitOps means you can update a single Git repository and automate the deployment of new applications or updates to existing ones. You can also use your Git repository as an audit trail of changes so that you can create processes such as review and approval for merging pull requests that implement configuration changes.
-See xref:../microshift_running_apps/microshift-gitops.adoc#microshift-gitops[Automating application management with the GitOps controller].
+include::modules/microshift-4-16-16-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-support_{context}"]
-=== Support
+include::modules/microshift-4-16-17-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-support-updates_{context}"]
-==== Getting a node ID
-With this release, you can get the ID of a {microshift-short} node. When opening a support case, you can provide the node ID to Red{nbsp}Hat Support to help in identifying issues with your node. See xref:../microshift_support/microshift-getting-node-id.adoc#microshift-getting-node-id[Getting your node ID].
+include::modules/microshift-4-16-18-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-security_{context}"]
-=== Security and compliance
+include::modules/microshift-4-16-19-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-ssl-medium-cipher-suites_{context}"]
-==== SSL Medium Strength Cipher Suites now supported
-During an SSL handshake between a client and a server, the cipher to use is negotiated between them. With this release, SSL Medium Strength Cipher Suites are now supported for the kube-controller-manager daemon, kube-scheduler control-plane process, and kubelet "node agent." This enhancement to the internal communication between Kubernetes components improves control plane communications security. (link:https://issues.redhat.com/browse/OCPBUGS-29037[OCPBUGS-29037])
+include::modules/microshift-4-16-20-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-doc-enhancements_{context}"]
-=== Documentation enhancements
+include::modules/microshift-4-16-21-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-route-config_{context}"]
-==== Route configuration now documented
-With this release, specific details for creating and managing supported route configurations are documented, see xref:../microshift_networking/microshift-configuring-routes.adoc#microshift-configuring-routes[Configuring routes].
+include::modules/microshift-4-16-23-dp.adoc[leveloffset=+2]
 
-//NOTE: Do NOT repeat bug fixes already noted in previous version z-streams
-[id="microshift-4-16-bug-fixes_{context}"]
-== Bug fixes
+include::modules/microshift-4-16-24-dp.adoc[leveloffset=+2]
 
-[discrete]
-[id="microshift-4-16-networking-bug-fixes"]
-=== Networking
+include::modules/microshift-4-16-25-dp.adoc[leveloffset=+2]
 
-Previously, the {microshift-short} load balancer controller tried to update the IP addresses of every `LoadBalancer` service in the node. Some of these services, such as those with a defined `loadBalancerClass`, have their own update procedures for external IPs. This conflicted with the {microshift-short} controller. Now, services that have a `loadBalancerClass` are filtered and IP addresses owned by other load balancer services are ignored by {microshift-short}. (link:https://issues.redhat.com/browse/OCPBUGS-30833[OCPBUGS-30833])
+include::modules/microshift-4-16-26-dp.adoc[leveloffset=+2]
 
-[discrete]
-[id="microshift-4-16-support-bug-fixes"]
-=== Support
+include::modules/microshift-4-16-27-dp.adoc[leveloffset=+2]
 
-Previously, when `microshift-etcd` unexpectedly exited, {microshift-short} tried to restart so that `microshift-etcd` could restart, but there was a lingering unit fragment. Every attempt to restart `microshift-etcd` failed, making the system unusable. The `--collect` flag was added to the `systemd-run` invocation used to start `microshift-etcd`. The additional flag results in systemd cleaning up the unit fragment even if the unit failed. The system now recovers and restarts. (link:https://issues.redhat.com/browse/OCPBUGS-33588[OCPBUGS-33588])
+include::modules/microshift-4-16-28-dp.adoc[leveloffset=+2]
 
-//check status for next release+
-[id="microshift-4-16-known-issues_{context}"]
-== Known issues
+include::modules/microshift-4-16-29-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-pods-writing-files-excess-memory-limits-crash_{context}"]
-=== Pods crash when writing files that exceed memory limits
-Because of an issue with {op-system-base}, when a pod tries to write files that are larger than configured memory limits to a persistent volume claim, the pod might crash with an out-of-memory error. The pod status shows `OOMKilled` when this occurs. Use the following workarounds to avoid this issue: link:https://access.redhat.com/solutions/7076169[Pods writing files larger than memory limit to PVCs tend to OOM frequently running on MicroShift](Red Hat Knowledgebase).
+include::modules/microshift-4-16-30-dp.adoc[leveloffset=+2]
 
-[id="microshift-4-16-asynchronous-errata-updates_{context}"]
-== Asynchronous errata updates
+include::modules/microshift-4-16-32-dp.adoc[leveloffset=+2]
 
-Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red Hat Network. All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
+include::modules/microshift-4-16-40-dp.adoc[leveloffset=+2]
 
-Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
-
-[NOTE]
-====
-Red Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
-====
-
-This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.
-
-[id="microshift-4-16-0-dp_{context}"]
-=== RHEA-2024:0043 - {microshift-short} 4.16.0 bug fix and security update advisory
-
-Issued: 27 June 2024
-
-{product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0043[RHSA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-1-dp_{context}"]
-=== RHBA-2024:4158 - {microshift-short} 4.16.1 bug fix and enhancement advisory
-
-Issued: 3 July 2024
-
-{product-title} release 4.16.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4158[RHBA-2024:4158] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4156[RHSA-2024:4156] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-2-dp_{context}"]
-=== RHBA-2024:4318 - {microshift-short} 4.16.2 bug fix and enhancement advisory
-
-Issued: 9 July 2024
-
-{product-title} release 4.16.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4318[RHBA-2024:4318] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4316[RHSA-2024:4316] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-3-dp_{context}"]
-=== RHBA-2024:4318 - {microshift-short} 4.16.3 bug fix and enhancement advisory
-
-Issued: 16 July 2024
-
-{product-title} release 4.16.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4471[RHBA-2024:4471] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4469[RHSA-2024:4469] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-3-bug-fixes_{context}"]
-==== Bug fixes
-
-* An error in validation allowed empty entries in the `listenAddress` configuration parameter. The empty entries prevented {microshift-short} from starting and rendered a difficult-to-understand error message. Empty entries in the list are now filtered.
-
-[id="microshift-4-16-4-dp_{context}"]
-=== RHBA-2024:4615 - {microshift-short} 4.16.4 bug fix and enhancement advisory
-
-Issued: 24 July 2024
-
-{product-title} release 4.16.4 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4615[RHBA-2024:4615] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4613[RHSA-2024:4613] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-5-dp_{context}"]
-=== RHBA-2024:4857 - {microshift-short} 4.16.5 bug fix and enhancement advisory
-
-Issued: 31 July 2024
-
-{product-title} release 4.16.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4857[RHBA-2024:4857] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4855[RHBA-2024:4855] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-6-dp_{context}"]
-=== RHBA-2024:4967 - {microshift-short} 4.16.6 bug fix and enhancement advisory
-
-Issued: 6 August 2024
-
-{product-title} release 4.16.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4967[RHBA-2024:4967] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4965[RHSA-2024:4965] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-7-dp_{context}"]
-=== RHBA-2024:5109 - {microshift-short} 4.16.7 bug fix and enhancement advisory
-
-Issued: 13 August 2024
-
-{product-title} release 4.16.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:5109[RHBA-2024:5109] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5107[RHSA-2024:5107] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-8-dp_{context}"]
-=== RHBA-2024:5424 - {microshift-short} 4.16.8 bug fix and enhancement advisory
-Issued: 20 August 2024
-
-{product-title} release 4.16.8 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5424[RHBA-2024:5424] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5422[RHSA-2024:5422] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-9-dp_{context}"]
-=== RHBA-2024:5759 - {microshift-short} 4.16.9 bug fix and enhancement advisory
-
-Issued: 29 August 2024
-
-{product-title} release 4.16.9 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5759[RHBA-2024:5759] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:5757[RHBA-2024:5757] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-10-dp_{context}"]
-=== RHBA-2024:6006 - {microshift-short} 4.16.10 bug fix and enhancement advisory
-
-Issued: 3 September 2024
-
-{product-title} release 4.16.10 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6006[RHBA-2024:6006] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6004[RHSA-2024:6004] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-11-dp_{context}"]
-=== RHBA-2024:6403 - {microshift-short} 4.16.11 bug fix and enhancement advisory
-
-Issued: 11 September 2024
-
-{product-title} release 4.16.11 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6403[RHBA-2024:6403] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:6401[RHBA-2024:6401] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-12-dp_{context}"]
-=== RHBA-2024:6634 - {microshift-short} 4.16.12 bug fix and enhancement advisory
-
-Issued: 17 September 2024
-
-{product-title} release 4.16.12 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6634[RHBA-2024:6634] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6632[RHSA-2024:6632] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-13-dp_{context}"]
-=== RHBA-2024:6688 - {microshift-short} 4.16.13 bug fix and enhancement advisory
-
-Issued: 19 September 2024
-
-{product-title} release 4.16.13 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6688[RHBA-2024:6688] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6687[RHSA-2024:6687] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-14-dp_{context}"]
-=== RHBA-2024:6826 - {microshift-short} 4.16.14 bug fix and enhancement advisory
-
-Issued: 24 September 2024
-
-{product-title} release 4.16.14 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6826[RHBA-2024:6826] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6824[RHSA-2024:6824] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-15-dp_{context}"]
-=== RHBA-2024:7176 - {microshift-short} 4.16.15 bug fix and enhancement advisory
-
-Issued: 2 October 2024
-
-{product-title} release 4.16.15 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7176[RHBA-2024:7176] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7174[RHSA-2024:7174] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-16-dp_{context}"]
-=== RHBA-2024:7601 - {microshift-short} 4.16.16 bug fix and enhancement advisory
-
-Issued: 8 October 2024
-
-{product-title} release 4.16.16 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7601[RHBA-2024:7601] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7599[RHSA-2024:7599] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-17-dp_{context}"]
-=== RHBA-2024:7946 - {microshift-short} 4.16.17 bug fix and enhancement advisory
-
-Issued: 16 October 2024
-
-{product-title} release 4.16.17 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7946[RHBA-2024:7946] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7944[RHSA-2024:7944] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-18-dp_{context}"]
-=== RHBA-2024:8262 - {microshift-short} 4.16.18 bug fix and enhancement advisory
-
-Issued: 24 October 2024
-
-{product-title} release 4.16.18 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8262[RHBA-2024:8262] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8260[RHSA-2024:8260] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-19-dp_{context}"]
-=== RHBA-2024:8417 - {microshift-short} 4.16.19 bug fix and enhancement advisory
-
-Issued: 30 October 2024
-
-{product-title} release 4.16.19 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8417[RHBA-2024:8417] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8415[RHSA-2024:8415] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-20-dp_{context}"]
-=== RHBA-2024:8685 - {microshift-short} 4.16.20 bug fix and enhancement advisory
-
-Issued: 6 November 2024
-
-{product-title} release 4.16.20 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8685[RHBA-2024:8685] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8683[RHSA-2024:8683] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-21-dp_{context}"]
-=== RHBA-2024:8988 - {microshift-short} 4.16.21 bug fix and enhancement advisory
-
-Issued: 13 November 2024
-
-{product-title} release 4.16.21 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8988[RHBA-2024:8988] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:8986[RHBA-2024:8986] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-23-dp_{context}"]
-=== RHBA-2024:9617 - {microshift-short} 4.16.23 bug fix and enhancement advisory
-
-Issued: 20 November 2024
-
-{product-title} release 4.16.23 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:9617[RHBA-2024:9617] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:9615[RHSA-2024:9615] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-24-dp_{context}"]
-=== RHSA-2024:10149 - {microshift-short} 4.16.24 security and bug fix advisory
-
-Issued: 26 November 2024
-
-{product-title} release 4.16.24 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHSA-2024:10149[RHSA-2024:10149] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10147[RHSA-2024:10147] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-25-dp_{context}"]
-=== RHBA-2024:10530 - {microshift-short} 4.16.25 bug fix and enhancement advisory
-
-Issued: 4 December 2024
-
-{product-title} release 4.16.25 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10530[RHBA-2024:10530] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10528[RHSA-2024:10528] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-26-dp_{context}"]
-=== RHBA-2024:10825 - {microshift-short} 4.16.26 bug fix and enhancement advisory
-
-Issued: 12 December 2024
-
-{product-title} release 4.16.26 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10825[RHBA-2024:10825] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10823[RHSA-2024:10823] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-27-dp_{context}"]
-=== RHBA-2024:10975 - {microshift-short} 4.16.27 bug fix and enhancement advisory
-
-Issued: 19 December 2024
-
-{product-title} release 4.16.27 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10975[RHBA-2024:10975] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10973[RHBA-2024:10973] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-28-dp_{context}"]
-=== RHBA-2024:11504 - {microshift-short} 4.16.28 bug fix and enhancement advisory
-
-Issued: 2 January 2025
-
-{product-title} release 4.16.28 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:11504[RHBA-2024:11504] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:11502[RHBA-2024:11502] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-29-dp_{context}"]
-=== RHBA-2025:0020 - {microshift-short} 4.16.29 bug fix and enhancement advisory
-
-Issued: 9 January 2025
-
-{product-title} release 4.16.29 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0020[RHBA-2025:0020] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0018[RHBA-2025:0018] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-30-dp_{context}"]
-=== RHBA-2025:0142 - {microshift-short} 4.16.30 bug fix and enhancement advisory
-
-Issued: 15 January 2025
-
-{product-title} release 4.16.30 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0142[RHBA-2025:0142] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0140[RHSA-2025:0140] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-32-dp_{context}"]
-=== RHBA-2025:0683 - {microshift-short} 4.16.32 bug fix and enhancement advisory
-
-Issued: 29 January 2025
-
-{product-title} release 4.16.32 is now available. With this release, {microshift-short} introduces a priority-based release cadence to provide the most important updates with the least disruption.
-
-The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0683[RHBA-2025:0683] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0652[RHBA-2025:0652] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-40-dp_{context}"]
-=== RHBA-2025:8127 - {microshift-short} 4.16.41 bug fix and enhancement advisory
-
-Issued: 28 May 2025
-
-{product-title} release 4.16.41 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:8127[RHBA-2025:8127] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:8116[RHBA-2025:8116] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
-
-[id="microshift-4-16-41-bug-fixes_{context}"]
-==== Bug fixes
-
-* Previously, the greenboot health check was marking a {op-system-ostree} healthy system as unhealthy due to a relatively low 300-second timeout. This timeout was not enough on systems with a slow network. With this release, the default greenboot wait timeout is now 600 seconds, meaning there is more time to download images. This results in an accurate system check.
-
-[id="microshift-4-16-47-dp_{context}"]
-=== RHBA-2025:14926 - {microshift-short} 4.16.47 bug fix advisory
-
-Issued: 3 September 2025
-
-{product-title} release 4.16.47 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:14926[RHBA-2025:14926] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:14859[RHSA-2025:14859] advisory.
-
-See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+include::modules/microshift-4-16-47-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-16-0-dp.adoc
+++ b/modules/microshift-4-16-0-dp.adoc
@@ -1,0 +1,22 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-0-dp_{context}"]
+= RHEA-2024:0043 - {microshift-short} 4.16.0 bug fix and security update advisory
+
+[role="_abstract"]
+Issued: 27 June 2024
+
+{product-title} release 4.16.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2024:0043[RHSA-2024:0043] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:0041[RHSA-2024:0041] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, the {microshift-short} load balancer controller tried to update the IP addresses of every `LoadBalancer` service in the node. Some of these services, such as those with a defined `loadBalancerClass`, have their own update procedures for external IPs. This conflicted with the {microshift-short} controller. Now, services that have a `loadBalancerClass` are filtered and IP addresses owned by other load balancer services are ignored by {microshift-short}. (link:https://issues.redhat.com/browse/OCPBUGS-30833[OCPBUGS-30833])
+
+* Previously, when `microshift-etcd` unexpectedly exited, {microshift-short} tried to restart so that `microshift-etcd` could restart, but there was a lingering unit fragment. Every attempt to restart `microshift-etcd` failed, making the system unusable. The `--collect` flag was added to the `systemd-run` invocation used to start `microshift-etcd`. The additional flag results in systemd cleaning up the unit fragment even if the unit failed. The system now recovers and restarts. (link:https://issues.redhat.com/browse/OCPBUGS-33588[OCPBUGS-33588])

--- a/modules/microshift-4-16-1-dp.adoc
+++ b/modules/microshift-4-16-1-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-1-dp_{context}"]
+= RHBA-2024:4158 - {microshift-short} 4.16.1 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 3 July 2024
+
+{product-title} release 4.16.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4158[RHBA-2024:4158] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4156[RHSA-2024:4156] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-10-dp.adoc
+++ b/modules/microshift-4-16-10-dp.adoc
@@ -1,0 +1,16 @@
+
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-10-dp_{context}"]
+= RHBA-2024:6006 - {microshift-short} 4.16.10 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 3 September 2024
+
+{product-title} release 4.16.10 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6006[RHBA-2024:6006] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6004[RHSA-2024:6004] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-11-dp.adoc
+++ b/modules/microshift-4-16-11-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-11-dp_{context}"]
+= RHBA-2024:6403 - {microshift-short} 4.16.11 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 11 September 2024
+
+{product-title} release 4.16.11 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6403[RHBA-2024:6403] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:6401[RHBA-2024:6401] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-12-dp.adoc
+++ b/modules/microshift-4-16-12-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-12-dp_{context}"]
+= RHBA-2024:6634 - {microshift-short} 4.16.12 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 17 September 2024
+
+{product-title} release 4.16.12 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6634[RHBA-2024:6634] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6632[RHSA-2024:6632] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-13-dp.adoc
+++ b/modules/microshift-4-16-13-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-13-dp_{context}"]
+= RHBA-2024:6688 - {microshift-short} 4.16.13 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 19 September 2024
+
+{product-title} release 4.16.13 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6688[RHBA-2024:6688] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6687[RHSA-2024:6687] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-14-dp.adoc
+++ b/modules/microshift-4-16-14-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-14-dp_{context}"]
+= RHBA-2024:6826 - {microshift-short} 4.16.14 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 24 September 2024
+
+{product-title} release 4.16.14 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:6826[RHBA-2024:6826] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:6824[RHSA-2024:6824] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-15-dp.adoc
+++ b/modules/microshift-4-16-15-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-15-dp_{context}"]
+= RHBA-2024:7176 - {microshift-short} 4.16.15 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 2 October 2024
+
+{product-title} release 4.16.15 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7176[RHBA-2024:7176] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7174[RHSA-2024:7174] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-16-dp.adoc
+++ b/modules/microshift-4-16-16-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-16-dp_{context}"]
+= RHBA-2024:7601 - {microshift-short} 4.16.16 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 8 October 2024
+
+{product-title} release 4.16.16 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7601[RHBA-2024:7601] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7599[RHSA-2024:7599] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-17-dp.adoc
+++ b/modules/microshift-4-16-17-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-17-dp_{context}"]
+= RHBA-2024:7946 - {microshift-short} 4.16.17 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 16 October 2024
+
+{product-title} release 4.16.17 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:7946[RHBA-2024:7946] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:7944[RHSA-2024:7944] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-18-dp.adoc
+++ b/modules/microshift-4-16-18-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-18-dp_{context}"]
+= RHBA-2024:8262 - {microshift-short} 4.16.18 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 24 October 2024
+
+{product-title} release 4.16.18 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8262[RHBA-2024:8262] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8260[RHSA-2024:8260] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-19-dp.adoc
+++ b/modules/microshift-4-16-19-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-19-dp_{context}"]
+= RHBA-2024:8417 - {microshift-short} 4.16.19 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 30 October 2024
+
+{product-title} release 4.16.19 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8417[RHBA-2024:8417] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8415[RHSA-2024:8415] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-2-dp.adoc
+++ b/modules/microshift-4-16-2-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-2-dp_{context}"]
+= RHBA-2024:4318 - {microshift-short} 4.16.2 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 9 July 2024
+
+{product-title} release 4.16.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4318[RHBA-2024:4318] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4316[RHSA-2024:4316] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-20-dp.adoc
+++ b/modules/microshift-4-16-20-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-20-dp_{context}"]
+= RHBA-2024:8685 - {microshift-short} 4.16.20 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 6 November 2024
+
+{product-title} release 4.16.20 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8685[RHBA-2024:8685] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:8683[RHSA-2024:8683] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-21-dp.adoc
+++ b/modules/microshift-4-16-21-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-21-dp_{context}"]
+= RHBA-2024:8988 - {microshift-short} 4.16.21 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 13 November 2024
+
+{product-title} release 4.16.21 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:8988[RHBA-2024:8988] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:8986[RHBA-2024:8986] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-23-dp.adoc
+++ b/modules/microshift-4-16-23-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-23-dp_{context}"]
+= RHBA-2024:9617 - {microshift-short} 4.16.23 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 20 November 2024
+
+{product-title} release 4.16.23 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:9617[RHBA-2024:9617] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:9615[RHSA-2024:9615] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-24-dp.adoc
+++ b/modules/microshift-4-16-24-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-24-dp_{context}"]
+= RHSA-2024:10149 - {microshift-short} 4.16.24 security and bug fix advisory
+
+[role="_abstract"]
+Issued: 26 November 2024
+
+{product-title} release 4.16.24 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHSA-2024:10149[RHSA-2024:10149] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10147[RHSA-2024:10147] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-25-dp.adoc
+++ b/modules/microshift-4-16-25-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-25-dp_{context}"]
+= RHBA-2024:10530 - {microshift-short} 4.16.25 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 4 December 2024
+
+{product-title} release 4.16.25 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10530[RHBA-2024:10530] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10528[RHSA-2024:10528] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-26-dp.adoc
+++ b/modules/microshift-4-16-26-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-26-dp_{context}"]
+= RHBA-2024:10825 - {microshift-short} 4.16.26 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 12 December 2024
+
+{product-title} release 4.16.26 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10825[RHBA-2024:10825] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:10823[RHSA-2024:10823] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-27-dp.adoc
+++ b/modules/microshift-4-16-27-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-27-dp_{context}"]
+= RHBA-2024:10975 - {microshift-short} 4.16.27 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 19 December 2024
+
+{product-title} release 4.16.27 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:10975[RHBA-2024:10975] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:10973[RHBA-2024:10973] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-28-dp.adoc
+++ b/modules/microshift-4-16-28-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-28-dp_{context}"]
+= RHBA-2024:11504 - {microshift-short} 4.16.28 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 2 January 2025
+
+{product-title} release 4.16.28 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:11504[RHBA-2024:11504] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:11502[RHBA-2024:11502] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-29-dp.adoc
+++ b/modules/microshift-4-16-29-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-29-dp_{context}"]
+= RHBA-2025:0020 - {microshift-short} 4.16.29 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 9 January 2025
+
+{product-title} release 4.16.29 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0020[RHBA-2025:0020] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0018[RHBA-2025:0018] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-3-dp.adoc
+++ b/modules/microshift-4-16-3-dp.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-3-dp_{context}"]
+= RHBA-2024:4318 - {microshift-short} 4.16.3 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 16 July 2024
+
+{product-title} release 4.16.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4471[RHBA-2024:4471] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4469[RHSA-2024:4469] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-3-bug-fixes_{context}"]
+== Bug fixes
+
+* An error in validation allowed empty entries in the `listenAddress` configuration parameter. The empty entries prevented {microshift-short} from starting and rendered a difficult-to-understand error message. Empty entries in the list are now filtered.

--- a/modules/microshift-4-16-30-dp.adoc
+++ b/modules/microshift-4-16-30-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-30-dp_{context}"]
+= RHBA-2025:0142 - {microshift-short} 4.16.30 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 15 January 2025
+
+{product-title} release 4.16.30 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0142[RHBA-2025:0142] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:0140[RHSA-2025:0140] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-32-dp.adoc
+++ b/modules/microshift-4-16-32-dp.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-32-dp_{context}"]
+= RHBA-2025:0683 - {microshift-short} 4.16.32 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 29 January 2025
+
+{product-title} release 4.16.32 is now available. With this release, {microshift-short} introduces a priority-based release cadence to provide the most important updates with the least disruption.
+
+The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:0683[RHBA-2025:0683] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0652[RHBA-2025:0652] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-4-dp.adoc
+++ b/modules/microshift-4-16-4-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-4-dp_{context}"]
+= RHBA-2024:4615 - {microshift-short} 4.16.4 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 24 July 2024
+
+{product-title} release 4.16.4 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4615[RHBA-2024:4615] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4613[RHSA-2024:4613] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-40-dp.adoc
+++ b/modules/microshift-4-16-40-dp.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-40-dp_{context}"]
+= RHBA-2025:8127 - {microshift-short} 4.16.41 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 28 May 2025
+
+{product-title} release 4.16.41 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:8127[RHBA-2025:8127] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:8116[RHBA-2025:8116] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+
+[id="microshift-4-16-41-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, the greenboot health check was marking a {op-system-ostree} healthy system as unhealthy due to a relatively low 300-second timeout. This timeout was not enough on systems with a slow network. With this release, the default greenboot wait timeout is now 600 seconds, meaning there is more time to download images. This results in an accurate system check.

--- a/modules/microshift-4-16-47-dp.adoc
+++ b/modules/microshift-4-16-47-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-47-dp_{context}"]
+= RHBA-2025:14926 - {microshift-short} 4.16.47 bug fix advisory
+
+[role="_abstract"]
+Issued: 3 September 2025
+
+{product-title} release 4.16.47 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2025:14926[RHBA-2025:14926] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:14859[RHSA-2025:14859] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-5-dp.adoc
+++ b/modules/microshift-4-16-5-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-5-dp_{context}"]
+= RHBA-2024:4857 - {microshift-short} 4.16.5 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 31 July 2024
+
+{product-title} release 4.16.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4857[RHBA-2024:4857] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:4855[RHBA-2024:4855] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-6-dp.adoc
+++ b/modules/microshift-4-16-6-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-6-dp_{context}"]
+= RHBA-2024:4967 - {microshift-short} 4.16.6 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 6 August 2024
+
+{product-title} release 4.16.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:4967[RHBA-2024:4967] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:4965[RHSA-2024:4965] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-7-dp.adoc
+++ b/modules/microshift-4-16-7-dp.adoc
@@ -1,0 +1,15 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-7-dp_{context}"]
+= RHBA-2024:5109 - {microshift-short} 4.16.7 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 13 August 2024
+
+{product-title} release 4.16.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2024:5109[RHBA-2024:5109] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5107[RHSA-2024:5107] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-8-dp.adoc
+++ b/modules/microshift-4-16-8-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-8-dp_{context}"]
+= RHBA-2024:5424 - {microshift-short} 4.16.8 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 20 August 2024
+
+{product-title} release 4.16.8 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5424[RHBA-2024:5424] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2024:5422[RHSA-2024:5422] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-9-dp.adoc
+++ b/modules/microshift-4-16-9-dp.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-16-9-dp_{context}"]
+= RHBA-2024:5759 - {microshift-short} 4.16.9 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 29 August 2024
+
+{product-title} release 4.16.9 is now available. The list of bug fixes that are included in the update is attached to the link:https://access.redhat.com/errata/RHBA-2024:5759[RHBA-2024:5759] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2024:5757[RHBA-2024:5757] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].

--- a/modules/microshift-4-16-about-this-release.adoc
+++ b/modules/microshift-4-16-about-this-release.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-16-about-this-release_{context}"]
+= About this release
+
+[role="_abstract"]
+{microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then, without relying on a network, flipping to and from that version and restarting.
+
+Version 4.16 of {product-title} includes new features and enhancements. {microshift-short} was introduced as Generally Available with {microshift-short} 4.14. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {OCP-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.
+
+You can deploy a {microshift-short} node to on-premise, cloud, disconnected, and offline environments.
+
+{microshift-short} {product-version} is supported on {op-system-base-full} or {op-system-ostree-first} 9.4.
+
+For lifecycle information, see the link:https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{product-title} Life Cycle Policy].

--- a/modules/microshift-4-16-asynchronous-errata-updates.adoc
+++ b/modules/microshift-4-16-asynchronous-errata-updates.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-16-asynchronous-errata-updates_{context}"]
+= Asynchronous errata updates
+
+[role="_abstract"]
+Security, bug fix, and enhancement updates for {microshift-short} {product-version} are released as asynchronous errata through the Red Hat Network.
+
+All {microshift-short} {product-version} errata are https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. For more information about asynchronous errata, read the https://access.redhat.com/product-life-cycles?product=Red%20Hat%20build%20of%20Microshift,Red%20Hat%20Device%20Edge[{microshift-short} Life Cycle].
+
+Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, you are notified through email whenever new errata relevant to your registered systems are released.
+
+[NOTE]
+====
+Red Hat Customer Portal user accounts must have systems registered and consuming {microshift-short} entitlements for {microshift-short} errata notification emails to generate.
+====
+
+This section is updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {microshift-short} {product-version}. Versioned asynchronous releases, for example with the form {microshift-short} {product-version}.z, are detailed in the following subsections.

--- a/modules/microshift-4-16-doc-enhancements.adoc
+++ b/modules/microshift-4-16-doc-enhancements.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-16-doc-enhancements_{context}"]
+= Documentation enhancements
+
+[role="_abstract"]
+You can also benefit by using the following documentation enhancements.
+
+[id="microshift-4-16-route-config_{context}"]
+== Route configuration now documented
+
+With this release, specific details for creating and managing supported route configurations are documented, see xref:../microshift_networking/microshift-configuring-routes.adoc#microshift-configuring-routes[Configuring routes].

--- a/modules/microshift-4-16-known-issues.adoc
+++ b/modules/microshift-4-16-known-issues.adoc
@@ -1,0 +1,16 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-16-known-issues_{context}"]
+= Known issues
+
+[role="_abstract"]
+Understand the known issue that impacts your {microshift-short} development and deployments.
+
+[id="microshift-4-16-pods-writing-files-excess-memory-limits-crash_{context}"]
+== Pods crash when writing files that exceed memory limits
+
+Because of an issue with {op-system-base}, when a pod tries to write files that are larger than configured memory limits to a persistent volume claim, the pod might crash with an out-of-memory error. The pod status shows `OOMKilled` when this occurs. Use the following workarounds to avoid this issue: link:https://access.redhat.com/solutions/7076169[Pods writing files larger than memory limit to PVCs tend to OOM frequently running on {microshift-short}](Red Hat Knowledgebase).

--- a/modules/microshift-4-16-new-features-and-enhancements.adoc
+++ b/modules/microshift-4-16-new-features-and-enhancements.adoc
@@ -1,0 +1,76 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-16-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-16-new-features-and-enhancements_{context}"]
+= New features and enhancements
+
+[role="_abstract"]
+This release adds improvements related to the following components and concepts.
+
+//L3 major categories with features in each as L4s
+[id="microshift-4-16-rhel_{context}"]
+== {op-system-base-full}
+
+* {microshift-short} {product-version} runs on {op-system-base-full} 9.4.
+
+[id="microshift-4-16-updates-supported_{context}"]
+== Update two minor versions in a single step
+
+Updating two minor versions in a single step is now supported. Updates for both single-version minor releases and patch releases are still supported.
+
+See the following list for details:
+
+* You can update from one long-life-cycle version of {microshift-short} directly to another, without applying the intermediate version. For example, you can update directly to 4.16 from 4.14. Updating 4.14 to 4.15 before updating to 4.16 is no longer required.
+* Now, you can focus on developing applications for your devices in remote locations and with limited bandwidth, rather than planning for updates.
+* {microshift-short} offers in-place updates on {op-system-ostree} systems with automatic system rollback capabilities and automatic back up and restore functions.
+* Updates of the RPMs on a non-OSTree system such as {op-system} are also supported.
+* See xref:../microshift_updating/microshift-update-options.adoc#microshift-update-options[Update options with {product-title} and {op-system-bundle}] for details.
+
+[id="microshift-4-16-custom-cert-auths_{context}"]
+== Customizable certificate authorities for the API server are supported
+
+With this release, you can configure a custom server certificate that has been issued by an external certificate authority (CA). The default API server certificate is issued by an internal {microshift-short} node CA. You can now replace this certificate with one that is issued by a CA that clients trust. See xref:../microshift_configuring/microshift_auth_security/microshift-custom-ca.adoc#microshift-custom-ca[Configuring custom certificate authorities].
+
+[id="microshift-4-16-audit-logging-config_{context}"]
+== Configurable policies for log file rotation and retention
+
+You can now configure audit logging policies to manage the retention policies for log files, ensuring that edge devices with limited storage capacities are not hampered by accumulated logging data. To configure audit log policies, use settings such as a maximum file size limit and maximum retained files to set a limit on log storage size. You can also choose an audit policy profile to specify the data collected. See xref:../microshift_configuring/microshift_auth_security/microshift-audit-logs-config.adoc#microshift-audit-logs-config[Configuring audit logs].
+
+[id="microshift-4-16-certificates-cleaning_{context}"]
+== Support for cleaning up certificates
+
+With this release, you can clean up custom certificates. For more information, see xref:../microshift_configuring/microshift_auth_security/microshift-custom-ca.adoc#microshift-custom-ca-certificates-cleaning_microshift-custom-ca[Cleaning up and recreating the custom certificates].
+
+[id="microshift-4-16-multus_{context}"]
+== Multiple networks capability now available
+
+With this release, using multiple networks is supported with the {microshift-short} Multus plugin. If you have advanced networking requirements, you can attach additional networks to a pod for high-performance network configurations. After installing the {microshift-short} Multus RPM package, you can use the Bridge, MACVLAN, or IPVLAN plugins to create additional networks. See xref:../microshift_networking/microshift_multiple_networks/microshift-cni-multus.adoc#microshift-multus-intro_microshift-cni-multus[Additional networks in {microshift-short}].
+
+[id="microshift-4-16-configure-ingress-router_{context}"]
+== Custom configurations for the ingress router are supported
+
+You can now configure ingress routes to create access to multiple services inside your {microshift-short} node. You can use a variety of combinations to customize the endpoint configuration for your use case. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-nw-router-con_microshift-nw-router[About configuring the router].
+
+[id="microshift-4-16-configure-route-admission-policy_{context}"]
+== Configuring the route admission policy now available
+
+You can now configure the route admission policy to allow routes to claim different paths of the same hostname across namespaces. See xref:../microshift_networking/microshift-nw-router.adoc#microshift-configuring-route-admission_microshift-nw-router[Configuring the route admission policy].
+
+[id="microshift-4-16-gitops_{context}"]
+== GitOps with Argo CD now available
+
+With this release, you can use the GitOps with Argo CD agent derived from GitOps 1.12 with {microshift-short}. Using GitOps means you can update a single Git repository and automate the deployment of new applications or updates to existing ones. You can also use your Git repository as an audit trail of changes so that you can create processes such as review and approval for merging pull requests that implement configuration changes.
+See xref:../microshift_running_apps/microshift-gitops.adoc#microshift-gitops[Automating application management with the GitOps controller].
+
+[id="microshift-4-16-support-updates_{context}"]
+== Getting a node ID
+
+With this release, you can get the ID of a {microshift-short} node. When opening a support case, you can provide the node ID to Red{nbsp}Hat Support to help in identifying issues with your node. See xref:../microshift_support/microshift-getting-node-id.adoc#microshift-getting-node-id[Getting your node ID].
+
+[id="microshift-4-16-ssl-medium-cipher-suites_{context}"]
+== SSL Medium Strength Cipher Suites now supported
+
+During an SSL handshake between a client and a server, the cipher to use is negotiated between them. With this release, SSL Medium Strength Cipher Suites are now supported for the kube-controller-manager daemon, kube-scheduler control-plane process, and kubelet "node agent." This enhancement to the internal communication between Kubernetes components improves control plane communications security. (link:https://issues.redhat.com/browse/OCPBUGS-29037[OCPBUGS-29037])


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-16617](https://issues.redhat.com/browse/OSDOCS-16617)

Link to docs preview:
https://101479--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-16-release-notes.html

QE review:
N/A, migration work only

Additional info:
This PR modularizes the release notes for DITA compatibility. It does not update content.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
