### PR TITLE
ROX-31725: Clarify StackRox scanner enablement during deprecation

### DIFF
--- a/integration/integrate-with-image-vulnerability-scanners.adoc
+++ b/integration/integrate-with-image-vulnerability-scanners.adoc
@@ -30,7 +30,9 @@ This enhanced support gives you greater flexibility and choice in managing your 
 == Scanners included in {product-title-short}
 
 * Scanner V4: Beginning with {product-title-short} version 4.4, a new scanner is introduced that is built on link:https://github.com/quay/claircore[Claircore], which also powers the link:https://github.com/quay/clair[Clair] scanner. Scanner V4 supports scanning of language and OS-specific image components. Scanner V4 is enabled by default during installation beginning in release 4.8. For more information about Scanner V4, including links to the installation documentation, see xref:../operating/examine-images-for-vulnerabilities.adoc#about-scanner-v4_examine-images-for-vulnerabilities[About {product-title-short} Scanner V4].
-* StackRox Scanner: This scanner was the default scanner in {product-title-short} before being replaced by Scanner V4. It originates from a fork of the Clair v2 open source scanner. If delegated scanning is configured and only the StackRox Scanner is installed on secured clusters, StackRox Scanner must also be enabled on the cluster where Central is installed or delegated scanning will not work.
+* StackRox Scanner: This scanner was the default scanner in {product-title-short} before being replaced by Scanner V4. It originates from a fork of the Clair v2 open source scanner. Keep the following guidelines in mind:
+** Although the StackRox Scanner is deprecated, it still must be enabled on the cluster where Central is installed due to software dependencies.
+** You can disable the StackRox scanner on secured clusters if Scanner V4 is enabled or if you do not need scanning by using secured clusters.
 
 [id="alternative-scanners_{context}"]
 == Alternative scanners

