### PR TITLE
OSDOCS-17366: Corrected additional items for ROSA Learning.

### DIFF
--- a/modules/learning-deploying-application-deployment-backend-microservice.adoc
+++ b/modules/learning-deploying-application-deployment-backend-microservice.adoc
@@ -5,6 +5,7 @@
 [id="learning-deploying-application-deployment-backend-microservice_{context}"]
 = Deploying the back-end microservice
 
+[role="_abstract"]
 The microservice serves internal web requests and returns a JSON object containing the current hostname and a randomly generated color string.
 
 .Procedure
@@ -15,7 +16,8 @@ The microservice serves internal web requests and returns a JSON object containi
 $ oc apply -f https://raw.githubusercontent.com/openshift-cs/rosaworkshop/master/rosa-workshop/ostoy/yaml/ostoy-microservice-deployment.yaml
 ----
 +
-.Example output
+*For example*:
++
 [source,terminal]
 ----
 $ oc apply -f https://raw.githubusercontent.com/openshift-cs/rosaworkshop/master/rosa-workshop/ostoy/yaml/ostoy-microservice-deployment.yaml

--- a/modules/learning-deploying-application-deployment-frontend-microservice.adoc
+++ b/modules/learning-deploying-application-deployment-frontend-microservice.adoc
@@ -5,9 +5,8 @@
 [id="learning-deploying-application-deployment-frontend-microservice_{context}"]
 = Deploying the front-end microservice
 
-The front-end deployment uses the Node.js front-end for the application and additional Kubernetes objects.
-
-Front-end deployment defines the following features:
+[role="_abstract"]
+The front-end deployment uses the Node.js front-end for the application and additional Kubernetes objects. Front-end deployment defines the following features:
 
 * Persistent volume claim
 * Deployment object
@@ -24,7 +23,8 @@ Front-end deployment defines the following features:
 $ oc apply -f https://raw.githubusercontent.com/openshift-cs/rosaworkshop/master/rosa-workshop/ostoy/yaml/ostoy-frontend-deployment.yaml
 ----
 +
-.Example output
+*For example*:
++
 [source,terminal]
 ----
 persistentvolumeclaim/ostoy-pvc created

--- a/modules/learning-deploying-application-deployment-new-project-cli.adoc
+++ b/modules/learning-deploying-application-deployment-new-project-cli.adoc
@@ -16,7 +16,8 @@ You can use {oc-first} to create a new project.
 $ oc new-project ostoy
 ----
 +
-.Example output
+*For example*:
++
 [source,terminal]
 ----
 Now using project "ostoy" on server "https://api.myrosacluster.abcd.p1.openshiftapps.com:6443".

--- a/modules/learning-deploying-application-deployment-obtain-route.adoc
+++ b/modules/learning-deploying-application-deployment-obtain-route.adoc
@@ -5,6 +5,7 @@
 [id="learning-deploying-application-deployment-obtain-route_{context}"]
 = Obtain the route to your application
 
+[role="_abstract"]
 Obtain the route to access the application.
 
 .Procedure
@@ -15,7 +16,8 @@ Obtain the route to access the application.
 $ oc get route
 ----
 +
-.Example output
+*For example*:
++
 [source,terminal]
 ----
 NAME          HOST/PORT                                                 PATH   SERVICES             PORT    TERMINATION   WILDCARD

--- a/modules/learning-deploying-application-deployment-retrieving-login.adoc
+++ b/modules/learning-deploying-application-deployment-retrieving-login.adoc
@@ -5,8 +5,11 @@
 [id="learning-deploying-application-deployment-retrieving-login_{context}"]
 = Retrieving the login command
 
+[role="_abstract"]
+Before creating a cluster, you need to log in to the {rosa-cli-first}.
+
 .Procedure
-. Confirm you are logged in to the {rosa-cli-first} by running the following command:
+. Confirm you are logged in to the {rosa-cli} by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/learning-deploying-application-deployment-viewing-application.adoc
+++ b/modules/learning-deploying-application-deployment-viewing-application.adoc
@@ -5,6 +5,9 @@
 [id="learning-deploying-application-deployment-viewing-application_{context}"]
 = Viewing the application
 
+[role="_abstract"]
+You can view the deployed OSToy application by going to the application's URL.
+
 .Procedure
 . Copy the `ostoy-route-ostoy.apps.<your-rosa-cluster>.abcd.p1.openshiftapps.com` URL output from the previous step.
 . Paste the copied URL into your web browser and press enter. You should see the homepage of your application. If the page does not load, make sure you used `http` and not `https`.

--- a/modules/learning-deploying-application-health-check-crash-pod.adoc
+++ b/modules/learning-deploying-application-health-check-crash-pod.adoc
@@ -5,6 +5,9 @@
 [id="learning-deploying-application-health-check-crash-pod_{context}"]
 = Crashing the pod 
 
+[role="_abstract"]
+You can test the failure states for your application by forcing the pod to crash.
+
 .Procedure
 . From the OSToy application web console, click *Home* in the left menu, and enter a message in the *Crash Pod* box, for example, `This is goodbye!`. 
 

--- a/modules/learning-deploying-application-health-check-forced-malfunction.adoc
+++ b/modules/learning-deploying-application-health-check-forced-malfunction.adoc
@@ -5,6 +5,9 @@
 [id="learning-deploying-application-health-check-forced-malfunction_{context}"]
 = Making the application malfunction
 
+[role="_abstract"]
+You can test your application's failure responses by intentionally causing the application to malfunction. 
+
 .Procedure
 
 * From the OSToy application, click *Toggle Health* in the *Toggle Health Status* tile. Watch *Current Health* switch to *I'm not feeling all that well*.

--- a/modules/learning-deploying-application-health-check-prepare.adoc
+++ b/modules/learning-deploying-application-health-check-prepare.adoc
@@ -5,7 +5,11 @@
 [id="learning-deploying-application-health-check-prepare_{context}"]
 = Preparing your desktop
 
+[role="_abstract"]
+You can set up your OSToy application from {cluster-manager-url}.
+
+
 .Procedure
-* From the OpenShift web console, select *Workloads > Deployments > ostoy-frontend* to view the OSToy deployment. 
+* From the {ocp-short} web console, select *Workloads > Deployments > ostoy-frontend* to view the OSToy deployment. 
 +
 image::5-ostoy-deployview.png[The web console deployments page]

--- a/modules/learning-deploying-application-health-check-view-pod.adoc
+++ b/modules/learning-deploying-application-health-check-view-pod.adoc
@@ -5,8 +5,11 @@
 [id="learning-deploying-application-health-check-view-pod_{context}"]
 = Viewing the revived pod
 
+[role="_abstract"]
+You can check the status of your revived pod within {cluster-manager-url}.
+
 .Procedure
-* From the OpenShift web console, quickly switch to the *Deployments* screen. You will see that the pod turns yellow, which means it is down. It should quickly revive and turn blue. The revival process happens quickly.
+* From the {ocp-short} web console, quickly switch to the *Deployments* screen. You will see that the pod turns yellow, which means it is down. It should quickly revive and turn blue. The revival process happens quickly.
 +
 image::5-ostoy-podcrash.gif[Deployment details page]
 

--- a/modules/learning-deploying-application-networking-intraculter-networking.adoc
+++ b/modules/learning-deploying-application-networking-intraculter-networking.adoc
@@ -5,6 +5,7 @@
 [id="learning-deploying-application-networking-intraculter-networking_{context}"]
 = Configuring intra-cluster networking
 
+[role="_abstract"]
 You can view your networking configurations in your OSToy application.
 
 .Procedure
@@ -20,7 +21,8 @@ image::deploying-networking-example.png[OSToy Networking page]
 $ oc get service <name_of_service> -o yaml
 ----
 +
-.Example output
+*For example*:
++
 [source,yaml]
 ----
 apiVersion: v1

--- a/modules/learning-deploying-application-s2i-deployments-create-new-project.adoc
+++ b/modules/learning-deploying-application-s2i-deployments-create-new-project.adoc
@@ -5,6 +5,10 @@
 [id="learning-deploying-application-s2i-deployments-create-new-project_{context}"]
 = Creating a new project
 
+[role="_abstract"]
+You can use the {oc-first} to create a new project within your cluster.
+
+.Procedure
 * Create a new project from the CLI by running the following command:
 +
 [source,terminal]

--- a/modules/learning-deploying-application-s2i-deployments-deploy-to-cluster.adoc
+++ b/modules/learning-deploying-application-s2i-deployments-deploy-to-cluster.adoc
@@ -5,10 +5,13 @@
 [id="learning-deploying-application-s2i-deployments-deploy-to-cluster_{context}"]
 = Using S2i to deploy OSToy on your cluster
 
+[role="_abstract"]
+You can use the source-to-image(s2i) to deploy your OSToy application on your cluster.
+
 .Procedure
-. Add a secret to OpenShift.
+. Add a secret to {ocp-short}.
 +
-This example emulates a `.env` file. Files are easily moved directly into an OpenShift environment and can even be renamed in the secret.
+This example emulates a `.env` file. Files are easily moved directly into an {ocp-short} environment and can even be renamed in the secret.
 +
 ** Run the following command, replacing `<UserName>` with your GitHub username:
 +
@@ -17,9 +20,9 @@ This example emulates a `.env` file. Files are easily moved directly into an Ope
 $ oc create -f https://raw.githubusercontent.com/<UserName>/ostoy/master/deployment/yaml/secret.yaml
 ----
 +
-. Add a ConfigMap to OpenShift.
+. Add a ConfigMap to {ocp-short}.
 +
-This example emulates an HAProxy config file, which is typically used for overriding default configurations in an OpenShift application. Files can be renamed in the ConfigMap.
+This example emulates an HAProxy config file, which is typically used for overriding default configurations in an {ocp-short} application. Files can be renamed in the ConfigMap.
 +
 ** Run the following command, replacing `<UserName>` with your GitHub username:
 +
@@ -32,7 +35,7 @@ $ oc create -f https://raw.githubusercontent.com/<UserName>/ostoy/master/deploym
 +
 You must deploy the microservice to ensure that the service environment variables are available from the UI application.
 +
-`--context-dir` builds the application defined in the `microservice` directory in the Git repository. The `app` label ensures the user interface (UI) application and microservice are both grouped in the OpenShift UI.
+`--context-dir` builds the application defined in the `microservice` directory in the Git repository. The `app` label ensures the user interface (UI) application and microservice are both grouped in the {ocp-short} UI.
 +
 ** Run the following command to create the microservice, replacing `<UserName>` with your GitHub username:
 +
@@ -44,7 +47,8 @@ $ oc new-app https://github.com/<UserName>/ostoy \
     --labels=app=ostoy
 ---- 
 +
-.Example output
+*Example output*:
++
 [source,terminal]
 ----
 --> Creating resources with label app=ostoy ...
@@ -67,7 +71,8 @@ $ oc new-app https://github.com/<UserName>/ostoy \
 $ oc status
 ----
 +
-.Example output
+*For example*:
++
 [source,terminal]
 ----
 In project ostoy-s2i on server https://api.myrosacluster.g14t.p1.openshiftapps.com:6443
@@ -92,7 +97,7 @@ $ oc new-app https://github.com/<UserName>/ostoy \
     --env=MICROSERVICE_NAME=OSTOY_MICROSERVICE
 ----
 +
-.Example output
+*For example*:
 +
 [source,terminal]
 ----
@@ -157,7 +162,7 @@ $ oc set volume deployment ostoy --add \
     -m /var/demo_files
 ----
 +
-. Expose the UI application as an OpenShift Route.
+. Expose the UI application as an {ocp-short} Route.
 
 ** Run the following command to deploy the application as an HTTPS application that uses the included TLS wildcard certificates:
 +

--- a/modules/learning-deploying-application-s2i-deployments-fork-repo.adoc
+++ b/modules/learning-deploying-application-s2i-deployments-fork-repo.adoc
@@ -5,8 +5,12 @@
 [id="learning-deploying-application-s2i-deployments-fork-repo_{context}"]
 = Fork the OSToy repository
 
-In order to trigger automated builds based on changes to the source code, you must set up a GitHub webhook. The webhook will trigger S2I builds when you push code into your GitHub repository. To set up the webhook, you must first fork link:https://github.com/openshift-cs/ostoy/fork[the repository].
+[role="_abstract"]
+To trigger automated builds based on changes to the source code, you must set up a GitHub webhook. The webhook will trigger S2I builds when you push code into your GitHub repository. 
 
+.Procedure
+* To set up the webhook, you must first link:https://github.com/openshift-cs/ostoy/fork[Create a new fork].
++
 [IMPORTANT]
 ====
 Replace `<UserName>` with your own GitHub username for the following URLs in this guide.

--- a/modules/learning-deploying-application-s2i-deployments-retrieving-login.adoc
+++ b/modules/learning-deploying-application-s2i-deployments-retrieving-login.adoc
@@ -5,8 +5,11 @@
 [id="learning-deploying-application-s2i-deployments-retrieving-login_{context}"]
 = Retrieving your login command
 
+[role="_abstract"]
+Before creating your cluster, you need to log in to the {rosa-cli-first}.
+
 .Procedure
-. Confirm you are logged in to the {rosa-cli-first} by running the following command:
+. Confirm you are logged in to the {rosa-cli} by running the following command:
 +
 [source,terminal]
 ----
@@ -15,7 +18,7 @@ rosa whoami
 +
 If you are logged in to the command-line interface, skip to "Creating a new project". If you are not logged in to the command-line interface, continue this procedure.
 
-. If you are not logged in to the {rosa-cli}, in {cluster-manager-url}, click the dropdown arrow next to your name in the upper-right and select *Copy Login Command*.
+. If you are not logged in to the {rosa-cli}, in {cluster-manager-url}, click the dropdown arrow next to your name in the upper-right and select *Copy login command*.
 +
 image::ostoy-cli-login.png[CLI Login]
 +
@@ -27,13 +30,15 @@ image::ostoy-cli-login.png[CLI Login]
 +
 . Log in to the CLI by running the copied command in your terminal.
 +
-.Example input
+*For example*:
++
 [source,terminal]
 ----
 $ oc login --token=RYhFlXXXXXXXXXXXX --server=https://api.osd4-demo.abc1.p1.openshiftapps.com:6443
 ----
 +
-.Example output
+*Example output*:
++
 [source,terminal]
 ----
 Logged into "https://api.myrosacluster.abcd.p1.openshiftapps.com:6443" as "rosa-user" using the token provided.

--- a/modules/learning-deploying-application-scaling-manual-pod.adoc
+++ b/modules/learning-deploying-application-scaling-manual-pod.adoc
@@ -33,7 +33,8 @@ image::deploy-scale-network.png[HPA Menu]
 $ oc get pods
 ----
 +
-.Example output
+*For example*:
++
 [source,terminal]
 ----
 NAME                                  READY     STATUS    RESTARTS   AGE
@@ -74,7 +75,7 @@ $ oc get pods
 +
 The output shows that there are now 3 pods for the microservice instead of only one.
 +
-.Example output
+*For example*:
 +
 [source,terminal]
 ----
@@ -104,14 +105,15 @@ image::deploy-scale-uiscale.png[UI Scale]
 
 Check your pod counts by using the CLI, the web UI, or the OSToy application:
 
-* From the {rosa-cli}, confirm that you are using two pods for the microservice by running the following command:
+. From the {rosa-cli}, confirm that you are using two pods for the microservice by running the following command:
 +
 [source,terminal]
 ----
 $ oc get pods
 ----
 +
-.Example output
+*For example*:
++
 [source,terminal]
 ----
 NAME                                  READY   STATUS    RESTARTS   AGE
@@ -120,10 +122,10 @@ ostoy-microservice-6666dcf455-2lcv4   1/1     Running   0          50m
 ostoy-microservice-6666dcf455-tqzmn   1/1     Running   0          75m
 ----
 
-* In the web UI, select *Workloads > Deployments > ostoy-microservice*.
+.  In the web UI, select *Workloads > Deployments > ostoy-microservice*.
 +
 image::deploy-scale-verify-workload.png[Verify the workload pods]
 
-* You can also confirm that there are two pods by selecting **Networking** in the navigation menu of the OSToy application. There should be two colored boxes for the two pods.
+. You can also confirm that there are two pods by selecting **Networking** in the navigation menu of the OSToy application. There should be two colored boxes for the two pods.
 +
 image::deploy-scale-colorspods.png[UI Scale]

--- a/modules/learning-deploying-application-scaling-node-autoscaling.adoc
+++ b/modules/learning-deploying-application-scaling-node-autoscaling.adoc
@@ -38,7 +38,7 @@ $ oc create -f https://raw.githubusercontent.com/openshift-cs/rosaworkshop/maste
 $ oc get pods
 ----
 +
-.Example output
+*For example*:
 +
 [source,terminal]
 ----
@@ -66,7 +66,7 @@ work-queue-5x2nq-96tfr   0/1     Pending   0          10s
 $ oc get nodes
 ----
 +
-.Example output
+*For example*:
 +
 [source,terminal]
 ----

--- a/modules/learning-deploying-application-scaling-pod-autoscaling.adoc
+++ b/modules/learning-deploying-application-scaling-pod-autoscaling.adoc
@@ -58,7 +58,7 @@ Because there is only one pod, increasing the workload should trigger an increas
 oc get pods --field-selector=status.phase=Running | grep microservice
 ----
 +
-.Example output
+*For example*:
 +
 [source,terminal]
 ----

--- a/modules/learning-deploying-application-storage-confirm.adoc
+++ b/modules/learning-deploying-application-storage-confirm.adoc
@@ -5,9 +5,12 @@
 [id="learning-deploying-application-storage-confirm_{context}"]
 = Confirming persistent storage
 
+[role="_abstract"]
+Within your OSToy application, you can verify that you configured your application's persistent storage.
+
 .Procedure
 . Wait for the pod to re-create.
-. On the OSToy app console, click *Persistent Storage* in the left menu.
+. On the OSToy application console, click *Persistent Storage* in the left menu.
 . Find the file you created, and open it to view and confirm the contents.
 +
 image::cloud-experts-storage-ostoy-existingfile.png[]
@@ -50,9 +53,10 @@ $ ls
 $ cat test-pv.txt
 ----
 +
-. Verify that the output is the text you entered in the OSToy app console.
+. Verify that the output is the text you entered in the OSToy application console.
 +
-.Example terminal
+*For example*:
++
 [source,terminal]
 ----
 $ oc get pods

--- a/modules/learning-deploying-application-storage-crash-pod.adoc
+++ b/modules/learning-deploying-application-storage-crash-pod.adoc
@@ -5,6 +5,9 @@
 [id="learning-deploying-application-storage-crash-pod_{context}"]
 = Crashing the pod
 
+[role="_abstract"]
+You can cause your application's pod to crash with a button in the OSToy application console.
+
 .Procedure
-. On the OSToy app console, click *Home* in the left menu.
+. On the OSToy application console, click *Home* in the left menu.
 . Click *Crash pod*.

--- a/modules/learning-deploying-application-storage-end-session.adoc
+++ b/modules/learning-deploying-application-storage-end-session.adoc
@@ -5,5 +5,8 @@
 [id="learning-deploying-application-storage-end-session_{context}"]
 = Ending the session
 
+[role="_abstract"]
+You can end your session from your terminal.
+
 .Procedure
 * Type `exit` in your terminal to quit the session and return to the CLI.

--- a/modules/learning-deploying-application-storage-storing.adoc
+++ b/modules/learning-deploying-application-storage-storing.adoc
@@ -5,6 +5,9 @@
 [id="learning-deploying-application-storage-storing_{context}"]
 = Storing your file
 
+[role="_abstract"]
+You can store files within your application from the OSToy application's console.
+
 .Procedure
 . In the OSToy app console, click *Persistent Storage* in the left menu.
 . In the *Filename* box, enter a file name with a `.txt` extension, for example `test-pv.txt`.

--- a/modules/learning-deploying-application-storage-viewing.adoc
+++ b/modules/learning-deploying-application-storage-viewing.adoc
@@ -5,8 +5,11 @@
 [id="learning-deploying-application-storage-viewing_{context}"]
 = Viewing a persistent volume claim
 
+[role="_abstract"]
+You can view your application's persistence volume claim from the {cluster-manager-url}.
+
 .Procedure
-. Navigate to the cluster's OpenShift web console.
+. Navigate to the cluster's {ocp-short} web console.
 . Click *Storage* in the left menu, then click *PersistentVolumeClaims* to see a list of all the persistent volume claims. 
 . Click a persistence volume claim to see the size, access mode, storage class, and other additional claim details. 
 +

--- a/modules/learning-deploying-configmaps-secrets-envvar-configmaps.adoc
+++ b/modules/learning-deploying-configmaps-secrets-envvar-configmaps.adoc
@@ -5,12 +5,14 @@
 [id="learning-deploying-configmaps-secrets-envvar-configmaps_{context}"]
 = Configuration using ConfigMaps
 
+[role="_abstract"]
 Config maps allow you to decouple configuration artifacts from container image content to keep containerized applications portable.
 
 .Procedure
-* In the OSToy app, in the left menu, click *Config Maps*, displaying the contents of the config map available to the OSToy application. The code snippet shows an example of a config map configuration:
+* In the OSToy application, in the left menu, click *Config Maps*, displaying the contents of the config map available to the OSToy application. The code snippet shows an example of a config map configuration:
 +
-.Example output
+*For example*:
++
 [source,text]
 ----
 kind: ConfigMap

--- a/modules/learning-deploying-configmaps-secrets-envvar-environment-variables.adoc
+++ b/modules/learning-deploying-configmaps-secrets-envvar-environment-variables.adoc
@@ -5,13 +5,15 @@
 [id="learning-deploying-configmaps-secrets-envvar-environment-variables_{context}"]
 = Configuration using environment variables
 
+[role="_abstract"]
 Using environment variables is an easy way to change application behavior without requiring code changes. It allows different deployments of the same application to potentially behave differently based on the environment variables. {product-title} makes it simple to set, view, and update environment variables for pods or deployments.
 
 .Procedure
 
-* In the OSToy app, in the left menu, click *ENV Variables*, displaying the environment variables available to the OSToy application. The code snippet shows an example of an environmental variable configuration:
+* In the OSToy application, in the left menu, click *ENV Variables*, displaying the environment variables available to the OSToy application. The code snippet shows an example of an environmental variable configuration:
 +
-.Example output
+*For example*:
++
 [source,text]
 ----
 {

--- a/modules/learning-deploying-configmaps-secrets-envvar-secrets.adoc
+++ b/modules/learning-deploying-configmaps-secrets-envvar-secrets.adoc
@@ -5,13 +5,15 @@
 [id="learning-deploying-configmaps-secrets-envvar-secrets_{context}"]
 = Configuration using secrets
 
+[role="_abstract"]
 Kubernetes `Secret` objects allow you to store and manage sensitive information, such as passwords, OAuth tokens, and SSH keys. Putting this information in a secret is safer and more flexible than putting it in plain text into a pod definition or a container image.
 
 .Procedure 
 
-* In the OSToy app, in the left menu, click *Secrets*, displaying the contents of the secrets available to the OSToy application. The code snippet shows an example of a secret configuration:
+* In the OSToy apppplication, in the left menu, click *Secrets*, displaying the contents of the secrets available to the OSToy application. The code snippet shows an example of a secret configuration:
 +
-.Example output
+*For example*:
++
 [source,text]
 ----
 USERNAME=my_user

--- a/modules/learning-deploying-s2i-webhook-cicd-configuration.adoc
+++ b/modules/learning-deploying-s2i-webhook-cicd-configuration.adoc
@@ -5,6 +5,10 @@
 [id="learning-deploying-s2i-webhook-cicd-configuration_{context}"]
 = Configuring your automated deployment
 
+[role="_abstract"]
+By using a GitHub webhook, you can configure an automated deployment for your OSToy application.
+
+.Procedure
 . Obtain the GitHub webhook trigger secret by running the following command:
 +
 [source,terminal]
@@ -12,7 +16,8 @@
 $ oc get bc/ostoy-microservice -o=jsonpath='{.spec.triggers..github.secret}'
 ----
 +
-.Example output
+*For example*:
++
 [source,terminal]
 ----
 `o_3x9M1qoI2Wj_cz1WiK`
@@ -30,7 +35,8 @@ You need to use this secret in a later step in this process.
 $ oc describe bc/ostoy-microservice
 ----
 +
-.Example output
+*For example*:
++
 [source,terminal]
 ----
 [...]
@@ -41,7 +47,8 @@ Webhook GitHub:
 
 . In the GitHub webhook URL, replace the `<secret>` text with the secret you retrieved. Your URL will resemble the following example output:
 +
-.Example output
+*For example*:
++
 [source,text]
 ----
 https://api.demo1234.openshift.com:443/apis/build.openshift.io/v1/namespaces/ostoy-s2i/buildconfigs/ostoy-microservice/webhooks/o_3x9M1qoI2Wj_czR1WiK/github

--- a/modules/learning-getting-idp-cli-overview.adoc
+++ b/modules/learning-getting-idp-cli-overview.adoc
@@ -1,12 +1,16 @@
 // Module included in the following assemblies:
 //
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-idp.adoc
-:_mod-docs-content-type: CONCEPT
-[id=learning-getting-started-idp-cli-overview_{context}]
-= Understanding IDP options
+:_mod-docs-content-type: PROCEDURE
+[id="learning-getting-started-idp-cli-overview_{context}"]
+= Viewing IDP options
 
-Before creating your IDP, you can view all IDP options by running the following command:
+[role="_abstract"]
+You can view your IDP options by using {rosa-cli-first}.
 
+.Procedure
+* Before creating your IDP, you can view all IDP options by running the following command:
++
 [source,terminal]
 ----
 $ rosa create idp --help

--- a/modules/learning-getting-idp-creating.adoc
+++ b/modules/learning-getting-idp-creating.adoc
@@ -2,9 +2,13 @@
 //
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-idp.adoc
 :_mod-docs-content-type: PROCEDURE
-[id=learning-getting-started-idp-creating_{context}]
+[id="learning-getting-started-idp-creating_{context}"]
 = Setting up an IDP with GitHub
 
+[role="_abstract"]
+You can use GitHub to set up your identity provider.
+
+.Procedure
 . Log in to your GitHub account.
 . Create a new GitHub organization where you are an administrator.
 +
@@ -13,7 +17,7 @@
 If you are already an administrator in an existing organization and you want to use that organization, skip to step 9.
 ====
 +
-Click the *+* icon, then click *New Organization*.
+. Click the *+* icon, then click *New Organization*.
 +
 image::cloud-experts-getting-started-idp-new-org.png[]
 
@@ -75,19 +79,3 @@ image::cloud-experts-getting-started-idp-inputs.png[]
 . Copy the returned link and paste it into your browser. The new IDP should be available under your chosen name. Click your IDP and use your GitHub credentials to access the cluster.
 +
 image::cloud-experts-getting-started-idp-login.png[]
-
-== Granting other users access to the cluster
-To grant access to other cluster user you will need to add their GitHub user ID to the GitHub organization used for this cluster.
-
-. In GitHub, go to the *Your organizations* page.
-
-. Click your *profile icon*, then *Your organizations*. Then click *<your-organization-name>*.  In our example, it is `my-rosa-cluster`.
-+
-image::cloud-experts-getting-started-idp-org.png[]
-
-. Click *Invite someone*.
-+
-image::cloud-experts-getting-started-idp-invite.png[]
-
-. Enter the GitHub ID of the new user, select the correct user, and click *Invite*.
-. Once the new user accepts the invitation, they will be able to log in to the {product-title} cluster using the {hybrid-console-second} link and their GitHub credentials.

--- a/modules/learning-getting-idp-granting-access.adoc
+++ b/modules/learning-getting-idp-granting-access.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * rosa_learning/creating_cluster_workshop/learning-getting-started-idp.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="learning-getting-started-idp-granting-access_{context}"]
+= Granting other users access to the cluster
+
+[role="_abstract"]
+To grant access to other cluster users, you will need to add their GitHub user ID to the GitHub organization used for this cluster.
+
+.Procedure
+. In GitHub, go to the *Your organizations* page.
+
+. Click your *profile icon*, then *Your organizations*. Then click *<your-organization-name>*.  In our example, it is `my-rosa-cluster`.
++
+image::cloud-experts-getting-started-idp-org.png[]
+
+. Click *Invite someone*.
++
+image::cloud-experts-getting-started-idp-invite.png[]
+
+. Enter the GitHub ID of the new user, select the correct user, and click *Invite*.
+. Once the new user accepts the invitation, they will be able to log in to the {product-title} cluster using the {hybrid-console-second} link and their GitHub credentials.

--- a/modules/learning-getting-learning-machine-pool-mixing-node-types.adoc
+++ b/modules/learning-getting-learning-machine-pool-mixing-node-types.adoc
@@ -5,8 +5,10 @@
 [id="learning-getting-started-learning-machine-pool-mixing-node-types_{context}"]
 = Mixing node types
 
