### PR TITLE
CNV-69410: Customizing VM MAC pool range

### DIFF
--- a/modules/virt-custom-kubemacpool-range.adoc
+++ b/modules/virt-custom-kubemacpool-range.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-using-mac-address-pool-for-vms.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-custom-kubemacpool-range_{context}"]
+= Customizing the MAC pool range
+
+[role="_abstract"]
+KubeMacPool works by allocating MAC addresses to VMs from a range. The `rangeStart` and `rangeEnd` parameters in the `HyperConverged` custom resource (CR) define the MAC pool range.
+
+As a cluster administrator, you can configure this range to ensure that MAC addresses for VMs hosted on {VirtProductName} do not conflict with other virtualization solutions on the same network.
+
+.Prerequisites
+
+* You have cluster administrator access on an {product-title} cluster.
+* You have installed the {oc-first}.
+
+.Procedure
+
+. Edit the `HyperConverged` CR by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
+----
+
+. Update the `HyperConverged` CR to configure the `rangeStart` and `rangeEnd` parameters that define your required MAC address range:
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  kubeMacPoolConfiguration:
+    rangeStart: "AA:00:00:00:00:00"
+    rangeEnd: "FD:FF:FF:FF:FF:FF"
+# ...
+----
+
+.Verification
+
+. Run the following command and observe the output:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc get hco kubevirt-hyperconverged -n {CNVNamespace} -o=jsonpath='{.spec.kubeMacPoolConfiguration}'
+----
++
+If you have successfully applied the configuration changes, the output shows the new MAC pool range you have configured:
++
+Example output:
++
+[source,terminal]
+----
+{
+  "rangeStart": "AA:00:00:00:00:00",
+  "rangeEnd": "FD:FF:FF:FF:FF:FF"
+}
+----
+
+. Optional. Create a new VM and run the following command to check the MAC address of the VM's network interface:
++
+[source,terminal]
+----
+$ oc get vmi <vm-name> -o=jsonpath='{.status.interfaces[0].macAddress}'
+----
++
+Example output:
++
+[source,yaml]
+----
+macAddress: AA:00:00:00:00:04
+----
++
+If you have successfully applied the configuration changes, the `macAddress` field in the VM interface is within the range you specified in your `kubeMacPoolConfiguration`, between the value of `rangeStart` and `rangeEnd`.

--- a/virt/vm_networking/virt-using-mac-address-pool-for-vms.adoc
+++ b/virt/vm_networking/virt-using-mac-address-pool-for-vms.adoc
@@ -1,12 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="virt-using-mac-address-pool-for-vms"]
 = Managing MAC address pools for network interfaces
-include::_attributes/common-attributes.adoc[]
 :context: virt-using-mac-address-pool-for-vms
 
 toc::[]
 
-The _KubeMacPool_ component allocates MAC addresses for virtual machine (VM) network interfaces from a shared MAC address pool. This ensures that each network interface is assigned a unique MAC address.
+[role="_abstract"]
+KubeMacPool allocates MAC addresses for virtual machine (VM) network interfaces from a shared MAC address pool. This ensures that each network interface is assigned a unique MAC address.
 
 A virtual machine instance created from that VM retains the assigned MAC address across reboots.
 
@@ -17,3 +18,4 @@ KubeMacPool does not handle virtual machine instances created independently from
 
 include::modules/virt-managing-kubemacpool-cli.adoc[leveloffset=+1]
 
+include::modules/virt-custom-kubemacpool-range.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/CNV-69410

Link to docs preview:
https://102778--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-using-mac-address-pool-for-vms.html#virt-custom-kubemacpool-range_virt-using-mac-address-pool-for-vms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
