### PR TITLE
OLS-2310: Create OLS 1.0.8 release notes

### DIFF
--- a/modules/ols-1-0-8-fixed-issues.adoc
+++ b/modules/ols-1-0-8-fixed-issues.adoc
@@ -1,0 +1,16 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-8-fixed-issues_{context}"]
+= Fixed issues
+
+{ols-official} 1.0.8 fixes the following issues:
+
+[NOTE]
+====
+Some linked Jira tickets are accessible only with {red-hat} credentials.
+====
+
+* Before this update, if you tried to attach two alerts with the same `alertname` to the {ols-long} prompt, the second alert would replace the first alert. With this update, it is now possible to attach multiple alerts with the same `alertname` to the {ols-long} prompt. https://issues.redhat.com/browse/OLS-2293[OLS-2293]

--- a/modules/ols-1-0-8-release-notes.adoc
+++ b/modules/ols-1-0-8-release-notes.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-1-8-release-notes_{context}"]
+= {ols-long} version 1.0.8
+
+{ols-official} 1.0.8 is now available on {ocp-product-title} 4.16 and later.
+
+[id="ols-1-0-8-enhancements_{context}"]
+== Enhancements
+
+The following enhancements have been made with {ols-official} 1.0.8:
+
+* With this update, it is now possible to attach the cluster details as YAML code to the {ols-long} prompt from the *Nodes* and *Add-ons* tabs of the Advanced Cluster Management UI.
+
+* With this update, it is now possible to attach `ApplicationSet` details as YAML to the {ols-long} prompt from the *Application details* page of the Advanced Cluster Management UI.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -13,6 +13,8 @@ The release notes highlight what is new and what has changed with each {ols-offi
 {ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
 ====
 
+include::modules/ols-1-0-8-release-notes.adoc[leveloffset=+1]
+include::modules/ols-1-0-8-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-7-release-notes.adoc[leveloffset=+1]
 include::modules/ols-1-0-7-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-6-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2310

Link to docs preview:
https://102689--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-0-1-8-release-notes_ols-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
