### PR TITLE
CNV-57760_2-dclowers: DOC: cross-cluster VM migrations TP

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -5010,6 +5010,12 @@ Topics:
     File: virt-configuring-live-migration
   - Name: Initiating and canceling live migration
     File: virt-initiating-live-migration
+  - Name: Enabling cross-cluster live migration for virtual machines
+    File: virt-enabling-cclm-for-vms
+  - Name: Configuring a cross-cluster live migration network
+    File: virt-configuring-cross-cluster-live-migration-network
+  - Name: About Migration Toolkit for Virtualization providers
+    File: virt-about-mtv-providers
 # Node maintenance mode
 - Name: Nodes
   Dir: nodes

--- a/modules/virt-configuring-root-ca-for-providers.adoc
+++ b/modules/virt-configuring-root-ca-for-providers.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-about-mtv-providers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configuring-root-ca-for-providers_{context}"]
+= Configuring the root certificate authority for providers
+
+[role="_abstract"]
+You must configure an {product-title} provider for each cluster that you are including in the migration, and each provider requires a certificate authority (CA) for the cluster. It is important to configure the root CA for the entire cluster to avoid CA expiration, which causes the provider to fail.
+
+.Procedure
+
+. Run the following command against the cluster for which you are creating the provider:
++
+[source,terminal]
+----
+$ oc get cm kube-root-ca.crt -o=jsonpath={.data.ca\\.crt}
+----
+
+. Copy the printed certificate.
+
+. In the {mtv-first} web console, create a provider and select *{VirtProductName}*.
+
+. Paste the certificate into the *CA certificate* field, as shown in the following example:
++
+[source,terminal]
+----
+-----BEGIN CERTIFICATE-----
+<CA_certificate_content>
+-----END CERTIFICATE-----
+----

--- a/modules/virt-creating-long-lived-account-and-token.adoc
+++ b/modules/virt-creating-long-lived-account-and-token.adoc
@@ -1,0 +1,188 @@
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-about-mtv-providers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-creating-long-lived-account-and-token_{context}"]
+== Creating the long-lived service account and token to use with MTV providers
+
+[role="_abstract"]
+When you register an {VirtProductName} provider in the {mtv-first} web console, you must supply credentials that allow MTV to interact with the cluster. Creating a long-lived service account and cluster role binding gives MTV persistent permissions to read and create virtual machine resources during migration.
+
+.Procedure
+
+. Create the cluster role as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: live-migration-role
+rules:
+  - apiGroups:
+      - forklift.konveyor.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - namespaces
+      - configmaps
+      - persistentvolumes
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - k8s.cni.cncf.io
+    resources:
+      - network-attachment-definitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - virtualmachines
+      - virtualmachines/finalizers
+      - virtualmachineinstancemigrations
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - kubevirts
+      - virtualmachineinstances
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datavolumes
+      - datavolumes/finalizers
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - instancetype.kubevirt.io
+    resources:
+      - virtualmachineclusterpreferences
+      - virtualmachineclusterinstancetypes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - instancetype.kubevirt.io
+    resources:
+      - virtualmachinepreferences
+      - virtualmachineinstancetypes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+----
+
+. Create the cluster role by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <filename>.yaml
+----
+
+. Create a service account by running the following command:
++
+[source,terminal]
+----
+$ oc create serviceaccount <service_account_name> -n <service_account_namespace>
+----
+
+. Create a cluster role binding that links the service account to the cluster role, by running the following command:
++
+[source,terminal]
+----
+$ oc create clusterrolebinding <service_account_name> --clusterrole=<cluster_role_name> --serviceaccount=<service_account_namespace>:<service_account_name>
+----
+
+. Create a secret to hold the token by saving the following manifest as a YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <name_of_secret>
+  namespace: <namespace_for_service_account>
+  annotations:
+    kubernetes.io/service-account.name: <service_account_name>
+type: kubernetes.io/service-account-token
+----
+
+. Apply the manifest by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+. After the secret is populated, run the following command to get the service account bearer token:
++
+[source,terminal]
+----
+$ TOKEN_BASE64=$(oc get secret "<name_of_secret>" -n "<namespace_bound_to_service_account>" -o jsonpath='{.data.token}')
+  TOKEN=$(echo "$TOKEN_BASE64" | base64 --decode)
+  echo "$TOKEN"
+----
+
+. Copy the printed token.
+
+. In the {mtv-first} web console, when you create a provider and select *{VirtProductName}*, paste the token into the *Service account bearer token* field.

--- a/modules/virt-setting-mtv-lm-feature-gates.adoc
+++ b/modules/virt-setting-mtv-lm-feature-gates.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-enabling-cclm-for-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-setting-mtv-lm-feature-gates_{context}"]
+= Setting a live migration feature gate in the {mtv-first}
+
+[role="_abstract"]
+You enable the {product-title} live migration feature gate in the {mtv-first} to allow virtual machines to migrate between clusters during cross-cluster live migration. This feature gate must be enabled in both clusters that participate in the migration.
+
+.Prerequisites
+
+* You have installed the {oc-first}.
+
+* You must have cluster admin privileges.
+
+* The `virt-synchronization-controller` pods must be running.
+
+.Procedure
+
+* To enable the feature gate by modifying the CR, run the following command:
++
+[source,terminal]
+----
+$ oc patch ForkliftController forklift-controller -n openshift-mtv --type json -p '[{"op": "add", "path": "/spec/feature_ocp_live_migration", "value": "true"}]'
+----
+
+.Verification
+
+* Verify that the feature gate is enabled by checking the `ForkliftController` custom resource (CR). Run the following command:
++
+[source,terminal]
+----
+$ oc get ForkliftController forklift-controller -n openshift-mtv -o yaml
+----
++
+Confirm that the `feature_ocp_live_migration` key value is set to `true`, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: forklift.konveyor.io/v1beta1
+kind: ForkliftController
+metadata:
+  name: forklift-controller
+  namespace: openshift-mtv
+spec:
+  feature_ocp_live_migration: "true"
+  feature_ui_plugin: "true"
+  feature_validation: "true"
+  feature_volume_populator: "true"
+----

