### PR TITLE
OSDOCS-17305 updated ESO assemblies and modules for edits and DITA

### DIFF
--- a/modules/eso-bitwarden-secret.adoc
+++ b/modules/eso-bitwarden-secret.adoc
@@ -21,7 +21,7 @@ The `bitwardenSecretManagerProvider` field enables the Bitwarden secrets manager
 | _string_
 | `mode` field enables the `bitwardenSecretManagerProvider` provider state, which can be set to `Enabled` or `Disabled`. If set to `Enabled`, the Operator ensures the plugin is deployed and synchronized. If set to `Disabled`, the Bitwarden provider plugin reconciliation is disabled. The plugin and resources remain in their current state, and are not managed by the Operator.
 | `Disabled`
-a| enum: [Enabled Disabled]
+| enum: [Enabled Disabled]
 
 Optional
 

--- a/modules/eso-cert-manager-config.adoc
+++ b/modules/eso-cert-manager-config.adoc
@@ -6,6 +6,7 @@
 [id="eso-cert-manager-config_{context}"]
 = certManagerConfig
 
+[role="_abstract"]
 The `certManagerConfig` field configures the `cert-manager` Operator settings.
 
 [cols="1,1,1,1,1",options="header"]
@@ -20,7 +21,7 @@ The `certManagerConfig` field configures the `cert-manager` Operator settings.
 | _string_
 | `mode` specifies whether to use cert-manager for certificate management instead of the built-in `cert-controller` which can be indicated by setting either `Enabled` or `Disabled`. If set to `Enabled`, uses `cert-manager` for obtaining the certificates for the webhook server and other components. If set to `Disabled`, uses the `cert-controller` for obtaining the certificates for the webhook server. `Disabled` is the default behavior.
 | false
-a| enum: [true false]
+| enum: [true false]
 
 Required
 
@@ -28,7 +29,7 @@ Required
 | _string_
 | `injectAnnotations` adds the `cert-manager.io/inject-ca-from` annotation to the webhooks and custom resource definitions (CRDs) to automatically configure the webhook with the `cert-manager` Operator certificate authority (CA). This requires CA Injector to be enabled in `cert-manager` Operator. Set this field to `true` or `false`. When set, this field cannot be changed.
 | false
-a| enum: [true false]
+| enum: [true false]
 
 Optional
 

--- a/modules/eso-cert-providers-config.adoc
+++ b/modules/eso-cert-providers-config.adoc
@@ -6,6 +6,7 @@
 [id="eso-cert-providers-config_{context}"]
 = certProvidersConfig
 
+[role="_abstract"]
 The `certProvidersConfig` defines the configuration for the certificate providers used to manage TLS certificates for webhook and plugins.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-condition.adoc
+++ b/modules/eso-condition.adoc
@@ -6,6 +6,7 @@
 [id="eso-condition_{context}"]
 = condition
 
+[role="_abstract"]
 The `condition` field holds information about the condition of the `external-secrets` deployment.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-conditional-status.adoc
+++ b/modules/eso-conditional-status.adoc
@@ -6,6 +6,7 @@
 [id="eso-conditional-status_{context}"]
 = conditionalStatus
 
+[role="_abstract"]
 The `conditionalStatus` field holds information about the current state of the `external-secrets` deployment.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-controller-config.adoc
+++ b/modules/eso-controller-config.adoc
@@ -6,6 +6,7 @@
 [id="eso-controller-config_{context}"]
 = controllerConfig
 
+[role="_abstract"]
 The `controllerConfig` specifies the configurations used by the controller when installing the `external-secrets` operand and the plugins.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-controller-status.adoc
+++ b/modules/eso-controller-status.adoc
@@ -6,6 +6,7 @@
 [id="eso-controller-status_{context}"]
 = controllerStatus
 
+[role="_abstract"]
 The `controllerStatus` field contains the observed conditions of the controllers used by the Operator.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-external-secrets-config.adoc
