### PR TITLE
OSDOCS:16989_1#AWS_IPI_CQA

### DIFF
--- a/installing/installing_aws/aws-compute-edge-zone-tasks.adoc
+++ b/installing/installing_aws/aws-compute-edge-zone-tasks.adoc
@@ -7,7 +7,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-After installing {product-title} on Amazon Web Services (AWS), you can further configure AWS {zone-type} and an edge compute pool.
+[role="_abstract"]
+
+After you install {product-title} on {aws-first}, you can further configure {aws-short} {zone-type} and an edge compute pool. Configure {aws-short} networking, subnets, compute pools, security groups, and zone data so {product-title} can create efficient, isolated edge compute nodes in {aws-short} {zone-type} with correct placement, networking, and workload control.
 
 // Extend existing clusters to use AWS Local Zones or Wavelength Zones
 include::modules/post-install-edge-aws-extend-cluster.adoc[leveloffset=+1]
@@ -21,10 +23,7 @@ include::modules/post-install-edge-aws-extend-cluster.adoc[leveloffset=+1]
 // About edge compute pools
 include::modules/edge-machine-pools-aws-local-zones.adoc[leveloffset=+2]
 
-[id="post-install-extend-existing-to-local-zones-mtu"]
-== Changing the cluster network MTU to support Local Zones or Wavelength Zones
-
-You might need to change the maximum transmission unit (MTU) value for the cluster network so that your cluster infrastructure can support {zone-type} subnets.
+include::modules/installation-changing-cluster-mtu-zones-about.adoc[leveloffset=+1]
 
 // About the cluster MTU
 include::modules/nw-cluster-mtu-change-about.adoc[leveloffset=+2]
@@ -73,17 +72,11 @@ include::modules/machineset-creating.adoc[leveloffset=+3]
 * xref:../../installing/installing_aws/ipi/installing-aws-localzone.adoc#installing-aws-localzone[Installing a cluster on AWS with compute nodes on AWS Local Zones]
 * xref:../../installing/installing_aws/ipi/installing-aws-wavelength-zone.adoc#installing-aws-wavelength-zone[Installing a cluster on AWS with compute nodes on AWS Wavelength Zones]
 
-// Creating user workloads in AWS Local Zones or Wavelength Zones
-include::modules/installation-extend-edge-nodes-aws-local-zones.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../installing/installing_aws/ipi/installing-aws-localzone.adoc#installing-aws-localzone[Installing a cluster on AWS with compute nodes on AWS Local Zones]
-* xref:../../installing/installing_aws/ipi/installing-aws-wavelength-zone.adoc#installing-aws-wavelength-zone[Installing a cluster on AWS with compute nodes on AWS Wavelength Zones]
 * xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
 
-[id="next-steps_aws-zone-tasks"]
-== Next steps
+* xref:../../networking/networking_operators/aws_load_balancer_operator/install-aws-load-balancer-operator.adoc#install-aws-load-balancer-operator_install-aws-load-balancer-operator[Installing the AWS Load Balancer Operator]
 
-* Optional: Use the AWS Load Balancer (ALB) Operator to expose a pod from a targeted edge compute node to services that run inside of a {zone-type} subnet from a public network. See xref:../../networking/networking_operators/aws_load_balancer_operator/install-aws-load-balancer-operator.adoc#install-aws-load-balancer-operator_install-aws-load-balancer-operator[Installing the AWS Load Balancer Operator].
+include::modules/installation-extend-edge-nodes-aws-local-zones-about.adoc[leveloffset=+1]
+
+// Creating user workloads in AWS Local Zones or Wavelength Zones
+include::modules/installation-extend-edge-nodes-aws-local-zones.adoc[leveloffset=+2]

--- a/installing/installing_aws/installation-config-parameters-aws.adoc
+++ b/installing/installing_aws/installation-config-parameters-aws.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Before you deploy an {product-title} cluster on AWS, you provide parameters to customize your cluster and the platform that hosts it. When you create the `install-config.yaml` file, you provide values for the required parameters through the command line. You can then modify the `install-config.yaml` file to customize your cluster further.
+[role="_abstract"]
+Before you deploy an {product-title} cluster on {aws-first}, you create the `install-config.yaml` file and provide parameters to customize your cluster and the platform that hosts it. You can then modify the `install-config.yaml` file to customize your cluster further.
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]

--- a/installing/installing_aws/installing-aws-account.adoc
+++ b/installing/installing_aws/installing-aws-account.adoc
@@ -8,8 +8,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Before you can install {product-title}, you must configure an
-{aws-first} account.
+
+To ensure {product-title} can successfully install and run the cluster in {aws-first}, you must configure an {aws-short} account with the correct identity and permissions before you start the installation.
 
 include::modules/installation-aws-route53.adoc[leveloffset=+1]
 
@@ -26,10 +26,6 @@ include::modules/installation-aws-iam-policies-about.adoc[leveloffset=+1]
 include::modules/installation-aws-permissions-iam-roles.adoc[leveloffset=+2]
 
 include::modules/installation-aws-add-iam-roles.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-launching-installer_installing-aws-customizations[Deploying the cluster]
 
 include::modules/installation-aws-access-analyzer.adoc[leveloffset=+2]
 

--- a/modules/edge-machine-pools-aws-local-zones.adoc
+++ b/modules/edge-machine-pools-aws-local-zones.adoc
@@ -17,12 +17,13 @@ endif::[]
 [id="edge-machine-pools-aws-local-zones_{context}"]
 = About edge compute pools
 
-Edge compute nodes are tainted compute nodes that run in AWS {zone-type} locations.
+[role="_abstract"]
+The edge compute pool configuration is common between {aws-first} {zone-type} locations. You can use the edge compute pool to create new labels to deploy applications onto {aws-first} {zone-type} nodes. Edge compute nodes are tainted compute nodes that run in {aws-short} {zone-type} locations.
 
 When deploying a cluster that uses {zone-type}, consider the following points:
 
 * Amazon EC2 instances in the {zone-type} are more expensive than Amazon EC2 instances in the Availability Zones.
-* The latency is lower between the applications running in AWS {zone-type} and the end user. A latency impact exists for some workloads if, for example, ingress traffic is mixed between {zone-type} and Availability Zones.
+* The latency is lower between the applications running in {aws-short} {zone-type} and the user. A latency impact exists for some workloads if, for example, ingress traffic is mixed between {zone-type} and Availability Zones.
 
 [IMPORTANT]
 ====
