### PR TITLE
OSDOCS:17043_5#GCP compute machines_CQA

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on {gcp-first}. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 //[IMPORTANT] admonition for UPI
@@ -19,10 +20,6 @@ include::modules/machineset-creating.adoc[leveloffset=+1]
 
 //Labeling GPU machine sets for the cluster autoscaler
 include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 
 //Configuring persistent disk types by using compute machine sets
 include::modules/machineset-gcp-pd-disk-types.adoc[leveloffset=+1]
@@ -51,11 +48,12 @@ include::modules/machineset-gcp-shielded-vms.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm[What is Shielded VM?]
-** link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#secure-boot[Secure Boot]
-** link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#vtpm[Virtual Trusted Platform Module (vTPM)]
-** link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#integrity-monitoring[Integrity monitoring]
-
+* link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#secure-boot[Secure Boot]
+* link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#vtpm[Virtual Trusted Platform Module (vTPM)]
+* link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#integrity-monitoring[Integrity monitoring]
+* xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]
 //Enabling customer-managed encryption keys for a compute machine set
+
 include::modules/machineset-gcp-enabling-customer-managed-encryption.adoc[leveloffset=+1]
 
 //Enabling GPU support for a compute machine set

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -38,7 +38,8 @@ endif::[]
 [id="machineset-creating_{context}"]
 = Creating a compute machine set
 
-In addition to the compute machine sets created by the installation program, you can create your own to dynamically manage the machine compute resources for specific workloads of your choice.
+[role="_abstract"]
+In addition to the compute machine sets created by the installation program, you can create your own compute machine sets to dynamically manage the machine compute resources for specific workloads of your choice. Use the {product-title} CLI to automate node provisioning.
 
 ifdef::vsphere[]
 [NOTE]
@@ -111,8 +112,8 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-  name: <infrastructure_id>-<role> <2>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+  name: <infrastructure_id>-<role>
   namespace: openshift-machine-api
 spec:
   replicas: 1
@@ -128,19 +129,21 @@ spec:
         machine.openshift.io/cluster-api-machine-type: <role>
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
     spec:
-      providerSpec: <3>
+      providerSpec:
         ...
 ----
-<1> The cluster infrastructure ID.
-<2> A default node label.
+
+where:
+
+`metadata.labels.machine.openshift.io/cluster-api-cluster`:: Specifies the cluster infrastructure ID.
+`metadata.labels.name`:: Specifies a default node label.
 +
 [NOTE]
 ====
 For clusters that have user-provisioned infrastructure, a compute machine set can only create `worker` and `infra` type machines.
 ====
-<3> The values in the `<providerSpec>` section of the compute machine set CR are platform-specific. For more information about `<providerSpec>` parameters in the CR, see the sample compute machine set CR configuration for your provider.
+`spec.template.metadata.spec.providerSpec`:: Specifies the values of the compute machine set CR. The values are platform-specific. For more information about `<providerSpec>` parameters in the CR, see the sample compute machine set CR configuration for your provider.
 --
-
 ifdef::vsphere[]
 .. If you are creating a compute machine set for a cluster that has user-provisioned infrastructure, note the following important values:
 +
@@ -157,8 +160,8 @@ template:
       value:
         apiVersion: machine.openshift.io/v1beta1
         credentialsSecret:
-          name: vsphere-cloud-credentials <1>
-        dataDisks: <2>
+          name: vsphere-cloud-credentials
+        dataDisks:
         - name: <disk_name>
           provisioningMode: <mode>
           sizeGiB: 10
@@ -171,22 +174,25 @@ template:
         numCPUs: 4
         numCoresPerSocket: 4
         snapshot: ""
-        template: <vm_template_name> <3>
+        template: <vm_template_name>
         userDataSecret:
-          name: worker-user-data <4>
+          name: worker-user-data
         workspace:
           datacenter: <vcenter_data_center_name>
           datastore: <vcenter_datastore_name>
           folder: <vcenter_vm_folder_path>
           resourcepool: <vsphere_resource_pool>
-          server: <vcenter_server_address> <5>
+          server: <vcenter_server_address>
 ----
