### PR TITLE
MIG-1768: MTC 1.8.11 Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -92,7 +92,7 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
-:mtc-version-z: 1.8.10
+:mtc-version-z: 1.8.11
 :mtc-legacy-image: 1.7
 :mtv-first: Migration Toolkit for Virtualization (MTV)
 :mtv-short: MTV

--- a/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc
@@ -15,6 +15,8 @@ The {mtc-short} enables you to migrate application workloads between {product-ti
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-11.adoc[leveloffset=+1]
+
 include::modules/migration-mtc-release-notes-1-8-10.adoc[leveloffset=+1]
 
 include::modules/migration-mtc-release-notes-1-8-9.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-11.adoc
+++ b/modules/migration-mtc-release-notes-1-8-11.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-11_{context}"]
+= {mtc-full} 1.8.11 release notes
+
+{mtc-first} 1.8.11 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {mtc-short} 1.8.10.


### PR DESCRIPTION
### JIRA

* [MIG-1768](https://issues.redhat.com/browse/MIG-1768)

### Version(s):

* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15
* OCP 4.16 → branch/enterprise-4.16
* OCP 4.17 → branch/enterprise-4.17
* OCP 4.18 → branch/enterprise-4.18
* OCP 4.19 → branch/enterprise-4.19
* OCP 4.20 → branch/enterprise-4.20
* OCP 4.21 → branch/enterprise-4.21

### Link to docs preview:

* [MTC 1.8.11 release notes](https://102587--ocpdocs-pr.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/release_notes/mtc-release-notes#migration-mtc-release-notes-1-8-11_mtc-release-notes)

### QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
