### PR TITLE
OCPBUGS-37095: Updated the prereqs on nw-ingress-route-secret-load-ex…

### DIFF
--- a/cicd/builds/running-entitled-builds.adoc
+++ b/cicd/builds/running-entitled-builds.adoc
@@ -46,7 +46,7 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // The following two xrefs are not included in the OSD and ROSA docs.
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../support/remote_health_monitoring/insights-operator-simple-access.adoc#insights-operator-simple-access[Importing simple content access certificates with {insights-operator}]
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../openshift_images/image-streams-manage.adoc#image-streams-managing[Managing image streams]
 * xref:../../cicd/builds/build-strategies.adoc#build-strategies[Build strategies]

--- a/etcd/etcd-performance.adoc
+++ b/etcd/etcd-performance.adoc
@@ -50,7 +50,7 @@ include::modules/etcd-tuning-parameters.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Understanding feature gates]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling-features[Understanding feature gates]
 
 // OCP timer tunables for etcd
 include::modules/etcd-timer-tunables.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc
@@ -77,7 +77,7 @@ include::modules/ipi-install-config-local-arbiter-node.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Understanding feature gates]
+* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling-features[Understanding feature gates]
 
 [id="ipi-install-configuration-files"]
 [id="additional-resources_config"]

--- a/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -52,7 +52,7 @@ include::modules/installation-vsphere-regions-zones-host-groups.adoc[leveloffset
 
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 
-* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
@@ -70,7 +70,7 @@ include::modules/configuring-vsphere-host-groups.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 
 // Services for a user-managed load balancer
 include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/ipi/installing-vsphere-installer-provisioned-customizations.adoc
@@ -48,7 +48,7 @@ include::modules/installation-vsphere-regions-zones-host-groups.adoc[leveloffset
 
 * xref:../../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[{vmw-full} CSI Driver Operator]
 
-* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
@@ -68,7 +68,7 @@ include::modules/configuring-vsphere-host-groups.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 
 // Specifying multiple NICS
 include::modules/installation-vsphere-multiple-nics.adoc[leveloffset=+2]

--- a/installing/installing_vsphere/post-install-vsphere-zones-regions-configuration.adoc
+++ b/installing/installing_vsphere/post-install-vsphere-zones-regions-configuration.adoc
@@ -55,4 +55,4 @@ include::modules/specifying-host-groups-vsphere.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]

--- a/machine_configuration/index.adoc
+++ b/machine_configuration/index.adoc
@@ -51,7 +51,7 @@ include::modules/checking-mco-node-status.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-configuring-on_mco-coreos-layering[About on-cluster image mode]
-* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 
 include::modules/checking-mco-node-status-configuring.adoc[leveloffset=+2]
 

--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -193,7 +193,7 @@ include::modules/coreos-layering-configuring-on-proc.adoc[leveloffset=+2]
 .Additional resources
 * xref:../openshift_images/managing_images/using-image-pull-secrets.adoc#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret]
 * xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-configuring-on-revert_mco-coreos-layering[Reverting an on-cluster custom layered image]
-* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 
 include::modules/coreos-layering-configuring-on-modifying.adoc[leveloffset=+2]
 

--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -13,7 +13,7 @@ include::snippets/technology-preview.adoc[]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 
 include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 

--- a/machine_management/cluster_api_machine_management/cluster-api-about.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-about.adoc
@@ -22,7 +22,7 @@ include::modules/capi-limitations.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling-features[Enabling features using feature gates]
 
 * xref:../../machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc#cluster-api-getting-started[Getting started with the Cluster API]
 

--- a/modules/nw-ingress-route-secret-load-external-cert.adoc
+++ b/modules/nw-ingress-route-secret-load-external-cert.adoc
@@ -6,36 +6,34 @@
 [id="nw-ingress-route-secret-load-external-cert_{context}"]
 = Creating a route with externally managed certificates
 
-You can configure {product-title} routes with third-party certificate management solutions by using the `.spec.tls.externalCertificate` field of the route API. You can reference externally managed TLS certificates via secrets, eliminating the need for manual certificate management. Using the externally managed certificate reduces errors ensuring a smoother rollout of certificate updates, enabling the OpenShift router to serve renewed certificates promptly. 
+[role="_abstract"] 
+You can configure {product-title} routes with third-party certificate management solutions by using the `.spec.tls.externalCertificate` field of the route API. You can reference externally managed TLS certificates via secrets, eliminating the need for manual certificate management.
 
-You can use externally managed certificates with both edge routes and re-encrypt routes.
+By using the externally managed certificate, you can reduce errors to ensure a smoother rollout of certificate updates and enable the OpenShift router to serve renewed certificates promptly. You can use externally managed certificates with both edge routes and re-encrypt routes.
 
 .Prerequisites
 
-* You must enable the `RouteExternalCertificate` feature gate.
-* You have `create` permission on the `routes/custom-host` sub-resource, which is used for both creating and updating routes.
-* You must have a secret containing a valid certificate/key pair in PEM-encoded format of type `kubernetes.io/tls`, which includes both `tls.key` and `tls.crt` keys.
-* You must place the referenced secret in the same namespace as the route you want to secure.
+* You must have a secret containing a valid certificate or key pair in PEM-encoded format of type `kubernetes.io/tls`, which includes both `tls.key` and `tls.crt` keys. Example command: `$ oc create secret tls myapp-tls --cert=server.crt --key=server.key`.
 
 .Procedure
 
-. Create a `role` in the same namespace as the secret to allow the router service account read access by running the following command:
+. Create a `role` object in the same namespace as the secret to allow the router service account read access by running the following command:
 +
 [source,terminal]
 ----
-$ oc create role secret-reader --verb=get,list,watch --resource=secrets --resource-name=<secret-name> \ <1> 
---namespace=<current-namespace> <2>
+$ oc create role secret-reader --verb=get,list,watch --resource=secrets --resource-name=<secret-name> \
+--namespace=<current-namespace>
 ----
-<1> Specify the actual name of your secret.
-<2> Specify the namespace where both your secret and route reside.
+* `<secret-name>`: Specify the actual name of your secret.
+* `<current-namespace>`: Specify the namespace where both your secret and route reside.
 
-. Create a `rolebinding` in the same namespace as the secret and bind the router service account to the newly created role by running the following command:
+. Create a `rolebinding` object in the same namespace as the secret and bind the router service account to the newly created role by running the following command:
 +
 [source,terminal]
 ----
-$ oc create rolebinding secret-reader-binding --role=secret-reader --serviceaccount=openshift-ingress:router --namespace=<current-namespace> <1>
+$ oc create rolebinding secret-reader-binding --role=secret-reader --serviceaccount=openshift-ingress:router --namespace=<current-namespace>
 ----
-<1> Specify the namespace where both your secret and route reside.
+* `<current-namespace>`: Specify the namespace where both your secret and route reside.
 
 . Create a YAML file that defines the `route` and specifies the secret containing your certificate using the following example. 
 +
@@ -51,27 +49,26 @@ spec:
   host: myedge-test.apps.example.com
   tls:
     externalCertificate:
-      name: <secret-name> <1>
+      name: <secret-name>
     termination: edge
     [...]
 [...]
 ----
-<1> Specify the actual name of your secret.
+* `<secret-name>`: Specify the actual name of your secret.
 
 . Create a `route` resource by running the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f <route.yaml> <1>
+$ oc apply -f <route.yaml>
 ----
-<1> Specify the generated YAML filename.
-
+* `<route.yaml>`: Specify the generated YAML filename.
 +
 If the secret exists and has a certificate/key pair, the router will serve the generated certificate if all prerequisites are met.
 +
 [NOTE]
 ====
-If `.spec.tls.externalCertificate` is not provided, the router will use default generated certificates. 
+If `.spec.tls.externalCertificate` is not provided, the router uses default generated certificates. 
 
 You cannot provide the `.spec.tls.certificate` field  or the `.spec.tls.key` field when using the `.spec.tls.externalCertificate` field.
 ====

--- a/networking/ingress_load_balancing/routes/secured-routes.adoc
+++ b/networking/ingress_load_balancing/routes/secured-routes.adoc
@@ -24,9 +24,9 @@ include::modules/nw-ingress-creating-a-passthrough-route.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-route-secret-load-external-cert.adoc[leveloffset=+1]
 
-ifndef::openshift-rosa-hcp[]
+ifndef::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
-* For troubleshooting routes with externally managed certificates, check the {product-title} router pod logs for errors, see xref:../../../support/troubleshooting/investigating-pod-issues.adoc#investigating-pod-issues[Investigating pod issues].
-endif::openshift-rosa-hcp[]
+* xref:../../../support/troubleshooting/investigating-pod-issues.adoc#investigating-pod-issues[Investigating pod issues]
+endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: nodes-cluster-enabling
-[id="nodes-cluster-enabling"]
+[id="nodes-cluster-enabling-features"]
 = Enabling features using feature gates
 include::_attributes/common-attributes.adoc[]
 

--- a/nodes/nodes/nodes-update-boot-images.adoc
+++ b/nodes/nodes/nodes-update-boot-images.adoc
@@ -13,7 +13,7 @@ include::snippets/technology-preview.adoc[]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 
 include::modules/mco-update-boot-images-about.adoc[leveloffset=+1]
 

--- a/nodes/pods/nodes-pods-configuring.adoc
+++ b/nodes/pods/nodes-pods-configuring.adoc
@@ -36,7 +36,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 * link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy] in the Kubernetes documentation
 
 include::modules/nodes-pods-configuring-pod-critical.adoc[leveloffset=+1]

