### PR TITLE
OSDOCS-17290:Removed incorrect CIDR HCP section from OSD/ROSA Classic docs

### DIFF
--- a/networking/networking_overview/cidr-range-definitions.adoc
+++ b/networking/networking_overview/cidr-range-definitions.adoc
@@ -143,4 +143,7 @@ You can use the link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Net
 endif::openshift-enterprise,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 // CIDR ranges for HCP
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 include::modules/hcp-cidr-ranges.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17290

Link to docs preview:
No preview as section removed from OSD,Classic, and ROSA HCP docs.

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- QE approval is not required to merge this PR as no procedure changes.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
