### PR TITLE
Testing claude callout transforms

### DIFF
--- a/modules/aws-outposts-load-balancer-clb.adoc
+++ b/modules/aws-outposts-load-balancer-clb.adoc
@@ -82,8 +82,8 @@ metadata:
   name: <application_name>
   namespace: <application_namespace>
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-subnets: <aws_subnet> # <1>
-    service.beta.kubernetes.io/aws-load-balancer-target-node-labels: <key_name>=<value> # <2>
+    service.beta.kubernetes.io/aws-load-balancer-subnets: <aws_subnet>
+    service.beta.kubernetes.io/aws-load-balancer-target-node-labels: <key_name>=<value>
 spec:
   ports:
   - name: http
@@ -94,8 +94,10 @@ spec:
     app: <application_name>
   type: LoadBalancer
 ----
-<1> Specify the subnet ID for the AWS VPC cluster.
-<2> Specify the key-value pair that matches the pair in the node label.
+where:
+
+<aws_subnet>:: Specifies the subnet ID for the AWS VPC cluster.
+<key_name>=<value>:: Specifies the key-value pair that matches the pair in the node label.
 
 . Create the `Service` CR by running the following command:
 +

--- a/modules/aws-outposts-machine-set.adoc
+++ b/modules/aws-outposts-machine-set.adoc
@@ -102,8 +102,8 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
-  name: <infrastructure_id>-outposts-<availability_zone> # <2>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+  name: <infrastructure_id>-outposts-<availability_zone>
   namespace: openshift-machine-api
 spec:
   replicas: 1
@@ -126,46 +126,48 @@ spec:
       providerSpec:
         value:
           ami:
-            id: <ami_id> # <3>
+            id: <ami_id>
           apiVersion: machine.openshift.io/v1beta1
           blockDevices:
             - ebs:
                 volumeSize: 120
-                volumeType: gp2 # <4>
+                volumeType: gp2
           credentialsSecret:
             name: aws-cloud-credentials
           deviceIndex: 0
           iamInstanceProfile:
             id: <infrastructure_id>-worker-profile
-          instanceType: m5.xlarge # <5>
+          instanceType: m5.xlarge
           kind: AWSMachineProviderConfig
           placement:
             availabilityZone: <availability_zone>
-            region: <region> # <6>
+            region: <region>
           securityGroups:
             - filters:
               - name: tag:Name
                 values:
                   - <infrastructure_id>-worker-sg
           subnet:
-            id: <subnet_id> # <7>
+            id: <subnet_id>
           tags:
             - name: kubernetes.io/cluster/<infrastructure_id>
               value: owned
           userDataSecret:
             name: worker-user-data
-      taints: # <8>
+      taints:
         - key: node-role.kubernetes.io/outposts
           effect: NoSchedule
 ----
-<1> Specifies the cluster infrastructure ID.
-<2> Specifies the name of the compute machine set. The name is composed of the cluster infrastructure ID, the `outposts` role name, and the Outpost availability zone.
-<3> Specifies the Amazon Machine Image (AMI) ID.
-<4> Specifies the EBS volume type. AWS Outposts requires gp2 volumes.
-<5> Specifies the AWS instance type. You must use an instance type that is configured in your Outpost.
-<6> Specifies the AWS region in which the Outpost availability zone exists.
-<7> Specifies the dedicated subnet for your Outpost.
-<8> Specifies a taint to prevent workloads from being scheduled on nodes that have the `node-role.kubernetes.io/outposts` label. To schedule user workloads in the Outpost, you must specify a corresponding toleration in the `Deployment` resource for your application.
+where:
+
+<infrastructure_id> (metadata.labels):: Specifies the cluster infrastructure ID.
+<infrastructure_id>-outposts-<availability_zone>:: Specifies the name of the compute machine set. The name is composed of the cluster infrastructure ID, the `outposts` role name, and the Outpost availability zone.
+<ami_id>:: Specifies the Amazon Machine Image (AMI) ID.
+`volumeType: gp2`:: Specifies the EBS volume type. AWS Outposts requires gp2 volumes.
+`instanceType`:: Specifies the AWS instance type. You must use an instance type that is configured in your Outpost.
+<region>:: Specifies the AWS region in which the Outpost availability zone exists.
+<subnet_id>:: Specifies the dedicated subnet for your Outpost.
+`taints`:: Specifies a taint to prevent workloads from being scheduled on nodes that have the `node-role.kubernetes.io/outposts` label. To schedule user workloads in the Outpost, you must specify a corresponding toleration in the `Deployment` resource for your application.
 --
 
 . Save your changes.

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -200,10 +200,12 @@ Ensure that the architecture of the `$RELEASE_IMAGE` matches the architecture of
 [source,terminal]
 ----
 $ oc image extract $CCO_IMAGE \
-  --file="/usr/bin/ccoctl.<rhel_version>" \// <1>
+  --file="/usr/bin/ccoctl.<rhel_version>" \//
   -a ~/.pull-secret
 ----
-<1> For `<rhel_version>`, specify the value that corresponds to the version of {op-system-base-full} that the host uses.
+where:
++
+<rhel_version>:: Specifies the value that corresponds to the version of {op-system-base-full} that the host uses.
 If no value is specified, `ccoctl.rhel8` is used by default.
 The following values are valid:
 +

--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -146,13 +146,15 @@ $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}'
 $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
-  --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+  --included \
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \
+  --to=<path_to_directory_for_credentials_requests>
 ----
-<1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+where:
+
+`--included`:: Specifies that the `--included` parameter includes only the manifests that your specific cluster configuration requires.
+<path_to_directory_with_installation_configuration>:: Specifies the location of the `install-config.yaml` file.
+<path_to_directory_for_credentials_requests>:: Specifies the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 [NOTE]
 ====
@@ -176,17 +178,19 @@ ifdef::aws-sts[]
 [source,terminal]
 ----
 $ ccoctl aws create-all \
-  --name=<name> \// <1>
-  --region=<aws_region> \// <2>
-  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <3>
-  --output-dir=<path_to_ccoctl_output_dir> \// <4>
-  --create-private-s3-bucket <5>
+  --name=<name> \
+  --region=<aws_region> \
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --output-dir=<path_to_ccoctl_output_dir> \
+  --create-private-s3-bucket
 ----
-<1> Specify the name used to tag any cloud resources that are created for tracking.
-<2> Specify the AWS region in which cloud resources will be created.
-<3> Specify the directory containing the files for the component `CredentialsRequest` objects.
-<4> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
-<5> Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
+where:
+
+<name>:: Specifies the name used to tag any cloud resources that are created for tracking.
+<aws_region>:: Specifies the AWS region in which cloud resources will be created.
+<path_to_credentials_requests_directory>:: Specifies the directory containing the files for the component `CredentialsRequest` objects.
+<path_to_ccoctl_output_dir>:: Optional: Specifies the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+`--create-private-s3-bucket`:: Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
 +
 [NOTE]
 ====
@@ -197,15 +201,17 @@ ifdef::google-cloud-platform[]
 [source,terminal]
 ----
 $ ccoctl gcp create-all \
-  --name=<name> \// <1>
-  --region=<gcp_region> \// <2>
-  --project=<gcp_project_id> \// <3>
-  --credentials-requests-dir=<path_to_credentials_requests_directory> <4>
+  --name=<name> \
+  --region=<gcp_region> \
+  --project=<gcp_project_id> \
+  --credentials-requests-dir=<path_to_credentials_requests_directory>
 ----
-<1> Specify the user-defined name for all created {gcp-short} resources used for tracking. If you plan to install the {gcp-short} Filestore Container Storage Interface (CSI) Driver Operator, retain this value.
-<2> Specify the {gcp-short} region in which cloud resources will be created.
-<3> Specify the {gcp-short} project ID in which cloud resources will be created.
-<4> Specify the directory containing the files of `CredentialsRequest` manifests to create {gcp-short} service accounts.
+where:
+
+<name>:: Specifies the user-defined name for all created {gcp-short} resources used for tracking. If you plan to install the {gcp-short} Filestore Container Storage Interface (CSI) Driver Operator, retain this value.
+<gcp_region>:: Specifies the {gcp-short} region in which cloud resources will be created.
+<gcp_project_id>:: Specifies the {gcp-short} project ID in which cloud resources will be created.
+<path_to_credentials_requests_directory>:: Specifies the directory containing the files of `CredentialsRequest` manifests to create {gcp-short} service accounts.
 +
 [NOTE]
 ====
