### PR TITLE
Update LokiStack configuration with global limits for retention and managementState

### DIFF
--- a/modules/installing-loki-operator-cli.adoc
+++ b/modules/installing-loki-operator-cli.adoc
@@ -149,26 +149,33 @@ metadata:
   name: logging-loki # <1>
   namespace: openshift-logging # <2>
 spec:
-  size: 1x.small # <3>
+  managementState: Managed
+  limits:
+    global: # <3>
+      retention: # <4>
+        days: 20 # Set the value as per requirement
+  size: 1x.small # <5>
   storage:
     schemas:
     - version: v13
-      effectiveDate: "<yyyy>-<mm>-<dd>" # <4>
+      effectiveDate: "<yyyy>-<mm>-<dd>" # <6>
     secret:
-      name: logging-loki-s3 # <5>
-      type: s3 # <6>
-  storageClassName: <storage_class_name> # <7>
+      name: logging-loki-s3 # <7>
+      type: s3 # <8>
+  storageClassName: <storage_class_name> # <9>
   tenants:
-    mode: openshift-logging # <8>
+    mode: openshift-logging # <10>
 ----
 <1> Use the name `logging-loki`.
 <2> You must specify `openshift-logging` as the namespace.
-<3> Specify the deployment size. Supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`. Additionally, `1x.pico` is supported starting with {logging} 6.1.
-<4> For new installations this date should be set to the equivalent of "yesterday", as this will be the date from when the schema takes effect.
-<5> Specify the name of your log store secret.
-<6> Specify the corresponding storage type.
-<7> Specify the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. You can list the available storage classes for your cluster by using the `oc get storageclasses` command.
-<8> The `openshift-logging` mode is the default tenancy mode where a tenant is created for log types, such as audit, infrastructure, and application. This enables access control for individual users and user groups to different log streams.
+<3> Define global limits that apply to the LokiStack instance. For information about setting stream-based retention, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html/configuring_logging/configuring-lokistack-storage#logging-loki-retention_configuring-the-log-store[Enabling stream-based retention with Loki]. This field does not impact the retention period for stored logs in object storage.
+<4> Retention is enabled in the cluster when this block is added to the CR.
+<5> Specify the deployment size. Supported size options for production instances of Loki are `1x.extra-small`, `1x.small`, or `1x.medium`. Additionally, `1x.pico` is supported starting with {logging} 6.1.
+<6> For new installations this date should be set to the equivalent of "yesterday", as this will be the date from when the schema takes effect.
+<7> Specify the name of your log store secret.
+<8> Specify the corresponding storage type.
+<9> Specify the name of a storage class for temporary storage. For best performance, specify a storage class that allocates block storage. You can list the available storage classes for your cluster by using the `oc get storageclasses` command.
+<10> The `openshift-logging` mode is the default tenancy mode where a tenant is created for log types, such as audit, infrastructure, and application. This enables access control for individual users and user groups to different log streams.
 
 
 . Apply the `LokiStack` CR object by running the following command:


### PR DESCRIPTION
Doc Reference: https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.3/html/installing_logging/installing-logging#install-loki-operator-cli_installing-logging 

By default, the retention config is not mentioned in standard installation YAML because of which end users use the exact same config for deployment and then object storage get flooded with a lot of logs. This breaks ODF and impacts the applications consuming storage from ODF.

It is required to add retention config in standard installation YAML in the documentation. If there is no retention, then the logs will not be remove / cleaned up from object storage until retention is configured or until lifecycle policy is configured on the object bucket.

Here is the updated config:
~~~
apiVersion: loki.grafana.com/v1
kind: LokiStack
metadata:
  name: logging-loki  1 
  namespace: openshift-logging  2 
spec:
  managementState: Managed 
  limits:  
    global:   3
      retention:   4
        days: 20   # Set the value as per requirement.
  size: 1x.small  5 
  storage:
    schemas:
    - version: v13
      effectiveDate: "<yyyy>-<mm>-<dd>"  6
    secret:
      name: logging-loki-s3  7
      type: s3  8 
  storageClassName: <storage_class_name>  9 
  tenants:
    mode: openshift-logging  10
~~~

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Logging 6.4, Logging 6.3, Logging 6.2, Logging 6.1, Logging 6.0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OBSDOCS-2467

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://102311--ocpdocs-pr.netlify.app/openshift-logging/latest/installing/installing-logging.html 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
