### PR TITLE
[RHDEVDOCS-6785] GA of the event-based pruner

### DIFF
--- a/modules/op-event-pruner-configuration.adoc
+++ b/modules/op-event-pruner-configuration.adoc
@@ -3,16 +3,14 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="event-pruner-configuration_{context}"]
-= Enabling the event-based pruner
+= Enabling the event-driven pruner
 
-:FeatureName: The event-based pruner
-include::snippets/technology-preview.adoc[]
+You can use the event-driven `tektonpruner` controller to automatically delete completed resources, such as `PipelineRuns` and `TaskRuns`, based on configurable policies. Unlike the job-based pruner, the event-driven pruner responds to resource events and removes completed resources in near real-time. The pruner supports both time-to-live (TTL) and history-based retention policies.
 
-You can use the event-based `tektonpruner` controller to automatically delete completed resources, such as `PipelineRuns` and `TaskRuns`, based on configurable policies. Unlike the default job-based pruner, the event-based pruner listens for resource events and prunes resources in near real time.
 
 [IMPORTANT]
 ====
-You must disable the default pruner in the `TektonConfig` custom resource (CR) before you enable the event-based pruner. If both pruner types are enabled, the deployment readiness status changes to `False` and the following error message is displayed on the output:
+You must disable the job-based pruner in the `TektonConfig` custom resource (CR) before you enable the event-driven pruner. If both pruner types are enabled, the deployment readiness status changes to `False` and the following error message is displayed on the output:
 
 [source,terminal]
 ----
@@ -21,8 +19,9 @@ Components not in ready state: Invalid Pruner Configuration!! Both pruners, tekt
 ====
 
 .Procedure
-
-. In your TektonConfig CR, disable the default pruner by setting the `spec.pruner.disabled` field to `true` and enable the event-based pruner by setting the `spec.tektonpruner.disabled` field to `false`. For example:
+. In your TektonConfig CR, disable the job-based pruner by setting `spec.pruner.disabled` field to `true` and enable the event-driven pruner by setting the `spec.tektonpruner.disabled` field to `false`.
++
+For example:
 +
 [source,yaml]
 ----
@@ -47,7 +46,7 @@ After you apply the updated CR, the Operator deploys the `tekton-pruner-controll
 +
 [cols="1,3",options="header"]
 |===
-|Config map 
+|Config map
 |Purpose
 
 |`tekton-pruner-default-spec`
@@ -73,9 +72,12 @@ After you apply the updated CR, the Operator deploys the `tekton-pruner-controll
 $ oc get pods -n openshift-pipelines
 ----
 
-. Verify that the output includes a `tekton-pruner-controller` pod in the `Running` state. Example output:
+. Verify that the output includes a `tekton-pruner-controller` and `tekton-pruner-webhook` pods in the `Running` state.
++
+Example output:
 +
 [source,terminal]
 ----
 $ tekton-pruner-controller-<id>       Running
+  tekton-pruner-webhook-<id>          Running
 ----

--- a/modules/op-event-pruner-observability.adoc
+++ b/modules/op-event-pruner-observability.adoc
@@ -3,12 +3,11 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="event-pruner-observability_{context}"]
-= Observability metrics of the event-based pruner
+= Observability metrics of the event-driven pruner
 
-:FeatureName: The event-based pruner
-include::snippets/technology-preview.adoc[]
+The event-driven pruner exposes detailed metrics through the `tekton-pruner-controller` controller `Service` definition on port `9090` in OpenTelemetry format for monitoring, troubleshooting, and capacity planning.
 
-The event-based pruner exposes detailed metrics through the `tekton-pruner-controller` controller `Service` definition on port `9090` in OpenTelemetry format for monitoring, troubleshooting, and capacity planning.
+Resource-level pruning rules configured using config maps in individual namespaces also emit metrics using the same labels, allowing you to track pruning at finer granularity.
 
 Following are categories of the metrics exposed:
 
@@ -40,7 +39,7 @@ Most pruner metrics use labels to provide additional context. You can use these 
 |===
 
 Resource processing metrics::
-The following resource processing metrics are exposed by the event-based pruner:
+The following resource processing metrics are exposed by the event-driven pruner:
 +
 [cols="3,1,3,2",options="header"]
 |===
@@ -51,7 +50,7 @@ The following resource processing metrics are exposed by the event-based pruner:
 
 
 Performance timing metrics::
