### PR TITLE
OBSDOCS-1699: 3.8 docs preview for Support's hackathon

### DIFF
--- a/modules/distr-tracing-tempo-about-rn.adoc
+++ b/modules/distr-tracing-tempo-about-rn.adoc
@@ -6,9 +6,12 @@
 [id="distr-tracing-product-overview_{context}"]
 = About this release
 
-{DTShortName} 3.7 is provided through the link:https://catalog.redhat.com/software/containers/rhosdt/tempo-operator-bundle/642c3e0eacf1b5bdbba7654a/history[{TempoOperator} 0.18.0] and based on the open source link:https://grafana.com/oss/tempo/[Grafana Tempo] 2.8.2.
+[role="_abstract"]
+{DTShortName} 3.8 is provided through the link:https://catalog.redhat.com/software/containers/rhosdt/tempo-operator-bundle/642c3e0eacf1b5bdbba7654a/history[{TempoOperator} 0.??.0] and based on the open source link:https://grafana.com/oss/tempo/[Grafana Tempo] 2.?.?.
 
+////
 [NOTE]
 ====
 Some linked Jira tickets are accessible only with Red Hat credentials.
 ====
+////

--- a/modules/distr-tracing-tempo-rn-bug-fixes.adoc
+++ b/modules/distr-tracing-tempo-rn-bug-fixes.adoc
@@ -6,6 +6,17 @@
 [id="fixed-issues_{context}"]
 = Fixed issues
 
-This release fixes the following CVE:
+Resolved issue with TLS certificates affecting Tempo pods::
+Before this update, the Tempo pods would stop to communicate because internal TLS certificates were renewed. With this update, the Tempo pods automatically restart when certificates are renewed.
++
+link:https://issues.redhat.com/browse/TRACING-5622[TRACING-5622]
 
-* link:https://access.redhat.com/security/cve/cve-2025-22874[CVE-2025-22874]
+Tempo query frontend no longer fails to fetch trace JSON::
+Before this update, clicking on *Trace* in the Jaeger UI and refreshing the page, or accessing *Trace* -> *Trace Timeline* -> *Trace JSON* from the Tempo query frontend, might result in the Tempo query pod failing with an EOF error. With this update, this issue is resolved.
++
+link:https://issues.redhat.com/browse/TRACING-5483[TRACING-5483]
+
+[NOTE]
+====
+Some linked Jira tickets are accessible only with Red Hat credentials.
+====

--- a/modules/distr-tracing-tempo-rn-enhancements.adoc
+++ b/modules/distr-tracing-tempo-rn-enhancements.adoc
@@ -6,5 +6,4 @@
 [id="new-features-and-enhancements_{context}"]
 = New features and enhancements
 
-Network policy to restrict API access::
-With this update, the {TempoOperator} creates a network policy for the Operator to restrict access to the used APIs.
+None.

--- a/modules/distr-tracing-tempo-rn-known-issues.adoc
+++ b/modules/distr-tracing-tempo-rn-known-issues.adoc
@@ -6,9 +6,11 @@
 [id="known-issues_{context}"]
 = Known issues
 
-Tempo query frontend fails to fetch trace JSON::
-In the Jaeger UI, clicking on *Trace* and refreshing the page, or accessing *Trace* -> *Trace Timeline* -> *Trace JSON* from the Tempo query frontend, might result in the Tempo query pod failing with an EOF error.
-+
-To work around this problem, use the distributed tracing UI plugin to view traces.
-+
-link:https://issues.redhat.com/browse/TRACING-5483[TRACING-5483]
+None.
+
+////
+[NOTE]
+====
+Some linked Jira tickets are accessible only with Red Hat credentials.
+====
+////

--- a/modules/distr-tracing-tempo-rn-technology-preview-features.adoc
+++ b/modules/distr-tracing-tempo-rn-technology-preview-features.adoc
@@ -8,5 +8,13 @@
 
 None.
 
