### PR TITLE
OSDOCS 17320 Enable sigstore 'openshift' clusterimagepolicy by default

### DIFF
--- a/modules/nodes-sigstore-configure-cluster-policy.adoc
+++ b/modules/nodes-sigstore-configure-cluster-policy.adoc
@@ -6,14 +6,15 @@
 [id="nodes-sigstore-configure-cluster-policy_{context}"]
 = Creating a cluster image policy CR
 
+[role="_abstract"]
 A `ClusterImagePolicy` custom resource (CR) enables a cluster administrator to configure a sigstore signature verification policy for the entire cluster. When enabled, the Machine Config Operator (MCO) watches the `ClusterImagePolicy` object and updates the `/etc/containers/policy.json` and `/etc/containers/registries.d/sigstore-registries.yaml` files on all the nodes in the cluster.
 
 The following example shows general guidelines on how to configure a `ClusterImagePolicy` object. For more details on the parameters, see "About cluster and image policy parameters."
 
-The default `openshift` cluster image policy provides sigstore support for the required {product-title} images. This cluster image policy is active only in clusters that have enabled Technology Preview features. You must not remove or modify this cluster image policy object. Cluster image policy names beginning with `openshift` are reserved for future system use.
-
-:FeatureName: The default `openshift` cluster image policy
-include::snippets/technology-preview.adoc[]
+[NOTE]
+====
+The default `ClusterImagePolicy` object, named `openshift`, provides sigstore support for the required {product-title} images, which are stored in the `quay.io/openshift-release-dev/ocp-release` repository. You must not remove or modify this cluster image policy object. Cluster image policy names beginning with `openshift` are reserved for future system use.
+====
 
 .Prerequisites
 // Taken from https://issues.redhat.com/browse/OCPSTRAT-918
@@ -30,7 +31,7 @@ $ oc image mirror quay.io/openshift-release-dev/ocp-release:sha256-1234567890abc
 mirror.com/image/repo:sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sig
 ----
 
-* If you are using a BYOPKI certificate as the root of trust, you enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`:
+* If you are using a BYOPKI certificate as the root of trust, you enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`.
 +
 [source,terminal]
 ----

--- a/modules/nodes-sigstore-configure.adoc
+++ b/modules/nodes-sigstore-configure.adoc
@@ -10,19 +10,9 @@ You can use the `ClusterImagePolicy` and `ImagePolicy` custom resource (CR) obje
 
 * Cluster image policy. A cluster image policy object enables a cluster administrator to configure a sigstore signature verification policy for the entire cluster. When enabled, the Machine Config Operator (MCO) watches the `ClusterImagePolicy` object and updates the `/etc/containers/policy.json` and `/etc/containers/registries.d/sigstore-registries.yaml` files on all nodes in the cluster.
 +
-[IMPORTANT]
+[NOTE]
 ====
-The default `openshift` cluster image policy provides sigstore support for the required {product-title} images. You must not remove or modify this cluster image policy object. This cluster image policy is Technology Preview and is active only in clusters that have enabled Technology Preview features. Cluster image policy names beginning with `openshift` are reserved for future system use.
-
-If registry mirrors are configured for the {product-title} release image repositories, `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev`, before enabling the Technology Preview feature set, you must mirror the sigstore signatures for the {product-title} release images into your mirror registry. Otherwise, the default `openshift` cluster image policy, which enforces signature verification for the release repository, blocks the ability of the Cluster Version Operator to move the CVO pod to new nodes, preventing the node update that results from the feature set change.
-
-You can use the `oc image mirror` command to mirror the signatures. For example:
-
-[source,terminal]
-----
-$ oc image mirror quay.io/openshift-release-dev/ocp-release:sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sig \
-mirror.com/image/repo:sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sig
-----
+The default `ClusterImagePolicy` object, named `openshift`, provides sigstore support for the required {product-title} images in the `quay.io/openshift-release-dev/ocp-release` repository.
 ====
 
 * Image policy. An image policy enables a cluster administrator or application developer to configure a sigstore signature verification policy for a specific namespace. The MCO watches an `ImagePolicy` instance in different namespaces and creates or updates the `/etc/crio/policies/<namespace>.json` and `/etc/containers/registries.d/sigstore-registries.yaml` files on all nodes in the cluster.
@@ -97,6 +87,11 @@ You must specify the following parameters:
 You can modify or remove a cluster image policy or an image policy by using the same commands as any other custom resource (CR) object.
 
 You can modify an existing policy by editing the policy YAML and running an `oc apply` command on the file or directly editing the `ClusterImagePolicy` or `ImagePolicy` object. Both methods apply the changes in the same manner.
+
+[NOTE]
+====
+The default `ClusterImagePolicy` object, named `openshift`, provides sigstore support for the required {product-title} images. You must not remove or modify this cluster image policy object. Cluster image policy names beginning with `openshift` are reserved for future system use.
+====
 
 You can create multiple policies for a cluster or namespace. This allows you to create different policies for different images or repositories.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17320

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
