### PR TITLE
OSDOCS-17380 CLI Manager 0.2.0 release notes

### DIFF
--- a/cli_reference/cli_manager/cli-manager-release-notes.adoc
+++ b/cli_reference/cli_manager/cli-manager-release-notes.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="cli-manager-release-notes"]
 = {cli-manager} release notes
-include::_attributes/common-attributes.adoc[]
 :context: cli-manager-release-notes
 
 toc::[]
@@ -14,6 +14,22 @@ include::snippets/technology-preview.adoc[]
 These release notes track the development of the {cli-manager} for {product-title}.
 
 For more information about the {cli-manager}, see xref:../../cli_reference/cli_manager/index.adoc#cli-manager-overview[About the {cli-manager}].
+
+[id="cli-manager-release-notes-0-2-0_{context}"]
+== {cli-manager} 0.2.0 (Technology Preview)
+
+Issued: 9 December 2025
+
+The following advisory is available for the {cli-manager} 0.2.0:
+
+* link:https://access.redhat.com/errata/RHBA-2025:22803[RHBA-2025:22803]
+
+[id="cli-manager-0-2-0-new-features-and-enhancements_{context}"]
+=== New features and enhancements
+
+* This release of the {cli-manager} updates the Kubernetes version to 1.34.
+
+* The `readOnlyRootFilesystem` flag is set to `true` for additional hardening of {product-title} pods.
 
 [id="cli-manager-release-notes-0-1-1_{context}"]
 == {cli-manager} 0.1.1 (Technology Preview)


### PR DESCRIPTION
Version(s): 4.17+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:[OSDOCS-17380](https://issues.redhat.com/browse/OSDOCS-17380)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://102708--ocpdocs-pr.netlify.app/openshift-enterprise/latest/cli_reference/cli_manager/cli-manager-release-notes.html#cli-manager-release-notes-0-2-0_cli-manager-release-notes 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
