### PR TITLE
removes unoffical abbreviation from main (no OSDOCS issue)

### DIFF
--- a/modules/hcp-deploy-openstack-create.adoc
+++ b/modules/hcp-deploy-openstack-create.adoc
@@ -82,7 +82,7 @@ $ df -h /var/lib
 
 [NOTE]
 ====
-The {rh-openstack} resources that the cluster API (CAPI) provider creates are tagged with the label `openshiftClusterID=<infraID>`. 
+The {rh-openstack} resources that the cluster API provider creates are tagged with the label `openshiftClusterID=<infraID>`.
 
 You can define additional tags for the resources as values in the `HostedCluster.Spec.Platform.OpenStack.Tags` field of a YAML manifest that you use to create the hosted cluster. After you scale up the node pool, the tags apply to resources.
 ====


### PR DESCRIPTION
Version(s):
4.19+

Issue:
N/A

Link to docs preview:
[Creating a hosted cluster on OpenStack](https://101822--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-deploy/hcp-deploy-openstack.html#hcp-deploy-openstack-create_hcp-deploy-openstack)

QE review:
N/A

Additional information: