### PR TITLE
DOCPLAN-30: Updates for assemblies to align with DITA migration

### DIFF
--- a/modules/metallb-installing-using-web-console.adoc
+++ b/modules/metallb-installing-using-web-console.adoc
@@ -3,9 +3,10 @@
 // * networking/metallb/metallb-operator-install.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="installing-the-metallb-operator-using-web-console_{context}"]
-= Installing the MetalLB Operator from the software catalog using the web console
+[id="metallb-installing-using-web-console_{context}"]
+= Installing the MetalLB Operator from the software catalog by using the web console
 
+[role="_abstract"]
 As a cluster administrator, you can install the MetalLB Operator by using the {product-title} web console.
 
 .Prerequisites

--- a/networking/networking_operators/metallb-operator/metallb-operator-install.adoc
+++ b/networking/networking_operators/metallb-operator/metallb-operator-install.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As a cluster administrator, you can add the MetalLB Operator so that the Operator can manage the lifecycle for an instance of MetalLB on your cluster.
 
 MetalLB and IP failover are incompatible. If you configured IP failover for your cluster, perform the steps to xref:../../../networking/configuring_network_settings/configuring-ipfailover.adoc#nw-ipfailover-remove_configuring-ipfailover[remove IP failover] before you install the Operator.

--- a/virt/post_installation_configuration/virt-configuring-certificate-rotation.adoc
+++ b/virt/post_installation_configuration/virt-configuring-certificate-rotation.adoc
@@ -1,9 +1,10 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-configuring-certificate-rotation"]
 = Configuring certificate rotation
-include::_attributes/common-attributes.adoc[]
 :context: virt-configuring-certificate-rotation
 
+[role="_abstract"]
 Configure certificate rotation parameters to replace existing certificates.
 
 toc::[]

--- a/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc
+++ b/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc
@@ -1,11 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-configuring-higher-vm-workload-density"]
 = Configuring higher VM workload density
-include::_attributes/common-attributes.adoc[]
 :context: virt-configuring-higher-vm-workload-density
 
 toc::[]
 
+[role="_abstract"]
 You can increase the number of virtual machines (VMs) on nodes by overcommitting memory (RAM). Increasing VM workload density can be useful in the following situations:
 
 * You have many similar workloads.

--- a/virt/post_installation_configuration/virt-node-placement-virt-components.adoc
+++ b/virt/post_installation_configuration/virt-node-placement-virt-components.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-node-placement-virt-components"]
 = Specifying nodes for {VirtProductName} components
-include::_attributes/common-attributes.adoc[]
 :context: virt-node-placement-virt-components
 
 toc::[]
 
-The default scheduling for virtual machines (VMs) on bare metal nodes is appropriate. Optionally, you can specify the nodes where you want to deploy {VirtProductName} Operators, workloads, and controllers by configuring node placement rules.
+[role="_abstract"]
+The default scheduling for virtual machines (VMs) on bare-metal nodes is appropriate. Optionally, you can specify the nodes where you want to deploy {VirtProductName} Operators, workloads, and controllers by configuring node placement rules.
 
 [NOTE]
 ====

--- a/virt/post_installation_configuration/virt-post-install-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-config.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-post-install-config"]
 = Postinstallation configuration
-include::_attributes/common-attributes.adoc[]
 :context: virt-post-install-config
 
 toc::[]
 
-The following procedures are typically performed after {VirtProductName} is installed. You can configure the components that are relevant for your environment:
+[role="_abstract"]
+The following procedures are typically performed after you install {VirtProductName}. You can configure the components that are relevant for your environment:
 
 // * Cluster
 

--- a/virt/post_installation_configuration/virt-post-install-network-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-network-config.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-post-install-network-config"]
 = Postinstallation network configuration
-include::_attributes/common-attributes.adoc[]
 :context: virt-post-install-network-config
 
 toc::[]
 