@@ -216,23 +222,25 @@ ifdef::azure-workload-id[]
 [source,terminal]
 ----
 $ ccoctl azure create-all \
-  --name=<azure_infra_name> \// <1>
-  --output-dir=<ccoctl_output_dir> \// <2>
-  --region=<azure_region> \// <3>
-  --subscription-id=<azure_subscription_id> \// <4>
-  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <5>
-  --dnszone-resource-group-name=<azure_dns_zone_resource_group_name> \// <6>
-  --tenant-id=<azure_tenant_id> \// <7>
-  --network-resource-group-name <azure_resource_group> <8>
+  --name=<azure_infra_name> \
+  --output-dir=<ccoctl_output_dir> \
+  --region=<azure_region> \
+  --subscription-id=<azure_subscription_id> \
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --dnszone-resource-group-name=<azure_dns_zone_resource_group_name> \
+  --tenant-id=<azure_tenant_id> \
+  --network-resource-group-name <azure_resource_group>
 ----
-<1> Specify the user-defined name for all created Azure resources used for tracking.
-<2> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
-<3> Specify the Azure region in which cloud resources will be created.
-<4> Specify the Azure subscription ID to use.
-<5> Specify the directory containing the files for the component `CredentialsRequest` objects.
-<6> Specify the name of the resource group containing the cluster's base domain Azure DNS zone.
-<7> Specify the Azure tenant ID to use.
-<8> Optional: Specify the virtual network resource group if it is different from the cluster resource group.
+where:
+
+<azure_infra_name>:: Specifies the user-defined name for all created Azure resources used for tracking.
+<ccoctl_output_dir>:: Optional: Specifies the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+<azure_region>:: Specifies the Azure region in which cloud resources will be created.
+<azure_subscription_id>:: Specifies the Azure subscription ID to use.
+<path_to_credentials_requests_directory>:: Specifies the directory containing the files for the component `CredentialsRequest` objects.
+<azure_dns_zone_resource_group_name>:: Specifies the name of the resource group containing the cluster's base domain Azure DNS zone.
+<azure_tenant_id>:: Specifies the Azure tenant ID to use.
+<azure_resource_group>:: Optional: Specifies the virtual network resource group if it is different from the cluster resource group.
 +
 [NOTE]
 ====

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -56,13 +56,15 @@ This command also creates a private key that the cluster requires during install
 [source,terminal]
 ----
 $ ccoctl aws create-identity-provider \
-  --name=<name> \// <1>
-  --region=<aws_region> \// <2>
-  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public <3>
+  --name=<name> \
+  --region=<aws_region> \
+  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public
 ----
-<1> `<name>` is the name used to tag any cloud resources that are created for tracking.
-<2> `<aws-region>` is the AWS region in which cloud resources will be created.
-<3> `<path_to_ccoctl_output_dir>` is the path to the public key file that the `ccoctl aws create-key-pair` command generated.
+where:
+
+<name>:: Specifies the name used to tag any cloud resources that are created for tracking.
+<aws_region>:: Specifies the AWS region in which cloud resources will be created.
+<path_to_ccoctl_output_dir>:: Specifies the path to the public key file that the `ccoctl aws create-key-pair` command generated.
 +
 .Example output
 [source,text]
@@ -94,13 +96,15 @@ $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}'
 $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
-  --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+  --included \
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \
+  --to=<path_to_directory_for_credentials_requests>
 ----
-<1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+where:
+
+`--included`:: Specifies that the `--included` parameter includes only the manifests that your specific cluster configuration requires.
+<path_to_directory_with_installation_configuration>:: Specifies the location of the `install-config.yaml` file.
+<path_to_directory_for_credentials_requests>:: Specifies the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 
 .. Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the following command:
 +

--- a/modules/cco-ccoctl-install-creating-manifests.adoc
+++ b/modules/cco-ccoctl-install-creating-manifests.adoc
@@ -120,10 +120,12 @@ baseDomain: example.com
 # ...
 platform:
   azure:
-    resourceGroupName: <azure_infra_name> # <1>
+    resourceGroupName: <azure_infra_name>
 # ...
 ----
-<1> This value must match the user-defined name for Azure resources that was specified with the `--name` argument of the `ccoctl azure create-all` command.
+where:
++
+<azure_infra_name>:: This value must match the user-defined name for Azure resources that was specified with the `--name` argument of the `ccoctl azure create-all` command.
 endif::azure-workload-id[]
 
 . If you have not previously created installation manifest files, do so by running the following command:

--- a/modules/cli-logging-in-kubeadmin.adoc
+++ b/modules/cli-logging-in-kubeadmin.adoc
@@ -92,10 +92,11 @@ endif::gcp[]
 +
 [source,terminal]
 ----
-$ export KUBECONFIG=<installation_directory>/auth/kubeconfig <1>
+$ export KUBECONFIG=<installation_directory>/auth/kubeconfig
 ----
-<1> For `<installation_directory>`, specify the path to the directory that you stored
-the installation files in.
+where:
++
+<installation_directory>:: Specifies the path to the directory that you stored the installation files in.
 
 . Verify you can run `oc` commands successfully using the exported configuration by running the following command:
 +

--- a/modules/create-user-workloads-aws-edge.adoc
+++ b/modules/create-user-workloads-aws-edge.adoc
@@ -30,20 +30,20 @@ After you extend an {product-title} in an AWS VPC cluster into an Outpost, you c
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: <application_name> # <1>
+  name: <application_name>
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: <application_name>
-  namespace: <application_namespace> # <2>
+  namespace: <application_namespace>
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
-  storageClassName: gp2-csi # <3>
+  storageClassName: gp2-csi
   volumeMode: Filesystem
 ---
 apiVersion: apps/v1
@@ -60,14 +60,14 @@ spec:
     metadata:
       labels:
         app: <application_name>
-        location: outposts # <4>
+        location: outposts
     spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      nodeSelector: # <5>
+      nodeSelector:
         node-role.kubernetes.io/outpost: ''
-      tolerations: # <6>
+      tolerations:
       - key: "node-role.kubernetes.io/outposts"
         operator: "Equal"
         value: ""
@@ -91,12 +91,14 @@ spec:
         persistentVolumeClaim:
           claimName: <application_name>
 ----
-<1> Specify a name for your application.
-<2> Specify a namespace for your application. The application namespace can be the same as the application name.
-<3> Specify the storage class name. For an edge compute configuration, you must use the `gp2-csi` storage class.
-<4> Specify a label to identify workloads deployed in the Outpost.
-<5> Specify the node selector label that targets edge compute nodes.
-<6> Specify tolerations that match the `key` and `effects` taints in the compute machine set for your edge compute machines. Set the `value` and `operator` tolerations as shown.
+where:
+
+<application_name> (metadata.name):: Specifies a name for your application.
+<application_namespace>:: Specifies a namespace for your application. The application namespace can be the same as the application name.
+`gp2-csi`:: Specifies the storage class name. For an edge compute configuration, you must use the `gp2-csi` storage class.
+`location: outposts`:: Specifies a label to identify workloads deployed in the Outpost.
+`nodeSelector`:: Specifies the node selector label that targets edge compute nodes.
+`tolerations`:: Specifies tolerations that match the `key` and `effects` taints in the compute machine set for your edge compute machines. Set the `value` and `operator` tolerations as shown.
 
 . Create the `Deployment` resource by running the following command:
 +
@@ -111,7 +113,7 @@ $ oc create -f <application_deployment>.yaml
 [source,yaml]
 ----
 apiVersion: v1
-kind: Service # <1>
+kind: Service
 metadata:
   name:  <application_name>
   namespace: <application_namespace>
@@ -121,11 +123,13 @@ spec:
       targetPort: 8080
       protocol: TCP
   type: NodePort
-  selector: # <2>
+  selector:
     app: <application_name>
 ----