--- a/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc
+++ b/observability/monitoring/configuring-core-platform-monitoring/configuring-performance-and-scalability.adoc
@@ -80,7 +80,7 @@ include::modules/monitoring-choosing-a-metrics-collection-profile.adoc[leveloffs
 
 * xref:../../../observability/monitoring/about-ocp-monitoring/key-concepts.adoc#configuring-metrics-collection-profiles_key-concepts[About metrics collection profiles]
 * xref:../../../observability/monitoring/accessing-metrics/accessing-metrics-as-an-administrator.adoc#viewing-a-list-of-available-metrics_accessing-metrics-as-an-administrator[Viewing a list of available metrics]
-* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 
 //Configuring pod topology spread constraints for core platform monitoring
 include::modules/monitoring-configuring-pod-topology-spread-constraints.adoc[leveloffset=+1,tags=**;CPM;!UWM]

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -113,7 +113,7 @@ include::modules/network-observability-viewing-network-events.adoc[leveloffset=+
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli_nodes-cluster-enabling[Enabling feature sets using the CLI]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli_nodes-cluster-enabling-features[Enabling feature sets using the CLI]
 * xref:../../networking/ovn_kubernetes_network_provider/ovn-kubernetes-troubleshooting-sources.adoc#nw-ovn-kubernetes-observability_ovn-kubernetes-sources-of-troubleshooting-information[Checking OVN-Kubernetes network traffic with OVS sampling using the CLI]
 
 //Topology

--- a/openshift_images/image-configuration.adoc
+++ b/openshift_images/image-configuration.adoc
@@ -16,7 +16,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 
 * xref:../openshift_images/image-streams-manage.adoc#images-imagestream-import-import-mode_image-streams-managing[Working with manifest lists]
 
-* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Understanding feature gates]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling-features[Understanding feature gates]
 endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/images-configuration-file.adoc[leveloffset=+1]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -50,7 +50,7 @@ to @api-approvers (github) or #forum-api-review (slack).
 |Configures the behavior of the web console interface, including the xref:../web_console/configuring-web-console.adoc#configuring-web-console[logout behavior].
 
 |`featuregate.config.openshift.io`
-|Enables xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[FeatureGates]
+|Enables xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[FeatureGates]
 so that you can use Tech Preview features.
 
 |`image.config.openshift.io`
@@ -362,5 +362,5 @@ include::modules/pod-disruption-eviction-policy.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 * link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy] in the Kubernetes documentation

