### PR TITLE
OCPBUGS Update topic map title to match assembly title

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2664,7 +2664,7 @@ Topics:
     File: nodes-pods-autoscaling
   - Name: Automatically adjust pod resource levels with the vertical pod autoscaler
     File: nodes-pods-vertical-autoscaler
-  - Name: Manually adjust pod resource levels
+  - Name: Adjust pod resource levels without pod disruption
     File: nodes-pods-adjust-resources-in-place
   - Name: Providing sensitive data to pods by using secrets
     File: nodes-pods-secrets


### PR DESCRIPTION
Noticed that the topic_map entry differs from the title of one particular assembly.