### PR TITLE
OSDOCS-17451 [NETOBSERV] Module short descriptions for installing-operators.adoc

### DIFF
--- a/modules/network-observability-kafka-option.adoc
+++ b/modules/network-observability-kafka-option.adoc
@@ -6,7 +6,10 @@
 [id="network-observability-kafka-option_{context}"]
 = Installing Kafka (optional)
 
-The Kafka Operator is supported for large scale environments. Kafka provides high-throughput and low-latency data feeds for forwarding network flow data in a more resilient, scalable way. You can install the Kafka Operator as link:https://access.redhat.com/documentation/en-us/red_hat_amq_streams/2.2[Red Hat AMQ Streams] from the Operator Hub, just as the {loki-op} and Network Observability Operator were installed. Refer to "Configuring the FlowCollector resource with Kafka" to configure Kafka as a storage option.
+[role="_abstract"]
+The Kafka Operator is supported for large-scale environments. Kafka provides high-throughput and low-latency data feeds for forwarding network flow data in a more resilient, scalable way.
+
+You can install the Kafka Operator as link:https://access.redhat.com/documentation/en-us/red_hat_amq_streams/2.2[Red Hat AMQ Streams] from the Operator Hub, just as the {loki-op} and Network Observability Operator were installed. Refer to "Configuring the FlowCollector resource with Kafka" to configure Kafka as a storage option.
 
 [NOTE]
 ====

--- a/modules/network-observability-loki-install.adoc
+++ b/modules/network-observability-loki-install.adoc
@@ -6,7 +6,10 @@
 [id="network-observability-loki-installation_{context}"]
 = Installing the {loki-op}
 
-The link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel9-operator/64479927e1820602a81cdf13[{loki-op} versions 6.0+] are the supported {loki-op} versions for Network Observability; these versions provide the ability to create a `LokiStack` instance using the `openshift-network` tenant configuration mode and provide fully-automatic, in-cluster authentication and authorization support for Network Observability. There are several ways you can install Loki. One way is by using the {product-title} web console Operator Hub.
+[role="_abstract"]
+Install the supported {loki-op} version from the software catalog to enable the secure `LokiStack` instance, which provides automatic in-cluster authentication and authorization for network observability.
+
+The link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel9-operator/64479927e1820602a81cdf13[{loki-op} versions 6.0+] are the supported {loki-op} versions for network observability; these versions provide the ability to create a `LokiStack` instance using the `openshift-network` tenant configuration mode and provide fully-automatic, in-cluster authentication and authorization support for network observability.
 
 .Prerequisites
 

--- a/modules/network-observability-loki-secret.adoc
+++ b/modules/network-observability-loki-secret.adoc
@@ -6,7 +6,12 @@
 [id="network-observability-loki-secret_{context}"]
 = Creating a secret for Loki storage
 
+[role="_abstract"]
+Create a secret with cloud storage credentials, such as for {aws-first}, to allow the Loki Operator to access the necessary object store for log persistence.
+
 The {loki-op} supports a few log storage options, such as AWS S3, {gcp-full} Storage, Azure, Swift, Minio, {rh-storage}. The following example shows how to create a secret for AWS S3 storage. The secret created in this example, `loki-s3`, is referenced in "Creating a LokiStack custom resource". You can create this secret in the web console or CLI.
+
+.Procedure
 
 . Using the web console, navigate to the *Project* -> *All Projects* dropdown and select *Create Project*.
 . Name the project `netobserv` and click *Create*.

--- a/modules/network-observability-lokistack-create.adoc
+++ b/modules/network-observability-lokistack-create.adoc
@@ -6,7 +6,10 @@
 [id="network-observability-lokistack-create_{context}"]
 = Creating a LokiStack custom resource
 
