### PR TITLE
OSDOCS#17021: Update the z-stream RNs for 4.19.18

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2945,6 +2945,58 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.19.18
+[id="ocp-4-19-18_{context}"]
+=== RHBA-2025:19301 - {product-title} {product-version}.18 image release and bug fix advisory
+
+Issued: 05 November 2025
+
+{product-title} release {product-version}.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:19301[RHBA-2025:19301] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:19299[RHBA-2025:19299] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.18 --pullspecs
+----
+
+[id="ocp-4-19-18-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, the `OAuth` route was not accepted by the private router when the DNS record was not registered in the `external-dns` Operator. This action led to improper URL resolution, and the console failed to access the `OAuth` route. As a consequence, the `Console ClusterOperator` was stuck. With this release, the `OAuth` route admission and URL resolution issues in the hosted cluster is fixed. As a result, the `OAuth` route is accessible and the console access is approved. (link:https://issues.redhat.com/browse/OCPBUGS-61407[OCPBUGS-61407])
+
+* Before this release, deleting a `VolumeSnapshot` object for a persistent volume provisioned by the {azure-short} file CSI driver also deleted the underlying fileshare and resulted in data loss. With this release, this issue is corrected by updating the driver to ensure that only the snapshot is removed. The source fileshare is preserved. (link:https://issues.redhat.com/browse/OCPBUGS-62911[OCPBUGS-62911])
+
+* Before this update, frequent driver configuration updates that were caused by an inconsistent storage class order in a hosted cluster namespace caused `ConfigMap` content flaps. This issue resulted in inconsistent storage class enforcement and affected user experience. With this release, the `ConfigMap` driver configuration is stabilized, which prevents storage classes from flapping, improves `ConfigMap` driver configuration stability, and prevents frequent flapping of a storage class order in a hosted cluster namespace. (link:https://issues.redhat.com/browse/OCPBUGS-62807[OCPBUGS-62807])
+
+* Before this update, Redfish transactions in {sno} nodes failed due to an empty `eTag` field in `metal3-ironic` container logs. As a consequence, users experienced failed Redfish transactions on {sno} nodes. With this release, the Redfish transaction `eTag` field issue is resolved, and results in correct `eTags`. As a result, the Redfish transaction does not fail, allowing the telecommunications company to use the `HostFirmwareSettings` parameter in {sno} nodes. (link:https://issues.redhat.com/browse/OCPBUGS-62961[OCPBUGS-62961])
+
+* Before this update, excessive CPU overcommitment that was greater than 200% caused the `KubeCPUOvercommit` alert to stop triggering after 10 minutes. As a consequence, users were unaware of the CPU overcommitment due to the missing alert. With this release, the `KubeCPUOvercommit` alert triggers correctly when CPU limits are overcommitted, and ensures timely resource management and improved cluster stability. (link:https://issues.redhat.com/browse/OCPBUGS-62965[OCPBUGS-62965])
+
+* Before this update, the `KubeMemoryOvercommit` alert falsely triggered on small multi-node clusters after memory-consuming spikes occurred within the permitted limits. With this release, the alert expression is adjusted to correctly account for small multi-node clusters. As a result, the `KubeMemoryOvercommit` alert does not falsely trigger after these instances. (link:https://issues.redhat.com/browse/OCPBUGS-62966[OCPBUGS-62966])
+
+* Before this update, a Kubernetes `StatefulSet` status replica alert did not activate for invalid pod specifications when a controller failed to create a pod. As a consequence, users received false assurance when the `StatefulSet` failed to create the required number of replicas. With this release, a Kubernetes `StatefulSet` replica count alert triggers for unsuccessful pod creation. As a result, the alert displays correctly when `StatefulSet` replicas do not match the configured amount. (link:https://issues.redhat.com/browse/OCPBUGS-62967[OCPBUGS-62967])
+
+* Before this update, the `KubeAggregatedAPIErrors` alert triggered based on the total number of errors across instances, and caused sensitive user alerts for multiple instances of an API. With this release, the alerting function for the `KubeAggregatedAPIErrors` alert is changed to operate at the instance level, reducing false alarms for APIs with multiple instances. (link:https://issues.redhat.com/browse/OCPBUGS-62968[OCPBUGS-62968])
+
+* Before this update, alerts were not filtered for cordoned nodes, leading to false positives for nodes under maintenance. As a consequence, users experienced false positives due to the filtering of cordoned nodes in alerts. With this release, the cordoned nodes are filtered from alerts to reduce false positives during maintenance. As a result, maintenance alerts are correct and false positives are reduced for cordoned nodes. (link:https://issues.redhat.com/browse/OCPBUGS-62969[OCPBUGS-62969])
+
+* Before this update, destroying an {product-title} cluster on {gcp-full} caused a panic error due to a null pointer reference cancellation in the `waitFor` method. This was due to a failed {gcp-full} API call or an uninitialized client. As a consequence, users experienced a panic error during cluster destruction on {gcp-full}. With this release, the null pointer issue in the cluster uninstaller is fixed, and panic errors during a {gcp-full} destruction are prevented. As a result, the panic error during cluster destruction on {gcp-full} is resolved, ensuring smooth deletion of resources. (link:https://issues.redhat.com/browse/OCPBUGS-62981[OCPBUGS-62981])
+
+* Before this update, an administrative user with a single namespace role created a pod and encountered a blank page while viewing metrics due to an incorrect perspective in the URL. As a consequence, the user could not view CPU usage metrics. With this release, the administrative user can view pod metrics in the developer perspective, and the user can view CPU usage metrics. (link:https://issues.redhat.com/browse/OCPBUGS-62999[OCPBUGS-62999])
+
+* Before this update, the {oci-csi-full} node registrar container logged `gRPC` connection checks every 10 seconds, excessively filling Elasticsearch space. This rapid log filling increased user costs. With this release, the logging frequency of `gRPC` connection checks in the `csi-node-registrar` container is reduced. As a result, the Elasticsearch log capacity is increased, which lowers costs and improves performance. (link:https://issues.redhat.com/browse/OCPBUGS-63193[OCPBUGS-63193])
+
+* Before this update, if a user did not define an EgressIP failover between gateway nodes with a proper IP address, the EgressIP address was not reassigned to the second gateway node after a reboot. This resulted in a communication failure between the pod and the external system. With this release, the EgressIP failover logic is improved for dual-stack environments, ensuring that the EgressIP address is properly reassigned to the available gateway node after a reboot. The communication between pods and external systems after a gateway node reboot is not interrupted. (link:https://issues.redhat.com/browse/OCPBUGS-63234[OCPBUGS-63234])
+
+* Before this update, the upgrade to {product-title} 4.18.24 triggered a kubelet failure on primary nodes due to `ocp-tuned-one-shot` service issues. As a consequence, the kubelet failed to start on primary nodes during upgrades. With this release, the kubelet issue is resolved by fixing the `ocp-tuned-one-shot` service. As a result, the kubelet starts on primary nodes after the upgrade. (link:https://issues.redhat.com/browse/OCPBUGS-63418[OCPBUGS-63418])
+
+[id="ocp-4-19-18-updating_{context}"]
+==== Updating
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.19.17
 [id="ocp-4-19-17_{context}"]
 === RHSA-2025:18233 - {product-title} {product-version}.17 image release and bug fix advisory


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-17021](https://issues.redhat.com//browse/OSDOCS-17021)

Link to docs preview:
[4.19.18](https://101760--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-4-19-18_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:

- Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/206)
- Art [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19)

