### PR TITLE
OSSM-11361 [DOCS] http route for waypoint not working and waypoint authorization not enforced

### DIFF
--- a/modules/ossm-adding-authorization-policy.adoc
+++ b/modules/ossm-adding-authorization-policy.adoc
@@ -30,7 +30,7 @@ spec:
   - from:
     - source:
         principals:
-        - cluster.local/ns/default/sa/curl
+        - cluster.local/ns/curl/sa/curl
     to:
     - operation:
         methods: ["GET"]
@@ -50,25 +50,32 @@ The `targetRefs` field specifies the service targeted by the authorization polic
 
 .Verification
 
-. Deploy the `curl` application in the `default` namespace by running the following command:
+. Create a namespace for a `curl` client by running the following command:
 +
 [source,terminal]
 ----
-$ oc apply -n default -f https://raw.githubusercontent.com/openshift-service-mesh/istio/refs/heads/master/samples/curl/curl.yaml
+$ oc create namespace curl
 ----
 
-. Wait and get the status of the `curl` deployment by running the following command:
+. Deploy a `curl` client by running the following command:
 +
 [source,terminal]
 ----
-$ oc -n default rollout status deploy/curl --timeout=3m
+$ oc apply -n curl -f https://raw.githubusercontent.com/openshift-service-mesh/istio/refs/heads/master/samples/curl/curl.yaml
+----
+
+. Apply the label for ambient mode to the `curl` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace curl istio.io/dataplane-mode=ambient
 ----
 
 . Verify that a `GET` request to the `productpage` service succeeds with an HTTP 200 response when made from the `default/curl` pod, by running the following command:
 +
 [source,terminal]
 ----
-$ oc -n default exec deploy/curl -- sh -c \
+$ oc -n curl exec deploy/curl -- sh -c \
   'curl -s -o /dev/null -w "HTTP %{http_code}\n" http://productpage.bookinfo.svc.cluster.local:9080/productpage'
 ----
 
@@ -76,7 +83,7 @@ $ oc -n default exec deploy/curl -- sh -c \
 +
 [source,terminal]
 ----
-$ oc -n default exec deploy/curl -- sh -c \
+$ oc -n curl exec deploy/curl -- sh -c \
   'curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST http://productpage.bookinfo.svc.cluster.local:9080/productpage'
 ----
 
@@ -90,9 +97,18 @@ $ oc exec "$(oc get pod -l app=ratings -n bookinfo \
 -- curl -sS productpage:9080/productpage
 ----
 
-. Delete the `curl` application to clean up resources by running the following command:
+. Clean up the resources by running the following commands:
+
+.. Delete the `curl` application by running the following command:
 +
 [source,terminal]
 ----
-$ oc delete -n default -f https://raw.githubusercontent.com/openshift-service-mesh/istio/refs/heads/master/samples/curl/curl.yaml
+$ oc delete -n curl -f https://raw.githubusercontent.com/openshift-service-mesh/istio/refs/heads/master/samples/curl/curl.yaml
+----
+
+.. Delete the `curl` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc delete namespace curl
 ----

--- a/modules/ossm-exposing-a-service-by-using-the-kubernetes-gateway-api-in-ambient-mode.adoc
+++ b/modules/ossm-exposing-a-service-by-using-the-kubernetes-gateway-api-in-ambient-mode.adoc
@@ -82,7 +82,7 @@ $ oc apply -f httpbin-waypoint.yaml
 $ oc label service httpbin -n httpbin istio.io/ingress-use-waypoint=true
 ----
 +
-The label ensures that traffic from the ingress gateway routes through the waypoint proxy and the L7 policies configured on the waypoint proxy are applied to the ingress traffic, before it reaches the `httpbin` service.
+The label ensures that traffic from the ingress gateway routes through the waypoint proxy and the Layer 7 (L7) policies configured on the waypoint proxy are applied to the ingress traffic, before it reaches the `httpbin` service.
 
 . Apply the waypoint label to the namespace so that all the services inside the namespace routes through the waypoint, by running the following command:
 +
@@ -165,7 +165,9 @@ metadata:
   namespace: httpbin
 spec:
   parentRefs:
-  - name: httpbin-waypoint
+  - group: ""
+    kind: service
+    name: httpbin
     namespace: httpbin
   rules:
   - matches:
