### PR TITLE
[enterprise-4.14] CNV#51222: Restoring doc Deploying a vm template

### DIFF
--- a/modules/virt-adding-templates-to-custom-namespace.adoc
+++ b/modules/virt-adding-templates-to-custom-namespace.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_templates/virt-deploying-vm-template-to-custom-namespace.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-adding-templates-to-custom-namespace_{context}"]
+= Adding templates to a custom namespace
+
+[role="_abstract"]
+The Scheduling, Scale, and Performance (SSP) Operator deploys virtual machine templates to the `openshift` namespace by default. To also publish these templates in a custom namespace, set the `commonTemplatesNamespace` field in the `HyperConverged` custom resource (CR). After the templates sync to the custom namespace, you can modify or delete them there.
+
+[NOTE]
+====
+Do not edit templates in the `openshift` namespace. The SSP Operator reconciles that namespace and overwrites changes.
+====
+
+.Prerequisites
+* Install the {oc-first}.
+* Log in as a user with cluster-admin privileges.
+
+.Procedure
+
+. Optional: Create the custom namespace if it does not already exist:
++
+[source,terminal]
+----
+$ oc create namespace <custom_namespace>
+----
+
+. Optional: View the list of templates in the `openshift` namespace:
++
+[source,terminal]
+----
+$ oc get templates -n openshift
+----
+
+. Open the `HyperConverged` CR in your default editor by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc edit hco -n {CNVNamespace} kubevirt-hyperconverged
+----
+
+. Add the `commonTemplatesNamespace` field and set your target namespace. For example:
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  commonTemplatesNamespace: <custom_namespace>
+----
+
+. Save and exit. The SSP Operator creates or updates the templates in the custom namespace.
+
+. Verify the templates in the custom namespace:
++
+[source,terminal]
+----
+$ oc get templates -n <custom_namespace>
+----

--- a/modules/virt-deleting-templates-from-custom-namespace.adoc
+++ b/modules/virt-deleting-templates-from-custom-namespace.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_templates/virt-deploying-vm-template-to-custom-namespace.adoc
+
+:_mod-docs-content-type: PROCEDURE
+
+[id="virt-deleting-templates-from-custom-namespace_{context}"]
+= Deleting templates from a custom namespace
+
+To delete virtual machine templates from a custom namespace, remove the `commonTemplateNamespace` attribute from the `HyperConverged` custom resource (CR) and delete each template from that custom namespace.
+
+.Procedure
+
+. Edit the `HyperConverged` CR in your default editor by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc edit hco -n {CNVNamespace} kubevirt-hyperconverged
+----
++
+. Remove the `commonTemplateNamespace` attribute:
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+spec:
+  commonTemplatesNamespace: <custom_namespace>
+----
++
+. Delete a specific template from the custom namespace that you removed from the `HyperConverged` CR:
++
+[source,terminal]
+----
+$ oc delete templates -n <custom_namespace> <template_name>
+----
+
+.Verification
+
+* Verify that the template was deleted from the custom namespace:
++
+[source,terminal]
+----
+$ oc get templates -n <custom_namespace>
+----

--- a/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc
+++ b/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc
@@ -11,21 +11,20 @@ You can create virtual machines (VMs) from Red Hat templates by using the {produ
 [id="virt-about-templates"]
 == About VM templates
 
-Boot sources::
+You can use VM templates to help you easily create VMs.
+
+Expedite creation with boot sources::
 You can expedite VM creation by using templates that have an available boot source. Templates with a boot source are labeled *Available boot source* if they do not have a custom label.
 +
-Templates without a boot source are labeled *Boot source required*. See xref:../../../virt/virtual_machines/creating_vms_custom/virt-creating-vms-from-custom-images-overview.adoc#virt-creating-vms-from-custom-images-overview[Creating virtual machines from custom images].
+Templates without a boot source are labeled *Boot source required*. See xref:../../storage/virt-automatic-bootsource-updates.adoc#virt-automatic-bootsource-updates[Managing automatic boot source updates] for details.
 
-Customization::
-You can customize the disk source and VM parameters before you start the VM:
+Customize before starting the VM::
+You can customize the disk source and VM parameters before you start the VM.
 
-* See xref:../../../virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc#virt-vm-storage-volume-types_virt-creating-vms-from-templates[storage volume types] and xref:../../../virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc#virt-storage-wizard-fields-web_virt-creating-vms-from-templates[storage fields] for details about disk source settings.
-
-* See the xref:../../../virt/getting_started/virt-web-console-overview.adoc#virtualmachine-details-overview_virt-web-console-overview[*Overview*], xref:../../../virt/getting_started/virt-web-console-overview.adoc#virtualmachine-details-yaml_virt-web-console-overview[*YAML*], and xref:../../../virt/getting_started/virt-web-console-overview.adoc#virtualmachine-details-configuration_virt-web-console-overview[*Configuration*] tab documentation for details about VM settings.
-
++
 [NOTE]
 ====
-If you copy a VM template with all its labels and annotations, your version of the template is marked as deprecated when a new version of the Scheduling, Scale, and Performance (SSP) Operator is deployed. You can remove this designation. See xref:../../../virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc#virt-customizing-vm-template-web_virt-creating-vms-from-templates[Customizing a VM template by using the web console].
+If you copy a VM template with all its labels and annotations, your version of the template is marked as deprecated when a new version of the Scheduling, Scale, and Performance (SSP) Operator is deployed. You can remove this designation. See xref:../../virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.adoc#virt-customizing-vm-template-web_virt-creating-vms-from-templates[Customizing a VM template by using the web console].
 ====
 
 {sno-caps}::
@@ -33,10 +32,10 @@ Due to differences in storage behavior, some templates are incompatible with {sn
 
 include::modules/virt-creating-vm-from-template.adoc[leveloffset=+1]
 
-include::modules/virt-vm-storage-volume-types.adoc[leveloffset=+2]
+include::modules/virt-customizing-vm-template-web.adoc[leveloffset=+1]
 
-include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
+include::modules/virt-creating-template.adoc[leveloffset=+1]
 
-include::modules/virt-customizing-vm-template-web.adoc[leveloffset=+2]
+include::modules/virt-adding-templates-to-custom-namespace.adoc[leveloffset=+1]
 
-include::modules/virt-creating-template.adoc[leveloffset=+2]
+include::modules/virt-deleting-templates-from-custom-namespace.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/CNV-51222

Link to docs preview:
https://102859--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/creating_vms_rh/virt-creating-vms-from-templates.html

Additional information:
Cherry Picked from 3ab5e5b607095bd3c731b23db9610db48b547f1b
xref: https://github.com/openshift/openshift-docs/pull/98186
