### PR TITLE
OSDOCS:17075# applying CQAs for Updating clusters

### DIFF
--- a/modules/about-manually-maintained-credentials-upgrade.adoc
+++ b/modules/about-manually-maintained-credentials-upgrade.adoc
@@ -7,6 +7,7 @@
 [id="about-manually-maintained-credentials-upgrade_{context}"]
 = Update requirements for clusters with manually maintained credentials
 
+[role="_abstract"]
 Before you update a cluster that uses manually maintained credentials with the Cloud Credential Operator (CCO), you must update the cloud provider resources for the new release.
 
 If the cloud credential management for your cluster was configured using the CCO utility (`ccoctl`), use the `ccoctl` utility to update the resources. Clusters that were configured to use manual mode without the `ccoctl` utility require manual updates for the resources.

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -1,40 +1,3 @@
-// Module included in the following assemblies:
-//
-//Postinstall and update content
-// * post_installation_configuration/changing-cloud-credentials-configuration.adoc
-// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
-//
-//Platforms that must use `ccoctl` and update content
-// * installing/installing_ibm_cloud/configuring-iam-ibm-cloud.adoc
-// * installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.doc
-// * installing/installing_nutanix/preparing-to-install-on-nutanix.adoc
-//
-// AWS assemblies:
-// * installing/installing_aws/installing-aws-customizations.adoc
-// * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
-// * installing/installing_aws/installing-aws-vpc.adoc
-// * installing/installing_aws/installing-aws-private.adoc
-// * installing/installing_aws/installing-aws-government-region.adoc
-// * installing/installing_aws/installing-aws-secret-region.adoc
-// * installing/installing_aws/installing-aws-china.adoc
-// * installing/installing_aws/installing-aws-outposts-remote-workers.adoc
-//
-// GCP assemblies:
-// * installing/installing_gcp/installing-gcp-customizations.adoc
-// * installing/installing_gcp/installing-gcp-network-customizations.adoc
-// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
-// * installing/installing_gcp/installing-gcp-vpc.adoc
-// * installing/installing_gcp/installing-gcp-shared-vpc.adoc
-// * installing/installing_gcp/installing-gcp-private.adoc
-//
-// Azure assemblies
-// * installing/installing_azure/installing-azure-customizations.adoc
-// * installing/installing_azure/installing-azure-government-region.adoc
-// * installing/installing_azure/installing-azure-private.adoc
-// * installing/installing_azure/installing-azure-vnet.adoc
-// * installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
-
-//Postinstall  and update content
 ifeval::["{context}" == "changing-cloud-credentials-configuration"]
 :postinstall:
 endif::[]
@@ -121,6 +84,9 @@ endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="cco-ccoctl-configuring_{context}"]
+
+
+[role="_abstract"]
 ifndef::update[= Configuring the Cloud Credential Operator utility]
 ifdef::update[= Configuring the Cloud Credential Operator utility for a cluster update]
 
@@ -200,10 +166,12 @@ Ensure that the architecture of the `$RELEASE_IMAGE` matches the architecture of
 [source,terminal]
 ----
 $ oc image extract $CCO_IMAGE \
-  --file="/usr/bin/ccoctl.<rhel_version>" \// <1>
+  --file="/usr/bin/ccoctl.<rhel_version>" \//
   -a ~/.pull-secret
 ----
-<1> For `<rhel_version>`, specify the value that corresponds to the version of {op-system-base-full} that the host uses.
+where:
+
+`<rhel_version>`:: Specify the value that corresponds to the version of {op-system-base-full} that the host uses.
 If no value is specified, `ccoctl.rhel8` is used by default.
 The following values are valid:
 +

--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -1,12 +1,8 @@
-// Module included in the following assemblies:
-//
-// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
-
-
 :_mod-docs-content-type: PROCEDURE
 [id="cco-ccoctl-upgrading_{context}"]
 = Updating cloud provider resources with the Cloud Credential Operator utility
 
+[role="_abstract"]
 The process for upgrading an {product-title} cluster that was configured using the CCO utility (`ccoctl`) is similar to creating the cloud provider resources during installation.
 
 [NOTE]
@@ -42,87 +38,89 @@ $ oc get secret bound-service-account-signing-key \
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the command for your cloud provider. The following commands process `CredentialsRequest` objects:
 +
 .Amazon Web Services (AWS)
-[%collapsible]
-====
 [source,terminal]
 ----
-$ ccoctl aws create-all \// <1>
-  --name=<name> \// <2>
-  --region=<aws_region> \// <3>
-  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <4>
-  --output-dir=<path_to_ccoctl_output_dir> \// <5>
-  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public \// <6>
-  --create-private-s3-bucket <7>
+$ ccoctl aws create-all \
+  --name=<name> \//
+  --region=<aws_region> \
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --output-dir=<path_to_ccoctl_output_dir> \
+  --public-key-file=
+  <path_to_ccoctl_output_dir>/serviceaccount-signer.public \
+  --create-private-s3-bucket
 ----
