### PR TITLE
OSDOCS-17179 [NETOBSERV] Outdated doc for netobserv CLI

### DIFF
--- a/modules/network-observability-netobserv-cli-install.adoc
+++ b/modules/network-observability-netobserv-cli-install.adoc
@@ -1,53 +1,66 @@
 // Module included in the following assemblies:
-
+//
 // * observability/network_observability/netobserv_cli/netobserv-cli-install.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-cli-install_{context}"]
 = Installing the Network Observability CLI
 
-Installing the Network Observability CLI (`oc netobserv`) is a separate procedure from the Network Observability Operator installation. This means that, even if you have the Operator installed from the software catalog, you need to install the CLI separately.
+[role="_abstract"]
+The Network Observability CLI gives you a lightweight way to quickly debug and troubleshoot network observability. It must be installed separately.
+
+Installing the Network Observability CLI (`oc netobserv`) is a separate procedure from the Network Observability Operator installation. This means that, even if the Operator is installed from the software catalog, the `CLI` must be installed separately.
 
 [NOTE]
 ====
-You can optionally use Krew to install the `netobserv` CLI plugin. For more information, see "Installing a CLI plugin with Krew".
+Users can optionally use Krew to install the `netobserv` CLI plugin. For more information, see "Installing a CLI plugin with Krew".
 ====
 
 .Prerequisites
 * You must install the {oc-first}.
 * You must have a macOS or Linux operating system.
+* You must install either `docker` or `podman`.
+
+[NOTE]
+====
+You can use `podman` or `docker` to run the installation commands. This procedure uses `podman`.
+====
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/cgw/netobserv/latest/[`oc netobserv` file] that corresponds with your architecture. For example, for the `amd64` archive:
+. Log in to the *Red Hat registry* by running the following command:
 +
 [source,terminal]
 ----
-$ curl -LO https://mirror.openshift.com/pub/cgw/netobserv/latest/oc-netobserv-amd64
+$ podman login registry.redhat.io
 ----
-. Make the file executable:
+
+. Extract the `oc-netobserv` file from the image by running the following commands:
 +
 [source,terminal]
 ----
-$ chmod +x ./oc-netobserv-amd64
+$ podman create --name netobserv-cli registry.redhat.io/network-observability/network-observability-cli-rhel9:1.10
+$ podman cp netobserv-cli:/oc-netobserv .
+$ podman rm netobserv-cli
 ----
-. Move the extracted `netobserv-cli` binary to a directory that is on your `PATH`, such as `/usr/local/bin/`:
+
+. Move the extracted file to a directory that is on the system's `PATH`, such as `/usr/local/bin/`, by running the following command:
 +
 [source,terminal]
 ----
-$ sudo mv ./oc-netobserv-amd64 /usr/local/bin/oc-netobserv
+$ sudo mv oc-netobserv /usr/local/bin/
 ----
 
 .Verification
 
-* Verify that `oc netobserv` is available:
+. Verify that `oc netobserv` is available:
 +
 [source,terminal]
 ----
 $ oc netobserv version
 ----
 +
-.Example output
+This command should produce an outcome similar to the following example:
 [source,terminal]
 ----
 Netobserv CLI version <version>


### PR DESCRIPTION
[OSDOCS-17179](https://issues.redhat.com//browse/OSDOCS-17179) [NETOBSERV] Outdated doc for netobserv CLI

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-17179

Link to docs preview:
* Installing the Network Observability CLI: https://101693--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-install.html#network-observability-cli-install_netobserv-cli-install 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Qualifies for the condensed change management process as it meets the 3 requirements: urgent as driven by ProdSec, straightforward, unlikely to generate discussion among stakeholders as stakeholders have already discussed.
* [role="_abstract"] added to "Installing the Network Observability CLI" only. All other modules are being handled by a separate Jira issue.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