+[IMPORTANT]
+====
+[subs="attributes+"]
+Technology Preview features are not supported with Red{nbsp}Hat production service level agreements (SLAs) and might not be functionally complete. Red{nbsp}Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+
 //:FeatureName: Each of these features
 //include::snippets/technology-preview.adoc[leveloffset=+1]

--- a/modules/otel-about-rn.adoc
+++ b/modules/otel-about-rn.adoc
@@ -6,9 +6,12 @@
 [id="otel-product-overview_{context}"]
 = About this release
 
-{OTELName} 3.7 is provided through the link:https://catalog.redhat.com/software/containers/rhosdt/opentelemetry-operator-bundle/615618406feffc5384e84400/history[{OTELOperator} 0.135.0] and based on the open source link:https://opentelemetry.io/docs/collector/[OpenTelemetry] release 0.135.0.
+[role="_abstract"]
+{OTELName} 3.8 is provided through the link:https://catalog.redhat.com/software/containers/rhosdt/opentelemetry-operator-bundle/615618406feffc5384e84400/history[{OTELOperator} 0.140.0] and based on the open source link:https://opentelemetry.io/docs/collector/[OpenTelemetry] release 0.140.0.
 
+////
 [NOTE]
 ====
 Some linked Jira tickets are accessible only with Red Hat credentials.
 ====
+////

--- a/modules/otel-collector-config-options.adoc
+++ b/modules/otel-collector-config-options.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * observability/otel/otel-configuration-of-otel-collector.adoc
+// * observability/otel/otel-configuration-of-otel-intro.adoc
 
 :_mod-docs-content-type: REFERENCE
 [id="otel-collector-config-options_{context}"]

--- a/modules/otel-collector-profile-signal.adoc
+++ b/modules/otel-collector-profile-signal.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-configuration-of-otel-intro.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="otel-collector-profile-signal_{context}"]
+= Profile signal
+
+[role="_abstract"]
+The Profile signal is an emerging telemetry data format for observing code execution and resource consumption.
+
+:FeatureName: The Profile signal
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+The Profile signal allows you to pinpoint inefficient code down to specific functions. Such profiling allows you to precisely identify performance bottlenecks and resource inefficiencies down to the specific line of code. By correlating such high-fidelity profile data with traces, metrics, and logs, it enables comprehensive performance analysis and targeted code optimization in production environments.
+
+Profiling can target an application or operating system:
+
+* Using profiling to observe an application can help developers validate code performance, prevent regressions, and monitor resource consumption such as of memory and CPU, and thus identify and improve inefficient code.
+
+* Using profiling to observe operating systems can provide insights into the infrastracture, system calls, kernel operations, and I/O wait times, and thus help in optimizing infrastructure for efficiency and cost savings.
+
+.OpenTelemetry Collector custom resource with the enabled Profile signal
+[source,yaml]
+----
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:   
+name: otel-profiles-collector
+  namespace: otel-profile
+spec:  
+ args: 
+   feature-gates: service.profilesSupport # <1>
+  config:     
+    receivers:       
+      otlp: # <2>
+        protocols:           
+          grpc: 
+           endpoint: '0.0.0.0:4317'
+          http: 
+           endpoint: '0.0.0.0:4318'
+    exporters: 
+       otlp/pyroscope: 
+           endpoint: "pyroscope.pyroscope-monitoring.svc.cluster.local:4317" # <3>
+    service:       
+      pipelines: # <4>
+         profiles:           
+           receivers: [otlp]
+           exporters: [otlp/pyroscope]
+# ...
+----
+<1> Enables profiles by setting the `feature-gates` field as shown here.
+<2> Configures the OTLP Receiver to set up the OpenTelemetry Collector to receive profiling data via the OTLP.
+<3> Configures where to export profiles to, such as a storage.
+<4> Defines a profiling pipeline, including a configuration for forwarding the received profile data to an OTLP-compatible profiling backend such as Grafana Pyroscope.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://opentelemetry.io/docs/specs/otel/profiles/[OpenTelemetry Profiles]
+* link:https://opentelemetry.io/docs/specs/semconv/general/profiles/[Profiles attributes]

