### PR TITLE
OSDOCS-17266 created z-stream RNs for 4-16-52

### DIFF
--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3396,6 +3396,41 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.16.52
+[id="ocp-4-16-52_{context}"]
+=== RHBA-2025:19901 - {product-title} {product-version}.52 bug fix and security update
+
+Issued: 12 November 2025
+
+{product-title} release {product-version}.52 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:19901[RHBA-2025:19901] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:19899[RHBA-2025:19899] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.52 --pullspecs
+----
+
+[id="ocp-4-16-52-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, a Machine Config Operator (MCO) incorrectly set an `Upgradeable=False` condition to all new nodes that were added to a cluster. A `PoolUpdating` reason was provided for the `Upgradeable=False` condition. With this release, the MCO now correctly sets an `Upgradeable=True` condition to all new nodes that get added to a cluster, which resolves the issue. (link:https://issues.redhat.com/browse/OCPBUGS-57423[OCPBUGS-57423])
+
+* Before this update, the controller created and deleted a file with a random name when setting up a session to {aws-first}, which caused the controller to continuously allocate more memory to cache the session. With this release, the controller now uses the same file name instead of a random one, allowing the kernel to re-use the `dentry` object instead of requesting a new one for each session. As a result, excessive memory allocation is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-63140[OCPBUGS-63140])
+
+* Before this update, the stale IP addresses in the `address_set` list corresponding to the Domain Name System (DNS) Egress Firewall rule were not removed. This resulted in an ever-growing `address_set` list leading to memory leak issues. With this release, the stale IP address are removed from the `address_set` list after a 5 second grace period. (link:https://issues.redhat.com/browse/OCPBUGS-63230[OCPBUGS-63230])
+
+* Before this update, deleting an `istag` resource with the `--dry-run=server` option unintentionally caused actual deletion of the image from the server. This unexpected deletion occurred due to the dry-run option being implemented incorrectly in the `oc delete istag` command. With this release, the dry-run option is now wired to the `oc delete istag` command, preventing accidental deletion of image objects and the `istag` object remains intact when using the `--dry-run=server` option. (link:https://issues.redhat.com/browse/OCPBUGS-63394[OCPBUGS-63394])
+
+* Before this update, the `ironic-inspector` container did not have the correct permissions to access the shared volume and save the `ramdisk` logs. As a consequence, this made it impossible to troubleshoot any issue on the ironic agent side. With this release, the shared volume is accessible, and the `ramdisk` logs can be saved. (link:https://issues.redhat.com/browse/OCPBUGS-63417[OCPBUGS-63417])
+
+* Before this update, the control plane nodes created before {product-title} 4.12 did not have the `node-role.kubernetes.io/control-plane` label. With this release, the Machine Config Operator (MCO) adds that label whenever it uncordons a control plane node, if it was missing. (link:https://issues.redhat.com/browse/OCPBUGS-63553[OCPBUGS-63553])
+
+[id="ocp-4-16-52-updating_{context}"]
+==== Updating
+
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.16.51
 [id="ocp-4-16-51_{context}"]
 === RHSA-2025:19017 - {product-title} {product-version}.51 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://github.com/wgabor0427/openshift-docs/pull/new/OSDOCS-17266


Link to docs preview:


QE review:


Additional information:
 To find the **Image** and **RPM** IDs, select the following links:

For the **Image** ID: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/218/diffs#b8895bbd3043920470b5fcb8c3dbbf69b57130fe

For the **RPM** ID: https://errata.devel.redhat.com/advisory/155935

**Must be on VPN to view** these links.