-You can deploy a `LokiStack` custom resource (CR) by using the web console or {oc-first} to create a namespace, or new project.
+[role="_abstract"]
+Deploy the `LokiStack` custom resource using the web console or {oc-first}, ensuring you configure the correct namespace, deployment size, and secret name for Loki object storage.
+
+You can deploy a `LokiStack` custom resource (CR) to create a namespace or new project.
 
 .Procedure
 

--- a/modules/network-observability-lokistack-ingestion-query.adoc
+++ b/modules/network-observability-lokistack-ingestion-query.adoc
@@ -5,7 +5,8 @@
 [id="network-observability-lokistack-configuring-ingestion_{context}"]
 = LokiStack ingestion limits and health alerts
 
-The LokiStack instance comes with default settings according to the configured size. It is possible to override some of these settings, such as the ingestion and query limits. An automatic alert in the web console notifies you when these limits are reached.
+[role="_abstract"]
+The `LokiStack` instance includes default ingestion and query limits that can be overridden by administrators to manage performance and prevent system alerts or errors.
 
 [NOTE]
 ====

--- a/modules/network-observability-multitenancy.adoc
+++ b/modules/network-observability-multitenancy.adoc
@@ -6,7 +6,10 @@
 [id="network-observability-multi-tenancy_{context}"]
 = Enabling multi-tenancy in network observability
 
-Multi-tenancy in the Network Observability Operator allows and restricts individual user access, or group access, to the flows stored in Loki and or Prometheus. Access is enabled for project administrators. Project administrators who have limited access to some namespaces can access flows for only those namespaces.
+[role="_abstract"]
+Enable multi-tenancy in network observability by configuring cluster roles and namespace roles to grant project administrators and developers granular, restricted access to flows and metrics in Loki and Prometheus.
+
+Access is enabled for project administrators. Project administrators who have limited access to some namespaces can access flows for only those namespaces.
 
 For Developers, multi-tenancy is available for both Loki and Prometheus but requires different access rights.
 

--- a/modules/network-observability-operator-install.adoc
+++ b/modules/network-observability-operator-install.adoc
@@ -6,7 +6,10 @@
 [id="network-observability-operator-installation_{context}"]
 = Installing the Network Observability Operator
 
-You can install the Network Observability Operator using the {product-title} web console Operator Hub. When you install the Operator,  it provides the `FlowCollector` custom resource definition (CRD). You can set specifications in the web console when you create the  `FlowCollector`.
+[role="_abstract"]
+Install the Network Observability Operator and use the setup wizard to create the `FlowCollector` custom resource definition (CRD) to complete the initial configuration.
+
+You can set specifications in the web console when you create the `FlowCollector`.
 
 [IMPORTANT]
 ====

--- a/modules/network-observability-operator-uninstall.adoc
+++ b/modules/network-observability-operator-uninstall.adoc
@@ -6,7 +6,8 @@
 [id="network-observability-operator-uninstall_{context}"]
 = Uninstalling the Network Observability Operator
 
-You can uninstall the Network Observability Operator using the {product-title} web console Operator Hub, working in the *Ecosystem* -> *Installed Operators* area.
+[role="_abstract"]
+Uninstall the Network Observability Operator using the {product-title} web console Operator Hub, working in the *Ecosystem* -> *Installed Operators* area.
 
 .Procedure
 

--- a/modules/network-observability-updating-migrating.adoc
+++ b/modules/network-observability-updating-migrating.adoc
@@ -6,12 +6,13 @@
 [id="network-observability-updating-migrating_{context}"]
 = Migrating removed stored versions of the FlowCollector CRD
 
-Network Observability Operator version 1.6 removes the old and deprecated `v1alpha1` version of the `FlowCollector` API. If you previously installed this version on your cluster, it might still be referenced in the `storedVersion` of the `FlowCollector` CRD, even if it is removed from the etcd store, which blocks the upgrade process. These references need to be manually removed.
+[role="_abstract"]
+Manually remove the deprecated `v1alpha1` version from the `FlowCollector` custom resource definition (CRD) `storedVersion` list to prevent upgrade errors and successfully migrate to Network Observability Operator 1.6.
 
 There are two options to remove stored versions:
 
 . Use the Storage Version Migrator Operator.
