### PR TITLE
RHDEVDOCS-6891: CQA 2.0: Work with shared resources

### DIFF
--- a/modules/ephemeral-storage-creating-a-shared-secret-instance.adoc
+++ b/modules/ephemeral-storage-creating-a-shared-secret-instance.adoc
@@ -1,4 +1,4 @@
-// Module included in the following assembly:
+// Module included in the following assemblies:
 //
 // * work_with_shared_resources/creating-shared-resource-csi-driver.adoc
 
@@ -7,10 +7,11 @@
 = Creating a SharedSecret custom resource
 
 [role="_abstract"]
-You can create a `SharedSecret` custom resource (CR) to share a `Secret` object across namespaces.
+Create a `SharedSecret` custom resource (CR) to share a `Secret` object across namespaces. By creating a `SharedSecret` custom resource (CR), you can share a `Secret` object across namespaces, ensuring that sensitive configuration data remains consistently accessible cluster-wide.
 
 .Prerequisites
 
+* You are logged in to the {ocp-product-title} cluster as an administrator.
 * You have created a `Secret` object that you want to share in other namespaces. To create a `Secret` object, see "Creating Secrets".
 * You have subscribed to the cluster and have entitlement keys synced through the Insights Operator.
 * You must have permissions to perform the following actions: 
@@ -31,7 +32,7 @@ You can create a `SharedSecret` custom resource (CR) to share a `Secret` object 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: share-etc-pki-entitlement # <1>
+  name: share-etc-pki-entitlement
   namespace: openshift-config-managed
 rules:
   - apiGroups:
@@ -45,7 +46,10 @@ rules:
       - list
       - watch
 ----
-<1> Name of the `Role` CR.
++
+--
+* `metadata.name` defines the name of the `Role` CR.
+--
 
 +
 .Example `RoleBinding` object
@@ -54,20 +58,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: share-etc-pki-entitlement # <1>
+  name: share-etc-pki-entitlement
   namespace: openshift-config-managed
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: share-etc-pki-entitlement # <2>
+  name: share-etc-pki-entitlement 
 subjects:
   - kind: ServiceAccount
-    name: csi-driver-shared-resource # <3>
+    name: csi-driver-shared-resource
     namespace: openshift-builds
 ----
-<1> Name of the `RoleBinding` CR.
-<2> Name of the `Role` CR.
-<3> Name of the `ServiceAccount` CR.
+* `metadata.name` defines the name of the `RoleBinding` CR.
+* `roleRef.name` defines the name of the `Role` CR.
+* `subjects.name` defines the name of the `ServiceAccount` CR.
 
 . Create a `SharedSecret` CR by using the following example configuration:
 +
@@ -76,13 +80,13 @@ subjects:
 apiVersion: sharedresource.openshift.io/v1alpha1
 kind: SharedSecret
 metadata:
-  name: shared-test-secret # <1>
+  name: shared-test-secret
 spec:
   secretRef:
     name: test-secret
-    namespace: <name_of_the_source_namespace>
+    namespace: openshift-config-managed
 ----
-<1> Replace `<name_of_the_source_namespace>` with the name of the `SharedSecret` CR.
+* `spec.secretRef.namespace` defines the name of the `SharedSecret` CR.
 
 . Create a `ClusterRole` object that grants RBAC permission to use the referenced shared resource by using the following example configuration: 
 +
@@ -91,7 +95,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: use-shared-test-secret # <1>
+  name: use-shared-test-secret
 rules:
   - apiGroups:
       - sharedresource.openshift.io
@@ -102,7 +106,51 @@ rules:
     verbs:
       - use
 ----
-<1> Name of the `ClusterRole` CR.
+* `metadata.name` defines the name of the `ClusterRole` CR.
+
+.Verification
+
+. Run the following command to verify that the required `Role` is created:
++
+[source,terminal]
+----
+$ oc get role share-etc-pki-entitlement -n openshift-config-managed
+----
++
+.Example output
+[source,terminal]
+----
+NAME                        CREATED AT
+share-etc-pki-entitlement   2025-11-19T12:05:32Z
+----
+
+. Run the following command to verify that the required `RoleBinding` is created:
++
+[source,terminal]
+----
+$ oc get rolebinding share-etc-pki-entitlement -n openshift-config-managed
+----
++
+.Example output
+[source,terminal]
+----
+NAME                        ROLE                             AGE
+share-etc-pki-entitlement   Role/share-etc-pki-entitlement   2m
+----
+
+. Run the following command to verify that the required `ClusterRole` is created:
++
+[source,terminal]
+----
+$ oc get clusterrole use-shared-test-secret
+----
++
+.Example output
+[source,terminal]
+----
+NAME                     CREATED AT
+use-shared-test-secret   2025-11-19T12:05:44Z
+----
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/ephemeral-storage-creating-sharedconfigmap-custom-resource.adoc
+++ b/modules/ephemeral-storage-creating-sharedconfigmap-custom-resource.adoc
@@ -7,10 +7,11 @@
 = Creating a SharedConfigMap custom resource
 
 [role="_abstract"]
-You can create a `SharedConfigMap` custom resource (CR) instance to share a `ConfigMap` object across namespaces. 
+Create a `SharedConfigMap` custom resource (CR) to share a `ConfigMap` object across namespaces. By creating a `SharedConfigMap` custom resource (CR), you can share configuration data across namespaces, ensuring that sensitive configuration data remains consistently accessible cluster-wide.
 
 .Prerequisites
 
+* You are logged in to the {ocp-product-title} cluster as an administrator.
 * You have created a `ConfigMap` object that you want to share in other namespaces. To create a `ConfigMap` object, see "Adding input secrets and configmaps".
 * You must have permissions to perform the following actions:
 ** Create the `sharedconfigmaps.sharedresource.openshift.io` CR at a cluster-scoped level.
@@ -31,14 +32,19 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: shared-test-config
-  namespace: <name_of_the_source_namespace> # <1>
+  namespace: <name_of_the_source_namespace>
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     resourceNames: ["shared-config"]
     verbs: ["get", "list", "watch"]
 ----
-<1> Replace `<name_of_the_source_namespace>` with the name of the source namespace.
++
+--
+where:
+
+`<name_of_the_source_namespace>`:: Specifies the name of the source namespace.
+--
 
 +
 .Example `RoleBinding` object
@@ -48,18 +54,22 @@ rules:
  kind: RoleBinding
  metadata:
    name: shared-test-config
-   namespace: <name_of_the_source_namespace> # <1>
+   namespace: <name_of_the_source_namespace>
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: Role
    name: shared-test-config
- subjects: # <2>
+ subjects:
    - kind: ServiceAccount
      name: csi-driver-shared-resource
      namespace: openshift-builds
 ----
-<1> Replace `<name_of_the_source_namespace>` with the name of the source namespace.
-<2> Specifies a list of service accounts for the Shared Resource CSI driver DaemonSet. When deployed with {builds-title}, the service account name is `csi-driver-shared-resource`, and the namespace matches the one where the {builds-operator} is deployed.
++
+where:
+
+`<name_of_the_source_namespace>`:: Specifies the name of the source namespace.
+
+`subjects`:: Specifies a list of service accounts for the Shared Resource CSI driver DaemonSet. When deployed with {builds-title}, the service account name is `csi-driver-shared-resource`, and the namespace matches the one where the {builds-operator} is deployed.
 
 . Create a `SharedConfigMap` CR for the `ConfigMap` object that you want to share across namespaces in the cluster. The following example shows a sample configuration:
 +
@@ -68,14 +78,18 @@ rules:
 apiVersion: sharedresource.openshift.io/v1alpha1
 kind: SharedConfigMap
 metadata:
-  name: share-test-config # <1>
+  name: share-test-config
 spec:
   configMapRef:
     name: shared-config
-    namespace: <name_of_the_source_namespace> # <2>
+    namespace: <name_of_the_source_namespace>
 ----