-<1> To create the AWS resources individually, use the "Creating AWS resources individually" procedure in the "Installing a cluster on AWS with customizations" content. This option might be useful if you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization.
-<2> Specify the name used to tag any cloud resources that are created for tracking.
-<3> Specify the AWS region in which cloud resources will be created.
-<4> Specify the directory containing the files for the component `CredentialsRequest` objects.
-<5> Specify the path to the output directory.
-<6> Specify the path to the `serviceaccount-signer.public` file that you extracted from the cluster.
-<7> Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
-====
++
+where:
+
+`ccoctl aws create-all`:: To create the AWS resources individually, use the "Creating AWS resources individually" procedure in the "Installing a cluster on AWS with customizations" content. This option might be useful if you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization.
+`<name>`:: Specify the name used to tag any cloud resources that are created for tracking.
+`<aws_region>`:: Specify the AWS region in which cloud resources will be created.
+`<path_to_credentials_requests_directory>`:: Specify the directory containing the files for the component `CredentialsRequest` objects.
+`<path_to_ccoctl_output_dir>`:: Specify the path to the output directory.
+`<path_to_ccoctl_output_dir>/serviceaccount-signer.public`:: Specify the path to the `serviceaccount-signer.public` file that you extracted from the cluster.
+`create-private-s3-bucket`:: Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
+
 +
 .{gcp-first}
-[%collapsible]
-====
 [source,terminal]
 ----
 $ ccoctl gcp create-all \
-  --name=<name> \// <1>
-  --region=<gcp_region> \// <2>
-  --project=<gcp_project_id> \// <3>
-  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <4>
-  --output-dir=<path_to_ccoctl_output_dir> \// <5>
-  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public \// <6>
+  --name=<name> \
+  --region=<gcp_region> \
+  --project=<gcp_project_id> \
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --output-dir=<path_to_ccoctl_output_dir> \
+  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public
 ----
-<1> Specify the user-defined name for all created {gcp-short} resources used for tracking.
-<2> Specify the {gcp-short} region in which cloud resources will be created.
-<3> Specify the {gcp-short} project ID in which cloud resources will be created.
-<4> Specify the directory containing the files of `CredentialsRequest` manifests to create {gcp-short} service accounts.
-<5> Specify the path to the output directory.
-<6> Specify the path to the `serviceaccount-signer.public` file that you extracted from the cluster.
-====
+where:
+
+`<name>`:: Specify the user-defined name for all created {gcp-short} resources used for tracking.
+`<gcp_region>`:: Specify the {gcp-short} region in which cloud resources will be created.
+`<gcp_project_id>`:: Specify the {gcp-short} project ID in which cloud resources will be created.
+`<path_to_credentials_requests_directory>`:: Specify the directory containing the files of `CredentialsRequest` manifests to create {gcp-short} service accounts.
+`<path_to_ccoctl_output_dir>`:: Specify the path to the output directory.
+`<path_to_ccoctl_output_dir>/serviceaccount-signer.public`:: Specify the path to the `serviceaccount-signer.public` file that you extracted from the cluster.
+
 +
 .{ibm-cloud-title}
-[%collapsible]
-====
 [source,terminal]
 ----
 $ ccoctl ibmcloud create-service-id \
-  --credentials-requests-dir=<path_to_credential_requests_directory> \// <1>
-  --name=<cluster_name> \// <2>
-  --output-dir=<installation_directory> \// <3>
-  --resource-group-name=<resource_group_name> <4>
+  --credentials-requests-dir=<path_to_credential_requests_directory> \
+  --name=<cluster_name> \
+  --output-dir=<installation_directory> \
+  --resource-group-name=<resource_group_name>
 ----
-<1> Specify the directory containing the files for the component `CredentialsRequest` objects.
-<2> Specify the name of the {product-title} cluster.
-<3> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
-<4> Optional: Specify the name of the resource group used for scoping the access policies.
-====
+where:
+
+`<path_to_credential_requests_directory>`:: Specify the directory containing the files for the component `CredentialsRequest` objects.
+`<cluster_name>`:: Specify the name of the {product-title} cluster.
+`<installation_directory>`:: Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+`<resource_group_name>`:: Optional: Specify the name of the resource group used for scoping the access policies.
+
 +
 .{azure-first}
-[%collapsible]
-====
 [source,terminal]
 ----
 $ ccoctl azure create-managed-identities \
