### PR TITLE
OCPBUGS 64727: Pod specification in user namespace support documentation is wrong

### DIFF
--- a/modules/nodes-pods-user-namespaces-configuring.adoc
+++ b/modules/nodes-pods-user-namespaces-configuring.adoc
@@ -14,7 +14,11 @@ For extra security, you can use the `restricted-v3` or `nested-container` SCC, w
 
 To require a specific SCC for a workload, you can add an SCC to a specific user or group by using the `oc adm policy add-scc-to-user` or `oc adm policy add-scc-to-group` command. For more information, see the "OpenShift CLI administrator command reference".
 
-Also, you can optionally use the `procMount` parameter in a pod specification to configure the `/proc` file system in pods as `unmasked`. Setting `/proc` to `unmasked`, which is generally considered as safe, bypasses the default masking behavior of the container runtime, and should be used only with an SCC that sets `hostUsers` to `false`.
+Also, you can optionally use the `procMount` parameter in a pod specification to configure the `/proc` file system in pods as `unmasked`. Setting `/proc` to `unmasked`, which is generally considered as safe, bypasses the default masking behavior of the container runtime, and should be used only with an SCC that sets `userNamespaceLevel` to `RequirePodLevel`.
+
+.Prerequisites
+
+* Log into an {product-title} cluster as a user configured with the `restricted-v3` or `nested-container` SCC, or as a user from a user group configured with either SCC. Alternatively, you can set the `restricted-v3` or `nested-container` SCC directly in the workload object.
 
 .Procedure
 
@@ -36,14 +40,20 @@ metadata:
     openshift.io/display-name: ""
     openshift.io/requester: system:admin
     openshift.io/sa.scc.mcs: s0:c27,c24
-    openshift.io/sa.scc.supplemental-groups: 1000/10000 <1>
-    openshift.io/sa.scc.uid-range: 1000/10000 <2>
+    openshift.io/sa.scc.supplemental-groups: 1000/10000
+    openshift.io/sa.scc.uid-range: 1000/10000
 # ...
   name: userns
 # ...
 ----
-<1> Specifies the default GID to require in the pod spec. The range for a Linux user namespace must be `65535` or lower. The default is `1000000000/10000`.
-<2> Specifies the default UID to require in the pod spec. The range for a Linux user namespace must be `65535` or lower. The default is `1000000000/10000`.
++
+--
+where:
+
+`metadata.annotations.openshift.io/sa.scc.supplemental-groups`:: Specifies the default GID to require in the pod spec. The range for a Linux user namespace must be `65535` or lower. The default is `1000000000/10000`.
+
+`metadata.annotations.openshift.io/sa.scc.uid-range`:: Specifies the default UID to require in the pod spec. The range for a Linux user namespace must be `65535` or lower. The default is `1000000000/10000`.
+--
 +
 [NOTE]
 ====
@@ -60,40 +70,37 @@ The range 1000/10000 means 10,000 values starting with ID 1000, so it specifies 
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: userns
   name: userns-pod
-# ...
 spec:
-#...
-  template:
-    metadata:
-      labels:
-        app: name
-      annotations:
-        openshift.io/required-scc: "restricted-v3" <1>     
-    spec:
-      hostUsers: false <2>
-      containers:
-      - name: userns-container
-        image: registry.access.redhat.com/ubi9
-        command: ["sleep", "1000"]
-        securityContext:
-          capabilities: <3>
-            drop: ["ALL"]
-          allowPrivilegeEscalation: false
-          runAsNonRoot: true <4>
-          procMount: Unmasked <5>
-          runAsUser: 1000 <6>
-          runAsGroup: 1000 <7>
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  hostUsers: false
+  containers:
+    name: userns-container
+    image: registry.access.redhat.com/ubi9
+    command: ["sleep", "1000"]
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      runAsNonRoot: true
+      procMount: Unmasked
+      capabilities:
+        add:
+        - "SETGID"
+        - "SETUID"
 # ...
 ----
