### PR TITLE
OSDOCS-15826 [NETOBSERV] Refactor release notes 1.5.0

### DIFF
--- a/modules/network-observability-operator-release-notes-1-5-0-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-5-0-fixed-issues.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-5-0-fixed-issues_{context}"]
+= Network Observability Operator 1.5.0 fixed issues
+
+[role="_abstract"]
+You can view the following fixed issues for the Network Observability Operator 1.5 release.
+
+* Previously, it was not possible to register the console plugin manually in the web console interface if the automatic registration of the console plugin was disabled. If the `spec.console.register` value was set to `false` in the `FlowCollector` resource, the Operator would override and erase the plugin registration.
+With this fix, setting the `spec.console.register` value to `false` does not impact the console plugin registration or registration removal. As a result, the plugin can be safely registered manually. (link:https://issues.redhat.com/browse/NETOBSERV-1134[*NETOBSERV-1134*])
+* Previously, using the default metrics settings, the *NetObserv/Health* dashboard was showing an empty graph named *Flows Overhead*. This metric was only available by removing "namespaces-flows" and "namespaces" from the `ignoreTags` list. With this fix, this metric is visible when you use the default metrics setting. (link:https://issues.redhat.com/browse/NETOBSERV-1351[*NETOBSERV-1351*])
+* Previously, the node on which the eBPF Agent was running would not resolve with a specific cluster configuration. This resulted in cascading consequences that culminated in a failure to provide some of the traffic metrics. With this fix, the eBPF agent's node IP is safely provided by the Operator, inferred from the pod status. Now, the missing metrics are restored. (link:https://issues.redhat.com/browse/NETOBSERV-1430[*NETOBSERV-1430*])
+* Previously, the Loki error 'Input size too long' error for the Loki Operator did not include additional information to troubleshoot the problem.
+With this fix, help is directly displayed in the web console next to the error with a direct link for more guidance. (link:https://issues.redhat.com/browse/NETOBSERV-1464[*NETOBSERV-1464*])
+* Previously, the console plugin read timeout was forced to 30s.
+With the `FlowCollector` `v1beta2` API update, you can configure the `spec.loki.readTimeout` specification to update this value according to the Loki Operator `queryTimeout` limit. (link:https://issues.redhat.com/browse/NETOBSERV-1443[*NETOBSERV-1443*])
+* Previously, the Operator bundle did not display some of the supported features by CSV annotations as expected, such as `features.operators.openshift.io/...`
+With this fix, these annotations are set in the CSV as expected. (link:https://issues.redhat.com/browse/NETOBSERV-1305[*NETOBSERV-1305*])
+* Previously, the `FlowCollector` status sometimes oscillated between `DeploymentInProgress` and `Ready` states during reconciliation.
+With this fix, the status only becomes `Ready` when all of the underlying components are fully ready. (link:https://issues.redhat.com/browse/NETOBSERV-1293[*NETOBSERV-1293*])

--- a/modules/network-observability-operator-release-notes-1-5-0-known-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-5-0-known-issues.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-5-0-known-issues_{context}"]
+= Network Observability Operator 1.5.0 known issues
+
+[role="_abstract"]
+You can view the following known issues for the Network Observability Operator 1.5 release.
+
+* When trying to access the web console, cache issues on OCP 4.14.10 prevent access to the *Observe* view. The web console shows the error message: `Failed to get a valid plugin manifest from /api/plugins/monitoring-plugin/`. The recommended workaround is to update the cluster to the latest minor version. If this does not work, you need to apply the workarounds described in this link:https://access.redhat.com/solutions/7052408[Red Hat Knowledgebase article].(link:https://issues.redhat.com/browse/NETOBSERV-1493[*NETOBSERV-1493*])
+
+* Since the 1.3.0 release of the Network Observability Operator, installing the Operator causes a warning kernel taint to appear. The reason for this error is that the network observability eBPF agent has memory constraints that prevent preallocating the entire hashmap table. The Operator eBPF agent sets the `BPF_F_NO_PREALLOC` flag so that pre-allocation is disabled when the hashmap is too memory expansive.

--- a/modules/network-observability-operator-release-notes-1-5-0-new-features-and-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-5-0-new-features-and-enhancements.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-5-0-new-features-and-enhancements_{context}"]
+= Network Observability Operator 1.5.0 new features and enhancements
+
+[role="_abstract"]
+You can view the following new features and enhancements for the Network Observability Operator 1.5 release.
+
+[id="network-observability-dns-enhancements-1.5_{context}"]
+== DNS tracking enhancements
+In 1.5, the TCP protocol is now supported in addition to UDP. New dashboards are also added to the *Overview* view of the Network Traffic page.
+
+////
+For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-dns-overview_nw-observe-network-traffic[Configuring DNS tracking] and xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-dns-tracking_nw-observe-network-traffic[Working with DNS tracking].
+////
+
+[id="network-observability-RTT-1.5_{context}"]
+== Round-trip time (RTT)
+You can use TCP handshake Round-Trip Time (RTT) captured from the `fentry/tcp_rcv_established` Extended Berkeley Packet Filter (eBPF) hookpoint to read smoothed round-trip time (SRTT) and analyze network flows. In the *Overview*, *Network Traffic*, and *Topology* pages in web console, you can monitor network traffic and troubleshoot with RTT metrics, filtering, and edge labeling.
+
+////
+For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-RTT-overview_nw-observe-network-traffic[RTT Overview] and xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-RTT_nw-observe-network-traffic[Working with RTT].
+////
+
+[id="network-observability-metrics-dashboard-enhancements_{context}"]
+== Metrics, dashboards, and alerts enhancements
+The network observability metrics dashboards in *Observe* → *Dashboards* → *NetObserv* have new metrics types you can use to create Prometheus alerts. You can now define available metrics in the `includeList` specification. In previous releases, these metrics were defined in the `ignoreTags` specification.
+
+////
+For a complete list of these metrics, see xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network observability metrics].
+////
+
+[id="network-observability-improved-lokistack-integration_{context}"]
+== Improvements for network observability without Loki
+You can create Prometheus alerts for the *Netobserv* dashboard using DNS, Packet drop, and RTT metrics, even if you don't use Loki. In the previous version of network observability, 1.4, these metrics were only available for querying and analysis in the *Network Traffic*, *Overview*, and *Topology* views, which are not available without Loki.
+
+////
+For more information, see xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-metrics_metrics-dashboards-alerts[Network observability metrics]
+////
+
+[id="network-observability-zones_{context}"]
+== Availability zones
+You can configure the `FlowCollector` resource to collect information about the cluster availability zones. This configuration enriches the network flow data with the link:https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone[`topology.kubernetes.io/zone`] label value applied to the nodes.
+
+////
+For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-zones_nw-observe-network-traffic[Working with availability zones]
+////
+
+[id="network-observability-enhanced-configuration-and-ui-1.5_{context}"]
+== Notable enhancements
+The 1.5 release of the Network Observability Operator adds improvements and new capabilities to the {product-title} web console plugin and the Operator configuration.
+
+[id="performance-enhancements-1.5_{context}"]
+== Performance enhancements
+* The `spec.agent.ebpf.kafkaBatchSize` default is changed from `10MB` to `1MB` to enhance eBPF performance when using Kafka.
++
+[IMPORTANT]
+=====
+When upgrading from an existing installation, this new value is not set automatically in the configuration. If you monitor a performance regression with the eBPF Agent memory consumption after upgrading, you might consider reducing the `kafkaBatchSize` to the new value.
+=====
+
+[id="web-console-enhancements-1.5_{context}"]
+== Web console enhancements:
+
+* There are new panels added to the *Overview* view for DNS and RTT: Min, Max, P90, P99.
+* There are new panel display options added:
+** Focus on one panel while keeping others viewable but with smaller focus.
+** Switch graph type.
+** Show *Top* and *Overall*.
+* A collection latency warning is shown in the *Custom time range* window.
+* There is enhanced visibility for the contents of the *Manage panels* and *Manage columns* pop-up windows.
+* The Differentiated Services Code Point (DSCP) field for egress QoS is available for filtering QoS DSCP in the web console *Network Traffic* page.
+
+[id="configuration-enhancements-1.5_{context}"]
+== Configuration enhancements:
+
+* The `LokiStack` mode in the `spec.loki.mode` specification simplifies installation by automatically setting URLs, TLS, cluster roles and a cluster role binding, as well as the `authToken` value. The `Manual` mode allows more control over configuration of these settings.
+* The API version changes from `flows.netobserv.io/v1beta1` to `flows.netobserv.io/v1beta2`.

--- a/modules/network-observability-operator-release-notes-1-5-0.adoc
+++ b/modules/network-observability-operator-release-notes-1-5-0.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-5-0_{context}"]
+= Network Observability Operator 1.5.0 advisory
+
+[role="_abstract"]
+You can view the following advisory for the Network Observability Operator 1.5 release.
+
+link:https://access.redhat.com/errata/RHSA-2024:0853[Network Observability Operator 1.5.0]

--- a/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+++ b/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
@@ -28,7 +28,14 @@ include::modules/network-observability-operator-release-notes-1-9-2-bug-fixes.ad
 //netobserv 1.6.2
 //netobserv 1.6.1
 //netobserv 1.6.0
-//netobserv 1.5.0
+
+include::modules/network-observability-operator-release-notes-1-5-0.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-5-0-new-features-and-enhancements.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-5-0-fixed-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-5-0-known-issues.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-4-2.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-15826](https://issues.redhat.com//browse/OSDOCS-15826) [NETOBSERV] Refactor release notes 1.5.0

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15826

Link to docs preview:
* 1.5 advisory: https://102252--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-5-0_network-observability-operator-archived-release-notes
* 1.5 new features: https://102252--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-5-0-new-features-and-enhancements_network-observability-operator-archived-release-notes
* 1.5 fixed issues: https://102252--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-5-0-fixed-issues_network-observability-operator-archived-release-notes
* 1.5 known issues: https://102252--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-5-0-known-issues_network-observability-operator-archived-release-notes

QE review:
QE is not required for this PR. This PR modularizes Network Observability Operator release notes for 1.3.0 only. There are no content changes.

Additional information:

* For 1.5.0, xrefs are being left as they are, and are being commented out for now. Adding them to "Additional resources" creates a long list of links, which is not helpful. However, at this time, it is unclear what the alternative is or if there is going to be an exception for xrefs in release note modules.
* The Network Observability Operator release notes are being modularized through a series of PRs. This means that things will get cleaned up and consolidated along the way.
* Some of these PRs may contain updates to previously merged content for the purpose of consistency.
* The network-observability-release-notes.adoc file will dwindle with each PR while the network-observability-operator-release-notes-archive.adoc file will grow.
In as many cases as possible, such as:
[id="network-observability-channel-removal-1.4_{context}"]
== Channel removal
existing ID in network-observability-release-notes.adoc has been used in the new module.
* Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. This will likely apply to release notes since it has been 1 assembly file and not all content is applicable to all OCP branches.
* I will manually verify content on each breach, and create manual cherry-picks accordingly.

**https://github.com/openshift/openshift-docs/pull/102143 must be merged first. Then rebase to capture 1.4.1 and 1.4.2**