### PR TITLE
OCPBUGS-64725: Adding image-set resource to Hub RDS

### DIFF
--- a/modules/telco-hub-crs-image-mirroring.adoc
+++ b/modules/telco-hub-crs-image-mirroring.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/telco-hub-rds.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="image-mirroring-crs_{context}"]
+= Image mirroring reference CRs
+
+.Image mirroring CRs
+[cols="4*", options="header", format=csv]
+|====
+Component,Reference CR,Description,Optional
+Mirroring configuration CRs,`imageset-config.yaml`,"Defines an `ImageSetConfiguration` CR for mirroring {product-title} channels and Operator packages specific to versions and target catalogs.",No
+|====

--- a/scalability_and_performance/telco-hub-rds.adoc
+++ b/scalability_and_performance/telco-hub-rds.adoc
@@ -230,6 +230,8 @@ include::modules/telco-hub-crs-logging.adoc[leveloffset=+1]
 
 include::modules/telco-hub-crs-container-registry.adoc[leveloffset=+1]
 
+include::modules/telco-hub-crs-image-mirroring.adoc[leveloffset=+1]
+
 include::modules/telco-hub-crs-installation.adoc[leveloffset=+1]
 
 include::modules/telco-hub-software-stack.adoc[leveloffset=+1]


### PR DESCRIPTION
OCPBUGS-64725: Adding image-set resource to Hub RDS

Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OCPBUGS-63642

Link to docs preview:
https://101875--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-hub-rds.html#image-mirroring-crs_telco-hub

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
