### PR TITLE
[RHDEVDOCS-6780] Include note about CR status field deprecation

### DIFF
--- a/modules/op-monitoring-pipeline-run-status-using-pipelines-as-code.adoc
+++ b/modules/op-monitoring-pipeline-run-status-using-pipelines-as-code.adoc
@@ -62,7 +62,13 @@ These error scenarios do not halt the execution of valid pipeline runs because t
 
 [discrete]
 .Status associated with Repository CRD
-The last 5 status messages for a pipeline run is stored inside the `Repository` custom resource.
+
+The last 5 status messages for a pipeline run is stored inside the `Repository` custom resource (CR).
+
+[NOTE]
+====
+The `pipelinerun_status` field in the `Repository` CR is scheduled for deprecation in a future release.
+====
 
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.21

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6780

Link to docs preview:
- A note under [Monitoring pipeline run status using Pipelines as Code](https://101579--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/managing-pipeline-runs-pac.html#monitoring-pipeline-run-status-using-pipelines-as-code_managing-pipeline-runs-pac)

QE review:
- [x] QE has approved this change.

Additional information:
Deprecated features in the Pipelines 1.21 RNs.