### PR TITLE
TELCODOCS#2433: Updated SNO+1 documentation with limit of 1 worker node

### DIFF
--- a/edge_computing/ztp-sno-additional-worker-node.adoc
+++ b/edge_computing/ztp-sno-additional-worker-node.adoc
@@ -5,11 +5,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can expand {sno} clusters with {ztp-first}. When you add worker nodes to {sno} clusters, the original {sno} cluster retains the control plane node role. Adding worker nodes does not require any downtime for the existing {sno} cluster.
+You can expand {sno} clusters with {ztp-first}. When you add a worker node to {sno} clusters, the original {sno} cluster retains the control plane node role. Adding a worker node does not require any downtime for the existing {sno} cluster.
 
 [NOTE]
 ====
-Although there is no specified limit on the number of worker nodes that you can add to a {sno} cluster, you must revaluate the reserved CPU allocation on the control plane node for the additional worker nodes.
+You can only expand a {sno} cluster with one additional worker node. It is not recommended to expand a {sno} cluster with more than one worker node.
 ====
 
 If you require workload partitioning on the worker node, you must deploy and remediate the managed cluster policies on the hub cluster before installing the node. This way, the workload partitioning `MachineConfig` objects are rendered and associated with the `worker` machine config pool before the {ztp} workflow applies the `MachineConfig` ignition file to the worker node.
@@ -17,7 +17,7 @@ If you require workload partitioning on the worker node, you must deploy and rem
 It is recommended that you first remediate the policies, and then install the worker node.
 If you create the workload partitioning manifests after installing the worker node, you must drain the node manually and delete all the pods managed by daemon sets. When the managing daemon sets create the new pods, the new pods undergo the workload partitioning process.
 
-:FeatureName: Adding worker nodes to {sno} clusters with {ztp}
+:FeatureName: Adding a worker node to {sno} clusters with {ztp}
 include::snippets/technology-preview.adoc[]
 
 [role="_additional-resources"]

--- a/modules/ztp-adding-worker-nodes.adoc
+++ b/modules/ztp-adding-worker-nodes.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="ztp-additional-worker-sno-proc_{context}"]
-= Adding worker nodes to {sno} clusters with {ztp}
+= Adding an additional worker node {sno} clusters with {ztp}
 
-You can add one or more worker nodes to existing {sno} clusters to increase available CPU resources in the cluster.
+You can add an additional worker node to existing {sno} clusters to increase available CPU resources in the cluster.
 
 .Prerequisites
 
@@ -87,7 +87,7 @@ When the ArgoCD `cluster` application synchronizes, two new manifests appear on 
 +
 [IMPORTANT]
 ====
-The `cpuset` field should not be configured for the worker node. Workload partitioning for worker nodes is added through management policies after the node installation is complete.
+The `cpuset` field should not be configured for the worker node. Workload partitioning for the worker node is added through management policies after the node installation is complete.
 ====
 
 .Verification

--- a/modules/ztp-worker-node-node-selector-compatibility.adoc
+++ b/modules/ztp-worker-node-node-selector-compatibility.adoc
@@ -6,4 +6,4 @@
 [id="ztp-additional-worker-node-selector-comp_{context}"]
 = PTP and SR-IOV node selector compatibility
 
-The PTP configuration resources and SR-IOV network node policies use `node-role.kubernetes.io/master: ""` as the node selector. If the additional worker nodes have the same NIC configuration as the control plane node, the policies used to configure the control plane node can be reused for the worker nodes. However, the node selector must be changed to select both node types, for example with the `"node-role.kubernetes.io/worker"` label.
+The PTP configuration resources and SR-IOV network node policies use `node-role.kubernetes.io/master: ""` as the node selector. If the additional worker node has the same NIC configuration as the control plane node, the policies used to configure the control plane node can be reused for the worker node. However, the node selector must be changed to select both node types, for example with the `"node-role.kubernetes.io/worker"` label.

--- a/modules/ztp-worker-node-preparing-policies.adoc
+++ b/modules/ztp-worker-node-preparing-policies.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="ztp-additional-worker-policies-{policy-gen-cr}_{context}"]
-= Using {policy-gen-cr} CRs to apply worker node policies to worker nodes
+= Using {policy-gen-cr} CRs to apply worker node policies to the worker node
 
-You can create policies for worker nodes using `{policy-gen-cr}` CRs.
+You can create policies for the additional worker node by using `{policy-gen-cr}` CRs.
 
 .Procedure
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2433](https://issues.redhat.com/browse/TELCODOCS-2433)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Expanding single-node OpenShift clusters with GitOps ZTP](https://103175--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-sno-additional-worker-node.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->