### PR TITLE
OSDOCS-15647: modularizes backup and restore MicroShift

### DIFF
--- a/microshift_troubleshooting/microshift-troubleshoot-backup-restore.adoc
+++ b/microshift_troubleshooting/microshift-troubleshoot-backup-restore.adoc
@@ -1,65 +1,19 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="microshift-troubleshoot-backup-restore"]
 = Troubleshooting data backup and restore
+
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-troubleshoot-backup-and-restore
 
 toc::[]
 
-To troubleshoot failed data backups and restorations, check the basics first, such as data paths, storage configuration, and storage capacity.
+[role="_abstract"]
+To troubleshoot failed data backups and restorations, check the basics first. For example, user permissions, system health and configuration, and storage capacity.
 
-[id="troubleshoot-backup-restore-microshift-backup-data-failed_{context}"]
-== Backing up data failed
-Data backups are automatic on `rpm-ostree` systems. If you are not using an `rpm-ostree` system and attempted to create a manual backup, the following reasons can cause the backup to fail:
+include::modules/microshift-backup-data-failed.adoc[leveloffset=+1]
 
-* Not waiting several minutes after a system start to successfully stop {microshift-short}. The system must complete health checks and any other background processes before a back up can succeed.
-* If {microshift-short} stopped running because of an error, you cannot perform a backup of the data.
-** Make sure the system is healthy.
-** Stop it in a healthy state before attempting a backup.
-* If you do not have sufficient storage for the data, the backup fails. Ensure that you have enough storage for the {microshift-short} data.
-* If you do not have sufficient permissions, a backup can fail. Ensure you have the correct user permissions to create a backup and perform the required configurations.
+include::modules/microshift-backup-logs.adoc[leveloffset=+1]
 
-[id="troubleshoot-backup-restore-microshift-backup-logs_{context}"]
-== Backup logs
-* Logs print to the terminal console during manual backups.
-* Logs are automatically generated for `rpm-ostree` system automated backups as part of the {microshift-short} journal logs. You can check the logs by running the following command:
-+
-[source,terminal]
-----
-$ sudo journalctl -u microshift
-----
+include::modules/microshift-restore-data-failed.adoc[leveloffset=+1]
 
-[id="troubleshoot-backup-restore-microshift-restore-data-failed_{context}"]
-== Restoring data failed
-The restoration of data can fail for many reasons, including storage and permission issues. Mismatched data versions can cause failures when {microshift-short} restarts.
-
-[id="troubleshoot-backup-restore-microshift-RPM-OSTree-data-restore-failed_{context}"]
-=== RPM-OSTree-based systems data restore failed
-Data restorations are automatic on `rpm-ostree` systems, but can fail, for example:
-
-* The only backups that are restored on `rpm-ostree` systems are backups from the current deployment or a rollback deployment. Backups are not taken on an unhealthy system.
-
-** Only the latest backups that have corresponding deployments are retained. Outdated backups that do not have a matching deployment are automatically removed.
-
-** Data is usually not restored from a newer version of {microshift-short}.
-
-** Ensure that the data you are restoring follows same versioning pattern as the update path. For example, if the destination version of {microshift-short} is an older version than the version of the {microshift-short} data you are currently using, the restoration can fail.
-
-[id="troubleshoot-backup-restore-microshift-rpm-manual-restore-data-failed_{context}"]
-=== RPM-based manual data restore failed
-If you are using an RPM system that is not `rpm-ostree` and tried to restore a manual backup, the following reasons can cause the restoration to fail:
-
-* If {microshift-short} stopped running because of an error, you cannot restore data.
-** Make sure the system is healthy.
-** Start it in a healthy state before attempting to restore data.
-
-* If you do not have enough storage space allocated for the incoming data, the restoration fails.
-** Make sure that your current system storage is configured to accept the restored data.
-
-* You are attempting to restore data from a newer version of {microshift-short}.
-** Ensure that the data you are restoring follows same versioning pattern as the update path. For example, if the destination version of {microshift-short} is an older version than the version of the {microshift-short} data you are attempting to use, the restoration can fail.
-
-[id="troubleshoot-backup-restore-microshift-storage-migration-failed_{context}"]
-== Storage migration failed
-Storage migration failures are typically caused by substantial changes in custom resources (CRs) from one {microshift-short} to the next. If a storage migration fails, there is usually an unresolvable discrepancy between versions that requires manual review.
-
+include::modules/microshift-storage-migration-failed.adoc[leveloffset=+1]

