### PR TITLE
OSSM-11371 [DOCS] Known issues addition to release notes post 3.2

### DIFF
--- a/modules/ossm-release-notes-3-2-known-issues.adoc
+++ b/modules/ossm-release-notes-3-2-known-issues.adoc
@@ -17,3 +17,15 @@
 A concurrency issue in `ztunnel` limits throughput scalability in {istio} ambient mode. Performance remains comparable to sidecar mode in most scenarios, but the issue can limit the potential to scale throughput performance.
 
 link:https://issues.redhat.com/browse/OSSM-11132[OSSM-11132]
+
+[id="istio-idecars-cannot-reach-istiod-on-s390x-and-powerpc-when-using-trpoxy-mode_{context}"]
+== Istio sidecars cannot reach `Istiod` on `s390x` and `PowerPC` when using `TPROXY` mode
+
+Configuring {istio} in sidecar mode with Transparent Proxy (TPROXY) on `s390x` and `PowerPC` hardware platforms causes the `istio-proxy` container to fail certificate signing and remain unready. As a consequence, the sidecar cannot reach the `Istiod` service and the connection times out. As a result, affected workloads cannot run successfully under these conditions.
+
+[id="waypoint-proxy-emits-incomplete-telemetry-on-s390x-platforms_{context}"]
+== Waypoint proxy emits incomplete telemetry on `s390x` platforms
+
+Running {istio} in ambient mode on the `s390x` hardware platform causes the waypoint proxy to emit incomplete telemetry after the namespace is enrolled. As a consequence, tools such as Kiali cannot generate accurate graphs or diagrams, resulting in missing edges, unknown fields, or no visualization data. As a result, telemetry-dependent observability features remain incomplete on affected clusters.
+
+link:https://issues.redhat.com/browse/OSSM-11285[OSSM-11285]

--- a/modules/ossm-release-notes-sail-operator-apis.adoc
+++ b/modules/ossm-release-notes-sail-operator-apis.adoc
@@ -26,5 +26,5 @@ Module included in the following assemblies:
 | GA
 
 | ZTunnel
-| TP
+| GA
 |===


### PR DESCRIPTION
Change type: Doc update; Known issues addition to release notes post 3.2

Doc JIRA: https://issues.redhat.com/browse/OSSM-11371

Fix Version: [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Doc Preview: https://102592--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes.html#istio-idecars-cannot-reach-istiod-on-s390x-and-powerpc-when-using-trpoxy-mode_ossm-release-notes

SME Review/QE Review: @sridhargaddam @fjglira @dcillera 
Peer Review: