### PR TITLE
[RHDEVDOCS-6789] /ok-to-test supported in discussion threads

### DIFF
--- a/modules/op-running-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-running-pipeline-run-using-pipelines-as-code.adoc
@@ -15,7 +15,7 @@ In the event of a pull request or a merge request, {pac} also runs pipelines fro
 * The author is a public member on the organization of the repository.
 * The pull request author is listed in the `approvers` or `reviewers` section of the `OWNERS` file in the root of the repository, as defined in the https://www.kubernetes.dev/docs/guide/owners/[Kubernetes documentation]. {pac} supports the specification for the `OWNERS` and `OWNERS_ALIASES` files. If the `OWNERS` file includes a https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md#filters[filters] section, {pac} matches approvers and reviewers only against the `.*` filter.
 
-If the pull request author does not meet the requirements, another user who meets the requirements can comment `/ok-to-test` on the pull request, and start the pipeline run.
+If the pull request author does not meet the requirements, another user who meets the requirements can comment `/ok-to-test` on the pull request or in a discussion thread reply to start the pipeline run.
 
 [discrete]
 .Pipeline run execution


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.21

Issue:
- https://issues.redhat.com/browse/SRVKP-8324

Link to docs preview:
- [Running a pipeline run using Pipelines as Code](https://102687--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/managing-pipeline-runs-pac.html#running-pipeline-run-using-pipelines-as-code_managing-pipeline-runs-pac)

QE review ([requested](https://redhat-internal.slack.com/archives/CG5GV6CJD/p1763980168561999)):
- [x] QE has approved this change.