-<1> The name of the secret in the `openshift-machine-api` namespace that contains the required vCenter credentials.
-<2> The collection of data disk definitions. 
-For more information, see "Configuring data disks by using machine sets".
-<3> The name of the {op-system} VM template for your cluster that was created during installation.
-<4> The name of the secret in the `openshift-machine-api` namespace that contains the required Ignition configuration credentials.
-<5> The IP address or fully qualified domain name (FQDN) of the vCenter server.
+
+where:
+
+`vsphere-cloud-credentials`:: Specifies the name of the secret in the `openshift-machine-api` namespace that contains the required vCenter credentials.
+`<disk_name>`:: Specifies the collection of data disk definitions. For more information, see "Configuring data disks by using machine sets".
+`<vm_template_name>`:: Specifies the name of the {op-system} VM template for your cluster that was created during installation.
+`worker-user-data`:: Specifies the name of the secret in the `openshift-machine-api` namespace that contains the required Ignition configuration credentials.
+`<vcenter_server_address>`:: Specifies the IP address or fully qualified domain name (FQDN) of the vCenter server.
+
 endif::vsphere[]
 
 . Create a `MachineSet` CR by running the following command:

--- a/modules/machineset-gcp-confidential-vm.adoc
+++ b/modules/machineset-gcp-confidential-vm.adoc
@@ -11,7 +11,8 @@ endif::[]
 [id="machineset-gcp-confidential-vm_{context}"]
 = Configuring Confidential VM by using machine sets
 
-By editing the machine set YAML file, you can configure the Confidential VM options that a machine set uses for machines that it deploys.
+[role="_abstract"]
+You create machine sets to scale clusters on {gcp-first}. By editing the machine set YAML file, you can configure the Confidential VM options that a machine set uses for machines that it deploys.
 
 For more information about Confidential VM features, functions, and compatibility, see the {gcp-short} Compute Engine documentation about link:https://cloud.google.com/confidential-computing/confidential-vm/docs/about-cvm#confidential-vm[Confidential VM].
 
@@ -38,9 +39,9 @@ spec:
     spec:
       providerSpec:
         value:
-          confidentialCompute: Enabled <1>
-          onHostMaintenance: Terminate <2>
-          machineType: n2d-standard-8 <3>
+          confidentialCompute: Enabled
+          onHostMaintenance: Terminate
+          machineType: n2d-standard-8
 endif::cpmso[]
 ifdef::cpmso[]
 apiVersion: machine.openshift.io/v1
@@ -50,25 +51,26 @@ kind: ControlPlaneMachineSet
       spec:
         providerSpec:
           value:
-            confidentialCompute: Enabled <1>
-            onHostMaintenance: Terminate <2>
-            machineType: n2d-standard-8 <3>
+            confidentialCompute: Enabled
+            onHostMaintenance: Terminate
+            machineType: n2d-standard-8
 endif::cpmso[]
 # ...
 ----
-<1> Specify whether Confidential VM is enabled. The following values are valid:
-
++
+where:
++
+ifndef::cpmso[]
+`spec.template.spec.providerSpec.value.confidentialCompute`:: Specifies whether Confidential VM is enabled.
+The following values are valid:
 `Enabled`:: Enables Confidential VM with a default selection of Confidential VM technology. The default selection is AMD Secure Encrypted Virtualization (AMD SEV).
 +
 [IMPORTANT]
 ====
 The `Enabled` value selects Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV), which is deprecated.
 ====
-
 `Disabled`:: Disables Confidential VM.
-
 `AMDEncryptedVirtualizationNestedPaging`:: Enables Confidential VM using AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP). AMD SEV-SNP supports n2d machines.
-
 `AMDEncryptedVirtualization`:: Enables Confidential VM using AMD SEV. AMD SEV supports c2d, n2d, and c3d machines.
 +
 [IMPORTANT]
