### PR TITLE
OSDOCS-17251: Added rollout statements to cert-manager-certificate-in…

### DIFF
--- a/modules/cert-manager-certificate-ingress.adoc
+++ b/modules/cert-manager-certificate-ingress.adoc
@@ -6,6 +6,20 @@
 [id="cert-manager-certificate-ingress_{context}"]
 = Creating certificates for the Ingress Controller
 
+[role="_abstract"]
+You can create a certificate for the Ingress Controller and then replace bootstrapped default self-signed certificates with cert-manager-managed external certificates.
+
+[NOTE]
+====
+Before using the procedure, ensure you understand the following Ingress Controller behaviors:
+
+* When certificates are renewed or rotated by using the cert-manager Operator, only the contents of the secret, such as the certificate and key, are updated. The secret name remains unchanged. Kubelet automatically propagates these updates to the mounted volume, allowing the router to detect the file changes and hot-reload the new certificate and key. As a result, no rolling update of the router deployment is triggered or required.
+
+* The secret name is referenced in the Ingress Controller configuration. If you want to replace the default ingress certificate or use different secret name in Ingress Controller configuration, you must patch or edit the configuration to apply the change. This operation triggers a rolling update for router pods where new router pods load the new cert/key pair.
+
+For more information, see this link:https://access.redhat.com/solutions/4542531[Red{nbsp}Hat Knowledgebase Solution].
+====
+
 .Prerequisites
 
 * You have access to the cluster with `cluster-admin` privileges.
@@ -16,38 +30,41 @@
 . Create an issuer. For more information, see "Configuring an issuer" in the "Additional resources" section.
 
 . Create a certificate:
-
++
 .. Create a YAML file, for example, `certificate.yaml`, that defines the `Certificate` object:
 +
 .Example `certificate.yaml` file
-+
-[source, yaml]
+[source,yaml]
 ----
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: <tls_cert> #<1>
+  name: <tls_cert>
   namespace: openshift-ingress
 spec:
   isCA: false
-  commonName: "apps.<cluster_base_domain>" #<2>
-  secretName: <secret_name> #<3>
+  commonName: "apps.<cluster_base_domain>"
+  secretName: <secret_name>
   dnsNames:
-  - "apps.<cluster_base_domain>" #<4>
-  - "*.apps.<cluster_base_domain>" #<4>
+  - "apps.<cluster_base_domain>"
+  - "\*.apps.<cluster_base_domain>"
   issuerRef:
-    name: <issuer_name> #<5>
+    name: <issuer_name>
     kind: Issuer
 ----
-<1> Provide a name for the certificate.
-<2> Specify the common name (CN).
-<3> Specify the name of the secret to create that contains the certificate.
-<4> Specify the DNS name of the ingress.
-<5> Specify the name of the issuer.
++
+where:
++
+`<tls_cert>`:: Specifies the name for the certificate.
+`<cluster_base_domain>`:: Specifies the common name (CN).
+`<secret_name>`:: Specifies the name of the secret to create that contains the certificate.
+`<cluster_base_domain>`:: Specifies the DNS name of the ingress.
+`<issuer_name>`:: Specifies the name of the issuer.
 
++
 .. Create the `Certificate` object by running the following command:
 +
-[source, terminal]
+[source,terminal]
 ----
 $ oc create -f certificate.yaml
 ----
@@ -56,11 +73,25 @@ $ oc create -f certificate.yaml
 
 .Verification
 
-* Verify that the certificate is created and ready to use by running the following command:
+. Verify that the certificate is created and ready to use by running the following command:
 +
-[source, terminal]
+[source,terminal]
 ----
-$ oc get certificate -w -n openshift-ingress
+$ oc get certificate -n openshift-ingress
+----
+
+. Verify the definition and content of the secret object by running the following command:
++
+[source,terminal]
+----
+$ oc get secret <secretName> -n openshift-ingress
+----
+
+. Verify that the default TLS certificate has the correct configuration details for the Ingress Controller by running the following command:
++
+[source,terminal]
+----
+$ oc get ingresscontroller default -n openshift-ingress-operator -o yaml | grep -A2 defaultCertificate
 ----
 +
-Once certificate is in `Ready` status, Ingress Controller on your cluster can start using the generated certificate secret.
+After the certificate is in `Ready` status, the Ingress Controller on your cluster can start using the generated certificate secret.

--- a/modules/customize-certificates-replace-default-router.adoc
+++ b/modules/customize-certificates-replace-default-router.adoc
@@ -8,6 +8,15 @@
 
 You can replace the default ingress certificate for all applications under the `.apps` subdomain. After you replace the certificate, all applications, including the web console and CLI, have encryption provided by the specified certificate.
 
