### PR TITLE
OCPBUGS#61209 : Warning for expired certificates when performing rollback

### DIFF
--- a/modules/cnf-image-based-upgrade-rollback.adoc
+++ b/modules/cnf-image-based-upgrade-rollback.adoc
@@ -32,6 +32,11 @@ You can manually roll back the changes if you encounter unresolvable issues afte
 * You have logged into the hub cluster as a user with `cluster-admin` privileges.
 * You ensured that the control plane certificates on the original stateroot are valid. If the certificates expired, see "Recovering from expired control plane certificates".
 
+[WARNING]
+====
+If you choose to upgrade a recently installed {sno} cluster for example, for testing purposes, you have a limited rollback timeframe of 24 hours or less. You can verify the rollback time by checking the `rollbackAvailabilityExpiration` field of the `ImageBasedUpgrade` custom resource.
+====
+
 .Procedure
 
 . To move to the rollback stage, patch the value of the `stage` field to `Rollback` in the `ImageBasedUpgrade` CR by running the following command:


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-61209](https://issues.redhat.com/browse/OCPBUGS-61209)

Link to docs preview:
https://103008--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/image_based_upgrade/cnf-image-based-upgrade-base.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
