### PR TITLE
DOCPLAN-30: Fixes for CNV postinstall docs for migration

### DIFF
--- a/modules/virt-configuring-certificate-rotation.adoc
+++ b/modules/virt-configuring-certificate-rotation.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/advanced_vm_management/virt-configuring-certificate-rotation.adoc
+// * virt/post_installation_configuration/virt-configuring-certificate-rotation.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="virt-configuring-certificate-rotation_{context}"]
@@ -23,7 +23,6 @@ $ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `spec.certConfig` fields as shown in the following example. To avoid overloading the system, ensure that all values are greater than or equal to 10 minutes. Express all values as strings that comply with the link:https://golang.org/pkg/time/#ParseDuration[golang `ParseDuration` format].
-
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -36,13 +35,26 @@ spec:
   certConfig:
     ca:
       duration: 48h0m0s
-      renewBefore: 24h0m0s <1>
+      renewBefore: 24h0m0s
     server:
-      duration: 24h0m0s  <2>
-      renewBefore: 12h0m0s  <3>
+      duration: 24h0m0s
+      renewBefore: 12h0m0s
 ----
-<1> The value of `ca.renewBefore` must be less than or equal to the value of `ca.duration`.
-<2> The value of `server.duration` must be less than or equal to the value of `ca.duration`.
-<3> The value of `server.renewBefore` must be less than or equal to the value of `server.duration`.
++
+** The value of `ca.renewBefore` must be less than or equal to the value of `ca.duration`.
+** The value of `server.duration` must be less than or equal to the value of `ca.duration`.
+** The value of `server.renewBefore` must be less than or equal to the value of `server.duration`.
 
-. Apply the YAML file to your cluster.
+. Apply updates to the `HyperConverged` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc apply -f kubevirt-hyperconverged.yaml
+----

--- a/modules/virt-removing-wasp-agent.adoc
+++ b/modules/virt-removing-wasp-agent.adoc
@@ -11,12 +11,12 @@ If you no longer need memory overcommitment, you can remove the `wasp-agent` com
 
 .Prerequisites
 
-* You are logged in to the cluster with the `cluster-admin` role.
+* You have logged in to the cluster with the `cluster-admin` role.
 * You have installed the {oc-first}.
 
 .Procedure
 
-. Revert the memory overcommitment configuration:
+. Revert the memory overcommitment configuration by running the following command:
 +
 [source,terminal]
 ----
@@ -25,21 +25,21 @@ $ oc -n openshift-cnv patch HyperConverged/kubevirt-hyperconverged \
   -p='[{"op": "remove", "path": "/spec/higherWorkloadDensity"}]'
 ----
 
-. Delete the `MachineConfig` that provisions swap memory:
+. Delete the `MachineConfig` that provisions swap memory by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete machineconfig 90-worker-swap
 ----
 
-. Delete the associated `KubeletConfig`:
+. Delete the associated `KubeletConfig` custom resource (CR) by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete kubeletconfig custom-config
 ----
 
-. Wait for the worker nodes to reconcile:
+. Wait for the worker nodes to reconcile, by running the following command and observing the output:
 +
 [source,terminal]
 ----
@@ -49,7 +49,7 @@ $ oc wait mcp worker --for condition=Updated=True --timeout=-1s
 
 .Verification
 
-* Confirm that swap is no longer enabled on a node:
+* Confirm that swap is no longer enabled on a node, by running the following command and observing the output:
 +
 [source,terminal]
 ----

--- a/modules/virt-troubleshooting-cert-rotation-parameters.adoc
+++ b/modules/virt-troubleshooting-cert-rotation-parameters.adoc
@@ -7,29 +7,33 @@
 = Troubleshooting certificate rotation parameters
 
 [role="_abstract"]
-Deleting one or more `certConfig` values causes them to revert to the default values, unless the default values conflict with one of the specific conditions. If the default values conflict with these conditions, you will receive an error.
+Deleting one or more `certConfig` values in the `HyperConverged` custom resource (CR) causes the `certConfig` values to revert to the default values.
 
