### PR TITLE
OSDOCS-15649-417: manual CP NW mods

### DIFF
--- a/microshift_networking/microshift-cni.adoc
+++ b/microshift_networking/microshift-cni.adoc
@@ -6,62 +6,24 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-The OVN-Kubernetes Container Network Interface (CNI) plugin is the default networking solution for a {microshift-short} node. OVN-Kubernetes is a virtualized network for pods and services that is based on Open Virtual Network (OVN).
+[role="_abstract"]
+You can use the OVN-Kubernetes Network Interface to create and manage network connections for internet-connected nodes.
 
-* Default network configuration and connections are applied automatically in {microshift-short} with the `microshift-networking` RPM during installation.
-* A node that uses the OVN-Kubernetes network plugin also runs Open vSwitch (OVS) on the node.
-* OVN-K configures OVS on the node to implement the declared network configuration.
-* Host physical interfaces are not bound by default to the OVN-K gateway bridge, `br-ex`. You can use standard tools on the host for managing the default gateway, such as the Network Manager CLI (`nmcli`).
-* Changing the CNI is not supported on {microshift-short}.
-
-Using configuration files or custom scripts, you can configure the following networking settings:
-
-* You can use subnet CIDR ranges to allocate IP addresses to pods.
-* You can change the maximum transmission unit (MTU) value.
-* You can configure firewall ingress and egress.
-* You can define network policies in the {microshift-short} node, including ingress and egress rules.
-* You can use the {microshift-short} Multus plug-in to chain other CNI plugins.
-* You can configure or remove the ingress router.
+include::modules/microshift-default-networking-plugin.adoc[leveloffset=+1]
 
 include::modules/microshift-cni-customization-matrix.adoc[leveloffset=+1]
 
 include::modules/microshift-default-settings.adoc[leveloffset=+2]
 
-[id="microshift-network-features_{context}"]
-== Network features
-Networking features available with {microshift-short} {product-version} include:
+include::modules/microshift-network-features.adoc[leveloffset=+1]
 
-* Kubernetes network policy
-* Dynamic node IP
-* Custom gateway interface
-* Second gateway interface
-* Node network on specified host interface
-* Blocking external access to NodePort service on specific host interfaces
+include::modules/microshift-ip-forward.adoc[leveloffset=+2]
 
-Networking features not available with {microshift-short} {product-version}:
-
-* Egress IP/firewall/QoS: disabled
-* Hybrid networking: not supported
-* IPsec: not supported
-* Hardware offload: not supported
-
-[id="microshift-ip-forward_{context}"]
-== IP forward
-The host network `sysctl net.ipv4.ip_forward` kernel parameter is automatically enabled by the `ovnkube-master` container when started. This is required to forward incoming traffic to the CNI. For example, accessing the NodePort service from outside of a node fails if `ip_forward` is disabled.
-
-[id="microshift-network-performance_{context}"]
-== Network performance optimizations
-By default, three performance optimizations are applied to OVS services to minimize resource consumption:
-
-* CPU affinity to `ovs-vswitchd.service` and `ovsdb-server.service`
-* `no-mlockall` to `openvswitch.service`
-* Limit handler and `revalidator` threads to `ovs-vswitchd.service`
+include::modules/microshift-network-performance.adoc[leveloffset=+1]
 
 include::modules/microshift-nw-components-svcs.adoc[leveloffset=+1]
 
-[id="microshift-bridge-mapping_{context}"]
-== Bridge mappings
-Bridge mappings allow provider network traffic to reach the physical network. Traffic leaves the provider network and arrives at the `br-int` bridge. A patch port between `br-int` and `br-ex` then allows the traffic to traverse to and from the provider network and the edge network. Kubernetes pods are connected to the `br-int` bridge through virtual ethernet pair: one end of the virtual ethernet pair is attached to the pod namespace, and the other end is attached to the `br-int` bridge.
+include::modules/microshift-bridge-mappings.adoc[leveloffset=+1]
 
 include::modules/microshift-nw-topology.adoc[leveloffset=+1]
 

