### PR TITLE
4.15 - OADP-7010: Release notes for 1.4.7

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -41,9 +41,9 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.4.6
-:oadp-version-1-3: 1.3.7
-:oadp-version-1-4: 1.4.6
+:oadp-version: 1.4.7
+:oadp-version-1-3: 1.3.8
+:oadp-version-1-4: 1.4.7
 :oadp-bsl-api: backupstoragelocations.velero.io
 :velero-overview: link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]
 :velero-link: link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -15,6 +15,7 @@ The release notes for {oadp-first} describe new features and enhancements, depre
 For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
 ====
 
+include::modules/oadp-1-4-7-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-6-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-5-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-4-release-notes.adoc[leveloffset=+1]
@@ -30,9 +31,12 @@ include::modules/oadp-1-4-0-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+3]
 include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+3]
 
+// TODO: Include this xref when the Operators book is added to the ROSA HCP docs.
+ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
+endif::openshift-rosa-hcp[]
 
 [id="oadp-converting-dpa-to-new-version-1-4-0_{context}"]
 === Converting DPA to the new version

--- a/modules/oadp-1-4-7-release-notes.adoc
+++ b/modules/oadp-1-4-7-release-notes.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-7-release-notes_{context}"]
+= {oadp-short} 1.4.7 release notes
+
+{oadp-first} 1.4.7 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.6.


### PR DESCRIPTION
### Cherry pick

* Cherry Picked from faf6016418c189112e8bcfc7f7718ce37551705b xref: https://github.com/openshift/openshift-docs/pull/102582

### JIRA

* [OADP-7010](https://issues.redhat.com/browse/OADP-7010)

### Version(s):

* OCP 4.15

### Link to docs preview:

* [OADP 1.4.7 release notes](https://102585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes#oadp-1-4-7-release-notes_oadp-1-4-release-notes)

### QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
