### PR TITLE
OSDOCS-17043_1#applying CQAs for machine sets_1

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on Amazon Web Services (AWS). For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
+[role="_abstract"]
+You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on {aws-first}. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 //[IMPORTANT] admonition for UPI
 include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
@@ -32,6 +33,7 @@ include::modules/machineset-imds-options.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html[Use the Instance Metadata Service to access instance metadata ({aws-short} documentation)]
 * xref:../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Boot image management]
 
 //Creating machines that use the Amazon EC2 Instance Metadata Service

--- a/modules/machineset-aws-existing-placement-group.adoc
+++ b/modules/machineset-aws-existing-placement-group.adoc
@@ -11,13 +11,14 @@ endif::[]
 [id="machineset-aws-existing-placement-group_{context}"]
 = Assigning machines to placement groups for Elastic Fabric Adapter instances by using machine sets
 
-You can configure a machine set to deploy machines on link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html[Elastic Fabric Adapter] (EFA) instances within an existing AWS placement group.
+[role="_abstract"]
+You can configure a machine set to deploy machines on Elastic Fabric Adapter (EFA) instances within an existing {aws-first} placement group. Using EFA instances to run control plane machines can improve network performance.
 
-EFA instances do not require placement groups, and you can use placement groups for purposes other than configuring an EFA. This example uses both to demonstrate a configuration that can improve network performance for machines within the specified placement group.
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html[EFA] instances do not require placement groups, and you can use placement groups for purposes other than configuring an EFA. This example uses both to demonstrate a configuration that can improve network performance for machines within the specified placement group.
 
 .Prerequisites
 
-* You created a placement group in the AWS console.
+* You created a placement group in the {aws-short} console.
 +
 [NOTE]
 ====
@@ -32,7 +33,7 @@ endif::cpmso[]
 . In a text editor, open the YAML file for an existing machine set or create a new one.
 
 . Edit the following lines under the `providerSpec` field:
-+
+
 [source,yaml]
 ----
 ifndef::cpmso[]
@@ -49,25 +50,30 @@ spec:
     spec:
       providerSpec:
         value:
-          instanceType: <supported_instance_type> # <1>
-          networkInterfaceType: EFA # <2>
+          instanceType: <supported_instance_type>
+          networkInterfaceType: EFA
           placement:
-            availabilityZone: <zone> # <3>
-            region: <region> # <4>
-          placementGroupName: <placement_group> # <5>
-          placementGroupPartition: <placement_group_partition_number> # <6>
+            availabilityZone: <zone>
+            region: <region>
+          placementGroupName: <placement_group>
+          placementGroupPartition: <placement_group_partition_number>
 # ...
 ----
-<1> Specify an instance type that link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types[supports EFAs].
-<2> Specify the `EFA` network interface type.
-<3> Specify the zone, for example, `us-east-1a`.
-<4> Specify the region, for example, `us-east-1`.
-<5> Specify the name of the existing AWS placement group to deploy machines in.
-<6> Optional: Specify the partition number of the existing AWS placement group to deploy machines in.
+
+where:
+
+--
+`spec.template.spec.providerSpec.value.instanceType`:: Specifies an instance type that link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types[supports EFAs].
+`spec.template.spec.providerSpec.value.networkInterfaceType`:: Specifies the `EFA` network interface type.
+`spec.template.spec.providerSpec.value.placement.availabilityZone`:: Specifies the zone, for example, `us-east-1a`.
+`spec.template.spec.providerSpec.value.placement.region`:: Specifies the region, for example, `us-east-1`.
+`spec.template.spec.providerSpec.value.placementGroupName`:: Specifies the name of the existing {aws-short} placement group to deploy machines in.
+`spec.template.spec.providerSpec.value.placementGroupPartition`:: Optional: Specifies the partition number of the existing AWS placement group to deploy machines in.
+--
 
 .Verification
 
-* In the AWS console, find a machine that the machine set created and verify the following in the machine properties:
+* In the {aws-short} console, find a machine that the machine set created and verify the following in the machine properties:
 
 ** The placement group field has the value that you specified for the `placementGroupName` parameter in the machine set.
 

