### PR TITLE
OLS-2338: Update text

### DIFF
--- a/modules/ols-large-language-model-overview.adoc
+++ b/modules/ols-large-language-model-overview.adoc
@@ -30,7 +30,7 @@ For more information, see link:https://docs.redhat.com/en/documentation/red_hat_
 
 You can use {rhoai} to host an LLM. 
 
-For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/configuring_your_model-serving_platform/configuring-your-model-serving-platform_rhoai-admin#about-model-serving_rhoai-admin[Single-model serving platform].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/configuring_your_model-serving_platform/configuring-your-model-serving-platform_rhoai-admin#about-model-serving_rhoai-admin[About model serving].
 
 [id="watsnx-with-ols_{context}"]
 == {watsonx} with {ols-long}


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Version(s): 1.0

Issue: https://issues.redhat.com/browse/OLS-2338

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