-  --name <azure_infra_name> \// <1>
-  --output-dir=<path_to_ccoctl_output_dir> \// <2>
-  --region <azure_region> \// <3>
-  --subscription-id <azure_subscription_id> \// <4>
-  --credentials-requests-dir <path_to_directory_for_credentials_requests> \// <5>
-  --issuer-url "${OIDC_ISSUER_URL}" \// <6>
-  --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name> \// <7>
-  --installation-resource-group-name "${AZURE_INSTALL_RG}" <8>
+  --name <azure_infra_name> \
+  --output-dir=<path_to_ccoctl_output_dir> \
+  --region <azure_region> \
+  --subscription-id <azure_subscription_id> \
+  --credentials-requests-dir <path_to_directory_for_credentials_requests> \
+  --issuer-url "${OIDC_ISSUER_URL}" \
+  --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name> \
+  --installation-resource-group-name "${AZURE_INSTALL_RG}"
 ----
-<1> The value of the `name` parameter is used to create an Azure resource group.
+where:
+
+`<azure_infra_name>`:: The value of the `name` parameter is used to create an Azure resource group.
 To use an existing Azure resource group instead of creating a new one, specify the `--oidc-resource-group-name` argument with the existing group name as its value.
-<2> Specify the path to the output directory.
-<3> Specify the region of the existing cluster.
-<4> Specify the subscription ID of the existing cluster.
-<5> Specify the directory containing the files for the component `CredentialsRequest` objects.
-<6> Specify the OIDC issuer URL from the existing cluster.
+`<path_to_ccoctl_output_dir>`:: Specify the path to the output directory.
+`<azure_region>`:: Specify the region of the existing cluster.
+`<azure_subscription_id>`:: Specify the subscription ID of the existing cluster.
+`<path_to_directory_for_credentials_requests>`:: Specify the directory containing the files for the component `CredentialsRequest` objects.
+`"${OIDC_ISSUER_URL}"`:: Specify the OIDC issuer URL from the existing cluster.
 You can obtain this value by running the following command:
 +
 [source,terminal]
@@ -131,8 +129,8 @@ $ oc get authentication cluster \
   -o jsonpath \
   --template='{ .spec.serviceAccountIssuer }'
 ----
-<7> Specify the name of the resource group that contains the DNS zone.
-<8> Specify the {azure-short} resource group name.
+`<azure_dns_zone_resourcegroup_name>`:: Specify the name of the resource group that contains the DNS zone.
+`"${AZURE_INSTALL_RG}"`:: Specify the {azure-short} resource group name.
 You can obtain this value by running the following command:
 +
 [source,terminal]
@@ -141,22 +139,22 @@ $ oc get infrastructure cluster \
   -o jsonpath \
   --template '{ .status.platformStatus.azure.resourceGroupName }'
 ----
-====
+
 +
 .Nutanix
-[%collapsible]
-====
 [source,terminal]
 ----
 $ ccoctl nutanix create-shared-secrets \
-  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <1>
-  --output-dir=<ccoctl_output_dir> \// <2>
-  --credentials-source-filepath=<path_to_credentials_file> <3>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --output-dir=<ccoctl_output_dir> \
+  --credentials-source-filepath=<path_to_credentials_file>
 ----
-<1> Specify the path to the directory that contains the files for the component `CredentialsRequests` objects.
-<2> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
-<3> Optional: Specify the directory that contains the credentials data YAML file. By default, `ccoctl` expects this file to be in `<home_directory>/.nutanix/credentials`.
-====
+where:
+
+`<path_to_credentials_requests_directory>`:: Specify the path to the directory that contains the files for the component `CredentialsRequests` objects.
+`<ccoctl_output_dir>`:: Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+`<path_to_credentials_file>`:: Optional: Specify the directory that contains the credentials data YAML file. By default, `ccoctl` expects this file to be in `<home_directory>/.nutanix/credentials`.
+
 +
 For each `CredentialsRequest` object, `ccoctl` creates the required provider resources and a permissions policy as defined in each `CredentialsRequest` object from the {product-title} release image.
 

--- a/modules/cco-determine-mode-cli.adoc
+++ b/modules/cco-determine-mode-cli.adoc
@@ -15,6 +15,7 @@ endif::[]
 [id="cco-determine-mode-cli_{context}"]
 = Determining the Cloud Credential Operator mode by using the CLI
 
+[role="_abstract"]
 You can determine what mode the Cloud Credential Operator (CCO) is configured to use by using the CLI.
 
 [NOTE]

--- a/modules/cco-determine-mode-gui.adoc
+++ b/modules/cco-determine-mode-gui.adoc
@@ -15,6 +15,7 @@ endif::[]
 [id="cco-determine-mode-gui_{context}"]
 = Determining the Cloud Credential Operator mode by using the web console
 
+[role="_abstract"]
 You can determine what mode the Cloud Credential Operator (CCO) is configured to use by using the web console.
 
 [NOTE]