-<1> Specifies the name of the `SharedConfigMap` CR.
-<2> Replace `<name_of_the_source_namespace>` with the name of your source namespace.
++
+where:
+
+`metadata.name`:: Specifies the name of the `SharedConfigMap` CR.
+
+`<name_of_the_source_namespace>`:: Specifies the name of your source namespace.
 
 . Create a `ClusterRole` CR instance that grants role-based access control (RBAC) permission to use the referenced shared resource. The following example shows a sample configuration:
 +
@@ -84,19 +98,67 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: <cluster_role_name> # <1>
+  name: <cluster_role_name>
 rules:
   - apiGroups:
       - sharedresource.openshift.io
     resources:
       - sharedconfigmaps
     resourceNames:
-      - share-test-config # <2>
+      - share-test-config
     verbs:
       - use
 ----
-<1> Replace `<cluster_role_name>` with the name of your cluster role.
-<2> Specifies the name of the `SharedSecret` CR.
++
+where:
+
+`<cluster_role_name>`:: Specifies the name of your cluster role.
+
+`rules.resourceNames`:: Defines name of the `SharedConfigMap` CR.
+
+.Verification
+
+. Run the following command to verify that the required `Role` is created:
++
+[source,terminal]
+----
+$ oc get role share-etc-pki-entitlement -n openshift-config-managed
+----
++
+.Example output
+[source,terminal]
+----
+NAME                        CREATED AT
+share-etc-pki-entitlement   2025-11-19T12:05:32Z
+----
+
+. Run the following command to verify that the required `RoleBinding` is created:
++
+[source,terminal]
+----
+$ oc get rolebinding share-etc-pki-entitlement -n openshift-config-managed
+----
++
+.Example output
+[source,terminal]
+----
+NAME                        ROLE                             AGE
+share-etc-pki-entitlement   Role/share-etc-pki-entitlement   2m
+----
+
+. Run the following command to verify that the required `ClusterRole` is created:
++
+[source,terminal]
+----
+$ oc get clusterrole use-shared-test-secret
+----
++
+.Example output
+[source,terminal]
+----
+NAME                     CREATED AT
+use-shared-test-secret   2025-11-19T12:05:44Z
+----
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/ephemeral-storage-sharing-configmaps-across-namespaces.adoc
+++ b/modules/ephemeral-storage-sharing-configmaps-across-namespaces.adoc
@@ -2,9 +2,9 @@
 //
 // * work_with_shared_resources/using-shared-resource-csi-driver.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="ephemeral-storage-sharing-configmaps-across-namespaces_{context}"]
 = Sharing a ConfigMap object across namespaces
 
 [role="_abstract"]
-A `ConfigMap` object stores non-sensitive configuration data, such as application URLs or feature flags. A `SharedConfigMap` custom resource (CR) enables you to securely share a `ConfigMap` object across multiple namespaces in a cluster without manual duplication. By sharing a `ConfigMap` object, you establish a single source of configuration data and ensure consistency across the cluster.
+A `ConfigMap` object stores non-sensitive data, such as URLs or feature flags. By using a `SharedConfigMap` custom resource (CR), you can share a `ConfigMap` object across namespaces without duplication, providing a single configuration source and ensuring consistency cluster-wide.

--- a/modules/ephemeral-storage-sharing-secrets-across-namespaces.adoc
+++ b/modules/ephemeral-storage-sharing-secrets-across-namespaces.adoc
@@ -2,7 +2,7 @@
 //
 // * work_with_shared_resources/using-shared-resource-csi-driver.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="ephemeral-storage-sharing-secret-across-namespaces_{context}"]
 = Sharing a Secret object across namespaces
 

--- a/modules/ephemeral-storage-using-a-sharedconfigmap-object-in-a-pod.adoc
+++ b/modules/ephemeral-storage-using-a-sharedconfigmap-object-in-a-pod.adoc
@@ -11,7 +11,9 @@ To access a `SharedConfigMap` custom resource (CR) from a pod, you must grant th
 
 .Prerequisites
 