@@ -31,21 +32,21 @@ Generally, the maximum transmission unit (MTU) between an Amazon EC2 instance in
 The network plugin can provide additional features, such as IPsec, that also affect the MTU sizing.
 
 ifdef::local-zone[]
-For more information, see link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation.
+For more information, see link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the {aws-short} documentation.
 endif::local-zone[]
 ifdef::wavelength-zone[]
-For more information, see link:https://docs.aws.amazon.com/wavelength/latest/developerguide/how-wavelengths-work.html[How AWS Wavelength work] in the AWS documentation.
+For more information, see link:https://docs.aws.amazon.com/wavelength/latest/developerguide/how-wavelengths-work.html[How AWS Wavelength work] in the {aws-short} documentation.
 endif::wavelength-zone[]
 ifdef::post-aws-zones[]
 You can access the following resources to learn more about a respective zone type:
 
-* See link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation.
+* See link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the {aws-short} documentation.
 
-* See link:https://docs.aws.amazon.com/wavelength/latest/developerguide/how-wavelengths-work.html[How AWS Wavelength work] in the AWS documentation.
+* See link:https://docs.aws.amazon.com/wavelength/latest/developerguide/how-wavelengths-work.html[How AWS Wavelength work] in the {aws-short} documentation.
 endif::post-aws-zones[]
 ====
 
-{product-title} 4.12 introduced a new compute pool, _edge_, that is designed for use in remote zones. The edge compute pool configuration is common between AWS {zone-type} locations. Because of the type and size limitations of resources like EC2 and EBS on {zone-type} resources, the default instance type can vary from the traditional compute pool.
+{product-title} 4.12 introduced a new compute pool, _edge_, that is designed for use in remote zones. The edge compute pool configuration is common between {aws-first} {zone-type} locations. Because of the type and size limitations of resources like EC2 and EBS on {zone-type} resources, the default instance type can vary from the traditional compute pool.
 
 The default Elastic Block Store (EBS) for {zone-type} locations is `gp2`, which differs from the non-edge compute pool. The instance type used for each {zone-type} on an edge compute pool also might differ from other compute pools, depending on the instance offerings on the zone.
 

--- a/modules/installation-aws-add-zone-locations.adoc
+++ b/modules/installation-aws-add-zone-locations.adoc
@@ -16,6 +16,7 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-aws-add-zone-locations_{context}"]
+
 ifdef::local-zone[]
 = Opting in to an AWS {zone-type}
 
@@ -29,7 +30,8 @@ ifdef::post-aws-zones[]
 
 endif::post-aws-zones[]
 
-If you plan to create subnets in AWS {zone-type}, you must opt in to each zone group separately.
+[role="_abstract"]
+Create a subnet in an {aws-first} {zone-type} when you need workloads to run physically closer to users or data sources than a standard {aws-short} {zone-type}. If you plan to create subnets in {aws-short} {zone-type}, you must opt in to each zone group separately.
 
 .Prerequisites
 
@@ -74,10 +76,11 @@ Depending on the AWS Region, the list of available zones might be long. The comm
 [source,terminal]
 ----
 $ aws ec2 modify-availability-zone-group \
-    --group-name "<value_of_GroupName>" \// <1>
+    --group-name "<value_of_GroupName>" \
     --opt-in-status opted-in
 ----
-<1> Replace `<value_of_GroupName>` with the name of the group of the {zone-type} where you want to create subnets.
+
+`<value_of_GroupName>`:: Replace with the name of the group of the {zone-type} where you want to create subnets.
 ifdef::local-zone[]
 For example, specify `us-east-1-nyc-1` to use the zone `us-east-1-nyc-1a` (US East New York).
 endif::local-zone[]

--- a/modules/installation-changing-cluster-mtu-zones-about.adoc
+++ b/modules/installation-changing-cluster-mtu-zones-about.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: CONCEPT
+[id="change-cluster-mtu-support-zones-about_{context}"]
+= About changing the cluster network MTU to support Local Zones or Wavelength Zone
+
+[role="_abstract"]
+You might need to change the maximum transmission unit (MTU) value for the cluster network so that your cluster infrastructure can support {zone-type} subnets.

--- a/modules/installation-cloudformation-subnet-localzone.adoc
+++ b/modules/installation-cloudformation-subnet-localzone.adoc
@@ -13,8 +13,9 @@ endif::[]
 [id="installation-cloudformation-subnet-localzone_{context}"]
 = CloudFormation template for the VPC subnet
 
-ifndef::outposts[You can use the following CloudFormation template to deploy the private and public subnets in a zone on {zone-type} infrastructure.]
-ifdef::outposts[You can use the following CloudFormation template to deploy the Outpost subnet.]
+[role="_abstract"]
+ifndef::outposts[Use the CloudFormation template to deploy the private and public subnets in a zone on {zone-type} infrastructure. The template provisions an `AWS::EC2::Subnet` and associates it with a specific {zone-type} and VPC route table to reduce latency.]
+ifdef::outposts[Use the CloudFormation template to deploy the private and public subnets in a zone on {zone-type} infrastructure. The template provisions an `AWS::EC2::Subnet` and associates it with a specific {zone-type} and VPC route table to reduce latency.]
 
 .CloudFormation template for VPC subnets
 [%collapsible]
@@ -97,7 +98,7 @@ ifndef::outposts[]
 endif::outposts[]
 ifdef::outposts[]
         Value: !Join ['-', [ !Ref ClusterName, !Ref PublicSubnetLabel, !Ref ZoneName]]
-      - Key: kubernetes.io/cluster/unmanaged # <1>
+      - Key: kubernetes.io/cluster/unmanaged
         Value: true
 endif::outposts[]
 
@@ -123,7 +124,7 @@ ifndef::outposts[]
 endif::outposts[]
 ifdef::outposts[]
         Value: !Join ['-', [!Ref ClusterName, !Ref PrivateSubnetLabel, !Ref ZoneName]]
-      - Key: kubernetes.io/cluster/unmanaged # <2>
+      - Key: kubernetes.io/cluster/unmanaged
         Value: true
 endif::outposts[]
 
