### PR TITLE
PR for OBSDOCS-2785: Modularize otel-configuring-otelcol-metrics.adoc 

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3243,8 +3243,6 @@ Topics:
     File: otel-configuring-metrics-for-monitoring-stack
   - Name: Forwarding telemetry data
     File: otel-forwarding-telemetry-data
-  - Name: Configuring the Collector metrics
-    File: otel-configuring-otelcol-metrics
   - Name: Gathering the observability data from multiple clusters
     File: otel-config-multicluster
   - Name: Troubleshooting the Red Hat build of OpenTelemetry

--- a/modules/otel-configuring-collector-metrics.adoc
+++ b/modules/otel-configuring-collector-metrics.adoc
@@ -1,9 +1,12 @@
-:_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
-[id="otel-configuring-metrics"]
-= Configuring the OpenTelemetry Collector metrics
-:context: otel-configuring-metrics
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-configuration-of-otel-collector.adoc
 
+:_mod-docs-content-type: PROCEDURE
+[id="otel-configuring-collector-metrics"]
+= Configuring the OpenTelemetry Collector metrics
+
+[role="_abstract"]
 The following list shows some of these metrics:
 
 	* Collector memory usage

--- a/modules/otel-configuring-collector-metrics.adoc
+++ b/modules/otel-configuring-collector-metrics.adoc
@@ -52,6 +52,3 @@ You can use the *Administrator* view of the web console to verify successful con
 . Filter by *Source: User*.
 . Check that the *ServiceMonitors* or *PodMonitors* in the `opentelemetry-collector-<instance_name>` format have the *Up* status.
 
-[role="_additional-resources"]
-.Additional resources
-* xref:../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#enabling-monitoring-for-user-defined-projects-uwm_preparing-to-configure-the-monitoring-stack-uwm[Enabling monitoring for user-defined projects]

--- a/modules/otel-configuring-collector-metrics.adoc
+++ b/modules/otel-configuring-collector-metrics.adoc
@@ -52,5 +52,6 @@ You can use the *Administrator* view of the web console to verify successful con
 . Filter by *Source: User*.
 . Check that the *ServiceMonitors* or *PodMonitors* in the `opentelemetry-collector-<instance_name>` format have the *Up* status.
 
+[role="_additional-resources"]
 .Additional resources
 * xref:../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#enabling-monitoring-for-user-defined-projects-uwm_preparing-to-configure-the-monitoring-stack-uwm[Enabling monitoring for user-defined projects]

--- a/modules/otel-configuring-collector-metrics.adoc
+++ b/modules/otel-configuring-collector-metrics.adoc
@@ -3,7 +3,7 @@
 // * observability/otel/otel-configuration-of-otel-collector.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="otel-configuring-collector-metrics"]
+[id="otel-configuring-collector-metrics'_{context}"]
 = Configuring the OpenTelemetry Collector metrics
 
 [role="_abstract"]

--- a/observability/otel/otel-collector/otel-collector-configuration-intro.adoc
+++ b/observability/otel/otel-collector/otel-collector-configuration-intro.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="otel-configuration-of-otel-collector"]
-= Configuring the Collector
 include::_attributes/common-attributes.adoc[]
 :context: otel-configuration-of-otel-collector
+[id="otel-configuration-of-otel-collector"]
+= Configuring the Collector
 
 toc::[]
 
@@ -18,3 +18,7 @@ include::modules/otel-creating-required-RBAC-resources-automatically.adoc[levelo
 include::modules/otel-configuring-collector-metrics.adoc[leveloffset=+1]
 
 include::modules/otel-target-allocator.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/monitoring/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#enabling-monitoring-for-user-defined-projects-uwm_preparing-to-configure-the-monitoring-stack-uwm[Enabling monitoring for user-defined projects]

--- a/observability/otel/otel-collector/otel-collector-configuration-intro.adoc
+++ b/observability/otel/otel-collector/otel-collector-configuration-intro.adoc
@@ -1,8 +1,8 @@
 :_mod-docs-content-type: ASSEMBLY
+[id="otel-configuration-of-otel-collector"]
+= Configuring the Collector
 include::_attributes/common-attributes.adoc[]
 :context: otel-configuration-of-otel-collector
-[id="otel-configuration-of-otel-collector_{context}"]
-= Configuring the Collector
 
 toc::[]
 
@@ -14,5 +14,7 @@ include::modules/otel-collector-deployment-modes.adoc[leveloffset=+1]
 include::modules/otel-collector-config-options.adoc[leveloffset=+1]
 
 include::modules/otel-creating-required-RBAC-resources-automatically.adoc[leveloffset=+1]
+
+include::modules/otel-configuring-collector-metrics.adoc[leveloffset=+1]
 
 include::modules/otel-target-allocator.adoc[leveloffset=+1]


### PR DESCRIPTION
⚠️ Only content movement across files. No new content to review.

**Affected Version(s):** OCP 4.12+

**Tracking JIRAs:** https://issues.redhat.com/browse/OBSDOCS-2785

**Doc preview:** https://102327--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-configuration-intro.html#otel-configuring-collector-metrics'_otel-configuration-of-otel-collector

**SME & QE review:** N/A

**Additional information:** 

- Created a new procedure module: `modules/otel-configuring-collector-metrics.adoc`.
- Moved the step-by-step procedure content from the assembly into the new proc module.
- Updated the assembly file to include the newly created procedure module.