### PR TITLE
OSDOCS#17479: Update the z-stream RNs for 4.12.83

### DIFF
--- a/modules/zstream-4-12-83-about.adoc
+++ b/modules/zstream-4-12-83-about.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-83-about_{context}"]
+= RHBA-2025:21830 - {product-title} {product-version}.83 bug fix and security update
+
+
+[role="_abstract"]
+Issued: 26 November 2025
+
+
+{product-title} release {product-version}.83, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:21830[RHBA-2025:21830] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:21828[RHBA-2025:21828] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.12.83 --pullspecs
+----

--- a/modules/zstream-4-12-83-bug-fixes.adoc
+++ b/modules/zstream-4-12-83-bug-fixes.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-83-bug-fixes_{context}"]
+= Bug fixes
+
+[role=”_abstract”]
+There are no notable bug fixes in this release.

--- a/modules/zstream-4-12-83-updating.adoc
+++ b/modules/zstream-4-12-83-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-83-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5324,3 +5324,14 @@ There are no notable bug fixes in this release.
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+// 4.12.83 about
+include::modules/zstream-4-12-83-about.adoc[leveloffset=+2]
+
+
+// 4.12.83 fixes
+include::modules/zstream-4-12-83-bug-fixes.adoc[leveloffset=+2]
+
+
+// 4.12.83 updating
+include::modules/zstream-4-12-83-updating.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-17479](https://issues.redhat.com//browse/OSDOCS-17479)

Link to docs preview:
[4.12.83](https://103054--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#zstream-4-12-83-about_release-notes)

QE review:
- [x] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MRs](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/249/diffs#dfd0929ff18f8d465588d8ef9dedba16af73a6a4)
Art [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12)