### PR TITLE
OBSDOCS-2641 - monitoring stack in 4.19 and 4.20 not supporting utf-8

### DIFF
--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -14,7 +14,7 @@ Learn about supported configurations for {ocp} monitoring to ensure stability an
 Backward compatibility for metrics, recording rules, or alerting rules is not guaranteed.
 ====
 
-The following modifications are explicitly not supported:
+The following actions and configurations are not supported:
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *Creating additional `ServiceMonitor`, `PodMonitor`, and `PrometheusRule` objects in the `openshift-&#42;` and `kube-&#42;` projects.*
@@ -36,6 +36,9 @@ This procedure is a supported exception to the preceding statement.
 endif::openshift-dedicated,openshift-rosa[]
 
 * *Installing custom Prometheus instances on {ocp}.* A custom instance is a Prometheus custom resource (CR) managed by the Prometheus Operator.
+
+* *Using UTF-8 metrics.* Although the {ocp} monitoring stack ships with Prometheus v3, which supports UTF-8 metrics, the monitoring stack itself does not support UTF-8 metrics. The support status might change in a future release.
+
 ifdef::openshift-dedicated,openshift-rosa[]
 * *Modifying the default platform monitoring components.* You should not modify any of the components defined in the `cluster-monitoring-config` config map. Red Hat SRE uses these components to monitor the core cluster components and Kubernetes services.
 endif::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2641
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://103077--ocpdocs-pr.netlify.app/openshift-monitoring/latest/support-for-monitoring/support-for-monitoring.html#support-considerations_support-for-monitoring
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
