### PR TITLE
[OSDOCS-15785]: Fixing typo in etcd command

### DIFF
--- a/modules/manually-restoring-cluster-etcd-backup.adoc
+++ b/modules/manually-restoring-cluster-etcd-backup.adoc
@@ -296,7 +296,7 @@ When you are finished the `/var/lib/etcd` directory must contain only the folder
 +
 [source,terminal]
 ----
-$ mv /tmp/etcd-pod.yaml /etc/kubernetes/manifests
+$ mv /root/manifests-backup/etcd-pod.yaml /etc/kubernetes/manifests
 ----
 +
 .. Verify that all the `etcd` containers have started:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-15785
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://102417--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#manually-restoring-cluster-etcd-backup_dr-restoring-cluster-state
- https://102417--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup-restore/etcd-disaster-recovery.html#manually-restoring-cluster-etcd-backup_etcd-disaster-recovery
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