--- a/modules/central-services-public-config.adoc
+++ b/modules/central-services-public-config.adoc
@@ -292,7 +292,7 @@ Setting a value for this parameter overrides the `central.db.image.registry`, `c
 
 [id="central-services-public-configuration-file-scanner_{context}"]
 == StackRox Scanner
-The following table lists the configurable parameters for the StackRox Scanner. The StackRox Scanner is deprecated.
+The following table lists the configurable parameters for the StackRox Scanner. Although the StackRox Scanner is deprecated, it still must be enabled on the cluster where Central is installed due to software dependencies.
 
 |===
 | Parameter | Description

--- a/modules/con-vuln-sources.adoc
+++ b/modules/con-vuln-sources.adoc
@@ -7,6 +7,11 @@
 = Vulnerability data sources
 
 Sources for vulnerabilities depend on the scanner that is used in your system. {product-title-short} contains two scanners: StackRox Scanner and Scanner V4. The StackRox Scanner is deprecated. Scanner V4 is the default image scanner.
++
+[NOTE]
+====
+Although the StackRox Scanner is deprecated, it still must be enabled on the cluster where Central is installed due to software dependencies.
+====
 
 [id="scanner-v4-vuln-sources"]
 == Scanner V4 sources

--- a/modules/default-requirements-central-services.adoc
+++ b/modules/default-requirements-central-services.adoc
@@ -14,7 +14,7 @@ Central services contain the following components:
 
 * Central
 * Scanner V4
-* StackRox Scanner (optional)
+* StackRox Scanner: Although the StackRox Scanner is deprecated, it still must be enabled on the cluster where Central is installed due to software dependencies.
 
 [id="default-requirements-central-services-central_{context}"]
 == Central

--- a/modules/install-central-operator.adoc
+++ b/modules/install-central-operator.adoc
@@ -78,7 +78,7 @@ spec:
 |Use this parameter to configure additional hostnames to resolve in the pod's hosts file.
 
 |===
-* *Scanner Component Settings*: Settings for the StackRox Scanner. See the "Scanner" table in the "Public configuration file" section in "Installing Central services for {product-title-short} on {osp}".
+* *Scanner Component Settings*: Settings for the StackRox Scanner. See the "Scanner" table in the "Public configuration file" section in "Installing Central services for {product-title-short} on {osp}". Although the StackRox Scanner is deprecated, it still must be enabled on the cluster where Central is installed due to software dependencies.
 * *Scanner V4 Component Settings*: Settings for Scanner V4 scanner, the default scanner. See the "Scanner V4" table in the "Public configuration file" section in "Installing Central services for {product-title-short} on {osp}".
 +
 You can configure the following options for Scanner V4:

--- a/modules/rhcos-enable-node-scan-scannerv4.adoc
+++ b/modules/rhcos-enable-node-scan-scannerv4.adoc
@@ -20,7 +20,7 @@ For information about supported platforms and architecture, see the link:https:/
 
 [NOTE]
 ====
-Node scanning with Scanner V4 is enabled by default in a new installation of release 4.8 and later. These steps are only required if you are updating from an earlier version of {product-title-short} and Scanner V4 was not enabled.
+Node scanning with Scanner V4 is enabled by default in a new installation of release 4.8 and later. These steps are only required if you are updating from an earlier version of {product-title-short} and Scanner V4 was not enabled. Although the StackRox Scanner is deprecated as of release 4.9, it still must be enabled on the cluster where Central is installed due to software dependencies.
 ====
 
 . Ensure that Scanner V4 is deployed in the Central cluster:

--- a/operating/examine-images-for-vulnerabilities.adoc
+++ b/operating/examine-images-for-vulnerabilities.adoc
@@ -18,7 +18,7 @@ With {product-title}, you can analyze images for vulnerabilities using the {prod
 
 {product-title-short} contains two scanners: Scanner V4 and the StackRox Scanner.
 
-Scanner V4, built on Claircore, is the default scanner as of release 4.8. The StackRox Scanner, which originates from a fork of the Clair v2 open source scanner, is deprecated.
+Scanner V4, built on Claircore, is the default scanner as of release 4.8. The StackRox Scanner, which originates from a fork of the Clair v2 open source scanner, is deprecated. Although the StackRox Scanner is deprecated, it still must be enabled on the cluster where Central is installed due to software dependencies.
 
 [NOTE]
 ====

--- a/release_notes/49-release-notes.adoc
+++ b/release_notes/49-release-notes.adoc
@@ -291,7 +291,7 @@ Some features available in earlier releases have been deprecated or removed.
 
 Deprecated functionality is still included in {product-title-short} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
 For the most recent list of major functionality deprecated and removed, see the following table.
-Additional removed or deprecated functionality is available after the table.
+Additional information about removed or deprecated functionality is available after the table.
 
 In the table, features are marked with the following statuses:
 
@@ -322,12 +322,12 @@ a|Admission controller configuration parameters:
 |GA
 |DEP
 
-|API token authentication for {cloud-redhat-com}^[1]^
+|API token authentication for {cloud-redhat-com}
 |DEP
 |DEP
 |DEP
 
-|Collections hierarchical implementation^[2]^
+|Collections hierarchical implementation
 |GA
 |GA
 |DEP 
@@ -342,32 +342,32 @@ a|Admission controller configuration parameters:
 |DEP
 |DEP
 
-|*Export Download Evidence as CSV* button^[3]^
+|*Export Download Evidence as CSV* button
 |GA
 |GA
 |REM
 
-|Google Container Registry integration^[4]^
+|Google Container Registry integration
 |DEP
 |DEP
 |DEP
 
-|GraphQL endpoints^[5]^
+|GraphQL endpoints
 |GA
 |GA
 |DEP
 
-|GraphQL image -> scan -> components and image -> scan -> components -> vulns queries^[6]^
+|GraphQL image -> scan -> components and image -> scan -> components -> vulns queries
 |GA
 |GA
 |REM
 
-|Kernel support packages and driver download functionality^[7]^
+|Kernel support packages and driver download functionality
 |DEP
 |DEP
 |DEP
 
-|Manifest installation method, also called the `roxctl` CLI installation method^[8]^
+|Manifest installation method, also called the `roxctl` CLI installation method
 |GA
 |GA
 |DEP
@@ -394,22 +394,22 @@ a|`roxctl` admission controller parameters:
 |DEP
 |DEP
 
-|`/v1/clustercves/suppress` APIs^[9,10]^
+|`/v1/clustercves/suppress` APIs
 |DEP
 |DEP
 |DEP
 
-|`/v1/clustercves/unsuppress` APIs^[9,10]^
+|`/v1/clustercves/unsuppress` APIs
 |DEP
 |DEP
 |DEP
 
-|`/v1/nodecves/suppress` APIs^[9,10]^
+|`/v1/nodecves/suppress` APIs
 |DEP
 |DEP
 |DEP
 
-|`/v1/nodecves/unsuppress` APIs^[9,10]^
+|`/v1/nodecves/unsuppress` APIs
 |DEP
 |DEP
 |DEP
@@ -419,7 +419,7 @@ a|`roxctl` admission controller parameters:
 |DEP
 |REM
 
-|Vulnerability Management (1.0) menu item^[11]^
+|Vulnerability Management (1.0) menu item
 |DEP
 |DEP
 |DEP
@@ -431,36 +431,56 @@ a|`roxctl` admission controller parameters:
 
 |===
 
-[.small]
---
-. API token authentication is deprecated. The corresponding cloud source integration uses service accounts for authentication.
+API token authentication for {cloud-redhat-com}::
 
-. The *Export Download Evidence as CSV* functionality was removed from the image, node, and platform CVE pages due to technical issues. This functionality is provided by new reporting features. For more information about creating and downloading vulnerability reports, see xref:../operating/manage-vulnerabilities/vulnerability-reporting.adoc#vulnerability-reporting[Vulnerability reporting].
+API token authentication is deprecated. The corresponding cloud source integration uses service accounts for authentication.
 
-. The current hierarchical implementation for defining Collections is deprecated and is anticipated to be replaced by a more comprehensive search-based definition in a future release.
+Collections hierarchical implementation::
 
-. The Google Container Registry integration is deprecated in response to the deprecation of Container Registry. You can use the Artifact Registry as a registry replacement and Scanner V4 as a scanner replacement.
+The current hierarchical implementation for defining Collections is deprecated and is anticipated to be replaced by a more comprehensive search-based definition in a future release.
+
+Export Download Evidence as CSV button::
+
+The *Export Download Evidence as CSV* functionality was removed from the image, node, and platform CVE pages due to technical issues. This functionality is provided by new reporting features. For more information about creating and downloading vulnerability reports, see xref:../operating/manage-vulnerabilities/vulnerability-reporting.adoc#vulnerability-reporting[Vulnerability reporting].
+
+Google Container Registry integration::
+
+The Google Container Registry integration is deprecated in response to the deprecation of Container Registry. You can use the Artifact Registry as a registry replacement and Scanner V4 as a scanner replacement.
 +
 For more information, see link:https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr[Transition from Container Registry] (Google Cloud documentation).
 
-. Kernel support packages and driver download functionality are deprecated.
+GraphQL endpoints::
 
-. All GraphQL endpoints are deprecated and are expected to be removed in a future release. The endpoints were created to support the {product-title-short} portal. All other uses are unsupported. 
+All GraphQL endpoints are deprecated and are expected to be removed in a future release. The endpoints were created to support the {product-title-short} portal. All other uses are unsupported. 
+
+GraphQL image -> scan -> components and image -> scan -> components -> vulns queries::
 
 . The deprecated and unsupported GraphQL query of image -> scan -> components and image -> scan -> components -> vulns has been eliminated in favor of image -> scan -> imageComponents and image -> scan -> imageComponents -> imageVulnerabilities.
 
-. The manifest installation method is deprecated and is expected to be removed in the future. Manifest installation is currently done by using the `roxctl {central,sensor,scanner} generate` command in the CLI, or by choosing the legacy installation method in the {product-title-short} portal. Use the Operator or Helm installation methods.
+Kernel support packages and driver download functionality::
 
-. A feature flag controls this API object, and you can enable or disable this API object by using the `ROX_VULN_MGMT_LEGACY_SNOOZE` environment variable.
+Kernel support packages and driver download functionality are deprecated.
 
-. The format for specifying duration in JSON requests to `v1/nodecves/suppress`, `v1/clustercves/suppress`, and `v1/imagecves/suppress` has been changed to the ProtoJSON format.
+Manifest installation method, also called the `roxctl` CLI installation method::
+
+The manifest installation method is deprecated and is expected to be removed in the future. Manifest installation is currently done by using the `roxctl {central,sensor,scanner} generate` command in the CLI, or by choosing the legacy installation method in the {product-title-short} portal. Use the Operator or Helm installation methods.
+
+StackRox Scanner::
+
+Although the StackRox Scanner is deprecated, it still must be enabled on the cluster where Central is installed due to software dependencies.
+
+Cluster CVEs and node CVEs suppress and unsuppress API objects::
+
+A feature flag controls these API objects, and you can enable or disable them by using the `ROX_VULN_MGMT_LEGACY_SNOOZE` environment variable.
+
+The format for specifying duration in JSON requests to `v1/nodecves/suppress`, `v1/clustercves/suppress`, and `v1/imagecves/suppress` has been changed to the ProtoJSON format.
 Only a numeric value representing seconds with optional fractional seconds for nanosecond precision and followed by the `s` suffix is supported.
 +
 For example, `0.300s`, `-5400s`, or `9900s`. The previously valid time units of `ns`, `us`, `µs`, `ms`, `m`, and `h` are no longer supported.
 
-. The *Vulnerability Management* -> *Dashboard* view is deprecated and is planned to be removed in a future release. You can use the *User workload vulnerabilities*, *Exception management*, *Platform vulnerabilities*, and *Node CVEs* views as alternatives.
+Vulnerability Management (1.0) menu item::
 
---
+The *Vulnerability Management* -> *Dashboard* view is deprecated and is planned to be removed in a future release. You can use the *User workload vulnerabilities*, *Exception management*, *Platform vulnerabilities*, and *Node CVEs* views as alternatives.
 
 [id="bug-fixes_{context}"]
 == Bug fixes in version 4.9.0


### PR DESCRIPTION
Version(s): 4.9

[Issue](https://issues.redhat.com/browse/ROX-31725)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
