### PR TITLE
next-4-rules: adds next 4 dita-vale rules to repo

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -19,16 +19,31 @@ Vale.Avoid = YES
 
 # Enable specifc DITA rules on assemblies
 AsciiDocDITA.AdmonitionTitle = error
-AsciiDocDITA.ThematicBreak = error
-AsciiDocDITA.TableFooter = error
-AsciiDocDITA.PageBreak = error
+AsciiDocDITA.AssemblyContents = error
+AsciiDocDITA.AuthorLine = error
+AsciiDocDITA.BlockTitle = error
+AsciiDocDITA.CalloutList = error
+AsciiDocDITA.ContentType = error
 AsciiDocDITA.DiscreteHeading = error
-AsciiDocDITA.SidebarBlock = error
-AsciiDocDITA.LineBreak = error
-AsciiDocDITA.EquationFormula = error
-AsciiDocDITA.TaskExample = error
+AsciiDocDITA.DocumentID = error
+AsciiDocDITA.DocumentTitle = error
 AsciiDocDITA.EntityReference = error
+AsciiDocDITA.EquationFormula = error
 AsciiDocDITA.ExampleBlock = error
+AsciiDocDITA.LineBreak = error
+AsciiDocDITA.NestedSection = error
+AsciiDocDITA.PageBreak = error
+AsciiDocDITA.RelatedLinks = error
+AsciiDocDITA.ShortDescription = error
+AsciiDocDITA.SidebarBlock = error
+AsciiDocDITA.TableFooter = error
+AsciiDocDITA.TaskContents = error
+AsciiDocDITA.TaskDuplicate = error
+AsciiDocDITA.TaskExample = error
+AsciiDocDITA.TaskSection = error
+AsciiDocDITA.TaskStep = error
+AsciiDocDITA.TaskTitle = error
+AsciiDocDITA.ThematicBreak = error
 
 # Disable module specific rules
 OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO

--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -9,11 +9,14 @@ BasedOnStyles = OpenShiftAsciiDoc, AsciiDoc, RedHat
 
 # Changing severity of a rule both enables and sets it (i.e; = YES)
 AsciiDocDITA.AdmonitionTitle = error
+AsciiDocDITA.AssemblyContents = error
 AsciiDocDITA.AuthorLine = error
 AsciiDocDITA.BlockTitle = error
 AsciiDocDITA.CalloutList = error
 AsciiDocDITA.ContentType = error
 AsciiDocDITA.DiscreteHeading = error
+AsciiDocDITA.DocumentID = error
+AsciiDocDITA.DocumentTitle = error
 AsciiDocDITA.EntityReference = error
 AsciiDocDITA.EquationFormula = error
 AsciiDocDITA.ExampleBlock = error
@@ -24,10 +27,12 @@ AsciiDocDITA.RelatedLinks = error
 AsciiDocDITA.ShortDescription = error
 AsciiDocDITA.SidebarBlock = error
 AsciiDocDITA.TableFooter = error
+AsciiDocDITA.TaskContents = error
 AsciiDocDITA.TaskDuplicate = error
 AsciiDocDITA.TaskExample = error
 AsciiDocDITA.TaskSection = error
 AsciiDocDITA.TaskStep = error
+AsciiDocDITA.TaskTitle = error
 AsciiDocDITA.ThematicBreak = error
 
 # Use local OpenShiftDocs Vocab terms


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-17616

Adds the newest https://github.com/jhradilek/asciidoctor-dita-vale 4 rules to the OpenShift repo.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
