### PR TITLE
OSDOCS#17523: Update the z-stream RNs for 4.20.6

### DIFF
--- a/modules/zstream-4-20-6-about.adoc
+++ b/modules/zstream-4-20-6-about.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-20-6-about_{context}"]
+= RHSA-2025:22257 - {product-title} {product-version}.6 bug fix advisory
+
+[role="_abstract"]
+Issued: 02 December 2025
+
+{product-title} release {product-version}.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:22257[RHSA-2025:22257] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:22255[RHSA-2025:22255] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.6 --pullspecs
+----

--- a/modules/zstream-4-20-6-bug-fixes.adoc
+++ b/modules/zstream-4-20-6-bug-fixes.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-6-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bugs are fixed for this release:
+
+* Before this update, the `CloudFront` object distribution was not deleted due to a failed tag-based retrieval, and caused persistence of resources, including the origin access identity. With this release, the `CloudFront` origin access identity is deleted after using the distribution command. As a result, the `CloudFront` object distribution and origin access identity are deleted after using the delete command. (link:https://issues.redhat.com/browse/OCPBUGS-63690[OCPBUGS-63690])
+
+* Before this update, a race condition in the Redfish API power interface caused power operations to fail during simultaneous access. As a consequence, users could not manage power settings. With this release, the race condition in the Redfish API power interface is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-64850[OCPBUGS-64850])
+
+* Before this update, the Ironic API service advertised an inaccessible IP address because there was no accessibility check. As a consequence, the inaccessible Ironic API service caused service unavailability for users. With this release, the advertised IP address for the Ironic API service checks for accessibility. As a result, the advertised IP address for the Ironic API service is reachable. (link:https://issues.redhat.com/browse/OCPBUGS-65519[OCPBUGS-65519])
+
+* Before this update, worker virtual machine (VM) creation failures in the `CentralUSEUAP` hub were due to a hard-coded `platformUpdateDomainCount` parameter in Microsoft Messaging API (MAPI) code. As a consequence, this caused  an incompatible `availability set` configuration and VM creation failures in the {azure-first} `CentralUSEUAP` hub. With this release, the hard-coded `platformUpdateDomainCount` parameter is updated to match the parameter in the `CentralUSEUAP` hub. As a result, worker VMs are created without `availability set` errors. (link:https://issues.redhat.com/browse/OCPBUGS-65708[OCPBUGS-65708])

--- a/modules/zstream-4-20-6-updating.adoc
+++ b/modules/zstream-4-20-6-updating.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-6-updating_{context}"]
+= Updating
+
+
+[role="_abstract"]
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -2977,6 +2977,16 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// About 4-20-6 release notes
+include::modules/zstream-4-20-6-about.adoc[leveloffset=+2]
+
+// 4-20-6 release notes bug fixes
+include::modules/zstream-4-20-6-bug-fixes.adoc[leveloffset=+2]
+
+// 4-20-6 release notes updating
+include::modules/zstream-4-20-6-updating.adoc[leveloffset=+2]
+
+
 // About 4-20-5 release notes
 include::modules/zstream-4-20-5-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-17523](https://issues.redhat.com//browse/OSDOCS-17523)

Link to docs preview:
[4.20.6](https://103298--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-6-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:

- Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/256#3de99c972e921f10598e44251d44e61134c09c02)
- Art [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20)