@@ -77,9 +79,34 @@ The use of Confidential Computing with AMD Secure Encrypted Virtualization (AMD 
 ====
 
 `IntelTrustedDomainExtensions`:: Enables Confidential VM using Intel Trusted Domain Extensions (Intel TDX). Intel TDX supports n2d machines.
+
+`spec.template.spec.providerSpec.value.onHostMaintenance`:: Specifies the behavior of the VM during a host maintenance event, such as a hardware or software update. For a machine that uses Confidential VM, this value must be set to `Terminate`, which stops the VM. Confidential VM does not support live VM migration.
+`spec.template.spec.providerSpec.value.machineType`:: Specifies a machine type that supports the Confidential VM option that you specified in the `confidentialCompute` field.
+endif::cpmso[]
+
+ifdef::cpmso[]
+`spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.confidentialCompute`:: Specifies whether Confidential VM is enabled.
+The following values are valid:
+`Enabled`:: Enables Confidential VM with a default selection of Confidential VM technology. The default selection is AMD Secure Encrypted Virtualization (AMD SEV).
 +
-<2> Specify the behavior of the VM during a host maintenance event, such as a hardware or software update. For a machine that uses Confidential VM, this value must be set to `Terminate`, which stops the VM. Confidential VM does not support live VM migration.
-<3> Specify a machine type that supports the Confidential VM option that you specified in the `confidentialCompute` field.
+[IMPORTANT]
+====
+The `Enabled` value selects Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV), which is deprecated.
+====
+`Disabled`:: Disables Confidential VM.
+`AMDEncryptedVirtualizationNestedPaging`:: Enables Confidential VM using AMD Secure Encrypted Virtualization Secure Nested Paging (AMD SEV-SNP). AMD SEV-SNP supports n2d machines.
+`AMDEncryptedVirtualization`:: Enables Confidential VM using AMD SEV. AMD SEV supports c2d, n2d, and c3d machines.
++
+[IMPORTANT]
+====
+The use of Confidential Computing with AMD Secure Encrypted Virtualization (AMD SEV) has been deprecated and will be removed in a future release.
+====
+
+`IntelTrustedDomainExtensions`:: Enables Confidential VM using Intel Trusted Domain Extensions (Intel TDX). Intel TDX supports n2d machines.
+
+`spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.onHostMaintenance`:: Specifies the behavior of the VM during a host maintenance event, such as a hardware or software update. For a machine that uses Confidential VM, this value must be set to `Terminate`, which stops the VM. Confidential VM does not support live VM migration.
+`spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.machineType`:: Specifies a machine type that supports the Confidential VM option that you specified in the `confidentialCompute` field.
+endif::cpmso[]
 
 .Verification
 

--- a/modules/machineset-gcp-enabling-customer-managed-encryption.adoc
+++ b/modules/machineset-gcp-enabling-customer-managed-encryption.adoc
@@ -11,7 +11,8 @@ endif::[]
 [id="machineset-gcp-enabling-customer-managed-encryption_{context}"]
 = Enabling customer-managed encryption keys for a machine set
 
-{gcp-first} Compute Engine allows users to supply an encryption key to encrypt data on disks at rest. The key is used to encrypt the data encryption key, not to encrypt the customer's data. By default, Compute Engine encrypts this data by using Compute Engine keys.
+[role="_abstract"]
+Use {gcp-first} Compute Engine to supply an encryption key to encrypt data on disks at rest. The key is used to encrypt the data encryption key, not to encrypt the customer's data. By default, Compute Engine encrypts this data by using Compute Engine keys.
 
 You can enable encryption with a customer-managed key in clusters that use the Machine API. You must first link:https://cloud.google.com/compute/docs/disks/customer-managed-encryption#before_you_begin[create a KMS key] and assign the correct permissions to a service account. The KMS key name, key ring name, and location are required to allow a service account to use your key.
 
@@ -55,20 +56,24 @@ spec:
           - type:
             encryptionKey:
               kmsKey:
-                name: machine-encryption-key <1>
-                keyRing: openshift-encrpytion-ring <2>
-                location: global <3>
-                projectID: openshift-gcp-project <4>
-              kmsKeyServiceAccount: openshift-service-account@openshift-gcp-project.iam.gserviceaccount.com <5>
+                name: machine-encryption-key
+                keyRing: openshift-encryption-ring
+                location: global
+                projectID: openshift-gcp-project
+              kmsKeyServiceAccount: openshift-service-account@openshift-gcp-project.iam.gserviceaccount.com
 ----
