### PR TITLE
OCPBUGS-20154: Updated the br-ex note to included statement about the…

### DIFF
--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -15,6 +15,8 @@ For more information about how to install the NMState Operator, see xref:../../n
 ====
 You cannot modify an existing `br-ex` bridge, an OVN-Kubernetes-managed Open vSwitch bridge, or any interfaces, bonds, VLANs, and so on that associate with the `br-ex` bridge. However, you can configure a customized br-ex bridge.
 
+The Kubernetes NMState Operator updates the network configuration of a secondary network interface controller (NIC). The Operator cannot update the network configuration of the primary NIC, or update the `br-ex` bridge on most on-premise networks.
+
 For more information, see "Creating a manifest object that includes a customized br-ex bridge" in the _Deploying installer-provisioned clusters on bare metal_ document or the _Installing a user-provisioned cluster on bare metal_ document.
 ====
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-20154](https://issues.redhat.com/browse/OCPBUGS-20154)

Link to docs preview:
* [Observing and updating the node network state and configuration](https://103165--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html)

- [ ] SME has approved this change.
- [ ] QE has approved this change.