-* You have created a `SharedConfigMap` CR instance for the config map that you want to share across namespaces in the cluster.
+* You are logged in to the {ocp-product-title} cluster  as one of the following users:
+** A cluster administrator who has created the `SharedConfigMap` CR instance for the `ConfigMap` object.
+** A user with permissions to access the target namespaces and to create or manage the `SharedConfigMap` CR for the `ConfigMap` to be shared.
 * You must have permissions to perform the following actions:
 ** Run the `oc get sharedconfigmaps` command to get the list of the `SharedConfigMap` CR instances.
 ** Run the `oc adm policy who-can use <sharedsecret_identifier>` command to check if a service account is allowed to use the `SharedSecret` CR and the service account is listed in your namespace.
@@ -32,17 +34,20 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: use-shared-config
-  namespace: <app_namespace> <1>
+  namespace: <app_namespace>
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: use-shared-config
 subjects:
   - kind: ServiceAccount
-    name: <service_account_name> <2> 
+    name: <service_account_name>
 ----
-<1> Replace `<app_namespace>` with the namespace name of your application.
-<2> Replace `<service_account_name>` with the service account name of your application.
++
+where:
+
+`<app_namespace>`:: Specifies the name of the namespace of your application.
+`<service_account_name>`:: Specifies the service account name of your application.
 
 . Mount the Shared Resource Container Storage Interface (CSI) Driver into a pod or any other resource that accepts `csi` volumes. 
 +
@@ -52,7 +57,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: example-shared-config
-  namespace: <app_namespace> # <1>
+  namespace: <app_namespace>
 spec:
   ...
   serviceAccountName: default
@@ -62,12 +67,45 @@ spec:
         readOnly: true 
         driver: csi.sharedresource.openshift.io
         volumeAttributes:
-          sharedConfigMap: share-test-config # <2>
+          sharedConfigMap: share-test-config
 ----
-<1> Replace <app_namespace> with the namespace name of your application.
-<2> Specifies the name of the `sharedConfigMap` object. 
++
+where:
+
+`<app_namespace>`:: Specifies the name of the namespace of your application.
+
+`volumes.volumeAttributes.sharedConfigMap`:: Specifies the name of the `sharedConfigMap` object. 
+
 +
 [IMPORTANT]
 ====
-If the value of `sharedConfigMap` attribute does not match the name of `sharedConfigMap` instance, the pod fails to start.
+The pod fails to start in the following cases:
+
+* The value of the `SharedConfigMap` attribute does not match the name of the `SharedConfigMap` instance.
+* A volume is defined but not mounted, the pod stays in the `ContainerCreating` state and eventually fails.
 ====
+
+.Verification
+
+. Run the following command to verify the permission granted to your service account:
++
+[source,terminal]
+----
+$ oc describe rolebinding share-etc-pki-entitlement -n openshift-config-managed
+----
++
+.Example output
++
+[source,terminal]
+----
+Name:         share-etc-pki-entitlement
+Labels:       <none>
+Annotations:  <none>
+Role:
+  Kind:  Role
+  Name:  share-etc-pki-entitlement
+Subjects:
+  Kind            Name                        Namespace
+  ----            ----                        ---------
+  ServiceAccount  csi-driver-shared-resource  openshift-builds
+----

--- a/modules/ephemeral-storage-using-a-sharedsecret-object-in-a-pod.adoc
+++ b/modules/ephemeral-storage-using-a-sharedsecret-object-in-a-pod.adoc
@@ -11,7 +11,9 @@ To access the `SharedSecret` custom resource (CR) from a pod, you grant role-bas
 
 .Prerequisites
 
-* You have created a `SharedSecret` CR instance for the `Secret` object that you want to share across namespaces in the cluster.
+* You are logged in to the {ocp-product-title} cluster  as one of the following users:
+** A cluster administrator who has created the `SharedSecret` CR instance for the `Secret` object.
+** A user with permissions to access the target namespaces and to create or manage the `SharedSecret` custom resource for the `Secret` to be shared.
 * You must have permissions to perform the following actions:
 ** Run the `oc adm policy who-can use <sharedsecret_identifier>` command to check if a service account is allowed to use the `SharedSecret` CR and the service account is listed in your namespace.
 ** Confirm that the service account of your pod is allowed to use the `csi` volume. If you created the pod as a user, confirm that you are allowed to use the `csi` volume.