-<1> The name of the customer-managed encryption key that is used for the disk encryption.
-<2> The name of the KMS key ring that the KMS key belongs to.
-<3> The {gcp-short} location in which the KMS key ring exists.
-<4> Optional: The ID of the project in which the KMS key ring exists. If a project ID is not set, the machine set `projectID` in which the machine set was created is used.
-<5> Optional: The service account that is used for the encryption request for the given KMS key. If a service account is not set, the Compute Engine default service account is used.
++
+where:
++
+--
+`spec.template.spec.providerSpec.value.disks.type.encryptionKey.kmsKey.name`:: Specifies the name of the customer-managed encryption key that is used for the disk encryption.
+`spec.template.spec.providerSpec.value.disks.type.encryptionKey.kmsKey.keyRing`:: Specifies the name of the KMS key ring that the KMS key belongs to.
+`spec.template.spec.providerSpec.value.disks.type.encryptionKey.kmsKey.location`:: Specifies the {gcp-short} location in which the KMS key ring exists.
+`spec.template.spec.providerSpec.value.disks.type.encryptionKey.kmsKey.projectID`:: Optional: Specifies the ID of the project in which the KMS key ring exists. If a project ID is not set, the machine set `projectID` in which the machine set was created is used.
+`spec.template.spec.providerSpec.value.disks.type.encryptionKey.kmsKeyServiceAccount`:: Optional: Specifies the service account that is used for the encryption request for the given KMS key. If a service account is not set, the Compute Engine default service account is used.
 +
 When a new machine is created by using the updated `providerSpec` object configuration, the disk encryption key is encrypted with the KMS key.