-. Uninstall and reinstall the Network Observability Operator, ensuring that the installation is in a clean state. 
+. Uninstall and reinstall the Network Observability Operator, ensuring that the installation is in a clean state.
 
 .Prerequisites
 * You have an older version of the Operator installed, and you want to prepare your cluster to install the latest version of the Operator. Or you have attempted to install the Network Observability Operator 1.6 and run into the error: `Failed risk of data loss updating "flowcollectors.flows.netobserv.io": new CRD removes version v1alpha1 that is listed as a stored version on the existing CRD`.
@@ -35,7 +36,7 @@ metadata:
 spec:
   resource:
     group: flows.netobserv.io
-    resource: flowcollectors 
+    resource: flowcollectors
     version: v1alpha1
 ----
 ... Save the file.
@@ -51,7 +52,7 @@ $ oc apply -f migrate-flowcollector-v1alpha1.yaml
 ----
 $ oc edit crd flowcollectors.flows.netobserv.io
 ----
-.. *Option 2: Reinstall*: Save the Network Observability Operator 1.5 version of the `FlowCollector` CR to a file, for example `flowcollector-1.5.yaml`. 
+.. *Option 2: Reinstall*: Save the Network Observability Operator 1.5 version of the `FlowCollector` CR to a file, for example `flowcollector-1.5.yaml`.
 +
 [source,terminal]
 ----

--- a/modules/network-observability-without-loki.adoc
+++ b/modules/network-observability-without-loki.adoc
@@ -5,7 +5,10 @@
 [id="network-observability-without-loki_{context}"]
 = Network observability without Loki
 
-You can use network observability without Loki by not performing the Loki installation steps and skipping directly to "Installing the Network Observability Operator". If you only want to export flows to a Kafka consumer or IPFIX collector, or you only need dashboard metrics, then you do not need to install Loki or provide storage for Loki. The following table compares available features with and without Loki.
+[role="_abstract"]
+Compare the features available with network observability with and without installing the {loki-op}.
+
+If you only want to export flows to a Kafka consumer or IPFIX collector, or you only need dashboard metrics, then you do not need to install Loki or provide storage for Loki. The following table compares available features with and without Loki.
 
 .Comparison of feature availability with and without Loki
 [options="header"]


### PR DESCRIPTION
[OSDOCS-17451](https://issues.redhat.com//browse/OSDOCS-17451) [NETOBSERV] Module short descriptions for installing-operators.adoc


Version(s):
4.16+ since migration-related

Issue:
https://issues.redhat.com/browse/OSDOCS-17451

Link to docs preview:
Short descriptions have been added to the following modules in the installing-operators.adoc assembly:

* Network observability without Loki: https://103293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-without-loki_network_observability
* Installing the Loki Operator: https://103293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-loki-installation_network_observability
* Creating a secret for Loki storage: https://103293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-loki-secret_network_observability
* Creating a LokiStack custom resource: https://103293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-lokistack-create_network_observability
* LokiStack ingestion limits and health alerts: https://103293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-lokistack-configuring-ingestion_network_observability
* Installing the Network Observability Operator: https://103293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-operator-installation_network_observability
* Enabling multi-tenancy in network observability: https://103293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-multi-tenancy_network_observability
* Migrating removed stored versions of the FlowCollector CRD: https://103293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-updating-migrating_network_observability
* Installing Kafka (optional): https://103293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-kafka-option_network_observability
* Uninstalling the Network Observability Operator: https://103293--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-operator-uninstall_network_observability

QE review:
QE is not required for this PR. This PR adds short descriptions to the network observability modules included in the installing-operators.adoc assembly. 

Additional information:
* The assembly included modules from Logging relating to the Loki Operator. Those have not been updated as they are part of Logging, not network observability.
* Callouts are being handled by a separate PR.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
