### PR TITLE
OSDOCS#15136: Comparison of oc-mirror workflows

### DIFF
--- a/disconnected/about-installing-oc-mirror-v2.adoc
+++ b/disconnected/about-installing-oc-mirror-v2.adoc
@@ -52,6 +52,8 @@ include::modules/oc-mirror-building-image-set-config-v2.adoc[leveloffset=+2]
 
 * xref:../updating/understanding_updates/intro-to-updates.adoc#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]
 
+include::modules/oc-mirror-workflows-table.adoc[leveloffset=+2]
+
 //Mirroring an image set in a partially disconnected environment
 include::modules/oc-mirror-workflows-partially-disconnected-v2.adoc[leveloffset=+2]
 

--- a/modules/oc-mirror-workflows-table.adoc
+++ b/modules/oc-mirror-workflows-table.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * installing/disconnected_install/installing-mirroring-disconnected-v2.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="oc-mirror-workflows-table_{context}"]
+= Comparison of oc-mirror workflows
+
+[role="_abstract"]
+Use the following table to compare the supported use cases for the mirror-to-disk (m2d), disk-to-mirror (d2m), and mirror-to-mirror (m2m) workflows.
+
+[%header,cols="3",cols="2,1,1",options="header",subs="quotes"]
+|===
+^|*Use Case*
+^|*Mirror To Disk (m2d) and Disk To Mirror (d2m)*
+^|*Mirror To Mirror (m2m)*
+
+^|The target registry exists in an environment with no internet access and no external access.
+^|&#10003;
+^|
+
+^|The target registry exists in an environment with no internet access but is accessible from another machine. For example, the target registry resides in a bastion host.
+^|
+^|&#10003;
+
+^|You must move content to the disconnected environment by using a physical method, such as USB devices.
+^|&#10003;
+^|
+
+^|The workflow moves content directly to the target registry without generating an intermediate tar file.
+^|
+^|&#10003;
+
+^|The workflow uses an internal cache to resume after failures but requires additional disk space.
+^|&#10003;
+^|
+
+^|The workflow does not use a cache, restarts from the beginning after a failure, and requires no additional disk space.
+^|
+^|&#10003;
+|===


### PR DESCRIPTION
Completing Ashwini's work: https://github.com/openshift/openshift-docs/pull/97676

Version(s):
4.16+

Issue:
[OSDOCS-15136](https://issues.redhat.com/browse/OSDOCS-15136)

Link to docs preview:
[Comparison of oc-mirror workflows](https://102607--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/about-installing-oc-mirror-v2.html#oc-mirror-workflows-table_about-installing-oc-mirror-v2)

QE review: Present in the original PR https://github.com/openshift/openshift-docs/pull/97676
- [x] QE has approved this change.


SME review: Present in the original PR https://github.com/openshift/openshift-docs/pull/97676
- [x] SME has approved this change.