-
+--
 ifeval::["{context}" == "cpmso-supported-features-gcp"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-gcp-enabling-gpu-support.adoc
+++ b/modules/machineset-gcp-enabling-gpu-support.adoc
@@ -6,7 +6,8 @@
 [id="machineset-gcp-enabling-gpu-support_{context}"]
 = Enabling GPU support for a compute machine set
 
-{gcp-first} Compute Engine enables users to add GPUs to VM instances. Workloads that benefit from access to GPU resources can perform better on compute machines with this feature enabled. {product-title} on {gcp-short} supports NVIDIA GPU models in the A2 and N1 machine series.
+[role="_abstract"]
+Use the {gcp-first} Compute Engine to add GPUs to Virtual Machine (VM) instances. Workloads that benefit from access to GPU resources can perform better on compute machines with this feature enabled. {product-title} on {gcp-short} supports NVIDIA GPU models in the A2 and N1 machine series.
 
 .Supported GPU configurations
 |====
@@ -83,13 +84,18 @@ GPUs for graphics workloads are not supported.
 ----
   providerSpec:
     value:
-      machineType: a2-highgpu-1g <1>
-      onHostMaintenance: Terminate <2>
-      restartPolicy: Always <3>
+      machineType: a2-highgpu-1g
+      onHostMaintenance: Terminate
+      restartPolicy: Always
 ----
-<1> Specify the machine type. Ensure that the machine type is included in the A2 machine series.
-<2> When using GPU support, you must set `onHostMaintenance` to `Terminate`.
-<3> Specify the restart policy for machines deployed by the compute machine set. Allowed values are `Always` or `Never`.
++
+where
++
+--
+`spec.template.spec.providerSpec.value.machineType`:: Specifies the machine type. Ensure that the machine type is included in the A2 machine series.
+`spec.template.spec.providerSpec.value.onHostMaintenance`:: Sets `onHostMaintenance` to `Terminate`. When using GPU support, you must set `onHostMaintenance` to `Terminate`.
+`spec.template.spec.providerSpec.value.restartPolicy`:: Specifies the restart policy for machines deployed by the compute machine set. The allowed values are `Always` or `Never`.
+--
 +
 .Example configuration for the N1 machine series
 [source,yaml]
@@ -97,14 +103,19 @@ GPUs for graphics workloads are not supported.
 providerSpec:
   value:
     gpus:
-    - count: 1 <1>
-      type: nvidia-tesla-p100 <2>
-    machineType: n1-standard-1 <3>
-    onHostMaintenance: Terminate <4>
-    restartPolicy: Always <5>
+    - count: 1
+      type: nvidia-tesla-p100
+    machineType: n1-standard-1
+    onHostMaintenance: Terminate
+    restartPolicy: Always
 ----
-<1> Specify the number of GPUs to attach to the machine.
-<2> Specify the type of GPUs to attach to the machine. Ensure that the machine type and GPU type are compatible.
-<3> Specify the machine type. Ensure that the machine type and GPU type are compatible.
-<4> When using GPU support, you must set `onHostMaintenance` to `Terminate`.
-<5> Specify the restart policy for machines deployed by the compute machine set. Allowed values are `Always` or `Never`.
++
+where
++
+--
+`spec.template.spec.providerSpec.value.gpus.count`:: Specifies the number of GPUs to attach to the machine.
+`spec.template.spec.providerSpec.value.gpus.type`:: Specifies the type of GPUs to attach to the machine. Ensure that the machine type and GPU type are compatible.
+`spec.template.spec.providerSpec.value.machineType`:: Specifies the machine type. Ensure that the machine type and GPU type are compatible.
+`spec.template.spec.providerSpec.value.onHostMaintenance`:: Sets `onHostMaintenance` to `Terminate`. When using GPU support, you must set `onHostMaintenance` to `Terminate`.
+`spec.template.spec.providerSpec.value.restartPolicy`:: Specifies the restart policy for machines deployed by the compute machine set. The allowed values are `Always` or `Never`.
+--

--- a/modules/machineset-gcp-pd-disk-types.adoc
+++ b/modules/machineset-gcp-pd-disk-types.adoc
@@ -11,7 +11,8 @@ endif::[]
 [id="machineset-gcp-pd-disk-types_{context}"]
 = Configuring persistent disk types by using machine sets
 
-You can configure the type of persistent disk that a machine set deploys machines on by editing the machine set YAML file.
+[role="_abstract"]
+Configure the persistent disk type for your machine set on {gcp-first} to match your workload requirements. Editing the `MachineSet` YAML file allows you to choose between standard, balanced, or SSD persistent disks.
 
 For more information about persistent disk types, compatibility, regional availability, and limitations, see the {gcp-short} Compute Engine documentation about link:https://cloud.google.com/compute/docs/disks#pdspecs[persistent disks].
 
@@ -39,17 +40,28 @@ spec:
         value:
           disks:
 ifndef::cpmso[]
-            type: <pd-disk-type> <1>
+            type: <pd-disk-type>
 endif::cpmso[]
 ifdef::cpmso[]
-            type: pd-ssd <1>
+            type: pd-ssd
 endif::cpmso[]
 ----
+
 ifndef::cpmso[]
-<1> Specify the persistent disk type. Valid values are `pd-ssd`, `pd-standard`, and `pd-balanced`. The default value is `pd-standard`.
++
+where:
++
+--
+`spec.template.spec.providerSpec.value.disks.type`:: Specifies the persistent disk type. Valid values are `pd-ssd`, `pd-standard`, and `pd-balanced`. The default value is `pd-standard`.
+--
 endif::cpmso[]
 ifdef::cpmso[]
-<1>  Control plane nodes must use the `pd-ssd` disk type.
++
+where:
++
+--
+`spec.template.spec.providerSpec.value.disks.type`:: Uses the `pd-ssd` disk type for control plane nodes. Using the `pd-ssd` disk type is required for control plane nodes.
+--
 endif::cpmso[]
 
 .Verification

--- a/modules/machineset-gcp-shielded-vms.adoc
+++ b/modules/machineset-gcp-shielded-vms.adoc
@@ -11,7 +11,8 @@ endif::[]
 [id="machineset-gcp-shielded-vms_{context}"]
 = Configuring Shielded VM options by using machine sets
 
-By editing the machine set YAML file, you can configure the Shielded VM options that a machine set uses for machines that it deploys.
+[role="_abstract"]
+Configure Shielded Virtual Machine (VM) options for your machine sets on {gcp-first} to help secure your cluster instances. By editing the `MachineSet` YAML file, you can configure the Shielded VM options that a machine set uses for machines that it deploys.
 
 For more information about Shielded VM features and functionality, see the {gcp-short} Compute Engine documentation about link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm[Shielded VM].
 
@@ -37,24 +38,30 @@ spec:
     spec:
       providerSpec:
         value:
-          shieldedInstanceConfig: <1>
-            integrityMonitoring: Enabled <2>
-            secureBoot: Disabled <3>
-            virtualizedTrustedPlatformModule: Enabled <4>
+          shieldedInstanceConfig:
+            integrityMonitoring: Enabled
+            secureBoot: Disabled
+            virtualizedTrustedPlatformModule: Enabled
 # ...
 ----
 +
+where:
++
 --
-<1> In this section, specify any Shielded VM options that you want.
-<2> Specify whether integrity monitoring is enabled. Valid values are `Disabled` or `Enabled`.
+ifndef::cpmso[]
+`spec.template.spec.providerSpec.value.shieldedInstanceConfig`:: Specifies the Shielded VM configuration.
+endif::cpmso[]
+ifdef::cpmso[]
+`spec.template.spec.providerSpec.value.shieldedInstanceConfig`:: Specifies the Shielded VM configuration.
+endif::cpmso[]
+`spec.template.spec.providerSpec.value.shieldedInstanceConfig.integrityMonitoring`:: Specifies whether integrity monitoring is enabled. Valid values are `Disabled` or `Enabled`.
 +
 [NOTE]
 ====
 When integrity monitoring is enabled, you must not disable virtual trusted platform module (vTPM).
 ====
-
-<3> Specify whether UEFI Secure Boot is enabled. Valid values are `Disabled` or `Enabled`.
-<4> Specify whether vTPM is enabled. Valid values are `Disabled` or `Enabled`.
+`spec.template.spec.providerSpec.value.shieldedInstanceConfig.secureBoot`:: Specifies whether UEFI Secure Boot is enabled. Valid values are `Disabled` or `Enabled`.
+`spec.template.spec.providerSpec.value.shieldedInstanceConfig.virtualizedTrustedPlatformModule`:: Specifies whether vTPM is enabled. Valid values are `Disabled` or `Enabled`.
 --
 
 .Verification

--- a/modules/machineset-label-gpu-autoscaler.adoc
+++ b/modules/machineset-label-gpu-autoscaler.adoc
@@ -17,7 +17,7 @@
 = Labeling GPU machine sets for the cluster autoscaler
 
 [role="_abstract"]
-You can use a machine set label to indicate which machines the cluster autoscaler can use to deploy GPU-enabled nodes.
+Label your machine sets to indicate which machines the cluster autoscaler can use for GPU-enabled nodes. Applying the accelerator label helps ensure that the autoscaler deploys the correct resources for your GPU workloads.
 
 .Prerequisites
 * Your cluster uses a cluster autoscaler.
@@ -42,8 +42,9 @@ spec:
 ----
 where:
 
-<accelerator_name>:: Specifies a label of your choice that consists of alphanumeric characters, `-`, `_`, or `.` and starts and ends with an alphanumeric character.
+`<accelerator_name>`:: Specifies a label of your choice that consists of alphanumeric characters, `-`, `_`, or `.` and starts and ends with an alphanumeric character.
 For example, you might use `nvidia-t4` to represent Nvidia T4 GPUs, or `nvidia-a10g` for A10G GPUs.
+
 +
 [NOTE]
 ====

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -8,10 +8,14 @@ ifeval::["{context}" == "creating-infrastructure-machinesets"]
 endif::[]
 
 :_mod-docs-content-type: REFERENCE
+include::_attributes/common-attributes.adoc[]
 [id="machineset-yaml-gcp_{context}"]
 =  Sample YAML for a compute machine set custom resource on {gcp-short}
 
-This sample YAML defines a compute machine set that runs in {gcp-first} and creates nodes that are labeled with
+[role="_abstract"]
+The sample YAML defines a compute machine set for {gcp-first}, enabling the automated provisioning of nodes within a specific VPC. When you apply this configuration by using the {product-title} CLI, you can ensure consistent scaling, scheduling, and infrastructure ID labeling for compute resources in your cluster.
+
+The sample YAML defines a compute machine set that runs in {gcp-full} and creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`,]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`,]
 where
