### PR TITLE
OSDOCS-15830 [NETOBSERV] Refactor release notes 1.9.0

### DIFF
--- a/modules/network-observability-operator-release-notes-1-8-0-new-features-and-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-8-0-new-features-and-enhancements.adoc
@@ -14,6 +14,7 @@ You can now enrich network flows with translated endpoint information, showing n
 
 For more information, see xref:../../../observability/network_observability/observing-network-traffic.adoc#network-observability-packet-translation-overview_nw-observe-network-traffic[Endpoint translation (xlat)] and xref:../../../observability/network_observability/observing-network-traffic.adoc#network-observability-packet-translation_nw-observe-network-traffic[Working with endpoint translation (xlat)].
 
+//OVN-Kubernetes only applies to OCP 4.17+. Noting for move to stand alone. Expect cherry-pick failures on 4.16, 4.15, 4.14, and 4.12
 [id="network-observability-operator-OVN-observability-1-8_{context}"]
 == OVN-Kubernetes networking events tracking
 

--- a/modules/network-observability-operator-release-notes-1-9-0-cves.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-0-cves.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-0-cves_{context}"]
+= Network Observability Operator 1.9.0 CVEs
+
+[role="_abstract"]
+You can review the CVEs for the Network Observability Operator 1.9.0 release.
+
+* link:https://access.redhat.com/security/cve/CVE-2025-26791[CVE-2025-26791]

