### PR TITLE
OSSM-11241 Remove "Tech preview" banner for Istio ambient mode in v3.2

### DIFF
--- a/install/ossm-istio-ambient-mode.adoc
+++ b/install/ossm-istio-ambient-mode.adoc
@@ -8,8 +8,6 @@ toc::[]
 
 {istio} ambient mode introduces an architecture for {SMProductName} without sidecar injection. The {istio} ambient mode is designed to simplify operations and reduce resource usage. Instead of injecting a sidecar proxy into each application pod, ambient mode uses a shared node-level proxy for Layer 4 (L4) functionality and an optional, dedicated proxy for Layer 7 (L7) features.
 
-include::snippets/technology-preview-istio-ambient-mode.adoc[]
-
 include::modules/ossm-about-istio-ambient-mode.adoc[leveloffset=+1]
 
 include::modules/ossm-installing-istio-ambient-mode.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; Remove "Tech preview" banner for Istio ambient mode in v3.2

Doc JIRA: https://issues.redhat.com/browse/OSSM-11241

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Doc Preview: https://101866--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-istio-ambient-mode.html

SME Review/QE Review: @MaxBab @sridhargaddam 
Peer Review: @max-cx 