### PR TITLE
OSDOCS-17258 created z-stream RNs for 4-18-28

### DIFF
--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3059,6 +3059,54 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.18.28
+[id="ocp-4-18-28_{context}"]
+=== RHBA-2025:19865 - {product-title} {product-version}.28 bug fix and security update
+
+Issued: 12 November 2025
+
+{product-title} release {product-version}.28 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:19865[RHBA-2025:19865] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:19863[RHBA-2025:19863] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.28 --pullspecs
+----
+
+[id="ocp-4-18-28-enhancements_{context}"]
+==== Enhancements
+
+* With this update, the `remoteWrite[].oauth2.proxyFromEnvironment` setting can now be used to configure a cluster-wide proxy in 4.18.z. This improvement backports a feature previously available only in 4.19 and later builds, allowing for more flexible and consistent proxy configurations. (link:https://issues.redhat.com/browse/OCPBUGS-63410[OCPBUGS-63410])
+
+[id="ocp-4-18-28-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, API and Ingress Virtual IP (VIP) addresses were automatically assigned even when a user-managed load balancer was in use. With this release, the API and Ingress VIPs are no longer automatically assigned. If these values are not explicitly set in the `install-config.yaml` configuration file, the installation fails with an error, prompting you to provide them. (link:https://issues.redhat.com/browse/OCPBUGS-53235[OCPBUGS-53235])
+
+* Before this update, it was possible for webhook failures to trigger a `kube-apiserver` crash while generating an audit log entry for a request. As a consequence, API server disruptions were possible. With this release, the audit system has been updated so that the `kube-apiserver` no longer crashes and the API disruptions are resolved. (link:https://issues.redhat.com/browse/OCPBUGS-61773[OCPBUGS-61773])
+
+* Before this update, Redfish transactions in some hardware models would fail due to the Baseboard Management Controller (BMC) sending an empty ETag. As a consequence, users could not use the `HostFirmwareSettings` custom resource (CR). With this release, the Redfish transaction with empty ETag issue has been resolved and returns the correct `ETag instances without warnings. As a result, the Redfish transaction no longer fails, allowing users to use the `HostFirmwareSettings` CR. (link:https://issues.redhat.com/browse/OCPBUGS-62647[OCPBUGS-62647])
+
+* Before this update, inconsistent updates to the driver-config ConfigMap in the hosted cluster namespace caused the driver-config ConfigMap content to flap, resulting in inconsistent storage class enforcement and affecting user experience. With this release, the driver-config ConfigMap stability has been restored, preventing the flapping of storage classes in the hosted cluster namespace. (link:https://issues.redhat.com/browse/OCPBUGS-62808[OCPBUGS-62808])
+
+* Before this update, the controller created and deleted a file with a random name when setting up a session to {aws-first}, which caused the controller to continuously allocate more memory to cache the session. With this release, the controller now uses the same file name instead of a random one, allowing the kernel to re-use the `dentry` instead of requesting a new one for each session. As a result, excessive memory allocation is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-63138[OCPBUGS-63138])
+
+* Before this update, gRPC connection logs were set at a highly verbose log level. This generated an excessive number of messages, which caused the logs to overflow. With this release, the gRPC connection logs have been moved to the V(4) log level. As a result, the logs no longer overflow, as these specific messages are now less verbose by default. (link:https://issues.redhat.com/browse/OCPBUGS-63324[OCPBUGS-63324])
+
+* Before this update, when a user ran the `ocp-tuned-one-shot.service` systemd unit that was owned by the Node Tuning Operator (NTO), a dependency failure might have occurred for the kubelet. As a consequence, the kubelet did not start. With this release, running the` ocp-tuned-one-shot.service` unit does not cause a dependency failure. As a result, the kubelet starts when you run the unit. (link:https://issues.redhat.com/browse/OCPBUGS-63450[OCPBUGS-63450])
+
+* Before this update, during failover, the system's duplicate address detection (DAD) could incorrectly disable the Egress IPv6 address if it was briefly present on both nodes, breaking the connection. With this release, the Egress IPv6 is configured to skip the DAD check during failover, guaranteeing uninterrupted egress IPv6 traffic after an Egress IP address successfully moves to a different node and ensuring greater network stability. (link:https://issues.redhat.com/browse/OCPBUGS-63459[OCPBUGS-63459])
+
+* Before this update, the Azure machine provider was not passing the `dataDisks` configuration from the compute machine set into the virtual machine creation API request for the Azure Stack Hub. As a consequence, new machines were created without the specified data disks because the configuration was silently ignored during the VM creation process. With this release, the VM creation for the Azure Stack Hub is updated to include the `dataDisks` configuration. An additional update manually implements the behavior of the `deletionPolicy: Delete` parameter in the controller because the Azure Stack Hub does not natively support this option. As a result, data disks are correctly provisioned on the Azure Stack Hub VMs. The `Delete` policy is also functionally supported, which ensures that disks are properly removed when their machines are removed. (link:https://issues.redhat.com/browse/OCPBUGS-63669[OCPBUGS-63669])
+
+
+[id="ocp-4-18-28-updating_{context}"]
+==== Updating
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 // 4.18.27
 [id="ocp-4-18-27_{context}"]
 === RHSA-2025:19047 - {product-title} {product-version}.27 bug fix and security update
@@ -3087,7 +3135,7 @@ $ oc adm release info 4.18.27 --pullspecs
 
 * Before this update, users without a project saw only part of the *Roles* list because of insufficient role-based access control (RBAC) permissions. With this release, the access logic is fixed. As a result, these users cannot open the *Roles* page, which keeps sensitive data secure. (link:https://issues.redhat.com/browse/OCPBUGS-63247[OCPBUGS-63247])
 
-* Before this update, during an update from 4.18.21 to 4.19.6, the Machine Config Operator (MCO) failed due to multiple labels in the `capacity.cluster-autoscaler.kubernetes.io/labels` annotation in one or more machine sets. With this release, the MCO accepts multiple labels in the `capacity.cluster-autoscaler.kubernetes.io/labels` annotation. As result, the MCO does not fail during the update to 4.19.6. (link:https://issues.redhat.com/browse/OCPBUGS-63346[OCPBUGS-63346]) 
+* Before this update, during an update from 4.18.21 to 4.19.6, the Machine Config Operator (MCO) failed due to multiple labels in the `capacity.cluster-autoscaler.kubernetes.io/labels` annotation in one or more machine sets. With this release, the MCO accepts multiple labels in the `capacity.cluster-autoscaler.kubernetes.io/labels` annotation. As result, the MCO does not fail during the update to 4.19.6. (link:https://issues.redhat.com/browse/OCPBUGS-63346[OCPBUGS-63346])
 
 [id="ocp-4-18-27-updating_{context}"]
 ==== Updating


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-17258

Link to docs preview:
https://102154--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#ocp-4-18-28_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
 To find the **Image** and **RPM** IDs, select the following links:

For the **Image** ID:  https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/215/diffs#3e4f5eb3f7525aac04e2bd17f9e380bca16d27f0

For the **RPM** ID: https://errata.devel.redhat.com/advisory/155924


**Must be on VPN to view** these links.


