### PR TITLE
OBSDOCS-2847 Fix issue based on non-negotiable modular elements in monitoring support section

### DIFF
--- a/modules/monitoring-support-policy-for-monitoring-operators.adoc
+++ b/modules/monitoring-support-policy-for-monitoring-operators.adoc
@@ -11,7 +11,8 @@ Monitoring Operators ensure that {ocp} monitoring resources function as designed
 
 While overriding CVO control for an Operator can be helpful during debugging, this is  unsupported and the cluster administrator assumes full control of the individual component configurations and upgrades.
 
-.Overriding the Cluster Version Operator
+[id="overriding-the-cluster-version-operator_{context}"]
+== Overriding the Cluster Version Operator
 
 The `spec.overrides` parameter can be added to the configuration for the CVO to allow administrators to provide a list of overrides to the behavior of the CVO for a component. Setting the `spec.overrides[].unmanaged` parameter to `true` for a component blocks cluster upgrades and alerts the administrator after a CVO override has been set:
 

--- a/support-for-monitoring/maintenance-and-support-for-monitoring.adoc
+++ b/support-for-monitoring/maintenance-and-support-for-monitoring.adoc
@@ -1,7 +1,9 @@
 :_mod-docs-content-type: ASSEMBLY
-include::_attributes/common-attributes.adoc[]
 [id="maintenance-and-support-for-monitoring"]
 = Maintenance and support for monitoring
+
+include::_attributes/common-attributes.adoc[]
+
 :context: maintenance-and-support-for-monitoring
 
 toc::[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2847
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://102946--ocpdocs-pr.netlify.app/openshift-monitoring/latest/support-for-monitoring/maintenance-and-support-for-monitoring.html#overriding-the-cluster-version-operator_maintenance-and-support-for-monitoring
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: `n/a`
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
