### PR TITLE
OSDOCS-17354 [NETOBSERV] Update version reference for Loki Operator version

### DIFF
--- a/modules/network-observability-loki-install.adoc
+++ b/modules/network-observability-loki-install.adoc
@@ -6,13 +6,13 @@
 [id="network-observability-loki-installation_{context}"]
 = Installing the {loki-op}
 
-The link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel9-operator/64479927e1820602a81cdf13[{loki-op} versions 5.7+] are the supported {loki-op} versions for Network Observability; these versions provide the ability to create a `LokiStack` instance using the `openshift-network` tenant configuration mode and provide fully-automatic, in-cluster authentication and authorization support for Network Observability. There are several ways you can install Loki. One way is by using the {product-title} web console Operator Hub.
+The link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel9-operator/64479927e1820602a81cdf13[{loki-op} versions 6.0+] are the supported {loki-op} versions for Network Observability; these versions provide the ability to create a `LokiStack` instance using the `openshift-network` tenant configuration mode and provide fully-automatic, in-cluster authentication and authorization support for Network Observability. There are several ways you can install Loki. One way is by using the {product-title} web console Operator Hub.
 
 .Prerequisites
 
-* Supported Log Store (AWS S3, {gcp-full} Storage, Azure, Swift, Minio, {rh-storage})
-* {product-title} 4.10+
-* Linux kernel 4.18+
+* You have administrator permissions.
+* You have access to the {product-title} web console.
+* You have access to a supported object store. For example: AWS S3, Google Cloud Storage, Azure, Swift, Minio, or OpenShift Data Foundation.
 
 .Procedure
 . In the {product-title} web console, click *Ecosystem* -> *Software Catalog*.


### PR DESCRIPTION
[OSDOCS-17354](https://issues.redhat.com//browse/OSDOCS-17354) [NETOBSERV] Update version reference for Loki Operator version

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-17354

Link to docs preview:
Installing the Loki Operator: https://102626--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-loki-installation_network_observability 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
