### PR TITLE
[enterprise-4.16] OSDOCS-17179 [NETOBSERV] Outdated doc for netobserv CLI

### DIFF
--- a/modules/network-observability-netobserv-cli-install.adoc
+++ b/modules/network-observability-netobserv-cli-install.adoc
@@ -1,53 +1,66 @@
 // Module included in the following assemblies:
-
+//
 // * observability/network_observability/netobserv_cli/netobserv-cli-install.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-cli-install_{context}"]
 = Installing the Network Observability CLI
 
-Installing the Network Observability CLI (`oc netobserv`) is a separate procedure from the Network Observability Operator installation. This means that, even if you have the Operator installed from OperatorHub, you need to install the CLI separately.
+[role="_abstract"]
+The Network Observability CLI gives you a lightweight way to quickly debug and troubleshoot network observability. It must be installed separately.
+
+Installing the Network Observability CLI (`oc netobserv`) is a separate procedure from the Network Observability Operator installation. This means that, even if the Operator is installed from the software catalog, the `CLI` must be installed separately.
 
 [NOTE]
 ====
-You can optionally use Krew to install the `netobserv` CLI plugin. For more information, see "Installing a CLI plugin with Krew".
+Users can optionally use Krew to install the `netobserv` CLI plugin. For more information, see "Installing a CLI plugin with Krew".
 ====
 
 .Prerequisites
 * You must install the {oc-first}.
 * You must have a macOS or Linux operating system.
+* You must install either `docker` or `podman`.
+
+[NOTE]
+====
+You can use `podman` or `docker` to run the installation commands. This procedure uses `podman`.
+====
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/cgw/netobserv/latest/[`oc netobserv` file] that corresponds with your architecture. For example, for the `amd64` archive:
+. Log in to the *Red Hat registry* by running the following command:
 +
 [source,terminal]
 ----
-$ curl -LO https://mirror.openshift.com/pub/cgw/netobserv/latest/oc-netobserv-amd64
+$ podman login registry.redhat.io
 ----
-. Make the file executable:
+
+. Extract the `oc-netobserv` file from the image by running the following commands:
 +
 [source,terminal]
 ----
-$ chmod +x ./oc-netobserv-amd64
+$ podman create --name netobserv-cli registry.redhat.io/network-observability/network-observability-cli-rhel9:1.10
+$ podman cp netobserv-cli:/oc-netobserv .
+$ podman rm netobserv-cli
 ----
-. Move the extracted `netobserv-cli` binary to a directory that is on your `PATH`, such as `/usr/local/bin/`:
+
+. Move the extracted file to a directory that is on the system's `PATH`, such as `/usr/local/bin/`, by running the following command:
 +
 [source,terminal]
 ----
-$ sudo mv ./oc-netobserv-amd64 /usr/local/bin/oc-netobserv
+$ sudo mv oc-netobserv /usr/local/bin/
 ----
 
 .Verification
 
-* Verify that `oc netobserv` is available:
+. Verify that `oc netobserv` is available:
 +
 [source,terminal]
 ----
 $ oc netobserv version
 ----
 +
-.Example output
+This command should produce an outcome similar to the following example:
 [source,terminal]
 ----
 Netobserv CLI version <version>


### PR DESCRIPTION
Cherry-picked from: 4af71aad16e858a4fab33e8d39ecc1051c9b8323

PR: https://github.com/openshift/openshift-docs/pull/101693

Version(s):
4.16

QE review:
QE is not required for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