@@ -180,7 +182,7 @@ spec:
       port: 8000
 
 ----
-* `spec.parentRefs` binds the `HTTPROUTE` resource to the waypoint Gateway resource. It configures L7 routing rules that the waypoint will enforce.
+* `spec.parentRefs` binds the `HTTPRoute` resource to the `httpbin` service. When combined with the `istio.io/ingress-use-waypoint=true` label on the service, the `HTTPRoute` configures the L7 routing rules that the waypoint proxy will enforce for traffic destined to that service.
 
 * `spec.rules.backendRefs` routes the matching traffic to the `httpbin` service by defining a `backendRefs` that includes the name and port of the `httpbin` service.
 
@@ -190,7 +192,7 @@ spec:
 ----
 $ oc apply -f httpbin-waypoint-hr.yaml
 ----
-
++
 [NOTE]
 ====
 In this example use case, traffic from the ingress gateway flows through the waypoint proxy because of the `istio.io/ingress-use-waypoint=true` label. The `HTTPRoute` resource then applies path-based routing policies before the traffic reaches the httpbin service.
@@ -216,7 +218,7 @@ $ oc create namespace curl
 +
 [source,terminal]
 ----
-$ oc apply -n curl
+$ oc apply -n curl -f https://raw.githubusercontent.com/openshift-service-mesh/istio/refs/heads/master/samples/curl/curl.yaml
 ----
 
 . Apply the label for ambient mode to the `curl` namespace by running the following command:
@@ -240,7 +242,7 @@ $ CURL_POD=$(oc get pods -n curl -l app=curl -o jsonpath='{.items[*].metadata.na
 $ oc exec $CURL_POD -n curl -- \
   curl -s -I \
     -H Host:httpbin.example.com \
-    <gateway_name>-istio.<gateway_namespace>.svc.cluster.local/headers
+    httpbin-gateway-istio.httpbin.svc.cluster.local/headers
 ----
 +
 The response should return a `200 OK` HTTP status, which indicates that the request was successful, similar to the following example:
@@ -259,7 +261,7 @@ server: istio-envoy
 $ oc exec $CURL_POD -n curl -- \
   curl -s -I \
     -H Host:httpbin.example.com \
-    <gateway_name>-istio.<gateway_namespace>.svc.cluster.local/get
+    httpbin-gateway-istio.httpbin.svc.cluster.local/get
 ----
 +
 The response returns a `404 Not Found` status, as expected, because the `/get` endpoint does not have a matching URI prefix in the `httpbin` `HTTPROUTE` resource, similar to the following example:
@@ -275,7 +277,7 @@ server: istio-envoy
 +
 [source,terminal]
 ----
-$ oc patch service <gateway_name>-istio -n <gateway_namespace> -p '{"spec": {"type": "LoadBalancer"}}'
+$ oc patch service httpbin-gateway-istio -n httpbin -p '{"spec": {"type": "LoadBalancer"}}'
 ----
 +
 [NOTE]
@@ -289,14 +291,14 @@ A gateway can also be exposed to traffic outside the cluster by using {ocp-short
 +
 [source,terminal]
 ----
-$ export INGRESS_HOST=$(oc get gtw <gateway_name> -n <gateway_namespace> -o jsonpath='{.status.addresses[0].value}')
+$ export INGRESS_HOST=$(oc get gtw httpbin-gateway -n httpbin -o jsonpath='{.status.addresses[0].value}')
 ----
 
 .. Set the `INGRESS_PORT` variable by running the following command:
 +
 [source,terminal]
 ----
-$ INGRESS_PORT=$(oc get gtw <gateway_name> -n <gateway_namespace> -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
+$ INGRESS_PORT=$(oc get gtw httpbin-gateway -n httpbin -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
 ----
 
 .. Using the gateway host, send a `curl` request to the `httpbin` service by running the following command:


### PR DESCRIPTION
Change type: Doc update; Docs: http route for waypoint not working and waypoint authorization not enforced

Doc JIRA: https://issues.redhat.com/browse/OSSM-11361

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Doc Preview: 

- https://102591--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/gateways/ossm-getting-traffic-into-a-mesh.html
- https://102591--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-istio-ambient-mode.html

SME Review/QE Review: @sridhargaddam @FilipB 
Peer Review: @kaldesai 