### PR TITLE
[RHDEVDOCS-7006] Add best practice to database config

### DIFF
--- a/modules/op-results-db.adoc
+++ b/modules/op-results-db.adoc
@@ -6,8 +6,10 @@
 [id="results-db_{context}"]
 = Configuring an external database server
 
-{tekton-results} uses a PostgreSQL database to store data. By default, the installation includes an internal PostgreSQL instance.
-You can configure the installation to use an external PostgreSQL server that already exists in your deployment.
+{tekton-results} stores data in a PostgreSQL database. By default, the installation includes an internal PostgreSQL instance intended for testing and nonproduction use. The default instance does not provide production-grade capabilities, such as automated backups, performance tuning, storage lifecycle management, or support for database-level modifications through the {pipelines-shortname} Operator.
+
+For production environments or business-critical workloads, you can configure {tekton-results} to connect to an external PostgreSQL-compatible database that is present in your environment.
+
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.21

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-7006

Link to docs preview:
- [Configuring an external database server](https://103269--ocpdocs-pr.netlify.app/openshift-pipelines/latest/records/using-tekton-results-for-openshift-pipelines-observability.html#results-db_using-tekton-results-for-openshift-pipelines-observability)

QE review:
- [x] QE has approved this change.
