### PR TITLE
OSDOCS-17301: Updated nw-ovn-kubernetes-migration.adoc prereq with no…

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -17,6 +17,12 @@ While performing the migration, your cluster is unavailable and workloads might 
 .Prerequisites
 
 * You have a cluster configured with the OpenShift SDN CNI network plugin in the network policy isolation mode.
++
+[IMPORTANT]
+====
+For a cluster that uses OpenShift SDN that is configured in either the multitenant or subnet isolation mode, you can still migrate to the OVN-Kubernetes network plugin by using the offline migration method. Note that after the migration operation, multitenant isolation mode is dropped, so you must manually configure network policies to achieve the same level of project-level isolation for pods and services.
+====
++
 * You installed the {oc-first}.
 * You have access to the cluster as a user with the `cluster-admin` role.
 * You have a recent backup of the etcd database.


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-17301](https://issues.redhat.com/browse/OSDOCS-17301)

Link to docs preview:
* [Migrating to the OVN-Kubernetes network plugin by using the offline migration method](https://102213--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn)

- [x] SME has approved this change (Approval on the Jira).
- [x] QE has approved this change.

