### PR TITLE
UDN-remove-referenced: Removed the a UserDefinedNetwork and NetworkAt…

### DIFF
--- a/modules/configuring-ovnk-additional-networks.adoc
+++ b/modules/configuring-ovnk-additional-networks.adoc
@@ -13,7 +13,7 @@ The {openshift-networking} OVN-Kubernetes network plugin allows the configuratio
 Pod and multi-network policy creation might remain in a pending state until the OVN-Kubernetes control plane agent in the nodes processes the associated `network-attachment-definition` CRD.
 ====
 
-You can configure an OVN-Kubernetes secondary network in layer 2, layer 3, or localnet topologies. For more information about features supported on these topologies, see "UserDefinedNetwork and NetworkAttachmentDefinition support matrix". 
+You can configure an OVN-Kubernetes secondary network in layer 2, layer 3, or localnet topologies. 
 
 The following sections provide example configurations for each of the topologies that OVN-Kubernetes currently allows for secondary networks.
 


### PR DESCRIPTION
The [4.17 Multiple networks](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/multiple_networks/index#configuration-ovnk-additional-networks_configuring-additional-network-ovnk) book has a reference to the "UserDefinedNetwork and NetworkAttachmentDefinition support matrix" document, but this document or section does not exist in 4.17.

See this [Slack thread](https://redhat-internal.slack.com/archives/CDCP2LA9L/p1762265539423539) for confirmation.


Version(s):
4.17

Issue:
N/A

Link to docs preview:

[Configuration for an OVN-Kubernetes secondary network](https://101697--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-ovnk.html#configuration-ovnk-additional-networks_configuring-additional-network-ovnk)
