### PR TITLE
CNV- 64948-2: Changed wording in glossary

### DIFF
--- a/modules/virt-networking-glossary.adoc
+++ b/modules/virt-networking-glossary.adoc
@@ -19,11 +19,11 @@ Multus:: A "meta" CNI plugin that allows multiple CNIs to exist so that a pod or
 Custom resource definition (CRD):: A link:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/[Kubernetes]
 API resource that allows you to define custom resources, or an object defined by using the CRD API resource.
 
-Network attachment definition (NAD):: A CRD introduced by the Multus project that allows you to attach pods, virtual machines, and virtual machine instances to one or more networks.
+`NetworkAttachmentDefinition`:: A CRD introduced by the Multus project that allows you to attach pods, virtual machines, and virtual machine instances to one or more networks.
 
-UserDefinedNetwork (UDN):: A namespace-scoped CRD introduced by the user-defined network API that can be used to create a tenant network that isolates the tenant namespace from other namespaces.
+`UserDefinedNetwork`:: A namespace-scoped CRD introduced by the user-defined network (UDN) API that can be used to create a tenant network that isolates the tenant namespace from other namespaces.
 
-ClusterUserDefinedNetwork (CUDN):: A cluster-scoped CRD introduced by the user-defined network API that cluster administrators can use to create a shared network across multiple namespaces.
+`ClusterUserDefinedNetwork`:: A cluster-scoped CRD introduced by the user-defined network API that cluster administrators can use to create a shared network across multiple namespaces.
 
 ifndef::openshift-rosa,openshift-dedicated[]
 Node network configuration policy (NNCP):: A CRD introduced by the nmstate project, describing the requested network configuration on nodes.


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/CNV-64948

Link to docs preview:
https://102605--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-configuring-pxe-booting.html#virt-networking-glossary_pxe-booting

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The PR has a change suggested in the peer review for https://github.com/openshift/openshift-docs/pull/101663. 
