### PR TITLE
OSSM-11157 [DOCS] Update version support table for 3.2

### DIFF
--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -6,193 +6,37 @@
 [id="ossm-release-notes-supported-versions_{context}"]
 = {SMProduct} supported versions
 
-See the following table for information about {SMProduct} 3.1.2 supported versions.
+[role="_abstract"]
+See the following table for information about {SMProduct} 3.2.0 supported versions.
 
-== {SMProduct} 3.1.2 supported versions
+== {SMProduct} 3.2.0 supported versions
 
 [cols="1,1"]
 |===
 | Feature | Supported versions
 
 |{SMProduct} 3 Operator
-|3.1.2
+|3.2.0
 
 |{SMProduct} `Istio` control plane resource
-|1.26.4
+|1.27.3
 
 |{ocp-product-title}
-|4.16 and later
+|4.18 and later
 
 | Envoy proxy
-| 1.34.6
+| 1.35.6
 
 | `IstioCNI` resource
-| 1.26.4
+| 1.27.3
+
+| `Ztunnel` resource
+| 1.27.3
 
 |Kiali Operator
-|2.11.3
+|2.17.1
 
 |Kiali control plane resource
-|2.11.3
+|2.17.1
 
 |===
-
-See the following table for information about {SMProduct} 3.1.1 supported versions.
-
-== {SMProduct} 3.1.1 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.1.1
-
-|{SMProduct} `Istio` control plane resource
-|1.26.3
-
-|{ocp-product-title}
-|4.16 and later
-
-| Envoy proxy
-| 1.34.3
-
-| `IstioCNI` resource
-| 1.26.3
-
-|Kiali Operator
-|2.11.2
-
-|===
-
-See the following table for information about {SMProduct} 3.1.0 supported versions.
-
-== {SMProduct} 3.1.0 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.1.0
-
-|{SMProduct} `Istio` control plane resource
-|1.26.2
-
-|{ocp-product-title}
-|4.16 and later
-
-| Envoy proxy
-| 1.34.2
-
-| `IstioCNI` resource
-| 1.26.2
-
-|Kiali Operator
-|2.11.1
-
-|===
-
-See the following table for information about {SMProduct} 3.0.3 supported versions.
-
-== {SMProduct} 3.0.3 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.0.3
-
-|{SMProduct} `Istio` control plane resource
-|1.24.6
-
-|{ocp-product-title}
-|4.14 and later
-
-| Envoy proxy
-| 1.32.6
-
-| `IstioCNI` resource
-| 1.24.6 ^[1]^
-
-|Kiali Operator
-|2.4.7
-
-|===
-
-. The `Istio` control plane and `IstioCNI` resources can be upgraded in any order, as long as their version difference is within one minor version.
-
-See the following table for information about {SMProduct} 3.0.2 supported versions.
-
-== {SMProduct} 3.0.2 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.0.2
-
-|{SMProduct} `Istio` control plane resource
-|1.24.5
-
-|{ocp-product-title}
-|4.14 and later
-
-| Envoy proxy
-| 1.32.6
-
-| `IstioCNI` resource
-| 1.24.5 ^[1]^
-|===
-
-See the following table for information about {SMProduct} 3.0.1 supported versions.
-
-== {SMProduct} 3.0.1 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.0.1
-
-|{SMProduct} `Istio` control plane resource
-|1.24.4
-
-|{ocp-product-title}
-|4.14 and later
-
-| Envoy proxy
-| 1.32.4
-
-| `IstioCNI` resource
-| 1.24.4 ^[1]^
-|===
-
-See the following table for information about {SMProduct} 3.0.0 supported versions.
-
-== {SMProduct} 3.0.0 supported versions
-
-[cols="1,1"]
-|===
-| Feature | Supported versions
-
-|{SMProduct} 3 Operator
-|3.0.0
-
-|{SMProduct} `Istio` control plane resource
-|1.24.3
-
-|{ocp-product-title}
-|4.14 and later
-
-| Envoy proxy
-| 1.32.4
-
-| `IstioCNI` resource
-| 1.24.3 ^[1]^
-|===
-
-//note to self for post GA: might be worth having Envoy proxy and IstioCNI attributes.

