### PR TITLE
OSDOCS-16580: Address Vale warnings and errors in "Upgrading"

### DIFF
--- a/modules/rosa-hcp-upgrade-options.adoc
+++ b/modules/rosa-hcp-upgrade-options.adoc
@@ -2,8 +2,7 @@
 [id="rosa-upgrade-options_{context}"]
 = Upgrade options for {product-title} clusters
 
-In OpenShift, upgrading means provisioning a new component with updated software and using it to replace an existing component that has outdated software.
-
+[role="_abstract"]
 You can control the impact of upgrades to your workload by controlling which parts of the cluster are upgraded, for example:
 
 Upgrade only the hosted control plane:: This initiates upgrade of the hosted control plane. It does not impact your worker nodes.

--- a/modules/rosa-hcp-upgrading-cli-control-plane.adoc
+++ b/modules/rosa-hcp-upgrading-cli-control-plane.adoc
@@ -10,6 +10,7 @@
 ifeval::["{context}" != "rosa-hcp-upgrading-whole-cluster"]
 = Upgrading the hosted control plane with the ROSA CLI
 
+[role="_abstract"]
 You can manually upgrade the hosted control plane of a {product-title} cluster by using the ROSA CLI. This method schedules the control plane for an upgrade if a more recent version is available, either immediately, or at a specified future time.
 
 [NOTE]
@@ -40,9 +41,9 @@ endif::[]
 +
 [source,terminal]
 ----
-$ rosa describe cluster --cluster=<cluster_name_or_id> <1>
+$ rosa describe cluster --cluster=<cluster_name_or_id>
 ----
-<1> Replace `<cluster_name_or_id>` with the cluster name or the cluster ID.
+Replace `<cluster_name_or_id>` with the cluster name or the cluster ID.
 
 . List the versions that you can upgrade your control plane to by running the following command:
 +
@@ -53,7 +54,7 @@ $ rosa list upgrade --cluster=<cluster_name_or_id>
 +
 The command returns a list of available updates, including the recommended version.
 +
-.Example output
+*Example output*
 +
 [source,terminal]
 ----

--- a/modules/rosa-hcp-upgrading-cli-machinepool.adoc
+++ b/modules/rosa-hcp-upgrading-cli-machinepool.adoc
@@ -10,6 +10,7 @@
 ifeval::["{context}" != "rosa-hcp-upgrading-whole-cluster"]
 = Upgrading machine pools with the ROSA CLI
 
+[role="_abstract"]
 You can manually upgrade one or more machine pools in a {hcp-title} cluster by using the ROSA CLI. This method schedules the specified machine pool for an upgrade if a more recent version is available, either immediately, or at a specified future time.
 
 [NOTE]
@@ -41,19 +42,22 @@ Machine pool configurations such as node drain timeout, max-unavailable, and max
 +
 [source,terminal]
 ----
-$ rosa describe cluster --cluster=<cluster_name_or_id> <1>
+$ rosa describe cluster --cluster=<cluster_name_or_id>
 ----
-<1> Replace `<cluster_name_or_id>` with the cluster name or the cluster ID.
+Replace `<cluster_name_or_id>` with the cluster name or the cluster ID.
 +
 ifeval::["{context}" != "rosa-hcp-upgrading-whole-cluster"]
-.Example output
+
+*Example output*
++
 [source,terminal]
 ----
 OpenShift Version:     4.14.0
 ----
 endif::[]
 ifeval::["{context}" == "rosa-hcp-upgrading-whole-cluster"]
-.Example output
+*Example output*
++
 [source,terminal]
 ----
 OpenShift Version:     4.14.8
@@ -70,7 +74,7 @@ $ rosa list upgrade --cluster <cluster-name> --machinepool <machinepool_name>
 +
 The command returns a list of available updates, including the recommended version.
 +
-.Example output
+*Example output*
 +
 [source,terminal]
 ----
@@ -93,7 +97,8 @@ Do not upgrade your machine pool to a version higher than your control plane. If
 $ rosa describe machinepool --cluster=<cluster_name_or_id> <machinepool_name>
 ----
 +
-.Example output
+*Example output*
++
 [source,terminal]
 ----
 Replicas: 5

--- a/upgrading/rosa-hcp-upgrading.adoc
+++ b/upgrading/rosa-hcp-upgrading.adoc
@@ -6,6 +6,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+In {product-title}, upgrading provisions a new component with updated software and uses it to replace an existing component that has outdated software.
+
 include::modules/rosa-hcp-upgrade-options.adoc[leveloffset=+1]
 
 .Additional resources


### PR DESCRIPTION
[OSDOCS-16580](https://issues.redhat.com//browse/OSDOCS-16580): Address Vale warnings and errors in "Upgrading"

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-16580

Link to docs preview:
https://102886--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/upgrading/rosa-hcp-upgrading.html

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
