### PR TITLE
OSDOCS-17399 [NETOBSERV] Update release notes link in stub page for 4.20

### DIFF
--- a/release_notes/addtl-release-notes.adoc
+++ b/release_notes/addtl-release-notes.adoc
@@ -56,7 +56,7 @@ M::
 xref:../migration_toolkit_for_containers/release_notes/mtc-release-notes.adoc#mtc-release-notes[{mtc-full} ({mtc-short})]
 
 N::
-xref:../observability/network_observability/network-observability-operator-release-notes-1-10.adoc#network-observability-operator-release-notes-1-10[Network Observability Operator]
+xref:../observability/network_observability/network-observability-operator-release-notes.adoc#network-observability-operator-release-notes[Network Observability Operator]
 +
 xref:../security/nbde_tang_server_operator/nbde-tang-server-operator-release-notes.adoc#nbde-tang-server-operator-release-notes[Network-bound Disk Encryption (NBDE) Tang Server Operator]
 


### PR DESCRIPTION
[OSDOCS-17399](https://issues.redhat.com//browse/OSDOCS-17399) [NETOBSERV] Update release notes link in stub page for 4.20

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-17399

Link to docs preview:
* Additional release notes: https://102779--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/addtl-release-notes.html > Network Observability Operator

QE review:
QE is not required for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
