### PR TITLE
[OSDOCS#17240]Removed air-gapped reference from ROSA HCP Whats new doc

### DIFF
--- a/modules/rosa-release-notes-Q4-2025.adoc
+++ b/modules/rosa-release-notes-Q4-2025.adoc
@@ -11,7 +11,7 @@ ifdef::openshift-rosa-hcp[]
 * ** On-Demand Capacity Reservations and Capacity Blocks for ML now supported.** You can now use pre-purchased Capacity Reservations when creating new machine pools on {product-title} clusters. For more information, see link:https://docs.redhat.com/documentation/red_hat_openshift_service_on_aws/4/html-single/cluster_administration/index#rosa-managing-worker-nodes[Managing compute nodes].
 
 * ** ImageDigestMirrorSets (IDMS) now supported.**
-{product-title} now supports ImageDigestMirrorSets (IDMS), enabling clusters to redirect image pulls to a private, mirrored registry. This critical enhancement means customers in air-gapped or restricted networks can host their own mirrors for third-party images while satisfying strict security and compliance requirements. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/images/index#images-registry-mirroring_image-configuration-hcp[Image registry mirroring for {product-title}].
+{product-title} now supports ImageDigestMirrorSets (IDMS), enabling clusters to redirect image pulls to a private, mirrored registry. This critical enhancement means customers in restricted networks can host their own mirrors for third-party images while satisfying strict security and compliance requirements. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/images/index#images-registry-mirroring_image-configuration-hcp[Image registry mirroring for {product-title}].
 
 * **{product-title} regions added.** {product-title} is now available in the following regions:
 +


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17240

Link to docs preview:
[What’s new for Red Hat OpenShift Service on AWS Q4 2025](https://101762--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- QE approval is not required for this PR as no procedural changes involved.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