--- a/modules/network-observability-operator-release-notes-1-9-0-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-0-fixed-issues.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-0-fixed-issues_{context}"]
+= Network Observability Operator 1.9.0 fixed issues
+
+[role="_abstract"]
+You can review the fixed issues for the Network Observability Operator 1.9.0 release.
+
+* Previously, when filtering by source or destination IP from the console plugin, using a Classless Inter-Domain Routing (CIDR) notation such as `10.128.0.0/24` did not work, returning results that should be filtered out. With this update, it is now possible to use a CIDR notation, with the results being filtered as expected. (link:https://issues.redhat.com/browse/NETOBSERV-2276[NETOBSERV-2276])
+
+* Previously, network flows might have incorrectly identified the network interfaces in use, especially with a risk of mixing up `eth0` and `ens5`. This issue only occurred when the eBPF agents were configured as `Privileged`. With this update, it has been fixed partially, and almost all network interfaces are correctly identified. Refer to the known issues below for more details. (link:https://issues.redhat.com/browse/NETOBSERV-2257[NETOBSERV-2257])
+
+* Previously, when the Operator checked for available Kubernetes APIs in order to adapt its behavior, if there was a stale API, this resulted in an error that prevented the Operator from starting normally. With this update, the Operator ignores error on unrelated APIs, logs errors on related APIs, and continues to run normally. (link:https://issues.redhat.com/browse/NETOBSERV-2240[NETOBSERV-2240])
+
+* Previously, users could not sort flows by *Bytes* or *Packets* in the *Traffic* flows view of the Console plugin. With this update, users can sort flows by *Bytes* and *Packets*. (link:https://issues.redhat.com/browse/NETOBSERV-2239[NETOBSERV-2239])
+
+* Previously, when configuring the `FlowCollector` resource with an IPFIX exporter, MAC addresses in the IPFIX flows were truncated to their 2 first bytes. With this update, MAC addresses are fully represented in the IPFIX flows. (link:https://issues.redhat.com/browse/NETOBSERV-2208[NETOBSERV-2208])
+
+* Previously, some of the warnings sent from the Operator validation webhook could lack clarity on what needed to be done. With this update, some of these messages have been reviewed and amended to make them more actionable. (link:https://issues.redhat.com/browse/NETOBSERV-2178[NETOBSERV-2178])
+
+* Previously, it was not obvious to figure out there was an issue when referencing a `LokiStack` from the `FlowCollector` resource, such as in case of typing error. With this update, the `FlowCollector` status clearly states that the referenced `LokiStack` is not found in that case. (link:https://issues.redhat.com/browse/NETOBSERV-2174[NETOBSERV-2174])
+
+* Previously, in the console plugin *Traffic flows* view, in case of text overflow, text ellipses sometimes hid much of the text to be displayed. With this update, it displays as much text as possible. (link:https://issues.redhat.com/browse/NETOBSERV-2119[NETOBSERV-2119])
+
+* Previously, the console plugin for network observability 1.8.1 and earlier did not work with the {product-title} 4.19 web console, making the *Network Traffic* page inaccessible. With this update, the console plugin is compatible and the *Network Traffic* page is accessible in network observability 1.9.0. (link:https://issues.redhat.com/browse/NETOBSERV-2046[NETOBSERV-2046])
+
+* Previously, when using conversation tracking (`logTypes: Conversations` or `logTypes: All` in the `FlowCollector` resource), the *Traffic* rates metrics visible in the dashboards were flawed, wrongly showing an out-of-control increase in traffic. Now, the metrics show more accurate traffic rates. However, note that in `Conversations` and `EndedConversations` modes, these metrics are still not completely accurate as they do not include long-standing connections. This information has been added to the documentation. The default mode `logTypes: Flows` is recommended to avoid these inaccuracy. (link:https://issues.redhat.com/browse/NETOBSERV-1955[NETOBSERV-1955])

--- a/modules/network-observability-operator-release-notes-1-9-0-known-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-0-known-issues.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-0-known-issues_{context}"]
+= Network Observability Operator 1.9.0 known issues
+
+[role="_abstract"]
+You can review the known issues for the Network Observability Operator 1.9.0 release.
+
+* The user-defined network (UDN) feature displays a configuration issue and a warning when used with {product-title} 4.18, even though it is supported. This warning can be ignored.  (link:https://issues.redhat.com/browse/NETOBSERV-2305[NETOBSERV-2305])
+
+* In some rare cases, the eBPF agent is unable to appropriately correlate flows with the involved interfaces when running in `privileged` modes with several network namespaces. A large part of these issues have been identified and resolved in this release, but some inconsistencies remain, especially with the `ens5` interface. (link:https://issues.redhat.com/browse/NETOBSERV-2287[NETOBSERV-2287])

--- a/modules/network-observability-operator-release-notes-1-9-0-new-features-and-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-0-new-features-and-enhancements.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-0-new-features-and-enhancements_{context}"]
+= Network Observability Operator 1.9.0 new features and enhancements
+
+[role="_abstract"]
+You can review the new features and enhancements for the Network Observability Operator 1.9.0 release.
+
+[id="user-defined-networks-with-network-observability_{context}"]
+== User-defined networks with network observability
+With this release, xref:../../../networking/multiple_networks/understanding-multiple-networks.adoc#understanding-multiple-networks[user-defined networks (UDN)] feature is generally available with network observability. When the `UDNMapping` feature is enabled in network observability, the *Traffic* flow table has a `UDN labels` column. You can filter logs on *Source Network Name* and *Destination Network Name* information.
+
+[id="filter-flowlogs-at-ingestion_{context}"]
+== Filter flowlogs at ingestion
+With this release, you can create filters to reduce the number of generated network flows and the resource usage of network observability components. The following filters can be configured:
+
+* eBPF Agent filters
+* Flowlogs-pipeline filters
+
+[id="ipsec-support_{context}"]
+== IPsec support
+This update brings the following enhancements to network observability when IPsec is enabled on {product-title}:
+
+* A new column named *IPsec Status* is displayed in the network observability *Traffic* flows view to show whether a flow was successfully IPsec-encrypted or if there was an error during encryption/decryption.
+
+* A new dashboard showing the percentage of encrypted traffic is generated.
+
+[id="network-observability-cli-1-9_{context}"]
+== Network Observability CLI
+The following filtering options are now available for packets, flows, and metrics capture:
+
+* Configure the ratio of packets being sampled by using the `--sampling` option.
+* Filter flows using a custom query by using the `--query` option.
+* Specify interfaces to monitor by using the `--interfaces` option.
+* Specify interfaces to exclude by using the `--exclude_interfaces` option.
+* Specify metric names to generate by using the `--include_list` option.
+
+For more information, see xref:../../../observability/network_observability/netobserv_cli/netobserv-cli-reference.adoc#network-observability-netobserv-cli-reference_netobserv-cli-reference[Network Observability CLI reference].

--- a/modules/network-observability-operator-release-notes-1-9-0-notable-technical-changes.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-0-notable-technical-changes.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-0-notable-technical-changes_{context}"]
+= Network Observability Operator release notes 1.9.0 notable technical changes
+
+[role="_abstract"]
+You can review the notable technical changes for the Network Observability Operator 1.6.0 release.
+
+* The `NetworkEvents` feature in network observability 1.9 has been updated to work with the newer Linux kernel of {product-title} 4.19. This update breaks compatibility with older kernels. As a result, the `NetworkEvents` feature can only be used with {product-title} 4.19. If you are using this feature with network observability 1.8 and {product-title} 4.18, consider avoiding a network observability upgrade or upgrade to network observability 1.9 and {product-title} to 4.19.
+
+* The `netobserv-reader` cluster role has been renamed to `netobserv-loki-reader`.
+
+* Improved CPU performance of the eBPF agents.

--- a/modules/network-observability-operator-release-notes-1-9-0-technology-preview-features.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-0-technology-preview-features.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-0-technology-preview-features_{context}"]
+= Network Observability Operator 1.9.0 Technology Preview features
+
+[role="_abstract"]
+You can review the Technology Preview features for the Network Observability Operator 1.9.0 release.
+
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+[id="ebpf-manager-operator-with-network-observability_{context}"]
+== eBPF Manager Operator with network observability
+
+The eBPF Manager Operator reduces the attack surface and ensures compliance, security, and conflict prevention by managing all eBPF programs. Network observability can use the eBPF Manager Operator to load hooks. This eliminates the need to provide the eBPF Agent with privileged mode or additional Linux capabilities like `CAP_BPF` and `CAP_PERFMON`. The eBPF Manager Operator with network observability is only supported on 64-bit AMD architecture.

--- a/modules/network-observability-operator-release-notes-1-9-0.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-0.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-0_{context}"]
+= Network Observability Operator 1.9.0 advisory
+
+[role="_abstract"]
+You can review the advisory for the Network Observability Operator 1.9.0 release.
+
+* link:https://access.redhat.com/errata/RHSA-2025:10020[Network Observability Operator 1.9]

--- a/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+++ b/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
@@ -21,7 +21,19 @@ include::modules/network-observability-operator-release-notes-1-9-2-advisory.ado
 include::modules/network-observability-operator-release-notes-1-9-2-bug-fixes.adoc[leveloffset=+1]
 
 //netobserv 1.9.1
-//netobserv 1.9.0
+include::modules/network-observability-operator-release-notes-1-9-0.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-9-0-new-features-and-enhancements.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-9-0-notable-technical-changes.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-9-0-technology-preview-features.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-9-0-cves.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-9-0-fixed-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-9-0-known-issues.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-8-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-15830](https://issues.redhat.com//browse/OSDOCS-15830) [NETOBSERV] Refactor release notes 1.9.0

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+ 

Rel notes refactor gets cherry-picked back to 4.12, 4.14, and 4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-15830

Link to docs preview:
* 1.9.0 advisory: https://102641--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-9-0_network-observability-operator-archived-release-notes
* 1.9.0 new features and enhancements: https://102641--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-9-0-new-features-and-enhancements_network-observability-operator-archived-release-notes 
* 1.9.0 notable technical changes: https://102641--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-9-0-notable-technical-changes_network-observability-operator-archived-release-notes 
* 1.9.0 Technology Preview features: https://102641--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-9-0-notable-technical-changes_network-observability-operator-archived-release-notes
* 1.9.0 CVEs: https://102641--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-9-0-cves_network-observability-operator-archived-release-notes
* 1.9.0 fixed issues: https://102641--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-9-0-fixed-issues_network-observability-operator-archived-release-notes
* 1.9.0 known issues: https://102641--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-9-0-known-issues_network-observability-operator-archived-release-notes

QE review:
QE is not required for this PR. This PR modularizes Network Observability Operator release notes for 1.3.0 only. There are no content changes. Straight copy/paste from existing content.

Additional information:

* For 1.9.0, per new guidance, there is an exception for xrefs in release notes modules. xrefs have been left as they are. There is a separate Jira to update xrefs in all newly created Network Observability Operator release note modules.
* The Network Observability Operator release notes are being modularized through a series of PRs. This means that things will get cleaned up and consolidated along the way.
* Some of these PRs may contain updates to previously merged content for the purpose of consistency.
* The network-observability-release-notes.adoc file will dwindle with each PR while the network-observability-operator-release-notes-archive.adoc file will grow.
In as many cases as possible, such as:
[id="network-observability-channel-removal-1.4_{context}"]
== Channel removal
existing ID in network-observability-release-notes.adoc has been used in the new module.
* Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. This will likely apply to release notes since it has been 1 assembly file and not all content is applicable to all OCP branches.
* I will manually verify content on each breach, and create manual cherry-picks accordingly.
------
* https://github.com/openshift/openshift-docs/pull/102562 must be merged first. Then rebase to capture 1.8.0 and 1.8.1.
   * Rebased 11/18/2025 AM. Captured updates from https://github.com/openshift/openshift-docs/pull/102562 .
------
* By this PR:
  * Rel notes for 1.1.0-1.6.2 including all z-streams, have been modularized. 
      * 45 new modules have been created for 1.1.0-1.8.1 including all z-streams.
      * 7 new modules are added with this PR
  * Rel notes for ~1.8.0, 1.8.1, 1.9.0,~ and 1.9.1 remain.
  * Rel notes for 1.9.2, 1.9.3, and 1.10.0 were modularized from the start as they were released when the new format was announced.
  * 1.9.2 and 1.9.3 are already in release_notes_archive
  * 1.10.0 can be moved to release_notes until 1.10.1
  * 1.10.1 modules will replace 1.10.0 modules in release_notes
  * 1.10.0 modules will be moved to release_notes_archive
  * Update stub to point to release_notes