### PR TITLE
OBSDOCS-2675: Modularize otel-config-multicluster.adoc

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3247,8 +3247,8 @@ Topics:
     File: otel-forwarding-telemetry-data
   - Name: Configuring the Collector metrics
     File: otel-configuring-otelcol-metrics
-  - Name: Gathering the observability data from multiple clusters
-    File: otel-config-multicluster
+  - Name: Receiving telemetry data
+    File: otel-receiving-telemetry-data
   - Name: Troubleshooting the Red Hat build of OpenTelemetry
     File: otel-troubleshooting
   - Name: Migrating to the Red Hat build of OpenTelemetry

--- a/modules/otel-receiving-telemetry-data-from-multiple-clusters.adoc
+++ b/modules/otel-receiving-telemetry-data-from-multiple-clusters.adoc
@@ -1,10 +1,13 @@
-:_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-[id="otel-gathering-observability-data-from-multiple-clusters"]
-= Gathering the observability data from multiple clusters
-:context: otel-gathering-observability-data-from-multiple-clusters
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-receiving-telemetry-data.adoc
 
-For a multicluster configuration, you can create one OpenTelemetry Collector instance in each one of the remote clusters and then forward all the telemetry data to one OpenTelemetry Collector instance.
+:_mod-docs-content-type: PROCEDURE
+[id="otel-receiving-telemetry-data-from-multiple-clusters_{context}"]
+= Receiving telemetry data from multiple clusters
+
+[role="_abstract"]
+If you need the Collector to receive telemetry data from multiple remote clusters, create one OpenTelemetry Collector instance in each one of the remote clusters, and then have all of their telemetry data forwarded to a central OpenTelemetry Collector instance.
 
 .Prerequisites
 

--- a/observability/otel/otel-receiving-telemetry-data.adoc
+++ b/observability/otel/otel-receiving-telemetry-data.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+:context: otel-receiving-telemetry-data
+[id="otel-receiving-telemetry-data"]
+= Receiving telemetry data
+
+toc::[]
+
+[role="_abstract"]
+After setting up the OpenTelemetry Collector and instrumenting your application, you need to connect the instrumentation and OpenTelemetry Collector so that the OpenTelemetry Collector can receive telemetry data from the instrumentation.
+
+include::modules/otel-receiving-telemetry-data-from-multiple-clusters.adoc[leveloffset=+1]
+

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -213,7 +213,7 @@ a|* xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-cr
 | xref:../observability/distr_tracing/distr-tracing-tempo-architecture.adoc#distr-tracing-tempo-architecture[{DTProductName}]
 
 | xref:../observability/otel/otel-installing.adoc#install-otel[Red Hat build of OpenTelemetry]
-| xref:../observability/otel/otel-config-multicluster.adoc#otel-config-multicluster[Gathering the observability data from multiple clusters]
+| xref:../observability/otel/otel-receiving-telemetry-data.adoc#otel-receiving-telemetry-data[Receiving telemetry data from multiple clusters]
 
 | xref:../observability/network_observability/network-observability-overview.adoc#network-observability-overview[About Network Observability]
 a|* xref:../observability/network_observability/metrics-alerts-dashboards.adoc#metrics-alerts-dashboards_metrics-alerts-dashboards[Using metrics with dashboards and alerts]


### PR DESCRIPTION
⚠️ Only content movement across files. No new content to review.

**Affected Version(s):** OCP 4.12+

**Tracking JIRAs:** https://issues.redhat.com/browse/OBSDOCS-2675

**Doc preview:** https://102189--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-receiving-telemetry-data.html

**SME & QE review:** N/A

**Additional information:** 

- Created a new procedure module: `modules/otel-receiving-telemetry-data-from-multiple-clusters.adoc`.
- Moved the step-by-step procedure content from the `otel-receiving-telemetry-data.adoc` assembly into the new module.
- Updated the assembly file to include the new procedure module.
- Renamed the assembly file to “Receiving telemetry data” for clarity and consistency
- Added an abstract paragraph to describe the purpose of the assembly.