### PR TITLE
OCPBUGS-27383: Replace bootstrap example with compute

### DIFF
--- a/modules/machine-user-infra-machines-iso.adoc
+++ b/modules/machine-user-infra-machines-iso.adoc
@@ -77,11 +77,11 @@ $ sudo coreos-installer install --ignition-url=http://<HTTP_server>/<node_type>.
 If you want to provide your Ignition config files through an HTTPS server that uses TLS, you can add the internal certificate authority (CA) to the system trust store before running `coreos-installer`.
 ====
 +
-The following example initializes a bootstrap node installation to the `/dev/sda` device. The Ignition config file for the bootstrap node is obtained from an HTTP web server with the IP address 192.168.1.2:
+The following example initializes a compute node installation to the `/dev/sda` device. The Ignition config file for the compute node is obtained from an HTTP web server with the IP address 192.168.1.2:
 +
 [source,terminal]
 ----
-$ sudo coreos-installer install --ignition-url=http://192.168.1.2:80/installation_directory/bootstrap.ign /dev/sda --ignition-hash=sha512-a5a2d43879223273c9b60af66b44202a1d1248fc01cf156c46d4a79f552b6bad47bc8cc78ddf0116e80c59d2ea9e32ba53bc807afbca581aa059311def2c3e3b
+$ sudo coreos-installer install --ignition-url=http://192.168.1.2:80/installation_directory/worker.ign /dev/sda --ignition-hash=sha512-a5a2d43879223273c9b60af66b44202a1d1248fc01cf156c46d4a79f552b6bad47bc8cc78ddf0116e80c59d2ea9e32ba53bc807afbca581aa059311def2c3e3b
 ----
 
 . Monitor the progress of the {op-system} installation on the console of the machine.


### PR DESCRIPTION
:rotating_light: Merge reviewer, please review only - no merge :rotating_light:

Version(s):
4.12+

Issue:
[OCPBUGS-27383](https://issues.redhat.com/browse/OCPBUGS-27383)

Link to docs preview:
[Creating RHCOS machines using an ISO image](https://102283--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-bare-metal-compute-user-infra.html#machine-user-infra-machines-iso_adding-bare-metal-compute-user-infra)

QE review:
- [x] QE has approved this change.

Additional information: