### PR TITLE
OSDOCS-15995: Customizing branding in ROSA and OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -243,8 +243,8 @@ Topics:
 #- Name: Configuring the web console
 #  File: configuring-web-console
 #  Distros: openshift-dedicated
-#- Name: Customizing the web console
-#  File: customizing-the-web-console
+- Name: Customizing the web console
+  File: customizing-the-web-console
 #  Distros: openshift-dedicated
 - Name: Dynamic plugins
   Dir: dynamic-plugin

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -416,8 +416,8 @@ Topics:
 #- Name: Configuring the web console
 #  File: configuring-web-console
 #  Distros: openshift-rosa
-#- Name: Customizing the web console
-#  File: customizing-the-web-console
+- Name: Customizing the web console
+  File: customizing-the-web-console
 #  Distros: openshift-rosa
 - Name: Dynamic plugins
   Dir: dynamic-plugin

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -219,6 +219,8 @@ Topics:
   File: using-dashboard-to-get-cluster-information
 - Name: Adding user preferences
   File: adding-user-preferences
+- Name: Customizing the web console
+  File: customizing-the-web-console
 - Name: Dynamic plugins
   Dir: dynamic-plugin
   Distros: openshift-rosa-hcp

--- a/modules/adding-a-custom-logo.adoc
+++ b/modules/adding-a-custom-logo.adoc
@@ -6,6 +6,7 @@
 [id="adding-a-custom-logo_{context}"]
 = Adding a custom logo and product name
 
+[role="_abstract"]
 You can create custom branding by adding a custom logo or custom product name. You can set both or one without the other, as these settings are independent of each other.
 
 .Prerequisites
@@ -34,9 +35,9 @@ metadata:
   name: console-custom-logo
   namespace: openshift-config
 binaryData:
-  console-custom-logo.png: <base64-encoded_logo> ... <1>
+  console-custom-logo.png: <base64-encoded_logo> ...
 ----
-<1> Provide a valid base64-encoded logo.
+Replace `<base64-encoded_logo>` with a base64-encoded string of the logo.
 ====
 
 . Edit the web console's Operator configuration to include `customLogoFile` and `customProductName`:
@@ -62,7 +63,7 @@ spec:
 +
 Once the Operator configuration is updated, it will sync the custom logo config map into the console namespace, mount it to the console pod, and redeploy.
 
-. Check for success. If there are any issues, the console cluster Operator will report a `Degraded` status, and the console Operator configuration will also report a `CustomLogoDegraded` status, but with reasons like `KeyOrFilenameInvalid` or `NoImageProvided`.
+. Check for success. If there are any issues, the console cluster Operator will report a `Degraded` status, and the console Operator configuration will also report a `CustomLogoDegraded` status, but with reasons such as `KeyOrFilenameInvalid` or `NoImageProvided`.
 +
 To check the `clusteroperator`, run:
 +

--- a/web_console/customizing-the-web-console.adoc
+++ b/web_console/customizing-the-web-console.adoc
@@ -1,22 +1,31 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="customizing-web-console"]
 = Customizing the web console in {product-title}
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: customizing-web-console
 
 toc::[]
 
-You can customize the {product-title} web console to set a custom logo,
-product name, links, notifications, and command-line downloads. This is
-especially helpful if you need to tailor the web console to meet specific
-corporate or government requirements.
+[role="_abstract"]
+You can customize the
+ifndef::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+{product-title}
+endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+{product-title}
+endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+web console to set
+ifndef::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+a custom logo, product name, links, notifications, and command-line downloads.
+endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+a custom logo and product name.
+endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
+This is especially helpful if you need to tailor the web console to meet specific corporate or government requirements.
 
-// Hiding in ROSA/OSD, as Hive overwrites changes to console config
-ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/adding-a-custom-logo.adoc[leveloffset=+1]
-
-endif::openshift-rosa,openshift-dedicated[]
 
 // Hiding in ROSA/OSD, as dedicated-admins cannot create resource "consolelinks"
 ifndef::openshift-rosa,openshift-dedicated[]
@@ -42,7 +51,7 @@ include::modules/adding-custom-notification-banners.adoc[leveloffset=+1]
 // Hiding in ROSA/OSD, as dedicated-admins cannot patch resource "customresourcedefinitions"
 include::modules/customizing-cli-downloads.adoc[leveloffset=+1]
 
-// Hiding in ROSA/OSD, as dedicated-admins cannot patch resource "customresourcedefinitions" 
+// Hiding in ROSA/OSD, as dedicated-admins cannot patch resource "customresourcedefinitions"
 include::modules/adding-yaml-examples-to-kube-resources.adoc[leveloffset=+1]
 
 // Hiding in ROSA/OSD, as dedicated-admins cannot create resource "consoles"
@@ -72,7 +81,7 @@ endif::openshift-rosa,openshift-dedicated[]
 ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-form-view.adoc[leveloffset=+2]
 
-// Hiding in ROSA/OSD, as dedicated-admins cannot patch resource "consoles" 
+// Hiding in ROSA/OSD, as dedicated-admins cannot patch resource "consoles"
 include::modules/odc_con_example-yaml-file-changes.adoc[leveloffset=+3]
 
 endif::openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
[OSDOCS-15995](https://issues.redhat.com/browse/OSDOCS-15995): Customizing branding in ROSA and OSD

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-15995

Link to docs preview:
OSD: https://101555--ocpdocs-pr.netlify.app/openshift-dedicated/latest/web_console/customizing-the-web-console.html
ROSA: https://101555--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/web_console/customizing-the-web-console.html
ROSA Classic: https://101555--ocpdocs-pr.netlify.app/openshift-rosa/latest/web_console/customizing-the-web-console.html

QE review:
N/A

Additional information:
- Adding existing OCP content to the OSD, ROSA HCP and Classic docs.
- Replacing a callout according to https://docs.google.com/document/d/1j78SA8Y-ZRlVATbVe6D8bdYj7mQzzhOJtGt1xH_3qa0.
- Addressing a couple of Vale warnings.