--- a/modules/microshift-bridge-mappings.adoc
+++ b/modules/microshift-bridge-mappings.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-cni.adoc.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-bridge-mappings_{context}"]
+= Bridge mappings
+
+[role="_abstract"]
+Understand how provider network traffic reaches the physical network through bridge mappings. The following concepts apply:
+
+* Traffic leaves the provider network and arrives at the `br-int` bridge.
+* A patch port between `br-int` and `br-ex` then allows the traffic to traverse to and from the provider network and the edge network.
+* Kubernetes pods are connected to the `br-int` bridge through a virtual ethernet pair. One end of the virtual ethernet pair is attached to the pod namespace, and the other end is attached to the `br-int` bridge.

--- a/modules/microshift-cni-customization-matrix.adoc
+++ b/modules/microshift-cni-customization-matrix.adoc
@@ -1,8 +1,12 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-cni.adoc.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="microshift-nw-customization-matrix_{context}"]
 = {microshift-short} networking configuration matrix
 
+[role="_abstract"]
 The following table summarizes the status of networking features and capabilities that are either present as defaults, supported for configuration, or not available with the {microshift-short} service:
 
 .{microshift-short} networking features and capabilities overview
@@ -10,7 +14,7 @@ The following table summarizes the status of networking features and capabilitie
 |===
 |Network capability|Availability|Configuration supported
 
-|Advertise address|Yes|Yes ^[1]^
+|Advertise address|Yes|Yes
 
 |Kubernetes network policy|Yes|Yes
 
@@ -18,9 +22,9 @@ The following table summarizes the status of networking features and capabilitie
 
 |Load balancing|Yes|Yes
 
-|Multicast DNS|Yes|Yes ^[2]^
+|Multicast DNS|Yes|Yes
 
-|Network proxies|Yes ^[3]^|CRI-O
+|Network proxies|Yes|CRI-O
 
 |Network performance|Yes|MTU configuration
 
@@ -30,7 +34,7 @@ The following table summarizes the status of networking features and capabilitie
 
 |Egress router|Not available|N/A
 
-|Firewall|No ^[4]^|Yes
+|Firewall|No|Yes
 
 |Hardware offloading|Not available|N/A
 
@@ -38,16 +42,23 @@ The following table summarizes the status of networking features and capabilitie
 
 |IPsec encryption for intra-cluster communication|Not available|N/A
 
-|IPv6|Supported ^[5]^|N/A
+|IPv6|Supported|N/A
 
-|Ingress router|Yes|Yes ^[6]^
+|Ingress router|Yes|Yes
 
-|Multiple networks plug-in|Yes|Yes
+|Multiple networks plugin|Yes|Yes
 |===
 
-1. If unset, the default value is set to the next immediate subnet after the service network. For example, when the service network is `10.43.0.0/16`, the `advertiseAddress` is set to `10.44.0.0/32`.
-2. You can use the multicast DNS protocol (mDNS) to allow name resolution and service discovery within a Local Area Network (LAN) using multicast exposed on the `5353/UDP` port.
-3. There is no built-in transparent proxying of egress traffic in {microshift-short}. Egress must be manually configured.
-4. Setting up the firewalld service is supported by {op-system-ostree}.
-5. IPv6 is supported in both single-stack and dual-stack networks with the OVN-Kubernetes network plugin. IPv6 can also be used by connecting to other networks with the {microshift-short} Multus CNI plugin.
-6. Configure by using the {microshift-short} `config.yaml` file.
+Additional details about networking capabilities::
+
+* `Advertise address`: If unset, the default value is set to the next immediate subnet after the service network. For example, when the service network is `10.43.0.0/16`, the `advertiseAddress` is set to `10.44.0.0/32`.
+
+* `Multicast DNS`: You can use the multicast DNS protocol (mDNS) to allow name resolution and service discovery within a Local Area Network (LAN) using multicast exposed on the `5353/UDP` port.
+
+* `Network proxies`: There is no built-in transparent proxying of egress traffic in {microshift-short}. Egress must be manually configured.
+
+* `Firewall`: Setting up the firewalld service is supported by {op-system-ostree}.
+
+* `IPv6`: Is supported in both single-stack and dual-stack networks with the OVN-Kubernetes network plugin. You can also use IPv6 by connecting to other networks with the {microshift-short} Multus CNI plugin.
+
+* `Ingress router`: Configure by using the {microshift-short} `config.yaml` file.

