### PR TITLE
OSDOCS-9182: Added note about windows word in Azure cluster name

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -162,6 +162,18 @@ Amazon Web Services (AWS).
 endif::aws[]
 ifdef::azure[]
 Microsoft Azure.
+
+[IMPORTANT]
+====
+Do not specify `windows`, `microsoft`, or other variants of these words in the `metadata.name` parameter of the `install-config.yaml` file. Specifying one of these words for the cluster name causes the installation program to generate an error message like the following example message:
+
+[source,terminal]
+----
+The resource name 'windows-xxxx-identity' or a part of the name is a trademarked or reserved word.
+----
+
+Additionally, specifying `login` at the beginning of the name in the `metadata.name` parameter of the `install-config.yaml` file results in the generation of an error message. You can specify `login` in the middle or end of the name.
+====
 endif::azure[]
 ifdef::gcp[]
 {gcp-first}.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-9182](https://issues.redhat.com/browse/OSDOCS-9182)

Link to docs preview:
* [Creating the installation configuration file](https://103168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-customizations.html#installation-initializing_installing-azure-customizations)
* https://103168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-customizations.html#installation-initializing_installing-azure-customizations
* https://103168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-vnet.html#installation-initializing_installing-azure-vnet
* https://103168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-restricted-networks-azure-installer-provisioned.html#installation-initializing_installing-restricted-networks-azure-installer-provisioned
* https://103168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/upi/installing-azure-user-infra.html#installation-initializing_installing-azure-user-infra
* https://103168--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/upi/installing-restricted-networks-azure-user-provisioned.html#installation-initializing_installing-restricted-networks-azure-user-provisioned

- [x] SME has approved this change.
- [x] QE has approved this change (Jinyun Ma).