+[role="_abstract"]
 You can also mix different worker node machine types in the same cluster by using new machine pools. You cannot change the node type of a machine pool once it is created, but you can create a new machine pool with different nodes by adding the `--instance-type` flag.
 
+.Procedure
 . For example, to change the database nodes to a different node type, run the following command:
 +
 [source,terminal]
@@ -14,7 +16,7 @@ You can also mix different worker node machine types in the same cluster by usin
 $ rosa create machinepool --cluster=<cluster-name> --name=<mp-name> --replicas=<number-nodes> --labels='<key=pair>' --instance-type=<type>
 ----
 +
-.Example input
+*For example*:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-learning-machine-pool-node-labels.adoc
+++ b/modules/learning-getting-learning-machine-pool-node-labels.adoc
@@ -5,14 +5,18 @@
 [id="learning-getting-started-learning-machine-pool-node-labels_{context}"]
 = Adding node labels
 
-. Use the following command to add node labels:
+[role="_abstract"]
+You can add node labels to your machine pools by using the {rosa-cli}.
+
+.Procedure
+* Use the following command to add node labels:
 +
 [source,terminal]
 ----
 $ rosa edit machinepool --cluster=<cluster-name> --replicas=<number-nodes> --labels='key=value' <machinepool-name>
 ----
 +
-.Example input
+*For example*:
 +
 [source,terminal]
 ----
@@ -20,7 +24,7 @@ $ rosa edit machinepool --cluster=my-rosa-cluster --replicas=2 --labels 'foo=bar
 ----
 +
 This adds 2 labels to the new machine pool.
-
++
 [IMPORTANT]
 ====
 This command replaces all machine pool configurations with the newly defined configuration. If you want to add another label *and* keep the old label, you must state both the new and preexisting the label. Otherwise the command will replace all preexisting labels with the one you wanted to add. Similarly, if you want to delete a label, run the command and state the ones you want, excluding the one you want to delete.

--- a/modules/learning-getting-learning-machine-pool-scaling-cli.adoc
+++ b/modules/learning-getting-learning-machine-pool-scaling-cli.adoc
@@ -17,7 +17,7 @@ Edit a machine pool to scale the number of worker nodes in that specific machine
 $ rosa list machinepools --cluster=<cluster-name>
 ----
 +
-.Example output
+*Example output*:
 +
 [source,terminal]
 ----
@@ -32,7 +32,7 @@ Default     No           2         m5.xlarge                                  us
 $ rosa edit machinepool --cluster=<cluster-name> --replicas=<number-nodes> <machinepool-name>
 ----
 +
-.Example input
+*For example*:
 +
 [source,terminal]
 ----
@@ -46,14 +46,14 @@ $ rosa edit machinepool --cluster=my-rosa-cluster --replicas 3 Default
 $ rosa describe cluster --cluster=<cluster-name> | grep Compute
 ----
 +
-.Example input
+*For example*:
 +
 [source,terminal]
 ----
 $ rosa describe cluster --cluster=my-rosa-cluster | grep Compute
 ----
 +
-.Example output
+*Example output*:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-started-accessing-cli.adoc
+++ b/modules/learning-getting-started-accessing-cli.adoc
@@ -5,8 +5,10 @@
 [id="learning-getting-started-accessing-cli_{context}"]
 = Accessing your cluster using the CLI
 
+[role="_abstract"]
 To access the cluster using the CLI, you must have the `oc` CLI installed. If you are following the tutorials, you already installed the `oc` CLI.
 
+.Procedure
 . Log in to the {cluster-manager-url}.
 . Click your username in the top right corner.
 . Click *Copy Login Command*.
@@ -26,7 +28,7 @@ image::cloud-experts-getting-started-accessing-copy-token.png[]
 $ oc login --token=sha256~GBAfS4JQ0t1UTKYHbWAK6OUWGUkdMGz000000000000 --server=https://api.my-rosa-cluster.abcd.p1.openshiftapps.com:6443
 ----
 +
-.Example output
+*Example output*:
 +
 [source,terminal]
 ----
@@ -44,7 +46,7 @@ Using project "default".
 $ oc whoami
 ----
 +
-.Example output
+*Example output*:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-started-accessing-hcm.adoc
+++ b/modules/learning-getting-started-accessing-hcm.adoc
@@ -2,8 +2,13 @@
 //
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-accessing.adoc
 :_mod-docs-content-type: PROCEDURE
+[id="learning-getting-started-accessing-hcm_{context}"]
 = Accessing the cluster via the {hybrid-console-second}
 
+[role="_abstract"]
+You can access your cluster by using {hybrid-console-second}.
+
+.Procedure
 . Log in to the {cluster-manager-url}.
 . To retrieve the {hybrid-console-second} URL run:
 +

--- a/modules/learning-getting-started-admin-cli.adoc
+++ b/modules/learning-getting-started-admin-cli.adoc
@@ -5,6 +5,10 @@
 [id="learning-getting-started-admin-cli_{context}"]
 = Creating an admin user using the CLI
 
+[role="_abstract"]
+You can use the {rosa-cli-first} to create an admin user for your clusters.
+
+.Procedure
 . Run the following command to create the admin user:
 +
 [source,terminal]
@@ -12,7 +16,7 @@
 $ rosa create admin --cluster=<cluster-name>
 ----
 +
-.Example output
+*Example output*:
 +
 [source,terminal]
 ----
@@ -33,7 +37,7 @@ $ oc login https://api.my-rosa-cluster.abcd.p1.openshiftapps.com:6443 \
 >    --password FWGYL-2mkJI-00000-00000
 ----
 +
-.Example output
+*Example output*:
 +
 [source,terminal]
 ----
@@ -53,7 +57,7 @@ Using project "default".
 $ oc whoami
 ----
 +
-.Example output
+*For example*:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-started-admin-rights-cli.adoc
+++ b/modules/learning-getting-started-admin-rights-cli.adoc
@@ -5,6 +5,10 @@
 [id="learning-getting-started-admin-rights-cli_{context}"]
 = Using the {rosa-cli}
 
+[role="_abstract"]
+You can use the {rosa-cli} to grant your user roles administrative access.
+
+.Procedure
 . Assuming you are the user who created the cluster, run one of the following commands to grant admin privileges:
 +
 * For `cluster-admin`:
@@ -28,7 +32,7 @@ $ rosa grant user dedicated-admin --user <idp_user_name> --cluster=<cluster-name
 $ rosa list users --cluster=<cluster-name>
 ----
 +
-.Example output
+*Example output*:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-started-admin-rights-web-ui.adoc
+++ b/modules/learning-getting-started-admin-rights-web-ui.adoc
@@ -3,11 +3,15 @@
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-admin-rights.adoc
 :_mod-docs-content-type: PROCEDURE
 [id="learning-getting-started-admin-rights-web-ui_{context}"]
-= Using the Red{nbsp}Hat OpenShift Cluster Manager UI
+= Using the Red{nbsp}Hat {cluster-manager}
 
+[role="_abstract"]
+You can grant cluster administrative access by using the {cluster-manager}.
+
+.Procedure
 . Log in to the {cluster-manager-url}.
 . Select your cluster.
-. Click the *Access Control* tab.
+. Click the *Access control* tab.
 . Click the *Cluster roles and Access* tab in the sidebar.
 . Click *Add user*.
 +

--- a/modules/learning-getting-started-autoscaling-cli.adoc
+++ b/modules/learning-getting-started-autoscaling-cli.adoc
@@ -1,15 +1,14 @@
 // Module included in the following assemblies:
 //
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-support.adoc
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 [id="learning-getting-started-autoscaling-cli_{context}"]
 = Enabling autoscaling for an existing machine pool using the CLI
 
-[NOTE]
-====
+[role="_abstract"]
 Cluster autoscaling can be enabled at cluster creation and when creating a new machine pool by using the `--enable-autoscaling` option.
-====
 
+.Procedure
 . Autoscaling is set based on machine pool availability. To find out which machine pools are available for autoscaling, run the following command:
 +
 [source,terminal]
@@ -17,7 +16,7 @@ Cluster autoscaling can be enabled at cluster creation and when creating a new m
 $ rosa list machinepools -c <cluster-name>
 ----
 +
-.Example output
+*For example*:
 +
 [source,terminal]
 ----
@@ -32,7 +31,7 @@ workers  No           2/2       m5.xlarge                          us-east-1f   
 $ rosa edit machinepool -c <cluster-name> --enable-autoscaling <machinepool-name> --min-replicas=<num> --max-replicas=<num>
 ----
 +
-.Example input
+*For example*:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-started-autoscaling-web-ui.adoc
+++ b/modules/learning-getting-started-autoscaling-web-ui.adoc
@@ -5,11 +5,10 @@
 [id="learning-getting-started-autoscaling-web-ui_{context}"]
 = Enabling autoscaling for an existing machine pool using the UI
 
-[NOTE]
-====
+[role="_abstract"]
 Cluster autoscaling can be enabled at cluster creation by checking the *Enable autoscaling* checkbox when creating machine pools.
-====
 
+.Procedure
 . Go to the *Machine pools* tab and click the three dots in the right..
 . Click *Edit*, then *Enable autoscaling*.
 . Edit the number of minimum and maximum node counts or leave the default numbers.
@@ -21,7 +20,7 @@ Cluster autoscaling can be enabled at cluster creation by checking the *Enable a
 $ rosa list machinepools -c <cluster-name>
 ----
 +
-.Example output
+*For example*:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-started-cluster-status.adoc
+++ b/modules/learning-getting-started-cluster-status.adoc
@@ -2,9 +2,13 @@
 //
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
 :_mod-docs-content-type: PROCEDURE
-[id=learning-getting-started-cluster-status_{context}]
+[id="learning-getting-started-cluster-status_{context}"]
 = Checking the installation status
 
+[role="_abstract"]
+You can check the status of your cluster by using the {rosa-cli-first}.
+
+.Procedure
 . Run one of the following commands to check the status of the cluster:
 +
 * For a detailed view of the cluster status, run:

--- a/modules/learning-getting-started-create-cluster.adoc
+++ b/modules/learning-getting-started-create-cluster.adoc
@@ -2,9 +2,13 @@
 //
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
 :_mod-docs-content-type: PROCEDURE
-[id=learning-getting-started-create-cluster_{context}]
+[id="learning-getting-started-create-cluster_{context}"]
 = Creating a cluster
 
+[role="_abstract"]
+You can create your {product-title} cluster using the {rosa-cli}.
+
+.Procedure
 . *Optional:* Run the following command to create the account-wide roles and policies, including the Operator policies and the AWS IAM roles and policies:
 +
 [IMPORTANT]
@@ -28,5 +32,5 @@ $ rosa create cluster --cluster-name $CLUSTER_NAME \
 --oidc-config-id $OIDC_ID \
 --sts --mode auto --yes
 ----
-
++
 The cluster is ready after about 10 minutes. The cluster will have a control plane across three AWS availability zones in your selected region and create two worker nodes in your AWS account.

--- a/modules/learning-getting-started-create-vpc.adoc
+++ b/modules/learning-getting-started-create-vpc.adoc
@@ -2,7 +2,7 @@
 //
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
 :_mod-docs-content-type: PROCEDURE
-[id=learning-getting-started-create-vpc_{context}]
+[id="learning-getting-started-create-vpc_{context}"]
 = Creating a VPC
 
 [role="_abstract"]
@@ -127,7 +127,7 @@ echo "export PUBLIC_SUBNET_ID=$PUBLIC_SUBNET_ID"
 echo "export PRIVATE_SUBNET_ID=$PRIVATE_SUBNET_ID"
 ----
 
-. The script outputs commands. Set the commands as environment variables to store the subnet IDs for later use. Copy and run the commands:
+. The script outputs commands. Set the commands as environment variables to store the subnet IDs for later use. Run the following commands:
 +
 [source,terminal]
 ----
@@ -142,7 +142,7 @@ $ export PRIVATE_SUBNET_ID=$PRIVATE_SUBNET_ID
 $ echo "Public Subnet: $PUBLIC_SUBNET_ID"; echo "Private Subnet: $PRIVATE_SUBNET_ID"
 ----
 +
-.Example output
+*For example*:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-started-deleting-cli.adoc
+++ b/modules/learning-getting-started-deleting-cli.adoc
@@ -5,6 +5,10 @@
 [id="learning-getting-started-deleting-cli_{context}"]
 = Deleting a {product-title} cluster using the CLI
 
+[role="_abstract"]
+You can delete your cluster using the {rosa-cli}.
+
+.Procedure
 . *Optional:* List your clusters to make sure you are deleting the correct one by running the following command:
 +
 [source,terminal]

--- a/modules/learning-getting-started-deleting-web-ui.adoc
+++ b/modules/learning-getting-started-deleting-web-ui.adoc
@@ -5,6 +5,10 @@
 [id="learning-getting-started-deleting-web-ui_{context}"]
 = Deleting a {product-title} cluster using the UI
 
+[role="_abstract"]
+You can delete your cluster using the {cluster-manager}.
+
+.Procedure
 . Log in to the {cluster-manager-url}, and locate the cluster you want to delete.
 
 . Click the three dots to the right of the cluster.

--- a/modules/learning-getting-started-env-variables.adoc
+++ b/modules/learning-getting-started-env-variables.adoc
@@ -2,10 +2,14 @@
 //
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
 :_mod-docs-content-type: PROCEDURE
-[id=learning-getting-started-env-variables_{context}]
+[id="learning-getting-started-env-variables_{context}"]
 = Creating additional environment variables
 
-* Run the following command to set up environment variables. These variables make it easier to run the command to create a {product-title} cluster:
+[role="_abstract"]
+You can use environmental variables to make it easier to run the command to create a {product-title} cluster.
+
+.Procedure
+* Run the following command to set up environment variables:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-started-learning-machine-pool-cli.adoc
+++ b/modules/learning-getting-started-learning-machine-pool-cli.adoc
@@ -6,7 +6,7 @@
 = Creating a machine pool with the {rosa-cli}
 
 [role="_abstract"]
-You can use {rosa-cli} to create a machine pool.
+You can use the {rosa-cli} to create a machine pool.
 
 .Procedure
 
@@ -17,7 +17,7 @@ You can use {rosa-cli} to create a machine pool.
 $ rosa create machinepool --cluster=<cluster-name> --name=<machinepool-name> --replicas=<number-nodes>
 ----
 +
-.Example input
+*For example*:
 +
 [source,terminal]
 ----
@@ -25,7 +25,7 @@ $ rosa create machinepool --cluster=<cluster-name> --name=<machinepool-name> --r
  --replicas=2
 ----
 +
