### PR TITLE
OSDOCS 17238 Update MCO to reflect API changes made for Status Reporting

### DIFF
--- a/machine_configuration/index.adoc
+++ b/machine_configuration/index.adoc
@@ -47,6 +47,12 @@ include::modules/checking-mco-status.adoc[leveloffset=+1]
 
 include::modules/checking-mco-node-status.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-configuring-on_mco-coreos-layering[About on-cluster image mode]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+
 include::modules/checking-mco-node-status-configuring.adoc[leveloffset=+2]
 
 [id="machine-config-operator-certificates_{context}"]

--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -186,12 +186,14 @@ include::modules/coreos-layering-configuring-on.adoc[leveloffset=+1]
 * xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-configuring-on-rebuild_mco-coreos-layering[Rebuilding an on-cluster custom layered image]
 * xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-configuring-on-revert_mco-coreos-layering[Reverting an on-cluster custom layered image]
 * xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-configuring-on-modifying_mco-coreos-layering[Modifying a custom layered image]
+* xref:../machine_configuration/index.adoc#checking-mco-node-status_machine-config-overview[About checking machine config node status]
 
 include::modules/coreos-layering-configuring-on-proc.adoc[leveloffset=+2]
 
 .Additional resources
 * xref:../openshift_images/managing_images/using-image-pull-secrets.adoc#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret]
 * xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-configuring-on-revert_mco-coreos-layering[Reverting an on-cluster custom layered image]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
 
 include::modules/coreos-layering-configuring-on-modifying.adoc[leveloffset=+2]
 

--- a/modules/checking-mco-node-status-configuring.adoc
+++ b/modules/checking-mco-node-status-configuring.adoc
@@ -11,6 +11,20 @@ During the update of a machine config pool (MCP), you can monitor the progress o
 
 For more information on the meaning of these fields, see "About checking machine config node status."
 
+.Prerequisites
+
+* In order to see specific machine config node output, as described in "About checking machine config node status", you must enable the `TechPreviewNoUpgrade` feature set on the cluster. For more information, see "Enabling features using feature gates".
++
+[NOTE]
+====
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
+====
++
+--
+:FeatureName: The custom layered image output
+include::snippets/technology-preview.adoc[]
+--
+
 .Procedure
 
 * View the update status of all nodes in the cluster, including the current and desired machine configurations, by running the following command:

--- a/modules/checking-mco-node-status.adoc
+++ b/modules/checking-mco-node-status.adoc
@@ -27,6 +27,19 @@ The node update process consists of the following phases and subphases that are 
 ** *Uncordoned*
 * *Updated* The MCO completed a node update and the current config version of the node is equal to the desired updated version.
 * *Resumed*. The MCO restarted the config drift monitor process and the node returns to operational state.
+* *ImagePulledFromRegistry*. The MCO has pulled the desired custom layered image. This condition applies only to nodes on which {image-mode-os-on-lower} has been configured.
++
+In order to see *ImagePulledFromRegistry* in the output, you must enable the `TechPreviewNoUpgrade` feature set on the cluster. For more information, see "Enabling features using feature gates".
++
+[NOTE]
+====
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
+====
++
+--
+:FeatureName: The `ImagePulledFromRegistry` condition 
+include::snippets/technology-preview.adoc[]
+--
 
 As the update moves through these phases, you can query the `MachineConfigNode` custom resource, which reports one of the following conditions for each phase:
 
@@ -141,6 +154,7 @@ $ oc describe machineconfignode/<machine_config_node_name>
 
 .Example output
 [source,text]
+----
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigNode
 metadata:
@@ -238,3 +252,17 @@ status:
 <1> The `MachineConfigNode` object name.
 <2> The new machine configuration. This field updates after the MCO validates the machine config in the `UPDATEPREPARED` phase, then the status adds the new configuration.
 <3> The current machine config on the node.
