### PR TITLE
CNV-52278: Configuring routes to cdi-uploadproxy

### DIFF
--- a/modules/virt-configuring-cdiuploadproxy-routes.adoc
+++ b/modules/virt-configuring-cdiuploadproxy-routes.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+
+// * virt/post_installation_configuration/virt-post-install-network-config.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-configuring-cdiuploadproxy-routes_{context}"]
+= Configuring additional routes to the `cdi-uploadproxy` service
+
+[role="_abstract"]
+As a cluster administrator, you can configure additional routes to the `cdi-uploadproxy` service to allow users to upload virtual machine images from outside the cluster.
+
+.Prerequisites
+
+* You installed the {oc-first}.
+* You logged in to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Configure the route to the external host by running the following command:
++
+[source,terminal]
+----
+$ oc create route reencrypt <route_name> -n openshift-cnv \
+    --insecure-policy=Redirect \
+    --hostname=<host_name_or_address> \
+    --service=cdi-uploadproxy
+----
++
+where:
+
+<route_name>:: Specifies the name to assign to this custom route.
+<host_name_or_address>:: Specifies the fully qualified domain name or IP address of the external host providing image upload access.
+
+. Run the following command to annotate the route. This ensures that the correct Containerized Data Importer (CDI) CA certificate is injected when certificates are rotated:
++
+[source,terminal]
+----
+$ oc annotate route <route_name> -n openshift-cnv \
+    operator.cdi.kubevirt.io/injectUploadProxyCert="true"
+----
++
+where:
+
+<route_name>:: The name of the route you created.

--- a/virt/post_installation_configuration/virt-post-install-network-config.adoc
+++ b/virt/post_installation_configuration/virt-post-install-network-config.adoc
@@ -70,3 +70,5 @@ include::modules/nw-sriov-network-attachment.adoc[leveloffset=+2]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 include::modules/virt-enabling-load-balancer-service-web.adoc[leveloffset=+1]
+include::modules/virt-configuring-cdiuploadproxy-routes.adoc[leveloffset=+1]
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Adding documentation for configuring external routes for the `cdi-uploadproxy` service. 
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16, 4.17, 4.18, 4.19, 4.20, 4.21

Issue:
[CNV-52278](https://issues.redhat.com/browse/CNV-52278)

Link to docs preview:
[Configuring additional routes to the `cdi-uploadproxy` service](https://102838--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-network-config.html#virt-configuring-cdiuploadproxy-routes_virt-post-install-network-config)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
