### PR TITLE
[OSDOCS#16694] Add content types to untagged modules, letters A-E

### DIFF
--- a/modules/admission-plug-ins-default.adoc
+++ b/modules/admission-plug-ins-default.adoc
@@ -2,6 +2,7 @@
 //
 // * architecture/admission-plug-ins.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="admission-plug-ins-default_{context}"]
 = Default admission plugins
 

--- a/modules/admission-webhook-types.adoc
+++ b/modules/admission-webhook-types.adoc
@@ -2,6 +2,7 @@
 //
 // * architecture/admission-plug-ins.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="admission-webhook-types_{context}"]
 = Types of webhook admission plugins
 

--- a/modules/admission-webhooks-about.adoc
+++ b/modules/admission-webhooks-about.adoc
@@ -2,6 +2,7 @@
 //
 // * architecture/admission-plug-ins.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="admission-webhooks-about_{context}"]
 = Webhook admission plugins
 

--- a/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
+++ b/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
@@ -6,6 +6,7 @@ ifeval::["{context}" == "configuring-iam-ibm-cloud"]
 :ibm-cloud:
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="alternatives-to-storing-admin-secrets-in-kube-system_{context}"]
 = Alternatives to storing administrator-level secrets in the kube-system project
 

--- a/modules/api-compatibility-common-terminology.adoc
+++ b/modules/api-compatibility-common-terminology.adoc
@@ -2,6 +2,7 @@
 //
 // * rest_api/understanding-compatibility-guidelines.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="api-compatibility-common-terminology_{context}"]
 = API compatibility common terminology
 

--- a/modules/api-compatibility-guidelines.adoc
+++ b/modules/api-compatibility-guidelines.adoc
@@ -2,6 +2,7 @@
 //
 // * rest_api/understanding-compatibility-guidelines.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="api-compatibility-guidelines_{context}"]
 = API compatibility guidelines
 

--- a/modules/applications-create-using-cli-modify.adoc
+++ b/modules/applications-create-using-cli-modify.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: PROCEDURE
 [id="applications-create-using-cli-modify_{context}"]
 = Modifying application creation
 

--- a/modules/arch-cluster-operators.adoc
+++ b/modules/arch-cluster-operators.adoc
@@ -2,6 +2,7 @@
 //
 // * architecture/control-plane.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="cluster-operators_{context}"]
 = Cluster Operators
 

--- a/modules/arch-olm-operators.adoc
+++ b/modules/arch-olm-operators.adoc
@@ -2,6 +2,7 @@
 //
 // * architecture/control-plane.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-operators_{context}"]
 = Add-on Operators
 

--- a/modules/architecture-machine-config-pools.adoc
+++ b/modules/architecture-machine-config-pools.adoc
@@ -3,6 +3,7 @@
 // * architecture/control-plane.adoc
 // * machine_configuration/index.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="architecture-machine-config-pools_{context}"]
 = Node configuration management with machine config pools
 

--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -2,6 +2,7 @@
 //
 // * architecture/control-plane.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="architecture-machine-roles_{context}"]
 = Machine roles in {product-title}
 

--- a/modules/architecture-platform-introduction.adoc
+++ b/modules/architecture-platform-introduction.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 // * architecture/architecture.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="architecture-platform-introduction_{context}"]
 = Introduction to {product-title}
 

--- a/modules/authentication-kubeadmin.adoc
+++ b/modules/authentication-kubeadmin.adoc
@@ -3,6 +3,7 @@
 // * authentication/removing-kubeadmin.adoc
 // * post_installation_configuration/preparing-for-users.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="understanding-kubeadmin_{context}"]
 = The kubeadmin user
 

--- a/modules/authentication-prometheus-system-metrics.adoc
+++ b/modules/authentication-prometheus-system-metrics.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/understanding-authentication.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="authentication-prometheus-system-metrics_{context}"]
 = Authentication metrics for Prometheus
 

--- a/modules/available-persistent-storage-options.adoc
+++ b/modules/available-persistent-storage-options.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/optimizing-storage.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="available-persistent-storage-options_{context}"]
 = Available persistent storage options
 

--- a/modules/aws-limits.adoc
+++ b/modules/aws-limits.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_planning/aws-ccs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="aws-limits_{context}"]
 = AWS account limits
 