--- a/modules/microshift-default-networking-plugin.adoc
+++ b/modules/microshift-default-networking-plugin.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-cni.adoc.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-default-networking-plugin_{context}"]
+= {microshift-short} default networking plugin
+
+[role="_abstract"]
+The OVN-Kubernetes Container Network Interface (CNI) plugin is the default networking solution for a {microshift-short} node. OVN-Kubernetes is a virtualized network for pods and services that is based on Open Virtual Network (OVN).
+
+* Changing the CNI is not supported on {microshift-short}.
+* Default network configuration and connections are applied automatically in {microshift-short} with the `microshift-networking` RPM during installation.
+* A node that uses the OVN-Kubernetes network plugin also runs Open vSwitch (OVS) on the node.
+* OVN-K configures OVS on the node to implement the declared network configuration.
+* Host physical interfaces are not bound by default to the OVN-K gateway bridge, `br-ex`. You can use standard tools on the host for managing the default gateway, such as the Network Manager CLI (`nmcli`).
+
+Using configuration files or custom scripts, you can configure the following networking settings:
+
+* You can use subnet CIDR ranges to allocate IP addresses to pods.
+* You can change the maximum transmission unit (MTU) value.
+* You can configure firewall ingress and egress.
+* You can define network policies in the {microshift-short}, including ingress and egress rules.
+* You can use the {microshift-short} Multus plugin to chain other CNI plugins.
+* You can configure or remove the ingress router.

--- a/modules/microshift-default-settings.adoc
+++ b/modules/microshift-default-settings.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * microshift_configuring/microshift-default-config-yaml.adoc
+// * microshift_networking/microshift-cni.adoc.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="microshift-yaml-default_{context}"]

--- a/modules/microshift-ip-forward.adoc
+++ b/modules/microshift-ip-forward.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-cni.adoc.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-ip-forward_{context}"]
+= IP forward
+
+[role="_abstract"]
+You must use `ip_forward` to access network connectivity.
+
+The host network `sysctl net.ipv4.ip_forward` kernel parameter is automatically enabled by the `ovnkube-master` container when started. This is required to forward incoming traffic to the CNI. For example, accessing the NodePort service from outside of a node fails if `ip_forward` is disabled.

--- a/modules/microshift-network-features.adoc
+++ b/modules/microshift-network-features.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-cni.adoc.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-network-features_{context}"]
+= Network features
+
+[role="_abstract"]
+Understand which networking feature are available and which are not for your {microshift-short} deployments.
+
+Networking features available with {microshift-short} {product-version} include:
+
+* Kubernetes network policy
+* Dynamic node IP
+* Custom gateway interface
+* Second gateway interface
+* Node network on specified host interface
+* Blocking external access to NodePort service on specific host interfaces
+
+Networking features not available with {microshift-short} {product-version}:
+
+* Egress IP/firewall/QoS: disabled
+* Hybrid networking: not supported
+* IPsec: not supported
+* Hardware offload: not supported

--- a/modules/microshift-network-performance.adoc
+++ b/modules/microshift-network-performance.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-cni.adoc.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-network-performance_{context}"]
+= Network performance optimizations
+
+[role="_abstract"]
+By default, three performance optimizations are applied to OVS services to minimize resource consumption:
+
+* CPU affinity to `ovs-vswitchd.service` and `ovsdb-server.service`
+* `no-mlockall` to `openvswitch.service`
+* Limit handler and `revalidator` threads to `ovs-vswitchd.service`

--- a/modules/microshift-nw-components-svcs.adoc
+++ b/modules/microshift-nw-components-svcs.adoc
@@ -3,9 +3,16 @@
 // * microshift_networking/microshift-cni.adoc
 
 :_mod-docs-content-type: CONCEPT
-[id="microshift-network-comps-svcs_{context}"]
+[id="microshift-nw-components-svcs_{context}"]
 = {microshift-short} networking components and services
