### PR TITLE
OSDOCS Missing hyperlink to OpenSSH key-based authentication setup in Prerequisites section of BYOH Windows instance documentation

### DIFF
--- a/modules/byoh-configuring.adoc
+++ b/modules/byoh-configuring.adoc
@@ -15,7 +15,7 @@ Any Windows instances that are to be attached to the cluster as a node must fulf
 * Port 22 must be open and running an SSH server.
 * The default shell for the SSH server must be the link:https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_server_configuration#configuring-the-default-shell-for-openssh-in-windows[Windows Command shell], or `cmd.exe`.
 * Port 10250 must be open for log collection.
-* An administrator user is present with the private key used in the secret set as an authorized SSH key.
+* An administrator user is present with the link:https://learn.microsoft.com/en-us/windows-server/administration/openssh/openssh_keymanagement#configure-key-based-authentication[private key used in the secret set as an authorized SSH key] (Microsoft documentation).
 * If you are creating a BYOH Windows instance for an installer-provisioned infrastructure (IPI) AWS cluster, you must add a tag to the AWS instance that matches the `spec.template.spec.value.tag` value in the compute machine set for your worker nodes. For example, `kubernetes.io/cluster/<cluster_id>: owned` or `kubernetes.io/cluster/<cluster_id>: shared`.
 * If you are creating a BYOH Windows instance on vSphere, communication with the internal API server must be enabled.
 * The hostname of the instance must follow the link:https://datatracker.ietf.org/doc/html/rfc1123[RFC 1123] DNS label requirements, which include the following standards:
@@ -52,4 +52,3 @@ data:
 ----
 <1> The address that the WMCO uses to reach the instance over SSH, either a DNS name or an IPv4 address. A DNS PTR record must exist for this address. It is recommended that you use a DNS name with your BYOH instance if your organization uses DHCP to assign IP addresses. If not, you need to update the `windows-instances` ConfigMap whenever the instance is assigned a new IP address.
 <2> The name of the administrator user created in the prerequisites.
-


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-63732

Link to docs preview:
[Configuring a BYOH Windows instance](https://101592--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/byoh-windows-instance.html) -- Added link in the 5th bullet.

QE review:
No QE. Link approved by WMCO team in stand-up meeting.