### PR TITLE
OCSDOCS 17279 RN Remove references to artifacts from Mounting an OCI image into a pod docs

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -917,7 +917,7 @@ By using the in-place pod resizing feature, you can apply a resize policy to cha
 [id="ocp-release-notes-machine-config-operator-mount-oci_{context}"]
 ==== Mounting an OCI image into a pod
 
-You can you use an image volume to mount an Open Container Initiative (OCI)-compliant container image or artifact directly into a pod. For more information, see xref:../nodes/pods/nodes-pods-image-volume.adoc#odes-pods-image-volume[Mounting an OCI image into a pod].
+You can you use an image volume to mount an Open Container Initiative (OCI)-compliant container image directly into a pod. For more information, see xref:../nodes/pods/nodes-pods-image-volume.adoc#odes-pods-image-volume[Mounting an OCI image into a pod].
 
 [id="ocp-release-notes-machine-config-operator-allocate-gpu_{context}"]
 ==== Allocating specific GPUs to pods (Technology Preview)


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17279

Update release note to remove the word _artifact_ from the _Mounting an OCI image into a pod_ release note, an aspect of the feature that is not included in 4.20 (but is in 4.21).

See related https://github.com/openshift/openshift-docs/pull/102039

Preview