--- a/modules/builds-about.adoc
+++ b/modules/builds-about.adoc
@@ -3,6 +3,7 @@
 //*builds/understanding-image-builds
 
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-about_{context}"]
 = Builds
 

--- a/modules/builds-adding-source-clone-secrets.adoc
+++ b/modules/builds-adding-source-clone-secrets.adoc
@@ -2,6 +2,7 @@
 //
 //* builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-adding-source-clone-secrets_{context}"]
 = Source clone secrets
 

--- a/modules/builds-binary-source.adoc
+++ b/modules/builds-binary-source.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-binary-source_{context}"]
 = Binary (local) source
 

--- a/modules/builds-build-environment.adoc
+++ b/modules/builds-build-environment.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-build-environment_{context}"]
 = Build environments
 

--- a/modules/builds-build-hooks.adoc
+++ b/modules/builds-build-hooks.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/triggering-builds-build-hooks.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-build-hooks_{context}"]
 = Build hooks
 

--- a/modules/builds-build-run-policy.adoc
+++ b/modules/builds-build-run-policy.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/advanced-build-operations.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-build-run-policy_{context}"]
 = Build run policy
 

--- a/modules/builds-chaining-builds.adoc
+++ b/modules/builds-chaining-builds.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/advanced-build-operations.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-chaining-builds_{context}"]
 = Chained builds
 

--- a/modules/builds-configuration-change-triggers.adoc
+++ b/modules/builds-configuration-change-triggers.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/triggering-builds-build-hooks.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-configuration-change-triggers_{context}"]
 = Configuration change triggers
 

--- a/modules/builds-configuration-parameters.adoc
+++ b/modules/builds-configuration-parameters.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/build-configuration.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="builds-configuration-parameters_{context}"]
 = Build controller configuration parameters
 

--- a/modules/builds-custom-strategy.adoc
+++ b/modules/builds-custom-strategy.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-custom-strategy_{context}"]
 = Custom strategy
 

--- a/modules/builds-define-build-inputs.adoc
+++ b/modules/builds-define-build-inputs.adoc
@@ -2,6 +2,7 @@
 //
 //* builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-define-build-inputs_{context}"]
 = Build inputs
 

--- a/modules/builds-docker-source-build-output.adoc
+++ b/modules/builds-docker-source-build-output.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/managing-build-output.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-docker-source-build-output_{context}"]
 = Build output
 

--- a/modules/builds-docker-strategy.adoc
+++ b/modules/builds-docker-strategy.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-docker-strategy_{context}"]
 = Docker strategy
 

--- a/modules/builds-dockerfile-source.adoc
+++ b/modules/builds-dockerfile-source.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-dockerfile-source_{context}"]
 = Dockerfile source
 

--- a/modules/builds-input-secrets-configmaps.adoc
+++ b/modules/builds-input-secrets-configmaps.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-input-secrets-configmaps_{context}"]
 = Input secrets and config maps
 

--- a/modules/builds-output-image-environment-variables.adoc
+++ b/modules/builds-output-image-environment-variables.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/managing-build-output.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="builds-output-image-environment-variables_{context}"]
 = Output image environment variables
 

--- a/modules/builds-output-image-labels.adoc
+++ b/modules/builds-output-image-labels.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/managing-build-output.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="builds-output-image-labels_{context}"]
 = Output image labels
 

--- a/modules/builds-secrets-overview.adoc
+++ b/modules/builds-secrets-overview.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-secrets-overview_{context}"]
 = What is a secret?
 

--- a/modules/builds-secrets-restrictions.adoc
+++ b/modules/builds-secrets-restrictions.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-secrets-restrictions_{context}"]
 = Secrets restrictions
 

--- a/modules/builds-source-code.adoc
+++ b/modules/builds-source-code.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //* builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-source-code_{context}"]
 = Git source
 

--- a/modules/builds-source-secret-combinations.adoc
+++ b/modules/builds-source-secret-combinations.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-source-secret-combinations_{context}"]
 = Source secret combinations
 

--- a/modules/builds-source-to-image.adoc
+++ b/modules/builds-source-to-image.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-source-to-image_{context}"]
 = Source-to-image strategy
 

--- a/modules/builds-strategy-custom-build.adoc
+++ b/modules/builds-strategy-custom-build.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/build-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-strategy-custom-build_{context}"]
 = Custom build
 

