### PR TITLE
MULTIARCH-5784 MTO 1.2.1 release notes

### DIFF
--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
@@ -6,11 +6,21 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The Multiarch Tuning Operator optimizes workload management within multi-architecture clusters and in single-architecture clusters transitioning to multi-architecture environments.
+The Multiarch Tuning Operator (MTO) optimizes workload management within multi-architecture clusters and in single-architecture clusters transitioning to multi-architecture environments.
 
 These release notes track the development of the Multiarch Tuning Operator.
 
 For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator].
+
+[id="multi-arch-tuning-operator-release-notes-1-2-1_{context}"]
+== Release notes for the Multiarch Tuning Operator 1.2.1
+
+Issued: 15 December 2025
+
+[id="multi-arch-tuning-operator-1-2-1-bug-fixes_{context}"]
+=== Bug fixes
+
+* Previously, the Multiarch Tuning Operator image inspector incorrectly processed images whose registry address included a digest, tag, and port number. The port portion of the registry was incorrectly interpreted as an image tag and was trimmed, causing the inspector to construct an invalid image reference. With this update, image references that contain a digest, tag, and registry port are now correctly parsed and handled. (link:https://issues.redhat.com/browse/MULTIARCH-5767[*MULTIARCH-5767*])
 
 [id="multi-arch-tuning-operator-release-notes-1-2-0_{context}"]
 == Release notes for the Multiarch Tuning Operator 1.2.0


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/MULTIARCH-5784

Link to docs preview:
https://103029--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.html#multi-arch-tuning-operator-release-notes-1-2-1_multi-arch-tuning-operator-release-notes

QE review:
- [x] QE has approved this change.

To be merged on December 12th 