+++ b/modules/eso-external-secrets-config.adoc
@@ -21,7 +21,7 @@ The `applicationConfig` specifies the configurations for the `external-secrets` 
 | _integer_
 | `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
 | 1
-a| The maximum range value is 5
+| The maximum range value is 5
 
 The minimum range value is 1
 
@@ -31,7 +31,7 @@ Optional
 | _string_
 | `operatingNamespace` restricts the `external-secrets` operand operations to the provided namespace. Enabling this field disables `ClusterSecretStore` and `ClusterExternalSecret`.
 |
-a| The maximum length is 63
+| The maximum length is 63
 
 The minimum length is 1
 
@@ -59,7 +59,7 @@ Optional
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
 | `tolerations` sets the pod tolerations. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[]
 |
-a| The maximum number of items is 50
+| The maximum number of items is 50
 
 The minimum number of items is 0
 
@@ -69,7 +69,7 @@ Optional
 | _object (keys:string, values:string)_
 | `nodeSelector` defines the scheduling criteria by using node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
 |
-a| The maximum number of properties is 50
+| The maximum number of properties is 50
 
 The minimum number of properties is 0
 

--- a/modules/eso-external-secrets-list.adoc
+++ b/modules/eso-external-secrets-list.adoc
@@ -6,6 +6,7 @@
 [id="eso-external-secrets-list_{context}"]
 = externalSecretsConfigList
 
+[role="_abstract"]
 The `externalSecretsConfigList` object fetches the list of `externalSecretsConfig` objects.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-external-secrets-manager-list.adoc
+++ b/modules/eso-external-secrets-manager-list.adoc
@@ -6,6 +6,7 @@
 [id="eso-external-secrets-manager-list_{context}"]
 = externalSecretsManagerList
 
+[role="_abstract"]
 The `externalSecretsManagerList` object fetches the list of `externalSecretsManager` objects.
 
 

--- a/modules/eso-external-secrets-manager-spec.adoc
+++ b/modules/eso-external-secrets-manager-spec.adoc
@@ -6,6 +6,7 @@
 [id="eso-external-secrets-manager-spec_{context}"]
 = externalSecretsManagerSpec
 
+[role="_abstract"]
 The `externalSecretsManagerSpec` field defines the desired behavior of the `externalSecretsManager` object.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-external-secrets-manager-status.adoc
+++ b/modules/eso-external-secrets-manager-status.adoc
@@ -6,6 +6,7 @@
 [id="eso-external-secrets-manager-status_{context}"]
 = externalSecretsManagerStatus
 
+[role="_abstract"]
 The `externalSecretsManagerStatus` field shows the most recently observed status of the `externalSecretsManager` object.
 
 [cols="1,1,1,1,1",options="header"]
@@ -26,7 +27,7 @@ The `externalSecretsManagerStatus` field shows the most recently observed status
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#time-v1-meta[_Time_]
 | `lastTransitionTime` records the most recent time the status of the condition changed.
 |
-a| Format: date-time
+| Format: date-time
 
 Type: string
 |===

--- a/modules/eso-external-secrets-manager.adoc
+++ b/modules/eso-external-secrets-manager.adoc
@@ -6,6 +6,7 @@
 [id="eso-external-secrets-manager_{context}"]
 = externalSecretsManager
 
+[role="_abstract"]
 The `externalSecretsManager` object defines the configuration and information of deployments managed by the {external-secrets-operator-short}. Set the name to `cluster` as this allows only one instance of `externalSecretsManager` per cluster.
 
 You can configure global options by using `externalSecretsManager`. This serves as a centralized configuration for managing multiple controllers of the Operator. The Operator automatically creates the `externalSecretsManager` object during installation.

--- a/modules/eso-external-secrets-spec.adoc
+++ b/modules/eso-external-secrets-spec.adoc
@@ -6,6 +6,7 @@
 [id="eso-external-secrets-spec_{context}"]
 = externalSecretsConfigSpec
 
+[role="_abstract"]
 The `externalSecretsConfigSpec` field defines the desired behavior of the `externalSecrets` object.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-external-secrets-status.adoc
+++ b/modules/eso-external-secrets-status.adoc
@@ -6,6 +6,7 @@
 [id="eso-external-secrets-status_{context}"]
 = externalSecretsConfigStatus
 
+[role="_abstract"]
 The `externalSecretsConfigStatus` field shows the most recently observed status of the `externalSecretsConfig` Object.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-external-secrets.adoc
+++ b/modules/eso-external-secrets.adoc
@@ -6,6 +6,7 @@
 [id="eso-external-secrets_{context}"]
 = externalSecretsConfig
 
+[role="_abstract"]
 The `externalSecretsConfig` object defines the configuration and information for the managed `external-secrets` operand deployment. Set the name to `cluster` as `externalSecretsConfig` object allows only one instance per cluster.
 
 Creating an `externalSecretsConfig` object triggers the deployment of the `external-secrets` operand and maintains the desired state.

--- a/modules/eso-global-config.adoc
+++ b/modules/eso-global-config.adoc
@@ -6,6 +6,7 @@
 [id="eso-global-config_{context}"]
 = globalConfig
 
+[role="_abstract"]
 The `globalConfig` field configures the behavior of the {external-secrets-operator-short}.
 
 
@@ -21,7 +22,7 @@ The `globalConfig` field configures the behavior of the {external-secrets-operat
 | _integer_
 | `labels` applies to all resources created by the Operator. This field can have a maximum of 20 entries
 | 1
-a| The maximum number of properties is 20
+| The maximum number of properties is 20
 
 The minimum number of properties is 0
 
@@ -31,7 +32,7 @@ Optional
 | _integer_
 | `logLevel` supports a range of values as defined in the link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use[kubernetes logging guidelines].
 | 1
-a| The maximum range value is 5
+| The maximum range value is 5
 
 The minimum range value is 1
 
@@ -53,7 +54,7 @@ Optional
 | link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#toleration-v1-core[_Toleration_] _array_
 | `tolerations` sets the pod tolerations. For more information, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[]
 |
-a| The maximum number of items is 50
+| The maximum number of items is 50
 
 The minimum number of items is 0
 
@@ -63,7 +64,7 @@ Optional
 | _object (keys:string, values:string)_
 | `nodeSelector` defines the scheduling criteria by using the node labels. For more information, see link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/[]
 |
-a| The maximum number of properties is 50
+| The maximum number of properties is 50
 
 The minimum number of properties is 0
 

--- a/modules/eso-mode.adoc
+++ b/modules/eso-mode.adoc
@@ -6,6 +6,7 @@
 [id="eso-mode_{context}"]
 = mode
 
+[role="_abstract"]
 The `mode` field indicates the operational state of the optional features.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-object-reference.adoc
+++ b/modules/eso-object-reference.adoc
@@ -20,7 +20,7 @@ The `ObjectReference` field refers to an object by its name, kind, and group.
 | _string_
 | `name` specifies the name of the resource being referred to.
 |
-a| The maximum length is 253 characters.
+| The maximum length is 253 characters.
 
 The minimum length is 1 character.
 
@@ -30,7 +30,7 @@ Required
 | _string_
 | `kind` specifies the kind of the resource being referred to.
 |
-a| The maximum length is 253 characters.
+| The maximum length is 253 characters.
 
 The minimum length is 1 character.
 
@@ -40,7 +40,7 @@ Optional
 | _string_
 | `group` specifies the group of the resource being referred to.
 |
-a| The maximum length is 253 characters.
+| The maximum length is 253 characters.
 
 The minimum length is 1 character.
 

--- a/modules/eso-plugins-config.adoc
+++ b/modules/eso-plugins-config.adoc
@@ -6,6 +6,7 @@
 [id="eso-plugiins-config_{context}"]
 = pluginsConfig
 
+[role="_abstract"]
 The `pluginsConfig` configures the optional plugins.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/eso-proxy-config.adoc
+++ b/modules/eso-proxy-config.adoc
@@ -6,6 +6,7 @@
 [id="eso-proxy-config_{context}"]
 = proxyConfig
 
+[role="_abstract"]
 The `proxyConfig` holds the proxy configurations which are made available in the operand containers and managed by the Operator as environment variables.
 
 [cols="1,1,1,1,1",options="header"]
@@ -20,7 +21,7 @@ The `proxyConfig` holds the proxy configurations which are made available in the
 | _string_
 | The `httpProxy` field contains the URL of the proxy for HTTP requests. This field can have a maximum of 2048 characters.
 |
-a| The maximum length is 2048 characters.
+| The maximum length is 2048 characters.
 
 The minimum length is 0 characters.
 
@@ -30,7 +31,7 @@ Optional
 | _string_
 | The `httpsProxy` field contains the URL of the proxy for HTTPS requests. This field can have a maximum of 2048 characters.
 |
-a| The maximum length is 2048 characters.
+| The maximum length is 2048 characters.
 
 The minimum length is 0 characters.
 
@@ -40,7 +41,7 @@ Optional
 | _string_
 | The `noProxy` field is a comma-separated list of hostnames, classless inter-domain routings (CIDRs), and IP addresses or a combination of the three for which the proxy should not be used. This field can have a maximum of 4096 characters.
 |
-a| The maximum length is 4096 characters.
+| The maximum length is 4096 characters.
 
 The minimum length is 0 characters.
 

--- a/modules/eso-secret-reference.adoc
+++ b/modules/eso-secret-reference.adoc
@@ -6,6 +6,7 @@
 [id="eso-secret-reference_{context}"]
 = secretReference
 
+[role="_abstract"]
 The `secretReference` field refers to a secret with the given name in the same namespace where it used.
 
 [cols="1,1,1,1,1",options="header"]
@@ -20,7 +21,7 @@ The `secretReference` field refers to a secret with the given name in the same n
 | _string_
 | `name` specifies the name of the secret resource being referred to.
 |
-a| The maximum length is 253.
+| The maximum length is 253.
 
 The minimum length is 1.
 

--- a/modules/eso-web-hook-config.adoc
+++ b/modules/eso-web-hook-config.adoc
@@ -6,6 +6,7 @@
 [id="eso-web-hook-config_{context}"]
 = webhookConfig
 
+[role="_abstract"]
 The `webhookConfig` field configures the specifics of the `external-secrets` application webhook.
 
 [cols="1,1,1,1,1",options="header"]

--- a/modules/external-secrets-bit-warden-config.adoc
+++ b/modules/external-secrets-bit-warden-config.adoc
@@ -6,6 +6,7 @@
 [id="external-secrets-bit-warden-config_{context}"]
 = Configuring the bitwardenSecretManagerProvider plugin
 
+[role="_abstract"]
 You can enable the `bitwardenSecretManagerProvider` to use the Bitwarden Secrets Manager provider as a source for your secrets.
 
 .Prerequisites

--- a/modules/external-secrets-cert-manager-config.adoc
+++ b/modules/external-secrets-cert-manager-config.adoc
@@ -6,6 +6,7 @@
 [id="external-secrets-cert-manager-config_{context}"]
 = Configuring cert-manager for the external-secrets certificate requirements
 
+[role="_abstract"]
 The `external-secrets` webhook and plugins can be assigned to `cert-manager` for certificate management. This configuration is optional.
 
 When `cert-manager` is not used, `external-secrets` defaults to its own certificate management. In this mode, it automatically generates the required certificates for the webhook, while you are responsible for manually configuring certificates for the plugins.
@@ -47,9 +48,9 @@ spec:
 where:
 
 injectAnnotation:: Must be set to `true` when enabled.
-name:: Name of the issuer object referenced in `ExternalSecretsConfig`.
-kind:: API issuer. Can be set to either `Issuer` or `ClusterIssuer`.
-group:: API issuer group. The group name must be `cert-manager.io`.
+name:: Specifies the name of the issuer object referenced in `ExternalSecretsConfig`.
+kind:: Specifies the API issuer. Can be set to either `Issuer` or `ClusterIssuer`.
+group:: Specifies the API issuer group. The group name must be `cert-manager.io`.
 mode:: Must be set to `Enabled`. This is an immutable field and cannot be modified once it is configured.
 
 . Save your changes.

--- a/modules/external-secrets-enable-operand-log-level.adoc
+++ b/modules/external-secrets-enable-operand-log-level.adoc
@@ -6,6 +6,7 @@
 [id="external-secrets-enable-operand-log-level_{context}"]
 = Setting a log level for the {external-secrets-operator} operand
 
+[role="_abstract"]
 You can set a log level for the {external-secrets-operator} to determine the verbosity of log messages.
 
 .Prerequisites

--- a/modules/external-secrets-enable-operator-log-level.adoc
+++ b/modules/external-secrets-enable-operator-log-level.adoc
@@ -6,6 +6,7 @@
 [id="external-secrets-enable-operator-log-level_{context}"]
 = Setting a log level for the {external-secrets-operator}
 
+[role="_abstract"]
 You can set a log level for the {external-secrets-operator} to determine the verbosity of the operator log messages.
 
 .Prerequisites
@@ -15,7 +16,7 @@ You can set a log level for the {external-secrets-operator} to determine the ver
 
 .Procedure
 
-* Update the subscription object for {external-secrets-operator} to provide the verbosity level for the operator logs by running the following command:
+* Update the subscription object for the {external-secrets-operator} to provide the verbosity level for the operator logs by running the following command:
 +
 [source,terminal]
 ----
@@ -24,9 +25,9 @@ $ oc -n <external_secrets_operator_namespace> patch subscription openshift-exter
 +
 where:
 
-external_secrets_operator_namespace:: Namespace where the operator is installed.
+external_secrets_operator_namespace:: Specifies the namespace where the Operator is installed.
 
-log_level:: Supports the value range of 1-5. The default is 2.
+log_level:: Specifies the level of log detail. Values range from 1-5. The default is 2.
 
 .Verification
 
@@ -37,7 +38,8 @@ log_level:: Supports the value range of 1-5. The default is 2.
 $ oc set env deploy/external-secrets-operator-controller-manager -n external-secrets-operator --list | grep -e OPERATOR_LOG_LEVEL -e container
 ----
 +
-.Example output
+The following example verifies that the log level of the {external-secrets-operator} is updated.
++
 [source,terminal]
 ----
 # deployments/external-secrets-operator-controller-manager, container manager

--- a/modules/external-secrets-enable-user-workload-monitor.adoc
+++ b/modules/external-secrets-enable-user-workload-monitor.adoc
@@ -6,6 +6,7 @@
 [id="external-secrets-enable-user-workload-monitor_{context}"]
 = Enabling user workload monitoring
 
+[role="_abstract"]
 You can enable monitoring for user-defined projects by configuring user workload monitoring in the cluster. For more information, see "Setting up metrics collection for user-defined projects".
 
 .Prerequisites

--- a/modules/external-secrets-operator-configure-proxy.adoc
+++ b/modules/external-secrets-operator-configure-proxy.adoc
@@ -6,6 +6,7 @@
 [id="external-secrets-operator-configure-proxy_{context}"]
 = Configuring the egress proxy for the {external-secrets-operator}
 
+[role="_abstract"]
 The egress proxy can be configured in the `ExternalSecretsConfig` or the `ExternalSecretsManager` custom resource (CR). The Operator and the operand make use of the {product-title} supported certificate authority (CA) bundle for the proxy validations.
 
 .Prerequisites
@@ -39,14 +40,14 @@ spec:
       httpsProxy: <https_proxy>
       noProxy: <no_proxy>
 ----
-
++
 where:
 
 <http_proxy>:: Specifies the proxy URL for the http requests.
 
-<https_proxy>:: Proxy URL for the https requests.
+<https_proxy>:: Specifies the proxy URL for the https requests.
 
-<no_proxy>:: Comma-separated list of hostnames, CIDRs, IPs or a combination of these, for which the proxy should not be used.
+<no_proxy>:: Specifies a comma-separated list of hostnames, CIDRs, IPs or a combination of these, for which the proxy should not be used.
 
 * To set the proxy in the `ExternalSecretsManager` CR, perform the following steps.
 

--- a/modules/external-secrets-operator-create-externalsecretsconfig.adoc
+++ b/modules/external-secrets-operator-create-externalsecretsconfig.adoc
@@ -7,7 +7,7 @@
 = Creating the ExternalSecretsConfig Operator
 
 [role="_abstract"]
-The purpose of creating the `ExternalSecretsConfig` is to install and configure the `external-secrets`. The configuration ensures that cert-manager and Bitwarden support are enabled.
+Create the `ExternalSecretsConfig` resource to install and configure the core `external-secrets` component. This setup helps ensure that features like Bitwarden and cert-manager support are correctly enabled.
 
 .Prerequisites
 
@@ -77,7 +77,7 @@ Verify that all custom resources (CRs) are present and that the APIs are using `
 $ oc get pods -n external-secret
 ----
 +
