### PR TITLE
[SRVCOM-4040] Update-link the must-gather section to the latest OCP docs

### DIFF
--- a/about/serverless-support.adoc
+++ b/about/serverless-support.adoc
@@ -30,6 +30,6 @@ include::modules/support-submitting-a-case.adoc[leveloffset=+1]
 
 When you open a support case, it is helpful to provide debugging information about your cluster to Red Hat Support. The `must-gather` tool enables you to collect diagnostic information about your {ocp-product-title} cluster, including data related to {ServerlessProductName}. For prompt support, supply diagnostic information for both {ocp-product-title} and {ServerlessProductName}.
 
-include::modules/about-must-gather.adoc[leveloffset=+2]
-include::modules/serverless-about-collecting-data.adoc[leveloffset=+2]
+For more information about the `must-gather` tool, see the link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/support/gathering-cluster-data#about-must-gather_gathering-cluster-data[must-gather tool documentation].
 
+include::modules/serverless-about-collecting-data.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
- serverless-docs-1.35
- serverless-docs-1.36
- serverless-docs-1.37

Issue:
- https://issues.redhat.com/browse/SRVCOM-4040

Link to docs preview:
- [Gathering diagnostic information for support](https://101765--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-support.html#serverless-support-gather-info)

QE review:
- [x] QE has approved this change.

Additional information: