### PR TITLE
OSDOCS-15827 [NETOBSERV] Refactor release notes 1.6.0

### DIFF
--- a/modules/network-observability-operator-release-notes-1-6-0-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-6-0-fixed-issues.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-6-0-fixed-issues_{context}"]
+= Network Observability Operator 1.6.0 fixed issues
+
+[role="_abstract"]
+You can review the following fixed issues for the Network Observability Operator 1.6.0.
+
+* Previously, a dead link to the OpenShift containter platform documentation was displayed in the Operator Lifecycle Manager (OLM) form for the `FlowMetrics` API creation. Now the link has been updated to point to a valid page. (link:https://issues.redhat.com/browse/NETOBSERV-1607[*NETOBSERV-1607*])
+* Previously, the Network Observability Operator description in the Operator Hub displayed a broken link to the documentation. With this fix, this link is restored. (link:https://issues.redhat.com/browse/NETOBSERV-1544[*NETOBSERV-1544*])
+* Previously, if Loki was disabled and the Loki `Mode` was set to `LokiStack`, or if Loki manual TLS configuration was configured, the Network Observability Operator still tried to read the Loki CA certificates. With this fix, when Loki is disabled, the Loki certificates are not read, even if there are settings in the Loki configuration. (link:https://issues.redhat.com/browse/NETOBSERV-1647[*NETOBSERV-1647*])
+* Previously, the `oc` `must-gather` plugin for the Network Observability Operator was only working on the `amd64` architecture and failing on all others because the plugin was using `amd64` for the `oc` binary. Now, the Network Observability Operator `oc` `must-gather` plugin collects logs on any architecture platform.
+* Previously, when filtering on IP addresses using `not equal to`, the Network Observability Operator would return a request error.
+Now, the IP filtering works in both `equal` and `not equal to` cases for IP addresses and ranges. (link:https://issues.redhat.com/browse/NETOBSERV-1630[*NETOBSERV-1630*])
+* Previously, when a user was not an admin, the error messages were not consistent with the selected tab of the *Network Traffic* view in the web console. Now, the `user not admin` error displays on any tab with improved display.(link:https://issues.redhat.com/browse/NETOBSERV-1621[*NETOBSERV-1621*])

--- a/modules/network-observability-operator-release-notes-1-6-0-known-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-6-0-known-issues.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-6-0-known-issues_{context}"]
+= Network Observability Operator 1.6.0 known issues
+
+[role="_abstract"]
+You can review the following known issues for the Network Observability Operator 1.6.0.
+
+* When the eBPF agent `PacketDrop` feature is enabled, and sampling is configured to a value greater than `1`, reported dropped bytes and dropped packets ignore the sampling configuration. While this is done on purpose to not miss any drops, a side effect is that the reported proportion of drops compared to non-drops becomes biased. For example, at a very high sampling rate, such as `1:1000`, it is likely that almost all the traffic appears to be dropped when observed from the console plugin. (link:https://issues.redhat.com/browse/NETOBSERV-1676[*NETOBSERV-1676*])
+* In the *Manage panels* window in the *Overview* tab, filtering on *total*, *bar*, *donut*, or *line* does not show any result. (link:https://issues.redhat.com/browse/NETOBSERV-1540[*NETOBSERV-1540*])
+* The SR-IOV secondary interface is not detected if the interface was created first and then the eBPF agent was deployed. It is only detected if the agent was deployed first and then the SR-IOV interface is created. (link:https://issues.redhat.com/browse/NETOBSERV-1697[*NETOBSERV-1697*])
+* When Loki is disabled, the *Topology* view in the OpenShift web console always shows the *Cluster* and *Zone* aggregation options in the slider beside the network topology diagram, even when the related features are not enabled. There is no specific workaround, besides ignoring these slider options. (link:https://issues.redhat.com/browse/NETOBSERV-1705[*NETOBSERV-1705*])
+* When Loki is disabled, and the OpenShift web console first loads, it might display an error: `Request failed with status code 400 Loki is disabled`. As a workaround, you can continue switching content on the *Network Traffic* page, such as clicking between the *Topology* and the *Overview* tabs. The error should disappear. (link:https://issues.redhat.com/browse/NETOBSERV-1706[*NETOBSERV-1706*])

--- a/modules/network-observability-operator-release-notes-1-6-0-new-features-and-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-6-0-new-features-and-enhancements.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-6-0-new-features-and-enhancements_{context}"]
+= Network Observability Operator 1.6.0 new features and enhancements
+
+[role="_abstract"]
+You can review the following new features and enhancements for the Network Observability Operator 1.6.0.
+
+[id="network-observability-lokiless-enhancements-1.6_{context}"]
+== Enhanced use of Network Observability Operator without Loki
+You can now use Prometheus metrics and rely less on Loki for storage when using the Network Observability Operator.
+
+// For more information, see xref:../../observability/network_observability/installing-operators.adoc#network-observability-without-loki_network_observability[Network observability without Loki].
+
+[id="network-observability-custom-metrics-1.6_{context}"]
+== Custom metrics API
+You can create custom metrics out of flowlogs data by using the `FlowMetrics` API. Flowlogs data can be used with Prometheus labels to customize cluster information on your dashboards. You can add custom labels for any subnet that you want to identify in your flows and metrics. This enhancement can also be used to more easily identify external traffic by using the new labels `SrcSubnetLabel` and `DstSubnetLabel`, which exists both in flow logs and in metrics. Those fields are empty when there is external traffic, which gives a way to identify it.
+
+//For more information, see xref:../../observability/network_observability/metrics-alerts-dashboards.adoc#network-observability-custom-metrics_metrics-dashboards-alerts[Custom metrics] and xref:../../observability/network_observability/flowmetric-api.adoc#flowmetric-flows-netobserv-io-v1alpha1[FlowMetric API reference].
+
+[id="network-observability-eBPF-performance-enhancements-1.6_{context}"]
+== eBPF performance enhancements
+Experience improved performances of the eBPF agent, in terms of CPU and memory, with the following updates:
+
+* The eBPF agent now uses TCX webhooks instead of TC.
+* The *NetObserv / Health* dashboard has a new section that shows eBPF metrics.
+** Based on the new eBPF metrics, an alert notifies you when the eBPF agent is dropping flows.
+* Loki storage demand decreases significantly now that duplicated flows are removed. Instead of having multiple, individual duplicated flows per network interface, there is one de-duplicated flow with a list of related network interfaces.
+
+[IMPORTANT]
+=====
+With the duplicated flows update, the *Interface* and *Interface Direction* fields in the *Network Traffic* table are renamed to *Interfaces* and *Interface Directions*, so any bookmarked *Quick filter* queries using these fields need to be updated to `interfaces` and `ifdirections`.
+=====
+////
+For more information, see xref:../../observability/network_observability/network-observability-operator-monitoring.adoc#network-observability-netobserv-dashboard-ebpf-agent-alerts_network_observability[Using the eBPF agent alert]
+and For more information, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-dashboards_network-observability-overview[Network observability metrics dashboards] and xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-quickfilter_nw-observe-network-traffic[Filtering the network traffic].
+////
+
+[id="network-observability-ebpf-collection-filtering-1.6_{context}"]
+== eBPF collection rule-based filtering
+You can use rule-based filtering to reduce the volume of created flows. When this option is enabled, the *Netobserv / Health* dashboard for eBPF agent statistics has the *Filtered flows rate* view.
+
+//For more information, see xref:../../observability/network_observability/observing-network-traffic.adoc#network-observability-ebpf-flow-rule-filter_nw-observe-network-traffic[eBPF flow rule filter].

--- a/modules/network-observability-operator-release-notes-1-6-0-technology-preview-features.adoc
+++ b/modules/network-observability-operator-release-notes-1-6-0-technology-preview-features.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-6-0-technology-preview-features_{context}"]
+= Network Observability Operator release notes 1.6.0 Technology Preview features
+
+[role="_abstract"]
+You can review the Technology Preview features for the Network Observability Operator 1.6.0 release.
+
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+[id="network-observability-cli-1.6_{context}"]
+== Network Observability CLI
+You can debug and troubleshoot network traffic issues without needing to install the Network Observability Operator by using the Network Observability CLI. Capture and visualize flow and packet data in real-time with no persistent storage requirement during the capture.
+
+////
+For more information, see xref:../../observability/network_observability/netobserv_cli/netobserv-cli-install.adoc#network-observability-netoberv-cli-about_netobserv-cli-install[Network Observability CLI] and link:https://access.redhat.com/errata/RHEA-2024:3869[Network Observability CLI 1.6.0].
+////

--- a/modules/network-observability-operator-release-notes-1-6-0.adoc
+++ b/modules/network-observability-operator-release-notes-1-6-0.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-6-0_{context}"]
+= Network Observability Operator release notes 1.6.0 advisory
+
+[role="_abstract"]
+You can review the advisory for the Network Observability Operator 1.6.0 release.
+
+* link:https://access.redhat.com/errata/RHSA-2024:3868[Network Observability Operator 1.6.0]

--- a/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+++ b/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
@@ -27,7 +27,14 @@ include::modules/network-observability-operator-release-notes-1-9-2-bug-fixes.ad
 //netobserv 1.7.0
 //netobserv 1.6.2
 //netobserv 1.6.1
-//netobserv 1.6.0
+
+include::modules/network-observability-operator-release-notes-1-6-0.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-6-0-new-features-and-enhancements.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-6-0-fixed-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-6-0-known-issues.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-5-0.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**https://github.com/openshift/openshift-docs/pull/102252 must be merged first. Then rebase to capture 1.5.0.**

[OSDOCS-15827](https://issues.redhat.com//browse/OSDOCS-15827) [NETOBSERV] Refactor release notes 1.6.0

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-15827

Link to docs preview:
* 1.6 advisory:
* 1.6 new features and enhancements: https://102310--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-6-0-new-features-and-enhancements_network-observability-operator-archived-release-notes
* 1.6 fixed issues: https://102310--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-6-0-fixed-issues_network-observability-operator-archived-release-notes
* 1.6 known issues: https://102310--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-6-0-known-issues_network-observability-operator-archived-release-notes

QE review:
QE is not required for this PR. This PR modularizes Network Observability Operator release notes for 1.3.0 only. There are no content changes.

Additional information:

* For 1.6.0, xrefs are being left as they are, and are being commented out for now. Adding them to "Additional resources" creates a long list of links, which is not helpful. However, at this time, it is unclear what the alternative is or if there is going to be an exception for xrefs in release note modules.
* The Network Observability Operator release notes are being modularized through a series of PRs. This means that things will get cleaned up and consolidated along the way.
* Some of these PRs may contain updates to previously merged content for the purpose of consistency.
* The network-observability-release-notes.adoc file will dwindle with each PR while the network-observability-operator-release-notes-archive.adoc file will grow.
In as many cases as possible, such as:
[id="network-observability-channel-removal-1.4_{context}"]
== Channel removal
existing ID in network-observability-release-notes.adoc has been used in the new module.
* Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. This will likely apply to release notes since it has been 1 assembly file and not all content is applicable to all OCP branches.
* I will manually verify content on each breach, and create manual cherry-picks accordingly.
