### PR TITLE
OSDOCS#17328: Update the z-stream RNs for 4.14.59

### DIFF
--- a/modules/zstream-4-14-59-about.adoc
+++ b/modules/zstream-4-14-59-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-59-about_{context}"]
+= RHSA-2025:21331 - {product-title} 4.14.59 bug fix and security update
+
+[role="_abstract"]
+Issued: 20 November 2025
+
+{product-title} release 4.14.59, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:21331[RHSA-2025:21331] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:21328[RHSA-2025:21328] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.59 --pullspecs
+----

--- a/modules/zstream-4-14-59-bug-fixes.adoc
+++ b/modules/zstream-4-14-59-bug-fixes.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-59-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bug is fixed with this release:
+
+* Before this update, the Machine API Controller (MAPI) in a {hcp} management cluster had a memory leak, and caused extreme memory use on the primary node. As a consequence, the cluster performance was affected. With this release, the memory leak in the MAPI controller is fixed, excessive memory use on primary nodes is reduced, and the cluster stability is improved. (link:https://issues.redhat.com/browse/OCPBUGS-65531[OCPBUGS-65531])

--- a/modules/zstream-4-14-59-updating.adoc
+++ b/modules/zstream-4-14-59-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-59-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.14 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3426,6 +3426,15 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.14.59 about
+include::modules/zstream-4-14-59-about.adoc[leveloffset=+2]
+
+// 4.14.59 fixes
+include::modules/zstream-4-14-59-bug-fixes.adoc[leveloffset=+2]
+
+// 4.14.59 updating
+include::modules/zstream-4-14-59-updating.adoc[leveloffset=+2]
+
 // 4.14.58
 [id="ocp-4-14-58_{context}"]
 === RHSA-2025:19058 - {product-title} 4.14.58 bug fix and security update


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-17328](https://issues.redhat.com//browse/OSDOCS-17328)

Link to docs preview:
[4.14.59](https://102797--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#zstream-4-14-59-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/235#fd0cf7650a392540479be6dd962779aee36e6b77)
ART [dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19)
Format change: This is the first time that the 4.14.z RNs file is modularized.
