### PR TITLE
OCPBUGS#63653: Updated the install config for configuring local node arbiter

### DIFF
--- a/modules/ipi-install-config-local-arbiter-node.adoc
+++ b/modules/ipi-install-config-local-arbiter-node.adoc
@@ -70,7 +70,6 @@ controlPlane: <4>
   platform:
     baremetal: {}
   replicas: 2 <5>
-featureSet: TechPreviewNoUpgrade
 platform:
   baremetal:
 # ...


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-63653](https://issues.redhat.com/browse/OCPBUGS-63653)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Configuring a local arbiter node](https://101660--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html#ipi-install-config-local-arbiter-node_ipi-install-installation-workflow)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->