### PR TITLE
[RHDEVDOCS-6790] Add error-log-snippet-number-of-lines setting

### DIFF
--- a/modules/op-customizing-pipelines-as-code-configuration.adoc
+++ b/modules/op-customizing-pipelines-as-code-configuration.adoc
@@ -40,7 +40,9 @@ To customize {pac}, cluster administrators can configure the following parameter
 
 | `auto-configure-repo-repository-template` | Configures a template to automatically generate the name for your new `Repository` custom resource (CR), if `auto-configure-new-github-repo` is enabled. | `{{repo_name}}-repo-cr`
 
-| `error-log-snippet` | Enables or disables the view of a log snippet for the failed tasks, with an error in a pipeline. You can disable this parameter in the case of data leakage from your pipeline. | `true`
+| `error-log-snippet` | Enables or disables the view of log snippets for failed tasks within a pipeline. You can disable this parameter to prevent potential data leakage. The snippets are automatically truncated to 65,000 characters. | `true`
+
+| `error-log-snippet-number-of-lines` | Configures the number of lines displayed in error log snippets. | `3`
 
 | `error-detection-from-container-logs` | Enables or disables the inspection of container logs to detect error message and expose them as annotations on the pull request. This setting applies only if you are using the GitHub app. | `true`
 


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.21

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6790

Link to docs preview:
- A table in [Customizing Pipelines as Code configuration](https://103265--ocpdocs-pr.netlify.app/openshift-pipelines/latest/pac/install-config-pipelines-as-code.html#customizing-pipelines-as-code-configuration_install-config-pipelines-as-code)

QE review:
- [x] QE has approved this change.

Additional info: 
Feature doc edit for a feature included in the [1.21 RNs](https://github.com/openshift/openshift-docs/pull/100818/files#diff-9ca23ca9c7e63ac32193bad5a3987905a783bd87d7b247401ae6307d35b94b3cR138).
