### PR TITLE
OSDOCS-17322 created zstream RNs for 4-17-44

### DIFF
--- a/modules/zstream-4-17-44-about.adoc
+++ b/modules/zstream-4-17-44-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-44-about_{context}"]
+= RHBA-2025:21225 - {product-title} {product-version}.44 bug fix advisory
+
+[role="_abstract"]
+Issued: 19 November 2025
+
+{product-title} release {product-version}.44 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:21225[RHBA-2025:21225] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:21221[RHBA-2025:21221] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.44--pullspecs
+----

--- a/modules/zstream-4-17-44-bug-fixes.adoc
+++ b/modules/zstream-4-17-44-bug-fixes.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-44-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+
+The following bugs are fixed for this release:
+
+* Before this update, API and Ingress Virtual IP (VIP) addresses were automatically assigned even when a user-managed load balancer was in use. With this release, the API and Ingress VIPs are no longer automatically assigned. If these values are not explicitly set in the `install-config.yaml`, the installation fails with an error, prompting you to provide them. (link:https://issues.redhat.com/browse/OCPBUGS-53236[OCPBUGS-53236])
+
+* Before this update, the *Authentication Error* message page was not properly rendering, causing an empty page and preventing error messages from being displayed to users. With this release, the *Authentication Error* message page now displays content, enhancing the user experience. (link:https://issues.redhat.com/browse/OCPBUGS-62631[OCPBUGS-62631])
+
+* Before this update, if the open virtual network (OVN)-Kubernetes controller was not processing updates from the Kubernetes API server and configuring the OVN databases on each node, then the OVN-Controller, which consumed this database, might have connected to the database before the OVN-Kubernetes controller had configured them. As a consequence, the OVN-Controller synced with a stale OVN database, consumed source network address translations (SNATs) that were configured to support the egress IP, and proceeded to the gratuitous address resolution protocol (GARP) for the associated IP address even though that IP address might have moved to another node. With this release, these GARPs are blocked when the OVN-Kubernetes controller is not processing updates. (link:https://issues.redhat.com/browse/OCPBUGS-63154[OCPBUGS-63154])
+
+* Before this update, when you ran the `ocp-tuned-one-shot.service` systemd unit that was owned by the Node Tuning Operator (NTO), a dependency failure might have occurred for the kubelet. As a consequence, the kubelet did not start. With this release, running the` ocp-tuned-one-shot.service` unit does not cause a dependency failure. As a result, the kubelet starts when you run the unit. (link:https://issues.redhat.com/browse/OCPBUGS-63504[OCPBUGS-63504])
+
+* Before this update, gRPC connection logs were set at a highly verbose log level. This generated an excessive number of messages, which caused the logs to overflow. With this release, the gRPC connection logs have been moved to the V(4) log level. Consequently, the logs no longer overflow, as these specific messages are now less verbose by default. (link:https://issues.redhat.com/browse/OCPBUGS-63682[OCPBUGS-63682])
+
+* Before this update, the Azure machine provider was not passing the `dataDisks` configuration from the `MachineSet` into the virtual machine creation API request for the Azure Stack Hub. As a consequence, new machines were created without the specified data disks because the configuration was silently ignored during the VM creation process. With this release, the VM creation for the Azure Stack Hub is updated to include the `dataDisks` configuration. An additional update manually implements the behavior of the `deletionPolicy: Delete` parameter in the controller because the Azure Stack Hub does not natively support this option. As a result, data disks are correctly provisioned on the Azure Stack Hub VMs. The `Delete` policy is also functionally supported, which ensures that disks are properly removed when their machines are removed. (link:https://issues.redhat.com/browse/OCPBUGS-63700[OCPBUGS-63700])
+

--- a/modules/zstream-4-17-44-updating.adoc
+++ b/modules/zstream-4-17-44-updating.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-44-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2933,6 +2933,15 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//  4.17.44 about
+include::modules/zstream-4-17-44-about.adoc[leveloffset=+2]
+
+//4.17.44 bug fixes
+include::modules/zstream-4-17-44-bug-fixes.adoc[leveloffset=+2]
+
+//4.17.44 bug fixes
+include::modules/zstream-4-17-44-updating.adoc[leveloffset=+2]
+
 // 4.17.42
 [id="ocp-4-17-43_{context}"]
 === RHBA-2025:19314 - {product-title} {product-version}.43 bug fix update and security


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-17322

Link to docs preview:
https://102504--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#zstream-4-17-44-about_release-notes




QE review:
- [ ] QE has approved this change.


Additional information:
These z-stream RNs are in a new modular format to prepare for DITA migration. Also, there is an **xref** error below. Ignore that error as it was decided that a special exception would be made for release notes.

To find the **Image** and **RPM** IDs, select the following links:

For the **Image** ID: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/231/diffs#ffa924ede19389f6b6e0dc0c20bd434fa978af9b

For the **RPM** ID: https://errata.devel.redhat.com/advisory/156130

**Must be on VPN to view** these links.
