### PR TITLE
OSDOCS-17362:Update the z-stream RNs for 4.18.29

### DIFF
--- a/modules/zstream-4-18-29-about.adoc
+++ b/modules/zstream-4-18-29-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-18-29-about_{context}"]
+= RHBA-2025:21797 - {product-title} {product-version}.29 bug fix advisory
+
+[role="_abstract"]
+Issued: 26 November 2025
+
+{product-title} release {product-version}.29 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:21797[RHBA-2025:21797] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:21794[RHBA-2025:21794] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.29--pullspecs
+----

--- a/modules/zstream-4-18-29-bug-fixes.adoc
+++ b/modules/zstream-4-18-29-bug-fixes.adoc
@@ -1,0 +1,45 @@
+
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-29-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bugs are fixed with this release:
+
+* Before this update, when a new secret was created or updated in any namespace, Alertmanager was reconciling even if that secret was not referenced in the `AlertmanagerConfig` resource. As a consequence, the Prometheus Operator generated excessive API calls, causing increased CPU usage on control plane nodes. With this release, Alertmanager only reconciles secrets that the `AlertmanagerConfig` resource explicitly references. (link:https://issues.redhat.com/browse/OCPBUGS-61965[OCPBUGS-61965]) 
+
+* Before this release, the `ccoctl` utility would automatically generate a new keypair if the private key was not found, even when users intentionally provided only the public key according to documented security procedures. This behavior caused a problem, as the newly generated keys would not match the cluster's keys, resulting in service outages for users following the correct process. With this update, the utility was changed to ensure a new keypair is never generated when the `--public-key-file` parameter is specified, and this parameter was added to all create-all functions for consistency. As a result, specifying the public key file now guarantees the provided key is used, ensuring the cluster continues to function as expected without interruption. (link:https://issues.redhat.com/browse/OCPBUGS-63548[OCPBUGS-63548])
+
+* Before this update, a Kube State Metrics (KSM) deny-list had typographical errors as demonstrated in the following example:
++
+[source,terminal,subs="verbatim"]
+----
+--metric-denylist=
+          ^kube_secret_labels$,
+          ^kube_.+_annotations$
+          ^kube_customresource_.+_annotations_info$,
+          ^kube_customresource_.+_labels_info$,
+----
++
+With this release, a missing comma is now included as shown in the following example:
++
+[source,terminal,subs="verbatim"]
+----
+--metric-denylist=
+          ^kube_secret_labels$,
+          ^kube_.+_annotations$,
+          ^kube_customresource_.+_annotations_info$,
+          ^kube_customresource_.+_labels_info$
+----
++
+As a result, the entries are correctly separated. (link:https://issues.redhat.com/browse/OCPBUGS-64579[OCPBUGS-64579])
+
+* Before this update, the `must-gather` pod could be scheduled on a node marked with a `NotReady` taint, resulting in deployment to an unavailable node and subsequent log collection failures. With this release, the scheduler now accounts for node taints and automatically applies a node selector to the pod specification. This change ensures that `must-gather` pods are not scheduled on tainted nodes, thereby preventing log collection failures. (link:https://issues.redhat.com/browse/OCPBUGS-64608[OCPBUGS-64608])
+
+* Before this update, the node log length was unlimited. As a consequence, an extremely large log could prevent the display of the log or cause the browser to crash. With this release, the node log length is limited to 1,000 lines. As a result, the log displays correctly. (link:https://issues.redhat.com/browse/OCPBUGS-64682[OCPBUGS-64682])
+
+* Before this update, when you directly navigated to a page created by a web console dynamic plugin, the web console might have redirected you to a different URL. With this release, the URL redirect is removed. (link:https://issues.redhat.com/browse/OCPBUGS-65533[OCPBUGS-65533])

--- a/modules/zstream-4-18-29-updating.adoc
+++ b/modules/zstream-4-18-29-updating.adoc
@@ -1,0 +1,12 @@
+
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-29-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -1,4 +1,3 @@
-:_mod-docs-content-type: ASSEMBLY
 [id="ocp-4-18-release-notes"]
 = {product-title} {product-version} release notes
 include::_attributes/common-attributes.adoc[]
@@ -3059,6 +3058,15 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+ 
+//4.18.29 about
+include::modules/zstream-4-18-29-about.adoc[leveloffset=+2]
+
+//4.18.29 bug fixes
+include::modules/zstream-4-18-29-bug-fixes.adoc[leveloffset=+2]
+
+//4.18.29 bug fixes
+include::modules/zstream-4-18-29-updating.adoc[leveloffset=+2]
 
 // 4.18.28
 [id="ocp-4-18-28_{context}"]
@@ -3102,7 +3110,6 @@ $ oc adm release info 4.18.28 --pullspecs
 * Before this update, during failover, the system's duplicate address detection (DAD) could incorrectly disable the Egress IPv6 address if it was briefly present on both nodes, breaking the connection. With this release, the Egress IPv6 is configured to skip the DAD check during failover, guaranteeing uninterrupted egress IPv6 traffic after an Egress IP address successfully moves to a different node and ensuring greater network stability. (link:https://issues.redhat.com/browse/OCPBUGS-63459[OCPBUGS-63459])
 
 * Before this update, the Azure machine provider was not passing the `dataDisks` configuration from the compute machine set into the virtual machine creation API request for the Azure Stack Hub. As a consequence, new machines were created without the specified data disks because the configuration was silently ignored during the VM creation process. With this release, the VM creation for the Azure Stack Hub is updated to include the `dataDisks` configuration. An additional update manually implements the behavior of the `deletionPolicy: Delete` parameter in the controller because the Azure Stack Hub does not natively support this option. As a result, data disks are correctly provisioned on the Azure Stack Hub VMs. The `Delete` policy is also functionally supported, which ensures that disks are properly removed when their machines are removed. (link:https://issues.redhat.com/browse/OCPBUGS-63669[OCPBUGS-63669])
-
 
 [id="ocp-4-18-28-updating_{context}"]
 ==== Updating
@@ -3170,11 +3177,11 @@ $ oc adm release info 4.18.26 --pullspecs
 
 * Before this update, the `MIRRORED_RELEASE_IMAGE` environment variable for the ignition server could fluctuate due to race conditions, causing unnecessary pod restarts. With this release, the `MIRRORED_RELEASE_IMAGE` values are consistent, stabilizing ignition server deployments. (link:https://issues.redhat.com/browse/OCPBUGS-61904[OCPBUGS-61904])
 
-* Before this update, control plane nodes created before {product-title} version 4.12 did not include the `node-role.kubernetes.io/control-plane` label. With this release, the Machine Config Operator (MCO) adds the label whenever it uncordons a control plane node. (link:https://issues.redhat.com/browse/OCPBUGS-62321[OCPBUGS-62321])
+* Before this update, control plane nodes created before OpenShift Container Platform version 4.12 did not include the `node-role.kubernetes.io/control-plane` label. With this release, the Machine Config Operator (MCO) adds the label whenever it uncordons a control plane node. (link:https://issues.redhat.com/browse/OCPBUGS-62321[OCPBUGS-62321])
 
-* Before this update, visiting the `/auth/error` page could display an improper error. With this release, the page renders a proper error message. (link:https://issues.redhat.com/browse/OCPBUGS-62326[OCPBUGS-62326])
+* Before this update, visiting the `/auth/error` page could display an improper error. With this release, the page renders a proper error message. (link:https://issues.redhat.com/browse/OCPBUGS-62326[OCPBUGS-62326]) 
 
-* Before this update, omitting the `--v1` or `--v2` flags when using oc-mirror could lead to inconsistent behavior. With this release, specifying `--v1` or `--v2` is mandatory. (link:https://issues.redhat.com/browse/OCPBUGS-62432[OCPBUGS-62432])
+* Before this update, omitting the `--v1` or `--v2` flags when using oc-mirror could lead to inconsistent behavior. With this release, specifying `--v1` or `--v2` is mandatory. (link:https://issues.redhat.com/browse/OCPBUGS-62432[OCPBUGS-62432]) 
 
 * Before this update, resizing a PVC immediately after creation could fail because the PV was temporarily not found. With this release, you can resize PVCs immediately after creation without errors. (link:https://issues.redhat.com/browse/OCPBUGS-62467[OCPBUGS-62467])
 
@@ -3734,7 +3741,7 @@ $ oc adm release info 4.18.14 --pullspecs
 
 * Previously, the omission of the `OLMManagedLabelKey` label on objects resulted in cluster operation failures. With this release, an update improves pod stability and ensures that the Operator Lifecycle Manager operates properly. (link:https://issues.redhat.com/browse/OCPBUGS-56098[OCPBUGS-56098])
 
-* Previously, an invalid `.tar` extraction format resulted in an improper file separation in the `ramdisk` logs, and caused file separators to appear randomly. With this release, an updated `ramdisk` log file  processes `.tar`` entries individually. This fix improves log readability, making them easier to interpret. (link:https://issues.redhat.com/browse/OCPBUGS-55938[OCPBUGS-55938])
+* Previously, an invalid `.tar` extraction format resulted in an improper file separation in the `ramdisk` logs, and caused file separators to appear randomly. With this release, an updated `ramdisk` log file  processes `.tar` entries individually. This fix improves log readability, making them easier to interpret. (link:https://issues.redhat.com/browse/OCPBUGS-55938[OCPBUGS-55938])
 
 * Previously, incorrectly formatted proxy variables in an external binary resulted in build failures. With this release, an update removes proxy environment variables from the build pod and prevents any build failures. (link:https://issues.redhat.com/browse/OCPBUGS-55699[OCPBUGS-55699])
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-17362

Link to docs preview:
https://102835--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-29-bug-fixes_release-notes