### PR TITLE
OCP-4.19: fix addtl-release-notes.adoc

### DIFF
--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -67,7 +67,7 @@ xref:../observability/network_observability/network-observability-operator-relea
 xref:../security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc#nbde-tang-server-operator-release-notes[Network-bound Disk Encryption (NBDE) Tang Server Operator]
 
 O::
-xref:../backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc#oadp-1-4-release-notes[{oadp-first}]
+xref:../backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc#oadp-1-5-release-notes[{oadp-first}]
 +
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/#Release%20Notes[{openshift-dev-spaces-productname}]
 +


### PR DESCRIPTION
### Cherry-pick

Cherry Picked from 9504f05f0717cedae2de68a1d7571ad671cffb99 xref: https://github.com/openshift/openshift-docs/pull/101776

### Description

Updating OCP 4.19: to remove unsupported link to OADP 1.4 release notes, which is unsupported on OCP 4.19

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