--- a/microshift_troubleshooting/microshift-version.adoc
+++ b/microshift_troubleshooting/microshift-version.adoc
@@ -6,7 +6,8 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-To begin troubleshooting, determine which version of {product-title} you have installed.
+[role="_abstract"]
+To begin troubleshooting, you must know which version of {product-title} you have installed.
 
 include::modules/microshift-version-cli.adoc[leveloffset=+1]
 

--- a/modules/microshift-backup-data-failed.adoc
+++ b/modules/microshift-backup-data-failed.adoc
@@ -1,0 +1,18 @@
+
+// Module included in the following assemblies:
+//
+// * microshift_troubleshooting/microshift-troubleshoot-backup-restore.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-backup-data-failed_{context}"]
+= Data backup failure
+
+[role="_abstract"]
+Data backups are automatic on `rpm-ostree` systems. If you are not using an `rpm-ostree` system and attempted to create a manual backup, the following reasons can cause the backup to fail:
+
+* Not waiting several minutes after a system start to successfully stop {microshift-short}. The system must complete health checks and any other background processes before a back up can succeed.
+* If {microshift-short} stopped running because of an error, you cannot perform a backup of the data.
+** Make sure the system is healthy.
+** Stop it in a healthy state before attempting a backup.
+* If you do not have enough storage for the data, the backup fails. Ensure that you have enough storage for {microshift-short} data.
+* If you do not have the required user permissions, a backup can fail. Ensure that you have the correct user permissions to create a backup and perform the required configurations.

--- a/modules/microshift-backup-logs.adoc
+++ b/modules/microshift-backup-logs.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * microshift_troubleshooting/microshift-troubleshoot-backup-restore.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-checking-backup-logs_{context}"]
+= Checking backup logs
+
+[role="_abstract"]
+Backup logs can help you identify where backups are and what processes occurred during manual and automatic backups.
+
+* Logs print to the terminal console during manual backups.
+* Logs are automatically generated for `rpm-ostree` system automated backups as part of the {microshift-short} journal logs.
+
+.Procedure
+
+* Check the logs by running the following command:
++
+[source,terminal]
+----
+$ sudo journalctl -u microshift
+----

--- a/modules/microshift-etcd-version.adoc
+++ b/modules/microshift-etcd-version.adoc
@@ -7,6 +7,7 @@
 [id="microshift-version-etcd_{context}"]
 = Checking the etcd version
 
+[role="_abstract"]
 You can get the version information for the etcd database included with your {microshift-short} by using one or both of the following methods, depending on the level of information that you need.
 
 .Procedure
@@ -21,7 +22,7 @@ $ microshift-etcd version
 .Example output
 [source,terminal,subs="attributes+"]
 ----
-microshift-etcd Version: 4.17.1
+microshift-etcd Version: 4.20.0
 Base etcd Version: 3.5.13
 ----
 
@@ -33,15 +34,15 @@ $ microshift-etcd version -o json
 ----
 +
 .Example output
