### PR TITLE
CNV-65188: Update resource limit minimum values

### DIFF
--- a/modules/virt-setting-resource-quota-limits-for-vms.adoc
+++ b/modules/virt-setting-resource-quota-limits-for-vms.adoc
@@ -21,8 +21,8 @@ $ oc label ns/my-virtualization-project  alpha.kubevirt.io/auto-memory-limits-ra
 Avoid managing resource quota limits manually. To prevent misconfigurations or scheduling issues, rely on the automatic resource limit management provided by {VirtProductName} unless you have a specific need to override the defaults.
 ====
 
-
-Resource quotas that only use requests automatically work with VMs. If your resource quota uses limits, you must manually set resource limits on VMs. Resource limits must be at least 100 MiB larger than resource requests.
+Resource quotas that only use requests automatically work with VMs. If your resource quota uses limits, you must manually set resource limits on VMs.
+Memory resource limits, defined by the `spec.template.spec.domain.resources.limits.memory` value, must be at least 500 MiB, or 2% larger than the `spec.template.spec.domain.memory.guest` value.
 
 .Procedure
 
@@ -39,13 +39,19 @@ spec:
   template:
     spec:
       domain:
-# ...
+        memory:
+          guest: 128Mi
         resources:
-          requests:
-            memory: 128Mi
           limits:
-            memory: 256Mi  <1>
+            memory: 256Mi
 ----
-<1> This configuration is supported because the `limits.memory` value is at least `100Mi` larger than the `requests.memory` value.
++
+where
++
+spec.template.spec.domain.memory.guest:: Specifies the actual amount of RAM that is shown to the guest operating system (OS) in the VM.
++
+spec.template.spec.domain.resources.limits.memory:: Specifies the hard limit for total memory consumption by the `virt-launcher` pod that hosts the VM. This limit must account for the guest OS RAM plus the hypervisor overhead.
++
+This example configuration is supported because the `spec.template.spec.domain.resources.limits.memory` value is at least `100Mi` larger than the `spec.template.spec.domain.memory.guest` value.
 
 . Save the `VirtualMachine` manifest.


### PR DESCRIPTION
Version(s):
Will cherrypick as far back as possible without conflicts. Minimum version of 4.18.

Issue:
https://issues.redhat.com/browse/CNV-65188

Link to docs preview:
https://103045--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-working-with-resource-quotas-for-vms.html#virt-setting-resource-quota-limits-for-vms_virt-working-with-resource-quotas-for-vms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
