### PR TITLE
OSDOCS-17319 updates to ESO documentation

### DIFF
--- a/modules/external-secrets-bit-warden-config.adoc
+++ b/modules/external-secrets-bit-warden-config.adoc
@@ -7,7 +7,7 @@
 = Configuring the bitwardenSecretManagerProvider plugin
 
 [role="_abstract"]
-You can enable the `bitwardenSecretManagerProvider` to use the Bitwarden Secrets Manager provider as a source for your secrets.
+Configure the `bitwardenSecretManagerProvider` plugin to use Bitwarden Secrets Manager as a source for your secrets. By using this integration, you can sync external secrets to your {product-title} cluster.
 
 .Prerequisites
 

--- a/modules/external-secrets-cert-manager-config.adoc
+++ b/modules/external-secrets-cert-manager-config.adoc
@@ -7,7 +7,7 @@
 = Configuring cert-manager for the external-secrets certificate requirements
 
 [role="_abstract"]
-The `external-secrets` webhook and plugins can be assigned to `cert-manager` for certificate management. This configuration is optional.
+Configure cert-manager to handle certificate management for the external-secrets webhook and plugins. This optional configuration automates certificate generation for plugins and eliminates the need for manual configuration.
 
 When `cert-manager` is not used, `external-secrets` defaults to its own certificate management. In this mode, it automatically generates the required certificates for the webhook, while you are responsible for manually configuring certificates for the plugins.
 

--- a/modules/external-secrets-enable-operand-log-level.adoc
+++ b/modules/external-secrets-enable-operand-log-level.adoc
@@ -7,7 +7,7 @@
 = Setting a log level for the {external-secrets-operator} operand
 
 [role="_abstract"]
-You can set a log level for the {external-secrets-operator} to determine the verbosity of log messages.
+Set the log level for the {external-secrets-operator} operand to control the verbosity of log messages. By doing this task, you can adjust the amount of detail recorded for troubleshooting or monitoring purposes.
 
 .Prerequisites
 

--- a/modules/external-secrets-enable-operator-log-level.adoc
+++ b/modules/external-secrets-enable-operator-log-level.adoc
@@ -7,7 +7,7 @@
 = Setting a log level for the {external-secrets-operator}
 
 [role="_abstract"]
-You can set a log level for the {external-secrets-operator} to determine the verbosity of the operator log messages.
+Set the log level for the {external-secrets-operator} to control the detail of log messages. By adjusting the verbosity, you can troubleshoot issues effectively and manage the volume of log data.
 
 .Prerequisites
 

--- a/modules/external-secrets-enable-user-workload-monitor.adoc
+++ b/modules/external-secrets-enable-user-workload-monitor.adoc
@@ -7,7 +7,9 @@
 = Enabling user workload monitoring
 
 [role="_abstract"]
-You can enable monitoring for user-defined projects by configuring user workload monitoring in the cluster. For more information, see "Setting up metrics collection for user-defined projects".
+To enable metrics collection for user-defined projects, configure user workload monitoring in the {product-title} cluster. With this configuration, you can maintain visibility into the performance and status of your specific project workloads.
+
+For more information, see "Setting up metrics collection for user-defined projects".
 
 .Prerequisites
 

--- a/modules/external-secrets-operand-install-cli.adoc
+++ b/modules/external-secrets-operand-install-cli.adoc
@@ -4,9 +4,10 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="external-secrets-operand-install-cli_{context}"]
-= Installing the External Secrets operand for Red Hat OpenShift by using the CLI
+= Installing the External Secrets operand by using the CLI
 
-You can use the command-line interface (CLI) to install the External Secrets operand.
+[role="_abstract"]
+Install the External Secrets operand on {product-title} by using the CLI to create the necessary configuration object. By completing this task, you ensure that the External Secrets Operator is properly configured to manage secrets from external APIs on your cluster.
 
 .Prerequisites
 
@@ -14,27 +15,35 @@ You can use the command-line interface (CLI) to install the External Secrets ope
 
 .Procedure
 
-. Create a `externalsecrets.openshift.operator.io` object by defining a YAML file with the following content:
+. Create an `externalsecretsconfig.openshift.operator.io` object by defining a YAML file with the following content:
 +
-.Example `externalsecrets.yaml` file
+.Example `externalsecretsconfig.yaml` file.
++
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1alpha1
-kind: ExternalSecrets
+kind: ExternalSecretsConfig
 metadata:
   labels:
-    app.kubernetes.io/name: external-secrets-operator
+    app: external-secrets-operator
+    app.kubernetes.io/name: cluster
   name: cluster