-This brief overview describes networking components and their operation in {microshift-short}. The `microshift-networking` RPM is a package that automatically pulls in any networking-related dependencies and systemd services to initialize networking, for example, the `microshift-ovs-init` systemd service.
+
+[role="_abstract"]
+Understand networking components and services and their operation in {microshift-short}.
+
+[NOTE]
+====
+The `microshift-networking` RPM is a package that automatically pulls in any networking-related dependencies and systemd services to initialize networking, for example, the `microshift-ovs-init` systemd service.
+====
 
 NetworkManager::
 NetworkManager is required to set up the initial gateway bridge on the {microshift-short} node. The NetworkManager and `NetworkManager-ovs` RPM packages are installed as dependencies to the `microshift-networking` RPM package, which contains the necessary configuration files. NetworkManager in {microshift-short} uses the `keyfile` plugin and is restarted after installation of the `microshift-networking` RPM package.

--- a/modules/microshift-nw-topology.adoc
+++ b/modules/microshift-nw-topology.adoc
@@ -5,17 +5,27 @@
 :_mod-docs-content-type: CONCEPT
 [id="microshift-network-topology_{context}"]
 = Network topology
-OVN-Kubernetes provides an overlay-based networking implementation. This overlay includes an OVS-based implementation of Service and NetworkPolicy. The overlay network uses the Geneve (Generic Network Virtualization Encapsulation) tunnel protocol. The pod maximum transmission unit (MTU) for the Geneve tunnel is set to the default route MTU if it is not configured.
+
+[role="_abstract"]
+OVN-Kubernetes provides an overlay-based networking implementation. This overlay includes an OVS-based implementation of `Service` and `NetworkPolicy` resources.
+
+The overlay network uses the Geneve (Generic Network Virtualization Encapsulation) tunnel protocol. The pod maximum transmission unit (MTU) for the Geneve tunnel is set to the default route MTU if it is not configured.
 
 To configure the MTU, you must set an equal-to or less-than value than the MTU of the physical interface on the host. A less-than value for the MTU makes room for the required information that is added to the tunnel header before it is transmitted.
 
-OVS runs as a systemd service on the {microshift-short} node. The OVS RPM package is installed as a dependency to the `microshift-networking` RPM package. OVS is started immediately when the `microshift-networking` RPM is installed.
+[IMPORTANT]
+====
+The MTU value of the OVN overlay networking in {microshift-short} must be 100 bytes smaller than the MTU value of the base network. If no MTU value is configured, {microshift-short} autoconfigures the value using the MTU value of the default gateway (Internet Protocol version 4 (IPv4) or Internet Protocol version 6 (IPv6)) of the host. If the auto-configuration does not work correctly, the MTU value can be configured manually. For example, if the MTU value of the network is `9000`, the OVN MTU size must be set to `8900`.
+====
+
+OVS runs as a systemd service on the {microshift-short} node. The OVS RPM package is installed as a dependency to the `microshift-networking` RPM package. OVS starts immediately when the `microshift-networking` RPM is installed.
 
 .{product-title} network topology
 image:317_RHbM_OVN_topology_0923.png[title="{microshift-short} uses an overlay-based networking implementation, details follow."]
 
 [id="microshift-description-ovn-logical-components_{context}"]
 == Description of the OVN logical components of the virtualized network
+
 OVN node switch::
 A virtual switch named `<node-name>`. The OVN node switch is named according to the hostname of the node.
 ** In this example, the `node-name` is `microshift-dev`.
@@ -35,6 +45,7 @@ A virtual switch named `ext_<node-name>.`
 
 [id="microshift-description-connections-network-topology_{context}"]
 == Description of the connections in the network topology figure
+
 * The north-south traffic between the network service and the OVN external switch `ext_microshift-dev` is provided through the host kernel by the gateway bridge `br-ex`.
 * The OVN gateway router `GR_microshift-dev` is connected to the external network switch `ext_microshift-dev` through the logical router port 4. Port 4 is attached with the node IP address 192.168.122.14.
 * The join switch `join` connects the OVN gateway router `GR_microshift-dev` to the OVN cluster router `ovn_cluster_router`. The IP address range is 100.62.0.0/16.


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-15649](https://issues.redhat.com/browse/OSDOCS-15649)

Link to docs preview:

QE review:
N/A no technical content updated; pre-migration structure only

Additional information:
Manual CP https://github.com/openshift/openshift-docs/pull/101707

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