--- a/modules/builds-strategy-docker-build.adoc
+++ b/modules/builds-strategy-docker-build.adoc
@@ -3,6 +3,7 @@
 //*builds/build-strategies.adoc
 //*builds/understanding-image-builds
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-strategy-docker-build_{context}"]
 = Docker build
 

--- a/modules/builds-strategy-pipeline-build.adoc
+++ b/modules/builds-strategy-pipeline-build.adoc
@@ -3,6 +3,7 @@
 //*builds/build-strategies.adoc
 //*builds/understanding-image-builds
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-strategy-pipeline-build_{context}"]
 = Pipeline build
 

--- a/modules/builds-strategy-pipeline-mapping-buildconfig-jenkins.adoc
+++ b/modules/builds-strategy-pipeline-mapping-buildconfig-jenkins.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 // * builds/build-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-strategy-pipeline-mapping-buildconfig-jenkins_{context}"]
 = Mapping between BuildConfig environment variables and Jenkins job parameters
 

--- a/modules/builds-strategy-s2i-build.adoc
+++ b/modules/builds-strategy-s2i-build.adoc
@@ -3,6 +3,7 @@
 //* builds/build-strategies.adoc
 //* builds/understanding-image-builds.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-strategy-s2i-build_{context}"]
 = Source-to-image build
 

--- a/modules/builds-strategy-s2i-environment-variables.adoc
+++ b/modules/builds-strategy-s2i-environment-variables.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 // * builds/build-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-strategy-s2i-environment-variables_{context}"]
 = Source-to-image environment variables
 

--- a/modules/builds-strategy-s2i-ignore-source-files.adoc
+++ b/modules/builds-strategy-s2i-ignore-source-files.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 // * builds/build-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-strategy-s2i-ignore-source-files_{context}"]
 = Ignoring source-to-image source files
 

--- a/modules/builds-triggers.adoc
+++ b/modules/builds-triggers.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/triggering-builds-build-hooks.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-triggers_{context}"]
 = Build triggers
 

--- a/modules/builds-troubleshooting-access-resources.adoc
+++ b/modules/builds-troubleshooting-access-resources.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/troubleshooting-builds.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="builds-troubleshooting-access-resources_{context}"]
 = Resolving denial for access to resources
 

--- a/modules/builds-troubleshooting-service-certificate-generation.adoc
+++ b/modules/builds-troubleshooting-service-certificate-generation.adoc
@@ -2,6 +2,7 @@
 //
 // *builds/troubleshooting-builds.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="builds-troubleshooting-service-certificate-generation_{context}"]
 = Service certificate generation failure
 

--- a/modules/builds-using-external-artifacts.adoc
+++ b/modules/builds-using-external-artifacts.adoc
@@ -2,6 +2,7 @@
 //
 //* builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="builds-using-external-artifacts_{context}"]
 = External artifacts
 

--- a/modules/builds-using-proxy-git-cloning.adoc
+++ b/modules/builds-using-proxy-git-cloning.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/creating-build-inputs.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="builds-using-proxy-git-cloning_{context}"]
 = Using a proxy
 

--- a/modules/builds-webhook-triggers.adoc
+++ b/modules/builds-webhook-triggers.adoc
@@ -2,6 +2,7 @@
 //
 // * builds/triggering-builds-build-hooks.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="builds-webhook-triggers_{context}"]
 = Webhook triggers
 

--- a/modules/byoh-removal.adoc
+++ b/modules/byoh-removal.adoc
@@ -2,6 +2,7 @@
 //
 // * windows_containers/creating_windows_machinesets/byoh-windows-instance.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="removing-byoh-windows-instance"]
 = Removing BYOH Windows instances
 You can remove BYOH instances attached to the cluster by deleting the instance's entry in the config map. Deleting an instance reverts that instance back to its state prior to adding to the cluster. Any logs and container runtime artifacts are not added to these instances.

--- a/modules/ccs-aws-customer-requirements.adoc
+++ b/modules/ccs-aws-customer-requirements.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_planning/aws-ccs.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="ccs-aws-customer-requirements_{context}"]
 = Customer requirements
 

--- a/modules/ccs-aws-iam.adoc
+++ b/modules/ccs-aws-iam.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_planning/aws-ccs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="ccs-aws-iam_{context}"]
 = Red Hat managed IAM references for AWS
 

