### PR TITLE
OCPBUGS-26219: Added ipam.type: host-local to nw-multus-vlan-object.adoc

### DIFF
--- a/modules/nw-multus-vlan-object.adoc
+++ b/modules/nw-multus-vlan-object.adoc
@@ -82,3 +82,5 @@ The following example demonstrates a `vlan` configuration with a secondary netwo
   }
 }
 ----
+
+* `ipam.type.host-local`: Allocates IPv4 and IPv6 IP addresses from a specified set of address ranges. IPAM plugin stores the IP addresses locally on the host filesystem so that the addresses remain unique to the host. 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-26219](https://issues.redhat.com/browse/OCPBUGS-26219)

Link to docs preview:
[VLAN configuration example](https://103043--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.html#nw-multus-vlan-config-example_configuring-additional-network-cni)


- [x] SME has approved this change (Andre Costa).
- [x] QE has approved this change (Weibin Liang).

https://www.cni.dev/plugins/current/ipam/host-local/

