### PR TITLE
Add docs for deleting non-admin backup

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-namespace-admin-use-cases.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-namespace-admin-use-cases.adoc
@@ -17,6 +17,8 @@ include::modules/oadp-self-service-creating-nabsl.adoc[leveloffset=+1]
 
 include::modules/oadp-self-service-creating-nab.adoc[leveloffset=+1]
 
+include::modules/oadp-self-service-deleting-nab.adoc[leveloffset=+1]
+
 include::modules/oadp-self-service-creating-nar.adoc[leveloffset=+1]
 
 include::modules/oadp-self-service-about-nadr.adoc[leveloffset=+1]

--- a/modules/oadp-self-service-deleting-nab.adoc
+++ b/modules/oadp-self-service-deleting-nab.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-namespace-admin-use-cases.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="oadp-self-service-deleting-nab_{context}"]
+= Deleting a NonAdminBackup CR
+
+[role="_abstract"]
+As a namespace admin user, you can delete a `NonAdminBackup` (NAB) custom resource (CR).
+
+.Prerequisites
+
+* You are logged in to the cluster as a namespace admin user.
+* The cluster administrator has installed the {oadp-short} Operator.
+* The cluster administrator has configured the `DataProtectionApplication` (DPA) CR to enable {oadp-short} Self-Service.
+* The cluster administrator has created a namespace for you and has authorized you to operate from that namespace.
+* You have created a NAB CR in your authorized namespace.
+
+
+.Procedure
+
+. Edit the `NonAdminBackup` CR YAML manifest file by running the following command:
++
+[source,terminal]
+----
+$ oc edit <nab_cr> -n <authorized_namespace> 
+----
++
+where:
+
+`<nab_cr>`:: Specifies the name of the NAB CR to be deleted.
+`<authorized_namespace>`:: Specifies the name of your authorized namespace.
+
+. Update the NAB CR YAML manifest file and add the `deleteBackup` flag as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: oadp.openshift.io/v1alpha1
+kind: NonAdminBackup
+metadata:
+  name: <nab_cr>
+spec:
+  backupSpec:
+    includedNamespaces:
+    - <authorized_namespace>
+    deleteBackup: true
+----
++
+where:
+
+`<nab_cr>`:: Specify the name of the NAB CR to be deleted.
+`<authorized_namespace>`:: Specify the name of your authorized namespace.
+`deleteBackup: true`:: Add the `deleteBackup` flag and set it to `true`.
+
+.Verification
+
+* Verify that the NAB CR is deleted by running the following command:
++
+[source,terminal]
+----
+$ oc get nab <nab_cr>
+----
++
+`<nab_cr>` is the name of the NAB CR you deleted.
++
+You should see an output as shown in the following example:
++
+[source,terminal]
+----
+Error from server (NotFound): nonadminbackups.oadp.openshift.io "test-nab" not found
+----


### PR DESCRIPTION
## Jira 

* [OADP-6763](https://issues.redhat.com/browse/OADP-6763)

##  Version

* OCP 4.21, 4.20, 4.19

## Preview

* [ Deleting a NonAdminBackup CR](https://102211--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-namespace-admin-use-cases.html#oadp-self-service-deleting-nab_oadp-self-service-namespace-admin-use-cases)

## QE Review

* [x] QE has approved this change.