--- a/modules/ccs-aws-provisioned.adoc
+++ b/modules/ccs-aws-provisioned.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_planning/aws-ccs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="ccs-aws-provisioned_{context}"]
 = Provisioned AWS Infrastructure
 

--- a/modules/ccs-aws-scp.adoc
+++ b/modules/ccs-aws-scp.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_planning/aws-ccs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="ccs-aws-scp_{context}"]
 = Minimum required service control policy (SCP)
 

--- a/modules/ccs-gcp-customer-requirements.adoc
+++ b/modules/ccs-gcp-customer-requirements.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_planning/gcp-ccs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="ccs-gcp-customer-requirements_{context}"]
 = Customer requirements
 

--- a/modules/ccs-gcp-iam.adoc
+++ b/modules/ccs-gcp-iam.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * osd_planning/gcp-ccs.adoc
+:_mod-docs-content-type: REFERENCE
 [id="ccs-gcp-iam_{context}"]
 
 = Red Hat managed {gcp-full} resources

--- a/modules/ccs-gcp-provisioned.adoc
+++ b/modules/ccs-gcp-provisioned.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_planning/gcp-ccs.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="ccs-gcp-provisioned_{context}"]
 = Provisioned {gcp-short} Infrastructure
 

--- a/modules/certificate-injection-using-operators.adoc
+++ b/modules/certificate-injection-using-operators.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/configuring-a-custom-pki.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="certificate-injection-using-operators_{context}"]
 = Certificate injection using Operators
 

--- a/modules/cli-getting-help.adoc
+++ b/modules/cli-getting-help.adoc
@@ -2,6 +2,7 @@
 //
 // * cli_reference/openshift_cli/getting-started.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cli-getting-help_{context}"]
 = Getting help
 

--- a/modules/cli-installing-cli-web-console.adoc
+++ b/modules/cli-installing-cli-web-console.adoc
@@ -2,6 +2,7 @@ ifeval::["{context}" == "updating-restricted-network-cluster"]
 :restricted:
 endif::[]
 
+:_mod-docs-content-type: PROCEDURE
 [id="cli-installing-cli-web-console_{context}"]
 = Installing the OpenShift CLI by using the web console
 

--- a/modules/cli-logging-out.adoc
+++ b/modules/cli-logging-out.adoc
@@ -2,6 +2,7 @@
 //
 // * cli_reference/openshift_cli/getting-started.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cli-logging-out_{context}"]
 = Logging out of the OpenShift CLI
 

--- a/modules/cli-using-cli.adoc
+++ b/modules/cli-using-cli.adoc
@@ -2,6 +2,7 @@
 //
 // * cli_reference/openshift_cli/getting-started.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cli-using-cli_{context}"]
 = Using the OpenShift CLI
 

--- a/modules/cluster-authentication-operator.adoc
+++ b/modules/cluster-authentication-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="cluster-authentication-operator_{context}"]
 = Cluster Authentication Operator
 

--- a/modules/cluster-autoscaler-operator.adoc
+++ b/modules/cluster-autoscaler-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-autoscaler-operator_{context}"]
 = Cluster Autoscaler Operator
 

--- a/modules/cluster-capi-operator.adoc
+++ b/modules/cluster-capi-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-capi-operator_{context}"]
 = {cluster-capi-operator}
 

--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -9,6 +9,7 @@ ifeval::["{context}" == "cluster-capabilities"]
 :cluster-caps:
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="cluster-cloud-controller-manager-operator_{context}"]
 ifdef::operators[= Cloud Controller Manager Operator]
 ifdef::cluster-caps[= Cloud controller manager capability]

--- a/modules/cluster-config-operator.adoc
+++ b/modules/cluster-config-operator.adoc
@@ -2,6 +2,7 @@
 //
 // *  operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-config-operator_{context}"]
 = Cluster Config Operator
 

--- a/modules/cluster-dns-operator.adoc
+++ b/modules/cluster-dns-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="dns-operator_{context}"]
 = DNS Operator
 

--- a/modules/cluster-kube-scheduler-operator.adoc
+++ b/modules/cluster-kube-scheduler-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-kube-scheduler-operator_{context}"]
 = Kubernetes Scheduler Operator
 

--- a/modules/cluster-kube-storage-version-migrator-operator.adoc
+++ b/modules/cluster-kube-storage-version-migrator-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-kube-storage-version-migrator-operator_{context}"]
 = Kubernetes Storage Version Migrator Operator
 

