### PR TITLE
CNV-62285: Move vTPM note to docs

### DIFF
--- a/modules/virt-adding-vtpm-to-vm.adoc
+++ b/modules/virt-adding-vtpm-to-vm.adoc
@@ -11,6 +11,11 @@ Adding a virtual Trusted Platform Module (vTPM) device to a virtual machine
 (VM) allows you to run a VM created from a Windows 11 image without a physical
 TPM device. A vTPM device also stores secrets for that VM.
 
+[IMPORTANT]
+====
+When you add a virtual Trusted Platform Module (vTPM) device to a Windows VM, it is important to make the vTPM device persistent. The BitLocker Drive is encrypted successfully and the encryption system check passes even if the vTPM device is not persistent. If the vTPM device is not persistent, it is discarded on shutdown.
+====
+
 .Prerequisites
 * You have installed the OpenShift CLI (`oc`).
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Move note about vTPMs from Release Notes to main documentation.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
[CNV-62285](https://issues.redhat.com/browse/CNV-62285)

Link to docs preview:
[Adding a vTPM device to a virtual machine](https://103007--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-using-vtpm-devices.html#virt-adding-vtpm-to-vm_virt-using-vtpm-devices)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
