### PR TITLE
OADP-6865: Replace GCP with Google Cloud

### DIFF
--- a/modules/oadp-release-notes-1-3-0.adoc
+++ b/modules/oadp-release-notes-1-3-0.adoc
@@ -27,11 +27,11 @@ Velero allows users to select between the two paths.
 
 For backup, specify the path during the installation through the `uploader-type` flag. The valid value is either `restic` or `kopia`. This field defaults to `kopia` if the value is not specified. The selection cannot be changed after the installation.
 
-.GCP Cloud authentication
+.{gcp-first} authentication
 
-Google Cloud Platform (GCP) authentication enables you to use short-lived Google credentials.
+{gcp-first} authentication enables you to use short-lived Google credentials.
 
-GCP with Workload Identity Federation enables you to use Identity and Access Management (IAM) to grant external identities IAM roles, including the ability to impersonate service accounts. This eliminates the maintenance and security risks associated with service account keys.
+{gcp-short} with Workload Identity Federation enables you to use Identity and Access Management (IAM) to grant external identities IAM roles, including the ability to impersonate service accounts. This eliminates the maintenance and security risks associated with service account keys.
 
 .AWS ROSA STS authentication
 
@@ -88,8 +88,8 @@ When restoring 30,000 resources for the first time, without an existing-resource
 Due to the asynchronous nature of the Data Mover operation, a post-hook might be attempted before the related pods persistent volumes (PVs) are released by the Data Mover persistent volume claim (PVC).
 
 
-.GCP-Workload Identity Federation VSL backup PartiallyFailed
-VSL backup `PartiallyFailed` when GCP workload identity is configured on GCP.
+.{gcp-first} Workload Identity Federation VSL backup PartiallyFailed
+VSL backup `PartiallyFailed` when {gcp-first} workload identity is configured on {gcp-short}.
 
 
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12422838[OADP 1.3.0 known issues] in Jira.


### PR DESCRIPTION
Version(s):
OCP 4.12-4.15

Issue:
[OADP-6865](https://issues.redhat.com/browse/OADP-6865)

Link to docs preview:
OADP 1.3.0 release notes

- [New features](https://103164--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html#new-features-1-3-0_oadp-release-notes)
- [Known issues](https://103164--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html#known-issues-1-3-0_oadp-release-notes)

QE review:
Bypassing QE review.

Goal:
Replace GCP and Google Cloud Platform instances with an attribute for Google Cloud