### PR TITLE
[enterprise-4.14] OCPBUGS-30975: Added note about calc max no of nodes with subnet figu…

### DIFF
--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -37,7 +37,7 @@ OVN-Kubernetes, the default network provider in {product-title} 4.14 and later v
 
 [IMPORTANT]
 ====
-The previous list includes join, transit, and masquerade IPv4 and IPv6 address subnets. If your cluster uses OVN-Kubernetes, do not include any of these IP address subnet ranges in any other CIDR definitions in your cluster or infrastructure.
+The earlier list includes join, transit, and masquerade IPv4 and IPv6 address subnets. If your cluster uses OVN-Kubernetes, do not include any of these IP address subnet ranges in any other CIDR definitions in your cluster or infrastructure.
 ====
 
 ifndef::openshift-rosa,openshift-dedicated[]
@@ -53,7 +53,7 @@ In the Machine classless inter-domain routing (CIDR) field, you must specify the
 
 [NOTE]
 ====
-Machine CIDR ranges cannot be changed after creating your cluster.
+You cannot change Machine CIDR ranges after you created your cluster.
 ====
 
 ifdef::openshift-rosa,openshift-dedicated[]
@@ -97,13 +97,24 @@ You can expand the range after cluster installation.
 endif::openshift-enterprise[]
 
 [id="host-prefix-description"]
-== Host Prefix
-In the Host Prefix field, you must specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine.
+== Host prefix
+
+In the `hostPrefix` parameter, you must specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine.
 
 ifdef::openshift-rosa,openshift-dedicated[]
 For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 512 cluster nodes, and 512 pods per node (both of which are beyond our maximum supported).
 endif::openshift-rosa,openshift-dedicated[]
 
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-rosa,openshift-dedicated[]
 For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 510 cluster nodes, and 510 pod IP addresses per node.
-endif::openshift-enterprise[]
+
+Consider another example where you set the `clusterNetwork.cidr` parameter to `10.128.0.0/16`, you define the complete address space for the cluster. This assigns a pool of 65536 IP addresses to your cluster. If you then set the `hostPrefix` parameter to `/23`, you define a subnet slice to each node in the cluster, where the `/23` slice becomes a subnet of the `/16` subnet network. This assigns 512 IP addresses to each node, where 2 IP addresses get reserved for networking and broadcasting purposes. The following example calculation uses these IP address figures to determine the maximum number of nodes that you can create for your cluster:
+
+[source,text]
+----
+65536 / 512 = 128
+----
+
+You can use the link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator] to calculate the maximum number of nodes for your cluster.
+endif::openshift-enterprise,openshift-rosa,openshift-dedicated[]
+


### PR DESCRIPTION
Cherry pick of #100822 with commit ID a5973623cc5335b74c073490ce4f581a11dd6f67

Version(s):
4.14

Issue:
[OCPBUGS-30975](https://issues.redhat.com/browse/OCPBUGS-30975)


