### PR TITLE
OSDOCS#17335: Add new module for encrypt etcd data in enterprise-4.16

### DIFF
--- a/microshift_install_get_ready/microshift-install-get-ready.adoc
+++ b/microshift_install_get_ready/microshift-install-get-ready.adoc
@@ -20,10 +20,14 @@ include::modules/microshift-install-rhel-tools-concepts.adoc[leveloffset=+1]
 
 include::modules/microshift-install-rhde-steps.adoc[leveloffset=+1]
 
+include::modules/microshift-encrypt-etcd-data.adoc[leveloffset=+1]
+
+
 [id="additional-resources_microshift-install-get-ready"]
 [role="_additional-resources"]
 == Additional resources
 
+* link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_storage_devices/encrypting-block-devices-using-luks_managing-storage-devices#luks-disk-encryption_encrypting-block-devices-using-luks[LUKS disk encryption]
 * xref:../microshift_cli_ref/microshift-oc-cli-install.adoc#microshift-oc-cli-install[Getting started with the OpenShift CLI]
 * link:https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/{ocp-version}/html/installing_with_an_rpm_package/index[Installing from an RPM package]
 * xref:../microshift_networking/microshift-networking-settings.adoc#microshift-networking[Understanding networking settings]

--- a/modules/microshift-encrypt-etcd-data.adoc
+++ b/modules/microshift-encrypt-etcd-data.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assembly:
+//
+// * microshift_install_get_ready/microshift-install-get-ready.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-encrypt-etcd-data_{context}"]
+= Encrypt etcd data
+
+Kubernetes objects are stored in an etcd database and might contain sensitive data. The etcd data is not encrypted by default. You can encrypt the disk that contains the etcd database by using the Linux Unified Key Setup-on-disk-format (LUKS) management tool for block device encryption.


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-17335](https://issues.redhat.com//browse/OSDOCS-17335)

Link to docs preview:
[Encrypt the etcd data]([url](https://102496--ocpdocs-pr.netlify.app/microshift/latest/microshift_install_get_ready/microshift-install-get-ready.html#microshift-encrypt-etcd-data_microshift-install-get-ready))

QE review:
- [ ] QE has approved this change.
QE approved the [PR](https://github.com/openshift/openshift-docs/pull/97979) update for `main`. This PR adds the same information to `4.16`.
