### PR TITLE
CNV#62394: RN 4.20 deprecate RHEL 8 kubevirt-virtctl RPM

### DIFF
--- a/virt/release_notes/virt-4-20-release-notes.adoc
+++ b/virt/release_notes/virt-4-20-release-notes.adoc
@@ -169,7 +169,12 @@ For a complete list of virtualization metrics, see the link:https://github.com/o
 Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
 
 * The `OperatorConditionsUnhealthy` alert is deprecated. You can safely xref:../../observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc#silencing-alerts-adm_managing-alerts-as-an-administrator[silence] it.
+
 * All hot plugged disks are persistent by default. The use of non-persistent hot plugged disks is deprecated. They will not be supported in future releases.
+
+// CNV-60596
+* The RHEL 8 `kubevirt-virtctl` RPM is deprecated. In 4.20, the RPM remains available but prints a deprecation message. Download the `virtctl` binary from the {product-title} web console instead of using the command line. The RPM will be removed in 4.21
+
 
 [id="virt-4-20-removed_{context}"]
 === Removed features
@@ -196,10 +201,10 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 * You can now use the Plug a Simple Socket Transport (passt) network binding plugin to connect a VM to a primary user-defined network (UDN). For more information, see xref:../../virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc#attaching-vm-to-primary-udn_virt-connecting-vm-to-primary-udn[Attaching a virtual machine to the primary user-defined network].
 
 //CNV-71951
-* You can now configure {ibm-name} Secure Execution virtual machines on {ibm-z-name} and {ibm-linuxone-name}. For more information, see xref:../../virt/creating_vm/virt-configuring-ibm-secure-execution-vms-ibm-z.adoc#virt-configuring-ibm-secure-execution-vms-ibm-z[Configuring {ibm-name} Secure Execution virtual machines on {ibm-z-name} and {ibm-linuxone-name}]  
+* You can now configure {ibm-name} Secure Execution virtual machines on {ibm-z-name} and {ibm-linuxone-name}. For more information, see xref:../../virt/creating_vm/virt-configuring-ibm-secure-execution-vms-ibm-z.adoc#virt-configuring-ibm-secure-execution-vms-ibm-z[Configuring {ibm-name} Secure Execution virtual machines on {ibm-z-name} and {ibm-linuxone-name}]
 
 // CNV-57725
-* As a Technology Preview, {VirtProductName} now provides the inject and eject functionality for virtual CD-ROMs. By using this functionality, you can insert and remove ISO images as CD-ROM volumes in running virtual machines. 
+* As a Technology Preview, {VirtProductName} now provides the inject and eject functionality for virtual CD-ROMs. By using this functionality, you can insert and remove ISO images as CD-ROM volumes in running virtual machines.
 +
 // ADD XREF TO SECTION WHEN IT IS AVAILABLE: For details, see xref:virt-inserting-cd-roms-in-virtual-machines.html[Inserting CD-ROMs in live virtual machines].
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/CNV-62394

Link to docs preview:
https://101820--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-20-release-notes.html#virt-4-20-deprecated_virt-4-20-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