-The following is example output that the `external-secrets` pods are in a `running` state
+The following is example output that the `external-secrets` pods are in a `running` state.
 +
 [source,terminal]
 ----

--- a/modules/external-secrets-operator-delete-upstream-operatorconfig.adoc
+++ b/modules/external-secrets-operator-delete-upstream-operatorconfig.adoc
@@ -7,7 +7,7 @@
 = Deleting the community {external-secrets-operator-short}
 
 [role="_abstract"]
-You must delete the `operatorconfigs.operator.external-secrets.io` custom resource (CR) for the community {external-secrets-operator-short} to delete the `external-secrets` application installed by the community {external-secrets-operator-short}.
+Delete the configuration resource for the community Operator so that the legacy application is fully removed. This action prevents conflicts before installing the {external-secrets-operator}.
 
 .Prerequisites
 
@@ -41,7 +41,7 @@ $ oc delete operatorconfig <config_name> -n <operator_namespace>
 
 .Verification
 
-. To verify that the `operatorconfig` was deleted, run the following command:
+. To verify that the `operatorconfig` is deleted, run the following command:
 +
 [source,terminal]
 ----

--- a/modules/external-secrets-operator-egress-allow-all-traffic.adoc
+++ b/modules/external-secrets-operator-egress-allow-all-traffic.adoc
@@ -6,13 +6,14 @@
 [id="external-secrets-operator-egress-allow-all-traffic_{context}"]
 = Adding a custom network policy to allow egress to all external providers
 
