### PR TITLE
OSDOCS-15642 created Microshift z-stream RNs

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -50,3 +50,5 @@ include::modules/microshift-4-17-27-dp.adoc[leveloffset=+2]
 include::modules/microshift-4-17-35-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-17-37-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-17-44-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-17-44-dp.adoc
+++ b/modules/microshift-4-17-44-dp.adoc
@@ -1,0 +1,16 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-44-dp_{context}"]
+= RHBA-2025:21225 - {microshift-short} 4.17.44 bug fix and enhancement update
+
+[role="_abstract"]
+Issued: 19 Nov 2025
+
+{product-title} release 4.17.44 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:21225[RHBA-2025:21225] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2025:21543[RHSA-2025:21543] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-15642

Link to docs preview:
https://102621--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-44-dp_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
 To find the **Image** and **RPM** IDs, select the following links:

For the **Image** ID: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/231/diffs#ffa924ede19389f6b6e0dc0c20bd434fa978af9b

For the **RPM** ID: https://errata.devel.redhat.com/advisory/156231

**Must be on VPN to view** this link.

There is an xref error below. Ignore that error as it was decided that a special exception would be made for release notes.