-.Example output
+*Example output*:
 +
 [source,terminal]
 ----
@@ -40,14 +40,14 @@ I: To view all machine pools, run 'rosa list machinepools -c my-rosa-cluster'
 $ rosa create machinepool --cluster=<cluster-name> --name=<machinepool-name> --replicas=<number-nodes> --labels=`<key=pair>`
 ----
 +
-.Example input
+*For example*:
 +
 [source,terminal]
 ----
 $ rosa create machinepool --cluster=my-rosa-cluster --name=db-nodes-mp --replicas=2 --labels='app=db','tier=backend'
 ----
 +
-.Example output
+*Example output*:
 +
 [source,terminal]
 ----
@@ -63,7 +63,7 @@ This creates an additional 2 nodes that can be managed as a unit and also assign
 $ rosa list machinepools --cluster=<cluster-name>
 ----
 +
-.Example output
+*Example output*:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-started-oidc-config.adoc
+++ b/modules/learning-getting-started-oidc-config.adoc
@@ -2,12 +2,13 @@
 //
 // * rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
 :_mod-docs-content-type: PROCEDURE
-[id=learning-getting-started-oidc-config_{context}]
+[id="learning-getting-started-oidc-config_{context}"]
 = Creating your OIDC configuration
 
 [role="_abstract"]
 In this workshop, we will use the automatic mode when creating the OIDC configuration. We will also store the OIDC ID as an environment variable for later use. The command uses the {rosa-cli} to create your cluster's unique OIDC configuration. 
 
+.Procedure
 * Create the OIDC configuration by running the following command:
 +
 [source,terminal]

--- a/modules/learning-getting-started-support-contacts.adoc
+++ b/modules/learning-getting-started-support-contacts.adoc
@@ -8,6 +8,7 @@
 [role="_abstract"]
 You can add additional email addresses for communications about your cluster. 
 
+.Procedure
 . On the {cluster-manager-first} user interface (UI), click *Cluster List* in the side navigation tabs.
 . Select the cluster that needs support.
 . Click the *Support* tab.

--- a/modules/learning-getting-started-support-page.adoc
+++ b/modules/learning-getting-started-support-page.adoc
@@ -8,6 +8,7 @@
 [role="_abstract"]
 You can request Red{nbsp}Hat support using the support page.
 
+.Procedure
 . Go to the link:https://support.redhat.com[Red{nbsp}Hat support page].
 . Click *Open a new Case*.
 +

--- a/modules/learning-getting-started-upgrading-cli.adoc
+++ b/modules/learning-getting-started-upgrading-cli.adoc
@@ -17,7 +17,7 @@ You can upgrade your cluster by using {rosa-cli}.
 $ rosa list upgrade -c <cluster-name>
 ----
 +
-.Example output
+*For example*:
 +
 [source,terminal]
 ----

--- a/modules/learning-getting-started-upgrading-recurring-updates.adoc
+++ b/modules/learning-getting-started-upgrading-recurring-updates.adoc
@@ -5,7 +5,11 @@
 [id="learning-getting-started-upgrading-recurring-updates_{context}"]
 = Setting up automatic recurring upgrades
 
-. Log in to the OpenShift Cluster Manager, and select the cluster you want to upgrade.
+[role="_abstract"]
+You can set your cluster to upgrade on a recurring basis within {cluster-manager}.
+
+.Procedure
+. Log in to the {cluster-manager}, and select the cluster you want to upgrade.
 . Click the *Settings* tab.
 . Under *Update Strategy*, click *Recurring updates*.
 . Set the day and time for the upgrade to occur.

--- a/modules/learning-getting-started-upgrading-web-ui.adoc
+++ b/modules/learning-getting-started-upgrading-web-ui.adoc
@@ -8,6 +8,7 @@
 [role="_abstract"]
 You can upgrade your cluster using {cluster-manager-url}.
 
+.Procedure
 . Log in to the {cluster-manager}, and select the cluster you want to upgrade.
 . Click the *Settings* tab.
 . If an upgrade is available, click *Update*.

--- a/modules/learning-lab-overview-lab-resources.adoc
+++ b/modules/learning-lab-overview-lab-resources.adoc
@@ -5,12 +5,15 @@
 [id="learning-lab-overview-lab-resources_{context}"]
 = Lab resources
 
+[role="_abstract"]
+The following materials are used throughout this lab tutorial.
+
 * link:https://github.com/openshift-cs/ostoy[OSToy application source code]
 * link:https://quay.io/ostoylab/ostoy-frontend[OSToy front-end container image]
 * link:https://quay.io/ostoylab/ostoy-microservice[OSToy microservice container image]
 * Deployment definition YAML files:
 +
-.`ostoy-frontend-deployment.yaml`
+`ostoy-frontend-deployment.yaml`:
 +
 [source,yaml]
 ----
@@ -154,7 +157,7 @@ data:
 type: Opaque
 ----
 +
-.`ostoy-microservice-deployment.yaml`
+`ostoy-microservice-deployment.yaml`:
 +
 [source,yaml]
 ----
@@ -214,7 +217,7 @@ spec:
 ----
 * S3 bucket manifest for ACK S3
 +
-.`s3-bucket.yaml`
+`s3-bucket.yaml`:
 +
 [source,yaml]
 ----

--- a/modules/learning-lab-overview-ui.adoc
+++ b/modules/learning-lab-overview-ui.adoc
@@ -5,6 +5,9 @@
 [id="learning-lab-overview-ui_{context}"]
 = Understanding the OSToy UI
 
+[role="_abstract"]
+The following image shows a breakdown of the OSToy application.
+
 image::ostoy-homepage.png[Preview of the OSToy homepage]
 
 . Pod name

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-accessing.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-accessing.adoc
@@ -6,10 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-getting-started-accessing
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2023-11-30
-
 [role="_abstract"]
 You can connect to your cluster using the {rosa-cli-first} or the {hybrid-console} user interface (UI).
 

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-admin-rights.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-admin-rights.adoc
@@ -6,10 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-getting-started-admin-rights
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2023-11-30
-
 [role="_abstract"]
 Administration (admin) privileges are not automatically granted to users that you add to your cluster. If you want to grant admin-level privileges to certain users, you will need to manually grant them to each user. You can grant admin privileges from either the {rosa-cli-first} or the Red{nbsp}Hat OpenShift Cluster Manager web user interface (UI).
 

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-admin.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-admin.adoc
@@ -5,10 +5,6 @@
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-getting-started-admin
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2023-11-27
-
 [role="_abstract"]
 Creating an administration (admin) user allows you to access your cluster quickly. Follow these steps to create an admin user. 
 

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-autoscaling.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-autoscaling.adoc
@@ -6,10 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-getting-started-autoscaling
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2024-01-04
-
 [role="_abstract"]
 The xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.adoc#rosa-nodes-about-autoscaling-nodes[cluster autoscaler] adds or removes worker nodes from a cluster based on pod resources.
 

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-deleting.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-deleting.adoc
@@ -6,10 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-getting-started-deleting
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2024-01-11
-
 [role="_abstract"]
 You can delete your {product-title} cluster using either the {rosa-cli-first} or the user interface (UI). 
 

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.adoc
@@ -7,21 +7,16 @@ include::_attributes/common-attributes.adoc[]
 :context: cloud-experts-getting-started-hcp
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2023-11-21
-//Updated for HCP 2024-07-01  
 [role="_abstract"]
 Follow this workshop to deploy a sample {product-title} cluster. You can then use your cluster in the next workshops.
 
 include::modules/learning-getting-started-objects-prereqs.adoc[leveloffset=+1]
 include::modules/learning-getting-started-create-vpc.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-vpc_rosa-sts-aws-prereqs[VPC documentation]