+[role="_abstract"]
 You must configure custom policies through the `ExternalSecretsConfig` custom resource to allow all egress to all external providers.
 
 .Prerequisites
 
 * An `ExternalSecretsConfig` must be predefined.
 
-* You must be able to define specific egress rules, including desitination ports and protocols
+* You must be able to define specific egress rules, including destination ports and protocols.
 
 .Procedure
 

--- a/modules/external-secrets-operator-egress-specific-provider.adoc
+++ b/modules/external-secrets-operator-egress-specific-provider.adoc
@@ -6,13 +6,14 @@
 [id="external-secrets-operator-egress-specific-provider_{context}"]
 = Adding a custom network policy to allow egress to a specific provider
 
+[role="_abstract"]
 You must configure custom policies through the `ExternalSecretsConfig` custom resource to allow all egress to a specific provider.
 
 .Prerequisites
 
 * An `ExternalSecretsConfig` must be predefined.
 
-* You must be able to define specific egress rules, including desitination ports and protocols
+* You must be able to define specific egress rules, including destination ports and protocols
 
 .Procedure
 
@@ -42,8 +43,8 @@ spec:
                 protocol: TCP
       - name: allow-external-secrets-egress
 ----
++
+where:
 
-componentName:: name for the core controller specified as `ExternalSecretsCoreController`.
-
-Egress rules must include the necessary ports, such as Transmission Control Protocol (TCP) port 443 for services like the {aws-short} Secrets Manager.
+componentName:: Specifies the name for the core controller which is `ExternalSecretsCoreController`. Egress rules must specify the required ports, such as Transmission Control Protocol (TCP) port 443, for services such as the {aws-short} Secrets Manager.
 