-By default, {VirtProductName} is installed with a single, internal pod network.
+[role="_abstract"]
+By default, {VirtProductName} uses a single internal pod network after installation.
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 After you install {VirtProductName}, you can install networking Operators and configure additional networks.
@@ -24,7 +25,7 @@ You can install the xref:../../networking/hardware_networks/about-sriov.adoc#abo
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-You can add the xref:../../networking/networking_operators/metallb-operator/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator] to manage the lifecycle for an instance of MetalLB on your cluster. For installation instructions, see xref:../../networking/networking_operators/metallb-operator/metallb-operator-install.adoc#installing-the-metallb-operator-using-web-console_metallb-operator-install[Installing the MetalLB Operator from the software catalog using the web console].
+You can add the xref:../../networking/networking_operators/metallb-operator/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator] to manage the lifecycle for an instance of MetalLB on your cluster. For installation instructions, see xref:../../networking/networking_operators/metallb-operator/metallb-operator-install.adoc#metallb-installing-using-web-console_metallb-operator-install[Installing the MetalLB Operator from the software catalog by using the web console].
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 [id="configuring-linux-bridge-network"]
@@ -37,7 +38,9 @@ include::modules/virt-creating-linux-bridge-nncp.adoc[leveloffset=+2]
 include::modules/virt-creating-linux-bridge-nad-web.adoc[leveloffset=+2]
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-.Next steps
+[id="configuring-linux-bridge-network-next-steps"]
+== Next steps
+
 * xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-attaching-vm-secondary-network-cli_virt-connecting-vm-to-linux-bridge[Attaching a virtual machine (VM) to a Linux bridge network]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
@@ -60,7 +63,8 @@ include::modules/nw-sriov-configuring-device.adoc[leveloffset=+2]
 
 include::modules/nw-sriov-network-attachment.adoc[leveloffset=+2]
 
-.Next steps
+[id="next-steps_{context}"]
+== Next steps
 
 * xref:../../virt/vm_networking/virt-connecting-vm-to-sriov.adoc#virt-attaching-vm-to-sriov-network_virt-connecting-vm-to-sriov[Attaching a virtual machine (VM) to an SR-IOV network]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/virt/post_installation_configuration/virt-post-install-storage-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-storage-config.adoc
@@ -1,21 +1,22 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-post-install-storage-config"]
 = Postinstallation storage configuration
-include::_attributes/common-attributes.adoc[]
 :context: virt-post-install-storage-config
 
 toc::[]
 
+[role="_abstract"]
 The following storage configuration tasks are mandatory:
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * You must configure a xref:../../storage/dynamic-provisioning.adoc#defining-storage-classes_dynamic-provisioning[default storage class] for your cluster. Otherwise, the cluster cannot receive automated boot source updates.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
-* You must configure xref:../../virt/storage/virt-configuring-storage-profile.adoc#virt-configuring-storage-profile[storage profiles] if your storage provider is not recognized by CDI. A storage profile provides recommended storage settings based on the associated storage class.
+* You must configure xref:../../virt/storage/virt-configuring-storage-profile.adoc#virt-configuring-storage-profile[storage profiles] if your storage provider is not recognized by the Containerized Data Importer (CDI). A storage profile provides recommended storage settings based on the associated storage class.
 
 Optional: You can configure local storage by using the hostpath provisioner (HPP).
 
-See the xref:../../virt/storage/virt-storage-config-overview.adoc#virt-storage-config-overview[storage configuration overview] for more options, including configuring the Containerized Data Importer (CDI), data volumes, and automatic boot source updates.
+See the xref:../../virt/storage/virt-storage-config-overview.adoc#virt-storage-config-overview[storage configuration overview] for more options, including configuring the CDI, data volumes, and automatic boot source updates.
 
 [id="configuring-local-storage-hpp"]
 == Configuring local storage by using the HPP
@@ -26,7 +27,7 @@ The HPP is a local storage provisioner designed for {VirtProductName}. To use th
 
 [IMPORTANT]
 ====
-HPP storage pools must not be in the same partition as the operating system. Otherwise, the storage pools might fill the operating system partition. If the operating system partition is full, performance can be effected or the node can become unstable or unusable.
+HPP storage pools must not be in the same partition as the operating system. Otherwise, the storage pools might fill the operating system partition. If the operating system partition is full, this might negatively impact performance, or the node can become unstable or unusable.
 ====
 
 include::modules/virt-creating-storage-class-csi-driver.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.16+
(older versions of docs are too different structurally to CP this further)

Issue:
https://issues.redhat.com/browse/DOCPLAN-30

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- Not required, Vale changes only.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
