### PR TITLE
OSDOCS-17248:removes SDN UDP port from OVN-K docs

### DIFF
--- a/modules/configuring-hybrid-ovnkubernetes.adoc
+++ b/modules/configuring-hybrid-ovnkubernetes.adoc
@@ -78,7 +78,7 @@ spec:
         hybridOverlayVXLANPort: 9898 <2>
 ----
 <1> Specify the CIDR configuration used for nodes on the additional overlay network. The `hybridClusterNetwork` CIDR must not overlap with the `clusterNetwork` CIDR.
-<2> Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `4789` port. For more information on this requirement, see link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken] in the Microsoft documentation.
+<2> Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `6081` port. For more information on this requirement, see link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken] in the Microsoft documentation.
 +
 [NOTE]
 ====
@@ -130,7 +130,7 @@ where:
 
 `cidr`:: Specify the CIDR configuration used for nodes on the additional overlay network. This CIDR must not overlap with the cluster network CIDR.
 `hostPrefix`:: Specifies the subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
-`hybridOverlayVXLANPort`:: Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `4789` port. For more information on this requirement, see link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken] in the Microsoft documentation.
+`hybridOverlayVXLANPort`:: Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `6081` port. For more information on this requirement, see link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken] in the Microsoft documentation.
 
 [NOTE]
 ====

--- a/modules/installation-about-custom-azure-vnet.adoc
+++ b/modules/installation-about-custom-azure-vnet.adoc
@@ -154,8 +154,6 @@ the Cluster Version Operator on port `9099`.
 |The default ports that Kubernetes reserves
 
 .6+|UDP
-|`4789`
-|VXLAN
 
 |`6081`
 |Geneve

--- a/modules/installation-aws-user-infra-requirements.adoc
+++ b/modules/installation-aws-user-infra-requirements.adoc
@@ -274,12 +274,12 @@ a `AWS::EC2::SecurityGroupIngress` resource.
 |`MasterIngressVxlan`
 |Vxlan packets
 |`udp`
-|`4789`
+|`6081`
 
 |`MasterIngressWorkerVxlan`
 |Vxlan packets
 |`udp`
-|`4789`
+|`6081`
 
 |`MasterIngressInternal`
 |Internal cluster communication and Kubernetes proxy metrics
@@ -391,12 +391,12 @@ a `AWS::EC2::SecurityGroupIngress` resource.
 |`WorkerIngressVxlan`
 |Vxlan packets
 |`udp`
-|`4789`
+|`6081`
 
 |`WorkerIngressWorkerVxlan`
 |Vxlan packets
 |`udp`
-|`4789`
+|`6081`
 
 |`WorkerIngressInternal`
 |Internal cluster communication

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -162,8 +162,6 @@ the Cluster Version Operator on port `9099`.
 |`22623`
 |The port handles traffic from the Machine Config Server and directs the traffic to the control plane machines.
 .6+|UDP
-|`4789`
-|VXLAN
 
 |`6081`
 |Geneve

--- a/modules/installation-vsphere-installer-network-requirements.adoc
+++ b/modules/installation-vsphere-installer-network-requirements.adoc
@@ -38,8 +38,6 @@ the Cluster Version Operator on port `9099`.
 |The default ports that Kubernetes reserves
 
 .5+|UDP
-|`4789`
-|virtual extensible LAN (VXLAN)
 
 |`6081`
 |Geneve


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-17248
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://101844--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/upi/installing-restricted-networks-azure-user-provisioned#:~:text=Table%203.%20Ports%20used%20for%20all%2Dmachine%20to%20all%2Dmachine%20communications

https://101844--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs#:~:text=control%20plane%20machines.-,UDP,-6081
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
