### PR TITLE
OSDOCS-17397 created z-stream RNs for 4-20-5

### DIFF
--- a/modules/zstream-4-20-5-about.adoc
+++ b/modules/zstream-4-20-5-about.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-20-5-about_{context}"]
+= RHBA-2025:21811 - {product-title} {product-version}.5 bug fix advisory
+
+[role="_abstract"]
+Issued: 25 November 2025
+
+{product-title} release {product-version}.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:21811[RHBA-2025:21811] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:21809[RHBA-2025:21809] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.5 --pullspecs
+----

--- a/modules/zstream-4-20-5-bug-fixes.adoc
+++ b/modules/zstream-4-20-5-bug-fixes.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-5-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bugs are fixed for this release:
+
+* Before this update, the `oauth` pods in the `openshift-authentication` namespaces could get stuck while rolling out changes when one of the corresponding nodes these pods are running on is not ready or not available. This was causing authentication to completely stop until the blocked rollout concludes. With this release, the pods can proceed with the rolling update even when an unhealthy node is down or unavailable (link:https://issues.redhat.com/browse/OCPBUGS-61896[OCPBUGS-61896])
+
+* Before this update, alerts in the project overview were not visible because the application was querying an incorrect API. With this release, the application now queries the correct API and displays the project alerts. (link:https://issues.redhat.com/browse/OCPBUGS-63125[OCPBUGS-63125])
+
+* Before this update, the aggregated API servers on {product-title} were provisioned with `in-memory` loopback certificates that were valid for only 1 year. With this release, the aggregated API servers on {product-title} are provisioned with `in-memory` loopback certificates that are valid for 3 years. (link:https://issues.redhat.com/browse/OCPBUGS-63532[OCPBUGS-63532])
+
+* Before this update, when directly navigating to a page created by a web console dynamic plugin, the web console might redirect to a different URL. With this release, the URL redirect has been removed. (link:https://issues.redhat.com/browse/OCPBUGS-63616[OCPBUGS-63616])
+
+* Before this release, any unrelated changes to a `netpol` resource triggered a full reconcile of the object, including deleting and re-adding rules. With this release, a `netpol` object fully reconciles when required. Otherwise, it is skipped. (link:https://issues.redhat.com/browse/OCPBUGS-64590[OCPBUGS-64590])
+
+* Before this update, the Horizontal Pod Autoscaler (HPA) form incorrectly mandated both CPU and memory values, forcing users to use YAML for single-metric HPAs (such as memory-only) or to rely on the default CPU setting. With this release, the form has been updated and leaving a field empty now correctly omits that metric, allowing users to create CPU-only, memory-only, or default 80% CPU HPAs from the web form. (link:https://issues.redhat.com/browse/OCPBUGS-64639[OCPBUGS-64639])
+
+* Before this update, it was impossible to schedule a `must-gather` pod to a specific worker node when the `--node-name` argument was used as the pod's node affinity accepted only control plane nodes. With this release, the `must-gather` logic is updated to avoid setting node affinity when the `--node-name` argument is set. (link:https://issues.redhat.com/browse/OCPBUGS-65523[OCPBUGS-65523])

--- a/modules/zstream-4-20-5-enhancements.adoc
+++ b/modules/zstream-4-20-5-enhancements.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-5-enhancements_{context}"]
+= Enhancements
+
+[role="_abstract"]
+The following enhancements for direct authentication with an external OpenID Connect (OIDC) identity provider are included in this z-stream release:
+
+General availability of direct authentication with an external OIDC identity provider::
+Using direct authentication with an external OIDC identity provider is now generally available. This authentication method bypasses the built-in OAuth server and uses the external identity provider directly.
+
+Support for additional identity providers::
+The following OIDC identity providers are now supported for direct authentication:
+
+* Active Directory Federation Services for Windows Server
+* GitLab
+* Google
+* Okta
+* Ping Identity
+* Red Hat Single Sign-On
+
+Deactivation of OAuth services::
+The following internal OAuth resources are now disabled when you configure direct authentication:
+
+* OpenShift OAuth server and OpenShift OAuth API server
+* User and group APIs (`*.user.openshift.io`)
+* OAuth APIs (`*.oauth.openshift.io`)
+* OAuth server and client configurations
+
+[IMPORTANT]
+====
+Ensure that you do not rely on these removed resources before configuring direct authentication.
+====
+
+Support for additional claim mappings::
+You can now use the `uid` and `extra` claim mapping fields when configuring an external OIDC provider for direct authentication.
+
+For more information, see xref:../authentication/external-auth.adoc#external-auth[Enabling direct authentication with an external OIDC identity provider].

--- a/modules/zstream-4-20-5-known-issues.adoc
+++ b/modules/zstream-4-20-5-known-issues.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-5-known-issues_{context}"]
+= Known issues
+
+[role="_abstract"]
+This release contains the following known issues:
+
+
+* When using GitLab or Google as the external OIDC identity provider for direct authentication, clicking *Log out* from the {product-title} web console does not log you out of the console. (link:https://issues.redhat.com/browse/OCPBUGS-61649[OCPBUGS-61649])
+
+* When using Active Directory Federation Services for Windows Server as the external OIDC identity provider for direct authentication, logging into the {product-title} web console the first time produces an authentication error. As a workaround, reload the web console until it displays properly. (link:https://issues.redhat.com/browse/OCPBUGS-62142[OCPBUGS-62142])
+
+* If you configure direct authentication with an external OIDC provider and do not provide a value for `issuerCertificateAuthority` for the issuer in the OIDC provider configuration, the Machine Config Operator degrades. This can cause the Console Operator to degrade and some control plane nodes might fail to become available. As a workaround, set the `issuerCertificateAuthority` value for the issuer. (link:https://issues.redhat.com/browse/OCPBUGS-62011[OCPBUGS-62011])
+
+

--- a/modules/zstream-4-20-5-updating.adoc
+++ b/modules/zstream-4-20-5-updating.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-5-updating_{context}"]
+= Updating
+
+
+[role="_abstract"]
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -2977,6 +2977,21 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// About 4-20-5 release notes
+include::modules/zstream-4-20-5-about.adoc[leveloffset=+2]
+
+// 4-20-5 release notes enhancements
+include::modules/zstream-4-20-5-enhancements.adoc[leveloffset=+2]
+
+// 4-20-5 release notes known issues
+include::modules/zstream-4-20-5-known-issues.adoc[leveloffset=+2]
+
+// 4-20-5 release notes bug fixes
+include::modules/zstream-4-20-5-bug-fixes.adoc[leveloffset=+2]
+
+// 4-20-5 release notes updating
+include::modules/zstream-4-20-5-updating.adoc[leveloffset=+2]
+
 //4.20.4
 [id="ocp-4-20-4_{context}"]
 === RHSA-2025:21228 - {product-title} {product-version}.4 image release, bug fix, and security update advisory


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-17397

Link to docs preview:
https://102896--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-5-about_release-notes

QE review:
- [ ] QE has approved this change.


Additional information:

These z-stream RNs are in a new modular format to prepare for DITA migration. Also, there is an xref error below. Ignore that error as it was decided that a special exception would be made for release notes.

To find the Image and RPM IDs, select the following links:

For the Image ID: https://[gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/231/diffs#ffa924ede19389f6b6e0dc0c20bd434fa978af9b](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/247/diffs#ba5bb70bf0ab02dfd07a5c51d663a41f31c9a9de)

For the RPM ID: https://errata.devel.redhat.com/advisory/156361

Must be on VPN to view these links.