-
 include::modules/learning-getting-started-oidc-config.adoc[leveloffset=+2]
 include::modules/learning-getting-started-env-variables.adoc[leveloffset=+1]
 include::modules/learning-getting-started-create-cluster.adoc[leveloffset=+1]
 include::modules/learning-getting-started-cluster-status.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../rosa_planning/rosa-sts-aws-prereqs.adoc#rosa-vpc_rosa-sts-aws-prereqs[VPC documentation]

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-idp.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-idp.adoc
@@ -6,12 +6,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-getting-started-idp
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2023-11-28
-
 [role="_abstract"]
 To log in to your cluster, set up an identity provider (IDP). This tutorial uses GitHub as an example IDP. See the full list of link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/install_rosa_classic_clusters/rosa-sts-config-identity-providers#understanding-idp-supported_rosa-sts-config-identity-providers[IDPs supported by {product-title}].
 
 include::modules/learning-getting-idp-cli-overview.adoc[leveloffset=+1]
 include::modules/learning-getting-idp-creating.adoc[leveloffset=+1]
+include::modules/learning-getting-idp-granting-access.adoc[leveloffset=+1]

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-managing-worker-nodes.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-managing-worker-nodes.adoc
@@ -6,9 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-getting-started-managing-worker-nodes
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2023-11-30
 [role="_abstract"]
 In {product-title}, changing aspects of your worker nodes is performed through the use of machine pools. A machine pool allows users to manage many machines as a single entity. Every {product-title} cluster has a default machine pool that is created when the cluster is created. You can create your machine pools using {rosa-cli-first} or within {cluster-manager-url}.
 

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-support.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-support.adoc
@@ -6,10 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-getting-started-support
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2024-01-17
-
 [role="_abstract"]
 Finding the right help when you need it is important. These are some of the resources at your disposal when you need assistance.
 

--- a/rosa_learning/creating_cluster_workshop/learning-getting-started-upgrading.adoc
+++ b/rosa_learning/creating_cluster_workshop/learning-getting-started-upgrading.adoc
@@ -6,9 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-getting-started-upgrading
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2024-01-08
 [role="_abstract"]
 {product-title} executes all cluster upgrades as part of the managed service. You do not need to run any commands or make changes to the cluster. You can schedule the upgrades at a convenient time.
 

--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-deployment.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-deployment.adoc
@@ -6,10 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-application-deployment
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 23-JAN-2024
-
 [role="_abstract"]
 Deploying an application involves creating a container image, storing it in an image repository, and defining Deployment object that uses that image.
 

--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-health-check.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-health-check.adoc
@@ -6,9 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-application-health-check
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2024-01-26
 [role="_abstract"]
 See how Kubernetes responds to pod failure by intentionally crashing your pod and making it unresponsive to the Kubernetes liveness probes.
 

--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-networking.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-networking.adoc
@@ -6,9 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-application-networking
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2023-12-14
 [role="_abstract"]
 The OSToy application uses intra-cluster networking to separate functions by using microservices.
 

--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-s2i-deployments.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-s2i-deployments.adoc
@@ -5,7 +5,6 @@
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-application-s2i-deployments
 toc::[]
-
 [role="_abstract"]
 The integrated Source-to-Image (S2I) builder is one method to deploy applications in {OCP-short}. The S2I is a tool for building reproducible, Docker-formatted container images. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/overview/getting-started-openshift-common-terms_openshift-editions[Glossary of common terms for {OCP}]. You must have a deployed {product-title} cluster before starting this process.
 

--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-scaling.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-scaling.adoc
@@ -9,9 +9,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :icons: font
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2024-04-10
 [role="_abstract"]
 Manually or automatically scale your pods by using the Horizontal Pod Autoscaler (HPA). You can also scale your cluster nodes.
 

--- a/rosa_learning/deploying_application_workshop/learning-deploying-application-storage.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-application-storage.adoc
@@ -6,10 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-application-storage
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 2024-04-30
-
 [role="_abstract"]
 {rosa-classic-first} and {product-title} support storing persistent volumes with either link:https://aws.amazon.com/ebs/[Amazon Web Services (AWS) Elastic Block Store (EBS)] or link:https://aws.amazon.com/efs/[AWS Elastic File System (EFS)].
 

--- a/rosa_learning/deploying_application_workshop/learning-deploying-configmaps-secrets-env-var.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-configmaps-secrets-env-var.adoc
@@ -6,10 +6,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-configmaps-secrets-envvar
 
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 05-07-2024
-
 [role="_abstract"]
 This tutorial shows how to configure the OSToy application by using link:https://docs.openshift.com/rosa/nodes/pods/nodes-pods-configmaps.html[config maps], link:https://docs.openshift.com/container-platform/latest/cicd/builds/creating-build-inputs.html#builds-input-secrets-configmaps_creating-build-inputs[secrets], and link:https://docs.openshift.com/container-platform/3.11/dev_guide/environment_variables.html[environment variables].
 

--- a/rosa_learning/deploying_application_workshop/learning-deploying-s2i-webhook-cicd.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-deploying-s2i-webhook-cicd.adoc
@@ -5,11 +5,7 @@
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cloud-experts-deploying-s2i-webhook-cicd
 :source-highlighter: coderay
-
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 05-07-2024
 [role="_abstract"]
 Automatically trigger a build and deploy any time you change the source code by using a webhook. For more information about this process, see link:https://docs.openshift.com/container-platform/latest/cicd/builds/triggering-builds-build-hooks.html[Triggering Builds].
 

--- a/rosa_learning/deploying_application_workshop/learning-lab-overview.adoc
+++ b/rosa_learning/deploying_application_workshop/learning-lab-overview.adoc
@@ -5,11 +5,6 @@
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: learning-lab-overview
 toc::[]
-
-//rosaworkshop.io content metadata
-//Brought into ROSA product docs 22-JAN-2024
-//Modified for HCP 15 October 2024
-
 [role="_abstract"]
 After successfully provisioning your cluster, follow this workshop to deploy an application on it to understand the concepts of deploying and operating container-based applications. 
 


### PR DESCRIPTION
Version(s):
`enterprise-4.20+`

Issue:
**[OSDOCS-17366](https://issues.redhat.com/browse/OSDOCS-17366)**

Link to docs preview:

- [**Accessing your cluster**](https://102917--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/creating_cluster_workshop/learning-getting-started-accessing.html)
- [**Creating an admin user**](https://102917--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/creating_cluster_workshop/learning-getting-started-admin.html)
- [**Granting admin privileges**](https://102917--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/creating_cluster_workshop/learning-getting-started-admin-rights.html)
- [**Creating a cluster**](https://102917--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/creating_cluster_workshop/learning-getting-started-hcp-for-hcp.html)
- [**Setting up an identity provider**](https://102917--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/creating_cluster_workshop/learning-getting-started-idp.html)
- [**Managing worker nodes**](https://102917--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_learning/creating_cluster_workshop/learning-getting-started-managing-worker-nodes.html)

Additional information:
This PR corrects a few additional items within ROSA Learning.