--- a/modules/otel-creating-required-RBAC-resources-automatically.adoc
+++ b/modules/otel-creating-required-RBAC-resources-automatically.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * observability/otel/otel-configuration-of-otel-collector.adoc
+// * observability/otel/otel-configuration-of-otel-intro.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="otel-creating-required-RBAC-resources-automatically_{context}"]

--- a/modules/otel-exporters-aws-cloudwatch-exporter.adoc
+++ b/modules/otel-exporters-aws-cloudwatch-exporter.adoc
@@ -24,6 +24,7 @@ include::snippets/technology-preview.adoc[]
         region: <aws_region_of_log_stream> # <3>
         endpoint: <protocol><service_endpoint_of_amazon_cloudwatch_logs> # <4>
         log_retention: <supported_value_in_days> # <5>
+        role_arn: "<iam_role>" # <6>
 # ...
 ----
 <1> Required. If the log group does not exist yet, it is automatically created.
@@ -31,6 +32,7 @@ include::snippets/technology-preview.adoc[]
 <3> Optional. If the AWS region is not already set in the default credential chain, you must specify it.
 <4> Optional. You can override the default Amazon CloudWatch Logs service endpoint to which the requests are forwarded. You must include the protocol, such as `https://`, as part of the endpoint value. For the list of service endpoints by region, see link:https://docs.aws.amazon.com/general/latest/gr/cwl_region.html[Amazon CloudWatch Logs endpoints and quotas] (AWS General Reference).
 <5> Optional. With this parameter, you can set the log retention policy for new Amazon CloudWatch log groups. If this parameter is omitted or set to `0`, the logs never expire by default. Supported values for retention in days are `1`, `3`, `5`, `7`, `14`, `30`, `60`, `90`, `120`, `150`, `180`, `365`, `400`, `545`, `731`, `1827`, `2192`, `2557`, `2922`, `3288`, or `3653`.
+<6> Optional. The AWS Identity and Access Management (IAM) role for uploading the logs segments to a different account.
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/otel-exporters-aws-emf-exporter.adoc
+++ b/modules/otel-exporters-aws-emf-exporter.adoc
@@ -35,6 +35,7 @@ include::snippets/technology-preview.adoc[]
         endpoint: <protocol><endpoint> # <5>
         log_retention: <supported_value_in_days> # <6>
         namespace: <custom_namespace> # <7>
+        role_arn: "<iam_role>" # <8>
 # ...
 ----
 <1> You can use the `log_group_name` parameter to customize the log group name or set the default `+/metrics/default+` value or the following placeholders:
@@ -64,6 +65,7 @@ If no resource attribute is found in the resource attribute map, the placeholder
 <5> Optional. You can override the default Amazon CloudWatch Logs service endpoint to which the requests are forwarded. You must include the protocol, such as `https://`, as part of the endpoint value. For the list of service endpoints by region, see link:https://docs.aws.amazon.com/general/latest/gr/cwl_region.html[Amazon CloudWatch Logs endpoints and quotas] (AWS General Reference).
 <6> Optional. With this parameter, you can set the log retention policy for new Amazon CloudWatch log groups. If this parameter is omitted or set to `0`, the logs never expire by default. Supported values for retention in days are `1`, `3`, `5`, `7`, `14`, `30`, `60`, `90`, `120`, `150`, `180`, `365`, `400`, `545`, `731`, `1827`, `2192`, `2557`, `2922`, `3288`, or `3653`.
 <7> Optional. A custom namespace for the Amazon CloudWatch metrics.
