### PR TITLE
OCPBUGS-31432: Added user-managed LB prereq to said documents

### DIFF
--- a/modules/nw-autoscaling-ingress-controller.adoc
+++ b/modules/nw-autoscaling-ingress-controller.adoc
@@ -6,7 +6,7 @@
 [id="nw-autoscaling-ingress-controller_{context}"]
 = Autoscaling an Ingress Controller
 
-You can automatically scale an Ingress Controller to dynamically meet routing performance or availability requirements, such as the requirement to increase throughput.
+You can automatically scale an Ingress Controller to dynamically meet routing performance or availability requirements. For example, the requirement to increase throughput.
 
 The following procedure provides an example for scaling up the default Ingress Controller.
 
@@ -14,6 +14,9 @@ The following procedure provides an example for scaling up the default Ingress C
 
 * You have the {oc-first} installed.
 * You have access to an {product-title} cluster as a user with the `cluster-admin` role.
+* On {vmw-first}, bare-metal, and Nutanix installer-provisioned infrastructure, scaling up Ingress Controller pods does not improve external traffic performance. To improve performance, ensure that you complete the following prerequisites:
+** You manually configured a user-managed load balancer for your cluster. 
+** You ensured that the load balancer was configured for the cluster nodes that handle incoming traffic from the Ingress Controller.
 * You installed the Custom Metrics Autoscaler Operator and an associated KEDA Controller.
 ** You can install the Operator by using the software catalog on the web console. After you install the Operator, you can create an instance of `KedaController`.
 
@@ -191,6 +194,7 @@ $ oc apply -f ingress-autoscaler.yaml
 ----
 
 .Verification
+
 * Verify that the default Ingress Controller is scaled out to match the value returned by the `kube-state-metrics` query by running the following commands:
 
 ** Use the `grep` command to search the Ingress Controller YAML file for the number of replicas:

--- a/modules/nw-scaling-ingress-controller.adoc
+++ b/modules/nw-scaling-ingress-controller.adoc
@@ -6,17 +6,21 @@
 [id="nw-ingress-controller-configuration_{context}"]
 = Scaling an Ingress Controller
 
-Manually scale an Ingress Controller to meeting routing performance or
-availability requirements such as the requirement to increase throughput. `oc`
-commands are used to scale the `IngressController` resource. The following
-procedure provides an example for scaling up the default `IngressController`.
+Manually scale an Ingress Controller to meeting routing performance or availability requirements such as the requirement to increase throughput. `oc` commands are used to scale the `IngressController` resource. The following procedure provides an example for scaling up the default `IngressController`.
 
 [NOTE]
 ====
 Scaling is not an immediate action, as it takes time to create the desired number of replicas.
 ====
 
+.Prerequisites
+
+* On {vmw-first}, bare-metal, and Nutanix installer-provisioned infrastructure, scaling up Ingress Controller pods does not improve external traffic performance. To improve performance, ensure that you complete the following prerequisites:
+** You manually configured a user-managed load balancer for your cluster. 
+** You ensured that the load balancer was configured for the cluster nodes that handle incoming traffic from the Ingress Controller.
+
 .Procedure
+
 . View the current number of available replicas for the default `IngressController`:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-31432](https://issues.redhat.com/browse/OCPBUGS-31432)

Link to docs preview:
* [Autoscaling an Ingress Controller](https://102959--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/ingress-operator.html#nw-autoscaling-ingress-controller_configuring-ingress)
* [Scaling an Ingress Controller](https://102959--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/ingress-operator.html#nw-ingress-controller-configuration_configuring-ingress)

- [x] SME has approved this change (Christian Passarelli).
- [x] QE has approved this change (Melvin Joseph).

