### PR TITLE
[enterprise-4.12] OCPBUGS#55692: Node description does not match OpenShift configuration

### DIFF
--- a/nodes/index.adoc
+++ b/nodes/index.adoc
@@ -19,7 +19,7 @@ Using the OpenShift CLI (`oc`) or the web console, you can perform the following
 
 The following components of a node are responsible for maintaining the running of pods and providing the Kubernetes runtime environment.
 
-Container runtime:: The container runtime is responsible for running containers. Kubernetes offers several runtimes such as containerd, cri-o, rktlet, and Docker.
+Container runtime:: The container runtime is responsible for running containers. {product-title} deploys the CRI-O container runtime on each of the {op-system-first} nodes in your cluster. The Windows Machine Config Operator (WMCO) deploys the containerd runtime on its Windows nodes.
 
 Kubelet:: Kubelet runs on nodes and reads the container manifests. It ensures that the defined containers have started and are running. The kubelet process maintains the state of work and the node server. Kubelet manages network rules and port forwarding. The kubelet manages containers that are created by Kubernetes only.
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/96002
