### PR TITLE
OCPBUGS-37095-18: Updated the prereqs on nw-ingress-route-secret-

### DIFF
--- a/cicd/builds/running-entitled-builds.adoc
+++ b/cicd/builds/running-entitled-builds.adoc
@@ -46,7 +46,7 @@ endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 // The following two xrefs are not included in the OSD and ROSA docs.
 ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 * xref:../../support/remote_health_monitoring/insights-operator-simple-access.adoc#insights-operator-simple-access[Importing simple content access certificates with Insights Operator]
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 //TODO: Add this xref when the Images book is added to ROSA HCP.
 ifndef::openshift-rosa-hcp[]

--- a/machine_configuration/mco-update-boot-images.adoc
+++ b/machine_configuration/mco-update-boot-images.adoc
@@ -82,7 +82,7 @@ include::modules/mco-update-boot-images-configuring.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 
 include::modules/mco-update-boot-images-disable.adoc[leveloffset=+1]
 

--- a/machine_management/cluster_api_machine_management/cluster-api-about.adoc
+++ b/machine_management/cluster_api_machine_management/cluster-api-about.adoc
@@ -22,7 +22,7 @@ include::modules/capi-limitations.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling-features[Enabling features using feature gates]
 
 * xref:../../machine_management/cluster_api_machine_management/cluster-api-getting-started.adoc#cluster-api-getting-started[Getting started with the Cluster API]
 

--- a/modules/nw-ingress-route-secret-load-external-cert.adoc
+++ b/modules/nw-ingress-route-secret-load-external-cert.adoc
@@ -9,7 +9,10 @@
 :FeatureName: Securing route with external certificates in TLS secrets
 include::snippets/technology-preview.adoc[]
 
-You can configure {product-title} routes with third-party certificate management solutions by using the `.spec.tls.externalCertificate` field of the route API. You can reference externally managed TLS certificates via secrets, eliminating the need for manual certificate management. Using the externally managed certificate reduces errors ensuring a smoother rollout of certificate updates, enabling the OpenShift router to serve renewed certificates promptly. 
+[role="_abstract"] 
+You can configure {product-title} routes with third-party certificate management solutions by using the `.spec.tls.externalCertificate` field of the route API. You can reference externally managed TLS certificates via secrets, eliminating the need for manual certificate management.
+
+By using the externally managed certificate, you can reduce errors to ensure a smoother rollout of certificate updates and enable the OpenShift router to serve renewed certificates promptly. You can use externally managed certificates with both edge routes and re-encrypt routes.
 
 [NOTE]
 ====
@@ -20,28 +23,27 @@ This feature applies to both edge routes and re-encrypt routes.
 
 * You must enable the `RouteExternalCertificate` feature gate.
 * You have `create` permission on the `routes/custom-host` sub-resource, which is used for both creating and updating routes.
-* You must have a secret containing a valid certificate/key pair in PEM-encoded format of type `kubernetes.io/tls`, which includes both `tls.key` and `tls.crt` keys.
-* You must place the referenced secret in the same namespace as the route you want to secure.
+* You must have a secret containing a valid certificate or key pair in PEM-encoded format of type `kubernetes.io/tls`, which includes both `tls.key` and `tls.crt` keys. Example command: `$ oc create secret tls myapp-tls --cert=server.crt --key=server.key`.
 
 .Procedure
 
-. Create a `role` in the same namespace as the secret to allow the router service account read access by running the following command:
+. Create a `role` object in the same namespace as the secret to allow the router service account read access by running the following command:
 +
 [source,terminal]
 ----
-$ oc create role secret-reader --verb=get,list,watch --resource=secrets --resource-name=<secret-name> \ <1> 
---namespace=<current-namespace> <2>
+$ oc create role secret-reader --verb=get,list,watch --resource=secrets --resource-name=<secret-name> \
+--namespace=<current-namespace>
 ----
-<1> Specify the actual name of your secret.
-<2> Specify the namespace where both your secret and route reside.
+* `<secret-name>`: Specify the actual name of your secret.
+* `<current-namespace>`: Specify the namespace where both your secret and route reside.
 
-. Create a `rolebinding` in the same namespace as the secret and bind the router service account to the newly created role by running the following command:
+. Create a `rolebinding` object in the same namespace as the secret and bind the router service account to the newly created role by running the following command:
 +
 [source,terminal]
 ----
-$ oc create rolebinding secret-reader-binding --role=secret-reader --serviceaccount=openshift-ingress:router --namespace=<current-namespace> <1>
+$ oc create rolebinding secret-reader-binding --role=secret-reader --serviceaccount=openshift-ingress:router --namespace=<current-namespace>
 ----
-<1> Specify the namespace where both your secret and route reside.
+* `<current-namespace>`: Specify the namespace where both your secret and route reside.
 
 . Create a YAML file that defines the `route` and specifies the secret containing your certificate using the following example. 
 +
@@ -57,26 +59,24 @@ spec:
   host: myedge-test.apps.example.com
   tls:
     externalCertificate:
-      name: <secret-name> <1>
+      name: <secret-name>
     termination: edge
     [...]
 [...]
 ----
-<1> Specify the actual name of your secret.
+* `<secret-name>`: Specify the actual name of your secret.
 
