### PR TITLE
OSDOCS#17391: Fixed 2 typos and added an attribute in the 4.20 RNs

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1200,7 +1200,7 @@ For more information, see xref:../storage/container_storage_interface/persistent
 [id="ocp-release-notes-storage-csi-aws-efs-cross-account-procedure-rewrite_{context}"]
 ==== AWS EFS cross account procedure revision
 
-To enhance usability and provide both Security Token Service (STS) and non-STS support, the Amazone Web Serivces (AWS) Elastic File Service (EFS) cross account support procedure has been revised.
+To enhance usability and provide both Security Token Service (STS) and non-STS support, the {aws-first} Elastic File Service (EFS) cross account support procedure has been revised.
 
 To view the revised procedure, see xref:../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-efs-cross-account_persistent-storage-csi-aws-efs[AWS EFS cross account support].
 
@@ -1793,7 +1793,7 @@ As a result, the controller handles errors during migration better.
 
 * Before this update, installing {sno} on `platform: None` with user-provisioned infrastructure was not supported, which led to installation failures. With this release, {sno} installation on `platform: None` is supported. (link:https://issues.redhat.com/browse/OCPBUGS-58216[OCPBUGS-58216])
 
-* Before this update, when you installed {product-title} on {aws-first}, the Machine Config Operator (MCO) for disabling boot image management failed to check edge compute machine pools. When determining whether to disable boot image management, the installation progream only checked the first compute machine pool entry in the `install-config.yaml`. As a consequence, when you specified multiple compute pools but only the second had a custom Amazon Machine Image (AMI), the installation program did not disable MCO boot image management and the MCO could overwrite the custom AMI. With this release, the installation program checks all edge compute machine pools for custom images. As a result, boot image management is disabled when a custom image is specified in any machine pool. (link:https://issues.redhat.com/browse/OCPBUGS-57803[OCPBUGS-57803])
+* Before this update, when you installed {product-title} on {aws-first}, the Machine Config Operator (MCO) for disabling boot image management failed to check edge compute machine pools. When determining whether to disable boot image management, the installation program only checked the first compute machine pool entry in the `install-config.yaml`. As a consequence, when you specified multiple compute pools but only the second had a custom Amazon Machine Image (AMI), the installation program did not disable MCO boot image management and the MCO could overwrite the custom AMI. With this release, the installation program checks all edge compute machine pools for custom images. As a result, boot image management is disabled when a custom image is specified in any machine pool. (link:https://issues.redhat.com/browse/OCPBUGS-57803[OCPBUGS-57803])
 
 * Before this update, the Agent-based Installer set the permissions for the etcd directory `/var/lib/etcd/member` as `0755` when using an {sno} deployment instead of `0700`, which is correctly set on a multi-node deployment. With this release, the etcd directory `/var/lib/etcd/member` permissions are set to `0700` for {sno} deployments. (link:https://issues.redhat.com/browse/OCPBUGS-57021[OCPBUGS-57201])
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-17391](https://issues.redhat.com//browse/OSDOCS-17391)

Link to docs preview:

- [AWS EFS Cross account procedure revision](https://102860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-storage-csi-aws-efs-cross-account-procedure-rewrite_release-notes)

- [Installer](https://102860--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-installer-bug-fixes_release-notes)

QE review:
N/A for spelling corrections and adding an attribute.

Additional information:
 - Engineering PR: 102666
