### PR TITLE
all-rules: enables remaining AsciidocDITA rules

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -19,19 +19,26 @@ Vale.Avoid = YES
 
 # Enable specifc DITA rules on assemblies
 AsciiDocDITA.AdmonitionTitle = error
-AsciiDocDITA.ThematicBreak = error
-AsciiDocDITA.TableFooter = error
-AsciiDocDITA.PageBreak = error
-AsciiDocDITA.DiscreteHeading = error
-AsciiDocDITA.SidebarBlock = error
-AsciiDocDITA.LineBreak = error
-AsciiDocDITA.EquationFormula = error
-AsciiDocDITA.TaskExample = error
-AsciiDocDITA.EntityReference = error
-AsciiDocDITA.ExampleBlock = error
+AsciiDocDITA.AuthorLine = error
+AsciiDocDITA.BlockTitle = error
+AsciiDocDITA.CalloutList = error
 AsciiDocDITA.ContentType = error
-AsciiDocDITA.ShortDescription = error
+AsciiDocDITA.DiscreteHeading = error
+AsciiDocDITA.EntityReference = error
+AsciiDocDITA.EquationFormula = error
+AsciiDocDITA.ExampleBlock = error
+AsciiDocDITA.LineBreak = error
 AsciiDocDITA.NestedSection = error
+AsciiDocDITA.PageBreak = error
+AsciiDocDITA.RelatedLinks = error
+AsciiDocDITA.ShortDescription = error
+AsciiDocDITA.SidebarBlock = error
+AsciiDocDITA.TableFooter = error
+AsciiDocDITA.TaskDuplicate = error
+AsciiDocDITA.TaskExample = error
+AsciiDocDITA.TaskSection = error
+AsciiDocDITA.TaskStep = error
+AsciiDocDITA.ThematicBreak = error
 
 # Disable module specific rules
 OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO

--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -9,19 +9,26 @@ BasedOnStyles = OpenShiftAsciiDoc, AsciiDoc, RedHat
 
 # Changing severity of a rule both enables and sets it (i.e; = YES)
 AsciiDocDITA.AdmonitionTitle = error
-AsciiDocDITA.ThematicBreak = error
-AsciiDocDITA.TableFooter = error
-AsciiDocDITA.PageBreak = error
-AsciiDocDITA.DiscreteHeading = error
-AsciiDocDITA.SidebarBlock = error
-AsciiDocDITA.LineBreak = error
-AsciiDocDITA.EquationFormula = error
-AsciiDocDITA.TaskExample = error
-AsciiDocDITA.EntityReference = error
-AsciiDocDITA.ExampleBlock = error
+AsciiDocDITA.AuthorLine = error
+AsciiDocDITA.BlockTitle = error
+AsciiDocDITA.CalloutList = error
 AsciiDocDITA.ContentType = error
-AsciiDocDITA.ShortDescription = error
+AsciiDocDITA.DiscreteHeading = error
+AsciiDocDITA.EntityReference = error
+AsciiDocDITA.EquationFormula = error
+AsciiDocDITA.ExampleBlock = error
+AsciiDocDITA.LineBreak = error
 AsciiDocDITA.NestedSection = error
+AsciiDocDITA.PageBreak = error
+AsciiDocDITA.RelatedLinks = error
+AsciiDocDITA.ShortDescription = error
+AsciiDocDITA.SidebarBlock = error
+AsciiDocDITA.TableFooter = error
+AsciiDocDITA.TaskDuplicate = error
+AsciiDocDITA.TaskExample = error
+AsciiDocDITA.TaskSection = error
+AsciiDocDITA.TaskStep = error
+AsciiDocDITA.ThematicBreak = error
 
 # Use local OpenShiftDocs Vocab terms
 Vale.Terms = YES


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-17184

Additional information:
Adds the rest of the AsciidocDITA rules to the OCP repo

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