@@ -30,7 +32,7 @@ If you are unable to complete the last two prerequisites, the cluster administra
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: use-shared-secret <1>
+  name: use-shared-secret
   namespace: app-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -38,10 +40,14 @@ roleRef:
   name: use-shared-secret
 subjects:
   - kind: ServiceAccount
-    name: <service_account_name> <2> 
+    name: <service_account_name>
 ----
-<1> Name of the `RoleBinding` CR. 
-<2> Replace `<service_account_name>` with the service account name of your application.
++
+where:
+
+`metadata.name`:: Defines the name of the `RoleBinding` CR. 
+
+`<service_account_name>`:: Specifies the name of the service account of your application.
 
 . Mount the shared resource `csi` driver into a pod or any other resource that accepts `csi` volumes. See the following example configuration:
 +
@@ -51,7 +57,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: example-shared-secret
-  namespace: <app_namespace> <1>
+  namespace: <app_namespace>
 spec:
   ...
   serviceAccountName: default
@@ -61,12 +67,46 @@ spec:
         readOnly: true 
         driver: csi.sharedresource.openshift.io
         volumeAttributes:
-          sharedSecret: shared-test-secret <2>
+          sharedSecret: shared-test-secret
 ----
-<1> Replace <app_namespace> with the namespace name of your application.
-<2> Value of the `sharedSecret` attribute that must be same as the name of the `SharedSecret` CR.
++
+where:
+
+`<app_namespace>`:: Specifies the name of the namespace of your application.
+
+`volumes.volumeAttributes.sharedSecret`:: Defines the value of the `sharedSecret` attribute that must be same as the name of the `SharedSecret` CR.
+
 +
 [IMPORTANT]
 ====
-If the value of the `sharedSecret` attribute does not match the name of the `SharedSecret` instance, the pod fails to start.
+The pod fails to start in the following cases:
+
+* The value of the `sharedSecret` attribute does not match the name of the `SharedSecret` instance.
+* A volume is defined but not mounted, the pod stays in the `ContainerCreating` state and eventually fails.
 ====
+
+.Verification
+
+. Run the following command to verify the permission granted to your service account:
++
+[source,terminal]
+----
+$ oc describe rolebinding share-etc-pki-entitlement -n openshift-config-managed
+----
++
+.Example output
++
+[source,terminal]
+----
+Name:         share-etc-pki-entitlement
+Labels:       <none>
+Annotations:  <none>
+Role:
+  Kind:  Role
+  Name:  share-etc-pki-entitlement
+Subjects:
+  Kind            Name                        Namespace
+  ----            ----                        ---------
+  ServiceAccount  csi-driver-shared-resource  openshift-builds
+----
+

--- a/modules/sharing-RHEL-entitlement-secret-across-namespaces.adoc
+++ b/modules/sharing-RHEL-entitlement-secret-across-namespaces.adoc
@@ -39,6 +39,7 @@ spec:
     namespace: openshift-config-managed
 EOF
 ----
+* `metadata.name` defines the name of the `SharedSecret` object.
 
 . Create a `ClusterRole` object to grant permission to access the `SharedSecret` object by using the following example configuration:
 +
@@ -47,7 +48,7 @@ EOF
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: use-share-etc-pki-entitlement # <1>
+  name: use-share-etc-pki-entitlement
 rules:
   - apiGroups:
       - sharedresource.openshift.io
@@ -58,7 +59,7 @@ rules:
     verbs:
       - use
 ----
-<1> Name of the `ClusterRole` CR.
+* `metadata.name` defines the name of the `ClusterRole` CR.
 
 . Create the `Role` and `RoleBinding` object that grants the Shared Resource CSI driver the permission to access the `SharedSecret` object:
 +
@@ -68,7 +69,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: share-etc-pki-entitlement # <1>
+  name: share-etc-pki-entitlement
   namespace: openshift-config-managed
 rules:
   - apiGroups:
@@ -82,8 +83,11 @@ rules:
       - list
       - watch
 ----