-<1> Specifies the SCC to use with this workload.
-<2> Specifies whether the pod is to be run in a user namespace. If `false`, the pod runs in a new user namespace that is created for the pod. If `true`, the pod runs in the host user namespace. The default is `true`.
-<3>  `capabilities` permit privileged actions without giving full root access. Technically, setting capabilities inside of a user namespace is safer than setting them outside, as the scope of the capabilities are limited by being inside user namespace, and can generally be considered to be safe. However, giving pods capabilities like `CAP_SYS_ADMIN` to any untrusted workload could increase the potential kernel surface area that a containerized process has access to and could find exploits in. Thus, capabilities inside of a user namespace are allowed at `baseline` level in pod security admission.
-<4> Specifies that processes inside the container run with a user that has any UID other than 0.
-<5> Optional: Specifies the type of proc mount to use for the containers. The `unmasked` value ensures that a container's `/proc` file system is mounted as read/write by the container process. The default is `Default`.
-<6> Specifies the user ID for processes that run inside of the container. This must fall in the range that you set in the `namespace` object. 
-<7> Specifies the group ID for processes that run inside of the containers. This must fall in the range that you set in the `namespace` object.
++
+where:
+
+`spec.hostUsers`:: Specifies whether the pod is to be run in a user namespace. If `false`, the pod runs in a new user namespace that is created for the pod. If `true`, the pod runs in the host user namespace. The default is `true`.
+`spec.containers.securityContext.runAsUser`:: Specifies the user ID for processes that run inside of the container. This must fall in the range that you set in the `namespace` object. 
+`spec.containers.securityContext.runAsGroup`:: Specifies the group ID for processes that run inside of the containers. This must fall in the range that you set in the `namespace` object.
+`spec.containers.securityContext.runAsNonRoot`:: Specifies that processes inside the container run with a user that has any UID other than 0.
+`spec.containers.securityContext.procMount`:: Specifies the type of proc mount to use for the containers. The `unmasked` value ensures that a container's `/proc` file system is mounted as read/write by the container process. The default is `Default`. This value is optional.
+`spec.containers.securityContext.capabilities.add`:: Specifies Linux capabilities to set in the user namespace. This permits privileged actions without giving full root access. Technically, setting capabilities inside of a user namespace is safer than setting them outside, as the scope of the capabilities are limited by being inside user namespace, and can generally be considered to be safe. However, giving pods capabilities like `CAP_SYS_ADMIN` to any untrusted workload could increase the potential kernel surface area that a containerized process has access to and could find exploits in. Thus, capabilities inside of a user namespace are allowed at `baseline` level in pod security admission. This value is optional.
 
 .. Create the object by running the following command:
 +
@@ -115,7 +122,7 @@ $ oc rsh -c <container_name> pod/<pod_name>
 .Example command
 [source,terminal]
 ----
-$ oc rsh -c userns-container_name pod/userns-pod
+$ oc rsh -c userns-container pod/userns-pod
 ----
 
 .. Display the user and group IDs being used inside the container:
@@ -146,6 +153,13 @@ sh-5.1$ lsns -t user
 4026532447 user       3   1 1000 /usr/bin/coreutils --coreutils-prog-shebang=sleep /usr/bin/sleep 1000 <1>
 ----
 <1> The UID for the process should be the same as you set in the pod spec.
+
+.. Exit the container shell session by using the following command:
++
+[source,terminal]
+----
+sh-5.1$ exit
+----
 
 . Check the UID being used by the node. The node is outside of the Linux user namespace. This user ID should be different from the UID being used in the container.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-64727

For the 4.20 (GA) docs, I incorrectly added a pod template to a pod spec. I changed the example to a deployment, which allow for a pod template.

Link to docs preview:
[Configuring Linux user namespace support](https://101951--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-user-namespaces.html#nodes-pods-user-namespaces-configuring_nodes-pods-user-namespaces) -- Updated paragraph 5, second sentence; prereqs; new code example, updated callouts; verification command.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
