### PR TITLE
OSDOCS-16575: Address Vale warnings and errors in "OpenShift Cluster Manager"

### DIFF
--- a/modules/ocm-accesscontrol-tab.adoc
+++ b/modules/ocm-accesscontrol-tab.adoc
@@ -6,6 +6,7 @@
 [id="ocm-accesscontrol-tab_{context}"]
 = Access control tab
 
+[role="_abstract"]
 The **Access control** tab allows the cluster owner to set up an identity provider, grant elevated permissions, and grant roles to other users.
 
 [id="ocm-accesscontrol-tab-identity-providers_{context}"]

--- a/modules/ocm-accessing.adoc
+++ b/modules/ocm-accessing.adoc
@@ -6,6 +6,7 @@
 [id="accessing-ocm_{context}"]
 = Accessing {cluster-manager-first}
 
+[role="_abstract"]
 You can access {cluster-manager} with your configured OpenShift account.
 
 .Prerequisites

--- a/modules/ocm-addons-tab.adoc
+++ b/modules/ocm-addons-tab.adoc
@@ -6,6 +6,7 @@
 [id="ocm-addons-tab_{context}"]
 = Add-ons tab
 
+[role="_abstract"]
 ifdef::openshift-rosa[]
 The **Add-ons** tab displays all of the optional add-ons that can be added to the cluster. Select the desired add-on, and then select **Install** below the description for the add-on that displays.
 endif::openshift-rosa[]

--- a/modules/ocm-cluster-history-tab.adoc
+++ b/modules/ocm-cluster-history-tab.adoc
@@ -6,4 +6,5 @@
 [id="ocm-cluster-history-tab_{context}"]
 = Cluster history tab
 
+[role="_abstract"]
 The **Cluster history** tab shows every change to the cluster from creation onward for each version. You can specify date ranges for your cluster history and use filters to search based on the description of the notification, the severity of the notification, the type of notification, and which role logged it. You may download your cluster history as a JSON or CSV file.

--- a/modules/ocm-cluster-tabs.adoc
+++ b/modules/ocm-cluster-tabs.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// ocm/ocm-overview.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ocm-cluster-tabs_{context}"]
+= Cluster tabs
+
+[role="_abstract"]
+Selecting an active, installed cluster shows tabs associated with that cluster. The following tabs display after the cluster's installation completes:
+
+* Overview
+* Access control
+* Add-ons
+* Cluster history
+* Networking
+* Machine pools
+* Support
+* Settings

--- a/modules/ocm-general-actions.adoc
+++ b/modules/ocm-general-actions.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// ocm/ocm-overview.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ocm-general-actions_{context}"]
+= General actions
+
+[role="_abstract"]
+On the top right of the cluster page, there are some actions that a user can perform on the entire cluster:
+
+* **Open console** launches a web console so that the cluster owner can issue commands to the cluster.
+* **Actions** drop-down menu allows the cluster owner to rename the display name of the cluster, edit the machine pools, and delete the cluster.
+ifdef::openshift-rosa[]
+You may also transfer the cluster's ownership to another user.
+endif::openshift-rosa[]
+* **Refresh** icon forces a refresh of the cluster.

--- a/modules/ocm-machinepools-tab.adoc
+++ b/modules/ocm-machinepools-tab.adoc
@@ -6,6 +6,7 @@
 [id="ocm-machinepools-tab_{context}"]
 = Machine pools tab
 
+[role="_abstract"]
 The **Machine pools** tab allows the cluster owner to create new machine pools if there is enough available quota, or edit an existing machine pool.
 
 Selecting the image:kebab.png[title=Other options] > **Edit** option opens the "Edit machine pool" dialog. In this dialog, you can change the node count per availability zone, edit node labels and taints, and view any associated AWS security groups.

--- a/modules/ocm-networking-tab-adding-ingress.adoc
+++ b/modules/ocm-networking-tab-adding-ingress.adoc
@@ -5,6 +5,7 @@
 [id="ocm-networking-tab-adding-ingress_{context}"]
 = Adding a network Ingress to your {product-title} cluster
 
+[role="_abstract"]
 You can add a network Ingress to your cluster from the {cluster-manager-url} web UI.
 
 .Prerequisites

--- a/modules/ocm-networking-tab-concept.adoc
+++ b/modules/ocm-networking-tab-concept.adoc
@@ -5,6 +5,7 @@
 [id="ocm-networking-tab_{context}"]
 = Networking tab
 