--- a/modules/cluster-machine-approver-operator.adoc
+++ b/modules/cluster-machine-approver-operator.adoc
@@ -2,6 +2,7 @@
 //
 // *  operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-machine-approver-operator_{context}"]
 = Cluster Machine Approver Operator
 

--- a/modules/cluster-monitoring-operator.adoc
+++ b/modules/cluster-monitoring-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-monitoring-operator_{context}"]
 = {cmo-full}
 

--- a/modules/cluster-network-operator.adoc
+++ b/modules/cluster-network-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-network-operator_{context}"]
 = Cluster Network Operator
 

--- a/modules/cluster-node-tuning-operator-default-profiles-set.adoc
+++ b/modules/cluster-node-tuning-operator-default-profiles-set.adoc
@@ -4,6 +4,7 @@
 // * post_installation_configuration/node-tasks.adoc
 // * nodes/nodes/nodes-node-tuning-operator.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="custom-tuning-default-profiles-set_{context}"]
 = Default profiles set on a cluster
 

--- a/modules/cluster-node-tuning-operator-verify-profiles.adoc
+++ b/modules/cluster-node-tuning-operator-verify-profiles.adoc
@@ -2,6 +2,7 @@
 //
 // * scalability_and_performance/using-node-tuning-operator.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="verifying-tuned-profiles-are-applied_{context}"]
 =  Verifying that the TuneD profiles are applied
 

--- a/modules/cluster-openshift-controller-manager-operators.adoc
+++ b/modules/cluster-openshift-controller-manager-operators.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-openshift-controller-manager-operator_{context}"]
 = OpenShift Controller Manager Operator
 

--- a/modules/cluster-storage-operator.adoc
+++ b/modules/cluster-storage-operator.adoc
@@ -11,6 +11,7 @@ ifeval::["{context}" == "cluster-capabilities"]
 :cluster-caps:
 endif::[]
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-storage-operator_{context}"]
 ifdef::operator-ref[= Cluster Storage Operator]
 ifdef::cluster-caps[= Cluster storage capability]

--- a/modules/cluster-version-operator.adoc
+++ b/modules/cluster-version-operator.adoc
@@ -2,6 +2,7 @@
 //
 // *  operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="cluster-version-operator_{context}"]
 = Cluster Version Operator
 

--- a/modules/compliance-anatomy.adoc
+++ b/modules/compliance-anatomy.adoc
@@ -2,6 +2,7 @@
 //
 // * security/compliance_operator/co-scans/compliance-operator-troubleshooting.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="compliance-anatomy_{context}"]
 = Anatomy of a scan
 

--- a/modules/compliance-applying.adoc
+++ b/modules/compliance-applying.adoc
@@ -2,6 +2,7 @@
 //
 // * security/compliance_operator/co-scans/compliance-operator-remediation.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="compliance-applying_{context}"]
 = Applying a remediation
 

--- a/modules/compliance-custom-storage.adoc
+++ b/modules/compliance-custom-storage.adoc
@@ -2,6 +2,7 @@
 //
 // * security/compliance_operator/co-scans/compliance-operator-advanced.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="compliance-custom-storage_{context}"]
 = Setting custom storage size for results
 While the custom resources such as `ComplianceCheckResult` represent an aggregated result of one check across all scanned nodes, it can be useful to review the raw results as produced by the scanner. The raw results are produced in the ARF format and can be large (tens of megabytes per node), it is impractical to store them in a Kubernetes resource backed by the `etcd` key-value store. Instead, every scan creates a persistent volume (PV) which defaults to 1GB size. Depending on your environment, you may want to increase the PV size accordingly. This is done using the `rawResultStorage.size` attribute that is exposed in both the `ScanSetting` and `ComplianceScan` resources.

--- a/modules/compliance-objects.adoc
+++ b/modules/compliance-objects.adoc
@@ -2,6 +2,7 @@
 //
 // * security/compliance_operator/co-scans/compliance-operator-advanced.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="compliance-objects_{context}"]
 = Using the ComplianceSuite and ComplianceScan objects directly
 

