### PR TITLE
RHDEVDOCS-6781: Added content for trigering PipelineRun on Git tags

### DIFF
--- a/modules/op-triggering-pipelinerun-on-git-tags-using-pipelines-as-code.adoc
+++ b/modules/op-triggering-pipelinerun-on-git-tags-using-pipelines-as-code.adoc
@@ -1,0 +1,50 @@
+// This module is included in the following assembly:
+// * pac/managing-pipeline-runs-pac.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="op-triggering-pipelinerun-on-git-tags-using-pipelines-as-code_{context}"]
+= Triggering a PipelineRun on Git tags
+
+[role="_abstract"]
+
+When you create or reference a Git tag in a repository that is integrated with {pac}, you can trigger a `PipelineRun` on a tag via GitOps comment. This capability enables you to test or deploy tagged versions of your code, supporting release-based workflows and version control practices.
+
+{pac} resolves the Git tag to its corresponding commit SHA and runs the `PipelineRun` defined for that commit. You can initiate or manage such runs by commenting on the tagged commit using supported GitOps commands.
+
+Triggering `PipelineRun` on Git tags is supported for GitHub App, GitHub Webhook, and GitLab integrations. This functionality is not currently available for Gitea, Bitbucket Cloud, or Bitbucket Data Center.
+
+== Supported GitOps commands
+
+* `/test tag:<tag>`:: Retrigger all matching `PipelineRun` for the tag commit
+* `/test <pipelinerun-name> tag:<tag>`:: Retrigger only the named `PipelineRun`
+* `/retest tag:<tag>`:: Retrigger all matching `PipelineRun` for the tag commit
+* `/retest <pipelinerun-name> tag:<tag>`:: Retrigger only the named `PipelineRun`
+* `/cancel tag:<tag>`:: Cancel all running `PipelineRun` for the tag commit
+* `/cancel <pipelinerun-name> tag:<tag>`:: Cancel only the named `PipelineRun`
+
+A `PipelineRun` configured to respond to tag events typically includes annotations such as `pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/*]"` and `pipelinesascode.tekton.dev/on-event: "[push]"`. These annotations ensure that tag creation events are recognized as push events and processed correctly. When a tag is created or referenced, {pac} treats it as a push event and uses the resolved commit SHA to run the associated `PipelineRun`. The same logic applies to subsequent GitOps commands added as comments on the tagged commit.
+
+Tag based triggering is particularly useful in continuous delivery scenarios where specific versions or releases are represented by tags. This method enables you to validate and promote release artifacts consistently without modifying the branch state.
+
+The following example shows a minimal `PipelineRun` configuration that triggers on tag events:
+
+[source,yaml]
+----
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-on-tag
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/tags/*]"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: tag-task
+        taskSpec:
+          steps:
+            - name: echo
+              image: registry.access.redhat.com/ubi9/ubi-micro
+              script: |
+                echo "tag: {{ git_tag }}"
+----

--- a/modules/op-triggering-pipelineruns-for-gitops-commands-using-tagged-commits.adoc
+++ b/modules/op-triggering-pipelineruns-for-gitops-commands-using-tagged-commits.adoc
@@ -1,0 +1,18 @@
+// This module is included in the following assembly:
+// * pac/managing-pipeline-runs-pac.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="op-triggering-pipelineruns-for-gitops-commands-using-tagged-commits_{context}"]
+= Triggering PipelineRuns for GitOps commands using tagged commits 
+
+[role="_abstract"]
+You can trigger a `PipelineRun` using a Git tag for tagged commits.
+
+.Procedure
+
+. Open your GitHub repository.
+. Navigate to the *Tags* view or the *Releases* section.
+. Select the required tag, for example `v1.0.0`, to view its associated commit.
+. Click the commit SHA for the selected tag.
+. In the comment field of the commit, enter a supported GitOps command, such as `/test tag:v1.0.0` or `/cancel tag:v1.0.0`.
+. Verify that {pac} processes the comment and triggers or updates the corresponding `PipelineRun`.

--- a/pac/managing-pipeline-runs-pac.adoc
+++ b/pac/managing-pipeline-runs-pac.adoc
@@ -10,6 +10,10 @@ include::modules/op-verifying-pipeline-run-pac.adoc[leveloffset=+1]
 
 include::modules/op-running-pipeline-run-using-pipelines-as-code.adoc[leveloffset=+1]
 
+include::modules/op-triggering-pipelinerun-on-git-tags-using-pipelines-as-code.adoc[leveloffset=+1]
+
+include::modules/op-triggering-pipelineruns-for-gitops-commands-using-tagged-commits.adoc[leveloffset=+2]
+
 include::modules/op-restarting-or-canceling-pipeline-run-using-pipelines-as-code.adoc[leveloffset=+1]
 
 include::modules/op-monitoring-pipeline-run-status-using-pipelines-as-code.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

cherry-pick to pipelines-docs-1.21

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6781

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Triggering a PipelineRun on Git tags](https://101992--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/managing-pipeline-runs-pac.html#op-triggering-pipelinerun-on-git-tags-using-pipelines-as-code_managing-pipeline-runs-pac)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @zakisk 
QE review: @srivickynesh 
Peer review: @ochromy 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