--- a/modules/cco-manual-upgrade-annotation.adoc
+++ b/modules/cco-manual-upgrade-annotation.adoc
@@ -8,6 +8,7 @@
 [id="cco-manual-upgrade-annotation_{context}"]
 = Indicating that the cluster is ready to upgrade
 
+[role="_abstract"]
 The Cloud Credential Operator (CCO) `Upgradable` status for a cluster with manually maintained credentials is `False` by default.
 
 .Prerequisites

--- a/modules/changing-cvo-log-level.adoc
+++ b/modules/changing-cvo-log-level.adoc
@@ -9,6 +9,7 @@
 :FeatureName: Changing the CVO log level
 include::snippets/technology-preview.adoc[]
 
+[role="_abstract"]
 The Cluster Version Operator (CVO) log level verbosity can be changed by the cluster administrator. There are four log levels.
 
 * `Normal` - The default log level. Contains working log information. Used when everything is fine. Provides helpful notices for auditing or common operations.
@@ -30,11 +31,13 @@ If `TraceAll` is turned on in a production cluster it may cause widespread perfo
 
 . Enter the following command into the CLI to change the log level.
 
++
 [source,terminal]
 ----
 $ oc patch clusterversionoperator/cluster --type=merge --patch '{"spec":{"operatorLogLevel":"<log_level>"}}'
 ----
 
++
 .Example output
 [source,terminal]
 ----

--- a/modules/gathering-clusterversion-history-cli.adoc
+++ b/modules/gathering-clusterversion-history-cli.adoc
@@ -6,6 +6,7 @@
 [id="gathering-clusterversion-history-cli_{context}"]
 = Gathering ClusterVersion history using the {oc-first}
 
+[role="_abstract"]
 You can view the ClusterVersion history using the {oc-first}.
 
 .Prerequisites

--- a/modules/gathering-clusterversion-history-console.adoc
+++ b/modules/gathering-clusterversion-history-console.adoc
@@ -6,6 +6,7 @@
 [id="gathering-clusterversion-history-console_{context}"]
 = Gathering ClusterVersion history in the {product-title} web console
 
+[role="_abstract"]
 You can view the ClusterVersion history in the {product-title} web console.
 
 .Prerequisites

--- a/modules/gathering-clusterversion-history.adoc
+++ b/modules/gathering-clusterversion-history.adoc
@@ -1,11 +1,8 @@
-// Module included in the following assemblies:
-//
-// * updating/troubleshooting_updates/gathering-data-cluster-update.adoc
-
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="gathering-clusterversion-history_{context}"]
-= Gathering ClusterVersion history 
+= Gathering ClusterVersion history
 
+[role="_abstract"]
 The Cluster Version Operator (CVO) records updates made to a cluster, known as the ClusterVersion history. The entries can reveal correlation between changes in cluster behavior with potential triggers, although correlation does not imply causation.
 
 [NOTE]

--- a/modules/gathering-log-data.adoc
+++ b/modules/gathering-log-data.adoc
@@ -1,9 +1,6 @@
-// Module included in the following assemblies:
-//
-// * updating/troubleshooting_updates/gathering-data-cluster-update.adoc
-
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="gathering-log-data_{context}"]
 = Gathering log data for a support case
 
+[role="_abstract"]
 To gather data from your cluster, including log data, use the `oc adm must-gather` command. See _Gathering data about your cluster_.

--- a/modules/kmm-example-cr.adoc
+++ b/modules/kmm-example-cr.adoc
@@ -6,6 +6,7 @@
 [id="kmm-example-cr_{context}"]
 = Example PreflightValidationOCP resource
 
+[role="_abstract"]
 The following example shows a `PreflightValidationOCP` resource in the YAML format.
 
 The example verifies all of the currently present modules against the upcoming `5.14.0-570.19.1.el9_6.x86_64` kernel. Because `.spec.pushBuiltImage` is set to `true`, KMM pushes the resulting images of Build/Sign into the defined repositories.
@@ -18,6 +19,6 @@ metadata:
   name: preflight
 spec:
   kernelVersion: 5.14.0-570.19.1.el9_6.x86_64
-  dtkImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fe0322730440f1cbe6fffaaa8cac131b56574bec8abe3ec5b462e17557fecb32 
+  dtkImage: quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:fe0322730440f1cbe6fffaaa8cac131b56574bec8abe3ec5b462e17557fecb32
   pushBuiltImage: true
 ----

--- a/modules/kmm-image-validation-stage.adoc
+++ b/modules/kmm-image-validation-stage.adoc
@@ -6,6 +6,7 @@
 [id="kmm-image-validation-stage_{context}"]
 = Image validation stage
 
+[role="_abstract"]
 Image validation is always the first stage of the preflight validation to be executed. If image validation is successful, no other validations are run on that specific module. The Operator uses the container runtime to check the image existence and accessibility for the updaded kernel in the module.
 
 If the image validation fails and there is a `build/sign` section in the module that is relevant to the upgraded kernel, the controller tries to build or sign the image. If the `PushBuiltImage` flag is defined in the `PreflightValidationOCP` resource, the controller will also try to push the resulting image into its repository. The resulting image name is taken from the definition of the `containerImage` field of the `Module` CR.

--- a/modules/kmm-validation-kickoff.adoc
+++ b/modules/kmm-validation-kickoff.adoc
@@ -6,6 +6,7 @@
 [id="kmm-validation-kickoff_{context}"]
 = Validation kickoff
 
+[role="_abstract"]
 Preflight validation is triggered by creating a `PreflightValidationOCP` resource in the cluster. This resource contains the following fields:
 
 `dtkImage`:: The DTK container image released for the specific {product-title} version of the cluster. If this value is not set, the `DTK_AUTO` feature cannot be used.
@@ -24,7 +25,7 @@ $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.20.0-x86_64 --
 $ oc adm release info quay.io/openshift-release-dev/ocp-release:4.20.0-aarch64 --image-for=driver-toolkit
 ----
 
-`kernelVersion`:: Required field that provides the version of the kernel that the cluster is upgraded to. 
+`kernelVersion`:: Required field that provides the version of the kernel that the cluster is upgraded to.
 +
 You can obtain the version by running the following command in the cluster:
 +

--- a/modules/kmm-validation-lifecycle.adoc
+++ b/modules/kmm-validation-lifecycle.adoc
@@ -6,6 +6,7 @@
 [id="kmm-validation-lifecycle_{context}"]
 = Validation lifecycle
 
+[role="_abstract"]
 Preflight validation attempts to validate every module loaded in the cluster. Preflight stops running validation on a `Module` resource after the validation is successful. If module validation fails, you can change the module definitions and Preflight tries to validate the module again in the next loop.
 
 If you want to run Preflight validation for an additional kernel, then you should create another `PreflightValidationOCP` resource for that kernel. After all the modules have been validated, it is recommended to delete the `PreflightValidationOCP` resource.

--- a/modules/kmm-validation-status.adoc
+++ b/modules/kmm-validation-status.adoc
@@ -6,6 +6,7 @@
 [id="kmm-validation-status_{context}"]
 = Validation status
 
+[role="_abstract"]
 A `PreflightValidationOCP` resource reports the status and progress of each module in the cluster that it attempts or has attempted to validate in its `.status.modules` list. Elements of that list contain the following fields:
 
 `name`:: The name of the `Module` resource.

--- a/modules/manually-maintained-credentials-upgrade-extract.adoc
+++ b/modules/manually-maintained-credentials-upgrade-extract.adoc
@@ -7,6 +7,7 @@
 [id="cco-ccoctl-upgrading-extracting_{context}"]
 = Extracting and preparing credentials request resources
 
+[role="_abstract"]
 Before updating a cluster that uses the Cloud Credential Operator (CCO) in manual mode, you must extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
 
 .Prerequisites
@@ -57,11 +58,13 @@ quay.io/openshift-release-dev/ocp-release@sha256:6a899c54dda6b844bb12a247e324a0f
 $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
-  --included \// <1>
-  --to=<path_to_directory_for_credentials_requests> <2>
+  --included \
+  --to=<path_to_directory_for_credentials_requests>
 ----
-<1> The `--included` parameter includes only the manifests that your specific cluster configuration requires for the target release.
-<2> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+where:
+
+`--included`:: The parameter includes only the manifests that your specific cluster configuration requires for the target release.
+`<path_to_directory_for_credentials_requests>`:: Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 This command creates a YAML file for each `CredentialsRequest` object.
 
@@ -88,9 +91,11 @@ spec:
       resource: "*"
   secretRef:
     name: cloud-credential-operator-iam-ro-creds
-    namespace: openshift-cloud-credential-operator <1>
+    namespace: openshift-cloud-credential-operator
 ----
-<1> This field indicates the namespace which must exist to hold the generated secret.
+where:
+
+`openshift-cloud-credential-operator`:: This field indicates the namespace which must exist to hold the generated secret.
 +
 The `CredentialsRequest` CRs for other platforms have a similar format with different platform-specific values.
 

--- a/modules/manually-maintained-credentials-upgrade.adoc
+++ b/modules/manually-maintained-credentials-upgrade.adoc
@@ -7,6 +7,7 @@
 [id="manually-maintained-credentials-upgrade_{context}"]
 = Manually updating cloud provider resources
 
+[role="_abstract"]
 Before upgrading a cluster with manually maintained credentials, you must create secrets for any new credentials for the release image that you are upgrading to. You must also review the required permissions for existing credentials and accommodate any new permissions requirements in the new release for those components.
 
 .Prerequisites
@@ -16,10 +17,7 @@ Before upgrading a cluster with manually maintained credentials, you must create
 .Procedure
 
 . Create YAML files with secrets for any `CredentialsRequest` custom resources that the new release image adds. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object.
-+
-.Sample AWS YAML files
-[%collapsible]
-====
+
 .Sample AWS `CredentialsRequest` object with secrets
 [source,yaml]
 ----
@@ -58,11 +56,7 @@ data:
   aws_access_key_id: <base64_encoded_aws_access_key_id>
   aws_secret_access_key: <base64_encoded_aws_secret_access_key>
 ----
-====
-+
-.Sample Azure YAML files
-[%collapsible]
-====
+
 [NOTE]
 =====
 Global Azure and Azure Stack Hub use the same `CredentialsRequest` object and secret formats.
@@ -106,11 +100,7 @@ data:
   azure_resourcegroup: <base64_encoded_azure_resourcegroup>
   azure_region: <base64_encoded_azure_region>
 ----
-====
-+
-.Sample {gcp-short} YAML files
-[%collapsible]
-====
+
 .Sample {gcp-short} `CredentialsRequest` object with secrets
 [source,yaml]
 ----
@@ -146,7 +136,6 @@ metadata:
 data:
   service_account.json: <base64_encoded_gcp_service_account_file>
 ----
-====
 
 . If the `CredentialsRequest` custom resources for any existing credentials that are stored in secrets have changed permissions requirements, update the permissions as required.
 

--- a/modules/nw-ingress-gateway-api-manage-succession.adoc
+++ b/modules/nw-ingress-gateway-api-manage-succession.adoc
@@ -6,6 +6,7 @@
 [id="nw-ingress-gateway-api-manage-succession_{context}"]
 = Preparing for Gateway API management succession by the Ingress Operator
 
+[role="_abstract"]
 Starting in {product-title} 4.19, the Ingress Operator manages the lifecycle of any Gateway API custom resource definitions (CRDs). This means that you will be denied access to creating, updating, and deleting any CRDs within the API groups that are grouped under Gateway API.
 
 Updating from a version before 4.19 of {product-title} where this management was not present requires you to replace or remove any Gateway API CRDs that already exist in the cluster so that they conform to the specific {product-title} specification required by the Ingress Operator. {product-title} version 4.19 requires Gateway API Standard version 1.2.1 CRDs.

--- a/modules/update-best-practices.adoc
+++ b/modules/update-best-practices.adoc
@@ -6,6 +6,7 @@
 [id="update-best-practices_{context}"]
 = Best practices for cluster updates
 
+[role="_abstract"]
 {product-title} provides a robust update experience that minimizes workload disruptions during an update.
 Updates will not begin unless the cluster is in an upgradeable state at the time of the update request.
 

--- a/modules/update-etcd-backup.adoc
+++ b/modules/update-etcd-backup.adoc
@@ -6,6 +6,7 @@
 [id="update-etcd-backup_{context}"]
 = etcd backups before cluster updates
 
+[role="_abstract"]
 etcd backups record the state of your cluster and all of its resource objects.
 You can use backups to attempt restoring the state of a cluster in disaster scenarios where you cannot recover a cluster in its currently dysfunctional state.
 

--- a/modules/update-preparing-ack.adoc
+++ b/modules/update-preparing-ack.adoc
@@ -6,6 +6,7 @@
 [id="update-preparing-ack_{context}"]
 = Providing the administrator acknowledgment
 
+[role="_abstract"]
 After you have evaluated your cluster for any removed APIs and have migrated any removed APIs, you can acknowledge that your cluster is ready to upgrade from {product-title} 4.19 to 4.20.
 
 [WARNING]

--- a/modules/update-preparing-conditional.adoc
+++ b/modules/update-preparing-conditional.adoc
@@ -2,10 +2,11 @@
 //
 // * updating/preparing_for_updates/updating-cluster-prepare.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="update-preparing-conditional_{context}"]
-= Assessing the risk of conditional updates
+= The risk of conditional updates
 
+[role="_abstract"]
 A _conditional update_ is an update target that is available but not recommended due to a known risk that applies to your cluster.
 The Cluster Version Operator (CVO) periodically queries the OpenShift Update Service (OSUS) for the most recent data about update recommendations, and some potential update targets might have risks associated with them.
 

--- a/modules/update-preparing-evaluate-alerts.adoc
+++ b/modules/update-preparing-evaluate-alerts.adoc
@@ -6,12 +6,13 @@
 [id="update-preparing-evaluate-alerts_{context}"]
 = Reviewing alerts to identify uses of removed APIs
 
+[role="_abstract"]
 Two alerts fire when an API is in use that will be removed in the next release:
 
 * `APIRemovedInNextReleaseInUse` - for APIs that will be removed in the next {product-title} release.
 * `APIRemovedInNextEUSReleaseInUse` - for APIs that will be removed in the next {product-title} Extended Update Support (EUS) release.
 
-.Procedure 
+.Procedure
 
 * If either of the alerts are firing in your cluster, review the alerts and take action to clear the alerts by migrating manifests and API clients to use the new API version.
 

--- a/modules/update-preparing-evaluate-apirequestcount-workloads.adoc
+++ b/modules/update-preparing-evaluate-apirequestcount-workloads.adoc
@@ -6,6 +6,7 @@
 [id="update-preparing-evaluate-apirequestcount-workloads_{context}"]
 = Using APIRequestCount to identify which workloads are using the removed APIs
 
+[role="_abstract"]
 You can examine the `APIRequestCount` resource for a given API version to help identify which workloads are using the API.
 
 .Prerequisites

--- a/modules/update-preparing-evaluate-apirequestcount.adoc
+++ b/modules/update-preparing-evaluate-apirequestcount.adoc
@@ -6,6 +6,7 @@
 [id="update-preparing-evaluate-apirequestcount_{context}"]
 = Using APIRequestCount to identify uses of removed APIs
 
+[role="_abstract"]
 You can use the `APIRequestCount` API to track API requests and review whether any of them are using one of the removed APIs.
 
 .Prerequisites

--- a/modules/update-preparing-list.adoc
+++ b/modules/update-preparing-list.adoc
@@ -6,6 +6,7 @@
 [id="update-preparing-list_{context}"]
 = Removed APIs
 
+[role="_abstract"]
 {product-title} 4.20 removed the following Kubernetes APIs. You must migrate manifests and API clients to use the appropriate API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/[Kubernetes documentation].
 
 .Kubernetes APIs removed from {product-title} 4.20

--- a/modules/update-preparing-migrate.adoc
+++ b/modules/update-preparing-migrate.adoc
@@ -6,4 +6,5 @@
 [id="update-preparing-migrate_{context}"]
 = Migrating instances of removed APIs
 
+[role="_abstract"]
 For information about how to migrate removed Kubernetes APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/[Deprecated API Migration Guide] in the Kubernetes documentation.

--- a/updating/preparing_for_updates/kmm-preflight-validation.adoc
+++ b/updating/preparing_for_updates/kmm-preflight-validation.adoc
@@ -13,6 +13,7 @@ To do: Remove this comment once 4.13 docs are EOL.
 ////
 // Updated for TELCODOCS-1848
 
+[role="_abstract"]
 Before performing an upgrade on the cluster with applied KMM modules, you must verify that kernel modules installed using KMM are able to be installed on the nodes after the cluster upgrade and possible kernel upgrade. Preflight attempts to validate every `Module` loaded in the cluster, in parallel. Preflight does not wait for validation of one `Module` to complete before starting validation of another `Module`.
 
 :FeatureName: Kernel Module Management Operator Preflight validation

--- a/updating/preparing_for_updates/preparing-manual-creds-update.adoc
+++ b/updating/preparing_for_updates/preparing-manual-creds-update.adoc
@@ -6,12 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-////
-WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
-
-To do: Remove this comment once 4.13 docs are EOL.
-////
-
+[role="_abstract"]
 The Cloud Credential Operator (CCO) `Upgradable` status for a cluster with manually maintained credentials is `False` by default.
 
 * For minor releases, for example, from 4.12 to 4.13, this status prevents you from updating until you have addressed any updated permissions and annotated the `CloudCredential` resource to indicate that the permissions are updated as needed for the next version. This annotation changes the `Upgradable` status to `True`.

--- a/updating/preparing_for_updates/updating-cluster-prepare-past-4-18.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare-past-4-18.adoc
@@ -11,6 +11,7 @@ Before you update from {product-title} 4.18 to a newer version, learn about some
 [id="migrating-workloads-to-different-nodes_{context}"]
 == Migrating workloads off of package-based {op-system-base} worker nodes
 
+[role="_abstract"]
 With the introduction of {product-title} 4.19, package-based {op-system-base} worker nodes are no longer supported. If you try to update your cluster while those nodes are up and running, the update will fail.
 
 You can reschedule pods running on {op-system-base} compute nodes to run on your {op-system} nodes instead by using node selectors.
@@ -34,13 +35,15 @@ metadata:
     node.openshift.io/os_version: '{product-version}'
     node-role.kubernetes.io/worker: ''
     failure-domain.beta.kubernetes.io/region: us-east-1
-    node.openshift.io/os_id: rhcos <1>
+    node.openshift.io/os_id: rhcos
     beta.kubernetes.io/instance-type: m4.large
     kubernetes.io/hostname: ip-10-0-131-14
     beta.kubernetes.io/arch: amd64
 #...
 ----
-<1> The label identifying the operating system that runs on the node, to match the pod node selector.
+where:
+
+rhcos:: The label identifying the operating system that runs on the node, to match the pod node selector.
 
 Any pods that you want to schedule to new {op-system} nodes must contain a matching label in its `nodeSelector` field. The following procedure describes how to add the label.
 

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -6,12 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-////
-WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
-
-To do: Remove this comment once 4.13 docs are EOL.
-////
-
+[role="_abstract"]
 Learn more about administrative tasks that cluster admins must perform to successfully initialize an update, as well as optional guidelines for ensuring a successful update.
 
 [id="kube-api-removals_{context}"]

--- a/updating/troubleshooting_updates/gathering-data-cluster-update.adoc
+++ b/updating/troubleshooting_updates/gathering-data-cluster-update.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 ifndef::openshift-origin[]
 When reaching out to Red Hat support for issues with an update, it is important to provide data for the support team to use for troubleshooting your failed cluster update.
 endif::openshift-origin[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Versions: 
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-17075

Link to docs preview:

- [Update requirements for clusters with manually maintained credentials](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#about-manually-maintained-credentials-upgrade_preparing-manual-creds-update)
- [Configuring the Cloud Credential Operator utility for a cluster update](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-ccoctl-configuring_preparing-manual-creds-update)
- [Updating cloud provider resources with the Cloud Credential Operator utility](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-ccoctl-upgrading_preparing-manual-creds-update) 
- [Determining the Cloud Credential Operator mode by using the CLI](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-determine-mode-cli_preparing-manual-creds-update) 
- [Determining the Cloud Credential Operator mode by using the web console](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-determine-mode-gui_preparing-manual-creds-update)
- [Indicating that the cluster is ready to upgrade](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-manual-upgrade-annotation_preparing-manual-creds-update)
- [Changing CVO log level (Technology Preview)](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update#changing-log-data_troubleshooting_updates)
- [Gathering ClusterVersion history using the OpenShift CLI (oc)](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update#gathering-clusterversion-history-cli_troubleshooting_updates)
- [Gathering ClusterVersion history in the OpenShift Container Platform web console](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update#gathering-clusterversion-history-console_troubleshooting_updates)
- [Gathering log data for a support case](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update#gathering-log-data_troubleshooting_updates)
- [Example PreflightValidationOCP resource](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation#kmm-example-cr_kmm-preflight-validation)
- [Image validation stage](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation#kmm-image-validation-stage_kmm-preflight-validation)
- [Validation kickoff](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation#kmm-validation-kickoff_kmm-preflight-validation)
- [Validation lifecycle](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation#kmm-validation-lifecycle_kmm-preflight-validation)
- [Validation status](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation#kmm-validation-lifecycle_kmm-preflight-validation)
- [Extracting and preparing credentials request resources](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-ccoctl-upgrading-extracting_preparing-manual-creds-update)
- [Manually updating cloud provider resources](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#manually-maintained-credentials-upgrade_preparing-manual-creds-update)
- [Preparing for Gateway API management succession by the Ingress Operator](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#nw-ingress-gateway-api-manage-succession_updating-cluster-prepare)
- [Best practices for cluster updates](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-best-practices_updating-cluster-prepare) 
- [etcd backups before cluster update](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-etcd-backup_updating-cluster-prepare)
- [Providing the administrator acknowledgment](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-preparing-ack_updating-cluster-prepare)
- [The risk of conditional updates](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-preparing-conditional_updating-cluster-prepare)
- [Reviewing alerts to identify uses of removed APIs](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-preparing-evaluate-alerts_updating-cluster-prepare)
- [Using APIRequestCount to identify uses of removed APIs](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-preparing-evaluate-apirequestcount_updating-cluster-prepare)
- [Using APIRequestCount to identify which workloads are using the removed APIs](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-preparing-evaluate-apirequestcount-workloads_updating-cluster-prepare)
- [Removed APIs](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-preparing-list_updating-cluster-prepare)
- [Migrating instances of removed APIs](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-preparing-migrate_updating-cluster-prepare)
- [Preflight validation for Kernel Module Management (KMM) Modules](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/kmm-preflight-validation)
- [Preparing to update a cluster with manually maintained credentials](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update)
- [Migrating workloads off of package-based RHEL worker nodes](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare-past-4-18#migrating-workloads-to-different-nodes_updating-cluster-prepare-past-4-18) 
- [Preparing to update to OpenShift Container Platform 4.20](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare)
- [Gathering data about your cluster update](https://103267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/updating/troubleshooting_updates/gathering-data-cluster-update)

QE review:
- [ ] QE has approved this change.
QE approval not required as no change to the content.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