--- a/modules/compliance-rescan.adoc
+++ b/modules/compliance-rescan.adoc
@@ -2,6 +2,7 @@
 //
 // * security/compliance_operator/co-scans/compliance-operator-advanced.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="compliance-rescan_{context}"]
 = Performing a rescan
 Typically you will want to re-run a scan on a defined schedule, like every Monday or daily. It can also be useful to re-run a scan once after fixing a problem on a node. To perform a single scan, annotate the scan with the `compliance.openshift.io/rescan=` option:

--- a/modules/compliance-review.adoc
+++ b/modules/compliance-review.adoc
@@ -2,6 +2,7 @@
 //
 // * security/compliance_operator/co-scans/compliance-operator-remediation.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="compliance-review_{context}"]
 = Reviewing a remediation
 

--- a/modules/connected-to-disconnected-config-registry.adoc
+++ b/modules/connected-to-disconnected-config-registry.adoc
@@ -2,6 +2,7 @@
 //
 // * post_installation_configuration/connected-to-disconnected.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="connected-to-disconnected-config-registry_{context}"]
 = Configuring the cluster for the mirror registry
 

--- a/modules/connected-to-disconnected-disconnect.adoc
+++ b/modules/connected-to-disconnected-disconnect.adoc
@@ -2,6 +2,7 @@
 //
 // * post_installation_configuration/connected-to-disconnected.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="connected-to-disconnected-disconnect_{context}"]
 = Disconnect the cluster from the network
 

--- a/modules/container-benefits.adoc
+++ b/modules/container-benefits.adoc
@@ -2,6 +2,7 @@
 //
 // * osd_architecture/osd-architecture.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="container-benefits_{context}"]
 = The benefits of containerized applications
 

--- a/modules/containers-about.adoc
+++ b/modules/containers-about.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 // * openshift_images/images-understand.aodc
 
+:_mod-docs-content-type: CONCEPT
 [id="containers-about_{context}"]
 = Containers
 

--- a/modules/control-plane-machine-set-operator.adoc
+++ b/modules/control-plane-machine-set-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="control-plane-machine-set-operator_{context}"]
 = Control Plane Machine Set Operator
 

--- a/modules/crd-custom-resource-definitions.adoc
+++ b/modules/crd-custom-resource-definitions.adoc
@@ -3,6 +3,7 @@
 // * operators/understanding/crds/crd-managing-resources-from-crds.adoc
 // * operators/understanding/crds/extending-api-with-crds.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="crd-custom-resource-definitions_{context}"]
 = Custom resource definitions
 

--- a/modules/creating-custom-live-rhcos-iso.adoc
+++ b/modules/creating-custom-live-rhcos-iso.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_sno/install-sno-installing-sno.adoc
 
 :_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="create-custom-live-rhcos-iso_{context}"]
 = Creating a custom live {op-system} ISO for remote server access
 

--- a/modules/creating-machines-bare-metal.adoc
+++ b/modules/creating-machines-bare-metal.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="creating-machines-bare-metal_{context}"]
 = Installing {op-system} and starting the {product-title} bootstrap process
 

--- a/modules/custom-tuning-example.adoc
+++ b/modules/custom-tuning-example.adoc
@@ -2,6 +2,7 @@
 //
 // * scalability_and_performance/using-node-tuning-operator.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="custom-tuning-example_{context}"]
 = Custom tuning examples
 

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -8,6 +8,7 @@ ifeval::["{context}" == "rosa-tuning-config"]
 :rosa-hcp-tuning:
 endif::[]
 
+:_mod-docs-content-type: REFERENCE
 [id="custom-tuning-specification_{context}"]
 = Custom tuning specification
 

--- a/modules/data-storage-management.adoc
+++ b/modules/data-storage-management.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/optimizing-storage.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="data-storage-management_{context}"]
 = Data storage management
 

--- a/modules/deploy-red-hat-openshift-container-storage.adoc
+++ b/modules/deploy-red-hat-openshift-container-storage.adoc
@@ -2,6 +2,7 @@
 //
 // * post_installation_configuration/storage-configuration.adoc
 
+:_mod-docs-content-type: REFERENCE
 [options="header",cols="1,1"]
 |===
 

--- a/modules/deployments-ab-testing.adoc
+++ b/modules/deployments-ab-testing.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/route-based-deployment-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-ab-testing_{context}"]
 = A/B deployments
 

