### PR TITLE
OCPBUGS#63555: oc-mirror v2 requires explict registry hostnames

### DIFF
--- a/modules/oc-mirror-building-image-set-config-v2.adoc
+++ b/modules/oc-mirror-building-image-set-config-v2.adoc
@@ -49,6 +49,11 @@ For more information, see _About the OpenShift Update Service_.
 <3> Set the Operator catalog to retrieve the {product-title} images from.
 <4> Specify only certain Operator packages to include in the image set. Remove this field to retrieve all packages in the catalog.
 <5> Specify any additional images to include in image set.
++
+[NOTE]
+====
+In oc-mirror plugin v2, you must use explicit registry hostnames for all images listed under `additionalImages`. Otherwise, images are mirrored to incorrect target paths.
+====
 
 // Are there more relevant example version numbers we can use in the example above?
 // Also, are there any other callouts that would be helpful for users here?

--- a/modules/oc-mirror-migration-process.adoc
+++ b/modules/oc-mirror-migration-process.adoc
@@ -60,6 +60,11 @@ mirror:
       packages:
         - name: aws-load-balancer-operator
 ----
++
+[NOTE]
+====
+When migrating from oc-mirror plugin v1 to v2, you must use explicit registry hostnames for all images listed under `additionalImages`. Otherwise, images are mirrored to incorrect target paths.
+====
 
 . Check the `cluster-resources` directory inside the working directory for IDMS, ITMS, `CatalogSource`, and `ClusterCatalog` resources by running the following command:
 +

--- a/modules/oc-mirror-oci-format.adoc
+++ b/modules/oc-mirror-oci-format.adoc
@@ -67,6 +67,11 @@ mirror:
 <4> Optionally, specify an alternative namespace and name to mirror the catalog as.
 <5> Optionally, specify additional Operator catalogs to pull from a registry.
 <6> Optionally, specify additional images to pull from a registry.
++
+[NOTE]
+====
+In oc-mirror plugin v2, you must use explicit registry hostnames for all images listed under `additionalImages`. Otherwise, images are mirrored to incorrect target paths. 
+====
 
 . Run the `oc mirror` command to mirror the OCI catalog to a target mirror registry:
 +

--- a/modules/oc-mirror-workflows-delete-v2.adoc
+++ b/modules/oc-mirror-workflows-delete-v2.adoc
@@ -46,12 +46,14 @@ delete:
 
 [IMPORTANT]
 ====
-Consider using the mirror-to-disk and disk-to-mirror workflows to reduce deletion issues.
+* Consider using the mirror-to-disk and disk-to-mirror workflows to reduce deletion issues.
+
+* In oc-mirror plugin v2, you must use explicit registry hostnames for all images listed under `additionalImages`. Otherwise, images are mirrored to incorrect target paths. 
 ====
 
 oc-mirror plugin v2 deletes only the manifests of the images, which does not reduce the storage occupied in the registry.
 
-To free up storage space from unnecessary images, such as those with deleted manifests, you must enable the garbage collector on your container registry. With the garbage collector enabled, the registry will delete the image blobs that no longer have references to any manifests, reducing the storage previously occupied by the deleted blobs. The process for enabling the garbage collector differs depending on your container registry. 
+To free up storage space from unnecessary images, such as those with deleted manifests, you must enable the garbage collector on your container registry. With the garbage collector enabled, the registry will delete the image blobs that no longer have references to any manifests, reducing the storage previously occupied by the deleted blobs. The process for enabling the garbage collector differs depending on your container registry.
 
 For more information, see "Resolving storage cleanup issues in the distribution registry".
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-63555](https://issues.redhat.com/browse/OCPBUGS-63555)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://102993--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/about-installing-oc-mirror-v2.html#oc-mirror-building-image-set-config-v2_about-installing-oc-mirror-v2

https://102993--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/oc-mirror-migration-v1-to-v2.html#oc-mirror-migration-process_oc-mirror-migration-v1-to-v2
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