@@ -144,9 +145,13 @@ Outputs:
     Value:
       !Join ["", [!Ref PrivateSubnet]]
 ----
+
 ifdef::outposts[]
-<1> You must include the `kubernetes.io/cluster/unmanaged` tag in the public subnet configuration for AWS Outposts.
-<2> You must include the `kubernetes.io/cluster/unmanaged` tag in the private subnet configuration for AWS Outposts.
+
+where:
+
+`kubernetes.io/cluster/unmanaged`:: You must include the `kubernetes.io/cluster/unmanaged` tag in the public subnet configuration for AWS Outposts.
+`kubernetes.io/cluster/unmanaged`:: You must include the `kubernetes.io/cluster/unmanaged` tag in the private subnet configuration for AWS Outposts.
 endif::outposts[]
 ====
 

--- a/modules/installation-cloudformation-vpc-carrier-gw.adoc
+++ b/modules/installation-cloudformation-vpc-carrier-gw.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing-aws-wavelength-zone.adoc (Installing a cluster on AWS with worker nodes on AWS Wavelength Zones)
-// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 
 ifeval::["{context}" == "installing-aws-wavelength-zone"]
 :wavelength-zone:
@@ -12,6 +12,7 @@ endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="installation-cloudformation-vpc-carrier-gw_{context}"]
+
 ifdef::wavelength-zone[]
 = CloudFormation template for the VPC Carrier Gateway
 
@@ -21,11 +22,11 @@ ifdef::post-aws-zones[]
 
 endif::post-aws-zones[]
 
-You can use the following CloudFormation template to deploy the Carrier Gateway on AWS Wavelength infrastructure.
+[role="_abstract"]
+Use the CloudFormation template to deploy the Carrier Gateway on {aws-first} Wavelength infrastructure. The template automates the creation of an {aws-short} Carrier Gateway for {product-title}. The template provisions an `AWS::EC2::CarrierGateway` and associates it with the cluster VPC to enable traffic routing to provide direct internet connectivity for resources in Wavelength Zones that use carrier networks.
 
 .CloudFormation template for VPC Carrier Gateway
-[%collapsible]
-====
+
 [source,yaml,subs="attributes+"]
 ----
 AWSTemplateFormatVersion: 2010-09-09
@@ -94,7 +95,6 @@ Outputs:
     Description: Public Route table ID
     Value: !Ref PublicRouteTable
 ----
-====
 
 ifeval::["{context}" == "installing-aws-wavelength-zone"]
 :!wavelength-zone:

--- a/modules/installation-creating-aws-vpc-carrier-gw.adoc
+++ b/modules/installation-creating-aws-vpc-carrier-gw.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing-aws-wavelength-zone.adoc (Installing a cluster on AWS with compute nodes on AWS Wavelength Zones)
-// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 
 ifeval::["{context}" == "installing-aws-wavelength-zone"]
 :wavelength-zone:
@@ -12,6 +12,8 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-creating-aws-vpc-carrier-gw_{context}"]
+
+[role="_abstract"]
 ifdef::wavelength-zone[]
 = Creating a VPC carrier gateway
 
@@ -21,6 +23,7 @@ ifdef::post-aws-zones[]
 
 endif::post-aws-zones[]
 
+[role=”_abstract”]
 To use public subnets in your {product-title} cluster that runs on Wavelength Zones, you must create the carrier gateway and associate the carrier gateway to the VPC. Subnets are useful for deploying load balancers or edge compute nodes.
 
 To create edge nodes or internet-facing load balancers in Wavelength Zones locations for your {product-title} cluster, you must create the following required network components:
@@ -68,17 +71,22 @@ If you do not use the provided CloudFormation template to create your AWS infras
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <stack_name> \// <1>
+$ aws cloudformation create-stack --stack-name <stack_name> \
   --region ${CLUSTER_REGION} \
-  --template-body file://<template>.yaml \// <2>
+  --template-body file://<template>.yaml \
   --parameters \//
-    ParameterKey=VpcId,ParameterValue="${VpcId}" \// <3>
-    ParameterKey=ClusterName,ParameterValue="${ClusterName}" <4>
+    ParameterKey=VpcId,ParameterValue="${VpcId}" \
+    ParameterKey=ClusterName,ParameterValue="${ClusterName}"
 ----
-<1> `<stack_name>` is the name for the CloudFormation stack, such as `clusterName-vpc-carrier-gw`. You need the name of this stack if you remove the cluster.
-<2> `<template>` is the relative path and the name of the CloudFormation template YAML file that you saved.
-<3> `<VpcId>` is the VPC ID extracted from the CloudFormation stack output created in the section named "Creating a VPC in AWS".
-<4> `<ClusterName>` is a custom value that prefixes to resources that the CloudFormation stack creates. You can use the same name that is defined in the `metadata.name` section of the `install-config.yaml` configuration file.
++
+where
++
+--
+`<stack_name>`:: The name for the CloudFormation stack, such as `clusterName-vpc-carrier-gw`. You need the name of this stack if you remove the cluster.
+`<template>`:: The relative path and the name of the CloudFormation template YAML file that you saved.
+`<VpcId>`:: The VPC ID extracted from the CloudFormation stack output created in the section named "Creating a VPC in AWS".
+`<ClusterName>`:: A custom value that prefixes to resources that the CloudFormation stack creates. You can use the same name that is defined in the `metadata.name` section of the `install-config.yaml` configuration file.
+--
 +
 .Example output
 [source,terminal]

--- a/modules/installation-creating-aws-vpc-subnets-edge.adoc
+++ b/modules/installation-creating-aws-vpc-subnets-edge.adoc
@@ -10,7 +10,9 @@ endif::[]
 [id="installation-creating-aws-vpc-subnets-edge_{context}"]
 = Creating subnets for AWS edge compute services
 
-Before you configure a machine set for edge compute nodes in your {product-title} cluster, you must create a subnet in {zone-type}.
+[role="_abstract"]
+You can automate creating subnets, route tables, and Carrier Gateways in {aws-short} {zone-type} to extend clusters into ultra-low-latency edge locations for edge workloads. Before you configure a machine set for edge compute nodes in your {product-title} cluster, you must create a subnet in {zone-type}.
+
 ifndef::outposts[Complete the following procedure for each Wavelength Zone that you want to deploy compute nodes to.]
 
 You can use the provided CloudFormation template and create a CloudFormation stack. You can then use this stack to custom provision a subnet.
