### PR TITLE
OLS-2337: Fix broken link

### DIFF
--- a/modules/ols-large-language-model-overview.adoc
+++ b/modules/ols-large-language-model-overview.adoc
@@ -23,14 +23,14 @@ Installing the {ols-long} Operator does not install an LLM provider. You must ha
 
 You can use {rhelai} to host an LLM. 
 
-For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_ai/1.4/html/generating_a_custom_llm_using_rhel_ai/index[Generating a custom LLM using RHEL AI].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_ai/1.5/html/generating_a_custom_llm_using_rhel_ai/index[Generating a custom LLM using RHEL AI].
 
 [id="rhoai-with-ols_{context}"]
 == {rhoai} with {ols-long}
 
 You can use {rhoai} to host an LLM. 
 
-For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_cloud_service/1/html/serving_models/about-model-serving_about-model-serving#single_model_serving_platform[Single-model serving platform].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/configuring_your_model-serving_platform/configuring-your-model-serving-platform_rhoai-admin#about-model-serving_rhoai-admin[Single-model serving platform].
 
 [id="watsnx-with-ols_{context}"]
 == {watsonx} with {ols-long}


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2337

Link to docs preview:
https://103189--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/install/ols-installing-openshift-lightspeed.html#ols-large-language-model-overview_ols-installing-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
