### PR TITLE
OSDOCS remove unneeded link to TP docs

### DIFF
--- a/machine_configuration/index.adoc
+++ b/machine_configuration/index.adoc
@@ -46,11 +46,6 @@ include::modules/checking-mco-status.adoc[leveloffset=+1]
 include::modules/checking-mco-node-status.adoc[leveloffset=+1]
 include::modules/checking-mco-node-status-configuring.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
-
-* For more information about feature gates, see xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-console_nodes-cluster-enabling[Enabling feature sets using the web console].
-
 [id="machine-config-operator-certificates_{context}"]
 == Understanding Machine Config Operator certificates
 


### PR DESCRIPTION
Removing a link to the Feature Gates docs that is no longer needed in 4.20+ docs, when the feature went GA.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: No QE needed