--- a/support/remote_health_monitoring/about-remote-health-monitoring.adoc
+++ b/support/remote_health_monitoring/about-remote-health-monitoring.adoc
@@ -99,7 +99,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * link:https://access.redhat.com/solutions/7066188[What data is being collected by the {insights-operator} in OpenShift?]
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 * The {insights-operator} source code is available for review and contribution. See the link:https://github.com/openshift/insights-operator/blob/master/docs/gathered-data.md[{insights-operator} upstream project] for a list of the items collected by the {insights-operator}.

--- a/web_console/dynamic-plugin/content-security-policy.adoc
+++ b/web_console/dynamic-plugin/content-security-policy.adoc
@@ -14,7 +14,7 @@ You can specify Content Security Policy (CSP) directives for your dynamic plugin
 The console currently uses the `Content-Security-Policy-Report-Only` response header, so the browser will only warn about CSP violations in the web console and enforcement of CSP policies will be limited. CSP violations will be logged in the browser console, but the associated CSP directives will not be enforced. This feature is behind a `feature-gate`, so you will need to manually enable it.
 
 ifndef::openshift-rosa-hcp,openshift-rosa[]
-For more information, see xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-console_nodes-cluster-enabling[Enabling feature sets using the web console].
+For more information, see xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-console_nodes-cluster-enabling-features[Enabling feature sets using the web console].
 endif::openshift-rosa-hcp,openshift-rosa[]
 ====
 

--- a/web_console/web-console.adoc
+++ b/web_console/web-console.adoc
@@ -20,5 +20,5 @@ include::modules/web-console-overview.adoc[leveloffset=+1]
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [role="_additional-resources"]
 .Additional resources
-* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc[Enabling feature sets using the web console]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling feature sets using the web console]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
[OCPBUGS-37095](https://issues.redhat.com/browse/OCPBUGS-37095)

Link to docs preview:
* [Creating a route with externally managed certificates](https://103104--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/routes/secured-routes.html#nw-ingress-route-secret-load-external-cert_secured-routes)
* [Dedicated](https://103104--ocpdocs-pr.netlify.app/openshift-dedicated/latest/networking/ingress_load_balancing/routes/secured-routes.html#nw-ingress-route-secret-load-external-cert_secured-routes)
* [ROSA classic](https://103104--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/networking/ingress_load_balancing/routes/secured-routes.html#nw-ingress-route-secret-load-external-cert_secured-routes)
* [ROSA HCP](https://103104--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ingress_load_balancing/routes/secured-routes.html#nw-ingress-route-secret-load-external-cert_secured-routes)

- [x] SME has approved this change (Chen Chen).
- [x] QE has approved this change (Hongan Li).