-<1> Defines the `service` resource.
-<2> Specify the label type to apply to managed pods.
+where:
+
+`kind: Service`:: Defines the `service` resource.
+`selector`:: Specifies the label type to apply to managed pods.
 
 . Create the `Service` CR by running the following command:
 +

--- a/modules/install-creating-install-config-aws-edge-zones.adoc
+++ b/modules/install-creating-install-config-aws-edge-zones.adoc
@@ -38,15 +38,19 @@ ifdef::local-zone[]
 # ...
 platform:
   aws:
-    region: <region_name> <1>
+    region: <region_name>
 compute:
 - name: edge
   platform:
     aws:
-      zones: <2>
+      zones:
       - <local_zone_name>
 #...
 ----
+where:
+
+<region_name>:: Specifies the AWS Region name.
+<local_zone_name>:: Specifies the {zone-type} name. The list of {zone-type} names that you use must exist in the same AWS Region specified in the `platform.aws.region` field.
 endif::local-zone[]
 ifdef::wavelength-zone[]
 +
@@ -55,18 +59,20 @@ ifdef::wavelength-zone[]
 # ...
 platform:
   aws:
-    region: <region_name> <1>
+    region: <region_name>
 compute:
 - name: edge
   platform:
     aws:
-      zones: <2>
+      zones:
       - <wavelength_zone_name>
 #...
 ----
+where:
+
+<region_name>:: Specifies the AWS Region name.
+<wavelength_zone_name>:: Specifies the {zone-type} name. The list of {zone-type} names that you use must exist in the same AWS Region specified in the `platform.aws.region` field.
 endif::wavelength-zone[]
-<1> The AWS Region name.
-<2> The list of {zone-type} names that you use must exist in the same AWS Region specified in the `platform.aws.region` field.
 +
 .Example of a configuration to install a cluster in the `us-west-2` AWS Region that extends edge nodes to {zone-type} in `Los Angeles` and `Las Vegas` locations
 +

--- a/modules/installation-applying-aws-security-groups.adoc
+++ b/modules/installation-applying-aws-security-groups.adoc
@@ -34,8 +34,8 @@ compute:
   platform:
     aws:
       additionalSecurityGroupIDs:
-        - sg-1 <1>
-        - sg-2
+        - <security_group_id>
+        - <security_group_id>
   replicas: 3
 controlPlane:
   hyperthreading: Enabled
@@ -43,16 +43,18 @@ controlPlane:
   platform:
     aws:
       additionalSecurityGroupIDs:
-        - sg-3
-        - sg-4
+        - <security_group_id>
+        - <security_group_id>
   replicas: 3
 platform:
   aws:
     region: us-east-1
-    subnets: <2>
-      - subnet-1
-      - subnet-2
-      - subnet-3
+    subnets:
+      - <subnet_id>
+      - <subnet_id>
+      - <subnet_id>
 ----
-<1> Specify the name of the security group as it appears in the Amazon EC2 console, including the `sg` prefix.
-<2> Specify subnets for each availability zone that your cluster uses.
+where:
+
+<security_group_id>:: Specifies the name of the security group as it appears in the Amazon EC2 console, including the `sg` prefix.
+<subnet_id>:: Specifies subnets for each availability zone that your cluster uses.

--- a/modules/installation-aws-add-zone-locations.adoc
+++ b/modules/installation-aws-add-zone-locations.adoc
@@ -71,10 +71,12 @@ Depending on the AWS Region, the list of available zones might be long. The comm
 [source,terminal]
 ----
 $ aws ec2 modify-availability-zone-group \
-    --group-name "<value_of_GroupName>" \// <1>
+    --group-name "<value_of_GroupName>" \//
     --opt-in-status opted-in
 ----
-<1> Replace `<value_of_GroupName>` with the name of the group of the {zone-type} where you want to create subnets.
+where:
++
+<value_of_GroupName>:: Replace with the name of the group of the {zone-type} where you want to create subnets.
 ifdef::local-zone[]
 For example, specify `us-east-1-nyc-1` to use the zone `us-east-1-nyc-1a` (US East New York).
 endif::local-zone[]

--- a/modules/installation-aws-config-yaml-customizations.adoc
+++ b/modules/installation-aws-config-yaml-customizations.adoc
@@ -17,34 +17,35 @@ For a full list and description of all installation configuration parameters, se
 .Sample `install-config.yaml` file for {aws-short}
 [source,yaml]
 ----
-apiVersion: v1 <1>
+apiVersion: v1
 baseDomain: example.com
 sshKey: ssh-ed25519 AAAA...
 pullSecret: '{"auths": ...}'
 metadata:
   name: example-cluster
-controlPlane: <2>
+controlPlane:
   name: master
   platform:
     aws:
       type: m6i.xlarge
   replicas: 3
-compute: <3>
+compute:
 -  name: worker
   platform:
     aws:
       type: c5.4xlarge
   replicas: 3
-networking: <4>
+networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-platform: <5>
+platform:
   aws:
     region: us-west-2
 ----
-<1> Parameters at the first level of indentation apply to the cluster globally.
-<2> The `controlPlane` stanza applies to control plane machines.
-<3> The `compute` stanza applies to compute machines.
-<4> The `networking` stanza applies to the cluster networking configuration. If you do not provide networking values, the installation program provides default values.
-<5> The `platform` stanza applies to the infrastructure platform that hosts the cluster.
+where:
+
+<controlPlane>:: Specifies the configuration for control plane machines.
+<compute>:: Specifies the configuration for compute machines.
+<networking>:: Specifies the cluster networking configuration. If you do not provide networking values, the installation program provides default values.
+<platform>:: Specifies the configuration for the infrastructure platform that hosts the cluster.

--- a/modules/installation-aws-edge-compute-pools-examples.adoc
+++ b/modules/installation-aws-edge-compute-pools-examples.adoc
@@ -77,7 +77,7 @@ compute:
   platform:
     aws:
       additionalSecurityGroupIDs:
-        - sg-1 <1>
+        - sg-1
         - sg-2
 platform:
   aws:
@@ -85,7 +85,9 @@ platform:
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ----
-<1> Specify the name of the security group as it is displayed on the Amazon EC2 console. Ensure that you include the `sg` prefix.
+where:
+
+<additionalSecurityGroupIDs>:: Specifies the name of the security group as it is displayed on the Amazon EC2 console. Ensure that you include the `sg` prefix.
 
 ifeval::["{context}" == "installing-aws-localzone"]
 :!local-zone:

--- a/modules/installation-aws-marketplace-subscribe.adoc
+++ b/modules/installation-aws-marketplace-subscribe.adoc
@@ -60,19 +60,21 @@ compute:
   name: worker
   platform:
     aws:
-      amiID: ami-06c4d345f7c207239 <1>
+      amiID: <ami_id>
       type: m5.4xlarge
   replicas: 3
 metadata:
   name: test-cluster
 platform:
   aws:
-    region: us-east-2 <2>
+    region: <region>
 sshKey: ssh-ed25519 AAAA...
 pullSecret: '{"auths": ...}'
 ----
-<1> The AMI ID from your AWS Marketplace subscription.
-<2> Your AMI ID is associated with a specific AWS Region. When creating the installation configuration file, ensure that you select the same AWS Region that you specified when configuring your subscription.
+where:
+
+<ami_id>:: Specifies the AMI ID from your AWS Marketplace subscription.
+<region>:: Specifies your AWS Region. Your AMI ID is associated with a specific AWS Region. When creating the installation configuration file, ensure that you select the same AWS Region that you specified when configuring your subscription.
 endif::ipi[]
 
 ifeval::["{context}" == "installing-aws-customizations"]

--- a/modules/installation-aws-upload-custom-rhcos-ami.adoc
+++ b/modules/installation-aws-upload-custom-rhcos-ami.adoc
@@ -28,27 +28,33 @@ link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Instal
 +
 [source,terminal]
 ----
-$ export AWS_PROFILE=<aws_profile> <1>
+$ export AWS_PROFILE=<aws_profile>
 ----