+[NOTE]
+====
+Before using the procedure, ensure you understand the following Ingress Controller behaviors:
+
+* When certificates are renewed or rotated by using external certificate management tools, only the contents of the secret, such as the certificate and key, are updated. The secret name remains unchanged. Kubelet automatically propagates these updates to the mounted volume, allowing the router to detect the file changes and hot-reload the new certificate and key. As a result, no rolling update of the router deployment is triggered or required.
+
+* For secret renewal or rotation, the cert-manager Operator changes the secret content, such as a cert/key pair, but does not change the secret name. This happens because kubelet automatically propagates changes to the secret in the volume mount. The router pod detects the file change and then hot reloads the new cert/key pair. Updating the secret content does not trigger rolling update.
+====
+
 .Prerequisites
 
 * You must have a wildcard certificate for the fully qualified `.apps` subdomain and its corresponding private key. Each should be in a separate PEM format file.
@@ -24,10 +33,13 @@ You can replace the default ingress certificate for all applications under the `
 [source,terminal]
 ----
 $ oc create configmap custom-ca \
-     --from-file=ca-bundle.crt=</path/to/example-ca.crt> \//<1>
+     --from-file=ca-bundle.crt=</path/to/example-ca.crt> \
      -n openshift-config
 ----
-<1> `</path/to/example-ca.crt>` is the path to the root CA certificate file on your local file system. For example, `/etc/pki/ca-trust/source/anchors`.
++
+where
++
+`</path/to/example-ca.crt>`:: The path to the root CA certificate file on your local file system. For example, `/etc/pki/ca-trust/source/anchors`.
 
 . Update the cluster-wide proxy configuration with the newly created config map:
 +
@@ -49,14 +61,17 @@ If you change any other parameter in the `openshift-config-user-ca-bundle.crt` f
 +
 [source,terminal]
 ----
-$ oc create secret tls <secret> \//<1>
-     --cert=</path/to/cert.crt> \//<2>
-     --key=</path/to/cert.key> \//<3>
+$ oc create secret tls <secret> \
+     --cert=</path/to/cert.crt> \
+     --key=</path/to/cert.key> \
      -n openshift-ingress
 ----
-<1> `<secret>` is the name of the secret that will contain the certificate chain and private key.
-<2> `</path/to/cert.crt>` is the path to the certificate chain on your local file system.
-<3> `</path/to/cert.key>` is the path to the private key associated with this certificate.
++
+where:
++
+`<secret>`:: Specifies the name of the secret that will contain the certificate chain and private key.
+`</path/to/cert.crt>`:: Specifies the path to the certificate chain on your local file system.
+`</path/to/cert.key>`:: Specifies the path to the private key associated with this certificate.
 
 . Update the Ingress Controller configuration with the newly created secret:
 +
@@ -64,13 +79,8 @@ $ oc create secret tls <secret> \//<1>
 ----
 $ oc patch ingresscontroller.operator default \
      --type=merge -p \
-     '{"spec":{"defaultCertificate": {"name": "<secret>"}}}' \//<1>
+     '{"spec":{"defaultCertificate": {"name": "<secret>"}}}' \
      -n openshift-ingress-operator
 ----
-<1> Replace `<secret>` with the name used for the secret in the previous step.
 +
-[IMPORTANT]
-====
-To trigger the Ingress Operator to perform a rolling update, you must update the name of the secret.
-Because the kubelet automatically propagates changes to the secret in the volume mount, updating the secret contents does not trigger a rolling update. For more information, see this link:https://access.redhat.com/solutions/4542531[Red{nbsp}Hat Knowledgebase Solution].
-====
+* `<secret>`:: Specifies the name used for the secret. Replace `<secret>` with the name used for the secret.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-17251](https://issues.redhat.com/browse/OSDOCS-17251)

Link to docs preview:
* [Creating certificates for the Ingress Controller](https://102604--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-creating-certificate.html#cert-manager-certificate-ingress_cert-manager-creating-certificate)
* [Replacing the default ingress certificate](https://102604--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/replacing-default-ingress-certificate.html#replacing-default-ingress_replacing-default-ingress)

- [x] SME has approved this change (Davide Salerno - Network edge engineers/Yuedong Wu).
- [x] QE has approved this change (Hongan LI).

Requested a network edge review on this [Slack](https://redhat-internal.slack.com/archives/CCH60A77E/p1763474812954409) channel.
