### PR TITLE
CNV-68980: Must gather image

### DIFF
--- a/modules/virt-troubleshoot-fusion-access-san.adoc
+++ b/modules/virt-troubleshoot-fusion-access-san.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * virt/storage/install-configure-fusion-access-san.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="troubleshoot-fusion-access-san_{context}"]
+= Troubleshooting {IBMFusionFirst}
+
+[role="_abstract"]
+
+If you encounter issues with {IBMFusionFirst}, provide the must-gather image to Red{nbsp}Hat support. This image contains critical data about your cluster and project resources, logs, and events from your deployment.
+
+.Procedure
+
+. To obtain the deployed version of {IBMFusionFirst}, run the following command:
++
+[source,terminal]
+----
+$ oc get fusionaccesses.fusion.storage.openshift.io  -n ibm-fusion-access fusionaccess-sample -o jsonpath='{.spec.storageScaleVersion}'
+----
++
+[NOTE]
+====
+This command returns the numeric value of the deployed version of {IBMFusionFirst} such as `2.11.0`.
+====
+
+. To create the `must-gather` image, run the following command:
++
+[source,terminal]
+----
+$ oc adm must-gather --image=icr.io/cpopen/ibm-spectrum-scale-must-gather:v<software_version>
+----
++
+* Replace `<software_version>` with the {IBMFusionFirst} version value.

--- a/virt/storage/install-configure-fusion-access-san.adoc
+++ b/virt/storage/install-configure-fusion-access-san.adoc
@@ -20,6 +20,8 @@ include::modules/virt-creating-storage-cluster-fusion-access-san.adoc[leveloffse
 
 include::modules/virt-creating-filesystem-fusion-access-san.adoc[leveloffset=+1]
 
+include::modules/virt-troubleshoot-fusion-access-san.adoc[leveloffset=+1]
+
 [id="fusion-san-next-steps_{context}"]
 == Next steps
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Add information about producing the must-gather image for IBM Fusion SAN troubleshooting.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
[CNV-68980](https://issues.redhat.com/browse/CNV-68980)

Link to docs preview:
[Troubleshooting IBM Fusion Access for SAN](https://102013--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/install-configure-fusion-access-san.html#troubleshoot-fusion-access-san_install-configure-fusion-access-san)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
