### PR TITLE
OBSDOCS-2759 Update TP/GA notices as approriate

### DIFF
--- a/ui_plugins/observability-ui-plugins-overview.adoc
+++ b/ui_plugins/observability-ui-plugins-overview.adoc
@@ -31,9 +31,6 @@ For more information, see the xref:../ui_plugins/logging-ui-plugin.adoc#logging-
 [id="troubleshooting_{context}"]
 == Troubleshooting
 
-:FeatureName: The {coo-full} troubleshooting panel UI plugin
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 The troubleshooting panel UI plugin for {ocp-product-title} version 4.16+ provides observability signal correlation, powered by the open source Korrel8r project.
 You can use the troubleshooting panel available from the *Observe* -> *Alerting* page to easily correlate metrics, logs, alerts, netflows, and additional observability signals and resources, across different data stores.
 Users of {ocp-product-title} version 4.17+ can also access the troubleshooting UI panel from the Application Launcher {launch}.
@@ -44,9 +41,6 @@ For more information, see the xref:../ui_plugins/troubleshooting-ui-plugin.adoc#
 
 [id="distributed-tracing_{context}"]
 == Distributed tracing
-
-:FeatureName: The {coo-full} distributed tracing UI plugin
-include::snippets/technology-preview.adoc[leveloffset=+2]
 
 The distributed tracing UI plugin adds tracing-related features to the web console on the *Observe* -> *Traces* page.
 You can follow requests through the front end and into the backend of microservices, helping you identify code errors and performance bottlenecks in distributed systems.


### PR DESCRIPTION
Version(s):
standalone-coo-docs-1-latest

Issue:
[OBSDOCS-2759](https://issues.redhat.com//browse/OBSDOCS-2759)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