-. Create a `route` resource by running the following command:
+. Create a `route` resource by running the following command. If the secret exists and has a certificate/key pair, the router serves the generated certificate if all prerequisites are met.
 +
 [source,terminal]
 ----
 $ oc apply -f <route.yaml> <1>
 ----
-<1> Specify the generated YAML filename.
-
-If the secret exists and has a certificate/key pair, the router will serve the generated certificate if all prerequisites are met.
+* `<route.yaml>`: Specify the generated YAML filename.
 
 [NOTE]
 ====
-If `.spec.tls.externalCertificate` is not provided, the router will use default generated certificates. 
+If `.spec.tls.externalCertificate` is not provided, the router uses default generated certificates. 
 
 You cannot provide the `.spec.tls.certificate` field  or the `.spec.tls.key` field when using the `.spec.tls.externalCertificate` field.
 ====

--- a/networking/ingress_load_balancing/routes/secured-routes.adoc
+++ b/networking/ingress_load_balancing/routes/secured-routes.adoc
@@ -31,4 +31,6 @@ include::modules/nw-ingress-route-secret-load-external-cert.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For troubleshooting routes with externally managed certificates, check the {product-title} router pod logs for errors, see xref:../../../support/troubleshooting/investigating-pod-issues.adoc#investigating-pod-issues[Investigating pod issues].
+* xref:../../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-cli_nodes-cluster-enabling-features[Enabling features using feature gates]
+
+* xref:../../../support/troubleshooting/investigating-pod-issues.adoc#investigating-pod-issues[Investigating pod issues]

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: nodes-cluster-enabling
-[id="nodes-cluster-enabling"]
+[id="nodes-cluster-enabling-features"]
 = Enabling features using feature gates
 include::_attributes/common-attributes.adoc[]
 

--- a/nodes/pods/nodes-pods-configuring.adoc
+++ b/nodes/pods/nodes-pods-configuring.adoc
@@ -36,7 +36,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 * link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy] in the Kubernetes documentation
 
 include::modules/nodes-pods-configuring-pod-critical.adoc[leveloffset=+1]

--- a/observability/monitoring/configuring-the-monitoring-stack.adoc
+++ b/observability/monitoring/configuring-the-monitoring-stack.adoc
@@ -278,7 +278,7 @@ include::modules/monitoring-choosing-a-metrics-collection-profile.adoc[leveloffs
 .Additional resources
 
 * See xref:../../observability/monitoring/managing-metrics.adoc#viewing-a-list-of-available-metrics_managing-metrics[Viewing a list of available metrics] for steps to view a list of metrics being collected for a cluster.
-* See xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc[Enabling features using feature gates] for steps to enable Technology Preview features.
+* See xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates] for steps to enable Technology Preview features.
 endif::openshift-dedicated,openshift-rosa,openshift-rosa-hcp[]
 
 // Controlling the impact of unbound metrics attributes in user-defined projects

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -372,5 +372,5 @@ include::modules/pod-disruption-eviction-policy.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 * link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy] in the Kubernetes documentation

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -597,7 +597,7 @@ Starting in {product-title} 4.14, Extended Update Support (EUS) is extended to t
 [id="ocp-release-notes-insights-operator-runtime-extractor_{context}"]
 ==== Insights Runtime Extractor (Technology Preview)
 
-In this release, the Insights Operator introduces the workload data collection _Insights Runtime Extractor_ feature to help Red{nbsp}Hat better understand the workload of your containers. Available as a Technology Preview, the Insights Runtime Extractor feature gathers runtime workload data and sends it to Red{nbsp}Hat. Red{nbsp}Hat uses the collected runtime workload data to gain insights that can help you make investment decisions that will drive and optimize how you use your {product-title} containers. For more information, see xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[_Enabling features using feature gates_].
+In this release, the Insights Operator introduces the workload data collection _Insights Runtime Extractor_ feature to help Red{nbsp}Hat better understand the workload of your containers. Available as a Technology Preview, the Insights Runtime Extractor feature gathers runtime workload data and sends it to Red{nbsp}Hat. Red{nbsp}Hat uses the collected runtime workload data to gain insights that can help you make investment decisions that will drive and optimize how you use your {product-title} containers. For more information, see xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates].
 
 [id="ocp-release-notes-insights-operator-rapid-recommendations_{context}"]
 ==== Rapid Recommendations

--- a/support/remote_health_monitoring/about-remote-health-monitoring.adoc
+++ b/support/remote_health_monitoring/about-remote-health-monitoring.adoc
@@ -99,7 +99,7 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * link:https://access.redhat.com/solutions/7066188[What data is being collected by the Insights Operator in OpenShift?]
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 * The Insights Operator source code is available for review and contribution. See the link:https://github.com/openshift/insights-operator/blob/master/docs/gathered-data.md[Insights Operator upstream project] for a list of the items collected by the Insights Operator.


### PR DESCRIPTION
Version(s):
4.16 to 4.18

Issue:
[OCPBUGS-37095](https://issues.redhat.com/browse/OCPBUGS-37095)

Link to docs preview:
* [Creating a route with externally managed certificates](https://103162--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/routes/secured-routes.html#nw-ingress-route-secret-load-external-cert_secured-routes)


- [x] SME has approved this change (Chen Chen)[Approval on other PR](https://github.com/openshift/openshift-docs/pull/103104#issuecomment-3586266505).
- [x] QE has approved this change (Hongan Li).