--- a/modules/external-secrets-operator-eso-install.adoc
+++ b/modules/external-secrets-operator-eso-install.adoc
@@ -6,4 +6,5 @@
 [id="external-secrets-operator-eso-install_{context}"]
 = Installing the {external-secrets-operator}
 
-Once the `operatorconfig` has been deleted and the community {external-secret-operator-short} has been deleted, you can install the {external-secrets-operator}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/security_and_compliance/index#external-secrets-operator-install[Installing the External Secrets Operator for Red Hat OpenShift].
+[role="_abstract"]
+Install the {external-secrets-operator} after cleaning up the community version. This establishes the officially supported service for managing secrets in your cluster. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/security_and_compliance/index#external-secrets-operator-install[Installing the External Secrets Operator for Red Hat OpenShift].

--- a/modules/external-secrets-operator-ingress-egress-rules.adoc
+++ b/modules/external-secrets-operator-ingress-egress-rules.adoc
@@ -6,6 +6,7 @@
 [id="external-secrets-operator-ingress-egress-rules_{context}"]
 = Default ingress and egress rules
 
+[role="_abstract"]
 The following table summarizes the default ingress and egress rules.
 
 [cols="1,1,1,1",options="header"]

--- a/modules/external-secrets-operator-proxy-considerations.adoc
+++ b/modules/external-secrets-operator-proxy-considerations.adoc
@@ -6,6 +6,7 @@
 [id="external-secrets-operator-proxy-considerations_{context}"]
 = Security considerations
 