-<1> The AWS profile name that holds your AWS credentials, like `govcloud` or `beijingadmin`.
+where:
+
+<aws_profile>:: Specifies the AWS profile name that holds your AWS credentials, like `govcloud` or `beijingadmin`.
 
 . Export the region to associate with your custom AMI as an environment
 variable:
 +
 [source,terminal]
 ----
-$ export AWS_DEFAULT_REGION=<aws_region> <1>
+$ export AWS_DEFAULT_REGION=<aws_region>
 ----
-<1> The AWS region, like `us-gov-east-1` or `cn-north-1`.
+where:
+
+<aws_region>:: Specifies the AWS region, like `us-gov-east-1` or `cn-north-1`.
 
 . Export the version of {op-system} you uploaded to Amazon S3 as an environment
 variable:
 +
 [source,terminal]
 ----
-$ export RHCOS_VERSION=<version> <1>
+$ export RHCOS_VERSION=<version>
 ----
-<1> The {op-system} VMDK version, like `{product-version}.0`.
+where:
+
+<version>:: Specifies the {op-system} VMDK version, like `{product-version}.0`.
 
 . Export the Amazon S3 bucket name as an environment variable:
 +
@@ -78,13 +84,13 @@ EOF
 [source,terminal]
 ----
 $ aws ec2 import-snapshot --region ${AWS_DEFAULT_REGION} \
-     --description "<description>" \ <1>
-     --disk-container "file://<file_path>/containers.json" <2>
+     --description "<description>" \
+     --disk-container "file://<file_path>/containers.json"
 ----
-<1> The description of your {op-system} disk being imported, like
-`rhcos-${RHCOS_VERSION}-x86_64-aws.x86_64`.
-<2> The file path to the JSON file describing your {op-system} disk. The JSON
-file should contain your Amazon S3 bucket name and key.
+where:
+
+<description>:: Specifies the description of your {op-system} disk being imported, like `rhcos-${RHCOS_VERSION}-x86_64-aws.x86_64`.
+<file_path>:: Specifies the file path to the JSON file describing your {op-system} disk. The JSON file should contain your Amazon S3 bucket name and key.
 
 . Check the status of the image import:
 +
@@ -125,22 +131,24 @@ Copy the `SnapshotId` to register the image.
 ----
 $ aws ec2 register-image \
    --region ${AWS_DEFAULT_REGION} \
-   --architecture x86_64 \ <1>
-   --description "rhcos-${RHCOS_VERSION}-x86_64-aws.x86_64" \ <2>
+   --architecture x86_64 \
+   --description "rhcos-${RHCOS_VERSION}-x86_64-aws.x86_64" \
    --ena-support \
-   --name "rhcos-${RHCOS_VERSION}-x86_64-aws.x86_64" \ <3>
+   --name "rhcos-${RHCOS_VERSION}-x86_64-aws.x86_64" \
    --virtualization-type hvm \
    --root-device-name '/dev/xvda' \
-   --block-device-mappings 'DeviceName=/dev/xvda,Ebs={DeleteOnTermination=true,SnapshotId=<snapshot_ID>}' <4>
+   --block-device-mappings 'DeviceName=/dev/xvda,Ebs={DeleteOnTermination=true,SnapshotId=<snapshot_ID>}'
 ----
-<1> The {op-system} VMDK architecture type, like `x86_64`,
+where:
+
+`--architecture`:: Specifies the {op-system} VMDK architecture type, like `x86_64`,
 ifndef::openshift-origin[]
 `aarch64`,
 endif::openshift-origin[]
 `s390x`, or `ppc64le`.
-<2> The `Description` from the imported snapshot.
-<3> The name of the {op-system} AMI.
-<4> The `SnapshotID` from the imported snapshot.
+`--description`:: Specifies the `Description` from the imported snapshot.
+`--name`:: Specifies the name of the {op-system} AMI.
+`<snapshot_ID>`:: Specifies the `SnapshotID` from the imported snapshot.
 
 To learn more about these APIs, see the AWS documentation for
 link:https://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-import-snapshot.html[importing snapshots]

--- a/modules/installation-cloudformation-subnet-localzone.adoc
+++ b/modules/installation-cloudformation-subnet-localzone.adoc
@@ -97,7 +97,7 @@ ifndef::outposts[]
 endif::outposts[]
 ifdef::outposts[]
         Value: !Join ['-', [ !Ref ClusterName, !Ref PublicSubnetLabel, !Ref ZoneName]]
-      - Key: kubernetes.io/cluster/unmanaged # <1>
+      - Key: kubernetes.io/cluster/unmanaged
         Value: true
 endif::outposts[]
 
@@ -123,7 +123,7 @@ ifndef::outposts[]
 endif::outposts[]
 ifdef::outposts[]
         Value: !Join ['-', [!Ref ClusterName, !Ref PrivateSubnetLabel, !Ref ZoneName]]
-      - Key: kubernetes.io/cluster/unmanaged # <2>
+      - Key: kubernetes.io/cluster/unmanaged
         Value: true
 endif::outposts[]
 
@@ -145,8 +145,10 @@ Outputs:
       !Join ["", [!Ref PrivateSubnet]]
 ----
 ifdef::outposts[]
-<1> You must include the `kubernetes.io/cluster/unmanaged` tag in the public subnet configuration for AWS Outposts.
-<2> You must include the `kubernetes.io/cluster/unmanaged` tag in the private subnet configuration for AWS Outposts.
+where:
+
+`kubernetes.io/cluster/unmanaged` (public subnet):: Specifies that you must include the `kubernetes.io/cluster/unmanaged` tag in the public subnet configuration for AWS Outposts.
+`kubernetes.io/cluster/unmanaged` (private subnet):: Specifies that you must include the `kubernetes.io/cluster/unmanaged` tag in the private subnet configuration for AWS Outposts.
 endif::outposts[]
 ====
 

--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -164,38 +164,33 @@ For installations on Amazon Web Services (AWS), {gcp-first}, Microsoft Azure, an
 apiVersion: v1
 baseDomain: my.domain.com
 proxy:
-  httpProxy: http://<username>:<pswd>@<ip>:<port> <1>
-  httpsProxy: https://<username>:<pswd>@<ip>:<port> <2>
+  httpProxy: http://<username>:<pswd>@<ip>:<port>
+  httpsProxy: https://<username>:<pswd>@<ip>:<port>
 ifndef::aws[]
-  noProxy: example.com <3>
+  noProxy: example.com
 endif::aws[]
 ifdef::aws[]
-  noProxy: ec2.<aws_region>.amazonaws.com,elasticloadbalancing.<aws_region>.amazonaws.com,s3.<aws_region>.amazonaws.com <3>
+  noProxy: ec2.<aws_region>.amazonaws.com,elasticloadbalancing.<aws_region>.amazonaws.com,s3.<aws_region>.amazonaws.com
 endif::aws[]
-additionalTrustBundle: | <4>
+additionalTrustBundle: |
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-additionalTrustBundlePolicy: <policy_to_add_additionalTrustBundle> <5>
+additionalTrustBundlePolicy: <policy_to_add_additionalTrustBundle>
 ----
-<1> A proxy URL to use for creating HTTP connections outside the cluster. The
-URL scheme must be `http`.
-<2> A proxy URL to use for creating HTTPS connections outside the cluster.
-<3> A comma-separated list of destination domain names, IP addresses, or other network CIDRs to exclude from proxying. Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass the proxy for all destinations.
+where:
+
+`httpProxy`:: Specifies a proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be `http`.
+`httpsProxy`:: Specifies a proxy URL to use for creating HTTPS connections outside the cluster.
+`noProxy`:: Specifies a comma-separated list of destination domain names, IP addresses, or other network CIDRs to exclude from proxying. Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass the proxy for all destinations.
 ifdef::aws[]
 If you have added the Amazon `EC2`,`Elastic Load Balancing`, and `S3` VPC endpoints to your VPC, you must add these endpoints to the `noProxy` field.
 endif::aws[]
 ifdef::vsphere[]
 You must include vCenter's IP address and the IP range that you use for its machines.
 endif::vsphere[]