+[role="_abstract"]
 The **Networking** tab provides a control plane API endpoint as well as the default application router. Both the control plane API endpoint and the default application router can be made private by selecting the respective box below label. If applicable, you can also find your virtual private cloud (VPC) details on this tab.
 
 ifdef::openshift-rosa-hcp[]

--- a/modules/ocm-overview-tab.adoc
+++ b/modules/ocm-overview-tab.adoc
@@ -6,6 +6,7 @@
 [id="ocm-overview-tab_{context}"]
 = Overview tab
 
+[role="_abstract"]
 The **Overview** tab provides information about how the cluster was configured:
 
 * **Cluster ID** is the unique identification for the created cluster. This ID can be used when issuing commands to the cluster from the command line.

--- a/modules/ocm-settings-tab.adoc
+++ b/modules/ocm-settings-tab.adoc
@@ -6,6 +6,7 @@
 [id="ocm-settings-tab_{context}"]
 = Settings tab
 
+[role="_abstract"]
 The **Settings** tab provides a few options for the cluster owner:
 
 ifdef::openshift-rosa[]

--- a/modules/ocm-support-tab.adoc
+++ b/modules/ocm-support-tab.adoc
@@ -6,6 +6,7 @@
 [id="ocm-support-tab_{context}"]
 = Support tab
 
+[role="_abstract"]
 In the *Support* tab, you can add notification contacts for individuals that should receive cluster notifications. The username or email address that you provide must relate to a user account in the Red Hat organization where the cluster is deployed.
 ifdef::openshift-dedicated,openshift-rosa[]
 For the steps to add a notification contact, see _Adding cluster notification contacts_.

--- a/ocm/ocm-overview.adoc
+++ b/ocm/ocm-overview.adoc
@@ -1,10 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ocm-overview"]
 = Red Hat OpenShift Cluster Manager
+
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: ocm-overview
 toc::[]
 
+[role="_abstract"]
 {cluster-manager-first} is a managed service where you can install, modify, operate, and upgrade your Red Hat OpenShift clusters. This service allows you to work with all of your organization’s clusters from a single dashboard.
 
 {cluster-manager} guides you to install {OCP}, {rosa-classic-title}, {hcp-title-first}, and {dedicated} clusters. It is also responsible for both {OCP} clusters after self-installation as well as your {rosa-classic-title}, {hcp-title-first}, and {dedicated} clusters.
@@ -28,31 +30,9 @@ For more information about {cluster-manager}, see the entire link:https://docs.r
 
 include::modules/ocm-accessing.adoc[leveloffset=+1]
 
-[id="ocm-general-actions"]
-== General actions
+include::modules/ocm-general-actions.adoc[leveloffset=+1]
 
-On the top right of the cluster page, there are some actions that a user can perform on the entire cluster:
-
-* **Open console** launches a web console so that the cluster owner can issue commands to the cluster.
-* **Actions** drop-down menu allows the cluster owner to rename the display name of the cluster, edit the machine pools, and delete the cluster.
-ifdef::openshift-rosa[]
-You may also transfer the cluster's ownership to another user.
-endif::openshift-rosa[]
-* **Refresh** icon forces a refresh of the cluster.
-
-[id="ocm-cluster-tabs"]
-== Cluster tabs
-
-Selecting an active, installed cluster shows tabs associated with that cluster. The following tabs display after the cluster's installation completes:
-
-* Overview
-* Access control
-* Add-ons
-* Cluster history
-* Networking
-* Machine pools
-* Support
-* Settings
+include::modules/ocm-cluster-tabs.adoc[leveloffset=+1]
 
 include::modules/ocm-overview-tab.adoc[leveloffset=+2]
 include::modules/ocm-accesscontrol-tab.adoc[leveloffset=+2]


### PR DESCRIPTION
[OSDOCS-16575](https://issues.redhat.com//browse/OSDOCS-16575): Address Vale warnings and errors in "OpenShift Cluster Manager"

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16575

Link to docs preview:
ROSA: https://101750--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/ocm/ocm-overview.html
Classic: https://101750--ocpdocs-pr.netlify.app/openshift-rosa/latest/ocm/ocm-overview.html
OSD: https://101750--ocpdocs-pr.netlify.app/openshift-dedicated/latest/ocm/ocm-overview.html

Note: There are no visible changes in the previews since this was all re-modularization and adding tags.

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