+[role="_abstract"]
 When using the {external-secrets-operator}, there are some security concerns you should consider:
 
 * The `external-secrets` operand fetches the secrets from the configured external providers and stores it in a Kubernetes native `Secrets` resource. This results in a secret zero problem. It is recommended to secure the secret objects using additional encryption. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation/4.9/html/planning_your_deployment/security-considerations_rhodf#data-encryption-options_rhodf[Data encryption options].

--- a/modules/external-secrets-operator-uninstall-helm.adoc
+++ b/modules/external-secrets-operator-uninstall-helm.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-helm_{context}"]
+= Uninstalling a helm installed community {external-secrets-operator-short}
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed using Helm. This helps you free up resources and maintain a clean environment for your cluster.
+
+.Procedure
+
+. Install the {external-secrets-operator}. The `external-secrets-operator` namespace must be null.
+
+. Delete the {external-secrets-short} by running the following command:
++
+[source,terminal]
+----
+$ oc helm delete <release_name> -n <operator_namespace>
+----
++
+[NOTE]
+====
+Using `helm delete` might delete all Custom Resource Definitions (CRDs) and CRs. It is recommended to installl the downstream Operator first if the namespace `external-secrets-operator` is empty.
+====

--- a/modules/external-secrets-operator-uninstall-olm.adoc
+++ b/modules/external-secrets-operator-uninstall-olm.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-olm_{context}"]
+= Uninstalling an Operator Lifecylce Manager installed community {external-secrets-operator-short}
+
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed by an Operator Lifecycle Manager (OLM) subscription. This helps you free up resources and maintain a clean environment for your cluster.
+
+.Procedure
+
+. Find the subscription name by running the following command:
++
+[source,terminal]
+----
+$ oc get subscription -n <operator_namespace> | grep external-secrets
+----
+
+. Delete the subscription by running the following command:
++
+[source,terminal]
+----
+$ oc delete subscription <subscription_name> -n <operator_namespace>
+----
+
+. Delete the `ClusterServiceVersion` by running the following command:
++
+[source,terminal]
+----
+$ oc delete csv <csv_name> -n <operator_namespace>
+----