-spec: {}
+spec:
+  controllerConfig:
+    networkPolicies:
+    - componentName: ExternalSecretsCoreController
+      egress:
+      - {}
+      name: allow-external-secrets-egress
 ----
 +
 For more information on spec configuration, see "External Secrets Operator for Red Hat OpenShift APIs".
 
-. Create the `externalsecrets.openshift.operator.io` object by running the following command:
+. Create the `externalsecretsconfigs.openshift.operator.io` object by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f externalsecrets.yaml
+$ oc create -f externalsecretsconfig.yaml
 ----
 
 .Verification
@@ -47,6 +56,7 @@ $ oc get pods -n external-secrets
 ----
 +
 .Example output
++
 [source,terminal]
 ----
 NAME                                                READY   STATUS    RESTARTS   AGE
@@ -59,25 +69,26 @@ external-secrets-webhook-b566658ff-7m4d5            1/1     Running   0         
 +
 [source,terminal]
 ----
-$ oc get externalsecrets.operator.openshift.io cluster -n external-secrets-operator -o jsonpath='{.status.conditions}' | jq .
+$ oc get externalsecretsconfig.operator.openshift.io cluster -n external-secrets-operator -o jsonpath='{.status.conditions}' | jq .
 ----
 +
 .Example output
++
 [source,terminal]
 ----
 [
   {
     "lastTransitionTime": "2025-06-17T14:57:04Z",
     "message": "",
-    "observedGeneration": 1,
+    "observedGeneration": 2,
     "reason": "Ready",
     "status": "False",
     "type": "Degraded"
   },
   {
-    "lastTransitionTime": "2025-06-17T14:57:04Z",
+    "lastTransitionTime": "2025-11-27T05:58:38Z,
     "message": "reconciliation successful",
-    "observedGeneration": 1,
+    "observedGeneration": 2,
     "reason": "Ready",
     "status": "True",
     "type": "Ready"

--- a/modules/external-secrets-operator-create-externalsecretsconfig.adoc
+++ b/modules/external-secrets-operator-create-externalsecretsconfig.adoc
@@ -31,32 +31,14 @@ metadata:
   name: cluster
 spec:
   appConfig:
-    logLevel: 3
-  webhookConfig:
-    certificateCheckInterval: 5m0s
+    logLevel: 1
   controllerConfig:
-    certProvider:
-      certManager:
-        certificateDuration: 8760h0m0s
-        certificateRenewBefore: 30m0s
-        injectAnnotations: "true"
-        issuerRef:
-          group: cert-manager.io
-          kind: Issuer
-          name: _<created_issuer_name>_
-    mode: Enabled
     networkPolicies:
-    - componentName: ExternalSecretsCoreController
-      egress:
-      - ports:
-        - port: 443
-          protocol: TCP
-        - port: 9998
-          protocol: TCP
+      - componentName: ExternalSecretsCoreController
+        egress:
+          - {}
         name: allow-external-secrets-egress
-    plugins:
-      bitwardenSecretManagerProvider:
-        mode: Enabled
+  plugins: {}
 ----
 
 . Create the `ExternalSecretsConfig` object by running the following command:

--- a/modules/external-secrets-operator-egress-allow-all-traffic.adoc
+++ b/modules/external-secrets-operator-egress-allow-all-traffic.adoc
@@ -39,3 +39,5 @@ spec:
         componentName: CoreController
         egress: # Allow all egress traffic
 ----
+
+

--- a/modules/external-secrets-operator-install-cli.adoc
+++ b/modules/external-secrets-operator-install-cli.adoc
@@ -23,7 +23,6 @@ $ oc new-project external-secrets-operator
 
 . Create an `OperatorGroup` object by defining a YAML file with the following content:
 +
-.Example `operatorGroup.yaml` file
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -44,7 +43,8 @@ $ oc create -f operatorGroup.yaml
 
 . Create a `Subscription` object by defining a YAML file with the following content:
 +
-.Example `subscription.yaml` file
+The following is an example of a `subscription.yaml` file.
++
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -53,11 +53,12 @@ metadata:
   name: openshift-external-secrets-operator
   namespace: external-secrets-operator
 spec:
-  channel: tech-preview-v0.1
+  channel: stable-v1
   name: openshift-external-secrets-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic
+  startingCSV: external-secrets-operator.v1.0.0
 ----
 
 . Create the `Subscription` object by running the following command:
@@ -76,11 +77,12 @@ $ oc create -f subscription.yaml
 $ oc get subscription -n external-secrets-operator
 ----
 +
-.Example output
+The following is example output verifying the {olm} subscription is created.
++
 [source,terminal]
 ----
-NAME                                  PACKAGE                               SOURCE          CHANNEL
-openshift-external-secrets-operator   openshift-external-secrets-operator   eso-010-index   tech-preview-v0.1
+NAME                                  PACKAGE                               SOURCE             CHANNEL
+openshift-external-secrets-operator   openshift-external-secrets-operator   redhat-operators   stable-v1
 ----
 
 . Verify whether the Operator is successfully installed by running the following command:
@@ -90,21 +92,23 @@ openshift-external-secrets-operator   openshift-external-secrets-operator   eso-
 $ oc get csv -n external-secrets-operator
 ----
 +
-.Example output
+The following is example output verifying that the Operator is installed.
++
 [source,terminal]
 ----
 NAME                               DISPLAY                                           VERSION   REPLACES   PHASE
-external-secrets-operator.v0.1.0   External Secrets Operator for Red Hat OpenShift   0.1.0                Succeeded
+external-secrets-operator.v1.0.0   External Secrets Operator for Red Hat OpenShift   1.0.0                Succeeded
 ----
 
-. Verify that the status of the {external-secrets-operator-short} is Running by entering the following command:
+. Verify that the status of the {external-secrets-operator-short} is `Running` by entering the following command:
 +
 [source,terminal]
 ----
 $ oc get pods -n external-secrets-operator
 ----
 +
-.Example output
+The following is example output verifying the {external-secrets-operator-short} is `Running`.
++
 [source,terminal]
 ----
 NAME                                                            READY   STATUS    RESTARTS   AGE

--- a/modules/external-secrets-operator-install-console.adoc
+++ b/modules/external-secrets-operator-install-console.adoc
@@ -6,7 +6,8 @@
 [id="external-secrets-operator-install-console_{context}"]
 = Installing the {external-secrets-operator} by using the web console
 
-You can use the web console to install the {external-secrets-operator}.
+[role="_abstract"]
+Install the {external-secrets-operator} by using the web console to add secret management features to your cluster. By doing this task, you can select an update channel and approval strategy to ensure the Operator stays current.
 
 .Prerequisites
 
@@ -22,14 +23,10 @@ You can use the web console to install the {external-secrets-operator}.
 . Enter *{external-secrets-operator-short}* in the search box.
 
 . Select the *{external-secrets-operator}* from the generated list and click *Install*.
-//+
-//[NOTE]
-//====
-//place holder for TechPreview release details or See supported {external-secrets-operator-short} versions in the following "Additional resources" section.
-//====
+
 . On the *Install Operator* page:
 
-.. Update the *Update channel*, if necessary. The channel defaults to *tech-preview-v0.1*, which installs the latest stable release of the {external-secrets-operator-short}.
+.. Update the *Update channel*, if necessary. The channel defaults to *stable-v1*, which installs the latest stable release of the {external-secrets-operator-short}.
 
 .. Select the version from *Version* drop-down list.
 

--- a/modules/external-secrets-operator-stablev1-channel.adoc
+++ b/modules/external-secrets-operator-stablev1-channel.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-stablev1-channel_{context}"]
+= About the {external-secrets-operator} stable-v1 channel
+
+[role="_abstract"]
+Select the `stable-v1` channel to install and update the latest release of the {external-secrets-operator}. By selecting this channel, you can use the most recent stable release for your Operator.
+
+[NOTE]
+====
+The `stable-v1` channel is the default and suggested channel while installing the {external-secrets-operator}.
+====
+
+The `stable-v1` channel offers the following update approval strategies:
+
+Automatic:: If you choose automatic updates for an installed {external-secrets-operator}, a new version of the {external-secrets-operator} is available in the `stable-v1` channel. The Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without human intervention.
+
+Manual:: If you select manual updates, when a newer version of the {external-secrets-operator} is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the {cert-manager-operator} updated to the new version.

--- a/modules/external-secrets-operator-stablev1-y-channel.adoc
+++ b/modules/external-secrets-operator-stablev1-y-channel.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-stablev1-y-channel_{context}"]
+= About the {external-secrets-operator} stable-v1.y channel
+
+[role="_abstract"]
+Select the stable-v1 channel to install and update the latest release of the {external-secrets-operator}. By selecting this channel, you can use the latest stable release and allows you to choose between automatic and manual updates.
+
+The y-stream version of the {external-secrets-operator} installs updates from the `stable-v1.y` channels such as `stable-v1.0`, `stable-v1.1`, and `stable-v1.2`. Select the `stable-v1.y` channel if you want to use the y-stream version and stay updated to the z-stream version of the {external-secrets-operator}.
+
+The `stable-v1.y` channel offers the following update approval strategies:
+
+Automatic:: If you choose automatic updates for an installed {external-secrets-operator}, a new z-stream version of the {external-secrets-operator} is available in the `stable-v1.y` channel. OLM automatically upgrades the running instance of your Operator without human intervention.
+
+Manual:: If you select manual updates, when a newer version of the {external-secrets-operator} is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the {external-secrets-operator} updated to the new version of the z-stream releases.

--- a/modules/external-secrets-operator-update-channels.adoc
+++ b/modules/external-secrets-operator-update-channels.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * security/external_secrets_operator/external-secrets-operator-install.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="external-secrets-operator-update-channels_{context}"]
+= Understanding update channels of the {external-secrets-operator}
+
+[role="_abstract"]
+Control the version of the {external-secrets-operator} in your cluster by selecting an update channel. By using this mechanism, you can declare a specific version track, ensuring your environment receives only the updates you require for stability.
+
+The {external-secrets-operator} offers the following update channels:
+
+* `stable-v1`
+* `stable-v1.y`
+
+

--- a/modules/external-secrets-remove-resources.adoc
+++ b/modules/external-secrets-remove-resources.adoc
@@ -6,7 +6,8 @@
 [id="external-secrets-remove-resources_{context}"]
 = Removing {external-secrets-operator} resources by using the web console
 
-After you have uninstalled the {external-secrets-operator}, you can optionally eliminate its associated resources from your cluster.
+[role="_abstract"]
+To clean up your cluster after uninstalling the {external-secrets-operator}, remove its associated resources. This deletes residual components, such as deployments and custom resource definitions.
 
 .Prerequisites
 
@@ -40,6 +41,7 @@ After you have uninstalled the {external-secrets-operator}, you can optionally e
 *** ACRAccessToken
 *** ClusterExternalSecret
 *** ClusterGenerator
+*** ClusterPushSecret
 *** ClusterSecretStore
 *** ECRAuthorizationToken
 *** ExternalSecret
@@ -47,10 +49,12 @@ After you have uninstalled the {external-secrets-operator}, you can optionally e
 *** GeneratorState
 *** GithubAccessToken
 *** Grafana
+*** MFA
 *** Password
 *** PushSecret
 *** QuayAccessToken
 *** SecretStore
+*** SSHKey
 *** STSSessionToken
 *** UUID
 *** VaultDynamicSecret

--- a/modules/zero-trust-manager-oidc-config.adoc
+++ b/modules/zero-trust-manager-oidc-config.adoc
@@ -26,10 +26,10 @@ Deploy the SPIRE OpenID Connect (OIDC) Discovery Provider by configuring the `Sp
 +
 [source,yaml]
 ----
-apiVersion: operator.openshift.io/v1alpha1
+aapiVersion: operator.openshift.io/v1alpha1
 kind: SpireOIDCDiscoveryProvider
 metadata:
-  name: cluster
+ name: cluster
 spec:
   logLevel: "info"
   logFormat: "text"

--- a/modules/zero-trust-manager-spiffe-csidriver-config.adoc
+++ b/modules/zero-trust-manager-spiffe-csidriver-config.adoc
@@ -28,7 +28,7 @@ Configure the Container Storage Interface (CSI) driver using the `SpiffeCSIDrive
 apiVersion: operator.openshift.io/v1alpha1
 kind: SpiffeCSIDriver
 metadata:
-  name: cluster
+ name: cluster
 spec:
   agentSocketPath: "/run/spire/agent-sockets"
   pluginName: "csi.spiffe.io"

--- a/modules/zero-trust-manager-spire-agent-config.adoc
+++ b/modules/zero-trust-manager-spire-agent-config.adoc
@@ -9,6 +9,7 @@
 [role="_abstract"]
 Use the `SpireAgent` custom resource to configure the SPIRE Agent `DaemonSet` on your nodes. This defines how the agent verifies workloads and manages identity attestation across your {product-title} cluster.
 
+
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
@@ -28,7 +29,7 @@ Use the `SpireAgent` custom resource to configure the SPIRE Agent `DaemonSet` on
 apiVersion: operator.openshift.io/v1alpha1
 kind: SpireAgent
 metadata:
-  name: cluster
+ name: cluster
 spec:
   socketPath: "/run/spire/agent-sockets"
   logLevel: "info"

--- a/modules/zero-trust-manager-spire-server-config.adoc
+++ b/modules/zero-trust-manager-spire-server-config.adoc
@@ -6,7 +6,8 @@
 [id="zero-trust-manager-spire-server-config_{context}"]
 = Deploying the SPIRE Server
 
-You can configure the `SpireServer` custom resource (CR) to deploy and configure a SPIRE Server.
+[role="_abstract"]
+Deploy the SPIRE Server by configuring the `SpireServer` custom resource (CR). This establishes a central authority that manages and issues identities to the workloads in your cluster.
 
 .Prerequisites
 
@@ -24,10 +25,10 @@ You can configure the `SpireServer` custom resource (CR) to deploy and configure
 +
 [source,yaml]
 ----
-apiVersion: operator.openshift.io/v1alpha1
+aapiVersion: operator.openshift.io/v1alpha1
 kind: SpireServer
 metadata:
-  name: cluster
+ name: cluster
 spec:
   logLevel: "info"
   logFormat: "text"

--- a/security/external_secrets_operator/external-secrets-operator-api.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-api.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="external-secrets-operator-api"]
-= {external-secrets-operator} APIs
+= External Secrets Operator for Red Hat OpenShift APIs
 include::_attributes/common-attributes.adoc[]
 :context: external-secrets-operator-api
 