-The following performance timing metrics are exposed by the event-based pruner:
+The following performance timing metrics are exposed by the event-driven pruner:
 +
 [cols="3,1,3,2,2",options="header"]
 |===
@@ -62,7 +61,7 @@ The following performance timing metrics are exposed by the event-based pruner:
 |===
 
 State tracking metrics::
-The following state tracking metrics are exposed by the event-based pruner:
+The following state tracking metrics are exposed by the event-driven pruner:
 +
 [cols="3,1,3",options="header"]
 |===
@@ -72,7 +71,7 @@ The following state tracking metrics are exposed by the event-based pruner:
 |===
 
 Error monitoring metrics::
-The following error monitoring metrics are exposed by the event-based pruner:
+The following error monitoring metrics are exposed by the event-driven pruner:
 +
 [cols="3,1,3,2",options="header"]
 |===

--- a/modules/op-event-pruner-reference.adoc
+++ b/modules/op-event-pruner-reference.adoc
@@ -3,63 +3,11 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="event-pruner-reference_{context}"]
-= Configuration of the event-based pruner
+= Configuration of the event-driven pruner
 
-:FeatureName: The event-based pruner
-include::snippets/technology-preview.adoc[]
+You can configure the pruning behavior of the event-driven pruner by modifying your `TektonConfig` custom resource (CR) for global and namespace-level policies, and config maps for resource-level pruning rules.
 
-You can configure the pruning behavior of the event-based pruner by modifying your `TektonConfig` custom resource (CR).
-
-The following is an example of the `TektonConfig` CR with the default configuration that uses global pruning rules:
-
-[source,yaml]
-----
-apiVersion: operator.tekton.dev/v1alpha1
-kind: TektonConfig
-metadata:
- name: config
-spec:
-  # ...
-  tektonpruner:
-    disabled: false
-    global-config:
-      enforcedConfigLevel: global
-      failedHistoryLimit: null
-      historyLimit: 10
-      namespaces: null
-      successfulHistoryLimit: null
-      ttlSecondsAfterFinished: null
-    options: {}
-  # ...
-----
-* `failedHistoryLimit`: The amount of retained failed runs.
-* `historyLimit`: The amount of runs to retain. Pruner uses this setting if status-specific limits are not defined.
-* `namespaces`: Definition of per-namespace pruning policies, when you set `enforcedConfigLevel` to `namespace`.
-* `successfulHistoryLimit`: The amount of retained successful runs. 
-* `ttlSecondsAfterFinished`: Time in seconds after completion, after which the pruner deletes resources.
-
-You can define pruning rules for individual namespaces by setting `enforcedConfigLevel` to `namespace` and configuring policies under the `namespaces` section. In the following example, a 60 second time to live (TTL) is applied to resources in the `dev-project` namespace:
-
-[source,yaml]
-----
-apiVersion: operator.tekton.dev/v1alpha1
-kind: TektonConfig
-metadata:
- name: config
-spec:
-  # ...
-  tektonpruner:
-    disabled: false
-    global-config:
-      enforcedConfigLevel: namespace
-      ttlSecondsAfterFinished: 300
-      namespaces:
-        dev-project:
-          ttlSecondsAfterFinished: 60
-  # ...
-----
-
-You can use the following parameters in your `TektonConfig` CR `tektonpruner`:
+You can use the following parameters in your `tektonpruner` configuration:
 
 [cols="1,3",options="header"]
 |===
@@ -86,5 +34,143 @@ You can use the following parameters in your `TektonConfig` CR `tektonpruner`:
 
 [NOTE]
 ====
-You can use TTL-based pruning to prune resources exceeding set expiration times. Use history-based pruning to prune resources exceeding the configured `historyLimit`.
+You can use TTL-based pruning to prune resources exceeding set expiration times.
+Use history-based pruning to prune resources exceeding the configured `historyLimit`.
+TTL and history limits operate independently.
 ====
