### PR TITLE
OCPBUGS 56744 Fix typo in MCN's MachineConfigNodePinnedImageSetsDegraded message

### DIFF
--- a/modules/machine-config-pin-preload-images.adoc
+++ b/modules/machine-config-pin-preload-images.adoc
@@ -96,7 +96,7 @@ metadata:
 # ...
   - lastTransitionTime: "2025-04-29T19:37:23Z"
     message: One or more PinnedImageSet is experiencing an error. See PinnedImageSet
-      list for more details
+      list for more details.
     reason: PrefetchFailed
     status: "True"
     type: PinnedImageSetsDegraded


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17278

Link to docs preview:
[Pinning images ](https://102029--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-pin-preload-images-about.html#machine-config-pin-preload-images_machine-config-operator)-> Updated "Example output for a failed image pull and pin".

QE review: No QE needed. 