### PR TITLE
OSDOCS-16613: Swapped out vSphere storage labels with new vSPhere v8,…

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -197,8 +197,8 @@ endif::upi[]
 `"vSphere Tagging"."Edit vSphere Tag Category"`
 `"vSphere Tagging"."Edit vSphere Tag"`
 `Sessions."Validate session"`
-`"Profile-driven storage"."Profile-driven storage update"`
-`"Profile-driven storage"."Profile-driven storage view"`
+`"VM storage policies"."Update VM storage policies"`
+`"VM storage policies"."View VM storage policies"`
 
 |vSphere vCenter Cluster
 |For VMs creation in the cluster root


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-16613](https://issues.redhat.com/browse/OSDOCS-16613)

Link to docs preview:
* [Required vCenter account privileges - IPI](https://103170--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/ipi/ipi-vsphere-installation-reqs.html#installation-vsphere-installer-infra-requirements-account_ipi-vsphere-installation-reqs)
* [Required vCenter account privileges - UPI](https://103170--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/upi/upi-vsphere-installation-reqs.html#installation-vsphere-installer-infra-requirements-account_upi-vsphere-installation-reqs)


- [x] SME has approved this change
- [x] QE has approved this change.

