### PR TITLE
OSDOCS#16699: Adding missing mod-docs-content-type for assemblies

### DIFF
--- a/backup_and_restore/application_backup_and_restore/troubleshooting/using-the-must-gather-tool.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting/using-the-must-gather-tool.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="using-the-must-gather-tool"]
 = Using the must-gather tool
 include::_attributes/common-attributes.adoc[]

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="installing-azure-stack-hub-network-customizations"]
 = Installing a cluster on Azure Stack Hub with network customizations
 include::_attributes/common-attributes.adoc[]

--- a/storage/container_storage_interface/persistent-storage-csi-alicloud-disk.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-alicloud-disk.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="persistent-storage-csi-alicloud-disk"]
 = AliCloud Disk CSI Driver Operator
 include::_attributes/common-attributes.adoc[]

--- a/storage/container_storage_interface/persistent-storage-csi-ibm-vpc-block.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ibm-vpc-block.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 include::_attributes/common-attributes.adoc[]
 [id="persistent-storage-csi-ibm-vpc-block"]
 = {ibm-title} VPC Block CSI Driver Operator

--- a/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ASSEMBLY
+
 [id="persistent-storage-csi-secrets-store"]
 = {secrets-store-driver}
 include::_attributes/common-attributes.adoc[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14-4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-16699

Link to docs preview:
None - metadata change only

QE review:
N/A
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
