### PR TITLE
CNV-70798: Update to 4.20 Release Notes

### DIFF
--- a/virt/release_notes/virt-4-20-release-notes.adoc
+++ b/virt/release_notes/virt-4-20-release-notes.adoc
@@ -216,6 +216,12 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 //[id="virt-4-20-ki-monitoring_{context}"]
 //=== Monitoring
 
+[id="virt-4-20-ki-installation-update_{context}"]
+=== Installation and update
+
+//CNV-70798
+* When upgrading from {VirtProductName} 4.19 to 4.20, you must remove the `wasp-agent` component before initating the upgrade. For more information about removing the `wasp-agent` component, see xref:../../virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc#virt-removing-wasp-agent_virt-configuring-higher-vm-workload-density[Removing the wasp-agent component].
+
 [id="virt-4-20-ki-networking_{context}"]
 === Networking
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Separate PR for [CNV-70798](https://issues.redhat.com//browse/CNV-70798) to update 4.20 Release Notes about removing `wasp-agent `before upgrading.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20

Issue:
[CNV-70798](https://issues.redhat.com/browse/CNV-70798)

Link to docs preview:
[Installation and Update Known Issues](https://102384--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-20-release-notes.html#virt-4-20-ki-installation-update_virt-4-20-release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