-The conditions are:
+If the default values conflict with one of the following conditions, you receive an error message instead:
 
 * The value of `ca.renewBefore` must be less than or equal to the value of `ca.duration`.
-
 * The value of `server.duration` must be less than or equal to the value of `ca.duration`.
-
 * The value of `server.renewBefore` must be less than or equal to the value of `server.duration`.
 
-If you remove the `server.duration` value in the following example, the default value of `24h0m0s` is greater than the value of `ca.duration`, conflicting with the specified conditions.
+For example, if you remove the `server.duration` value, the default value of `24h0m0s` is greater than the value of `ca.duration`, which conflicts with the specified conditions:
 
-Example:
-
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
-certConfig:
-   ca:
-     duration: 4h0m0s
-     renewBefore: 1h0m0s
-   server:
-     duration: 4h0m0s
-     renewBefore: 4h0m0s
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: {CNVNamespace}
+spec:
+  # ...
+  certConfig:
+    ca:
+      duration: 4h0m0s
+      renewBefore: 1h0m0s
+    server:
+      duration: 4h0m0s
+      renewBefore: 4h0m0s
+# ...
 ----
 
 This results in the following error message:
@@ -39,4 +43,4 @@ This results in the following error message:
 error: hyperconvergeds.hco.kubevirt.io "kubevirt-hyperconverged" could not be patched: admission webhook "validate-hco.kubevirt.io" denied the request: spec.certConfig: ca.duration is smaller than server.duration
 ----
 
-The error message only mentions the first conflict. Review all certConfig values before you proceed.
+The error message only mentions the first conflict. Review all `certConfig` values before you proceed.

--- a/modules/virt-wasp-agent-pod-eviction.adoc
+++ b/modules/virt-wasp-agent-pod-eviction.adoc
@@ -7,26 +7,26 @@
 = Pod eviction conditions used by wasp-agent
 
 [role="_abstract"]
-The wasp agent manages pod eviction when the system is heavily loaded and nodes are at risk. Eviction is triggered if one of the following conditions is met:
+The wasp agent manages pod eviction when the system is heavily loaded and nodes are at risk. Eviction triggers if one of the following conditions occurs:
 
 High swap I/O traffic::
 
-This condition is met when swap-related I/O traffic is excessively high. 
+This condition occurs when swap-related I/O traffic is excessively high.
 +
 Condition:
 +
 [source,text]
 ----
-averageSwapInPerSecond > maxAverageSwapInPagesPerSecond 
+averageSwapInPerSecond > maxAverageSwapInPagesPerSecond
 &&
 averageSwapOutPerSecond > maxAverageSwapOutPagesPerSecond
 ----
 +
-By default, `maxAverageSwapInPagesPerSecond` and `maxAverageSwapOutPagesPerSecond` are set to 1000 pages. The default time interval for calculating the average is 30 seconds.
+By default, the `maxAverageSwapInPagesPerSecond` and `maxAverageSwapOutPagesPerSecond` values are 1000 pages. The default time interval for calculating the average is 30 seconds.
 
 High swap utilization::
 
-This condition is met when swap utilization is excessively high, causing the current virtual memory usage to exceed the factored threshold. The `NODE_SWAP_SPACE` setting in your `MachineConfig` object can impact this condition.
+This condition occurs when swap utilization is excessively high, causing the current virtual memory usage to exceed the factored threshold. The `NODE_SWAP_SPACE` setting in your `MachineConfig` object can impact this condition.
 +
 Condition:
 +


### PR DESCRIPTION
Version(s):
4.18+

Issue:
- https://issues.redhat.com/browse/DOCPLAN-30
- https://issues.redhat.com/browse/DOCPLAN-29

Link to docs preview:
- https://102767--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-certificate-rotation.html
- https://102767--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