+<8> Optional. The AWS Identity and Access Management (IAM) role for uploading the metrics segments to a different account.
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/otel-exporters-google-cloud-exporter.adoc
+++ b/modules/otel-exporters-google-cloud-exporter.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-collector/otel-collector-exporters.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="otel-exporters-google-cloud-exporter_{context}"]
+= Google Cloud Exporter
+
+[role="_abstract"]
+You can use the Google Cloud Exporter to export telemetry data to Google Cloud Operations Suite. Using the Google Cloud Exporter, you can export metrics to Google Cloud Monitoring, logs to Google Cloud Logging, and traces to Google Cloud Trace.
+
+:FeatureName: The Google Cloud Exporter
+include::snippets/technology-preview.adoc[]
+
+.OpenTelemetry Collector custom resource with the enabled Google Cloud Exporter
+[source,yaml]
+----
+# ...
+  env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /var/secrets/google/key.json # <1>
+  volumeMounts:
+    - name: google-application-credentials
+      mountPath: /var/secrets/google
+      readOnly: true
+  volumes:
+    - name: google-application-credentials
+      secret:
+        secretName: google-application-credentials
+  config:
+    exporters:
+      googlecloud:
+        project: # <2>
+# ...
+----
+<1> The `GOOGLE_APPLICATION_CREDENTIALS` environment variable that points to the authentication `key.json` file. The `key.json` file is mounted as a secret volume to the OpenTelemetry Collector.
+<2> Optional. The project identifier. If not specified, the project is automatically determined from the credentials.
++
+By default, the exporter sends telemetry data to the project specified in the `project` field of the exporter's configuration. You can have an override set up on a per-metric basis by using the `gcp.project.id` resource attribute. For example, if a metric has a label project, you can use the Group-by-Attributes Processor to promote it to a resource label, and then use the Resource Processor to rename the attribute from `project` to `gcp.project.id`.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://cloud.google.com/monitoring[Google Cloud Monitoring]
+* link:https://cloud.google.com/logging[Google Cloud Logging]
+* link:https://cloud.google.com/trace[Google Cloud Trace]
+* link:https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#deploy[Google Cloud Guides: Configure Workload Identity Federation with Kubernetes]

--- a/modules/otel-forwarding-data-to-aws.adoc
+++ b/modules/otel-forwarding-data-to-aws.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-forwarding-telemetry-data.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="otel-forwarding-data-to-aws_{context}"]
+= Forwarding telemetry data to AWS
+
+[role="_abstract"]
+You can have metrics, logs, and traces forwarded to the Amazon CloudWatch and AWS X-Ray services by using the following exporters of the OpenTelemetry Collector: AWS CloudWatch Logs Exporter, AWS EMF Exporter, and AWS X-Ray Exporter.
+
+// Currently, this docs repository does not permit linking from here to the sections for AWS CloudWatch Logs Exporter, AWS EMF Exporter, and AWS X-Ray Exporter. See the xref to the "Exporters" page placed in observability/otel/otel-forwarding-telemetry-data.adoc.

--- a/modules/otel-forwarding-data-to-google-cloud.adoc
+++ b/modules/otel-forwarding-data-to-google-cloud.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-forwarding-telemetry-data.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="otel-forwarding-data-to-google-cloud_{context}"]
+= Forwarding telemetry data to Google Cloud
+
+[role="_abstract"]
+You can have metrics, logs, and traces forwarded to Google Cloud Operations Suite by using the Google Cloud Exporter of the OpenTelemetry Collector.
+
+// Currently, this docs repository does not permit linking from here to the Google Cloud Exporter section. See the xref to the "Exporters" page placed in observability/otel/otel-forwarding-telemetry-data.adoc.

--- a/modules/otel-receivers-filelog-receiver.adoc
+++ b/modules/otel-receivers-filelog-receiver.adoc
@@ -32,3 +32,48 @@ include::snippets/technology-preview.adoc[]
 ----
 <1> A list of file glob patterns that match the file paths to be read.
 <2> An array of Operators. Each Operator performs a simple task such as parsing a timestamp or JSON. To process logs into a desired format, chain the Operators together.
