### PR TITLE
OCPBUGS#66178: Made alignment in name and namespace to avoid YAML parsing error

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -75,7 +75,7 @@ include::modules/creating-infra-machines.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../architecture/control-plane.adoc#architecture-machine-config-pools_control-plane[Node configuration management with machine config pools] for more information on grouping infra machines in a custom pool.
+* xref:../architecture/control-plane.adoc#architecture-machine-config-pools_control-plane[Node configuration management with machine config pools].
 
 [id="assigning-machineset-resources-to-infra-nodes"]
 == Assigning machine set resources to infrastructure nodes
@@ -89,9 +89,9 @@ include::modules/binding-infra-node-workloads-using-taints-tolerations.adoc[leve
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler] for general information on scheduling a pod to a node.
-* See xref:moving-resources-to-infrastructure-machinesets[Moving resources to infrastructure machine sets] for instructions on scheduling pods to infra nodes.
-* See xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations] for more details about different effects of taints.
+* xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler].
+* xref:moving-resources-to-infrastructure-machinesets[Moving resources to infrastructure machine sets].
+* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations].
 
 [id="moving-resources-to-infrastructure-machinesets"]
 == Moving resources to infrastructure machine sets

--- a/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
@@ -110,7 +110,7 @@ $ oc edit VerticalPodAutoscalerController default -n openshift-vertical-pod-auto
 apiVersion: autoscaling.openshift.io/v1
 kind: VerticalPodAutoscalerController
 metadata:
- name: default
+  name: default
   namespace: openshift-vertical-pod-autoscaler
 # ...
 spec:
@@ -146,7 +146,7 @@ For example:
 apiVersion: autoscaling.openshift.io/v1
 kind: VerticalPodAutoscalerController
 metadata:
- name: default
+  name: default
   namespace: openshift-vertical-pod-autoscaler
 # ...
 spec:
@@ -256,7 +256,7 @@ $ oc edit VerticalPodAutoscalerController default -n openshift-vertical-pod-auto
 apiVersion: autoscaling.openshift.io/v1
 kind: VerticalPodAutoscalerController
 metadata:
- name: default
+  name: default
   namespace: openshift-vertical-pod-autoscaler
 # ...
 spec:
@@ -292,7 +292,7 @@ For example:
 apiVersion: autoscaling.openshift.io/v1
 kind: VerticalPodAutoscalerController
 metadata:
- name: default
+  name: default
   namespace: openshift-vertical-pod-autoscaler
 # ...
 spec:


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-66178

Link to docs preview:
https://103176--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html
https://103176--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html

QE review:
Not required.
