### PR TITLE
OSDOCS#17327: Update the z-stream RNs for 4.19.19

### DIFF
--- a/modules/zstream-4-19-19-about.adoc
+++ b/modules/zstream-4-19-19-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-19-about_{context}"]
+= RHBA-2025:21363 - {product-title} {product-version}.19 bug fix advisory
+
+[role="_abstract"]
+Issued: 19 November 2025
+
+{product-title} release {product-version}.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:21363[RHBA-2025:21363] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:21361[RHBA-2025:21361] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.19 --pullspecs
+----

--- a/modules/zstream-4-19-19-bug-fixes.adoc
+++ b/modules/zstream-4-19-19-bug-fixes.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-19-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bugs are fixed with this release:
+
+* Before this update, French users experienced a login screen in Spanish due to a locale mismatch. As a consequence, the user interface displayed an incorrect language: Spanish instead of French. With this release, the login screen language is corrected for French users. As a result, the login screen  displays in French for French users, and improves localization. (link:https://issues.redhat.com/browse/OCPBUGS-58892[OCPBUGS-58892])
+
+* Before this update, a bonded network configuration caused missing `bootMACAddress` configuration setting errors, and prevented host registrations with the Ironic API service. As a consequence, users could not register hosts with the Ironic service due to missing setting. With this release, bonded network MAC consistency is restored for the Ironic service agent registration. As a result, bonded network MAC consistency is correct, and the host registration in the Assisted Installer in successful. (link:https://issues.redhat.com/browse/OCPBUGS-62441[OCPBUGS-62441])
+
+* Before this update, the Control Plane Operator (CPO) incorrectly used the overridden image for the Cluster Version Operator (CVO). As a consequence, the user experienced a CVO deployment with an incorrect image. With this release, the CVO correctly uses image overrides for the CVO. As a result, the correct image is used for CVO deployment. (link:https://issues.redhat.com/browse/OCPBUGS-62959[OCPBUGS-62959])
+
+* Before this update, the User Workload Monitoring Prometheus Operator excessively accessed the Kubernetes API because of an improper Secret reference object in the `AlertmanagerConfig` custom resource definition. As a result, User Workload Monitoring overloaded the Kubernetes API, and caused increased primary node CPU use With this release, excessive Secret object `GET` requests in the User Workload Monitoring Prometheus Operator are reduced. As a result, the API load on primary nodes is optimized. (link:https://issues.redhat.com/browse/OCPBUGS-63197[OCPBUGS-63197])
+
+* Before this update, the kubelet server certificate was not updated after a certificate rotation due to unauthorized access. As a consequence, the cluster failed to start in a healthy state because of an unauthorized access after the rotation. With this release, the kubelet server certificate is updated after a rotation. As a result, the certificate rotation in {product-title} clusters is successful, which ensures secure communication and a healthy cluster state. (link:https://issues.redhat.com/browse/OCPBUGS-63342[OCPBUGS-63342])
+
+* Before this update, the data disk configuration from a MachineSet Custom Resource Definition (CRD) was not passed to the `StorageProfile` object when a virtual machine (VM) was created on Azure Stack. This action caused the configuration to be ignored. As a consequence, user custom disk configurations were applied to VMs. With this release, data disk configuration in a MachineSet CRD is passed to the `StorageProfile` object, which ensures consistent handling on Azure Stack. As a result, data disk configurations are passed to the `StorageProfile` object, proper setup on Azure Stack is ensured, and VM creation is improved. (link:https://issues.redhat.com/browse/OCPBUGS-63578[OCPBUGS-63578])
+
+* Before this update, the communication matrix project failed to create endpoint slices for open ports 9193 and 9194 on the primary node due to a missing service connection. As a consequence, missing endpoint slices for open ports caused inaccurate communication matrixes. With this release, the service is connected to open ports 9193 and 9194, resolving the missing endpoint slices, which ensures accurate communication matrixes for {product-title} users. (link:https://issues.redhat.com/browse/OCPBUGS-63586[OCPBUGS-63586])
+
+* Before this update, large journal downloads caused browser crashes in the node log viewer. As a consequence, journal logs overloaded and crashed the log viewer, affecting user experience. With this release, the log download size is limited, which prevents browser crashes and displays journal lines in the log viewer. (link:https://issues.redhat.com/browse/OCPBUGS-63607[OCPBUGS-63607])
+
+* Before this update, the denylist metric incorrectly formatted the regular expression for the Kubernetes custom resource by omitting the `annotations` field. As a consequence, users experienced missing metrics due to an incorrect denylist configuration. With this release, unnecessary entries are removed from the metric denylist. As a result, registry metrics include missing annotations, and data accuracy is improved. (link:https://issues.redhat.com/browse/OCPBUGS-64578[OCPBUGS-64578])
+
+* Before this update, the node scheduled a pod on a tainted node with no specific tolerance. As a consequence, the must-gather pod was scheduled on an unavailable node, and caused the log collection to fail. With this release, the pod is scheduled on a tainted node only if it includes a specific tolerance for the taint on the node where it should be scheduled. (link:https://issues.redhat.com/browse/OCPBUGS-64585[OCPBUGS-64585])
+
+
+

--- a/modules/zstream-4-19-19-updating.adoc
+++ b/modules/zstream-4-19-19-updating.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-19-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2949,6 +2949,15 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.19.19 about
+include::modules/zstream-4-19-19-about.adoc[leveloffset=+2]
+
+// 4.19.19 fixes
+include::modules/zstream-4-19-19-bug-fixes.adoc[leveloffset=+2]
+
+// 4.19.19 updating
+include::modules/zstream-4-19-19-updating.adoc[leveloffset=+2]
+
 // 4.19.18
 [id="ocp-4-19-18_{context}"]
 === RHBA-2025:19301 - {product-title} {product-version}.18 image release and bug fix advisory


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-17327](https://issues.redhat.com//browse/OSDOCS-17327)

Link to docs preview:
[4.19.19](https://102737--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-19-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:

- Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/235#fd0cf7650a392540479be6dd962779aee36e6b77)
- ART [dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19)

Format change: This is the first time that the 4.19.z RNs file is modularized.