-<4> If provided, the installation program generates a config map that is named `user-ca-bundle` in
-the `openshift-config` namespace to hold the additional CA
-certificates. If you provide `additionalTrustBundle` and at least one proxy setting, the `Proxy` object is configured to reference the `user-ca-bundle` config map in the `trustedCA` field. The Cluster Network
-Operator then creates a `trusted-ca-bundle` config map that merges the contents specified for the `trustedCA` parameter
-with the {op-system} trust bundle. The `additionalTrustBundle` field is required unless
-the proxy's identity certificate is signed by an authority from the {op-system} trust
-bundle.
-<5> Optional: The policy to determine the configuration of the `Proxy` object to reference the `user-ca-bundle` config map in the `trustedCA` field. The allowed values are `Proxyonly` and `Always`. Use `Proxyonly` to reference the `user-ca-bundle` config map only when `http/https` proxy is configured. Use `Always` to always reference the `user-ca-bundle` config map. The default value is `Proxyonly`.
+`additionalTrustBundle`:: Specifies that if provided, the installation program generates a config map that is named `user-ca-bundle` in the `openshift-config` namespace to hold the additional CA certificates. If you provide `additionalTrustBundle` and at least one proxy setting, the `Proxy` object is configured to reference the `user-ca-bundle` config map in the `trustedCA` field. The Cluster Network Operator then creates a `trusted-ca-bundle` config map that merges the contents specified for the `trustedCA` parameter with the {op-system} trust bundle. The `additionalTrustBundle` field is required unless the proxy's identity certificate is signed by an authority from the {op-system} trust bundle.
+`additionalTrustBundlePolicy`:: Optional: Specifies the policy to determine the configuration of the `Proxy` object to reference the `user-ca-bundle` config map in the `trustedCA` field. The allowed values are `Proxyonly` and `Always`. Use `Proxyonly` to reference the `user-ca-bundle` config map only when `http/https` proxy is configured. Use `Always` to always reference the `user-ca-bundle` config map. The default value is `Proxyonly`.
 +
 [NOTE]
 ====

--- a/modules/installation-creating-aws-vpc-carrier-gw.adoc
+++ b/modules/installation-creating-aws-vpc-carrier-gw.adoc
@@ -66,17 +66,19 @@ If you do not use the provided CloudFormation template to create your AWS infras
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <stack_name> \// <1>
+$ aws cloudformation create-stack --stack-name <stack_name> \
   --region ${CLUSTER_REGION} \
-  --template-body file://<template>.yaml \// <2>
-  --parameters \//
-    ParameterKey=VpcId,ParameterValue="${VpcId}" \// <3>
-    ParameterKey=ClusterName,ParameterValue="${ClusterName}" <4>
+  --template-body file://<template>.yaml \
+  --parameters \
+    ParameterKey=VpcId,ParameterValue="${VpcId}" \
+    ParameterKey=ClusterName,ParameterValue="${ClusterName}"
 ----
-<1> `<stack_name>` is the name for the CloudFormation stack, such as `clusterName-vpc-carrier-gw`. You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path and the name of the CloudFormation template YAML file that you saved.
-<3> `<VpcId>` is the VPC ID extracted from the CloudFormation stack output created in the section named "Creating a VPC in AWS".
-<4> `<ClusterName>` is a custom value that prefixes to resources that the CloudFormation stack creates. You can use the same name that is defined in the `metadata.name` section of the `install-config.yaml` configuration file.
+where:
+
+<stack_name>:: Specifies the name for the CloudFormation stack, such as `clusterName-vpc-carrier-gw`. You need the name of this stack if you remove the cluster.
+<template>:: Specifies the relative path and the name of the CloudFormation template YAML file that you saved.
+`${VpcId}`:: Specifies the VPC ID extracted from the CloudFormation stack output created in the section named "Creating a VPC in AWS".
+`${ClusterName}`:: Specifies a custom value that prefixes to resources that the CloudFormation stack creates. You can use the same name that is defined in the `metadata.name` section of the `install-config.yaml` configuration file.
 +
 .Example output
 [source,terminal]

--- a/modules/installation-creating-aws-vpc-localzone.adoc
+++ b/modules/installation-creating-aws-vpc-localzone.adoc
@@ -30,25 +30,24 @@ If you do not use the provided CloudFormation template to create your AWS infras
 ----
 [
   {
-    "ParameterKey": "VpcCidr", <1>
-    "ParameterValue": "10.0.0.0/16" <2>
+    "ParameterKey": "VpcCidr",
+    "ParameterValue": "10.0.0.0/16"
   },
   {
-    "ParameterKey": "AvailabilityZoneCount", <3>
-    "ParameterValue": "3" <4>
+    "ParameterKey": "AvailabilityZoneCount",
+    "ParameterValue": "3"
   },
   {
-    "ParameterKey": "SubnetBits", <5>
-    "ParameterValue": "12" <6>
+    "ParameterKey": "SubnetBits",
+    "ParameterValue": "12"
   }
 ]
 ----
-<1> The CIDR block for the VPC.
-<2> Specify a CIDR block in the format `x.x.x.x/16-24`.
-<3> The number of availability zones to deploy the VPC in.
-<4> Specify an integer between `1` and `3`.
-<5> The size of each subnet in each availability zone.
-<6> Specify an integer between  `5` and `13`, where `5` is `/27` and `13` is `/19`.
+where:
+
+`VpcCidr`:: Specifies the CIDR block for the VPC. Specify a CIDR block in the format `x.x.x.x/16-24`.
+`AvailabilityZoneCount`:: Specifies the number of availability zones to deploy the VPC in. Specify an integer between `1` and `3`.
+`SubnetBits`:: Specifies the size of each subnet in each availability zone. Specify an integer between  `5` and `13`, where `5` is `/27` and `13` is `/19`.
 
 . Go to the section of the documentation named "CloudFormation template for the VPC", and then copy the syntax from the provided template. Save the copied template syntax as a YAML file on your local system. This template describes the VPC that your cluster requires.
 
@@ -61,16 +60,15 @@ You must enter the command on a single line.
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <name> \// <1>
-     --template-body file://<template>.yaml \// <2>
-     --parameters file://<parameters>.json  <3>
+$ aws cloudformation create-stack --stack-name <name> \
+     --template-body file://<template>.yaml \
+     --parameters file://<parameters>.json
 ----
-<1> `<name>` is the name for the CloudFormation stack, such as `cluster-vpc`.
-You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path to and name of the CloudFormation template
-YAML file that you saved.
-<3> `<parameters>` is the relative path and the name of the CloudFormation
-parameters JSON file.
+where:
+
+<name>:: Specifies the name for the CloudFormation stack, such as `cluster-vpc`. You need the name of this stack if you remove the cluster.
+<template>:: Specifies the relative path to and name of the CloudFormation template YAML file that you saved.
+<parameters>:: Specifies the relative path and the name of the CloudFormation parameters JSON file.
 +
 .Example output
 [source,terminal]

