### PR TITLE
OSDOCS-17315-Added required Google Cloud APIs back to OSD docs that were removed in error.

### DIFF
--- a/modules/ccs-gcp-customer-procedure.adoc
+++ b/modules/ccs-gcp-customer-procedure.adoc
@@ -62,9 +62,9 @@ For more information about configuring {gcp-short} organization policy constrain
 |`compute.googleapis.com`
 |Used for creating and managing virtual machines, firewalls, networks, persistent disk volumes, and load balancers.
 
-// |link:https://cloud.google.com/apis/docs/overview[Google Cloud APIs]
-// |`cloudapis.googleapis.com`
-// |
+|link:https://cloud.google.com/apis/docs/overview[Google Cloud APIs]
+|`cloudapis.googleapis.com`
+|Used for managing Google Cloud services and resources.
 
 |link:https://cloud.google.com/resource-manager/reference/rest[Cloud Resource Manager API]
 |`cloudresourcemanager.googleapis.com`
@@ -74,9 +74,9 @@ For more information about configuring {gcp-short} organization policy constrain
 |`dns.googleapis.com`
 |Used for creating DNS zones and managing DNS records for the cluster domains.
 
-// |link:https://cloud.google.com/firewall/docs/reference/network-security/rest[Network Security API]
-// |`networksecurity.googleapis.com`
-// |Purpose
+|link:https://cloud.google.com/firewall/docs/reference/network-security/rest[Network Security API]
+|`networksecurity.googleapis.com`
+|Used for creating, managing, and enforcing network security policies for your applications and resources within Google Cloud.
 
 |link:https://cloud.google.com/iam/docs/reference/credentials/rest[IAM Service Account Credentials API]
 |`iamcredentials.googleapis.com`
@@ -107,7 +107,7 @@ For more information about configuring {gcp-short} organization policy constrain
 |Used to identify governance rules applied to customer’s {gcp-full} that might impact cluster creation or management.
 
 |link:https://cloud.google.com/iap/docs/reference/rest[Cloud Identity-Aware Proxy API]
-|`iap.googleapis.com` ^[*]^
+|`iap.googleapis.com`
 |Used in emergency situations to troubleshoot cluster nodes that are otherwise inaccessible.
 
 This API is required for clusters deployed with Private Service Connect.

--- a/modules/osd-release-notes-Q4-2025.adoc
+++ b/modules/osd-release-notes-Q4-2025.adoc
@@ -3,7 +3,14 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="osd-q4-2025_{context}"]
-=== Q4 2025
+= Q4 2025
+
+* **Required API services table updated.**
+The _Required API services_ table within the _Required customer procedure_ guide has been updated to restore APIs that were previously removed due to a bug. These APIs are required for new {product-title} on {GCP} cluster creation. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-customer-procedure_gcp-ccs[Required customer procedure].
 
 * **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.20 are now available for new clusters.
 
+* **Extended Update Support (EUS) channel group now available.**
+You can now select the EUS channel group when creating or editing your {product-title} cluster. The EUS channel group allows you to extend the life cycle of your even-numbered version {product-title} cluster, giving you additional time to plan and budget for future upgrades. This channel group also provides continued security patches and critical bug fixes.
++
+For additional information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#sd-life-cycle-dates_osd-life-cycle[Life cycle dates].

--- a/osd_whats_new/osd-whats-new.adoc
+++ b/osd_whats_new/osd-whats-new.adoc
@@ -6,24 +6,19 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 With its foundation in Kubernetes, {product-title} is a complete {OCP} cluster provided as a cloud service, configured for high availability, and dedicated to a single customer.
 
-{product-title} is professionally managed by Red Hat and hosted on {GCP} or {AWS}. Each {product-title} cluster includes a fully managed link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/architecture/control-plane[control plane] (Control and Infrastructure nodes), application nodes, installation and management by Red Hat Site Reliability Engineers (SRE), premium Red Hat Support, and cluster services such as logging, metrics, monitoring, notifications portal, and a cluster portal.
+{product-title} is professionally managed by Red{nbsp}Hat and hosted on {GCP} or {AWS}. Each {product-title} cluster includes a fully managed link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/architecture/control-plane[control plane] (Control and Infrastructure nodes), application nodes, installation and management by Red{nbsp}Hat Site Reliability Engineers (SRE), premium Red{nbsp}Hat Support, and cluster services such as logging, metrics, monitoring, notifications portal, and a cluster portal.
 
-{product-title} clusters are available on the link:https://console.redhat.com/openshift[Hybrid Cloud Console]. With the Red Hat {cluster-manager} application, you can deploy {product-title} clusters to either on-premise or cloud environments.
+{product-title} clusters are available on the link:https://console.redhat.com/openshift[Hybrid Cloud Console]. With the Red{nbsp}Hat {cluster-manager} application, you can deploy {product-title} clusters to either on-premise or cloud environments.
 
-[id="osd-new-changes-and-updates_{context}"]
-== New changes and updates
+Find new additions, recent changes, and relevant updates for {product-title} listed below in quarterly increments.
 
-[id="osd-q4-2025_{context}"]
-=== Q4 2025
-
-* **Extended Update Support (EUS) channel group now available.**
-You can now select the EUS channel group when creating or editing your {product-title} cluster. The EUS channel group allows you to extend the life cycle of your even-numbered version {product-title} cluster, giving you additional time to plan and budget for future upgrades as well as providing continued security patches and critical bug fixes. For additional information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/introduction_to_openshift_dedicated/policies-and-service-definition#sd-life-cycle-dates_osd-life-cycle[Life cycle dates].
-
+include::modules/osd-release-notes-Q4-2025.adoc[leveloffset=+1]
 
 [id="osd-q3-2025_{context}"]
