### PR TITLE
OBSDOCS-1997: Add a redirect to logging docs and remove them

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3044,46 +3044,46 @@ Topics:
 #      File: logging-5-8-release-notes
 #    - Name: Logging 5.7
 #      File: logging-5-7-release-notes
-  - Name: Logging 6.2
-    Dir: logging-6.2
-    Topics:
-    - Name: Support
-      File: log62-cluster-logging-support
-    - Name: Release notes
-      File: log6x-release-notes-6.2
-    - Name: About logging 6.2
-      File: log6x-about-6.2
-    - Name: Configuring log forwarding
-      File: log6x-clf-6.2
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.2
-    - Name: Configuring LokiStack storage
-      File: log6x-loki-6.2
-    - Name: Configuring LokiStack for OTLP
-      File: log6x-configuring-lokistack-otlp-6.2
-    - Name: Visualization for logging
-      File: log6x-visual-6.2
-  - Name: Logging 6.1
-    Dir: logging-6.1
-    Topics:
-    - Name: Support
-      File: log61-cluster-logging-support
-    - Name: Release notes
-      File: log6x-release-notes-6.1
-    - Name: About logging 6.1
-      File: log6x-about-6.1
-    - Name: Configuring log forwarding
-      File: log6x-clf-6.1
-    - Name: Configuring the logging collector
-      File: 6x-cluster-logging-collector-6.1
-    - Name: Configuring LokiStack storage
-      File: log6x-loki-6.1
-    - Name: Configuring LokiStack for OTLP
-      File: log6x-configuring-lokistack-otlp-6.1
-    - Name: OpenTelemetry data model
-      File: log6x-opentelemetry-data-model-6.1
-    - Name: Visualization for logging
-      File: log6x-visual-6.1
+#  - Name: Logging 6.2
+#    Dir: logging-6.2
+#    Topics:
+#    - Name: Support
+#      File: log62-cluster-logging-support
+#    - Name: Release notes
+#      File: log6x-release-notes-6.2
+#    - Name: About logging 6.2
+#      File: log6x-about-6.2
+#    - Name: Configuring log forwarding
+#      File: log6x-clf-6.2
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.2
+#    - Name: Configuring LokiStack storage
+#      File: log6x-loki-6.2
+#    - Name: Configuring LokiStack for OTLP
+#      File: log6x-configuring-lokistack-otlp-6.2
+#    - Name: Visualization for logging
+#      File: log6x-visual-6.2
+#  - Name: Logging 6.1
+#    Dir: logging-6.1
+#    Topics:
+#    - Name: Support
+#      File: log61-cluster-logging-support
+#    - Name: Release notes
+#      File: log6x-release-notes-6.1
+#    - Name: About logging 6.1
+#      File: log6x-about-6.1
+#    - Name: Configuring log forwarding
+#      File: log6x-clf-6.1
+#    - Name: Configuring the logging collector
+#      File: 6x-cluster-logging-collector-6.1
+#    - Name: Configuring LokiStack storage
+#      File: log6x-loki-6.1
+#    - Name: Configuring LokiStack for OTLP
+#      File: log6x-configuring-lokistack-otlp-6.1
+#    - Name: OpenTelemetry data model
+#      File: log6x-opentelemetry-data-model-6.1
+#    - Name: Visualization for logging
+#      File: log6x-visual-6.1
 #  - Name: Support
 #    File: cluster-logging-support
 #  - Name: Troubleshooting logging
@@ -3096,8 +3096,8 @@ Topics:
 #    - Name: Troubleshooting logging alerts
 #      File: troubleshooting-logging-alerts
 #      File: cluster-logging-log-store-status
-#  - Name: About Logging
-#    File: cluster-logging
+     - Name: About Logging
+       File: about-logging
 #  - Name: Installing Logging
 #    File: cluster-logging-deploying
 #  - Name: Updating Logging

--- a/observability/logging/about-logging.adoc
+++ b/observability/logging/about-logging.adoc
@@ -7,7 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can deploy {logging} on your {product-title} cluster, and use it to collect and aggregate node system audit logs, application container logs, and infrastructure logs.
+As a cluster administrator, you can deploy {logging} on an {product-title} cluster, and use it to collect and aggregate node system audit logs, application container logs, and infrastructure logs.
 
 You can use {logging} to perform the following tasks:
 


### PR DESCRIPTION
Version(s): 4.20
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2646
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://103084--ocpdocs-pr.netlify.app/openshift-dedicated/latest/observability/logging/about-logging.html
https://103084--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/about-logging.html
https://103084--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/observability/logging/about-logging.html
https://103084--ocpdocs-pr.netlify.app/openshift-rosa/latest/observability/logging/about-logging.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Not required.

Additional information:
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/94807. Apart from adding a link to the new standalone docs, this only comments out the Logging sections that are no longer required from topic map. Due to the urgency of these changes, the actual removal of files will be handled in a separate PR: https://github.com/openshift/openshift-docs/pull/101124