--- a/ossm-release-notes/ossm-release-notes-feature-support-tables.adoc
+++ b/ossm-release-notes/ossm-release-notes-feature-support-tables.adoc
@@ -6,20 +6,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{SMProductVersion} feature support tables provide guidance on feature availability in {SMProduct} 3.
+[role="_abstract"]
+{SMProductVersion} feature support tables give guidance on feature availability in {SMProduct} 3.
 
 [id="release-notes-definitions_{context}"]
 == Definitions
 
 For {SMProductName} 3, features that are Generally Available (GA) are fully supported and are suitable for production use.
 
-Technology Preview (TP) features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. See the link:https://access.redhat.com/support/offerings/techpreview[Technology Preview scope of support on the Red Hat Customer Portal] for more information about Technology Preview features.
+Technology Preview (TP) features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features give early access to upcoming product features, enabling customers to test functionality and give feedback during the development process. See the link:https://access.redhat.com/support/offerings/techpreview[Technology Preview scope of support on the Red Hat Customer Portal] for more information about Technology Preview features.
 
-Developer Preview (DP) features are not supported by Red Hat in any way and are not functionally complete or production-ready. Do not use Developer Preview features for production or business-critical workloads. Developer Preview features provide early access to upcoming product features in advance of their possible inclusion in a Red Hat product offering, enabling customers to test functionality and provide feedback during the development process. These features might not have any documentation, are subject to change or removal at any time, and testing is limited. Red Hat might provide ways to submit feedback on Developer Preview features without an associated SLA.
+Developer Preview (DP) features are not supported by Red Hat in any way and are not functionally complete or production-ready. Do not use Developer Preview features for production or business-critical workloads. Developer Preview features give early access to upcoming product features in advance of their possible inclusion in a Red Hat product offering, enabling customers to test functionality and give feedback during the development process. These features might not have any documentation, are subject to change or removal at any time, and testing is limited. Red Hat might give ways to submit feedback on Developer Preview features without an associated SLA.
 
 Not available (NA) features might not be available with {SMProductName} 3.
 
 include::modules/ossm-release-notes-sail-operator-apis.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-istio-deployment-lifecycle.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -28,15 +30,19 @@ include::modules/ossm-release-notes-istio-deployment-lifecycle.adoc[leveloffset=
 * xref:../install/ossm-istioctl-tool.adoc#ossm-support-for-istioctl_ossm-istioctl-tool[Support for Istioctl]
 
 include::modules/ossm-release-notes-istio-traffic-management.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-kubernetes-gateway-api.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-security-features.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-observability-features.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-consoles-and-dashboards.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-extensibility-features.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-istio-ambient-mode.adoc[leveloffset=+1]
 
-// commented out in case it is needed for GA
-//[role="_additional-resources"]
 //[id="additional-resources_{context}"]
 //.Additional resources
 

--- a/ossm-release-notes/ossm-release-notes-version-support-tables.adoc
+++ b/ossm-release-notes/ossm-release-notes-version-support-tables.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{SMProductName} supports the {SMProduct} 3 Operator, {SMProduct} `Istio` control plane resource, Envoy proxy, and the `IstioCNI` resource on supported versions of {ocp-product-title}.
+[role="_abstract"]
+{SMProductName} supports the {SMProduct} 3 Operator, {SMProduct} `{istio}` control plane resource, Envoy proxy, and the `IstioCNI` resource on supported versions of {ocp-product-title}.
 
 include::modules/ossm-release-notes-supported-versions.adoc[leveloffset=+1]
 
@@ -14,6 +15,5 @@ include::modules/ossm-release-notes-supported-versions.adoc[leveloffset=+1]
 [id="additional-resources-supported-versions_{context}"]
 .Additional resources
 
-* For the latest supported versions of {Kialiproduct}, {KialiServer}, and the {SMPlugin}, see xref:../observability/kiali/ossm-console-plugin.adoc#ossm-install-console-plugin_ossm-console-plugin[Installing {SMPlugin}].
+* xref:../observability/kiali/ossm-console-plugin.adoc#ossm-install-console-plugin_ossm-console-plugin[Installing {SMPlugin}].
 
-//Note to next release notes writer: also update ossm-console-plugin


### PR DESCRIPTION
Change type: Doc update; Update version support table for 3.2

Doc JIRA: https://issues.redhat.com/browse/OSSM-11157

Fix Version: [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Doc Preview: https://101662--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables.html

SME Review/QE Review: @jewertow @sridhargaddam 
Peer Review: @kaldesai 