### PR TITLE
OSDOCS#17023:  Update the z-stream RNs for 4.15.59

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2812,6 +2812,34 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.15.59
+[id="ocp-4-15-59_{context}"]
+=== RHSA-2025:19306 - {product-title} 4.15.59 bug fix and security update
+
+Issued: 06 November 2025
+
+{product-title} release 4.15.59 is now available. The list of bug fixes that are included in this update is documented in the link:https://access.redhat.com/errata/RHSA-2025:19306[RHSA-2025:19306] advisory. The RPM packages that are included in this update are provided by the link:https://access.redhat.com/errata/RHBA-2025:19304[RHBA-2025:19304] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.59 --pullspecs
+----
+
+[id="ocp-4-15-59-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, Operator installations failed on customer clusters because of network timeouts. With this release, Operator installations are successful because the catalog cache refreshing interval is extended and network timeout issues are avoided. (link:https://issues.redhat.com/browse/OCPBUGS-57430[OCPBUGS-57430])
+
+* Before this update, the `id` property was used in the `properties.storageProfile.[osDiskImage/dataDiskImages].source` parameter for {azure-first}, which was not supported after 8 October 2025. As a consequence, users could not install {product-title} on {azure-short}. With this release, the `id` property is replaced with `storageAccountId` in the `storageProfile.osDiskImage.source` parameter for certain {product-title} installations on {azure-short}. As a result, {product-title} clusters on {azure-short} comply with storage profile requirements and installations after 8 October 2025 are successful. (link:https://issues.redhat.com/browse/OCPBUGS-62849[OCPBUGS-62849])
+
+[id="ocp-4-15-59-updating_{context}"]
+==== Updating
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
+
 // 4.15.58
 [id="ocp-4-15-58_{context}"]
 === RHBA-2025:16160 - {product-title} 4.15.58 bug fix and security update
@@ -2839,7 +2867,6 @@ $ oc adm release info 4.15.58 --pullspecs
 [id="ocp-4-15-58-updating_{context}"]
 ==== Updating
 To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster by using the CLI].
-
 
 // 4.15.57
 [id="ocp-4-15-57_{context}"]


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-17023](https://issues.redhat.com//browse/OSDOCS-17023)

Link to docs preview:
[4.15.59](https://101848--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#ocp-4-15-59_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/207)
Art [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.15)

