### PR TITLE
OSDOCS-17361 [NETOBSERV] Refactor release notes 1.9.1

### DIFF
--- a/modules/network-observability-operator-release-notes-1-9-1-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-1-fixed-issues.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-1-fixed-issues_{context}"]
+= Network Observability Operator 1.9.1 fixed issues
+
+[role="_abstract"]
+You can review the fixed issues for the Network Observability Operator 1.9.1 release.
+
+* Before this update, network flows were not observed on {product-title} 4.15 due to an incorrect attach mode setting. This stopped users from monitoring network flows correctly, especially with certain catalogs. With this release, the default attach mode for {product-title} versions older than 4.16.0 is set to `tc`, so flows are now observed on {product-title} 4.15. (link:https://issues.redhat.com/browse/NETOBSERV-2333[NETOBSERV-2333])
+
+* Before this update, if an IPFIX collector restarted, configuring an IPFIX exporter could lose its connection and stop sending network flows to the collector. With this release, the connection is restored, and network flows continue to be sent to the collector. (link:https://issues.redhat.com/browse/NETOBSERV-2315[NETOBSERV-2315])
+
+* Before this update, when you configured an IPFIX exporter, flows without port information (such as ICMP traffic) were ignored, which caused errors in logs. TCP flags and ICMP data were also missing from IPFIX exports. With this release, these details are now included. Missing fields (like ports) no longer cause errors and are part of the exported data. (link:https://issues.redhat.com/browse/NETOBSERV-2307[NETOBSERV-2307])
+
+* Before this update, the User Defined Networks (UDN) Mapping feature showed a configuration issue and warning on {product-title} 4.18 because the OpenShift version was incorrectly set in the code. This impacted the user experience. With this release, UDN Mapping now supports {product-title} 4.18 without warnings, making the user experience smooth. (link:https://issues.redhat.com/browse/NETOBSERV-2305[NETOBSERV-2305])
+
+* Before this update, the expand function on the *Network Traffic* page had compatibility problems with {product-title} Console 4.19. This resulted in empty menu space when expanding and an inconsistent user interface. With this release, the compatibility problem in the `NetflowTraffic` part and `theme hook` is resolved. The side menu in the *Network Traffic* view is now properly managed, which improves how you interact with the user interface. (link:https://issues.redhat.com/browse/NETOBSERV-2304[NETOBSERV-2304])

--- a/modules/network-observability-operator-release-notes-1-9-1.adoc
+++ b/modules/network-observability-operator-release-notes-1-9-1.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+// * network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-9-1_{context}"]
+= Network Observability Operator 1.9.1 advisory
+
+[role="_abstract"]
+You can review the advisory for the Network Observability Operator 1.9.1 release.
+
+The following advisory is available for the Network Observability Operator 1.9.1:
+
+* link:https://access.redhat.com/errata/RHEA-2025:12024[2025:12024 Network Observability Operator 1.9.1]

--- a/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+++ b/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
@@ -20,7 +20,10 @@ include::modules/network-observability-operator-release-notes-1-9-2-advisory.ado
 
 include::modules/network-observability-operator-release-notes-1-9-2-bug-fixes.adoc[leveloffset=+1]
 
-//netobserv 1.9.1
+include::modules/network-observability-operator-release-notes-1-9-1.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-9-1-fixed-issues.adoc[leveloffset=+1]
+
 include::modules/network-observability-operator-release-notes-1-9-0.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-9-0-new-features-and-enhancements.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-17361](https://issues.redhat.com//browse/OSDOCS-17361) [NETOBSERV] Refactor release notes 1.9.1

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+ 

Rel notes refactor gets cherry-picked back to 4.12, 4.14, and 4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-17361

Link to docs preview:
* 1.9.1 advisory: https://102709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-9-1_network-observability-operator-archived-release-notes
* 1.9.1 fixed issues: https://102709--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#network-observability-operator-release-notes-1-9-1-fixed-issues_network-observability-operator-archived-release-notes 

QE review:
QE is not required for this PR. This PR modularizes Network Observability Operator release notes for 1.9.1 only. There are no content changes.

Additional information:

* The Network Observability Operator release notes are being modularized through a series of PRs. This means that things will get cleaned up and consolidated along the way.
* Some of these PRs may contain updates to previously merged content for the purpose of consistency.
* The network-observability-release-notes.adoc file will dwindle with each PR while the network-observability-operator-release-notes-archive.adoc file will grow.
In as many cases as possible, such as:
[id="network-observability-channel-removal-1.4_{context}"]
== Channel removal
existing ID in network-observability-release-notes.adoc has been used in the new module.
* Since not all content applies to every OCP branch, it is possible there will be cherry-pick failures. This will likely apply to release notes since it has been 1 assembly file and not all content is applicable to all OCP branches.
* I will manually verify content on each breach, and create manual cherry-picks accordingly.
------
* https://github.com/openshift/openshift-docs/pull/102641 must be merged first. Then rebase to capture 1.9.0 .
   * Rebased 11/19/2025 AM. Captured 1.9.0 from https://github.com/openshift/openshift-docs/pull/102641 .
------
* By this PR:
  * Rel notes for 1.1.0-1.6.2 including all z-streams, have been modularized. 
      * 52 new modules have been created for 1.1.0-1.9.0 including all z-streams.
      * 2 new modules are added with this PR
  * Rel notes for ~1.8.0, 1.8.1, 1.9.0,and 1.9.1~  remain.
  * Rel notes for 1.9.2, 1.9.3, and 1.10.0 were modularized from the start as they were released when the new format was announced.
  * 1.9.2 and 1.9.3 are already in release_notes_archive
  * 1.10.0 can be moved to release_notes until 1.10.1
  * 1.10.1 modules will replace 1.10.0 modules in release_notes
  * 1.10.0 modules will be moved to release_notes_archive
  * Update stub to point to release_notes