--- a/modules/installation-creating-aws-vpc-subnets-edge.adoc
+++ b/modules/installation-creating-aws-vpc-subnets-edge.adoc
@@ -35,37 +35,39 @@ ifdef::outposts[* You have obtained the required information about your environm
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <stack_name> \// <1>
+$ aws cloudformation create-stack --stack-name <stack_name> \
   --region ${CLUSTER_REGION} \
-  --template-body file://<template>.yaml \// <2>
+  --template-body file://<template>.yaml \
   --parameters \
-    ParameterKey=VpcId,ParameterValue="${VPC_ID}" \// <3>
-    ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \// <4>
-    ParameterKey=ZoneName,ParameterValue="${ZONE_NAME}" \// <5>
-    ParameterKey=PublicRouteTableId,ParameterValue="${ROUTE_TABLE_PUB}" \// <6>
-    ParameterKey=PublicSubnetCidr,ParameterValue="${SUBNET_CIDR_PUB}" \// <7>
-    ParameterKey=PrivateRouteTableId,ParameterValue="${ROUTE_TABLE_PVT}" \// <8>
-ifndef::outposts[    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" <9>]
+    ParameterKey=VpcId,ParameterValue="${VPC_ID}" \
+    ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \
+    ParameterKey=ZoneName,ParameterValue="${ZONE_NAME}" \
+    ParameterKey=PublicRouteTableId,ParameterValue="${ROUTE_TABLE_PUB}" \
+    ParameterKey=PublicSubnetCidr,ParameterValue="${SUBNET_CIDR_PUB}" \
+    ParameterKey=PrivateRouteTableId,ParameterValue="${ROUTE_TABLE_PVT}" \
+ifndef::outposts[    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}"]
 ifdef::outposts[]
-    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" \// <9>
+    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" \
     ParameterKey=PrivateSubnetLabel,ParameterValue="private-outpost" \
     ParameterKey=PublicSubnetLabel,ParameterValue="public-outpost" \
-    ParameterKey=OutpostArn,ParameterValue="${OUTPOST_ARN}" <10>
+    ParameterKey=OutpostArn,ParameterValue="${OUTPOST_ARN}"
 endif::outposts[]
 ----
-ifndef::outposts[<1> `<stack_name>` is the name for the CloudFormation stack, such as `cluster-wl-<local_zone_shortname>` for Local Zones and `cluster-wl-<wavelength_zone_shortname>` for Wavelength Zones. You need the name of this stack if you remove the cluster.]
-ifdef::outposts[<1> `<stack_name>` is the name for the CloudFormation stack, such as `cluster-<outpost_name>`.]
-<2> `<template>` is the relative path and the name of the CloudFormation template YAML file that you saved.
-<3> `${VPC_ID}` is the VPC ID, which is the value `VpcID` in the output of the CloudFormation template for the VPC.
-<4> `${CLUSTER_NAME}` is the value of *ClusterName* to be used as a prefix of the new AWS resource names.
-<5> `${ZONE_NAME}` is the value of {zone-type} name to create the subnets.
-ifndef::outposts[<6> `${ROUTE_TABLE_PUB}` is the Public Route Table Id extracted from the CloudFormation template. For Local Zones, the public route table is extracted from the VPC CloudFormation Stack. For Wavelength Zones, the value must be extracted from the output of the VPC's carrier gateway CloudFormation stack.]
-ifdef::outposts[<6> `${ROUTE_TABLE_PUB}` is the Public Route Table ID created in the `${VPC_ID}` used to associate the public subnets on Outposts. Specify the public route table to associate the Outpost subnet created by this stack.]
-<7> `${SUBNET_CIDR_PUB}` is a valid CIDR block that is used to create the public subnet. This block must be part of the VPC CIDR block `VpcCidr`.
-ifndef::outposts[<8> `${ROUTE_TABLE_PVT}` is the *PrivateRouteTableId* extracted from the output of the VPC's CloudFormation stack.]
-ifdef::outposts[<8> `${ROUTE_TABLE_PVT}` is the Private Route Table ID created in the `${VPC_ID}` used to associate the private subnets on Outposts. Specify the private route table to associate the Outpost subnet created by this stack.]
-<9> `${SUBNET_CIDR_PVT}` is a valid CIDR block that is used to create the private subnet. This block must be part of the VPC CIDR block `VpcCidr`.
-ifdef::outposts[<10> `${OUTPOST_ARN}` is the Amazon Resource Name (ARN) for the Outpost.]
+where:
+
+ifndef::outposts[<stack_name>:: Specifies the name for the CloudFormation stack, such as `cluster-wl-<local_zone_shortname>` for Local Zones and `cluster-wl-<wavelength_zone_shortname>` for Wavelength Zones. You need the name of this stack if you remove the cluster.]
+ifdef::outposts[<stack_name>:: Specifies the name for the CloudFormation stack, such as `cluster-<outpost_name>`.]
+<template>:: Specifies the relative path and the name of the CloudFormation template YAML file that you saved.
+`${VPC_ID}`:: Specifies the VPC ID, which is the value `VpcID` in the output of the CloudFormation template for the VPC.
+`${CLUSTER_NAME}`:: Specifies the value of *ClusterName* to be used as a prefix of the new AWS resource names.
+`${ZONE_NAME}`:: Specifies the value of {zone-type} name to create the subnets.
+ifndef::outposts[`${ROUTE_TABLE_PUB}`:: Specifies the Public Route Table Id extracted from the CloudFormation template. For Local Zones, the public route table is extracted from the VPC CloudFormation Stack. For Wavelength Zones, the value must be extracted from the output of the VPC's carrier gateway CloudFormation stack.]
+ifdef::outposts[`${ROUTE_TABLE_PUB}`:: Specifies the Public Route Table ID created in the `${VPC_ID}` used to associate the public subnets on Outposts. Specify the public route table to associate the Outpost subnet created by this stack.]
+`${SUBNET_CIDR_PUB}`:: Specifies a valid CIDR block that is used to create the public subnet. This block must be part of the VPC CIDR block `VpcCidr`.
+ifndef::outposts[`${ROUTE_TABLE_PVT}`:: Specifies the *PrivateRouteTableId* extracted from the output of the VPC's CloudFormation stack.]
+ifdef::outposts[`${ROUTE_TABLE_PVT}`:: Specifies the Private Route Table ID created in the `${VPC_ID}` used to associate the private subnets on Outposts. Specify the private route table to associate the Outpost subnet created by this stack.]
+`${SUBNET_CIDR_PVT}`:: Specifies a valid CIDR block that is used to create the private subnet. This block must be part of the VPC CIDR block `VpcCidr`.
+ifdef::outposts[`${OUTPOST_ARN}`:: Specifies the Amazon Resource Name (ARN) for the Outpost.]
 +
 .Example output
 [source,text]

--- a/modules/installation-creating-aws-vpc-subnets-lz.adoc
+++ b/modules/installation-creating-aws-vpc-subnets-lz.adoc
@@ -29,27 +29,29 @@ If you do not use the provided CloudFormation template to create your AWS infras
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <stack_name> \// <1>
+$ aws cloudformation create-stack --stack-name <stack_name> \
   --region ${CLUSTER_REGION} \
-  --template-body file://<template>.yaml \// <2>
+  --template-body file://<template>.yaml \
   --parameters \
-    ParameterKey=VpcId,ParameterValue="${VPC_ID}" \// <3>
-    ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \// <4>
-    ParameterKey=ZoneName,ParameterValue="${ZONE_NAME}" \// <5>
-    ParameterKey=PublicRouteTableId,ParameterValue="${ROUTE_TABLE_PUB}" \// <6>
-    ParameterKey=PublicSubnetCidr,ParameterValue="${SUBNET_CIDR_PUB}" \// <7>
-    ParameterKey=PrivateRouteTableId,ParameterValue="${ROUTE_TABLE_PVT}" \// <8>
-    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" <9>
+    ParameterKey=VpcId,ParameterValue="${VPC_ID}" \
+    ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \
+    ParameterKey=ZoneName,ParameterValue="${ZONE_NAME}" \
+    ParameterKey=PublicRouteTableId,ParameterValue="${ROUTE_TABLE_PUB}" \
+    ParameterKey=PublicSubnetCidr,ParameterValue="${SUBNET_CIDR_PUB}" \
+    ParameterKey=PrivateRouteTableId,ParameterValue="${ROUTE_TABLE_PVT}" \
+    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}"
 ----
-<1> `<stack_name>` is the name for the CloudFormation stack, such as `cluster-wl-<local_zone_shortname>`. You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path and the name of the CloudFormation template
-YAML file that you saved.
-<3> `${VPC_ID}` is the VPC ID, which is the value `VpcID` in the output of the CloudFormation template for the VPC.
-<4> `${ZONE_NAME}` is the value of {zone-type} name to create the subnets.
-<5> `${CLUSTER_NAME}` is the value of *ClusterName* to be used as a prefix of the new AWS resource names.
-<6> `${SUBNET_CIDR_PUB}` is a valid CIDR block that is used to create the public subnet. This block must be part of the VPC CIDR block `VpcCidr`.
-<7> `${ROUTE_TABLE_PVT}` is the *PrivateRouteTableId* extracted from the output of the VPC's CloudFormation stack.
-<8> `${SUBNET_CIDR_PVT}` is a valid CIDR block that is used to create the private subnet. This block must be part of the VPC CIDR block `VpcCidr`.
+where:
+
+<stack_name>:: Specifies the name for the CloudFormation stack, such as `cluster-wl-<local_zone_shortname>`. You need the name of this stack if you remove the cluster.
+<template>:: Specifies the relative path and the name of the CloudFormation template YAML file that you saved.
+`${VPC_ID}`:: Specifies the VPC ID, which is the value `VpcID` in the output of the CloudFormation template for the VPC.
+`${CLUSTER_NAME}`:: Specifies the value of *ClusterName* to be used as a prefix of the new AWS resource names.
+`${ZONE_NAME}`:: Specifies the value of {zone-type} name to create the subnets.
+`${ROUTE_TABLE_PUB}`:: Specifies the Public Route Table ID extracted from the CloudFormation template.
+`${SUBNET_CIDR_PUB}`:: Specifies a valid CIDR block that is used to create the public subnet. This block must be part of the VPC CIDR block `VpcCidr`.
+`${ROUTE_TABLE_PVT}`:: Specifies the *PrivateRouteTableId* extracted from the output of the VPC's CloudFormation stack.
+`${SUBNET_CIDR_PVT}`:: Specifies a valid CIDR block that is used to create the private subnet. This block must be part of the VPC CIDR block `VpcCidr`.
 
 .Example output
 

--- a/modules/installation-creating-aws-vpc-subnets-wz.adoc
+++ b/modules/installation-creating-aws-vpc-subnets-wz.adoc
@@ -29,27 +29,29 @@ If you do not use the provided CloudFormation template to create your AWS infras
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <stack_name> \ <1>
+$ aws cloudformation create-stack --stack-name <stack_name> \
   --region ${CLUSTER_REGION} \
-  --template-body file://<template>.yaml \ <2>
+  --template-body file://<template>.yaml \
   --parameters \
-    ParameterKey=VpcId,ParameterValue="${VPC_ID}" \ <3>
-    ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \ <4>
-    ParameterKey=ZoneName,ParameterValue="${ZONE_NAME}" \ <5>
-    ParameterKey=PublicRouteTableId,ParameterValue="${ROUTE_TABLE_PUB}" \ <6>
-    ParameterKey=PublicSubnetCidr,ParameterValue="${SUBNET_CIDR_PUB}" \ <7>
-    ParameterKey=PrivateRouteTableId,ParameterValue="${ROUTE_TABLE_PVT}" \ <8>
-    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" <9>
+    ParameterKey=VpcId,ParameterValue="${VPC_ID}" \
+    ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \
+    ParameterKey=ZoneName,ParameterValue="${ZONE_NAME}" \
+    ParameterKey=PublicRouteTableId,ParameterValue="${ROUTE_TABLE_PUB}" \
+    ParameterKey=PublicSubnetCidr,ParameterValue="${SUBNET_CIDR_PUB}" \
+    ParameterKey=PrivateRouteTableId,ParameterValue="${ROUTE_TABLE_PVT}" \
+    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}"
 ----
-<1> `<stack_name>` is the name for the CloudFormation stack, such as `cluster-wl-<wavelength_zone_shortname>`. You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path and the name of the CloudFormation template YAML file that you saved.
-<3> `${VPC_ID}` is the VPC ID, which is the value `VpcID` in the output of the CloudFormation template for the VPC.
-<4> `${ZONE_NAME}` is the value of {zone-type} name to create the subnets.
-<5> `${CLUSTER_NAME}` is the value of *ClusterName* to be used as a prefix of the new AWS resource names.
-<6> `${ROUTE_TABLE_PUB}` is the *PublicRouteTableId* extracted from the output of the VPC's carrier gateway CloudFormation stack.
-<7> `${SUBNET_CIDR_PUB}` is a valid CIDR block that is used to create the public subnet. This block must be part of the VPC CIDR block `VpcCidr`.
-<8> `${ROUTE_TABLE_PVT}` is the *PrivateRouteTableId* extracted from the output of the VPC's CloudFormation stack.
-<9> `${SUBNET_CIDR_PVT}` is a valid CIDR block that is used to create the private subnet. This block must be part of the VPC CIDR block `VpcCidr`.
+where:
+
+<stack_name>:: Specifies the name for the CloudFormation stack, such as `cluster-wl-<wavelength_zone_shortname>`. You need the name of this stack if you remove the cluster.
+<template>:: Specifies the relative path and the name of the CloudFormation template YAML file that you saved.
+`${VPC_ID}`:: Specifies the VPC ID, which is the value `VpcID` in the output of the CloudFormation template for the VPC.
+`${CLUSTER_NAME}`:: Specifies the value of *ClusterName* to be used as a prefix of the new AWS resource names.
+`${ZONE_NAME}`:: Specifies the value of {zone-type} name to create the subnets.
+`${ROUTE_TABLE_PUB}`:: Specifies the *PublicRouteTableId* extracted from the output of the VPC's carrier gateway CloudFormation stack.
+`${SUBNET_CIDR_PUB}`:: Specifies a valid CIDR block that is used to create the public subnet. This block must be part of the VPC CIDR block `VpcCidr`.
+`${ROUTE_TABLE_PVT}`:: Specifies the *PrivateRouteTableId* extracted from the output of the VPC's CloudFormation stack.
+`${SUBNET_CIDR_PVT}`:: Specifies a valid CIDR block that is used to create the private subnet. This block must be part of the VPC CIDR block `VpcCidr`.
 
 .Example output
 [source,terminal]

--- a/modules/installation-generate-aws-user-infra-install-config.adoc
+++ b/modules/installation-generate-aws-user-infra-install-config.adoc
@@ -44,10 +44,11 @@ endif::restricted[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create install-config --dir <installation_directory> <1>
+$ ./openshift-install create install-config --dir <installation_directory>
 ----
-<1> For `<installation_directory>`, specify the directory name to store the
-files that the installation program creates.
+where:
++
+<installation_directory>:: Specifies the directory name to store the files that the installation program creates.
 +
 [IMPORTANT]
 ====

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -231,10 +231,11 @@ endif::azure[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create install-config --dir <installation_directory> <1>
+$ ./openshift-install create install-config --dir <installation_directory>
 ----
-<1> For `<installation_directory>`, specify the directory name to store the
-files that the installation program creates.
+where:
+
+<installation_directory>:: Specifies the directory name to store the files that the installation program creates.
 +
 When specifying the directory:
 ifndef::ibm-power-vs[]
@@ -499,15 +500,17 @@ ifdef::azure+restricted[]
 +
 [source,yaml]
 ----
-networkResourceGroupName: <vnet_resource_group> <1>
-virtualNetwork: <vnet> <2>
-controlPlaneSubnet: <control_plane_subnet> <3>
-computeSubnet: <compute_subnet> <4>
+networkResourceGroupName: <vnet_resource_group>
+virtualNetwork: <vnet>
+controlPlaneSubnet: <control_plane_subnet>
+computeSubnet: <compute_subnet>
 ----
-<1> Replace `<vnet_resource_group>` with the resource group name that contains the existing virtual network (VNet).
-<2> Replace `<vnet>` with the existing virtual network name.
-<3> Replace `<control_plane_subnet>` with the existing subnet name to deploy the control plane machines.
-<4> Replace `<compute_subnet>` with the existing subnet name to deploy compute machines.
+where:
+
+<vnet_resource_group>:: Specifies the resource group name that contains the existing virtual network (VNet).
+<vnet>:: Specifies the existing virtual network name.
+<control_plane_subnet>:: Specifies the existing subnet name to deploy the control plane machines.
+<compute_subnet>:: Specifies the existing subnet name to deploy compute machines.
 endif::azure+restricted[]
 ifdef::gcp+restricted[]
 .. Define the network and subnets for the VPC to install the cluster in under the parent `platform.gcp` field:

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -322,18 +322,19 @@ endif::single-step,azure-restricted[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create cluster --dir <installation_directory> \ <1>
-    --log-level=info <2>
+$ ./openshift-install create cluster --dir <installation_directory> \
+    --log-level=info
 ----
-<1> For `<installation_directory>`, specify the
+where:
++
+<installation_directory>:: Specifies the
 ifdef::custom-config[]
 location of your customized `./install-config.yaml` file.
 endif::custom-config[]
 ifdef::no-config[]
 directory name to store the files that the installation program creates.
 endif::no-config[]
-<2> To view different installation details, specify `warn`, `debug`, or
-`error` instead of `info`.
+<log-level>:: Specifies the installation program log level. You can specify `warn`, `debug`, or `error` instead of `info`.
 
 ifdef::azure-gov,azure-private[]
 +

--- a/modules/installing-a-cluster-with-multiarch-support.adoc
+++ b/modules/installing-a-cluster-with-multiarch-support.adoc
@@ -40,17 +40,19 @@ The output must contain `release architecture multi` to indicate that the `opens
 apiVersion: v1
 baseDomain: example.openshift.com
 compute:
-- architecture: amd64 <1>
+- architecture: <architecture>
   hyperthreading: Enabled
   name: worker
   platform: {}
   replicas: 3
 controlPlane:
-  architecture: arm64 <2>
+  architecture: <architecture>
   name: master
   platform: {}
   replicas: 3
 # ...
 ----
-<1> Specify the architecture of the worker node. You can set this field to either `arm64` or `amd64`.
-<2> Specify the control plane node architecture. You can set this field to either `arm64` or `amd64`.
+where:
+
+<architecture> (worker):: Specifies the architecture of the worker node. You can set this field to either `arm64` or `amd64`.
+<architecture> (control plane):: Specifies the control plane node architecture. You can set this field to either `arm64` or `amd64`.

--- a/modules/installing-aws-edge-zones-custom-vpc-config.adoc
+++ b/modules/installing-aws-edge-zones-custom-vpc-config.adoc
@@ -37,7 +37,7 @@ ifdef::local-zone[]
 platform:
   aws:
     region: us-west-2
-    subnets: <1>
+    subnets:
     - publicSubnetId-1
     - publicSubnetId-2
     - publicSubnetId-3
@@ -47,7 +47,9 @@ platform:
     - publicSubnetId-LocalZone-1
 # ...
 ----
-<1> List of subnet IDs created in the zones: Availability and {zone-type}.
+where:
+
+`subnets`:: Specifies the list of subnet IDs created in the zones: Availability and {zone-type}.
 endif::local-zone[]
 ifdef::wavelength-zone[]
 .Example installation configuration file with {zone-type} subnets
@@ -57,7 +59,7 @@ ifdef::wavelength-zone[]
 platform:
   aws:
     region: us-west-2
-    subnets: <1>
+    subnets:
     - publicSubnetId-1
     - publicSubnetId-2
     - publicSubnetId-3
@@ -67,7 +69,9 @@ platform:
     - publicOrPrivateSubnetID-Wavelength-1
 # ...
 ----
-<1> List of subnet IDs created in the zones: Availability and {zone-type}.
+where:
+
+`subnets`:: Specifies the list of subnet IDs created in the zones: Availability and {zone-type}.
 endif::wavelength-zone[]
 
 ifeval::["{context}" == "installing-aws-localzone"]

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -217,13 +217,15 @@ $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}'
 $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
-  --included \// <1>
-  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
-  --to=<path_to_directory_for_credentials_requests> <3>
+  --included \
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \
+  --to=<path_to_directory_for_credentials_requests>
 ----
-<1> The `--included` parameter includes only the manifests that your specific cluster configuration requires.
-<2> Specify the location of the `install-config.yaml` file.
-<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+where:
+
+`--included`:: Specifies that the `--included` parameter includes only the manifests that your specific cluster configuration requires.
+`<path_to_directory_with_installation_configuration>`:: Specifies the location of the `install-config.yaml` file.
+`<path_to_directory_for_credentials_requests>`:: Specifies the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 This command creates a YAML file for each `CredentialsRequest` object.
 +

--- a/modules/nw-aws-load-balancer-with-outposts.adoc
+++ b/modules/nw-aws-load-balancer-with-outposts.adoc
@@ -36,7 +36,7 @@ kind: Ingress
 metadata:
   name: <application_name>
   annotations:
-    alb.ingress.kubernetes.io/subnets: <subnet_id> # <1>
+    alb.ingress.kubernetes.io/subnets: <subnet_id>
 spec:
   ingressClassName: alb
   rules:
@@ -50,7 +50,9 @@ spec:
                 port:
                   number: 80
 ----
-<1> Specifies the subnet to use.
+where:
+
+<subnet_id>:: Specifies the subnet to use.
 * To use the Application Load Balancer in an Outpost, specify the Outpost subnet ID.
 * To use the Application Load Balancer in the cloud, you must specify at least two subnets in different availability zones.
 --

--- a/modules/nw-aws-nlb-new-cluster.adoc
+++ b/modules/nw-aws-nlb-new-cluster.adoc
@@ -21,19 +21,21 @@ Create an Ingress Controller backed by an AWS NLB on a new cluster.
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir <installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory>
 ----
-<1> For `<installation_directory>`, specify the name of the directory that
-contains the `install-config.yaml` file for your cluster.
+where:
+
+<installation_directory>:: Specifies the name of the directory that contains the `install-config.yaml` file for your cluster.
 
 . Create a file that is named `cluster-ingress-default-ingresscontroller.yaml` in the `<installation_directory>/manifests/` directory:
 +
 [source,terminal]
 ----
-$ touch <installation_directory>/manifests/cluster-ingress-default-ingresscontroller.yaml <1>
+$ touch <installation_directory>/manifests/cluster-ingress-default-ingresscontroller.yaml
 ----
-<1> For `<installation_directory>`, specify the directory name that contains the
-`manifests/` directory for your cluster.
+where:
+
+<installation_directory>:: Specifies the directory name that contains the `manifests/` directory for your cluster.
 +
 After creating the file, several network configuration files are in the
 `manifests/` directory, as shown:

--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -42,9 +42,11 @@ Customizing your network configuration by modifying the {product-title} manifest
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir <installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory>
 ----
-<1> `<installation_directory>` specifies the name of the directory that contains the `install-config.yaml` file for your cluster.
+where:
++
+<installation_directory>:: Specifies the name of the directory that contains the `install-config.yaml` file for your cluster.
 
 . Create a stub manifest file for the advanced network configuration that is named `cluster-network-03-config.yml` in the `<installation_directory>/manifests/` directory:
 +

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -146,9 +146,11 @@ endif::openshift-origin[]
 +
 [source,terminal]
 ----
-$ ssh-keygen -t ed25519 -N '' -f <path>/<file_name> <1>
+$ ssh-keygen -t ed25519 -N '' -f <path>/<file_name>
 ----
-<1> Specify the path and file name, such as `~/.ssh/id_ed25519`, of the new SSH key. If you have an existing key pair, ensure your public key is in the your `~/.ssh` directory.
+where:
++
+<path>/<file_name>:: Specifies the path and file name, such as `~/.ssh/id_ed25519`, of the new SSH key. If you have an existing key pair, ensure your public key is in the your `~/.ssh` directory.
 +
 ifndef::ibm-power-vs[]
 [NOTE]
@@ -202,9 +204,11 @@ endif::ibm-power-vs[]
 +
 [source,terminal]
 ----
-$ ssh-add <path>/<file_name> <1>
+$ ssh-add <path>/<file_name>
 ----
-<1> Specify the path and file name for your SSH private key, such as `~/.ssh/id_ed25519`
+where:
++
+<path>/<file_name>:: Specifies the path and file name for your SSH private key, such as `~/.ssh/id_ed25519`
 +
 .Example output
 [source,terminal]


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-16989

Link to docs preview:
[Preparing to install](https://101732--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/ipi-aws-preparing-to-install#ssh-agent-using_ipi-aws-preparing-to-install)
[Deploying the cluster](https://101732--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-default#installation-launching-installer_installing-aws-default)
[Numerous examples in this assembly](https://101732--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-customizations)

QE review:
Not needed, docs-only change

Claude was instructed to traverse the **installing/installing_aws/ipi** folder, scan each assembly for modules that contained callout/annotation pairs, and replace them with definition lists. Additional instructions were given to preserve conditional structure and rephrase the annotation text to "Specifies ..." format.