+
+Global configuration of the event-driven pruner::
+
+The following example shows the default `TektonConfig` CR configuration, which applies global pruning rules:
++
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+ name: config
+spec:
+  # ...
+  tektonpruner:
+    disabled: false
+    global-config:
+      enforcedConfigLevel: global
+      failedHistoryLimit: 5
+      historyLimit: 10
+      successfulHistoryLimit: 5
+      ttlSecondsAfterFinished: 3600
+    options: {}
+  # ...
+----
+* `failedHistoryLimit`: The amount of retained failed runs.
+* `historyLimit`: The amount of runs to retain. Pruner uses this setting if status-specific limits are not defined.
+* `successfulHistoryLimit`: The amount of retained successful runs.
+* `ttlSecondsAfterFinished`: Time in seconds after completion, after which the pruner deletes resources.
+
+Namespace-level configuration of the event-driven pruner::
+
+You can define pruning rules for individual namespaces by setting `enforcedConfigLevel` to `namespace` and configuring policies under the `namespaces` section. In the following example, a 60 second time to live (TTL) is applied to resources in the `dev-project` and `staging` namespaces:
++
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+ name: config
+spec:
+  # ...
+  tektonpruner:
+    disabled: false
+    global-config:
+      enforcedConfigLevel: namespace
+      ttlSecondsAfterFinished: 300
+      namespaces:
+        dev-project:
+          ttlSecondsAfterFinished: 60
+        staging:
+          ttlSecondsAfterFinished: 60
+  # ...
+----
+
+Resource-level configuration of the event-driven pruner::
+
+If you have configured the namespace-level configuration of the event-driven pruner, you can further configure resource-level pruning rules by creating a `tekton-pruner-namespace-spec` config map in your namespace. Resource-level rules take precedence over global and namespace-level pruning configuration when defined for a specific resource type.
++
+When multiple config maps apply to the same resource, the event-driven pruner applies the most specific rule.
++
+The following example defines a TTL and a history limit for both `PipelineRun` and `TaskRun` resources:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: user-specified-namespace
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
+data:
+  ns-config: |
+    ttlSecondsAfterFinished: 300
+    historyLimit: 5
+----
++
+The `tekton-pruner-namespace-spec` name and the `app.kubernetes.io/part-of: tekton-pruner` and `pruner.tekton.dev/config-type: namespace` labels are required on all resource-level pruning config maps for the pruner controller to process them correctly. Config maps missing these labels or using an incorrect name are ignored.
+
+Resource-level configuration of the event-driven pruner with selectors::
+
+In the following example, the pruning rule applies only if the resource has both the `priority: high` label and the `compliance: required` annotation. Resources that do not match this selector fall back to the namespace default or other selectors with lower specificity:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-pruner-namespace-spec
+  namespace: user-specified-namespace
+  labels:
+    app.kubernetes.io/part-of: tekton-pruner
+    pruner.tekton.dev/config-type: namespace
+data:
+  ns-config: |
+    ttlSecondsAfterFinished: 3600
+
+    pipelineRuns:
+      - selector:
+        - matchLabels:
+            priority: high
+          matchAnnotations:
+            compliance: required
+        ttlSecondsAfterFinished: 7776000
+        successfulHistoryLimit: 100
+        failedHistoryLimit: 100
+----
+
+Common values::
+
+The following tables provide recommended values for TTL and history limits for `PipelineRuns` and `TaskRuns`. Use these values to help configure pruning policies that balance cluster performance, resource retention, and operational requirements.
++
+[cols="1,1,2", options="header"]
+|===
+| Time period | Seconds | Use case
+
+| 5 minutes | 300 | Development and testing with rapid iteration
+| 30 minutes | 1800 | Short-lived experiments
+| 1 hour | 3600 | CI pipelines
+| 6 hours | 21600 | Daily builds
+| 1 day | 86400 | Staging environments
+| 7 days | 604800 | Production, short retention
+| 30 days | 2592000 | Compliance, auditing
+| 90 days | 7776000 | Regulated industries
+|===
++
+[cols="1,1,1,2", options="header"]
+|===
+| Environment | `successfulHistoryLimit` | `failedHistoryLimit` | Reason
+
+| Development | 3-5 | 5-10 | Increase feedback turnaround and reduce storage requirements
+| Staging | 5-10 | 10-20 | Balance retention and resources
+| Production | 10-50 | 20-100 | Audit trial and debugging
+| CI/CD | 3-5 | 10-20 | Provide recent context for failure analysis
+|===


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.21

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6785

Link to docs preview:
- [The event-driven pruner](https://102806--ocpdocs-pr.netlify.app/openshift-pipelines/latest/install_config/customizing-configurations-in-the-tektonconfig-cr.html#event-pruner-configuration_customizing-configurations-in-the-tektonconfig-cr)

QE review:
- [x] QE has approved this change.

Additional information:

