### PR TITLE
OBSDOCS-2883 Missing Documentation on TroubleshootingPanel UI Plugin Version Support

### DIFF
--- a/modules/coo-troubleshooting-ui-plugin-install.adoc
+++ b/modules/coo-troubleshooting-ui-plugin-install.adoc
@@ -7,7 +7,7 @@
 = Installing the {coo-full} Troubleshooting UI plugin
 
 .Prerequisites
-* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have access to an {ocp-product-title} cluster version 4.19+ as a user with the `cluster-admin` cluster role.
 * You have logged in to the {ocp-product-title} web console.
 * You have installed the {coo-full}
 

--- a/release-notes/cluster-observability-operator-release-notes.adoc
+++ b/release-notes/cluster-observability-operator-release-notes.adoc
@@ -20,7 +20,7 @@ The following table provides information about which features are available depe
 | COO Version   | OCP Versions       | Distributed tracing   | Logging   | Troubleshooting panel | ACM alerts | Incident detection
 | 1.1+          | 4.12 - 4.14        | ✔                     | ✔         | ✘                     | ✘          | ✘
 | 1.1+          | 4.15               | ✔                     | ✔         | ✘                     | ✔          | ✘
-| 1.1+          | 4.16 - 4.18        | ✔                     | ✔         | ✔                     | ✔          | ✘
+| 1.1+          | 4.16 - 4.18        | ✔                     | ✔         | ✘                     | ✔          | ✘
 | 1.2+          | 4.19+              | ✔                     | ✔         | ✔                     | ✔          | ✔
 |===
 
@@ -51,7 +51,7 @@ The incidents view in the monitoring UI plugin supports silenced alerts in this 
 link:https://issues.redhat.com/browse/COO-1280[COO-1280]
 
 Troubleshooting reaches General Availability::
-The troubleshooting feature in the {coo-full} reaches General Availability (GA) status in this release for {ocp-product-title} versions 4.19+. The troubleshooting UI plugin provides observability signal correlation, powered by the open source Korrel8r project. With the troubleshooting panel you can easily correlate metrics, logs, alerts, netflows, and additional observability signals and resources, across different data stores.
+The troubleshooting feature in the {coo-full} reaches General Availability (GA) status in this release for {ocp-product-title} versions 4.19+ and is not supported in earlier versions. The troubleshooting UI plugin provides observability signal correlation, powered by the open source Korrel8r project. With the troubleshooting panel you can easily correlate metrics, logs, alerts, netflows, and additional observability signals and resources, across different data stores.
 +
 For more information, see xref:../ui_plugins/troubleshooting-ui-plugin.adoc#troubleshooting-ui-plugin[Troubleshooting UI plugin]
 


### PR DESCRIPTION
Version(s):
standalone-coo-docs-1-latest

Issue:
[OBSDOCS-2883](https://issues.redhat.com//browse/OBSDOCS-2883)

Link to docs preview:
https://103266--ocpdocs-pr.netlify.app/openshift-coo/latest/release-notes/cluster-observability-operator-release-notes.html
https://103266--ocpdocs-pr.netlify.app/openshift-coo/latest/ui_plugins/troubleshooting-ui-plugin.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