--- a/modules/deployments-canary-deployments.adoc
+++ b/modules/deployments-canary-deployments.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/deployment-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-canary-deployments_{context}"]
 = Canary deployments
 

--- a/modules/deployments-comparing-deploymentconfigs.adoc
+++ b/modules/deployments-comparing-deploymentconfigs.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/what-deployments-are.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-comparing-deploymentconfigs_{context}"]
 = Comparing Deployment and DeploymentConfig objects
 

--- a/modules/deployments-custom-strategy.adoc
+++ b/modules/deployments-custom-strategy.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/deployment-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-custom-strategy_{context}"]
 = Custom strategy
 

--- a/modules/deployments-deploymentconfigs.adoc
+++ b/modules/deployments-deploymentconfigs.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/what-deployments-are.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-and-deploymentconfigs_{context}"]
 = DeploymentConfig objects
 

--- a/modules/deployments-graceful-termination.adoc
+++ b/modules/deployments-graceful-termination.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/route-based-deployment-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-graceful-termination_{context}"]
 = Graceful termination
 

--- a/modules/deployments-kube-deployments.adoc
+++ b/modules/deployments-kube-deployments.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/what-deployments-are.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-kube-deployments_{context}"]
 = Deployments
 

--- a/modules/deployments-n1-compatibility.adoc
+++ b/modules/deployments-n1-compatibility.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/route-based-deployment-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-n1-compatibility_{context}"]
 = N-1 compatibility
 

--- a/modules/deployments-proxy-shards.adoc
+++ b/modules/deployments-proxy-shards.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/route-based-deployment-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-proxy-shard_{context}"]
 = Proxy shards and traffic splitting
 

--- a/modules/deployments-recreate-strategy.adoc
+++ b/modules/deployments-recreate-strategy.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/deployment-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-recreate-strategy_{context}"]
 = Recreate strategy
 

--- a/modules/deployments-replicasets.adoc
+++ b/modules/deployments-replicasets.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/what-deployments-are.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-repliasets_{context}"]
 = Replica sets
 

--- a/modules/deployments-replicationcontrollers.adoc
+++ b/modules/deployments-replicationcontrollers.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/what-deployments-are.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-replicationcontrollers_{context}"]
 = Replication controllers
 

--- a/modules/deployments-rolling-strategy.adoc
+++ b/modules/deployments-rolling-strategy.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/deployment-strategies.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-rolling-strategy_{context}"]
 = Rolling strategy
 

--- a/modules/deployments-triggers.adoc
+++ b/modules/deployments-triggers.adoc
@@ -2,6 +2,7 @@
 //
 // * applications/deployments/managing-deployment-processes.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="deployments-triggers_{context}"]
 = Deployment triggers
 

--- a/modules/determining-where-installation-issues-occur.adoc
+++ b/modules/determining-where-installation-issues-occur.adoc
@@ -2,6 +2,7 @@
 //
 // * support/troubleshooting/troubleshooting-installations.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="determining-where-installation-issues-occur_{context}"]
 = Determining where installation issues occur
 

--- a/modules/digging-into-machine-config.adoc
+++ b/modules/digging-into-machine-config.adoc
@@ -2,6 +2,7 @@
 //
 // * architecture/architecture_rhcos.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="digging-into-machine-config_{context}"]
 = Changing Ignition configs after installation
 

--- a/modules/disable-quickstarts-admin-console.adoc
+++ b/modules/disable-quickstarts-admin-console.adoc
@@ -2,6 +2,7 @@
 //
 // * web_console/configuring-web-console.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="disable-quickstarts-admin-console_{context}"]
 = Disabling quick starts in the web console
 

--- a/modules/dr-scenario-cluster-state-issues.adoc
+++ b/modules/dr-scenario-cluster-state-issues.adoc
@@ -4,6 +4,7 @@
 // * post_installation_configuration/cluster-tasks.adoc
 // * etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="dr-scenario-cluster-state-issues_{context}"]
 = Issues and workarounds for restoring a persistent storage state
 

--- a/modules/dynamic-provisioning-annotations.adoc
+++ b/modules/dynamic-provisioning-annotations.adoc
@@ -3,6 +3,7 @@
 // * storage/dynamic-provisioning.adoc
 // * microshift_storage/dynamic-provisioning-microshift.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="storage-class-annotations_{context}"]
 = Storage class annotations
 

