### PR TITLE
OLS-2289: Remove language implying cluster must be connected to the Internet

### DIFF
--- a/modules/ols-installing-operator-from-operatorhub.adoc
+++ b/modules/ols-installing-operator-from-operatorhub.adoc
@@ -10,7 +10,7 @@ Install the {ols-long} Operator so that you can configure the {ols-long} Service
 
 .Prerequisites
 
-* You have deployed {ocp-product-title} 4.16 to 4.19. The cluster must be connected to the Internet and have telemetry enabled.
+* You have deployed {ocp-product-title} 4.16 to 4.19.
 
 * You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
 

--- a/modules/ols-installing-operator-from-software-catalog.adoc
+++ b/modules/ols-installing-operator-from-software-catalog.adoc
@@ -7,7 +7,7 @@
 
 .Prerequisites
 
-* You have deployed {ocp-product-title} 4.20 or later. The cluster must be connected to the Internet and have telemetry enabled.
+* You have deployed {ocp-product-title} 4.20 or later.
 
 * You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2289

Link to docs preview:
https://102153--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/install/ols-installing-openshift-lightspeed.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
