### PR TITLE
OSDOCS-17515 created z-stream RNs for 4-19-20

### DIFF
--- a/modules/zstream-4-19-19-about.adoc
+++ b/modules/zstream-4-19-19-about.adoc
@@ -2,7 +2,7 @@
 //
 // * release_notes/ocp-4-19-release-notes.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: CONCEPT
 [id="zstream-4-19-19-about_{context}"]
 = RHBA-2025:21363 - {product-title} {product-version}.19 bug fix advisory
 

--- a/modules/zstream-4-19-20-about.adoc
+++ b/modules/zstream-4-19-20-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-29-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-19-20-about_{context}"]
+= RHBA-2025:22278 - {product-title} {product-version}.20 bug fix advisory
+
+[role="_abstract"]
+Issued: 2 December 2025
+
+{product-title} release {product-version}.20 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:22278[RHBA-2025:22278] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:22276[RHBA-2025:22276] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.20 --pullspecs
+----

--- a/modules/zstream-4-19-20-bug-fixes.adoc
+++ b/modules/zstream-4-19-20-bug-fixes.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-20-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bugs are fixed with this release:
+
+* Before this update, if NetworkManager was restarted or crashed on a node with a `br-ex` interface managed by NMState, the node lost network connectivity. With this release, a fallback check in the dispatcher script was added to detect NMState-managed `br-ex` interfaces by checking for the `br-ex-br` bridge ID when the standard `br-ex` bridge ID is not found. As a result, nodes with this interface type do not lose network connectivity when NetworkManager restarts or crashes. (link:https://issues.redhat.com/browse/OCPBUGS-62168[OCPBUGS-62168])
+
+* Before this update, during the mirror operation, `oc-mirror` inadvertently set the executable program flag on some synchronized files that did not contain executable program code or scripts, potentially causing unexpected execution. With this release, unintended executable program flags have been removed from the synchronized files. As a result, correct file permissions are set, preventing unintended execution of synchronized files. (link:https://issues.redhat.com/browse/OCPBUGS-64683[OCPBUGS-64683])
+
+* Before this update, when directly navigating to a page created by a web console dynamic plugin, the web console might redirect to a different URL. With this release, the URL redirect has been removed. (link:https://issues.redhat.com/browse/OCPBUGS-64834[OCPBUGS-64834])
+
+* Before this update, the `ccoctl` utility did not support pagination when retrieving `CloudFront` distributions. As a result, if the distribution to be deleted was not included in the first batch of results, the `CloudFront` distribution and its associated origin access identity could not be deleted successfully during the `ccoctl` {aws-first} delete operation. With this release, pagination support is added to the `ccoctl` utility when fetching `CloudFront` distributions, ensuring that the distribution can be located and deleted properly. (link:https://issues.redhat.com/browse/OCPBUGS-65478[OCPBUGS-65478])
+
+* Before this update, a race condition in the Redfish Power interface caused power operations to fail during simultaneous access. As a consequence, users were unable to manage power states reliably. With this release, the race condition in the Redfish Power interface has been resolved, ensuring successful power operations. As a result, users can now manage power states reliably. (link:https://issues.redhat.com/browse/OCPBUGS-65572[OCPBUGS-65572])
+
+* Before this update, it was impossible to schedule a `must-gather` pod to a specific worker node when the `--node-name` argument was used as the pod's node affinity accepted only control plane nodes. With this release, the `must-gather` logic is updated to avoid setting node affinity when the `--node-name` argument is set. (link:https://issues.redhat.com/browse/OCPBUGS-65594[OCPBUGS-65594])

--- a/modules/zstream-4-19-20-updating.adoc
+++ b/modules/zstream-4-19-20-updating.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-20-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -696,7 +696,7 @@ The MCS CA and MCS cert are valid for 10 years and are automatically rotated by 
 
 [NOTE]
 ====
-This automatic certificate rotation applies only to clusters that use machine sets. For clusters that do not use machine sets, such as vSphere user-provisioned infrastructure clusters, you are required to manually rotate these certificates. For more information on manual certificate rotation, see the Red{nbsp}Hat Knowledgebase article link:https://access.redhat.com/articles/regenerating_cluster_certificates#regenerating-ca-certificates-for-the-machine-config-server-5[Regenerating CA certificates for the Machine Config Server]. 
+This automatic certificate rotation applies only to clusters that use machine sets. For clusters that do not use machine sets, such as vSphere user-provisioned infrastructure clusters, you are required to manually rotate these certificates. For more information on manual certificate rotation, see the Red{nbsp}Hat Knowledgebase article link:https://access.redhat.com/articles/regenerating_cluster_certificates#regenerating-ca-certificates-for-the-machine-config-server-5[Regenerating CA certificates for the Machine Config Server].
 ====
 
 For more information about the MCO certificates, see xref:../security/certificate_types_descriptions/machine-config-operator-certificates.adoc#cert-types-machine-config-operator-certificates[Machine Config Operator certificates].
@@ -2948,6 +2948,15 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+
+// 4.19.20 about
+include::modules/zstream-4-19-20-about.adoc[leveloffset=+2]
+
+// 4.19.20 fixes
+include::modules/zstream-4-19-20-bug-fixes.adoc[leveloffset=+2]
+
+// 4.19.20 updating
+include::modules/zstream-4-19-20-updating.adoc[leveloffset=+2]
 
 // 4.19.19 about
 include::modules/zstream-4-19-19-about.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-17515

Link to docs preview:
https://103233--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-20-about_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
These z-stream RNs are in a new modular format to prepare for DITA migration. **Also, there is an xref error below.** Ignore that error as it was decided that a special exception would be made for release notes.

To find the Image and RPM IDs, select the following links:

For the Image ID: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/259/diffs#1d5f4cbb386c43296a0836d5f48f9e7e4d4b3b1f
For the RPM ID: https://errata.devel.redhat.com/advisory/156647

Must be on VPN to view these links.

