### PR TITLE
[SRVKE-1725] sidecar.istio.io/inject incorrectly set as annotation

### DIFF
--- a/modules/serverless-ossm-v1x-jwt.adoc
+++ b/modules/serverless-ossm-v1x-jwt.adoc
@@ -21,7 +21,7 @@ For {ocp-product-title}, if you require sidecar injection for pods in these name
 
 .Procedure
 
-. Add the `sidecar.istio.io/inject="true"` annotation to your service:
+. Add the `sidecar.istio.io/inject="true"` label to your service:
 +
 .Example service
 [source,yaml]
@@ -33,12 +33,13 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
+      labels:
         sidecar.istio.io/inject: "true" <1>
+      annotations:
         sidecar.istio.io/rewriteAppHTTPProbers: "true" <2>
-...
+#...
 ----
-<1> Add the `sidecar.istio.io/inject="true"` annotation.
+<1> Add the `sidecar.istio.io/inject="true"` label.
 <2> You must set the annotation `sidecar.istio.io/rewriteAppHTTPProbers: "true"` in your Knative service, because {ServerlessProductName} versions 1.14.0 and higher use an HTTP probe as the readiness probe for Knative services by default.
 
 . Apply the `Service` resource:

--- a/modules/serverless-ossm-v2x-jwt.adoc
+++ b/modules/serverless-ossm-v2x-jwt.adoc
@@ -21,7 +21,7 @@ For {ocp-product-title}, if you require sidecar injection for pods in these name
 
 .Procedure
 
-. Add the `sidecar.istio.io/inject="true"` annotation to your service:
+. Add the `sidecar.istio.io/inject="true"` label to your service:
 +
 .Example service
 [source,yaml]
@@ -33,12 +33,13 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
+      labels:
         sidecar.istio.io/inject: "true" <1>
+      annotations:
         sidecar.istio.io/rewriteAppHTTPProbers: "true" <2>
-...
+#...
 ----
-<1> Add the `sidecar.istio.io/inject="true"` annotation.
+<1> Add the `sidecar.istio.io/inject="true"` label.
 <2> You must set the annotation `sidecar.istio.io/rewriteAppHTTPProbers: "true"` in your Knative service, because {ServerlessProductName} versions 1.14.0 and higher use an HTTP probe as the readiness probe for Knative services by default.
 
 . Apply the `Service` resource:


### PR DESCRIPTION
Version(s):
- serverless-docs-1.35
- serverless-docs-1.36
- serverless-docs-1.37

Issue:
- https://issues.redhat.com/browse/SRVKE-1725

Link to docs preview:
- Procedure in [Using JSON Web Token authentication with Service Mesh 1.x](https://102937--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-access/serverless-ossm-v1x-jwt.html) and [Using JSON Web Token authentication with Service Mesh 2.x](https://102937--ocpdocs-pr.netlify.app/openshift-serverless/latest/knative-serving/config-access/serverless-ossm-v2x-jwt.html)

QE review:
- [x] QE has approved this change.