--- a/modules/virt-setting-openshiftv-lm-feature-gates.adoc
+++ b/modules/virt-setting-openshiftv-lm-feature-gates.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * virt/live_migration/virt-enabling-cclm-for-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-setting-openshiftv-lm-feature-gates_{context}"]
+= Setting a live migration feature gate for each cluster in {VirtProductName}
+
+[role="_abstract"]
+To enable cross-cluster live migration, you must set a feature gate for each of the two clusters in {VirtProductName}.
+
+.Prerequisites
+
+* You have installed the {oc-first}.
+
+* You must have cluster admin privileges.
+
+* The `virt-synchronization-controller` pods must be running.
+
+.Procedure
+
+* Set the feature gate by running the following command for each cluster:
++
+[source,terminal]
+----
+$ oc patch hyperconverged kubevirt-hyperconverged -n openshift-cnv --type json -p '[{"op":"replace", "path": "/spec/featureGates/decentralizedLiveMigration", "value": true}]'
+----
+
+.Verification
+
+* To verify that the feature gate enablement is successful for each cluster, run the following command in the {VirtProductName} namespace to locate the synchronization pods:
++
+[source,terminal]
+----
+$ oc get -n {CNVNamespace} pod | grep virt-synchronization
+----
++
+Example output:
++
+[source,terminal]
+----
+virt-synchronization-controller-898789f8fc-nsbsm      1/1     Running   0               5d1h
+virt-synchronization-controller-898789f8fc-vmmfj      1/1     Running   0               5d1h
+----

--- a/virt/live_migration/virt-about-mtv-providers.adoc
+++ b/virt/live_migration/virt-about-mtv-providers.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="virt-about-mtv-providers"]
+= About {mtv-first} providers
+:context: virt-about-mtv-providers
+
+toc::[]
+
+[role="_abstract"]
+To migrate a virtual machine (VM) across {product-title} clusters, you must configure an {product-title} provider for each cluster that you are including in the migration. If MTV is already installed on a cluster, a local provider already exists.
+
+:FeatureName: Cross-cluster live migration
+include::snippets/technology-preview.adoc[]
+
+.Next steps
+
+* See link:https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.9/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-source-provider_cnv[Adding a Red Hat {VirtProductName} source provider] and link:https://docs.redhat.com/en/documentation/migration_toolkit_for_virtualization/2.9/html-single/installing_and_using_the_migration_toolkit_for_virtualization/index#adding-source-provider_dest_cnv[Adding an {VirtProductName} destination provider].
+
+include::modules/virt-configuring-root-ca-for-providers.adoc[leveloffset=+1]
+
+include::modules/virt-creating-long-lived-account-and-token.adoc[leveloffset=+1]

--- a/virt/live_migration/virt-configuring-cross-cluster-live-migration-network.adoc
+++ b/virt/live_migration/virt-configuring-cross-cluster-live-migration-network.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="virt-configuring-cross-cluster-live-migration-network"]
+= Configuring a cross-cluster live migration network
+:context: virt-configuring-cross-cluster-live-migration-network
+
+toc::[]
+
+Cross-cluster live migration requires that the clusters be connected in the same network. Specifically, `virt-handler` pods must be able to communicate.
+
+:FeatureName: Cross-cluster live migration
+include::snippets/technology-preview.adoc[]
+
+include::modules/nw-multus-bridge-object.adoc[leveloffset=+1]
+
+include::modules/virt-configuring-secondary-network-vm-live-migration.adoc[leveloffset=+1]

--- a/virt/live_migration/virt-enabling-cclm-for-vms.adoc
+++ b/virt/live_migration/virt-enabling-cclm-for-vms.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="virt-enabling-cclm-for-vms"]
+= Enabling cross-cluster live migration for virtual machines
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: virt-enabling-cclm-for-vms
+
+toc::[]
+
+Cross-cluster live migration enables users to move a virtual machine (VM) workload from one {product-title} cluster to another cluster without disruption. You enable cross-cluster live migration by setting cluster feature gates in {VirtProductName} and {mtv-first}.
+
+.Prerequisites
+
+* {VirtProductName} 4.20 or later must be installed.
+
+* The {product-title} and {VirtProductName} minor release versions must match. For example, if the {product-title} version is 4.20.0, the {VirtProductName} must also be 4.20.0.
+
+* Two {product-title} clusters are required, and the migration network for both clusters must be connected to the same L2 network segment.
+
+* You must have cluster administration privileges and appropriate RBAC privileges to manage VMs on both clusters.
+
+:FeatureName: Cross-cluster live migration
+include::snippets/technology-preview.adoc[]
+
+include::modules/virt-setting-openshiftv-lm-feature-gates.adoc[leveloffset=+1]
+
+include::modules/virt-setting-mtv-lm-feature-gates.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/CNV-57760

Link to docs preview:
* https://101620--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-about-mtv-providers.html
* https://101620--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-configuring-cross-cluster-live-migration-network.html
* https://101620--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-enabling-cclm-for-vms.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Continuing the work from #100011 by @aspauldi.
Carrying forward all previous feedback and applying the remaining updates while Audrey is out of office