### PR TITLE
[RHDEVDOCS-6786] Add `tkn pac cel` command

### DIFF
--- a/modules/op-pipelines-as-code-command-reference.adoc
+++ b/modules/op-pipelines-as-code-command-reference.adoc
@@ -36,9 +36,8 @@ $ tkn pac --help
 
 == Utility commands
 
-=== bootstrap
+bootstrap::
 
-.Bootstrapping {pac} installation and configuration
 [options="header"]
 |===
 
@@ -58,9 +57,8 @@ If you do not have an {OCP} cluster, it asks you for the public URL that points 
 
 |===
 
-=== repository
+repository::
 
-.Managing {pac} repositories
 [options="header"]
 |===
 
@@ -74,9 +72,8 @@ If you do not have an {OCP} cluster, it asks you for the public URL that points 
 
 |===
 
-=== generate
+generate::
 
-.Generating pipeline runs using {pac}
 [options="header"]
 |===
 
@@ -92,9 +89,8 @@ For example, if it detects a `setup.py` file at the repository root, the link:ht
 
 |===
 
-=== resolve
+resolve::
 
-.Resolving and executing pipeline runs using {pac}
 [options="header"]
 |===
 
@@ -115,3 +111,124 @@ The `-f` option can also accept a directory path and apply the `tkn pac resolve`
 You can override the default information gathered from the Git repository by specifying parameter values using the `-p` option. For example, you can use a Git branch as a revision and a different repository name.
 
 |===
+
+cel::
+
+[options="header"]
+|===
+
+| Command | Description
+
+| `tkn pac cel` | Evaluate CEL (Common Expression Language) expressions against webhook payloads and headers. Because the command requires access to the raw webhook payload and header data provided by the Git provider, it is intended for administrator use for testing and debugging event filtering logic in {pac}.
+
+|===
+
+:FeatureName: The `tkn pac cel` command
+include::snippets/technology-preview.adoc[]
+
+The `tkn pac cel` command uses the following syntax:
+
+[source,terminal]
+----
+tkn pac cel -b <body.json> -H <headers.txt> [-p <provider>]
+----
+
+[options="header"]
+|===
+| Option | Description
+
+| `-b, --body` | Specify the JSON payload file.
+| `-H, --headers` | Specify the headers file (plain text, JSON, or gosmee script).
+| `-p, --provider` | Optional: specify the Git provider (`auto`, `github`, `gitlab`, `bitbucket-cloud`, `bitbucket-datacenter`, `gitea`).
+|===
+
+*Header formats*
+
+The `tkn pac cel` command supports the following header formats:
+
+* Plain HTTP header format
++
+[source,text]
+----
+X-GitHub-Event: pull_request
+Content-Type: application/json
+User-Agent: GitHub-Hookshot/abc123
+----
+
+* JSON header format
++
+[source,json]
+----
+{
+  "X-GitHub-Event": "pull_request",
+  "Content-Type": "application/json",
+  "User-Agent": "GitHub-Hookshot/abc123"
+}
+----
+
+* Gosmee-generated shell scripts
++
+The `tkn pac cel` command automatically detects and parses headers from gosmee `--save` scripts. The following is an example using GitHub:
++
+[source,bash]
+----
+#!/usr/bin/env bash
+curl -X POST "http://localhost:8080/" \
+  -H "X-GitHub-Event: pull_request" \
+  -H "Content-Type: application/json" \
+  -H "User-Agent: GitHub-Hookshot/abc123" \
+  -d @payload.json
+----
+
+*Interactive mode*
+
+The `tkn pac cel` command displays an interactive `CEL expression` prompt when executed in a terminal. Expression history is navigable using arrow keys and persists between sessions. Pressing *Enter* on an empty line exits the prompt.
+
+*Non-interactive mode*
+
+The `tkn pac cel` command accepts CEL expressions using standard input (stdin), allowing evaluation without using the interactive prompt. For example:
+
+[source,terminal]
+----
+echo 'event == "pull_request"' | tkn pac cel -b body.json -H headers.txt
+----
+
+*Available variables*
+
+The `tkn pac cel` command exposes the following variables that can be used in CEL expressions to filter or inspect events:
+
+* `event`: Event type (`push`, `pull_request`)
+* `target_branch`: Target branch name
+* `source_branch`: Source branch name
+* `target_url`: Target repository URL
+* `source_url`: Source repository URL
+* `event_title`: Pull request title or commit message
+* `body.*`: All fields from the webhook payload
+* `headers.*`: All HTTP headers
+* `files.*`: Always empty in CLI mode
+* `pac.*`: All PAC parameters for backward compatibility
+
+[NOTE]
+====
+When evaluating CEL expressions locally using the CLI, `files.*` variables are always empty, and functions such as `fileChanged`, `fileDeleted`, and `fileModified` are unavailable.
+====
+
+*Example expressions*
+
+The following expressions illustrate typical use cases, including event filtering, branch matching, and header inspection:
+
+[source,terminal]
+----
+event == "pull_request" && target_branch == "main"
+event == "pull_request" && source_branch.matches(".*feat/.*")
+body.action == "synchronize"
+!body.pull_request.draft
+headers["x-github-event"] == "pull_request"
+----
+
+*History storage*
+
+The `tkn pac cel` command maintains a persistent history and creates the `cel-history` directory automatically if it does not exist in the following paths:
+
+* *Linux or macOS:* `~/.cache/tkn-pac/cel-history`
+* *Windows:* `%USERPROFILE%\.cache\tkn-pac\cel-history`


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.21

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6786

Link to docs preview:
- last entry in the [Utility commands](https://102685--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/pac-command-reference.html#utility-commands) section

QE review ([requested](https://redhat-internal.slack.com/archives/CG5GV6CJD/p1763980168561999)):
- [x] QE has approved this change.
