### PR TITLE
CNV- 58841: Added <shortdesc> to Storage sections

### DIFF
--- a/modules/virt-operations-requiring-scratch-space.adoc
+++ b/modules/virt-operations-requiring-scratch-space.adoc
@@ -6,6 +6,9 @@
 [id="virt-operations-requiring-scratch-space_{context}"]
 = CDI operations that require scratch space
 
+[role="_abstract"]
+To import and process virtual machine (VM) images, the Containerized Data Importer (CDI) uses scratch space as temporary storage during specific operations such as registry imports and image uploads.
+
 [options="header"]
 |===
 | Type | Reason

--- a/virt/storage/virt-preparing-cdi-scratch-space.adoc
+++ b/virt/storage/virt-preparing-cdi-scratch-space.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+To support image import and processing, configure the Containerized Data Importer (CDI) scratch space and the required storage class so that CDI can temporarily store and convert virtual machine (VM) images.
+
 include::modules/virt-about-scratch-space.adoc[leveloffset=+1]
 
 include::modules/virt-operations-requiring-scratch-space.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/CNV-58841

Link to docs preview:

- https://102798--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-preparing-cdi-scratch-space.html#virt-operations-requiring-scratch-space_virt-preparing-cdi-scratch-space
- https://102798--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-preparing-cdi-scratch-space.html

QE review:
- [ ] QE has approved this change.
(QE approval is not required)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
