### PR TITLE
BSI Profile fix typo and references

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -102,6 +102,13 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |`x86_64`
 |
 
+|rhcos4-bsi ^[1]^
+|BSI IT-Grundschutz (Basic Protection) Building Block SYS.1.6 and APP.4.4
+|Node ^[2]^
+|link:https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf[BSI Basic Protection Compendium]
+|`x86_64`
+|
+
 |ocp4-bsi-2022 ^[3]^
 |BSI IT-Grundschutz (Basic Protection) Building Block SYS.1.6 and APP.4.4
 |Platform
@@ -116,14 +123,7 @@ The following tables reflect the latest available profiles in the Compliance Ope
 |`x86_64`
 |
 
-|rhcos4-bsi ^[3]^
-|BSI IT-Grundschutz (Basic Protection) Building Block SYS.1.6 and APP.4.4
-|Node ^[2]^
-|link:https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf[BSI Basic Protection Compendium]
-|`x86_64`
-|
-
-|ocp4-bsi-2022 ^[3]^
+|rhcos4-bsi-2022 ^[3]^
 |BSI IT-Grundschutz (Basic Protection) Building Block SYS.1.6 and APP.4.4
 |Node ^[2]^
 |link:https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf[BSI Basic Protection Compendium]
@@ -133,9 +133,9 @@ The following tables reflect the latest available profiles in the Compliance Ope
 
 |===
 [.small]
-1. The  `ocp4-bsi` and `ocp4-bsi-node` profiles maintain the most up-to-date version of the BSI Basic Protection Profile as it becomes available in the Compliance Operator. If you want to adhere to a specific version, such as BSI 2022, use the `ocp4-bsi-2022` and `ocp4-bsi-node-2022` profiles.
+1. The  `ocp4-bsi`, `ocp4-bsi-node`, `rhcos4-bsi` profiles maintain the most up-to-date version of the BSI Basic Protection Profile as it becomes available in the Compliance Operator. If you want to adhere to a specific version, such as BSI 2022, use the `ocp4-bsi-2022`, `ocp4-bsi-node-2022` or `rhcos4-bsi-2022` profiles.
 2. Node profiles must be used with the relevant Platform profile. For more information, see _Compliance Operator profile types_.
-3. Edition 2022 is the latest available English edition of the BSI IT-Grundschutz (Basic Protection) compendium. There were no changes for Building Blocks SYS.1.6 and APP.4.4 in the latest published German compendium (edition 2023).
+3. Edition 2022 is the latest available English edition of the BSI IT-Grundschutz (Basic Protection) compendium. There were no changes for Building Blocks SYS.1.6 and APP.4.4, SYS1.1 and SYS.1.3 in the latest published German compendium (edition 2023).
 
 For more information, see link:https://access.redhat.com/articles/7045834[*BSI Quick Check*].
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 
* all supported Versions

Issue:
* With CO1.8 there were enhancements to the supported BSI Profiles, the docs had some typos.
* `ocp4-bsi-2022` was duplicated and `rhcos4-bwi-2022` was missing. 
* Some references where wrong (3 instead of 1)
* The "footnotes" where not updated to include the rhcos4 versions.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
