### PR TITLE
OSDOCS-17482 [NETOBSERV] Update flowcollector API docs for 1.10.1

### DIFF
--- a/modules/network-observability-flowcollector-api-specifications.adoc
+++ b/modules/network-observability-flowcollector-api-specifications.adoc
@@ -94,7 +94,7 @@ Type::
 | `string`
 | `deploymentModel` defines the desired type of deployment for flow processing. Possible values are: +
 
-- `Direct` (default) to make the flow processor listen directly from the agents. +
+- `Direct` (default) to make the flow processor listen directly from the agents. Only recommended on small clusters, below 15 nodes. +
 
 - `Kafka` to make flows sent to a Kafka pipeline before consumption by the processor. +
 
@@ -2672,9 +2672,10 @@ configuration, you can disable it and install your own instead.
 
 | `enable`
 | `boolean`
-| Set `enable` to `true` to deploy network policies on the namespaces used by Network Observability (main and privileged). It is disabled by default.
-These network policies better isolate the Network Observability components to prevent undesired connections to them.
-This option is enabled by default, disable it to manually manage network policies
+| Deploys network policies on the namespaces used by Network Observability (main and privileged).
+These network policies better isolate the Network Observability components to prevent undesired connections from and to them.
+This option is enabled by default when using with OVNKubernetes, and disabled otherwise (it has not been tested with other CNIs).
+When disabled, you can manually create the network policies for the Network Observability components.
 
 |===
 == .spec.processor


### PR DESCRIPTION
[OSDOCS-17482](https://issues.redhat.com//browse/OSDOCS-17482) [NETOBSERV] Update flowcollector API docs for 1.10.1

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-17482

Link to docs preview:
https://103268--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/flowcollector-api.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
API docs are autogenerated. Migration changes for autogenerated docs remain TBD. Leaving autogenerated content as is.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