@@ -23,7 +27,7 @@ is the node label to add.
 [id="cpmso-yaml-provider-spec-gcp-oc_{context}"]
 == Values obtained by using the  OpenShift CLI
 
-In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI.
+In the following example, you can obtain some of the values for your cluster by using the {product-title} CLI.
 
 Infrastructure ID:: The `<infrastructure_id>` string is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
@@ -48,7 +52,7 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
   name: <infrastructure_id>-w-a
   namespace: openshift-machine-api
 spec:
@@ -63,11 +67,11 @@ spec:
       labels:
         machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
+        machine.openshift.io/cluster-api-machine-role: <role>
         machine.openshift.io/cluster-api-machine-type: <role>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
+        machine.openshift.io/cluster-api-machine-role: <infra>
         machine.openshift.io/cluster-api-machine-type: <infra>
 endif::infra[]
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a
@@ -90,11 +94,11 @@ endif::infra[]
           disks:
           - autoDelete: true
             boot: true
-            image: <path_to_image> <3>
+            image: <path_to_image>
             labels: null
             sizeGb: 128
             type: pd-ssd
-          gcpMetadata: <4>
+          gcpMetadata:
           - key: <custom_metadata_key>
             value: <custom_metadata_value>
           kind: GCPMachineProviderSpec
