### PR TITLE
ROX-13701: Add roxctl image check info

### DIFF
--- a/integration/integrate-with-ci-systems.adoc
+++ b/integration/integrate-with-ci-systems.adoc
@@ -32,8 +32,10 @@ You can check {product-title-short} policies during builds.
 
 .Procedure
 
-. Configure policies that apply to the build stage of the container lifecycle.
-. Integrate with the registry that images are pushed to during the build.
+. Configure policies in {product-title-short} that apply to the build stage of the container lifecycle.
+. Integrate {product-title-short} with the registry that images are pushed to during the build.
+.. In your CI system, configure {product-title-short} to check your builds against policies by using an {product-title-short} token to connect to {product-title-short} and run the `roxctl image check` command. This command queries Central and Scanner to check the input image against a set of policies. If the image violates any build-time policy of the requested policy set, which is by default all policies, then the FAIL_BUILD_ENFORCEMENT flag is set. The check result is an error with the return code of 1.
+.. Configure your CI system to fail the build if the `roxctl image check` command returns an error code of `1`.
 
 [role="_additional-resources"]
 .Additional resources
@@ -43,7 +45,9 @@ You can check {product-title-short} policies during builds.
 
 include::modules/integrate-ci-check-existing-build-phase-policies.adoc[leveloffset=+2]
 
-include::modules/policy-enforcement-deploy.adoc[leveloffset=+3]
+include::modules/
+
+include::modules/policy-enforcement-deploy.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/checking-images-against-build-policies.adoc
+++ b/modules/checking-images-against-build-policies.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * integration/integrate-with-ci-systems.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="checking-images-against-build-policies_{context}"]
+= Checking images against build-time policies
+
+[role="_abstract"]
+In your CI system, configure {product-title-short} to check your builds to make sure images do not violate policies that you have configured by using the `roxctl image check` command. 
+
+This command queries Central and Scanner to check the input image against a set of policies. If the image violates any build-time policy of the requested policy set, which is by default all policies, then the FAIL_BUILD_ENFORCEMENT flag is set. The check result is an error with the return code of 1.
+
+.Prerequisites
+
+* You have configured an {product-title-short} API token.
+* You have configured build-time policies.
+
+.Procedure
+
+. In your CI system, configure a job to check the images in the build against your configured policies. Ensure that the `roxctl image check` command is included, as shown in the following example:
++
+[source,terminal]
+----
+$ roxctl image check --endpoint "$STACKROX_CENTRAL_HOST:443" --image "<your_registry/repo/image_name>"
+----
+
+where:
+
+`endpoint`::
+
+Specifies the address of Central.
+
+`<your_registry/repo/image_name>`::
+
+Specifies the registry and path to the image that you want to check.
+
+

--- a/modules/checking-images.adoc
+++ b/modules/checking-images.adoc
@@ -15,7 +15,9 @@ $ roxctl image check --image=_<image_name>_
 ----
 +
 The format is defined in the API reference.
-To cause {rh-rhacs-first} to re-pull image metadata and image scan results from the associated registry and scanner, add the `--force` option.
+To cause {rh-rhacs-first} to re-pull image metadata and image scan results from the associated registry and scanner, add the `--force` option. 
++
+This command queries Central and Scanner to check the input image against a set of policies. If the image violates any build-time policy of the requested policy set, which is by default all policies, then the FAIL_BUILD_ENFORCEMENT flag is set. The check result is an error with the return code of 1.
 +
 [NOTE]
 ====

--- a/modules/roxctl-image-check.adoc
+++ b/modules/roxctl-image-check.adoc
@@ -6,7 +6,7 @@
 [id="roxctl-image-check_{context}"]
 = roxctl image check
 
-Check images for build time policy violations, and report them.
+Check images for build time policy violations, and report them. This command queries Central and Scanner to check the input image against a set of policies. If the image violates any build-time policy of the requested policy set, which is by default all policies, then the FAIL_BUILD_ENFORCEMENT flag is set. The check result is an error with the return code of 1.
 
 .Usage
 [source,terminal]


### PR DESCRIPTION
Version(s):

4.7+

Issues:

https://issues.redhat.com/browse/ROX-23701

Links to docs previews:

https://101488--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/checking-policy-compliance.html
https://101488--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/command-reference/roxctl-image.html
https://101488--ocpdocs-pr.netlify.app/openshift-acs/latest/integration/integrate-with-ci-systems.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