@@ -35,43 +37,67 @@ ifdef::outposts[* You have obtained the required information about your environm
 +
 [source,terminal]
 ----
-$ aws cloudformation create-stack --stack-name <stack_name> \// <1>
+$ aws cloudformation create-stack --stack-name <stack_name> \
   --region ${CLUSTER_REGION} \
-  --template-body file://<template>.yaml \// <2>
+  --template-body file://<template>.yaml \
   --parameters \
-    ParameterKey=VpcId,ParameterValue="${VPC_ID}" \// <3>
-    ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \// <4>
-    ParameterKey=ZoneName,ParameterValue="${ZONE_NAME}" \// <5>
-    ParameterKey=PublicRouteTableId,ParameterValue="${ROUTE_TABLE_PUB}" \// <6>
-    ParameterKey=PublicSubnetCidr,ParameterValue="${SUBNET_CIDR_PUB}" \// <7>
-    ParameterKey=PrivateRouteTableId,ParameterValue="${ROUTE_TABLE_PVT}" \// <8>
-ifndef::outposts[    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" <9>]
+    ParameterKey=VpcId,ParameterValue="${VPC_ID}" \
+    ParameterKey=ClusterName,ParameterValue="${CLUSTER_NAME}" \
+    ParameterKey=ZoneName,ParameterValue="${ZONE_NAME}" \
+    ParameterKey=PublicRouteTableId,ParameterValue="${ROUTE_TABLE_PUB}" \
+    ParameterKey=PublicSubnetCidr,ParameterValue="${SUBNET_CIDR_PUB}" \
+    ParameterKey=PrivateRouteTableId,ParameterValue="${ROUTE_TABLE_PVT}" \
+ifndef::outposts[    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}"]
 ifdef::outposts[]
-    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" \// <9>
+    ParameterKey=PrivateSubnetCidr,ParameterValue="${SUBNET_CIDR_PVT}" \
     ParameterKey=PrivateSubnetLabel,ParameterValue="private-outpost" \
     ParameterKey=PublicSubnetLabel,ParameterValue="public-outpost" \
-    ParameterKey=OutpostArn,ParameterValue="${OUTPOST_ARN}" <10>
+    ParameterKey=OutpostArn,ParameterValue="${OUTPOST_ARN}"
 endif::outposts[]
 ----
-ifndef::outposts[<1> `<stack_name>` is the name for the CloudFormation stack, such as `cluster-wl-<local_zone_shortname>` for Local Zones and `cluster-wl-<wavelength_zone_shortname>` for Wavelength Zones. You need the name of this stack if you remove the cluster.]
-ifdef::outposts[<1> `<stack_name>` is the name for the CloudFormation stack, such as `cluster-<outpost_name>`.]
-<2> `<template>` is the relative path and the name of the CloudFormation template YAML file that you saved.
-<3> `${VPC_ID}` is the VPC ID, which is the value `VpcID` in the output of the CloudFormation template for the VPC.
-<4> `${CLUSTER_NAME}` is the value of *ClusterName* to be used as a prefix of the new AWS resource names.
-<5> `${ZONE_NAME}` is the value of {zone-type} name to create the subnets.
-ifndef::outposts[<6> `${ROUTE_TABLE_PUB}` is the Public Route Table Id extracted from the CloudFormation template. For Local Zones, the public route table is extracted from the VPC CloudFormation Stack. For Wavelength Zones, the value must be extracted from the output of the VPC's carrier gateway CloudFormation stack.]
-ifdef::outposts[<6> `${ROUTE_TABLE_PUB}` is the Public Route Table ID created in the `${VPC_ID}` used to associate the public subnets on Outposts. Specify the public route table to associate the Outpost subnet created by this stack.]
-<7> `${SUBNET_CIDR_PUB}` is a valid CIDR block that is used to create the public subnet. This block must be part of the VPC CIDR block `VpcCidr`.
-ifndef::outposts[<8> `${ROUTE_TABLE_PVT}` is the *PrivateRouteTableId* extracted from the output of the VPC's CloudFormation stack.]
-ifdef::outposts[<8> `${ROUTE_TABLE_PVT}` is the Private Route Table ID created in the `${VPC_ID}` used to associate the private subnets on Outposts. Specify the private route table to associate the Outpost subnet created by this stack.]
-<9> `${SUBNET_CIDR_PVT}` is a valid CIDR block that is used to create the private subnet. This block must be part of the VPC CIDR block `VpcCidr`.
-ifdef::outposts[<10> `${OUTPOST_ARN}` is the Amazon Resource Name (ARN) for the Outpost.]
+
+ifndef::outposts[]
++
+where
++
+`<stack_name>`:: Specifies the name for the CloudFormation stack, such as `cluster-wl-<local_zone_shortname>` for Local Zones and `cluster-wl-<wavelength_zone_shortname>` for Wavelength Zones. You need the name of this stack if you remove the cluster.
+`<template>`:: Specifies the relative path and the name of the CloudFormation template YAML file that you saved.
+`${VPC_ID}`:: Specifies the VPC ID, which is the value `VpcID` in the output of the CloudFormation template for the VPC.
+`${CLUSTER_NAME}`:: Specifies the value of *ClusterName* to be used as a prefix of the new AWS resource names.
+`${ZONE_NAME}`:: Specifies the value of {zone-type} name to create the subnets.
+`${ROUTE_TABLE_PUB}`:: Specifies the Public Route Table Id extracted from the CloudFormation template. For Local Zones, the public route table is extracted from the VPC CloudFormation Stack. For Wavelength Zones, the value must be extracted from the output of the VPC's carrier gateway CloudFormation stack.
+`${SUBNET_CIDR_PUB}`:: Specifies a valid CIDR block that is used to create the public subnet. This block must be part of the VPC CIDR block `VpcCidr`.
+`${ROUTE_TABLE_PVT}`:: Specifies the *PrivateRouteTableId* extracted from the output of the VPC's CloudFormation stack.
+`${SUBNET_CIDR_PVT}`:: Specifies a valid CIDR block that is used to create the private subnet. This block must be part of the VPC CIDR block `VpcCidr`.
 +
 .Example output
 [source,text]
 ----
 arn:aws:cloudformation:us-east-1:123456789012:stack/<stack_name>/dbedae40-820e-11eb-2fd3-12a48460849f
 ----
+endif::outposts[]
+
+ifdef::outposts[]
++
+where
++
+`<stack_name>`:: Specifies the name for the CloudFormation stack, such as `cluster-<outpost_name>`.
+`<template>`:: Specifies the relative path and the name of the CloudFormation template YAML file that you saved.
+`${VPC_ID}`:: Specifies the VPC ID, which is the value `VpcID` in the output of the CloudFormation template for the VPC.
+`${CLUSTER_NAME}`:: Specifies the value of *ClusterName* to be used as a prefix of the new AWS resource names.
+`${ZONE_NAME}`:: Specifies the value of {zone-type} name to create the subnets.
+`${ROUTE_TABLE_PUB}`:: Specifies the Public Route Table ID created in the `${VPC_ID}` used to associate the public subnets on Outposts. Specify the public route table to associate the Outpost subnet created by this stack.
+`${SUBNET_CIDR_PUB}`:: Specifies a valid CIDR block that is used to create the public subnet. This block must be part of the VPC CIDR block `VpcCidr`.
+`${OUTPOST_ARN}`:: Specifies the Amazon Resource Name (ARN) for the Outpost.
+`${SUBNET_CIDR_PVT}`:: Specifies a valid CIDR block that is used to create the private subnet. This block must be part of the VPC CIDR block `VpcCidr`.
+`${ROUTE_TABLE_PVT}`:: Specifies the Private Route Table ID created in the `${VPC_ID}` used to associate the private subnets on Outposts. Specify the private route table to associate the Outpost subnet created by this stack.
++
+.Example output
+[source,text]
+----
+arn:aws:cloudformation:us-east-1:123456789012:stack/<stack_name>/dbedae40-820e-11eb-2fd3-12a48460849f
+----
+endif::outposts[]
 
 .Verification
 

--- a/modules/installation-extend-edge-nodes-aws-local-zones-about.adoc
+++ b/modules/installation-extend-edge-nodes-aws-local-zones-about.adoc
@@ -1,0 +1,15 @@
+:_mod-docs-content-type: CONCEPT
+[id="creating-user-workloads-aws-zones-about_{context}"]
+= About creating user workloads in AWS Local Zones or Wavelength Zones
+
+[role="_abstract"]
+When you use the installation program to create a cluster, the installation program automatically specifies a taint effect of `NoSchedule` to each edge compute node. So, a scheduler does not add a new pod, or deployment, to a node if the pod does not match the specified tolerations for a taint.
+
+You can modify the taint for better control over how nodes create workloads in each {zone-type} subnet.
+
+The installation program creates the compute machine set manifests file with `node-role.kubernetes.io/edge` and `node-role.kubernetes.io/worker` labels applied to each edge compute node that is located in a {zone-type} subnet.
+
+[NOTE]
+====
+The examples in the procedure are for a Local Zones infrastructure. If you are working with a Wavelength Zones infrastructure, ensure you adapt the examples to what is supported in this infrastructure.
+====

--- a/modules/installation-extend-edge-nodes-aws-local-zones.adoc
+++ b/modules/installation-extend-edge-nodes-aws-local-zones.adoc
@@ -6,20 +6,12 @@
 [id="installation-extend-edge-nodes-aws-local-zones_{context}"]
 = Creating user workloads in AWS Local Zones or Wavelength Zones
 
-After you create an Amazon Web Service (AWS) {zone-type} infrastructure and deploy your cluster, you can use edge compute nodes to create user workloads in {zone-type} subnets.
-
-When you use the installation program to create a cluster, the installation program automatically specifies a taint effect of `NoSchedule` to each edge compute node. This means that a scheduler does not add a new pod, or deployment, to a node if the pod does not match the specified tolerations for a taint. You can modify the taint for better control over how nodes create workloads in each {zone-type} subnet.
-
-The installation program creates the compute machine set manifests file with `node-role.kubernetes.io/edge` and `node-role.kubernetes.io/worker` labels applied to each edge compute node that is located in a {zone-type} subnet.
-
-[NOTE]
-====
-The examples in the procedure are for a Local Zones infrastructure. If you are working with a Wavelength Zones infrastructure, ensure you adapt the examples to what is supported in this infrastructure.
-====
+[role="_abstract"]
+After you create an {aws-first} {zone-type} infrastructure and deploy your cluster, you can use edge compute nodes to create user workloads in {zone-type} subnets.
 
 .Prerequisites
 
-* You have access to the OpenShift CLI (`oc`).
+* You have access to the {oc-first}.
 * You deployed your cluster in a Virtual Private Cloud (VPC) with defined {zone-type} subnets.
 * You ensured that the compute machine set for the edge compute nodes on {zone-type} subnets specifies the taints for `node-role.kubernetes.io/edge`.
 
@@ -46,14 +38,14 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: gp2-csi <1>
+  storageClassName: gp2-csi
   volumeMode: Filesystem
 ---
 apiVersion: apps/v1
-kind: Deployment <2>
+kind: Deployment
 metadata:
-  name: <local_zone_application> <3>
-  namespace: <local_zone_application_namespace> <4>
+  name: <local_zone_application>
+  namespace: <local_zone_application_namespace>
 spec:
   selector:
     matchLabels:
@@ -63,14 +55,14 @@ spec:
     metadata:
       labels:
         app: <local_zone_application>
-        zone-group: ${ZONE_GROUP_NAME} <5>
+        zone-group: ${ZONE_GROUP_NAME}
     spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      nodeSelector: <6>
+      nodeSelector:
         machine.openshift.io/zone-group: ${ZONE_GROUP_NAME}
-      tolerations: <7>
+      tolerations:
       - key: "node-role.kubernetes.io/edge"
         operator: "Equal"
         value: ""
@@ -94,13 +86,16 @@ spec:
         persistentVolumeClaim:
           claimName: <pvc_name>
 ----
-<1> `storageClassName`: For the Local Zone configuration, you must specify `gp2-csi`.
-<2> `kind`: Defines the `deployment` resource.
-<3> `name`: Specifies the name of your Local Zone application. For example, `local-zone-demo-app-nyc-1`.
-<4> `namespace:` Defines the namespace for the AWS Local Zone where you want to run the user workload. For example: `local-zone-app-nyc-1a`.
-<5> `zone-group`: Defines the group to where a zone belongs. For example, `us-east-1-iah-1`.
-<6> `nodeSelector`: Targets edge compute nodes that match the specified labels.
-<7> `tolerations`: Sets the values that match with the `taints` defined on the `MachineSet` manifest for the Local Zone node.
++
+where:
+
+`storageClassName`:: You must specify this the Local Zone configuration.
+`kind`:: Defines the `deployment` resource.
+`name`:: Specifies the name of your Local Zone application. For example, `local-zone-demo-app-nyc-1`.
+`namespace`:: Defines the namespace for the {aws-short} Local Zone where you want to run the user workload. For example: `local-zone-app-nyc-1a`.
+`zone-group`:: Defines the group to where a zone belongs. For example, `us-east-1-iah-1`.
+`nodeSelector`:: Targets edge compute nodes that match the specified labels.
+`tolerations`:: Sets the values that match with the `taints` defined on the `MachineSet` manifest for the Local Zone node.
 
 . Create a `service` resource YAML file for the node. This resource exposes a pod from a targeted edge compute node to services that run inside your Local Zone network.
 +
@@ -108,7 +103,7 @@ spec:
 [source,yaml]
 ----
 apiVersion: v1
-kind: Service <1>
+kind: Service
 metadata:
   name:  <local_zone_application>
   namespace: <local_zone_application_namespace>
@@ -118,8 +113,11 @@ spec:
       targetPort: 8080
       protocol: TCP
   type: NodePort
-  selector: <2>
+  selector:
     app: <local_zone_application>
 ----
-<1> `kind`: Defines the `service` resource.
-<2> `selector:` Specifies the label type applied to managed pods.
++
+where:
+
+`kind`:: Defines the `service` resource.
+`selector`:: Specifies the label type applied to managed pods.

--- a/modules/nw-cluster-mtu-change-about.adoc
+++ b/modules/nw-cluster-mtu-change-about.adoc
@@ -1,13 +1,14 @@
 // Module included in the following assemblies:
 //
 // * networking/changing-cluster-network-mtu.adoc
-// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-cluster-mtu-change-about_{context}"]
 = About the cluster MTU
 
-During installation, the cluster network MTU is set automatically based on the primary network interface MTU of cluster nodes. You do not usually need to override the detected MTU.
+[role="_abstract"]
+During installation, the cluster network maximum transmission unit (MTU) is set automatically based on the primary network interface MTU of cluster nodes. Typically, you do not need to override the detected MTU, but in some instances you must override it.
 
 You might want to change the MTU of the cluster network for one of the following reasons:
 

--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/changing-cluster-network-mtu.adoc
-// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 // * installing/installing_aws/ipi/installing-aws-outposts.adoc
 
 ifeval::["{context}" == "aws-compute-edge-tasks-local-zone"]
@@ -17,15 +17,20 @@ ifeval::["{context}" == "installing-aws-outposts"]
 :outposts:
 endif::[]
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="nw-cluster-mtu-change_{context}"]
-ifndef::outposts[= Changing the cluster network MTU]
-ifdef::outposts[= Changing the cluster network MTU to support AWS Outposts]
 
+ifndef::outposts[]
+= Changing the cluster network MTU
+endif::outposts[]
 ifdef::outposts[]
-During installation, the maximum transmission unit (MTU) for the cluster network is detected automatically based on the MTU of the primary network interface of nodes in the cluster. You might need to decrease the MTU value for the cluster network to support an AWS Outposts subnet.
+= Changing the cluster network MTU to support AWS Outposts
 endif::outposts[]
 
+[role="_abstract"]
+ifdef::outposts[]
+You might need to decrease the maximum transmission unit (MTU) value for the cluster network to support an AWS Outposts subnet. During installation, the MTU for the cluster network is detected automatically based on the MTU of the primary network interface of nodes in the cluster.
+endif::outposts[]
 ifndef::outposts[As a cluster administrator, you can increase or decrease the maximum transmission unit (MTU) for your cluster.]
 
 [IMPORTANT]
@@ -46,5 +51,5 @@ endif::local-zone,wavelength-zone,post-aws-zones,outposts[]
 * You have installed the {oc-first}.
 * You have access to the cluster using an account with `cluster-admin` permissions.
 * You have identified the target MTU for your cluster. The MTU for the OVN-Kubernetes network plugin must be set to `100` less than the lowest hardware MTU value in your cluster.
-* If your nodes are physical machines, ensure that the cluster network and the connected network switches support jumbo frames. 
+* If your nodes are physical machines, ensure that the cluster network and the connected network switches support jumbo frames.
 * If your nodes are virtual machines (VMs), ensure that the hypervisor and the connected network switches support jumbo frames.

--- a/modules/nw-cluster-mtu-checking.adoc
+++ b/modules/nw-cluster-mtu-checking.adoc
@@ -1,14 +1,15 @@
 // Module included in the following assemblies:
 //
 // * networking/changing-cluster-network-mtu.adoc
-// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 // * installing/installing_aws/ipi/installing-aws-outposts.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-cluster-mtu-checking_{context}"]
 = Checking the current cluster MTU value
 
-Use the following procedure to obtain the current maximum transmission unit (MTU) for the cluster network.
+[role="_abstract"]
+To ensure network stability and performance in a hybrid environment where part of your cluster is in the cloud and part is an on-premise environment, you can obtain the current maximum transmission unit (MTU) for the cluster network.
 
 .Procedure
 

--- a/modules/nw-cluster-mtu-finalizing-migration.adoc
+++ b/modules/nw-cluster-mtu-finalizing-migration.adoc
@@ -2,7 +2,7 @@
 //
 // * networking/changing-cluster-network-mtu.adoc
 // * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
-// * installing/installing_aws/ipi/installing-aws-outposts.adoc 
+// * installing/installing_aws/ipi/installing-aws-outposts.adoc
 
 ifeval::["{context}" == "aws-compute-edge-tasks-local-zone"]
 :local-zone:
@@ -21,7 +21,9 @@ endif::[]
 [id="nw-cluster-mtu-finalizing-migration_{context}"]
 = Finalizing the MTU migration
 
-Use the following procedure to finalize the MTU migration.
+[role="_abstract"]
+Finalize the MTU migration to apply the new maximum transmission unit (MTU) settings to the OVN-Kubernetes network plugin. This updates the cluster configuration and triggers a rolling reboot of the nodes to complete the process.
+
 
 .Procedure
 

--- a/modules/nw-cluster-mtu-migration.adoc
+++ b/modules/nw-cluster-mtu-migration.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/changing-cluster-network-mtu.adoc
-// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 // * installing/installing_aws/ipi/installing-aws-outposts.adoc
 
 ifeval::["{context}" == "aws-compute-edge-tasks-local-zone"]
@@ -21,7 +21,8 @@ endif::[]
 [id="nw-cluster-mtu-migration_{context}"]
 = Beginning the MTU migration
 
-Use the following procedure to start the MTU migration.
+[role="_abstract"]
+Start the maximum transmission unit (MTU) migration by specifying the migration configuration for the cluster network and machine interfaces. The Machine Config Operator performs a rolling reboot of the nodes to prepare the cluster for the MTU change.
 
 .Procedure
 

--- a/modules/nw-cluster-mtu-verifying-configuration.adoc
+++ b/modules/nw-cluster-mtu-verifying-configuration.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/changing-cluster-network-mtu.adoc
-// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 // * installing/installing_aws/ipi/installing-aws-outposts.adoc
 
 ifeval::["{context}" == "aws-compute-edge-tasks-local-zone"]
@@ -21,7 +21,8 @@ endif::[]
 [id="nw-cluster-mtu-verifying-configuration_{context}"]
 = Verifying the machine configuration
 
-Use the following procedure to verify the machine configuration.
+[role="_abstract"]
+Verify the machine configuration on your hosts to confirm that the maximum transmission unit (MTU) migration applied successfully. Checking the configuration state and system settings help ensures that the nodes use the correct migration script.
 
 .Procedure
 

--- a/modules/post-install-edge-aws-extend-cluster.adoc
+++ b/modules/post-install-edge-aws-extend-cluster.adoc
@@ -4,25 +4,26 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="post-install-edge-aws-extend-cluster_{context}"]
-= Extend existing clusters to use AWS Local Zones or Wavelength Zones
+= Extend existing clusters to use {aws-short} Local Zones or Wavelength Zones
 
-As a post-installation task, you can extend an existing {product-title} cluster on Amazon Web Services (AWS) to use AWS {zone-type}.
+[role="_abstract"]
+As a post-installation task, you can extend an existing {product-title} cluster on {aws-full} to use {aws-short} {zone-type}.
 
 Extending nodes to {zone-type} locations comprises the following steps:
 
 - Adjusting the cluster-network maximum transmission unit (MTU).
-- Opting in the {zone-type} group to AWS {zone-type}.
+- Opting in the {zone-type} group to {aws-short} {zone-type}.
 - Creating a subnet in the existing VPC for a {zone-type} location.
 +
 [IMPORTANT]
 ====
-Before you extend an existing {product-title} cluster on AWS to use {zone-type}, check that the existing VPC contains available Classless Inter-Domain Routing (CIDR) blocks. These blocks are needed for creating the subnets.
+Before you extend an existing {product-title} cluster on {aws-short} to use {zone-type}, check that the existing VPC contains available Classless Inter-Domain Routing (CIDR) blocks. These blocks are needed for creating the subnets.
 ====
 +
 - Creating the machine set manifest, and then creating a node in each Local Zone or Wavelength Zone location.
 - Local Zones only: Adding the permission  `ec2:ModifyAvailabilityZoneGroup` to the Identity and Access Management (IAM) user or role, so that the required network resources can be created. For example:
 +
-.Example of an additional IAM policy for AWS Local Zones deployments
+.Example of an additional IAM policy for {aws-short} Local Zones deployments
 [source,yaml]
 ----
 {
@@ -41,7 +42,7 @@ Before you extend an existing {product-title} cluster on AWS to use {zone-type},
 +
 - Wavelength Zone only: Adding the permissions  `ec2:ModifyAvailabilityZoneGroup`, `ec2:CreateCarrierGateway`, and `ec2:DeleteCarrierGateway` to the Identity and Access Management (IAM) user or role, so that the required network resources can be created. For example:
 +
-.Example of an additional IAM policy for AWS Wavelength Zones deployments
+.Example of an additional IAM policy for {aws-short} Wavelength Zones deployments
 [source,yaml]
 ----
 {

--- a/modules/post-install-edge-aws-extend-machineset.adoc
+++ b/modules/post-install-edge-aws-extend-machineset.adoc
@@ -1,12 +1,13 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="post-install-edge-aws-extend-machineset"]
-= Creating a machine set manifest for an AWS Local Zones or Wavelength Zones node
+= Creating a machine set manifest for an {aws-short} Local Zones or Wavelength Zones node
 
-After you create subnets in AWS {zone-type}, you can create a machine set manifest.
+[role="_abstract"]
+After you create subnets in {aws-full} {zone-type}, you can create a machine set manifest. Gathering {aws-short} API data helps you to manually preserve the correct edge machine pool labels.
 
 The installation program sets the following labels for the `edge` machine pools at cluster installation time:
 
@@ -18,25 +19,30 @@ The following procedure details how you can create a machine set configuraton th
 
 .Prerequisites
 
-* You have created subnets in AWS {zone-type}.
+* You have created subnets in {aws-short} {zone-type}.
 
 .Procedure
 
-* Manually preserve `edge` machine pool labels when creating the machine set manifest by gathering the AWS API. To complete this action, enter the following command in your command-line interface (CLI):
+* Manually preserve `edge` machine pool labels when creating the machine set manifest by gathering the {aws-short} API. To complete this action, enter the following command in your command-line interface (CLI):
 +
 [source,terminal]
 ----
-$ aws ec2 describe-availability-zones --region <value_of_Region> \// <1>
+$ aws ec2 describe-availability-zones --region <value_of_Region> \
     --query 'AvailabilityZones[].{
 	ZoneName: ZoneName,
 	ParentZoneName: ParentZoneName,
 	GroupName: GroupName,
 	ZoneType: ZoneType}' \
-    --filters Name=zone-name,Values=<value_of_ZoneName> \// <2>
+    --filters Name=zone-name,Values=<value_of_ZoneName> \
     --all-availability-zones
 ----
-<1> For `<value_of_Region>`, specify the name of the region for the zone.
-<2> For `<value_of_ZoneName>`, specify the name of the {zone-type}.
++
+where:
++
+--
+`<value_of_Region>`:: Specify the name of the region for the zone.
+`<value_of_ZoneName>`:: Specify the name of the {zone-type}.
+--
 +
 .Example output for Local Zone `us-east-1-nyc-1a`
 [source,terminal]

--- a/modules/post-install-extend-existing-to-zone-type.adoc
+++ b/modules/post-install-extend-existing-to-zone-type.adoc
@@ -1,14 +1,15 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc 
+// * installing/installing_aws/aws-compute-edge-zone-tasks.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="post-install-existing-local-zone-subnet_{context}"]
-= Create network requirements in an existing VPC that uses AWS Local Zones or Wavelength Zones
+= Create network requirements in an existing VPC that uses {aws-short} Local Zones or Wavelength Zones
 
+[role="_abstract"]
 If you want a Machine API to create an Amazon EC2 instance in a remote zone location, you must create a subnet in a {zone-type} location. You can use any provisioning tool, such as Ansible or Terraform, to create subnets in the existing Virtual Private Cloud (VPC).
 
-You can configure the CloudFormation template to meet your requirements. The following subsections include steps that use CloudFormation templates to create the network requirements that extend an existing VPC to use an AWS {zone-type}.
+You can configure the CloudFormation template to meet your requirements. The following subsections include steps that use CloudFormation templates to create the network requirements that extend an existing VPC to use an {aws-short} {zone-type}.
 
 Extending nodes to Local Zones requires that you create the following resources:
 
@@ -18,9 +19,9 @@ Extending nodes to Wavelength Zones requires that you create the following resou
 
 * 1 VPC Carrier Gateway associated to the provided VPC ID.
 * 1 VPC Route Table for Wavelength Zones with a default route entry to VPC Carrier Gateway.
-* 2 VPC Subnets: public and private. The public subnet associates to the public route table for an AWS Wavelength Zone. The private subnet associates to the provided route table ID.
+* 2 VPC Subnets: public and private. The public subnet associates to the public route table for an {aws-short} Wavelength Zone. The private subnet associates to the provided route table ID.
 
 [IMPORTANT]
 ====
-Considering the limitation of NAT Gateways in Wavelength Zones, the provided CloudFormation templates support only associating the private subnets with the provided route table ID. A route table ID is attached to a valid NAT Gateway in the AWS Region.
+Considering the limitation of NAT Gateways in Wavelength Zones, the provided CloudFormation templates support only associating the private subnets with the provided route table ID. A route table ID is attached to a valid NAT Gateway in the {aws-short} Region.
 ====


### PR DESCRIPTION
Versions:
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-16989

Link to docs preview:
- [AWS Local Zone or Wavelength Zone tasks](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks)
- [Installation configuration parameters for AWS](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws)
- [Configuring an AWS account](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account)
- [About edge compute pools](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#edge-machine-pools-aws-local-zones_aws-compute-edge-zone-tasks)
- [Opting in to AWS Local Zones or Wavelength Zones](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#installation-aws-add-zone-locations_aws-compute-edge-zone-tasks)
- [About changing the cluster network MTU to support Local Zones or Wavelength Zone](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#change-cluster-mtu-support-zones-about_aws-compute-edge-zone-tasks)
- [CloudFormation template for the VPC subnet in AWS Local Zone or Wavelength Zone tasks](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#installation-cloudformation-subnet-localzone_aws-compute-edge-zone-tasks)
- [CloudFormation template for the VPC subnet in Extending an AWS VPC cluster into an AWS Outpost](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-outposts#installation-cloudformation-subnet-localzone_installing-aws-outposts)
- [Wavelength Zones only: CloudFormation template for the VPC Carrier Gateway](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#installation-cloudformation-vpc-carrier-gw_aws-compute-edge-zone-tasks)
- [Wavelength Zones only: Creating a VPC carrier gateway](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#installation-creating-aws-vpc-carrier-gw_aws-compute-edge-zone-tasks)
- [Creating subnets for AWS edge compute services (AWS Local Zone or Wavelength Zone tasks)](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#installation-creating-aws-vpc-subnets-edge_aws-compute-edge-zone-tasks)
- [Creating subnets for AWS edge compute services (Extending an AWS VPC cluster into an AWS Outpost)](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-outposts#installation-creating-aws-vpc-subnets-edge_installing-aws-outposts)
- [About creating user workloads in AWS Local Zones or Wavelength Zones](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#creating-user-workloads-aws-zones-about_aws-compute-edge-zone-tasks)
- [Creating user workloads in Amazon Web Services (AWS) Local Zones or Wavelength Zones](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#installation-extend-edge-nodes-aws-local-zones_aws-compute-edge-zone-tasks)
- [About the cluster MTU](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/changing-cluster-network-mtu#nw-cluster-mtu-change-about_changing-cluster-network-mtu) 
- [Changing the cluster network MTU to support AWS outposts](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/installing-aws-outposts#nw-cluster-mtu-change_installing-aws-outposts)
- [Checking the current cluster MTU value](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/changing-cluster-network-mtu#nw-cluster-mtu-checking_changing-cluster-network-mtu) 
- [Finalizing the MTU migration](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/changing-cluster-network-mtu#nw-cluster-mtu-finalizing-migration_changing-cluster-network-mtu)
- [Beginning the MTU migration](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/changing-cluster-network-mtu#nw-cluster-mtu-migration_changing-cluster-network-mtu)
- [Verifying the machine configuration](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/changing-cluster-network-mtu#nw-cluster-mtu-verifying-configuration_changing-cluster-network-mtu)
- [Extend existing clusters to use AWS Local Zones or Wavelength Zones](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#post-install-edge-aws-extend-cluster_aws-compute-edge-zone-tasks)
- [Creating a machine set manifest for an AWS Local Zones or Wavelength Zones node](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#post-install-edge-aws-extend-machineset)
- [Create network requirements in an existing VPC that uses AWS Local Zones or Wavelength Zones](https://103169--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/aws-compute-edge-zone-tasks#post-install-existing-local-zone-subnet_aws-compute-edge-zone-tasks)

QE review:
- [ ] QE has approved this change.
No content changes, so QE approval is not required.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
