### PR TITLE
RHDEVDOCS-6928: Content creation for GitOpsService CR

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -84,6 +84,8 @@ Distros: openshift-gitops
 Topics:
 - Name: Configuring Resource Quota
   File: configuring-resource-quota
+- Name: Configure resource requests and limits for GitOps plugin components
+  File: configure-resource-requests-and-limits-for-gitops-plugin-components
 ---
 Name: Argo CD applications
 Dir: argocd_applications

--- a/managing_resource/configure-resource-requests-and-limits-for-gitops-plugin-components.adoc
+++ b/managing_resource/configure-resource-requests-and-limits-for-gitops-plugin-components.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="configure-resource-requests-and-limits-for-gitops-plugin-components"]
+= Configure resource requests and limits for GitOps plugin components
+:context: configure-resource-requests-and-limits-for-gitops-plugin-components
+
+toc::[]
+
+You can configure CPU and memory resource requests and limits for the {gitops-shortname} console plugin and its backend cluster components. Resource allocation is controlled through the `GitOpsService` custom resource (CR) and can be modified during creation or update. The `GitOpsService` controller reconciles both the backend and plugin resources. You can define separate or identical resource configurations for each component, depending on your requirements. This feature is  beneficial for scenarios requiring specific resource requests and limits for components, which can effectively address memory and performance issues.
+
+// Enabling the GitOpsService custom resource
+include::modules/gitops-enabling-the-gitopsservice-custom-resource.adoc[leveloffset=+1]
+
+// Behavior of resource configuration
+include::modules/gitops-plugin-resource-behavior.adoc[leveloffset=+1]

--- a/modules/gitops-enabling-the-gitopsservice-custom-resource.adoc
+++ b/modules/gitops-enabling-the-gitopsservice-custom-resource.adoc
@@ -1,0 +1,66 @@
+// Module is included in the following assemblies:
+//
+// * managing_resource/configure-resource-requests-and-limits-for-gitops-plugin-components.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-enabling-the-gitopsservice-custom-resource_{context}"]
+= Enabling the GitOpsService custom resource
+
+[role="_abstract"]
+To enable resource configuration for the {gitops-shortname} plugin components, specify the `.spec.consolePlugin.backend.resources` field for the backend component and the `.spec.consolePlugin.gitopsPlugin.resources` field for the {gitops-shortname} console plugin. The `resources` section defines the `requests` (minimum resources) and `limits` (maximum resources) for each component.
+
+.Prerequisites
+
+* You have logged in to the {OCP} cluster as an administrator.
+* You have installed the {gitops-title} Operator on your {OCP} cluster.
+
+.Procedure
+
+. Get the `GitOpsService` CR by running the following command.
++
+[source,terminal]
+----
+$ oc get gitopsService -A
+----
+
+. Edit the `GitOpsService` CR by running the following command.
++
+[source,terminal]
+----
+$ oc edit gitopsservice cluster -n openshift-gitops
+----
+
+. In the `.spec.consolePlugin` section, add the `.backend.resources` and `.gitopsPlugin.resources` fields. These sections define requests and limits for CPU and memory.
++
+.Example configuration
+[source,yaml]
+----
+apiVersion: pipelines.openshift.io/v1alpha1
+kind: GitopsService
+metadata:
+  name: cluster
+spec:
+  consolePlugin:
+    backend:
+      resources:
+        limits:
+          cpu: 100m
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 1Gi
+    gitopsPlugin:
+      resources:
+        limits:
+          cpu: 200m
+          memory: 2Gi
+        requests:
+          cpu: 100m
+          memory: 1Gi
+----
+
+After you update the `GitOpsService` CR, the `GitOpsService` controller applies the specified resource requests and limits to the backend and the {gitops-shortname} plugin components.
+
+.Verification
+
+. Ensure that the requests and limits values in the pod specifications match the configuration you have added to the `GitOpsService` CR.

--- a/modules/gitops-plugin-resource-behavior.adoc
+++ b/modules/gitops-plugin-resource-behavior.adoc
@@ -1,0 +1,34 @@
+// Module is included in the following assemblies:
+//
+// * managing_resource/configure-resource-requests-and-limits-for-gitops-plugin-components.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="gitops-plugin-resource-behavior_{context}"]
+= Behavior of resource configuration
+
+[role="_abstract"]
+The following information describes how the `GitOpsService` controller applies resource values defined in the `GitOpsService` custom resource (CR).
+
+* *Specified values:*
+When you define resource values in the `GitOpsService` CR, the `GitOpsService` controller applies those values only to the components you specify. For example, if you configure resource limits only for the backend, those values apply to the backend deployment and not to the plugin.
+
+* *Default values:*  
+If you do not define any resource values in the `GitOpsService` custom resource, the `GitOpsService` controller applies default values to all components.
+
+.Default resource values
+[cols="2,3,3,3,3", options="header"]
+|===
+| Component | Request CPU | Request Memory | Limit CPU | Limit Memory
+
+| Backend
+| 250m
+| 128Mi
+| 500m
+| 256Mi
+
+| GitOps plugin
+| 250m
+| 128Mi
+| 500m
+| 256Mi
+|===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

cherry-pick to gitops-docs-1.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6928

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Configure resource requests and limits for GitOps plugin components](https://101566--ocpdocs-pr.netlify.app/openshift-gitops/latest/managing_resource/configure-resource-requests-and-limits-for-gitops-plugin-components.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @svghadi nakhil@redhat.com
QE review: @Naveena-058 
Peer review: @shivanisathe25 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
