### PR TITLE
MCO Update the machine config node module title to be more JTBD

### DIFF
--- a/modules/checking-mco-node-status-configuring.adoc
+++ b/modules/checking-mco-node-status-configuring.adoc
@@ -4,8 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="checking-mco-node-status-configuring_{context}"]
-= Checking machine config node status
+= Checking node status during updates
 
+[role="_abstract"]
 During the update of a machine config pool (MCP), you can monitor the progress of all of the nodes in your cluster by using the `oc get machineconfignodes` and `oc describe machineconfignodes` commands. These commands provide information that can be helpful if issues arise during the update and you need to troubleshoot a node.
 
 For more information on the meaning of these fields, see "About checking machine config node status."

--- a/modules/checking-mco-node-status.adoc
+++ b/modules/checking-mco-node-status.adoc
@@ -4,9 +4,10 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="checking-mco-node-status_{context}"]
-= About checking machine config node status
+= About node status during updates
 
-If you make changes to a machine config pool (MCP) that results in a new machine config, for example by using a `MachineConfig` or `KubeletConfig` object, you can get detailed information about the progress of the node updates by using the machine config nodes custom resource. 
+[role="_abstract"]
+If you make changes to a machine config pool (MCP) that results in a new machine config, for example by using a `MachineConfig` or `KubeletConfig` object, you can get detailed information about the progress of the node updates by using the machine config nodes custom resource. This information can be helpful if issues arise during the update and you need to troubleshoot a node.
 
 The `MachineConfigNode` custom resource allows you to monitor the progress of individual node updates as they move through the update phases. This information can be helpful with troubleshooting if one of the nodes has an issue during the update. The custom resource reports where in the update process the node is at the moment, the phases that have completed, and the phases that are remaining.
 


### PR DESCRIPTION
I wanted to change the name of the modules that document the machine config node feature, which reports the status of nodes after you update, or make specific changes, to the node. The current titles, _About checking machine config node status_ and _Checking machine config node status_  were based on the _Checking machine config pool status_ module that proceeds them. To me these titles seem too feature-centric. I want something more Jobs to be Done style.

I also added _abstract_ tags and slightly tweaked the intro paragraph of `checking-mco-node-status.adoc` to make to better fit the new standards.

I would love feedback on any of these changes. 

Link to docs preview:
[About node status during updates](https://102928--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#checking-mco-node-status_machine-config-overview) -- New title.
[Checking node status during updates](https://102928--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#checking-mco-node-status-configuring_machine-config-overview) -- New title; small addition to first paragraph.

QE review:
No QE