+
+To collect logs from application containers, you can use this receiver with sidecar injection. The {OTELOperator} allows injecting an OpenTelemetry Collector as a sidecar container into a application pod. This approach is useful when your application writes logs to files within the container filesystem. To access the generated files, both pods require a shared volume for the application container and the sidecar Collector. This receiver can then tail log files and apply Operators to parse and transform the logs. To use this receiver in sidecar mode to collect logs from application containers, you must configure volume mounts in the `OpenTelemetryCollector` custom resource. The Collector requires access to the log files through a shared volume, such as `emptyDir`, that is mounted in both the application container and the sidecar Collector container. The following is a complete example of this approach:
+
+.OpenTelemetry Collector custom resource with the Filelog Receiver configured in sidecar mode
+[source,yaml]
+----
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: filelog
+  namespace: otel-logging
+spec:
+  mode: sidecar
+  volumeMounts: # <1>
+  - name: logs
+    mountPath: /var/log/app
+  config:
+    receivers:
+      filelog:
+        include: # <2>
+        - /var/log/app/*.log
+        operators:
+        - type: regex_parser
+          regex: '^(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) \[(?P<level>\w+)\] (?P<message>.*)$'
+          timestamp:
+            parse_from: attributes.timestamp
+            layout: '%Y-%m-%d %H:%M:%S'
+    processors: {}
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors: []
+          exporters: [debug]
+----
+<1> Defines the volume mount that the sidecar Collector uses to access the target log files. This volume must match the volume name defined in the application deployment.
+<2> Specifies file glob patterns for matching the log files to tail. This receiver watches these paths for new log entries.
++
+[IMPORTANT]
+====
+The `volumeMounts` field in the `OpenTelemetryCollector` custom resource is critical for the sidecar to access log files. The volume specified here must be defined in the application's `Deployment` or `Pod` specification. Both the application container and the sidecar Collector must mount the same volume.
+====

--- a/modules/otel-receivers-prometheus-remote-write-receiver.adoc
+++ b/modules/otel-receivers-prometheus-remote-write-receiver.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-collector/otel-collector-receivers.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="otel-receivers-prometheus-remote-write-receiver_{context}"]
+= Prometheus Remote Write Receiver
+
+[role="_abstract"]
+The Prometheus Remote Write Receiver receives metrics from Prometheus via the Remote Write protocol and converts them to the OpenTelemetry format. This receiver supports only the Prometheus Remote Write v2 protocol.
+
+:FeatureName: The Prometheus Remote Write Receiver
+include::snippets/technology-preview.adoc[]
+
+.OpenTelemetry Collector custom resource with the enabled Prometheus Remote Write Receiver
+[source,yaml]
+----
+# ...
+  config:
+    receivers:
+      prometheusremotewrite:
+        endpoint: 0.0.0.0:9009 # <1>
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheusremotewrite]
+# ...
+----
+<1> The endpoint where the receiver listens for Prometheus Remote Write requests.
+
+The following are the prerequisites for using the Prometheus Remote Write Receiver with Prometheus:
+
+* Prometheus is started with the metadata WAL records feature flag enabled:
++
+[source,yaml]
+----
+./prometheus --config.file config.yml --enable-feature=metadata-wal-records
+----
+
+* Prometheus Remote Write v2 Protocol is enabled in the Prometheus configuration file:
++
+[source,yaml]
+----
+remote_write:
+  - url: "<your_chosen_prometheus_remote_write_receiver_endpoint>"
+    protobuf_message: io.prometheus.write.v2.Request
+----
+
+* Native histograms are enabled in Prometheus. For more information about enabling native histograms in Prometheus, see the Prometheus documentation.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://prometheus.io/docs/prometheus/latest/feature_flags/#metadata-wal-records[Metadata WAL Records]
+* link:https://prometheus.io/docs/specs/prw/remote_write_spec_2_0/[Prometheus Remote-Write 2.0 specification [EXPERIMENTAL]]
+* link:https://prometheus.io/docs/specs/native_histograms/[Native Histograms]

--- a/modules/otel-rn-bug-fixes.adoc
+++ b/modules/otel-rn-bug-fixes.adoc
@@ -6,4 +6,22 @@
 [id="fixed-issues_{context}"]
 = Fixed issues
 
-None.
+Fixed BearerTokenAuth Extension errors::
+Before this update, the BearerTokenAuth Extension might log errors when the service account token was refreshed. With this update, the extension correctly handles token file refresh without producing errors.
++
+link:https://issues.redhat.com/browse/TRACING-5678[TRACING-5678]
+
+Fixed errors from the CA Injector of cert-manager::
+Before this update, the CA Injector of cert-manager was logging errors related to fetching the certificates for the {OTELOperator}. With this update, the OpenTelemetry Collector no longer relies on cert-manager, preventing unnecessary error logs.
++
+link:https://issues.redhat.com/browse/TRACING-5590[TRACING-5590] 
+
+Fixed short-term token authentication for the AWS Cloud Watch Exporter::
+Before this update, the AWS Cloud Watch Exporter ignored short-term token authentication using an Amazon Resource Name (ARN). With this update, the exporter correctly handles short-term token authentication.
++
+link:https://issues.redhat.com/browse/TRACING-5528[TRACING-5528]
+
+[NOTE]
+====
+Some linked Jira tickets are accessible only with Red Hat credentials.
+====

--- a/modules/otel-rn-deprecated-features.adoc
+++ b/modules/otel-rn-deprecated-features.adoc
@@ -6,26 +6,4 @@
 [id="deprecated-features_{context}"]
 = Deprecated features
 
-The OpenCensus Receiver is deprecated::
-The OpenCensus Receiver, which provided backward compatibility with the OpenCensus format, is deprecated and might be removed in a future release.
-
-The Collector's service metrics telemetry address is deprecated::
-The `metrics.address` field in the `OpenTelemetryCollector` custom resource (CR) is deprecated and might be removed in a future release. As an alternative, use the `metrics.readers` field instead.
-+
-Example of using the `readers` field:
-+
-[source,yaml]
-----
-# ...
-  config:
-    service:
-      telemetry:
-        metrics:
-          readers:
-          - pull:
-              exporter:
-                prometheus:
-                  host: 0.0.0.0
-                  port: 8888
-# ...
-----
+None.

--- a/modules/otel-rn-enhancements.adoc
+++ b/modules/otel-rn-enhancements.adoc
@@ -6,6 +6,5 @@
 [id="new-features-and-enhancements_{context}"]
 = New features and enhancements
 
-Network policy to restrict API access:: With this update, the {OTELOperator} creates a network policy for itself and the OpenTelemetry Collector to restrict access to the used APIs.
-
-Native sidecars:: With this update, the {OTELOperator} uses native sidecars on {product-title} 4.16 or later.
+Operator Network policy improvements::
+With this update, the Operator Network policy for the Kubernetes API server becomes more specific and uses the API Server namespace and pod labels.

--- a/modules/otel-rn-known-issues.adoc
+++ b/modules/otel-rn-known-issues.adoc
@@ -7,3 +7,10 @@
 = Known issues
 
 None.
+
+////
+[NOTE]
+====
+Some linked Jira tickets are accessible only with Red Hat credentials.
+====
+////

--- a/modules/otel-rn-removed-features.adoc
+++ b/modules/otel-rn-removed-features.adoc
@@ -6,8 +6,4 @@
 [id="removed-features_{context}"]
 = Removed features
 
-The LokiStack Exporter is removed::
-The LokiStack Exporter, which exported data to a LokiStack instance, is removed and no longer supported. You can export data to a LokiStack instance by using the OTLP HTTP Exporter instead.
-
-The Routing Processor is removed::
-The Routing Processor, which routed telemetry data to an exporter is removed and no longer supported. You can route telemetry data by using the Routing Connector instead.
+None.

--- a/modules/otel-rn-technology-preview-features.adoc
+++ b/modules/otel-rn-technology-preview-features.adoc
@@ -6,6 +6,15 @@
 [id="technology-preview-features_{context}"]
 = Technology Preview features
 
+Google Cloud Exporter (Technology Preview)::
+This release introduces the Google Cloud Exporter as a Technology Preview feature for the Collector of the {OTELName}. You can use the Google Cloud Exporter to export metrics, logs, and traces to Google Cloud's observability services: Cloud Monitoring, Cloud Logging, and Cloud Trace.
+
+Profile signal (Technology Preview)::
+This release introduces support for the Profile signal as a Technology Preview feature for receiving, processing, and exporting data in the Profile signal format. The Profile signal is a new observability data format for capturing the low-level performance of application code.
+
+Prometheus Remote Write Receiver (Technology Preview)::
+This release introduces the Prometheus Remote Write Receiver as a Technology Preview feature for the Collector of the {OTELName}. You can use the Prometheus Remote Write Receiver to export metrics from the Prometheus server.
+
 [IMPORTANT]
 ====
 [subs="attributes+"]
@@ -14,5 +23,5 @@ Technology Preview features are not supported with Red{nbsp}Hat production servi
 For more information about the support scope of Red{nbsp}Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 
-Probabilistic Sampling Processor (Technology Preview)::
-This release introduces the Probabilistic Sampling Processor as a Technology Preview feature for the {OTELShortName} Collector. The Probabilistic Sampling Processor samples a specified percentage of trace spans or log records statelessly and per request. You can use the Probabilistic Sampling Processor if you handle high volumes of telemetry data and seek to reduce costs by reducing processed data volumes.
+//:FeatureName: Each of these features
+//include::snippets/technology-preview.adoc[leveloffset=+1]

--- a/observability/distr_tracing/distr-tracing-rn.adoc
+++ b/observability/distr_tracing/distr-tracing-rn.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="distr-tracing-rn"]
-= Release notes for the {TempoName} 3.7
+= Release notes for the {TempoName} 3.8
 :context: distr-tracing-rn
 
 
@@ -11,7 +11,7 @@ include::modules/distr-tracing-tempo-about-rn.adoc[leveloffset=+1]
 
 include::snippets/distr-tracing-and-otel-disclaimer-about-docs-for-supported-features-only.adoc[]
 
-include::modules/distr-tracing-tempo-rn-enhancements.adoc[leveloffset=+1]
+// include::modules/distr-tracing-tempo-rn-enhancements.adoc[leveloffset=+1]
 
 // None included with this release
 // include::modules/distr-tracing-tempo-rn-technology-preview-features.adoc[leveloffset=+1]
@@ -22,7 +22,7 @@ include::modules/distr-tracing-tempo-rn-enhancements.adoc[leveloffset=+1]
 // None included with this release
 // include::modules/distr-tracing-tempo-rn-removed-features.adoc[leveloffset=+1]
 
-include::modules/distr-tracing-tempo-rn-known-issues.adoc[leveloffset=+1]
+// include::modules/distr-tracing-tempo-rn-known-issues.adoc[leveloffset=+1]
 
 include::modules/distr-tracing-tempo-rn-bug-fixes.adoc[leveloffset=+1]
 

--- a/observability/otel/otel-collector/otel-collector-configuration-intro.adoc
+++ b/observability/otel/otel-collector/otel-collector-configuration-intro.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
-:context: otel-configuration-of-otel-collector
-[id="otel-configuration-of-otel-collector_{context}"]
+:context: otel-configuration-of-otel-intro
+[id="otel-configuration-of-otel-intro_{context}"]
 = Configuring the Collector
 
 toc::[]
@@ -12,6 +12,8 @@ The {OTELName} Operator uses a custom resource definition (CRD) file that define
 include::modules/otel-collector-deployment-modes.adoc[leveloffset=+1]
 
 include::modules/otel-collector-config-options.adoc[leveloffset=+1]
+
+include::modules/otel-collector-profile-signal.adoc[leveloffset=+1]
 
 include::modules/otel-creating-required-RBAC-resources-automatically.adoc[leveloffset=+1]
 

--- a/observability/otel/otel-collector/otel-collector-exporters.adoc
+++ b/observability/otel/otel-collector/otel-collector-exporters.adoc
@@ -33,6 +33,8 @@ include::modules/otel-exporters-aws-xray-exporter.adoc[leveloffset=+1]
 
 include::modules/otel-exporters-file-exporter.adoc[leveloffset=+1]
 
+include::modules/otel-exporters-google-cloud-exporter.adoc[leveloffset=+1]
+
 [id="additional-resources_{context}"] 
 [role="_additional-resources"]
 == Additional resources

--- a/observability/otel/otel-collector/otel-collector-receivers.adoc
+++ b/observability/otel/otel-collector/otel-collector-receivers.adoc
@@ -39,6 +39,8 @@ include::modules/otel-receivers-journald-receiver.adoc[leveloffset=+1]
 
 include::modules/otel-receivers-kubernetesevents-receiver.adoc[leveloffset=+1]
 
+include::modules/otel-receivers-prometheus-remote-write-receiver.adoc[leveloffset=+1]
+
 [id="additional-resources_{context}"]
 [role="_additional-resources"]
 == Additional resources

--- a/observability/otel/otel-forwarding-telemetry-data.adoc
+++ b/observability/otel/otel-forwarding-telemetry-data.adoc
@@ -14,6 +14,18 @@ include::modules/otel-forwarding-logs-to-tempostack.adoc[leveloffset=+1]
 
 include::modules/otel-forwarding-data-to-third-party-systems.adoc[leveloffset=+1]
 
+include::modules/otel-forwarding-data-to-aws.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/otel/otel-collector/otel-collector-exporters.adoc#otel-collector-exporters[Exporters]
+
+include::modules/otel-forwarding-data-to-google-cloud.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../observability/otel/otel-collector/otel-collector-exporters.adoc#otel-collector-exporters[Exporters]
+
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources

--- a/observability/otel/otel-rn.adoc
+++ b/observability/otel/otel-rn.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="otel_rn"]
-= Release notes for the {OTELName} 3.7
+= Release notes for the {OTELName} 3.8
 :context: otel-rn
 
 toc::[]
@@ -14,14 +14,15 @@ include::modules/otel-rn-enhancements.adoc[leveloffset=+1]
 
 include::modules/otel-rn-technology-preview-features.adoc[leveloffset=+1]
 
-include::modules/otel-rn-deprecated-features.adoc[leveloffset=+1]
+// None included with this release
+// include::modules/otel-rn-deprecated-features.adoc[leveloffset=+1]
 
-include::modules/otel-rn-removed-features.adoc[leveloffset=+1]
+// None included with this release
+// include::modules/otel-rn-removed-features.adoc[leveloffset=+1]
 
 // None included with this release
 // include::modules/otel-rn-known-issues.adoc[leveloffset=+1]
 
-// None included with this release
-// include::modules/otel-rn-bug-fixes.adoc[leveloffset=+1]
+include::modules/otel-rn-bug-fixes.adoc[leveloffset=+1]
 
 include::modules/support.adoc[leveloffset=+1]


### PR DESCRIPTION
3.8 docs preview for Suppport's hackathon #102927:

- https://github.com/openshift/openshift-docs/pull/102702
- https://github.com/openshift/openshift-docs/pull/102760
- https://github.com/openshift/openshift-docs/pull/102819
- https://github.com/openshift/openshift-docs/pull/102804
- https://github.com/openshift/openshift-docs/pull/102897
- NOTE: Also see (different target branch) https://github.com/openshift/openshift-docs/pull/102964

Preview links

- https://102927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-rn.html
- https://102927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr-tracing-rn.html
- https://102927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-configuration-intro.html
- https://102927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-exporters.html
- https://102927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-receivers.html
- https://102927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-forwarding-telemetry-data.html
- https://102927--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-installing.html
- https://102964--ocpdocs-pr.netlify.app/openshift-coo/latest/ui_plugins/distributed-tracing-ui-plugin.html#coo-distributed-tracing-ui-plugin-using_distributed-tracing-ui-plugin