-[source,terminal,subs="attributes+"]
+[source,terminal]
 ----
 {
   "major": "4",
-  "minor": "16",
-  "gitVersion": "4.17.1~rc.1",
+  "minor": "20",
+  "gitVersion": "4.20.0",
   "gitCommit": "140777711962eb4e0b765c39dfd325fb0abb3622",
   "gitTreeState": "clean",
-  "buildDate": "2024-05-10T16:37:53Z",
+  "buildDate": "2025-11-03T16:37:53Z",
   "goVersion": "go1.21.9"
   "compiler": "gc",
   "platform": "linux/amd64",

--- a/modules/microshift-restore-data-failed.adoc
+++ b/modules/microshift-restore-data-failed.adoc
@@ -1,0 +1,39 @@
+
+// Module included in the following assemblies:
+//
+// * microshift_troubleshooting/microshift-troubleshoot-backup-restore.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-restore-data-failed_{context}"]
+= Data restoration failure
+
+[role="_abstract"]
+The restoration of data can fail for many reasons, including storage and permission issues. Mismatched data versions can cause failures when {microshift-short} restarts.
+
+[id="microshift-image-based-systems-data-restore-failed_{context}"]
+== Image-based systems data restore failed
+
+Data restorations are automatic on `rpm-ostree` systems, but can fail, for example:
+
+* The only backups that are restored on `rpm-ostree` systems are backups from the current deployment or a rollback deployment. Backups are not taken on an unhealthy system.
+
+** Only the latest backups that have corresponding deployments are retained. Outdated backups that do not have a matching deployment are automatically removed.
+
+** Data is usually not restored from a newer version of {microshift-short}.
+
+** Ensure that the data you are restoring follows same versioning pattern as the update path. For example, if the destination version of {microshift-short} is an older version than the version of the {microshift-short} data you are currently using, the restoration can fail.
+
+[id="microshift-rpm-manual-restore-data-failed_{context}"]
+== RPM-based manual data restore failed
+
+If you are using an RPM system that is not `rpm-ostree` and tried to restore a manual backup, the following reasons can cause the restoration to fail:
+
+* If {microshift-short} stopped running because of an error, you cannot restore data.
+** Make sure the system is healthy.
+** Start it in a healthy state before attempting to restore data.
+
+* If you do not have enough storage space allocated for the incoming data, the restoration fails.
+** Make sure that your current system storage is configured to accept the restored data.
+
+* You are attempting to restore data from a newer version of {microshift-short}.
+** Ensure that the data you are restoring follows same versioning pattern as the update path. For example, if the destination version of {microshift-short} is an older version than the version of the {microshift-short} data you are attempting to use, the restoration can fail.

--- a/modules/microshift-storage-migration-failed.adoc
+++ b/modules/microshift-storage-migration-failed.adoc
@@ -1,0 +1,13 @@
+
+// Module included in the following assemblies:
+//
+// * microshift_troubleshooting/microshift-troubleshoot-backup-restore.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-storage-migration-failed_{context}"]
+= Storage migration failure
+
+[role="_abstract"]
+Storage migration failures are typically caused by significant changes in custom resources (CRs) from one {microshift-short} version to the next.
+
+* If a storage migration fails, there is usually an unresolvable discrepancy between versions that requires manual review.

--- a/modules/microshift-version-api.adoc
+++ b/modules/microshift-version-api.adoc
@@ -6,11 +6,12 @@
 [id="microshift-version-api_{context}"]
 = Checking the {microshift-short} version using the API
 
+[role="_abstract"]
 To begin troubleshooting, you must know your {microshift-short} version. One way to get this information is by using the API.
 
 .Procedure
 
-* To get the version number using the OpenShift CLI (`oc`), view the `kube-public/microshift-version` config map by running the following command:
+* To get the version number using the {oc-first}, view the `kube-public/microshift-version` config map by running the following command:
 +
 [source,terminal]
 ----
@@ -23,12 +24,11 @@ $ oc get configmap -n kube-public microshift-version -o yaml
 apiVersion: v1
 data:
   major: "4"
-  minor: "13"
-  version: 4.13.8-0.microshift-fa441af87431
+  minor: "20"
+  version: 4.20.0-0.microshift-fa441af87431
 kind: ConfigMap
 metadata:
-  creationTimestamp: "2023-08-03T21:06:11Z"
+  creationTimestamp: "2025-11-03T21:06:11Z"
   name: microshift-version
   namespace: kube-public
 ----
-//update output to 4.14

--- a/modules/microshift-version-cli.adoc
+++ b/modules/microshift-version-cli.adoc
@@ -6,7 +6,8 @@
 [id="microshift-version-cli_{context}"]
 = Checking the version using the command-line interface
 
-To begin troubleshooting, you must know your {microshift-short} version. One way to get this information is by using the CLI.
+[role="_abstract"]
+To begin troubleshooting, you must know your {microshift-short} version. One way to get this information is by using the command-line interface (CLI).
 
 .Procedure
 
@@ -20,6 +21,6 @@ $ microshift version
 .Example output
 [source,terminal,subs="attributes+"]
 ----
-{product-title} Version: {product-version}-0.microshift-e6980e25
+{microshift-short} Version: {product-version}-0.microshift-e6980e25
 Base OCP Version: {product-version}
 ----


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-15647](https://issues.redhat.com/browse/OSDOCS-15647)

Link to docs preview:
https://101688--ocpdocs-pr.netlify.app/microshift/latest/microshift_troubleshooting/microshift-troubleshoot-backup-restore.html
https://101688--ocpdocs-pr.netlify.app/microshift/latest/microshift_support/microshift-etcd.html#microshift-version-etcd_microshift-etcd
https://101688--ocpdocs-pr.netlify.app/microshift/latest/microshift_troubleshooting/microshift-version.html

QE review:
- N/A pre-migration structure only, no technical content changes

Additional info:
Also touches up the version check assembly for conversion, since it was there and an easy fix.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
