### PR TITLE
OSDOCS-17324:Update the z-stream RNs for 4.20.4

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -2967,6 +2967,38 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.20.4
+[id="ocp-4-20-4_{context}"]
+=== RHSA-2025:21228 - {product-title} {product-version}.4 image release, bug fix, and security update advisory
+
+Issued: 18 November 2025
+
+{product-title} release {product-version}.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:21228[RHBA-2025:21228] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:21223[RHBA-2025:21223] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.4 --pullspecs
+----
+
+[id="ocp-4-20-4-bug-fixes_{context}"]
+==== Bug fixes
+
+* Before this update, the horizontal pod autoscaler (HPA) form in the web console incorrectly required you to provide values for both CPU and memory utilization, even though the API allows for HPAs to be created with a single metric or with no metrics (to use the API default). As a consequence, you could not use the form to create single-metric HPAs, for example, Memory-only, or HPAs that rely on the API default (80% CPU). This issue required you to use the YAML view for these common configurations. With this release, the HPA form logic is updated to align with the API so that the user interface no longer requires both fields to be completed. As a result, an empty utilization field correctly omits that HPA metric from the HPA manifest, which allows the API to apply its default behavior or create a single-metric HPA. You can use the HPA form to create single-metric HPAs, for example, CPU-only or Memory-only. If both utilization fields are left empty, the HPA is created and correctly falls back to the API default of 80% CPU utilization. (link:https://issues.redhat.com/browse/OCPBUGS-63339[OCPBUGS-63339])
+
+* Before this update, during rolling cluster updates from etcd 3.5.19 to a release of 3.6, the wrong membership data could be propagated to new members. As a consequence, cluster updates failed with an error indicating too many learner members in the cluster. With this release, etcd is updated to 3.5.24, which includes fixes that prevent membership-related errors. (link:https://issues.redhat.com/browse/OCPBUGS-63474[OCPBUGS-63474])
+
+* Before this update, the `ccoctl` utility would automatically generate a new keypair if the private key was not found, even when users intentionally provided only the public key as per documented security procedures. This behavior caused a problem, as the newly generated keys would not match the cluster's keys, resulting in service outages for users following the correct process. With this update, the utility was changed to ensure a new keypair is never generated when the `--public-key-file` parameter is specified, and this parameter was added to all create-all functions for consistency. As a result, specifying the public key file now guarantees the provided key is used, ensuring the cluster continues to function as expected without interruption. (link:https://issues.redhat.com/browse/OCPBUGS-63546[OCPBUGS-63546])
+
+* Before this update, the binary version data for Kubernetes binaries was incorrectly set to `v0.0.0`, which caused problems with vulnerability scanning tools. With this release, the build issue is fixed. As a result, the most recent upstream `kube` version is shown, for example, `v1.33.5`. (link:https://issues.redhat.com/browse/OCPBUGS-63749[OCPBUGS-63749])
+
+[id="ocp-4-20-4-updating_{context}"]
+==== Updating
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
 //4.20.3
 [id="ocp-4-20-3_{context}"]
 === RHSA-2025:19890 - {product-title} {product-version}.3 image release, bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-17324

Link to docs preview:
https://102494--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-4-20-4_release-notes

Additional information:
4.20.4 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/232
4.20.4 ART advisories: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20