--- a/modules/machineset-capacity-reservation.adoc
+++ b/modules/machineset-capacity-reservation.adoc
@@ -27,7 +27,9 @@ ifdef::aws[= Configuring Capacity Reservations by using machine sets]
 ifdef::azure[on-demand Capacity Reservation with Capacity Reservation groups on {azure-full} clusters.]
 ifdef::aws[Capacity Reservations on {aws-full} clusters, including On-Demand Capacity Reservations and Capacity Blocks for ML.]
 
+[role="_abstract"]
 You can configure a machine set to deploy machines on any available resources that match the parameters of a capacity request that you define.
+
 These parameters specify the
 ifdef::azure[VM size,]
 ifdef::aws[instance type,]
@@ -39,7 +41,7 @@ can accommodate the capacity request, the deployment succeeds.
 
 For more information, including limitations and suggested use cases for this
 ifdef::azure[{azure-short} offering, see link:https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-overview[On-demand Capacity Reservation] in the {azure-full} documentation.]
-ifdef::aws[{aws-short} offering, see link:https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/capacity-reservation-overview.html[On-Demand Capacity Reservations and Capacity Blocks for ML] in the {aws-short} documentation.]
+ifdef::aws[{aws-full} offering, see link:https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/capacity-reservation-overview.html[On-Demand Capacity Reservations and Capacity Blocks for ML] in the {aws-short} documentation.]
 
 ifdef::azure[]
 [NOTE]
@@ -68,7 +70,6 @@ endif::aws[]
 
 . Edit the following section under the `providerSpec` field:
 +
---
 .Sample configuration
 [source,yaml]
 ----
@@ -88,11 +89,11 @@ tag::compute[]
       providerSpec:
         value:
 ifdef::azure[]
-          capacityReservationGroupID: <capacity_reservation_group> # <1>
+          capacityReservationGroupID: <capacity_reservation_group>
 endif::azure[]
 ifdef::aws[]
-          capacityReservationId: <capacity_reservation> # <1>
-          marketType: <market_type> # <2>
+          capacityReservationId: <capacity_reservation>
+          marketType: <market_type>
 endif::aws[]
 end::compute[]
 tag::controlplane[]
@@ -101,30 +102,53 @@ tag::controlplane[]
         providerSpec:
           value:
 ifdef::azure[]
-            capacityReservationGroupID: <capacity_reservation_group> # <1>
+            capacityReservationGroupID: <capacity_reservation_group>
 endif::azure[]
 ifdef::aws[]
-            capacityReservationId: <capacity_reservation> # <1>
-            marketType: <market_type> # <2>
+            capacityReservationId: <capacity_reservation>
+            marketType: <market_type>
 endif::aws[]
 end::controlplane[]
 # ...
 ----
-<1> Specify the ID of the
++
+where:
++
+tag::compute[]
+ifdef::azure[]
+`<capacity_reservation_group>`::
+endif::azure[]
+ifdef::aws[]
+`<capacity_reservation>`::
+endif::aws[]
+end::compute[]
+tag::controlplane[]
+ifdef::azure[]
+`<capacity_reservation_group>`::
+endif::azure[]
+ifdef::aws[]
+`<capacity_reservation>`::
+endif::aws[]
+end::controlplane[]
+Specifies the ID of the
 ifdef::azure[Capacity Reservation group]
 ifdef::aws[Capacity Block for ML or On-Demand Capacity Reservation]
 that you want the machine set to deploy machines on.
+
 ifdef::aws[]
-<2> Specify the market type to use.
+`<market_type>`::
+Specifies the market type to use.
 The following values are valid:
++
+--
 `CapacityBlock`:: Use this market type with Capacity Blocks for ML.
 `OnDemand`:: Use this market type with On-Demand Capacity Reservations.
 tag::compute[]
 `Spot`:: Use this market type with Spot Instances.
 This option is not compatible with Capacity Reservations.
 end::compute[]
-endif::[]
 --
+endif::aws[]
 
 .Verification
 

--- a/modules/machineset-creating-dedicated-instances.adoc
+++ b/modules/machineset-creating-dedicated-instances.adoc
@@ -7,7 +7,8 @@
 [id="machineset-creating-dedicated-instance_{context}"]
 = Creating Dedicated Instances by using machine sets
 