+
+For clusters configured with {image-mode-os-on-lower}, the machine config node output also includes the name of the custom layered image that was applied to affected nodes.
+
+include::snippets/mco-mcn-ocl-example.adoc[]
+
+In order to see the custom layered image in the output, you must enable the `TechPreviewNoUpgrade` feature set on the cluster. For more information, see "Enabling features using feature gates".
+
+[NOTE]
+====
+Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
+====
+
+:FeatureName: The custom layered image output
+include::snippets/technology-preview.adoc[]

--- a/modules/coreos-layering-configuring-on-proc.adoc
+++ b/modules/coreos-layering-configuring-on-proc.adoc
@@ -177,6 +177,24 @@ NAME                                             PREPARED   BUILDING   SUCCEEDED
 layered-image-ad5a3cad36303c363cf458ab0524e7c0   False      True       False       False         False    12m <1>
 ----
 <1> The `MachineOSBuild` is named in the `<MachineOSConfig_CR_name>-<hash>` format.
++
+The build is complete when `BUILDING` is `False` and `SUCCEEDED` is `True`.
+
+. When the build is complete, verify that the image has been applied to the nodes in the affected pool by running a command similar to the following:
++
+[source,terminal]
+----
+$ oc describe machineconfignode/<machine_config_node_name>
+----
++
+--
+include::snippets/mco-mcn-ocl-example.adoc[]
+--
++
+--
+:FeatureName: The `ImagePulledFromRegistry` condition
+include::snippets/technology-preview.adoc[]
+--
 
 . Verify that the `MachineOSConfig` object contains a reference to the new custom layered image by running the following command:
 +

--- a/snippets/mco-mcn-ocl-example.adoc
+++ b/snippets/mco-mcn-ocl-example.adoc
@@ -1,0 +1,39 @@
+// Text snippet included in the following modules:
+//
+// * modules/coreos-layering-configuring-on
+// * modules/checking-mco-node-status
+
+:_mod-docs-content-type: SNIPPET
+
+.Example machine config node output
+[source,terminal]
+----
+Name:         ip-10-0-14-86.us-west-1.compute.internal
+API Version:  machineconfiguration.openshift.io/v1
+Kind:         MachineConfigNode
+# ...
+Spec:
+  Config Image:
+    Desired Image:  image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:b485378fd8f7963ed74f14ce64f4f1e511e1601d49302b3046b1b78a83f539e3 <1>
+  Config Version:
+    Desired:  rendered-worker-d63c7736923b60b8b82492ae9a1eef40
+  Node:
+    Name:  ip-10-0-14-86.us-west-1.compute.internal
+  Pool:
+    Name:  worker
+# ...
+Status:
+  Conditions:
+# ...
+    Message:               Action during update to image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:b485378fd8f7963ed74f14ce64f4f1e511e1601d49302b3046b1b78a83f539e3: Successfully pulled OS image image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:b485378fd8f7963ed74f14ce64f4f1e511e1601d49302b3046b1b78a83f539e3 from registry
+    Reason:                ImagePulledFromRegistry
+    Status:                False
+    Type:                  ImagePulledFromRegistry
+# ...
+  Config Image:
+    Current Image:  image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:b485378fd8f7963ed74f14ce64f4f1e511e1601d49302b3046b1b78a83f539e3
+    Desired Image:  image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/ocb-image@sha256:b485378fd8f7963ed74f14ce64f4f1e511e1601d49302b3046b1b78a83f539e3
+# ...
+----
+<1> Digested image pull spec for the new custom layered image.
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17238

Link to docs preview:
Machine creation overview -> [About checking machine config node status](https://102021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#checking-mco-node-status_machine-config-overview) -- Added `ImagePulledFromRegistry` condition with TP snippet, Example machine config node output and preceding paragraph with TP snippet, and Additional Resource links.
Image mode for OpenShift -> [Using the on-cluster image mode to apply a custom layered image](https://102021--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering#coreos-layering-configuring-on-proc_mco-coreos-layering) --  Added verification step 4 with TP snippet, and Additional Resource link to the Feature Gate assembly. 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
