### PR TITLE
OSSM-11484 [DOCS] No mention of Loadbalancer service for on-premise cluster(baremetal) when using  multi-primary multi-network topology.

### DIFF
--- a/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
@@ -5,6 +5,7 @@
 [id="ossm-installing-multi-primary-multi-network-mesh_{context}"]
 = Installing a multi-primary multi-network mesh
 
+[role="_abstract"]
 Install {istio} in the multi-primary multi-network topology on two {ocp-product-title} clusters.
 
 [NOTE]
@@ -16,15 +17,34 @@ You can adapt these instructions for a mesh spanning more than two clusters.
 
 .Prerequisites
 
-* You have installed the {SMProduct} 3 Operator on all of the clusters that comprise the mesh.
+* You have installed the {SMProduct} 3 Operator on all of the clusters that include the mesh.
 
-* You have completed "Creating certificates for a multi-cluster mesh".
+* You have created certificates for the multi-cluster mesh.
 
-* You have completed "Applying certificates to a multi-cluster topology".
+* You have applied certificates to the multi-cluster topology.
 
 * You have created an {istio} Container Network Interface (CNI) resource.
 
-* You have `istioctl` installed on the laptop you can use to run these instructions.
+* You have `istioctl` installed.
+
+[IMPORTANT]
+====
+In on-premise environments, such as those running on bare metal, {ocp-product-title} clusters often do not include a native load-balancer capability. A service of type `LoadBalancer`, such as the `istio-eastwestgateway`, will not automatically be assigned an external IP address.
+To ensure the required external IP assignment for cross-cluster communication, cluster administrators must install and configure the MetalLB Operator.
+MetalLB is valuable in bare metal or bare metal-like infrastructures when fault-tolerant access to an application via an external IP address is necessary. Once deployed, MetalLB provides a platform-native load balancer.
+In addition to bare metal, the MetalLB Operator can offer load balancing for installations on other infrastructures that might lack native load-balancer capability, including:
+
+* VMware vSphere
+
+* IBM Z® and IBM® LinuxONE
+
+* IBM Z® and IBM® LinuxONE for Red Hat Enterprise Linux (RHEL) KVM
+
+* IBM Power®
+
+For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/networking_operators/metallb-operator[MetalLB Operator].
+====
+
 
 .Procedure
 


### PR DESCRIPTION
Change type: Doc update; No mention of Loadbalancer service for on-premise cluster(baremetal) when using  multi-primary multi-network topology.

Doc JIRA: https://issues.redhat.com/browse/OSSM-11484

Fix Version: 

- [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
- [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)
- [service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)
- [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Doc Preview: https://103148--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-multi-cluster-topologies.html#ossm-installing-multi-primary-multi-network-mesh_ossm-multi-cluster-topologies

SME Review/QE Review: @fjglira @yxun 
Peer Review: @Dhruv-Soni11 