### PR TITLE
Update nodes-pods-adjust-resources-in-place-about.adoc

### DIFF
--- a/modules/nodes-pods-adjust-resources-in-place-about.adoc
+++ b/modules/nodes-pods-adjust-resources-in-place-about.adoc
@@ -50,12 +50,12 @@ $ oc edit pod <pod_name>  --subresource resize
 
 [source,terminal]
 ----
-$ apply -f <file_name>.yaml --subresource resize
+$ oc apply -f <file_name>.yaml --subresource resize
 ----
 
 [source,terminal]
 ----
-$ patch pod <pod_name> --subresource resize --patch \
+$ oc patch pod <pod_name> --subresource resize --patch \
   '{"spec":{"containers":[{"name":"pause", "resources":{"requests":{"cpu":"800m"}, "limits":{"cpu":"800m"}}}]}}'
 ----
 


### PR DESCRIPTION
Hi Team,

Issue: 

The oc command prefix is missing in the pod resizing examples in the following OpenShift 4.20 documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/nodes/index#nodes-pods-adjust-resources-in-place-about_nodes-pods-adjust-resources-in-place


Current Example commands:

~~~
$ oc edit pod <pod_name>  --subresource resize

$ apply -f <file_name>.yaml --subresource resize

$ patch pod <pod_name> --subresource resize --patch \
  '{"spec":{"containers":[{"name":"pause", "resources":{"requests":{"cpu":"800m"}, "limits":{"cpu":"800m"}}}]}}'
~~~


Expected Example commands:

~~~
$ oc edit pod <pod_name>  --subresource resize

$ oc apply -f <file_name>.yaml --subresource resize

$ oc patch pod <pod_name> --subresource resize --patch \
  '{"spec":{"containers":[{"name":"pause", "resources":{"requests":{"cpu":"800m"}, "limits":{"cpu":"800m"}}}]}}'  
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20

Issue:

https://issues.redhat.com/browse/OCPBUGS-64573


Link to docs preview:
https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/nodes/index#nodes-pods-adjust-resources-in-place-about_nodes-pods-adjust-resources-in-place


QE review:
- Tested on cluster by @mburke5678 and verified
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