--- a/security/external_secrets_operator/external-secrets-operator-install.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-install.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="external-secrets-operator-install"]
-= Installing the {external-secrets-operator}
+= Installing the External Secrets Operator for Red Hat OpenShift
 include::_attributes/common-attributes.adoc[]
 :context: external-secrets-operator-install
 
 toc::[]
 
-The {external-secrets-operator} is not installed on the {product-title} by default. Install the {external-secrets-operator-short} by using either the web console or the command-line interface (CLI).
+[role="-abstract"]
+To manage external secrets on {product-title}, install the {external-secrets-operator-short} by using the web console or the command-line interface (CLI).
 
 //Limitations of application installation and uninstallation
 include::modules/external-secrets-operator-limitations.adoc[leveloffset=+1]
@@ -25,3 +26,20 @@ include::modules/external-secrets-operator-install-cli.adoc[leveloffset=+1]
 
 //== Installing the external secrets operand using CLI
 include::modules/external-secrets-operand-install-cli.adoc[leveloffset=+1]
+
+//== updating external secrets channels
+include::modules/external-secrets-operator-update-channels.adoc[leveloffset=+1]
+
+//== updating external secrets stable v1 channels
+include::modules/external-secrets-operator-stablev1-channel.adoc[leveloffset=+2]
+
+//== updating external secrets stable v1.y channels
+include::modules/external-secrets-operator-stablev1-y-channel.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="external-secrets-operator-update-channels_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
+* xref:../../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators]
+

