### PR TITLE
WMCO Clarifying the infrastructure install prereqs to clarify platform:none is UPI only

### DIFF
--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -20,7 +20,10 @@ Dual NIC is not supported on WMCO-managed Windows instances.
 
 * You have installed the OpenShift CLI (`oc`).
 
-* You have installed your cluster using installer-provisioned infrastructure, or using user-provisioned infrastructure with the `platform: none` field set in your `install-config.yaml` file.
+* You have installed your cluster using one of the following infrastructures: 
+
+** Any installer-provisioned infrastructure 
+** A user-provisioned infrastructure with the `platform: none` field set in your `install-config.yaml` file
 
 * You have configured hybrid networking with OVN-Kubernetes for your cluster. For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-ovnkubernetes[Configuring hybrid networking].
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17091

Per a [conversation in Slack](https://redhat-internal.slack.com/archives/CM4ERHBJS/p1761850056660769), the [following bullet in the WMCO docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/windows_container_support_for_openshift/enabling-windows-container-workloads) is not clear:

> You have installed your cluster using installer-provisioned infrastructure, or using user-provisioned infrastructure with the platform: none field set in your install-config.yaml file.

This PR aims to clarify. 