-You can run a machine that is backed by a Dedicated Instance by using Machine API integration. Set the `tenancy` field in your machine set YAML file to launch a Dedicated Instance on AWS.
+[role="_abstract"]
+You can run a machine that is backed by a Dedicated Instance by using Machine API integration. Set the `tenancy` field in your machine set YAML file to launch a Dedicated Instance on {aws-first}.
 
 .Procedure
 

--- a/modules/machineset-creating-imds-options.adoc
+++ b/modules/machineset-creating-imds-options.adoc
@@ -7,10 +7,11 @@
 [id="machineset-creating-imds-options_{context}"]
 = Configuring IMDS by using machine sets
 
+[role="_abstract"]
 You can specify whether to require the use of IMDSv2 by adding or editing the value of `metadataServiceOptions.authentication` in the machine set YAML file for your machines.
 
 .Prerequisites
-* To use IMDSv2, your AWS cluster must have been created with {product-title} version 4.7 or later.
+* To use IMDSv2, your {aws-first} cluster must have been created with {product-title} version 4.7 or later.
 
 .Procedure
 * Add or edit the following lines under the `providerSpec` field:
@@ -20,6 +21,9 @@ You can specify whether to require the use of IMDSv2 by adding or editing the va
 providerSpec:
   value:
     metadataServiceOptions:
-      authentication: Required <1>
+      authentication: Required
 ----
-<1> To require IMDSv2, set the parameter value to `Required`. To allow the use of both IMDSv1 and IMDSv2, set the parameter value to `Optional`. If no value is specified, both IMDSv1 and IMDSv2 are allowed.
+
+where:
+
+`providerSpec.value.metadataServiceOptions.authentication`:: Specifies whether to require IMDSv2. Set this parameter to `Required` to require IMDSv2. Set this parameter to `Optional` to allow the use of both IMDSv1 and IMDSv2. If you do not specify a value, both IMDSv1 and IMDSv2 are allowed.

--- a/modules/machineset-creating-non-guaranteed-instances.adoc
+++ b/modules/machineset-creating-non-guaranteed-instances.adoc
@@ -19,6 +19,7 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="machineset-creating-non-guaranteed-instance_{context}"]
+
 ifdef::aws[= Creating Spot Instances by using compute machine sets]
 ifdef::azure[= Creating Spot VMs by using compute machine sets]
 ifdef::gcp[= Creating Spot VMs by using compute machine sets]
@@ -40,8 +41,8 @@ endif::[]
 
 .Procedure
 * Add the following line under the `providerSpec` field:
-+
 ifdef::aws[]
++
 [source,yaml]
 ----
 providerSpec:
@@ -49,16 +50,19 @@ providerSpec:
     spotMarketOptions: {}
 ----
 +
+--
 You can optionally set the `spotMarketOptions.maxPrice` field to limit the cost of the Spot Instance. For example you can set `maxPrice: '2.50'`.
-+
-If the `maxPrice` is set, this value is used as the hourly maximum spot price. If it is not set, the maximum price defaults to charge up to the On-Demand Instance price.
-+
+
 [NOTE]
 ====
+If the `maxPrice` is set, this value is used as the hourly maximum spot price. If it is not set, the maximum price defaults to charge up to the On-Demand Instance price.
+
 It is strongly recommended to use the default On-Demand price as the `maxPrice` value and to not set the maximum price for Spot Instances.
 ====
+--
 endif::aws[]
 ifdef::azure[]
++
 [source,yaml]
 ----
 providerSpec:
@@ -66,16 +70,19 @@ providerSpec:
     spotVMOptions: {}
 ----
 +
+--
 You can optionally set the `spotVMOptions.maxPrice` field to limit the cost of the Spot VM. For example you can set `maxPrice: '0.98765'`. If the `maxPrice` is set, this value is used as the hourly maximum spot price. If it is not set, the maximum price defaults to `-1` and charges up to the standard VM price.
