### PR TITLE
update init bundle language

### DIFF
--- a/modules/portal-generate-init-bundle.adoc
+++ b/modules/portal-generate-init-bundle.adoc
@@ -46,9 +46,8 @@ You must have the `Admin` user role to create an init bundle.
 ifndef::cloud-svc[]
 . Find the address of the {product-title-short} portal as described in "Verifying Central installation using the Operator method".
 endif::cloud-svc[]
-. Log in to the {product-title-short} portal.
-. If you do not have secured clusters, the *Platform Configuration* -> *Clusters* page appears.
-. Click *Create init bundle*.
+. Log in to the {product-title-short} portal. 
+. If you do not have secured clusters or existing init bundles, the *Platform Configuration* -> *Clusters* page appears. Click *Create init bundle*.
 . Enter a name for the cluster init bundle.
 . Select your platform.
 . Select the installation method you will use for your secured clusters: *Operator* or *Helm chart*.


### PR DESCRIPTION
Version(s): 4.7+

Issue: n/a

Links to docs previews:

https://101979--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.html
https://101979--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/init-bundle-cloud-other-generate.html
https://101979--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/init-bundle-ocp.html
https://101979--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/init-bundle-other.html

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
