### PR TITLE
OSDOCS-17350:Corrected formatting error in Creating a WIF configuration doc

### DIFF
--- a/modules/create-wif-cluster-cli.adoc
+++ b/modules/create-wif-cluster-cli.adoc
@@ -52,9 +52,7 @@ $ ocm gcp create wif-config --name <wif_name> \ <1>
 <2> Replace `<gcp_project_id>` with the ID of the {GCP} project where the WIF configuration will be implemented.
 <3> Optional: Replace `<osd_version>` with the desired {product-title} version the wif-config will need to support. If you do not specify a version, the wif-config will support the latest {product-title} y-stream version as well as the last three supported {product-title} y-stream versions (beginning with version 4.17).
 <4> Optional: Replace `<gcp_project_id>` with the ID of the dedicated project where the workload identity pools and providers will be created and managed. If the `--federated-project` flag is not specified, the workload identity pools and providers will be created and managed in the project specified by the `--project` flag.
-
 +
-
 [NOTE]
 =====
 Using a dedicated project to create and manage workload identity pools and providers is recommended by {GCP}.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17350

Link to docs preview:
https://102608--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.html#create-wif-configuration_osd-creating-a-cluster-on-gcp-with-workload-identity-federation

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
