### PR TITLE
OSDOCS#17264: Update the z-stream RNs for 4.20.3

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1510,6 +1510,11 @@ Support for Docker v2 registries is deprecated and is planned for removal in a f
 
 The Red{nbsp}Hat Marketplace is deprecated. Customers who use the partner software from the Marketplace should contact the software vendor about how to migrate from the Marketplace Operator to an Operator in the Red{nbsp}Hat Ecosystem Catalog. It is expected that the Marketplace index will be removed in an upcoming {product-title} release. For more information, see link:https://access.redhat.com/articles/7130828[Sunset of the Red Hat Marketplace, operated by IBM].
 
+[id="ocp-4-20-cso-deprecation"]
+==== {rhq-cso} deprecation
+
+The {rhq-cso} is deprecated and is planned for removal in a future release of {product-title}. The official replacement product of the {rhq-cso} is Red{nbsp}Hat Advanced Cluster Security for Kubernetes.
+
 [id="ocp-release-removed-features_{context}"]
 === Removed features
 
@@ -2942,6 +2947,34 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+
+//4.20.3
+[id="ocp-4-20-3_{context}"]
+=== RHSA-2025:19890 - {product-title} {product-version}.3 image release, bug fix, and security update advisory
+
+Issued: 11 November 2025
+
+{product-title} release {product-version}.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:19890[RHSA-2025:19890] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:19888[RHBA-2025:19888] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.3 --pullspecs
+----
+
+[id="ocp-4-20-3-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, the communication matrix project failed to create EndPointSlice objects for open ports 9193 and 9194 on the primary node because of a missing service connection. As a consequence, inaccurate communication matrixes resulted. With this release, the service is connected to open ports 9193 and 9194, which resolve the missing EndPointSlice objects. As a result, open ports 9193 and 9194 on the primary node are associated with a service, resulting in accurate communication matrixes for {product-title} users. (link:https://issues.redhat.com/browse/OCPBUGS-63587[OCPBUGS-63587])
+
+* Before this update, the metric denylist incorrectly formatted the regular expression for the `kube_customresource`, omitting the `annotations` field. As a consequence, users experienced missing metrics due to an incorrect denylist configuration. With this release, unnecessary entries are removed from the metric denylist. As a result, registry metrics include missing annotations, which improves data accuracy. (link:https://issues.redhat.com/browse/OCPBUGS-64577[OCPBUGS-64577])
+
+[id="ocp-4-20-3-updating_{context}"]
+==== Updating
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 //4.20.2
 [id="ocp-4-20-2_{context}"]


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-17264](https://issues.redhat.com//browse/OSDOCS-17264)

Link to docs preview:
[4.20.3](https://102179--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-3_release-notes)
[Deprecated features](https://102179--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-cso-deprecation)


QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/216#ee3e4b192e4b89565ada8be9954f366189877fa9)
Art [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20)

**Mergers: I found instances of `denylist` and `EndPointSlice` in DRC without the backticks. Therefore, I did not include them here in the bug text.