--- a/modules/dynamic-provisioning-available-plugins.adoc
+++ b/modules/dynamic-provisioning-available-plugins.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/dynamic-provisioning.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="available-plug-ins_{context}"]
 = Available dynamic provisioning plugins
 

--- a/modules/dynamic-provisioning-aws-definition.adoc
+++ b/modules/dynamic-provisioning-aws-definition.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/dynamic-provisioning.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="aws-definition_{context}"]
 = AWS Elastic Block Store (EBS) object definition
 

--- a/modules/dynamic-provisioning-azure-disk-definition.adoc
+++ b/modules/dynamic-provisioning-azure-disk-definition.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/dynamic-provisioning.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="azure-disk-definition_{context}"]
 = Azure Disk object definition
 

--- a/modules/dynamic-provisioning-azure-file-considerations.adoc
+++ b/modules/dynamic-provisioning-azure-file-considerations.adoc
@@ -2,6 +2,7 @@
 //
 // storage/persistent_storage/persistent-storage-azure-file.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="azure-file-considerations_{context}"]
 = Considerations when using Azure File
 

--- a/modules/dynamic-provisioning-cinder-definition.adoc
+++ b/modules/dynamic-provisioning-cinder-definition.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/dynamic-provisioning.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="openstack-cinder-storage-class_{context}"]
 = {rh-openstack} Cinder object definition
 

--- a/modules/dynamic-provisioning-defining-storage-class.adoc
+++ b/modules/dynamic-provisioning-defining-storage-class.adoc
@@ -4,6 +4,7 @@
 // * microshift_storage/dynamic-provisioning-microshift.adoc
 
 
+:_mod-docs-content-type: CONCEPT
 [id="defining-storage-classes_{context}"]
 = Defining a storage class
 

--- a/modules/dynamic-provisioning-gce-definition.adoc
+++ b/modules/dynamic-provisioning-gce-definition.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/dynamic-provisioning.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="gce-persistentdisk-storage-class_{context}"]
 = GCE PersistentDisk (gcePD) object definition
 

--- a/modules/dynamic-provisioning-manila-csi-definition.adoc
+++ b/modules/dynamic-provisioning-manila-csi-definition.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/dynamic-provisioning.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="openstack-manila-csi-definition_{context}"]
 = {rh-openstack} Manila Container Storage Interface (CSI) object definition
 

--- a/modules/dynamic-provisioning-storage-class-definition.adoc
+++ b/modules/dynamic-provisioning-storage-class-definition.adoc
@@ -4,6 +4,7 @@
 // * microshift_storage/dynamic-provisioning-microshift.adoc
 
 
+:_mod-docs-content-type: REFERENCE
 [id="basic-storage-class-definition_{context}"]
 = Basic StorageClass object definition
 

--- a/modules/dynamic-provisioning-vsphere-definition.adoc
+++ b/modules/dynamic-provisioning-vsphere-definition.adoc
@@ -2,6 +2,7 @@
 //
 // * storage/dynamic-provisioning.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="vsphere-definition_{context}"]
 = VMware vSphere object definition
 

--- a/modules/etcd-operator.adoc
+++ b/modules/etcd-operator.adoc
@@ -2,6 +2,7 @@
 //
 // * operators/operator-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="etcd-cluster-operator_{context}"]
 = etcd cluster Operator
 

--- a/modules/example-apache-httpd-configuration.adoc
+++ b/modules/example-apache-httpd-configuration.adoc
@@ -2,6 +2,7 @@
 //
 // * authentication/identity_providers/configuring-ldap-identity-provider.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="example-apache-httpd-configuration_{context}"]
 = Example Apache HTTPD configuration for basic identity providers
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-16694](https://issues.redhat.com//browse/OSDOCS-16694)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] ~~QE has approved this change.~~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Tagging was done manually on a programmatically determined list of core modules. Modules that do not include a content type and do not have the following prefixes were included: 
`'/(about-gitops|argo-cd|go-|cluster-logging|log6x|es-|developer-cli-odo|sbo-|op-|monitoring-|serverless-|codeready-workspaces|kn-|knative-|odc-|ossm-|distr-tracing-|cco-dashboard|dedicated|rosa|sd-|osd-|configuring-a-proxy-|sd-hcp-|ibi-|rdma-|cnf-|eco-|kmm-|ptp-|psap-|telco-|ztp-|oadp-)'`