### PR TITLE
[enterprise-4.19] OSDOCS#13984: use opm CLI reference for oc-mirror v2

### DIFF
--- a/disconnected/about-installing-oc-mirror-v2.adoc
+++ b/disconnected/about-installing-oc-mirror-v2.adoc
@@ -139,6 +139,11 @@ include::modules/oc-mirror-operator-catalog-filtering.adoc[leveloffset=+1]
 // Image set configuration parameters
 include::modules/oc-mirror-imageset-config-parameters-v2.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[opm CLI reference]
+
 // Command reference for oc-mirror v2
 include::modules/oc-mirror-command-reference-v2.adoc[leveloffset=+1]
 

--- a/modules/oc-mirror-imageset-config-parameters-v2.adoc
+++ b/modules/oc-mirror-imageset-config-parameters-v2.adoc
@@ -12,11 +12,13 @@ The oc-mirror plugin v2 requires an image set configuration file that defines wh
 
 [NOTE]
 ====
-Using the `minVersion` and `maxVersion` properties to filter for a specific Operator version range can result in a multiple channel heads error. The error message states that there are `multiple channel heads`. This is because when the filter is applied, the update graph of the Operator is truncated.
+* When selecting bundles for mirroring, the oc-mirror plugin v2 does not automatically detect group/version/kind (GVK) and bundle dependencies. You must explicitly specify the required Operators, their channels, and the Operator versions in the `ImageSetConfiguration` file. For more information, see "opm CLI reference".
 
-OLM requires that every Operator channel contains versions that form an update graph with exactly one end point, that is, the latest version of the Operator. When the filter range is applied, that graph can turn into two or more separate graphs or a graph that has more than one end point.
+* Using the `minVersion` and `maxVersion` properties to filter for a specific Operator version range can result in a multiple channel heads error. The error message states that there are `multiple channel heads`. This is because when the filter is applied, the update graph of the Operator is truncated.
 
-To avoid this error, do not filter out the latest version of an Operator. If you still run into the error, depending on the Operator, either the `maxVersion` property must be increased or the `minVersion` property must be decreased. Because every Operator graph can be different, you might need to adjust these values until the error resolves.
+* OLM requires that every Operator channel contains versions that form an update graph with exactly one end point, that is, the latest version of the Operator. When the filter range is applied, that graph can turn into two or more separate graphs or a graph that has more than one end point.
+
+* To avoid this error, do not filter out the latest version of an Operator. If you still run into the error, depending on the Operator, either the `maxVersion` property must be increased or the `minVersion` property must be decreased. Because every Operator graph can be different, you might need to adjust these values until the error resolves.
 ====
 
 .`ImageSetConfiguration` parameters


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/103001