### PR TITLE
OSDOCS-17516 created zstream RNs for 4-17-45

### DIFF
--- a/modules/zstream-4-17-44-about.adoc
+++ b/modules/zstream-4-17-44-about.adoc
@@ -2,7 +2,7 @@
 //
 // * release_notes/ocp-4-17-release-notes.adoc
 
-:_mod-docs-content-type: REFERENCE
+:_mod-docs-content-type: CONCEPT
 [id="zstream-4-17-44-about_{context}"]
 = RHBA-2025:21225 - {product-title} {product-version}.44 bug fix advisory
 

--- a/modules/zstream-4-17-45-about.adoc
+++ b/modules/zstream-4-17-45-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-17-45-about_{context}"]
+= RHBA-2025:22266 - {product-title} {product-version}.45 bug fix advisory
+
+[role="_abstract"]
+Issued: 3 December 2025
+
+{product-title} release {product-version}.45 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:22266[RHBA-2025:22266] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:22264[RHBA-2025:22264] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.45--pullspecs
+----

--- a/modules/zstream-4-17-45-bug-fixes.adoc
+++ b/modules/zstream-4-17-45-bug-fixes.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-45-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bugs are fixed for this release:
+
+* Before this update, URLs passed to the `AlertmanagerConfig` receiver, specifically for Slack and Discord configurations, were not validated. With this release, URL validation is implemented, ensuring that only valid URLs are accepted and invalid ones are rejected. (link:https://issues.redhat.com/browse/OCPBUGS-58408[OCPBUGS-58408])
+
+* Before this update, a Kube State Metrics (KSM) deny-list had typographical errors as demonstrated in the following example:
++
+[source,terminal,subs="verbatim"]
+----
+--metric-denylist=
+          ^kube_secret_labels$,
+          ^kube_.+_annotations$
+          ^kube_customresource_.+_annotations_info$,
+          ^kube_customresource_.+_labels_info$,
+----
++
+With this release, a missing comma is now included as shown in the following example:
++
+[source,terminal,subs="verbatim"]
+----
+--metric-denylist=
+          ^kube_secret_labels$,
+          ^kube_.+_annotations$,
+          ^kube_customresource_.+_annotations_info$,
+          ^kube_customresource_.+_labels_info$,
+----
++
+As a result, the entries are correctly separated. (link:https://issues.redhat.com/browse/OCPBUGS-64580[OCPBUGS-64580])
+
+* Before this update, the `must-gather` pod could be scheduled on a node marked with a `NotReady` taint, resulting in deployment to an unavailable node and subsequent log collection failures. With this release, the scheduler now accounts for node taints and automatically applies a node selector to the pod specification. This change ensures that `must-gather` pods are not scheduled on tainted nodes, thereby preventing log collection failures. (link:https://issues.redhat.com/browse/OCPBUGS-64615[OCPBUGS-64615])
+
+* Before this update, during failover, the system's duplicate address detection (DAD) could incorrectly disable the Egress IPv6 address if it was briefly present on both nodes, breaking the connection. With this release, the Egress IPv6 is configured to skip the DAD check during failover, guaranteeing uninterrupted egress IPv6 traffic after an Egress IP address successfully moves to a different node. As a result, greater network stability is ensured. (link:https://issues.redhat.com/browse/OCPBUGS-64674[OCPBUGS-64674])
+
+* Before this update, the *Observe -> Metric* page used the cluster-wide metrics API even when you did not have cluster-wide metrics API permissions. As a consequence, the query input showed an error and the autocomplete for the query input did not work without cluster-wide metrics API access. With this release, the `namespace-tenancy` metrics API is used if you do not have cluster-wide metrics API permissions, As a result, an error does not occur and autocomplete is available for the metrics within the selected namespace. (link:https://issues.redhat.com/browse/OCPBUGS-64942[OCPBUGS-64942])
+
+* Before this update, the `ccoctl` utility did not support pagination when retrieving `CloudFront` distributions. As a result, if the distribution to be deleted was not included in the first batch of results, the `CloudFront` distribution and its associated origin access identity could not be deleted successfully during the `ccoctl` {aws-first} delete operation. With this release, pagination support is added to the `ccoctl` utility when fetching `CloudFront` distributions, ensuring that the distribution can be located and deleted properly. (link:https://issues.redhat.com/browse/OCPBUGS-65480[OCPBUGS-65480])
+
+* Before this update, a regression in `runc` prevented pods which had the `shareProcessNamespace` object set to `true` from running properly. With this release, the regression has been corrected. As a result, the underlying issue is resolved, and pods using the `shareProcessNamespace` object can now start and function as expected. (link:https://issues.redhat.com/browse/OCPBUGS-65977[OCPBUGS-65977])

--- a/modules/zstream-4-17-45-updating.adoc
+++ b/modules/zstream-4-17-45-updating.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-45-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2942,6 +2942,16 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//  4.17.45 about
+include::modules/zstream-4-17-45-about.adoc[leveloffset=+2]
+
+//4.17.45 bug fixes
+include::modules/zstream-4-17-45-bug-fixes.adoc[leveloffset=+2]
+
+//4.17.45 bug fixes
+include::modules/zstream-4-17-45-updating.adoc[leveloffset=+2]
+
+
 //  4.17.44 about
 include::modules/zstream-4-17-44-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-17516

Link to docs preview:
https://103272--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#zstream-4-17-45-about_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
These z-stream RNs are in a new modular format to prepare for DITA migration. Also, there is an xref error below. Ignore that error as it was decided that a special exception would be made for release notes.

To find the Image and RPM IDs, select the following links:

For the Image ID: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/257/diffs#df8b0412da08afb74958c049fedaa9baf10e6886

For the RPM ID: https://errata.devel.redhat.com/advisory/156642

Must be on VPN to view these links.