@@ -104,9 +108,9 @@ endif::infra[]
           networkInterfaces:
           - network: <infrastructure_id>-network
             subnetwork: <infrastructure_id>-worker-subnet
-          projectID: <project_name> <5>
+          projectID: <project_name>
           region: us-central1
-          serviceAccounts: <6>
+          serviceAccounts:
           - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
@@ -116,33 +120,35 @@ endif::infra[]
             name: worker-user-data
           zone: us-central1-a
 ifdef::infra[]
-      taints: <7>
+      taints:
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
 ----
-<1> For `<infrastructure_id>`, specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster.
+
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster.
 ifndef::infra[]
-<2> For `<node>`, specify the node label to add.
+`<role>`:: Specifies the node label to add.
 endif::infra[]
 ifdef::infra[]
-<2> For `<infra>`, specify the `<infra>` node label.
+`<infra>`:: Specifies the `<infra>` node label.
 endif::infra[]
-<3> Specify the path to the image that is used in current compute machine sets.
+`<path_to_image>`:: Specifies the path to the image that is used in current compute machine sets. To use a {gcp-short} Marketplace image, specify the offer to use:
 +
-To use a {gcp-short} Marketplace image, specify the offer to use:
-+
---
 * {product-title}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-413-x86-64-202305021736`
 * {opp}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-opp-413-x86-64-202305021736`
 * {oke}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-oke-413-x86-64-202305021736`
---
-<4> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the {gcp-short} documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
-<5> For `<project_name>`, specify the name of the {gcp-short} project that you use for your cluster.
-<6> Specifies a single service account. Multiple service accounts are not supported.
+
+`<gcpMetadata>`:: Optional: Specifies the custom metadata in the form of a `key:value` pair. For example use cases, see the {gcp-short} documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
+`<project_name>`:: Specifies the name of the {gcp-short} project that you use for your cluster.
+`<serviceAccounts>`:: Specifies a single service account. Multiple service accounts are not supported.
 ifdef::infra[]
-<7> Specify a taint to prevent user workloads from being scheduled on infra nodes.
-+
+`<taints>`:: Specifies a taint to prevent user workloads from being scheduled on infra nodes.
+endif::infra[]
+
+ifdef::infra[]
 [NOTE]
 ====
 After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].

--- a/modules/nvidia-gpu-aws-deploying-the-node-feature-discovery-operator.adoc
+++ b/modules/nvidia-gpu-aws-deploying-the-node-feature-discovery-operator.adoc
@@ -8,7 +8,10 @@
 [id="nvidia-gpu-aws-deploying-the-node-feature-discovery-operator_{context}"]
 = Deploying the Node Feature Discovery Operator
 
-After the GPU-enabled node is created, you need to discover the GPU-enabled node so it can be scheduled. To do this, install the Node Feature Discovery (NFD) Operator. The NFD Operator identifies hardware device features in nodes. It solves the general problem of identifying and cataloging hardware resources in the infrastructure nodes so they can be made available to {product-title}.
+[role="_abstract"]
+After the GPU-enabled node is created, you need to discover the GPU-enabled node so it can be scheduled. To do this, install the Node Feature Discovery (NFD) Operator.
+
+The NFD Operator identifies hardware device features in nodes. It solves the general problem of identifying and cataloging hardware resources in the infrastructure nodes so they can be made available to {product-title}.
 
 .Procedure
 
@@ -32,9 +35,9 @@ NAME                                       READY    STATUS     RESTARTS   AGE
 nfd-controller-manager-8646fcbb65-x5qgk    2/2      Running 7  (8h ago)   1d
 ----
 
-. Browse to the installed Oerator in the console and select *Create Node Feature Discovery*.
+. Browse to the installed Operator in the console and select *Create Node Feature Discovery*.
 
-. Select *Create* to build a NFD custom resource. This creates NFD pods in the `openshift-nfd` namespace that poll the {product-title} nodes for hardware resources and catalogue them.
+. Select *Create* to build a NFD custom resource. This creates NFD pods in the `openshift-nfd` namespace that poll the {product-title} nodes for hardware resources and catalog them.
 
 .Verification
 

--- a/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
@@ -3,10 +3,12 @@
 //  * machine_management/creating-machinesets/creating-machineset-aws.adoc
 
 :_mod-docs-content-type: PROCEDURE
+include::_attributes/common-attributes.adoc[]
 [id="nvidia-gpu-gcp-adding-a-gpu-node_{context}"]
 = Adding a GPU node to an existing {product-title} cluster
 
-You can copy and modify a default compute machine set configuration to create a GPU-enabled machine set and machines for the {gcp-short} cloud provider.
+[role="_abstract"]
+You can copy and modify a default compute machine set configuration to create a GPU-enabled machine set and machines for the {gcp-short} provider. This assists compute-intensive workloads that require hardware acceleration.
 
 The following table lists the validated instance types:
 
@@ -27,11 +29,11 @@ The following table lists the validated instance types:
 
 .Procedure
 
-. Make a copy of an existing `MachineSet`.
+. Make a copy of an existing `MachineSet` configuration.
 
 . In the new copy, change the machine set `name` in `metadata.name` and in both instances of `machine.openshift.io/cluster-api-machineset`.
 
-. Change the instance type to add the following two lines to the newly copied `MachineSet`:
+. Change the instance type to add the following two lines to the newly copied `MachineSet` configuration:
 +
 ----
 machineType: a2-highgpu-1g
@@ -165,7 +167,7 @@ myclustername-2pt9p-worker-c-6pbg6.c.openshift-qe.internal       Ready      work
 myclustername-2pt9p-worker-gpu-a-wxcr6.c.openshift-qe.internal   Ready      worker                 4h35m   v1.34.2
 ----
 
-. View the machines and machine sets that exist in the `openshift-machine-api` namespace by running the following command. Each compute machine set is associated with a different availability zone within the {gcp-short} region. The installer automatically load balances compute machines across availability zones.
+. View the machines and machine sets that exist in the `openshift-machine-api` namespace by running the following command. Each compute machine set is associated with a different availability zone within the {gcp-short} region. The installation program automatically load balances compute machines across availability zones.
 +
 [source,terminal]
 ----
@@ -293,7 +295,7 @@ machineset.machine.openshift.io/myclustername-2pt9p-worker-gpu-a created
 $ oc -n openshift-machine-api get machinesets | grep gpu
 ----
 +
-The MachineSet replica count is set to `1` so a new `Machine` object is created automatically.
+The `MachineSet` replica count is set to `1` so a new `Machine` object is created automatically.
 
 +
 .Example output


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions:
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-17043

Link to docs preview:

- [Creating a compute machine set on Google Cloud](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp)
- [Creating a compute machine set](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-creating_creating-machineset-gcp)
- [Configuring Confidential VM by using machine sets](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-gcp-confidential-vm_creating-machineset-gcp)
- [Enabling customer-managed encryption keys for a machine set](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-gcp-enabling-customer-managed-encryption_creating-machineset-gcp)
- [Enabling GPU support for a compute machine set](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-gcp-enabling-gpu-support_creating-machineset-gcp)
- [Configuring persistent disk types by using machine sets](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-gcp-pd-disk-types_creating-machineset-gcp)
- [Configuring Shielded VM options by using machine sets](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-gcp-shielded-vms_creating-machineset-gcp)
- [Labeling GPU machine sets for the cluster autoscaler](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-label-gpu-autoscaler_creating-machineset-gcp)
- [Sample YAML for a compute machine set custom resource on Google Cloud](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-yaml-gcp_creating-machineset-gcp)
- [Deploying the Node Feature Discovery Operator](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#nvidia-gpu-aws-deploying-the-node-feature-discovery-operator_creating-machineset-gcp)
- [Adding a GPU node to an existing OpenShift Container Platform cluster](https://103103--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#nvidia-gpu-gcp-adding-a-gpu-node_creating-machineset-gcp)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
