### PR TITLE
OSDOCS-15564: adds RHEL 10 relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-21-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-21-release-notes.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-microshift.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate a single node in low-resource edge environments.
+{product-title-first} provides developers and IT organizations with small-form-factor and edge computing delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge.
 
 include::modules/microshift-4-21-about-this-release.adoc[leveloffset=+1]
 

--- a/modules/microshift-4-21-about-this-release.adoc
+++ b/modules/microshift-4-21-about-this-release.adoc
@@ -7,6 +7,8 @@
 = About this release
 
 [role="_abstract"]
+Built on {OCP} and Kubernetes, {microshift-short} provides an efficient way to operate a single node in low-resource edge environments.
+
 {microshift-short} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
 Version {product-version} of {microshift-short} includes new features and enhancements. Update to the latest version of {microshift-short} to receive all of the latest features, bug fixes, and security updates. {microshift-short} is derived from {OCP} {ocp-version} and uses the CRI-O container runtime. New features, changes, and known issues that pertain to {microshift-short} are included in this topic.

--- a/modules/microshift-4-21-tech-preview.adoc
+++ b/modules/microshift-4-21-tech-preview.adoc
@@ -11,7 +11,7 @@ Some features in this release are currently in Technology Preview. These experim
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
-[id="microshift-4-21-TP-feature1_{context}"]
-== TP feature 1
+[id="microshift-4-21-TP-rhel-10_{context}"]
+== {op-system-base} 10 now available
 
-ipsum delorum etc
+{op-system-base-full} is now available as a Technology Preview feature for use with {microshift-short} 4.21. You can now use all of the new features of {op-system-base} with your {op-system-bundle} deployments. You must update to {microshift-short} 4.21 to use {op-system-base} 10.


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-15564

Link to docs preview:
https://102277--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html#microshift-4-21-TP-rhel-10_release-notes

Reviewa:
- [x] QE approved this change.
- [x] SME approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
