### PR TITLE
OBSDOCS-2538: Logging 5.8 EOL

### DIFF
--- a/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-8-release-notes.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/logging-5-8-end-of-life.adoc[]
+
 include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]

--- a/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
+++ b/observability/logging/logging_release_notes/logging-5-9-release-notes.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::snippets/logging-5-9-end-of-life.adoc[]
+
 Logging is provided as an installable component, with a distinct release cycle from the core {product-title}. The link:https://access.redhat.com/support/policy/updates/openshift_operators#platform-agnostic[Red Hat OpenShift Container Platform Life Cycle Policy] outlines release compatibility.
 
 include::snippets/logging-stable-updates-snip.adoc[leveloffset=+1]

--- a/snippets/logging-5-8-end-of-life.adoc
+++ b/snippets/logging-5-8-end-of-life.adoc
@@ -1,0 +1,11 @@
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-11-26
+:_mod-docs-content-type: SNIPPET
+
+.Red{nbsp}Hat {logging-uc} 5.8 end of life
+
+Red{nbsp}Hat {logging-uc} 5.8 is no longer supported.
+
+{logging-uc} 5.8 reached End of Life on November 3, 2025.
+The suggested replacement is {logging-uc} 6.
+For details about migrating, see the link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.0/html/upgrading_logging/index[Upgrading {logging-uc}].

--- a/snippets/logging-5-9-end-of-life.adoc
+++ b/snippets/logging-5-9-end-of-life.adoc
@@ -1,0 +1,11 @@
+:_newdoc-version: 2.18.4
+:_template-generated: 2025-11-26
+:_mod-docs-content-type: SNIPPET
+
+.Red{nbsp}Hat {logging-uc} 5.9 end of life
+
+Red{nbsp}Hat {logging-uc} 5.9 is no longer supported.
+
+{logging-uc} 5.9 reached End of Life on November 3, 2025.
+The suggested replacement is {logging-uc} 6.
+For details about migrating, see the link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/6.0/html/upgrading_logging/index[Upgrading {logging-uc}].


### PR DESCRIPTION
Version(s): 4.15, 4.14, 4.13, 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2538
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://103092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-8-release-notes.html
https://103092--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/logging/logging_release_notes/logging-5-9-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