--- a/modules/external-secrets-operator-uninstall-raw-manifests.adoc
+++ b/modules/external-secrets-operator-uninstall-raw-manifests.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="external-secrets-operator-uninstall-raw-manifests_{context}"]
+= Uninstalling a raw manifest installed community {external-secrets-operator-short}
+
+[role="_abstract"]
+Remove the community {external-secrets-operator-short} that was installed by raw manifests. This helps you free up resources and maintain a clean environment for your cluster.
+
+.Procedure
+
+* To remove the communiity {external-secrets-operator-short} that was installed by raw manifests, run the following command:
++
+[source,terminal]
+----
+$ oc delete -f /path/to/your/old/manifests.yaml -n <operator_namespace>
+----

--- a/modules/external-secrets-operator-uninstall-upstream-eso.adoc
+++ b/modules/external-secrets-operator-uninstall-upstream-eso.adoc
@@ -7,7 +7,9 @@
 = Uninstalling the community {external-secrets-operator-short}
 
 [role="_abstract"]
-You must uninstall the community {external-secrets-operator-short} to prevent it from being recreated or conflicting with the new one.
+Uninstall the community {external-secrets-operator-short} to prevent conflicts or accidental recreation after you migrate to {external-secrets-operator}.
+
+You must uninstall the community {external-secrets-operator-short} to prevent it from being recreated or conflicting with the new one. The steps to uninstall are different based on how the community {external-secrets-operator-short} was installed but the prerequisites are the same for each.
 
 .Prerequisites
 
@@ -15,41 +17,4 @@ You must uninstall the community {external-secrets-operator-short} to prevent it
 
 * You must have deleted the `operatorconfig`.
 
-.Procedure
 
-. If you installed the community {external-secrets-operator-short} by an Operator Lifecycle Manager (OLM) subscription, delete the Operator by performing the following steps:
-
-.. Find the subscription name by running the following command:
-+
-[source,terminal]
-----
-$ oc get subscription -n <operator_namespace> | grep external-secrets
-----
-
-.. Delete the subscription by running the following command:
-+
-[source,terminal]
-----
-$ oc delete subscription <subscription_name> -n <operator_namespace>
-----
-
-.. Delete the `ClusterServiceVersion` by running the following command:
-+
-[source,terminal]
-----
-$ oc delete csv <csv_name> -n <operator_namespace>
-----
-
-. If you installed the community {external-secret-operator} by Helm, delete the Operator by running the following command:
-+
-[source,terminal]
-----
-$ helm uninstall <release_name> -n <operator_namespace>
-----
-
-. If you installed the community {external-secret-operator} by raw manifests, delete the Operator by running the following command:
-+
-[source,terminal]
-----
-$ oc delete -f /path/to/your/old/manifests.yaml -n <operator_namespace>
-----