-<1> Name of the `Role` CR.
-
++
+--
+* `metadata.name` defines the name of the `Role` CR.
+--
++
 .Example `RoleBinding` object
 +
 [source,yaml]
@@ -91,7 +95,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: share-etc-pki-entitlement # <1>
+  name: share-etc-pki-entitlement
   namespace: openshift-config-managed
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -100,11 +104,10 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: csi-driver-shared-resource
-    namespace: openshift-builds # <2>
+    namespace: openshift-builds
 ----
-+
-<1> Name of the `RoleBinding` CR.
-<2> Name of the namespace where `openshift-builds` is installed.
+* `metadata.name` defines the name of the `RoleBinding` CR.
+* `subjects.namespace` defines the name of the namespace where `openshift-builds` is installed.
 
 . Create a `RoleBinding` object for the `builder` and `pipeline` service accounts in the namespace where builds run:
 +
@@ -113,7 +116,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: use-share-etc-pki-entitlement # <1>
+  name: use-share-etc-pki-entitlement
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -125,7 +128,8 @@ subjects:
     name: builder
 ----
 +
-<1> Name of the `RoleBinding` CR for the `builder` and `pipeline` service accounts.
+* `metadata.name` defines the name of the `RoleBinding` CR for the `builder` and `pipeline` service accounts.
+
 +
 [NOTE]
 ====
@@ -156,14 +160,19 @@ spec:
   volumes:
   - csi:
       driver: csi.sharedresource.openshift.io
-      readOnly: true # <1>
+      readOnly: true
       volumeAttributes:
-        sharedSecret: <sharedsecret_object_name> # <2>
+        sharedSecret: <sharedsecret_object_name>
     name: etc-pki-entitlement 
   output:
-    image: <output_image_location> # <3>
+    image: <output_image_location>
 EOF
 ----
-<1> You must set `readOnly` to `true` to mount the shared resource in the build.
-<2> Replace `<sharedsecret_object_name>` with the name of the `SharedSecret` object to include it in the build.
-<3> Replace `<output_image_location>` with the location where you want to push the built image.
++
+where:
+
+`volumes.csi.readOnly`:: Defines that you must set `readOnly` to `true` to mount the shared resource in the build.
+
+`<sharedsecret_object_name>`:: Specifies the name of the `SharedSecret` object to include it in the build.
+
+`<output_image_location>`:: Specifies the location where you want to push the built image.

--- a/work_with_shared_resources/using-shared-resource-csi-driver.adoc
+++ b/work_with_shared_resources/using-shared-resource-csi-driver.adoc
@@ -8,14 +8,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Storage vendors have traditionally provided storage drivers as a part of Kubernetes. With the implementation of the Container Storage Interface (CSI), third-party providers can deliver storage plugins by using a standard interface without changing the core Kubernetes code. CSI Operators give {builds-shortname}' users storage options, such as volume snapshots that are not possible with in-tree volume plugins.
-
-The Shared Resource CSI driver is a special type of CSI driver that allows cluster administrators to securely share `Secret` and `ConfigMap` objects across namespaces by using the `csi` volume type. The Shared resources CSI driver provisions inline ephemeral volumes, enabling pods and {ocp-product-title} Builds to use these shared resources.
-
-The Shared Resource CSI driver supports the following types of custom resources:
-
-* `SharedSecret` custom resource for sharing `Secret` objects
-* `SharedConfigMap` custom resource for sharing `ConfigMap` objects
+To securely share `Secret` and `ConfigMap` objects across namespaces, use the Shared Resource Container Storage Interface (CSI) driver with the `csi` volume type. This driver provisions inline ephemeral volumes, enabling pods and {builds-shortname} to utilize these shared configuration resources.
 
 include::modules/ephemeral-storage-sharing-secrets-across-namespaces.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): build-docs-1.5, 1.6, 1.7
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/RHDEVDOCS-6891
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://102701--ocpdocs-pr.netlify.app/openshift-builds/latest/work_with_shared_resources/using-shared-resource-csi-driver.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
As per [this](See this thread -  https://redhat-internal.slack.com/archives/C0508QK0RHN/p1760704684080379
) thread, I have not updated the block titles.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