--- a/security/external_secrets_operator/external-secrets-operator-proxy.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-proxy.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="external-secrets-operator-proxy"]
-= About the egress proxy for the {external-secrets-operator}
+= About the egress proxy for the External Secrets Operator for Red Hat OpenShift
 include::_attributes/common-attributes.adoc[]
 :context: external-secrets-operator-proxy
 

--- a/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-uninstall.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="external-secrets-operator-uninstall"]
-= Uninstalling the {external-secrets-operator}
+= Uninstalling the External Secrets Operator for Red Hat OpenShift
 include::_attributes/common-attributes.adoc[]
 :context: external-secrets-operator-uninstall
 

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
@@ -4,9 +4,14 @@
 
 toc::[]
 
-You can deploy the following operands by creating the respective custom resources (CRs). You must deploy the operands in the following sequence to ensure successful installation.
+[role="_abstract"]
+Deploy the {zero-trust-full} operands by creating their custom resources in a specific order. Adhering to the sequence helps ensure the successful installation of components, such as the SPIRE Server, SPIRE Agent, and SPIFFE CSI driver.
 
-* `ZeroTrustWorkloadIdentityManager` CR* SPIRE Server
+You must deploy the operands in the following sequence to ensure successful installation:
+
+* `ZeroTrustWorkloadIdentityManager` CR
+
+* SPIRE Server
 
 * SPIRE Agent
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17319

Link to docs preview:
https://102710--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-config-net-policy.html
https://102710--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-install.html
https://102710--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.html
https://102710--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-uninstall.html


QE review:
- [ ] QE has approved this change.


Additional information:

