### PR TITLE
OSDOCS-17363:Update the z-stream RNs for 4.16.53

### DIFF
--- a/modules/zstream-4-16-53-about.adoc
+++ b/modules/zstream-4-16-53-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-16-53-about_{context}"]
+= RHBA-2025:21825 - {product-title} {product-version}.53 bug fix advisory
+
+
+[role="_abstract"]
+Issued: 26 November 2025
+
+{product-title} release {product-version}.53 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:21825[RHBA-2025:21825] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:21823[RHBA-2025:21823] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.53 --pullspecs
+----

--- a/modules/zstream-4-16-53-bug-fixes.adoc
+++ b/modules/zstream-4-16-53-bug-fixes.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-53-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bugs are fixed for this release:
+
+* Before this update, API and Ingress Virtual IP (VIP) addresses were automatically assigned even when a user-managed load balancer was in use. With this release, the API and Ingress VIPs are no longer automatically assigned. If these values are not explicitly set in the `install-config.yaml`, the installation fails with an error, prompting you to provide them. (link:https://issues.redhat.com/browse/OCPBUGS-53237[OCPBUGS-53237])
+
+* Before this update, installing an {aws-short} cluster in either the Commercial Cloud Services (C2S) region or the Secret Commercial Cloud Services (SC2S) region failed because the installation program added unsupported security groups to the load balancer. With this release, the installation program no longer adds unsupported security groups to the load balancer for a cluster that needs to be installed in either the C2S region or SC2S region. (link:https://issues.redhat.com/browse/OCPBUGS-54165[OCPBUGS-54165])
+
+* Before this update, if the OVNKube-controller was not processing updates from the Kubernetes API server and configuring the open virtual network (OVN) databases on each node, then the OVN-Controller, which consumed this database, might have connected to the database before the OVNKube-controller had configured them. As a consequence, the OVN-Controller synced with a stale OVN database, consumed source network address translations (SNATs) that were configured to support EgressIP, and proceeded to the gratuitous address resolution protocol (GARP) for the associated IP even though that IP might have moved to another node. With this release, these GARPs are blocked when the OVNKube-controller is not processing updates. (link:https://issues.redhat.com/browse/OCPBUGS-63155[OCPBUGS-63155])
+
+* Before this update, the ccoctl utility would automatically generate a new keypair if the private key was not found, even when users intentionally provided only the public key according to documented security procedures. This behavior caused a problem, as the newly generated keys would not match the cluster keys, resulting in service outages for users following the correct process. With this release, the utility is changed to ensure a new keypair is never generated when the `--public-key-file` parameter is specified, and this parameter is added to all `create-all` functions for consistency. As a result, specifying the public key file now guarantees the provided key is used, which ensures that the cluster continues to function as expected without interruption. (link:https://issues.redhat.com/browse/OCPBUGS-63550[OCPBUGS-63550])
+
+* Before this update, the `/auth/error` page did not render correctly. As a consequence, the page was empty and error details did not appear. With this release, the front end error page content now renders on the `/auth/error` page. As a result, the expected error content is displayed. (link:https://issues.redhat.com/browse/OCPBUGS-64649[OCPBUGS-64649])
+
+* Before this update, during failover, the system's duplicate address detection (DAD) could incorrectly disable the Egress IPv6 address if it was briefly present on both nodes, breaking the connection. With this release, the Egress IPv6 is configured to skip the DAD check during failover, which guarantees uninterrupted egress IPv6 traffic after an Egress IP address successfully moves to a different node and ensures greater network stability. (link:https://issues.redhat.com/browse/OCPBUGS-64944[OCPBUGS-64944])

--- a/modules/zstream-4-16-53-updating.adoc
+++ b/modules/zstream-4-16-53-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-53-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3396,6 +3396,15 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// About 4-16-53 release notes
+include::modules/zstream-4-16-53-about.adoc[leveloffset=+2]
+
+// 4-16-53 release notes bug fixes
+include::modules/zstream-4-16-53-bug-fixes.adoc[leveloffset=+2]
+
+// 4-16-53 release notes updating
+include::modules/zstream-4-16-53-updating.adoc[leveloffset=+2]
+
 //4.16.52
 [id="ocp-4-16-52_{context}"]
 === RHBA-2025:19901 - {product-title} {product-version}.52 bug fix and security update


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-17363

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Additional information:
4.16.53 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/248
4.16.53 ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16