### PR TITLE
OSDOCS-16284-vxlan: Removed VXLAN entry from UDN tables

### DIFF
--- a/modules/installation-about-custom-azure-vnet.adoc
+++ b/modules/installation-about-custom-azure-vnet.adoc
@@ -154,8 +154,6 @@ the Cluster Version Operator on port `9099`.
 |The default ports that Kubernetes reserves
 
 .6+|UDP
-|`4789`
-|VXLAN
 
 |`6081`
 |Geneve

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -162,8 +162,6 @@ the Cluster Version Operator on port `9099`.
 |`22623`
 |The port handles traffic from the Machine Config Server and directs the traffic to the control plane machines.
 .6+|UDP
-|`4789`
-|VXLAN
 
 |`6081`
 |Geneve

--- a/modules/installation-vsphere-installer-network-requirements.adoc
+++ b/modules/installation-vsphere-installer-network-requirements.adoc
@@ -38,8 +38,6 @@ the Cluster Version Operator on port `9099`.
 |The default ports that Kubernetes reserves
 
 .5+|UDP
-|`4789`
-|virtual extensible LAN (VXLAN)
 
 |`6081`
 |Geneve


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OSDOCS-16284](https://issues.redhat.com/browse/OSDOCS-16284)

Link to docs preview:
* [Network security group requirements](https://101871--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-government-region.html#installation-about-custom-azure-vnet-nsg-requirements_installing-azure-government-region)


- [ ] SME has approved this change.
- [ ] QE has approved this change.