--- a/modules/external-secrets-query-operator-metrics.adoc
+++ b/modules/external-secrets-query-operator-metrics.adoc
@@ -6,6 +6,7 @@
 [id="external-secrets-query-operator-metrics_{context}"]
 = Querying metrics for the {external-secrets-operator}
 
+[role="_abstract"]
 As a cluster administrator, or as a user with view access to all namespaces, you can query the Operator metrics by using the {product-title} web console or the command-line interface (CLI). For more information, see "Accessing metrics".
 
 .Prerequisites

--- a/security/external_secrets_operator/external-secrets-log-levels.adoc
+++ b/security/external_secrets_operator/external-secrets-log-levels.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 After the {external-secrets-operator} is installed, you can customize its behavior by editing the `ExternalSecretsConfig` custom resource (CR). This lets you modify components like the external-secrets controller, the cert-controller, the webhook, and the `bitwardenSecretManagerProvider` plugin and also lets you set environment variables for the Operator pod.
 
 [role="_additional-resources"]

--- a/security/external_secrets_operator/external-secrets-monitoring.adoc
+++ b/security/external_secrets_operator/external-secrets-monitoring.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 By default, the {external-secrets-operator} exposes metrics for the Operator and the operands. You can configure OpenShift Monitoring to collect these metrics by using the Prometheus Operator format.
 
 // Enabling user workload monitoring for the external-secrets-operator operand

--- a/security/external_secrets_operator/external-secrets-operator-api.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-api.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 {external-secrets-operator} uses the following two APIs to configure the `external-secrets` application deployment.
 
 //:FeatureName: The {external-secrets-operator}

--- a/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-config-net-policy.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 The {external-secrets-operator} includes pre-defined `NetworkPolicies` for security, but you must configure additonal, custom policies through the `ExternalSecretsConfig` custom resource to set the external-secrets controller egress allow policies to communicate with external providers. These configurable policies are set via the `ExternalSecretsConfig` custom resource to establish the egress allow policy.
 
 // Adding network policy to connect to permit all egress traffic

--- a/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can migrate from the community version of the {external-secrets-operator-short}. Migrating to {external-secrets-operator} provides you with an officially supported product giving you access to enterprise-grade support. It also provides you with seamless integration from installation to upgrades.
+[role="_abstract"]
+Migrate from the community {external-secrets-operator-short} to the {external-secrets-operator} supported version. This conversion provides you with enterprise-grade support and seamless integration for managing external secrets.
 
 The following migration versions have been fully tested.
 
@@ -32,7 +33,7 @@ The migration does not support rollbacks.
 
 [NOTE]
 ====
-{external-secrets-operator} is based on the upstream version 0.19.0. Do not attempt to migrate from a higher version of the {external-secrets-operator-short}.
+{external-secrets-operator} is based on the upstream version 0.19.0. Do not try to migrate from a higher version of the {external-secrets-operator-short}.
 ====
 
 // Deleting the operatorconfig
@@ -40,6 +41,15 @@ include::modules/external-secrets-operator-delete-upstream-operatorconfig.adoc[l
 
 // Uninstalling the upstream {external-secrets-operator}
 include::modules/external-secrets-operator-uninstall-upstream-eso.adoc[leveloffset=+1]
+
+// Uninstalling the upstream {external-secrets-operator} installed by helm
+include::modules/external-secrets-operator-uninstall-helm.adoc[leveloffset=+2]
+
+// Uninstalling the upstream {external-secrets-operator} installed by OLM
+include::modules/external-secrets-operator-uninstall-olm.adoc[leveloffset=+2]
+
+// Uninstalling the upstream {external-secrets-operator} installed by raw manifests
+include::modules/external-secrets-operator-uninstall-raw-manifests.adoc[leveloffset=+2]
 
 // Removing {external-secrets-operator-short} using CLI
 include::modules/external-secrets-operator-eso-install.adoc[leveloffset=+1]

--- a/security/external_secrets_operator/external-secrets-operator-proxy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-proxy.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 If a cluster-wide egress proxy is configured in {product-title}, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. OLM automatically updates all of the Operator’s deployments with the `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.
 
 // Configure egress proxy


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17305

Link to docs preview:
https://102281--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.html


QE review:
- [ ] QE has approved this change.


Additional information:

