### PR TITLE
RHDEVDOCS-6937: Content creation for config notifications in namespace feature

### DIFF
--- a/argocd_instance/argo-cd-cr-component-properties.adoc
+++ b/argocd_instance/argo-cd-cr-component-properties.adoc
@@ -29,6 +29,12 @@ include::modules/proc_configuring-by-using-the-ocp-web-console.adoc[leveloffset=
 // Configuring the NotificationsConfiguration CR by using the CLI
 include::modules/proc_configuring-notificationsconfiguration-crd-by-using-the-ocp-cli.adoc[leveloffset=+2]
 
+// Configuring Notifications in any Namespace
+include::modules/gitops-configuring-notifications-any-namespace.adoc[leveloffset=+1]
+
+// Understanding configuration notifications behavior across namespaces
+include::modules/gitops-understanding-configuration-notifications-behavior-across-namespaces.adoc[leveloffset=+2]
+
 // Enabling annotation-based resource tracking in Argo CD
 include::modules/con_enabling_annotation_based_resource_tracking_in_argo_cd.adoc[leveloffset=+1]
 

--- a/modules/gitops-configuring-notifications-any-namespace.adoc
+++ b/modules/gitops-configuring-notifications-any-namespace.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * argocd_instance/argo-cd-cr-component-properties.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="gitops-configuring-notifications-any-namespace_{context}"]
+= Configuring Notifications in any Namespace
+
+[role="_abstract"]
+By default, Argo CD manages notification configuration only within the control plane namespace. With {gitops-title} Operator, cluster administrators can enable teams to manage notification settings for their applications from additional namespaces.
+
+To enable this functionality, configure the target namespaces in the Argo CD custom resource (CR). The {gitops-title} Operator reconciles the corresponding notification resources only for namespaces that are explicitly defined in the ArgoCD CR.
+
+[NOTE]
+====
+To enable notification configuration in a namespace, you must add the namespace to the following fields in the Argo CD CR:
+
+* `.spec.sourceNamespaces`: Enables the `Apps in Any Namespace` feature for the Application controller.
+* `.spec.notifications.sourceNamespaces`: Allows the Notifications controller to read configuration from that namespace.
+
+If a namespace is not included in these fields, notification configuration for that namespace is not processed.
+====
+
+.Procedure
+
+. List the ArgoCD CRs in the cluster:
++
+[source,terminal]
+----
+$ oc get argocd -A
+----
+
+. Edit the target ArgoCD CR:
++
+[source,terminal]
+----
+$ oc edit argocd <cr_name> -n <namespace>
+----
+
+. Under the `spec` section, add each target namespace to the `sourceNamespaces` and `notifications.sourceNamespaces` fields.
++
+The following example enables the `example-argocd` instance to manage applications and notification configurations in the `foo` namespace:
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  sourceNamespaces:
+    - foo
+  notifications:
+    enabled: true
+    sourceNamespaces:
+      - foo
+----
+
+.Verification
+
+. Verify that the Argo CD instance recognizes the updated `sourceNamespaces` configuration by checking the settings in the Argo CD CR.

--- a/modules/gitops-understanding-configuration-notifications-behavior-across-namespaces.adoc
+++ b/modules/gitops-understanding-configuration-notifications-behavior-across-namespaces.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * argocd_instance/argo-cd-cr-component-properties.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="gitops-understanding-configuration-notifications-behavior-across-namespaces_{context}"]
+= Understanding configuration notifications behavior across namespaces
+
+[role="_abstract"]
+When the Configuring notifications in any namespace feature is enabled, the {gitops-title} Operator performs additional actions to support delegated notification configuration. For each delegated namespace, the {gitops-title} Operator automatically creates a `NotificationsConfiguration` custom resource (CR) named `default-notifications-configuration`. Application teams can update this CR to define or modify their notification settings.
+
+The Notifications controller determines which configuration to apply by using the following resolution behavior:
+
+* The controller first checks for the delegated `NotificationsConfiguration` CR or the corresponding config map (`argocd-notifications-cm`) and Secret (`argocd-notification-secret`) in the namespace of the application.
+* If no delegated configuration is found, the controller falls back to the central configuration resources (ConfigMap and Secret) defined in the control plane namespace.
+
+To enable this model, the {gitops-title} Operator creates a `Role` and a `RoleBinding` in each delegated namespace, granting the Notifications controller permission to read `ConfigMaps` and `Secrets`. The {gitops-title} Operator also applies the `argocd.argoproj.io/notifications-managed-by-cluster-argocd` label to each delegated namespace.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-6937

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

[Configuring Notifications in any Namespace](https://102761--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties.html#gitops-configuring-notifications-any-namespace_argo-cd-cr-component-properties)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @nmirasch 
QE review: @Naveena-058 
Peer review: @shivanisathe25 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
