### PR TITLE
OSDOCS-16490: adds feature gates release note MicroShift

### DIFF
--- a/modules/microshift-4-21-new-features-enhancements.adoc
+++ b/modules/microshift-4-21-new-features-enhancements.adoc
@@ -10,23 +10,27 @@
 This release adds improvements related to the following components and concepts.
 
 //4.21 is not an EUS release, so one minor version update is supported
-[id="microshift-4-21-placeholder-feature1_{context}"]
-== placeholder feature 1
+[id="microshift-4-21-feature-gates_{context}"]
+== Feature gates now available for developers
+
+As an application developer, you now can experiment with upcoming Kubernetes features to evaluate their potential benefits for specific use cases. Enable feature gates to test new functions for current or future deployments. With this release, you can experiment with capabilities such as advanced CPU management, enhanced scheduling features, or experimental storage options. For more information, see the following link:
+
+* xref:../microshift_configuring/microshift-feature-gates.adoc#microshift-feature-gates[Using feature gates to develop solutions]
 
 //TODO add new features and enhancements as needed
-[id="microshift-4-21-placeholder-feature2_{context}"]
-== placeholder feature 2
+//[id="microshift-4-21-placeholder-feature2_{context}"]
+//== placeholder feature 2
 
 //TODO add new features and enhancements as needed
-[id="microshift-4-21-placeholder-feature3_{context}"]
-== placeholder feature 3
+//[id="microshift-4-21-placeholder-feature3_{context}"]
+//== placeholder feature 3
 
 //etc
 
-[id="microshift-4-21-doc-enhancements_{context}"]
-== Documentation enhancements
+//[id="microshift-4-21-doc-enhancements_{context}"]
+//== Documentation enhancements
 
-* enhancement bullet placeholder 1
+//* enhancement bullet placeholder 1
 
-* enhancement bullet placeholder 2
+//* enhancement bullet placeholder 2
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-16490](https://issues.redhat.com/browse/OSDOCS-16490)

Link to docs preview:
[Feature gates release note](https://101630--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html#microshift-4-21-feature-gates_release-notes)

Reviews:
- [x] QE has approved this change.
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Feature doc, https://github.com/openshift/openshift-docs/pull/101637
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
