### PR TITLE
OCPBUGS#45035: Fixed the hyperlink and made statement consistency.

### DIFF
--- a/security/certificate_types_descriptions/ingress-certificates.adoc
+++ b/security/certificate_types_descriptions/ingress-certificates.adoc
@@ -83,7 +83,7 @@ Ingress to the cluster via a secured route uses the default certificate of the I
 
 == Management
 
-Ingress certificates are managed by the user. See xref:../../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[Replacing the default ingress certificate] for more information.
+Ingress certificates are managed by the user. For more information, see xref:../../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[Replacing the default ingress certificate] .
 
 == Renewal
 

--- a/security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc
+++ b/security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 Monitoring components secure their traffic with service CA certificates. These certificates are valid for 2 years and are replaced automatically on rotation of the service CA, which is every 13 months.
 
-If the certificate lives in the `openshift-monitoring` or `openshift-logging` namespace, it is system managed and rotated automatically.
+If the certificate is present in the `openshift-monitoring` or `openshift-logging` namespace, it is system managed and rotated automatically.
 
 == Management
 

--- a/security/certificate_types_descriptions/olm-certificates.adoc
+++ b/security/certificate_types_descriptions/olm-certificates.adoc
@@ -12,7 +12,7 @@ All certificates for Operator Lifecycle Manager (OLM) components (`olm-operator`
 
 When installing Operators that include webhooks or API services in their `ClusterServiceVersion` (CSV) object, OLM creates and rotates the certificates for these resources. Certificates for resources in the `openshift-operator-lifecycle-manager` namespace are managed by OLM.
 
-OLM will not update the certificates of Operators that it manages in proxy environments. These certificates must be managed by the user using the subscription config.
+OLM does not update the certificates of Operators that it manages in proxy environments. These certificates must be managed by the user using the subscription config.
 
 [role="_additional-resources"]
 .Next steps

--- a/security/certificate_types_descriptions/proxy-certificates.adoc
+++ b/security/certificate_types_descriptions/proxy-certificates.adoc
@@ -64,7 +64,7 @@ The user-provided trust bundle is represented as a config map. The config map is
 
 Complete proxy support means connecting to the specified proxy and trusting any signatures it has generated. Therefore, it is necessary to let the user specify a trusted root, such that any certificate chain connected to that trusted root is also trusted.
 
-If you use the {op-system} trust bundle, place CA certificates in `/etc/pki/ca-trust/source/anchors`. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/securing_networks/using-shared-system-certificates_securing-networks[Using shared system certificates] in the {op-system-base-full} _Securing networks_ document.
+If you use the {op-system} trust bundle, place CA certificates in `/etc/pki/ca-trust/source/anchors`. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/securing_networks/using-shared-system-certificates[Using shared system certificates] in the {op-system-base-full} _Securing networks_ document.
 
 == Expiration
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-45035

Links to Docs Preview: 
https://103147--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/ingress-certificates.html
https://103147--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.html
https://103147--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/olm-certificates.html
https://103147--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/proxy-certificates.html


QE review:
Not required.


