### PR TITLE
OSDOCS-17243 RODOO 1.1.3 release notes in 4.16

### DIFF
--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -14,6 +14,20 @@ These release notes track the development of the {run-once-operator} for {produc
 
 For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
 
+[id="run-once-duration-override-operator-release-notes-1-1-3"]
+== {run-once-operator} 1.1.3
+
+Issued: 12 November 2025
+
+The following advisory is available for the {run-once-operator} 1.1.3:
+
+* link:https://access.redhat.com/errata/RHBA-2025:21109[RHBA-2025:21109]
+
+[id="run-once-duration-override-operator-1-1-3-bug-fixes"]
+=== Bug fixes
+
+* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
 [id="run-once-duration-override-operator-release-notes-1-1-2"]
 == {run-once-operator} 1.1.2
 


### PR DESCRIPTION
Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-17243](https://issues.redhat.com/browse/OSDOCS-17243)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: https://101832--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html#run-once-duration-override-operator-release-notes-1-1-3
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