-=== Q3 2025
+== Q3 2025
 
 * **Updates to Workload Identity Federation (WIF) permissions and roles.**
 The default IAM permissions for WIF in the link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.19/vanilla.yaml[managed-cluster-config] template have been updated. This means newly created WIF configurations will have fewer, less overly permissive permissions by default.
@@ -40,9 +35,8 @@ In alignment with the principle of least privilege as well as {gcp-full}'s prefe
 * **Support for managing workload identity pools and providers in a dedicated {GCP} project.**
 {product-title} on {GCP} now supports the option of creating and managing workload identity pools and providers in a specified dedicated project during the creation of a WIF configuration. Red{nbsp}Hat plans on offering this option for existing WIF configurations in an upcoming release. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-configuration_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a WIF configuration].
 
-
-
-=== Q2 2025
+[id="osd-q2-2025_{context}"]
+== Q2 2025
 
 // * **{product-title} SDN network plugin blocks future major upgrades**
 * **Updated version requirements for migration from OpenShift SDN to OVN-Kubernetes.**
@@ -58,7 +52,7 @@ For more information about migrating to OVN-Kubernetes, see xref:../networking/o
 {product-title} on {GCP} users can now enable or disable Secure Boot for Shielded VMs on a per machine basis. For more information, see xref:../osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.adoc#osd-managing-worker-nodes[Managing compute nodes].
 
 [id="osd-q1-2025_{context}"]
-=== Q1 2025
+== Q1 2025
 
 * **Support for new {gcp-short} instances.** {product-title} version 4.18 and later now supports `n4` and `c3` instance types on {gcp-full}. For more information, see xref:../osd_architecture/osd_policy/osd-service-definition.adoc#gcp-compute-types_osd-service-definition[{gcp-full} compute types].
 
@@ -81,7 +75,7 @@ For more information about migrating to OVN-Kubernetes, see xref:../networking/o
 * **Red{nbsp}Hat SRE log-based alerting endpoints have been updated.** {product-title} customers who are using a firewall to control egress traffic can now remove all references to `*.osdsecuritylogs.splunkcloud.com:9997` from your firewall allowlist. {product-title} clusters still require the `http-inputs-osdsecuritylogs.splunkcloud.com:443` log-based alerting endpoint to be accessible from the cluster.
 
 [id="osd-q4-2024_{context}"]
-=== Q4 2024
+== Q4 2024
 
 * **Workload Identity Federation (WIF) authentication type is now available.** {product-title} on {gcp-first} customers can now use WIF as an authentication type when creating a cluster. WIF is a {gcp-short} Identity and Access Management (IAM) feature that provides third parties a secure method to access resources on a customer's cloud account.
 WIF is {gcp-full}'s preferred method for credential authentication.
@@ -99,7 +93,7 @@ For more information, see  xref:../osd_gcp_clusters/creating-a-gcp-psc-enabled-p
 
 
 [id="osd-q3-2024_{context}"]
-=== Q3 2024
+== Q3 2024
 
 * ** Support for {gcp-short} A2 instance types with A100 80GB GPUs.** {product-title} on {GCP} now supports A2 instance types with A100 80GB GPUs. These instance types meet the specific requirements listed by IBM Watsonx.ai. For more information, see xref:../osd_architecture/osd_policy/osd-service-definition.adoc#gcp-compute-types_osd-service-definition[{gcp-full} compute types].
 
@@ -122,7 +116,7 @@ For more information, see xref:../osd_planning/osd-limits-scalability.adoc#contr
 For more information about region availabilities, see xref:../osd_architecture/osd_policy/osd-service-definition.adoc#regions-availability-zones_osd-service-definition[Regions and availability zones].
 
 [id="osd-q2-2024_{context}"]
-=== Q2 2024
+== Q2 2024
 
 * **Cluster delete protection.** {product-title} on {GCP}  users can now enable the cluster delete protection option, which helps to prevent users from accidentally deleting a cluster.
 //Removed link as is no longer valid. Need to decide if we need a link here and if so, what it will be.
@@ -133,14 +127,14 @@ For more information about region availabilities, see xref:../osd_architecture/o
 * **Support for new {gcp-short} instances.** {product-title} now supports more worker node types and sizes on {gcp-full}. For more information, see xref:../osd_architecture/osd_policy/osd-service-definition.adoc#gcp-compute-types_osd-service-definition[{gcp-full} compute types].
 
 [id="osd-q1-2024_{context}"]
-=== Q1 2024
+== Q1 2024
 
 * **{product-title} regions added.** {product-title} on {GCP} is now available in the Delhi, India (`asia-south2`) region. For more information on region availabilities, see xref:../osd_architecture/osd_policy/osd-service-definition.adoc#regions-availability-zones_osd-service-definition[Regions and availability zones].
 
 * **Policy constraint update.** {product-title} on {GCP} users are now allowed to deploy clusters with the `constraints/iam.allowedPolicyMemberDomains` constraint in place. This feature allows users to restrict the set of identities that are allowed to be used in Identity and Access Management policies, further enhancing overall security for their resources.
 
 [id="osd-q4-2023_{context}"]
-=== Q4 2023
+== Q4 2023
 
 * **Policy constraint update.** {product-title} on {GCP} users can now enable UEFISecureBoot during cluster installation, as required by the {gcp-short} ShieldVM policy. This new feature adds further protection from boot or kernel-level malware or rootkits.
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17315

Link to docs preview:

- [Required customer procedure](https://102328--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html#ccs-gcp-customer-procedure_gcp-ccs)
- [Q4 2025 OSD What's new](https://102328--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html#osd-q4-2025_osd-whats-new)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- QE approval is not required for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
