### PR TITLE
OSDOCS-16017_4_15#Deprecate oVirt CSI driver for 4.15

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -1333,6 +1333,11 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 
+|Persistent storage using oVirt CSI Driver Operator
+|General Availability
+|Deprecated
+|Deprecated
+
 |====
 
 //


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

oVirt CSI Driver Operator will be removed in 4.21, but was deprecated in 4.14+. This PR puts the deprecation notice in the 4.15 RNs.

Subject to Change Management

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-16017
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

PTAL: @gcharot @RomanBednar @jsafrane @duanwei33 @wsun1 @sferich888 @kalexand-rh @mwerner2113 
