### PR TITLE
 OSDOCS-17043_4#applying CQAs for bare metal_1

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on bare metal. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]

--- a/modules/machineset-yaml-baremetal.adoc
+++ b/modules/machineset-yaml-baremetal.adoc
@@ -1,24 +1,17 @@
 // Module included in the following assemblies:
 //
-// * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
 
-ifeval::["{context}" == "creating-infrastructure-machinesets"]
-:infra:
-endif::[]
-
 :_mod-docs-content-type: REFERENCE
-[id="machineset-yaml-vsphere_{context}"]
+[id="machineset-yaml-baremetal_{context}"]
 = Sample YAML for a compute machine set custom resource on bare metal
 
-This sample YAML defines a compute machine set that runs on bare metal and creates nodes that are labeled with
-ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
-ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
+[role="_abstract"]
+You can define and apply a compute machine set on bare-metal infrastructure to automate node provisioning.
 
-In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
-ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
-is the node label to add.
+The sample bare metal YAML defines a compute machine set that runs on bare-metal infrastructure and creates nodes that are labeled with `node-role.kubernetes.io/<role>: ""`.
+
+In the sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `<role>` is the node label to add.
 
 [source,yaml]
 ----
@@ -27,82 +20,58 @@ kind: MachineSet
 metadata:
   creationTimestamp: null
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-ifndef::infra[]
-  name: <infrastructure_id>-<role> <2>
-endif::infra[]
-ifdef::infra[]
-  name: <infrastructure_id>-infra <2>
-endif::infra[]
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+  name: <infrastructure_id>-<role>
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
-endif::infra[]
-ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
-endif::infra[]
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <3>
-        machine.openshift.io/cluster-api-machine-type: <role> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
-endif::infra[]
-ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <3>
-        machine.openshift.io/cluster-api-machine-type: <infra> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
-endif::infra[]
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
     spec:
       metadata:
         creationTimestamp: null
         labels:
-ifndef::infra[]
-          node-role.kubernetes.io/<role>: "" <3>
-endif::infra[]
-ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <3>
-      taints: <4>
-      - key: node-role.kubernetes.io/infra
-        effect: NoSchedule
-endif::infra[]
+          node-role.kubernetes.io/<role>: ""
       providerSpec:
         value:
           apiVersion: baremetal.cluster.k8s.io/v1alpha1
           hostSelector: {}
           image:
-            checksum: http:/172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2.<md5sum> <4>
-            url: http://172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2 <5>
+            checksum: <image_checksum>
+            url: <image_url>
           kind: BareMetalMachineProviderSpec
           metadata:
             creationTimestamp: null
           userData:
             name: worker-user-data-managed
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
+
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the {oc-first} installed, you can obtain the infrastructure ID by running the following command:
 +
 [source,terminal]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
-ifndef::infra[]
-<2> Specify the infrastructure ID and node label.
-<3> Specify the node label to add.
-<4> Edit the `checksum` URL to use the API VIP address.
-<5> Edit the `url` URL to use the API VIP address.
-endif::infra[]
 
-ifeval::["{context}" == "creating-infrastructure-machinesets"]
-:!infra:
-endif::[]
-ifeval::["{context}" == "cluster-tasks"]
-:!infra:
-endif::[]
+
+`<infrastructure_id>-<role>`:: Specifies the infrastructure ID and `<role>` node label.
+`<role>`:: Specifies the node label to add.
+
+[NOTE]
+====
+`<image_checksum>`:: Specifies the image checksum, the URL that you edit to use the API VIP address, in the following format:  `\http://172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2.<md5sum>`.
+
+`<image_url>`:: Specifies the image URL, the URL that you edit to use the API VIP address, in the following format: `\http://172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2`.
+====


### PR DESCRIPTION
Versions:
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17043

Link to docs preview:
- [Creating a compute machine set on bare metal](https://103102--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-bare-metal.html#machineset-yaml-vsphere_creating-machineset-bare-metal)
- [Sample YAML for a compute machine set custom resource on bare metal](https://103102--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-bare-metal.html#machineset-yaml-vsphere_creating-machineset-bare-metal) (Managing compute machines with the Machine API) 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
