### PR TITLE
[monitoring-docs-4.17] OBSDOCS-2495 - CMO TLS/configMap updates cause Prometheus restarts

### DIFF
--- a/about-ocp-monitoring/monitoring-stack-architecture.adoc
+++ b/about-ocp-monitoring/monitoring-stack-architecture.adoc
@@ -38,6 +38,15 @@ include::modules/monitoring-monitoring-stack-in-ha-clusters.adoc[leveloffset=+1]
 * xref:../configuring-core-platform-monitoring/storing-and-recording-data.adoc#configuring-persistent-storage_storing-and-recording-data[Configuring persistent storage]
 * xref:../configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc#configuring-performance-and-scalability[Configuring performance and scalability]
 
+//TLS security and rotation in the monitoring stack
+include::modules/monitoring-tls-security-and-rotation.adoc[leveloffset=+1]
+
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#tls-security-profiles[Configuring TLS security profiles]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
+
 //Glossary of common terms for OCP monitoring
 include::modules/monitoring-common-terms.adoc[leveloffset=+1]
 
@@ -47,5 +56,4 @@ ifndef::openshift-dedicated,openshift-rosa[]
 == Additional resources
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/support/index#about-remote-health-monitoring[About remote health monitoring]
 * xref:../configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm.adoc#granting-users-permission-to-monitor-user-defined-projects_preparing-to-configure-the-monitoring-stack-uwm[Granting users permissions for monitoring for user-defined projects]
-* link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/security_and_compliance/index#tls-security-profiles[Configuring TLS security profiles]
 endif::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-default-monitoring-components.adoc
+++ b/modules/monitoring-default-monitoring-components.adoc
@@ -52,9 +52,3 @@ You can use {cmo-full} config map settings to manage monitoring-plugin resources
 |===
 
 The monitoring stack monitors all components within the stack. The components are automatically updated when {ocp} is updated.
-
-[NOTE]
-====
-All components of the monitoring stack use the TLS security profile settings that are centrally configured by a cluster administrator.
-If you configure a monitoring stack component that uses TLS security settings, the component uses the TLS security profile settings that already exist in the `tlsSecurityProfile` field in the global {ocp} `apiservers.config.openshift.io/cluster` resource.
-====

--- a/modules/monitoring-tls-security-and-rotation.adoc
+++ b/modules/monitoring-tls-security-and-rotation.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assembly:
+//
+// * observability/monitoring/monitoring-stack-architecture.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="tls-security-and-rotation_{context}"]
+= TLS security and rotation in the monitoring stack
+
+[role="_abstract"]
+Learn how TLS profiles and certificate rotation work in the {ocp} monitoring stack to keep communication secure.
+
+TLS security profiles for monitoring components::
+All components of the monitoring stack use the TLS security profile settings that are centrally configured by a cluster administrator.
+The monitoring stack component uses the TLS security profile settings that already exist in the `tlsSecurityProfile` field in the global {ocp} `apiservers.config.openshift.io/cluster` resource.
+
+TLS certificate rotation and automatic restarts::
+The {cmo-first} manages the internal TLS certificate lifecycle for the monitoring components. These certificates secure the internal communication between the monitoring components.
++
+During certificate rotation, the {cmo-short} updates secrets and config maps, which triggers automatic restarts of affected pods. This is an expected behavior, and the pods recover automatically.
++
+The following example shows events that occur during certificate rotation:
++
+[source,terminal]
+----
+$ oc get events -n openshift-monitoring
+
+LAST SEEN   TYPE      REASON              OBJECT                                   MESSAGE
+2h39m       Normal    SecretUpdated       deployment/cluster-monitoring-operator   Updated Secret/grpc-tls -n openshift-monitoring because it changed
+2h39m       Normal    SecretCreated       deployment/cluster-monitoring-operator   Created Secret/prometheus-user-workload-grpc-tls -n openshift-user-workload-monitoring because it was missing
+2h39m       Normal    SecretCreated       deployment/cluster-monitoring-operator   Created Secret/thanos-querier-grpc-tls -n openshift-monitoring because it was missing
+2h39m       Normal    SecretCreated       deployment/cluster-monitoring-operator   Created Secret/thanos-ruler-grpc-tls -n openshift-user-workload-monitoring because it was missing
+2h39m       Normal    SecretCreated       deployment/cluster-monitoring-operator   Created Secret/prometheus-k8s-grpc-tls -n openshift-monitoring because it was missing
+2h38m       Warning   FailedMount         pod/prometheus-k8s-0                     MountVolume.SetUp failed for volume "secret-grpc-tls" : secret "prometheus-k8s-grpc-tls" not found
+2h39m       Normal    Created             pod/prometheus-k8s-0                     Created container kube-rbac-proxy-thanos
+2h39m       Normal    Started             pod/prometheus-k8s-0                     Started container kube-rbac-proxy-thanos
+2h39m       Normal    SuccessfulDelete    statefulset/prometheus-k8s               delete Pod prometheus-k8s-0 in StatefulSet prometheus-k8s successful
+2h39m       Normal    SuccessfulCreate    statefulset/prometheus-k8s               create Pod prometheus-k8s-0 in StatefulSet prometheus-k8s successful
+----


### PR DESCRIPTION
manual cherry-pick of https://github.com/openshift/openshift-docs/pull/102438 to standalne 4.17