-+
-Azure caps Spot VM prices at the standard price. Azure will not evict an instance due to pricing if the instance is set with the default `maxPrice`. However, an instance can still be evicted due to capacity restrictions.
+
+{azure-full} caps Spot VM prices at the standard price. {azure-short} will not evict an instance due to pricing if the instance is set with the default `maxPrice`. However, an instance can still be evicted due to capacity restrictions.
 
 [NOTE]
 ====
 It is strongly recommended to use the default standard VM price as the `maxPrice` value and to not set the maximum price for Spot VMs.
 ====
+--
 endif::azure[]
 ifdef::gcp[]
++
 [source,yaml]
 ----
 providerSpec:
@@ -91,19 +98,22 @@ This parameter is not compatible with setting the `providerSpec.value.preemptibl
 ====
 endif::gcp[]
 ifdef::gcp-legacy-preempt[]
++
+--
 [source,yaml]
 ----
 providerSpec:
   value:
     preemptible: true
 ----
-+
+
 If `preemptible` is set to `true`, the machine is labeled as an `interruptible-instance` after the instance is launched.
-+
+
 [NOTE]
 ====
 This parameter is not compatible with setting the `providerSpec.value.provisioningModel` value to `"Spot"`.
 ====
+--
 endif::gcp-legacy-preempt[]
 
 ifeval::["{context}" == "creating-machineset-aws"]

--- a/modules/machineset-dedicated-instances.adoc
+++ b/modules/machineset-dedicated-instances.adoc
@@ -7,6 +7,9 @@
 [id="machineset-dedicated-instance_{context}"]
 = Machine sets that deploy machines as Dedicated Instances
 
-You can create a machine set running on AWS that deploys machines as Dedicated Instances. Dedicated Instances run in a virtual private cloud (VPC) on hardware that is dedicated to a single customer. These Amazon EC2 instances are physically isolated at the host hardware level. The isolation of Dedicated Instances occurs even if the instances belong to different AWS accounts that are linked to a single payer account. However, other instances that are not dedicated can share hardware with Dedicated Instances if they belong to the same AWS account.
+[role="_abstract"]
+You can create a machine set running on {aws-first} that deploys machines as Dedicated Instances. Dedicated Instances run in a virtual private cloud (VPC) on hardware that is dedicated to a single customer.
+
+These Amazon EC2 instances are physically isolated at the host hardware level. The isolation of Dedicated Instances occurs even if the instances belong to different {aws-short} accounts that are linked to a single payer account. However, other instances that are not dedicated can share hardware with Dedicated Instances if they belong to the same {aws-short} account.
 
 Instances with either public or dedicated tenancy are supported by the Machine API. Instances with public tenancy run on shared hardware. Public tenancy is the default tenancy. Instances with dedicated tenancy run on single-tenant hardware.

--- a/modules/machineset-imds-options.adoc
+++ b/modules/machineset-imds-options.adoc
@@ -11,11 +11,14 @@ endif::[]
 [id="machineset-imds-options_{context}"]
 = Machine set options for the Amazon EC2 Instance Metadata Service
 
-You can use machine sets to create machines that use a specific version of the Amazon EC2 Instance Metadata Service (IMDS). Machine sets can create machines that allow the use of both IMDSv1 and link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html[IMDSv2] or machines that require the use of IMDSv2.
+[role="_abstract"]
+You can use machine sets to create machines that use a specific version of the Amazon EC2 Instance Metadata Service (IMDS). Configuring Amazon EC2 IMDS behavior for control plane machines improves security.
+
+Machine sets can create machines that allow the use of both IMDSv1 and IMDSv2 or machines that require the use of IMDSv2.
 
 [NOTE]
 ====
-To use IMDSv2 on AWS clusters that were created with {product-title} version 4.6 or earlier, you must update your boot image. For more information, see "Boot image management".
+To use IMDSv2 on {aws-first} clusters that were created with {product-title} version 4.6 or earlier, you must update your boot image. For more information, see "Boot image management".
 ====
 
 ifndef::cpmso[]
@@ -24,7 +27,7 @@ endif::cpmso[]
 
 [IMPORTANT]
 ====
-Before configuring a machine set to create machines that require IMDSv2, ensure that any workloads that interact with the AWS metadata service support IMDSv2.
+Before configuring a machine set to create machines that require IMDSv2, ensure that any workloads that interact with the {aws-short} metadata service support IMDSv2.
 ====
 
 ifeval::["{context}" == "cpmso-supported-features-aws"]

--- a/modules/machineset-label-gpu-autoscaler.adoc
+++ b/modules/machineset-label-gpu-autoscaler.adoc
@@ -44,7 +44,6 @@ spec:
 where:
 
 `<accelerator_name>`:: Specifies a label of your choice that consists of alphanumeric characters, `-`, `_`, or `.` and starts and ends with an alphanumeric character. For example, you might use `nvidia-t4` to represent Nvidia T4 GPUs, or `nvidia-a10g` for A10G GPUs.
-
 +
 [NOTE]
 ====

--- a/modules/machineset-non-guaranteed-instance.adoc
+++ b/modules/machineset-non-guaranteed-instance.adoc
@@ -26,24 +26,20 @@ ifdef::gcp-legacy-preempt[= Machine sets that deploy machines preemptible VM ins
 
 [role="_abstract"]
 ifdef::aws[]
-You can save on costs by creating a compute machine set running on AWS that deploys machines as non-guaranteed Spot Instances. Spot Instances use unused AWS EC2 capacity and are less expensive than On-Demand Instances. You can use Spot Instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
+You can save on costs by creating a compute machine set running on {aws-first} that deploys machines as non-guaranteed Spot Instances. Spot Instances utilize unused {aws-short} EC2 capacity and are less expensive than On-Demand Instances. You can use Spot Instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
 endif::aws[]
 ifdef::azure[]
-You can save on costs by creating a compute machine set running on Azure that deploys machines as non-guaranteed Spot VMs. Spot VMs use unused Azure capacity and are less expensive than standard VMs. You can use Spot VMs for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
+You can save on costs by creating a compute machine set running on {azure-first} that deploys machines as non-guaranteed Spot VMs. Spot VMs use unused {azure-short} capacity and are less expensive than standard VMs. You can use Spot VMs for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
 endif::azure[]
 ifdef::gcp[]
-You can save on costs by creating a compute machine set running on {gcp-short} that deploys machines as non-guaranteed Spot VMs.
-Spot VMs use excess Compute Engine capacity and are less expensive than normal instances.
-You can use Spot VMs for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
+You can save on costs by creating a compute machine set running on {gcp-short} that deploys machines as non-guaranteed Spot VMs. Spot VMs use excess Compute Engine capacity and are less expensive than normal instances. You can use Spot VMs for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
 endif::gcp[]
 ifdef::gcp-legacy-preempt[]
-You can save on costs by creating a compute machine set running on {gcp-short} that deploys machines as non-guaranteed preemptible VM instances.
-Preemptible VM instances use excess Compute Engine capacity and are less expensive than normal instances.
-You can use preemptible VM instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
+You can save on costs by creating a compute machine set running on {gcp-short} that deploys machines as non-guaranteed preemptible VM instances. Preemptible VM instances use excess Compute Engine capacity and are less expensive than normal instances. You can use preemptible VM instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
 endif::gcp-legacy-preempt[]
 
 ifdef::aws[]
-AWS EC2 can terminate a Spot Instance at any time. AWS gives a two-minute warning to the user when an interruption occurs. {product-title} begins to remove the workloads from the affected instances when AWS issues the termination warning.
+{aws-short} EC2 can terminate a Spot Instance at any time. {aws-short} gives a two-minute warning to the user when an interruption occurs. {product-title} begins to remove the workloads from the affected instances when {aws-short} issues the termination warning.
 
 Interruptions can occur when using Spot Instances for the following reasons:
 
@@ -51,19 +47,19 @@ Interruptions can occur when using Spot Instances for the following reasons:
 * The demand for Spot Instances increases
 * The supply of Spot Instances decreases
 
-When AWS terminates an instance, a termination handler running on the Spot Instance node deletes the machine resource. To satisfy the compute machine set `replicas` quantity, the compute machine set creates a machine that requests a Spot Instance.
+When {aws-short} terminates an instance, a termination handler running on the Spot Instance node deletes the machine resource. To satisfy the compute machine set `replicas` quantity, the compute machine set creates a machine that requests a Spot Instance.
 endif::aws[]
 ifdef::azure[]
-Azure can terminate a Spot VM at any time. Azure gives a 30-second warning to the user when an interruption occurs. {product-title} begins to remove the workloads from the affected instances when Azure issues the termination warning.
+{azure-short} can terminate a Spot VM at any time. {azure-short} gives a 30-second warning to the user when an interruption occurs. {product-title} begins to remove the workloads from the affected instances when {azure-short} issues the termination warning.
 
 Interruptions can occur when using Spot VMs for the following reasons:
 
 * The instance price exceeds your maximum price
 * The supply of Spot VMs decreases
-* Azure needs capacity back
+* {azure-short} needs capacity back
 
 
-When Azure terminates an instance, a termination handler running on the Spot VM node deletes the machine resource. To satisfy the compute machine set `replicas` quantity, the compute machine set creates a machine that requests a Spot VM.
+When {azure-short} terminates an instance, a termination handler running on the Spot VM node deletes the machine resource. To satisfy the compute machine set `replicas` quantity, the compute machine set creates a machine that requests a Spot VM.
 endif::azure[]
 ifdef::gcp[]
 [NOTE]

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -16,21 +16,33 @@ endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="machineset-yaml-aws_{context}"]
-=  Sample YAML for a compute machine set custom resource on AWS
+=  Sample YAML for a compute machine set custom resource on {aws-short}
 
+[role="_abstract"]
 ifndef::edge[]
-The sample YAML defines a compute machine set that runs in the `us-east-1a` Amazon Web Services (AWS) Local Zone and creates nodes that are labeled with
+The sample YAML defines a compute machine set that runs in the `us-east-1a` {aws-first} Local Zone and creates nodes that are labeled with
 endif::edge[]
 ifndef::infra,edge[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 ifdef::edge[]
-This sample YAML defines a compute machine set that runs in the `us-east-1-nyc-1a` Amazon Web Services (AWS) zone and creates nodes that are labeled with `node-role.kubernetes.io/edge: ""`.
+This sample YAML defines a compute machine set that runs in the `us-east-1-nyc-1a` {aws-short} zone and creates nodes that are labeled with `node-role.kubernetes.io/edge: ""`.
+endif::edge[]
 
+ifdef::infra,edge[]
+The sample YAML specifies a taint to prevent user workloads from being scheduled on
+ifdef::infra[`infra`]
+ifdef::edge[`edge`]
+nodes.
+
+After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+endif::infra,edge[]
+
+ifdef::edge[]
 [NOTE]
 ====
-If you want to reference the sample YAML file in the context of Wavelength Zones, ensure that you replace the AWS Region and zone information with supported Wavelength Zone values.
+If you want to reference the sample YAML file in the context of Wavelength Zones, ensure that you replace the {aws-short} Region and zone information with supported Wavelength Zone values.
 ====
-endif::[]
+endif::edge[]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra,edge[`<role>`]
@@ -44,15 +56,15 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra,edge[]
-  name: <infrastructure_id>-<role>-<zone> <2>
+  name: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
-  name: <infrastructure_id>-infra-<zone> <2>
+  name: <infrastructure_id>-infra-<zone>
 endif::infra[]
 ifdef::edge[]
-  name: <infrastructure_id>-edge-<zone> <2>
+  name: <infrastructure_id>-edge-<zone>
 endif::edge[]
   namespace: openshift-machine-api
 spec:
@@ -74,17 +86,17 @@ endif::infra[]
       labels:
         machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra,edge[]
-        machine.openshift.io/cluster-api-machine-role: <role> <3>
+        machine.openshift.io/cluster-api-machine-role: <role>
         machine.openshift.io/cluster-api-machine-type: <role>
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: infra <3>
+        machine.openshift.io/cluster-api-machine-role: infra
         machine.openshift.io/cluster-api-machine-type: infra
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
 ifdef::edge[]
-        machine.openshift.io/cluster-api-machine-role: edge <3>
+        machine.openshift.io/cluster-api-machine-role: edge
         machine.openshift.io/cluster-api-machine-type: edge
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
 endif::edge[]
@@ -106,7 +118,7 @@ endif::edge[]
       providerSpec:
         value:
           ami:
-            id: ami-046fe691f52a953f9 <4>
+            id: ami-046fe691f52a953f9
           apiVersion: machine.openshift.io/v1beta1
           blockDevices:
             - ebs:
@@ -121,8 +133,8 @@ endif::edge[]
           instanceType: m6i.large
           kind: AWSMachineProviderConfig
           placement:
-            availabilityZone: <zone> <5>
-            region: <region> <6>
+            availabilityZone: <zone>
+            region: <region>
           securityGroups:
             - filters:
                 - name: tag:Name
@@ -137,21 +149,21 @@ ifndef::edge[]
             filters:
               - name: tag:Name
                 values:
-                  - <infrastructure_id>-subnet-private-<zone> <7>
+                  - <infrastructure_id>-subnet-private-<zone>
 endif::edge[]
 ifdef::edge[]
-              id: <value_of_PublicSubnetIds> <7>
+              id: <value_of_PublicSubnetIds>
           publicIp: true
 endif::edge[]
           tags:
             - name: kubernetes.io/cluster/<infrastructure_id>
               value: owned
-            - name: <custom_tag_name> <8>
+            - name: <custom_tag_name>
               value: <custom_tag_value>
           userDataSecret:
             name: worker-user-data
 ifdef::infra,edge[]
-      taints: <9>
+      taints:
 ifdef::infra[]
         - key: node-role.kubernetes.io/infra
 endif::infra[]
@@ -161,64 +173,56 @@ endif::edge[]
           effect: NoSchedule
 endif::infra,edge[]
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
 [source,terminal]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 ifndef::infra,edge[]
-<2> Specify the infrastructure ID, role node label, and zone.
-<3> Specify the role node label to add.
+`<infrastructure_id>-<role>-<zone>`:: Specifies the infrastructure ID, role node label, and zone.
+`<role>`:: Specifies the role node label to add.
 endif::infra,edge[]
 ifdef::infra[]
-<2> Specify the infrastructure ID, `infra` role node label, and zone.
-<3> Specify the `infra` role node label.
+`<infrastructure_id>-infra-<zone>`:: Specifies the infrastructure ID, `infra` role node label, and zone.
+`<infra>`:: Specifies the `infra` role node label.
 endif::infra[]
 ifdef::edge[]
-<2> Specify the infrastructure ID, `edge` role node label, and zone name.
-<3> Specify the `edge` role node label.
+`<infrastructure_id>-edge-<zone>`:: Specifies the infrastructure ID, `edge` role node label, and zone name.
+`<edge>`:: Specifies the `edge` role node label.
 endif::edge[]
-<4> Specify a valid {op-system-first} Amazon
-Machine Image (AMI) for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
-+
+[NOTE]
+====
+The `spec.template.spec.providerSpec.value.ami.id` stanza specifies a valid {op-system-first} Amazon Machine Image (AMI) for your AWS zone for your {product-title} nodes. If you want to use an {aws-short} Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[{aws-short} Marketplace] to obtain an AMI ID for your region.
+
 [source,terminal]
 ----
 $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.ami.id}{"\n"}' \
     get machineset/<infrastructure_id>-<role>-<zone>
 ----
+====
 ifndef::edge[]
-<5> Specify the zone name, for example, `us-east-1a`.
+`<zone>`:: Specifies the zone name, for example, `us-east-1a`.
 endif::edge[]
 ifdef::edge[]
-<5> Specify the zone name, for example, `us-east-1-nyc-1a`.
+`<zone>`:: Specifies the zone name, for example, `us-east-1-nyc-1a`.
 endif::edge[]
-<6> Specify the region, for example, `us-east-1`.
+`<region>`:: Specifies the region, for example, `us-east-1`.
 ifndef::edge[]
-<7> Specify the infrastructure ID and zone.
+`<infrastructure_id>-subnet-private-<zone>`:: Specifies the infrastructure ID and zone.
 endif::edge[]
 ifdef::edge[]
-<7> The ID of the public subnet that you created in AWS {zone-type}. You created this public subnet ID when you finished the procedure for "Creating a subnet in an AWS zone".
+`<value_of_PublicSubnetIds>`:: Indicates the ID of the public subnet that you created in {aws-short} {zone-type}. You created this public subnet ID when you finished the procedure for "Creating a subnet in an {aws-short} zone".
 endif::edge[]
-<8> Optional: Specify custom tag data for your cluster. For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
+`<custom_tag_name>`:: Optional: Specifies custom tag data for your cluster. For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
 +
 [NOTE]
 ====
-Custom tags can also be specified during installation in the `install-config.yml` file. If the `install-config.yml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yml` file.
+Custom tags can also be specified during installation in the `install-config.yaml` file. If the `install-config.yaml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yaml` file.
 ====
-ifdef::infra,edge[]
-<9> Specify a taint to prevent user workloads from being scheduled on
-ifdef::infra[`infra`]
-ifdef::edge[`edge`]
-nodes.
-+
-[NOTE]
-====
-After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
-====
-
-endif::infra,edge[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :!infra:

--- a/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
@@ -6,6 +6,7 @@
 [id="nvidia-gpu-aws-adding-a-gpu-node_{context}"]
 = Adding a GPU node to an existing {product-title} cluster
 
+[role="_abstract"]
 You can copy and modify a default compute machine set configuration to create a GPU-enabled machine set and machines for the AWS EC2 cloud provider.
 
 For more information about the supported instance types, see the following NVIDIA documentation:


### PR DESCRIPTION
Versions:
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17043

Link to docs preview:

- [Creating a compute machine set on AWS](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws)
- [Assigning machines to placement groups for Elastic Fabric Adapter instances by using machine sets](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-aws-existing-placement-group_creating-machineset-aws)
- [Configuring Capacity Reservations by using machine sets](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws#machineset-capacity-reservation_cpmso-supported-features-aws) (AWS)
- [Configuring Capacity Reservation by using machine sets ](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-azure#machineset-capacity-reservation_cpmso-supported-features-azure)  (Azure)
- [Creating Dedicated Instances by using machine sets](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-creating-dedicated-instance_creating-machineset-aws)
- [Configuring IMDS by using machine sets](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-creating-imds-options_creating-machineset-aws)
- [Creating Spot Instances by using compute machine sets](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-creating-non-guaranteed-instance_creating-machineset-aws) (AWS)
- [Creating Spot VMs by using compute machine sets](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure#machineset-creating-non-guaranteed-instance_creating-machineset-azure) (Azure)
- [Creating Spot VMs by using compute machine sets](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-creating-non-guaranteed-instance_creating-machineset-gcp) (GCP)
- [Creating preemptible VM instances by using compute machine sets](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-creating-non-guaranteed-instance_legacy-preempt) 
- [Machine sets that deploy machines as Dedicated Instances](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-dedicated-instance_creating-machineset-aws)
- [Machine set options for the Amazon EC2 Instance Metadata Service](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-imds-options_creating-machineset-aws)
- [Labelling GPU machine sets for the cluster autoscaler](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-label-gpu-autoscaler_creating-machineset-aws)
- [Machine sets that deploy machines as Spot Instances](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-non-guaranteed-instance_creating-machineset-aws) (AWS)
- [Machine sets that deploy machines as Spot Instances](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-non-guaranteed-instance_creating-machineset-gcp) (GCP)
- [Machine sets that deploy machines as Spot Instances](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure#machineset-non-guaranteed-instance_creating-machineset-azure) (Azure)
- [Sample YAML for a compute machine set custom resource on AWS](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-yaml-aws_creating-machineset-aws) (Creating a compute machine set)

- [Sample YAML for a compute machine set custom resource on AWS](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-aws_creating-infrastructure-machinesets) (Creating infrastructure machine sets)

- [Sample YAML for a compute machine set custom resource on AWS](
https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#machineset-yaml-aws_aws-compute-edge-zone-tasks) (AWS Local Zone or Wavelength Zone tasks)

- [Adding a GPU node to an existing OpenShift Container Platform cluster](https://102915--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#nvidia-gpu-aws-adding-a-gpu-node_creating-machineset-aws)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
