### PR TITLE
OSDOCS-17554 updated modules to comply with DITA

### DIFF
--- a/modules/external-secrets-operator-delete-upstream-operatorconfig.adoc
+++ b/modules/external-secrets-operator-delete-upstream-operatorconfig.adoc
@@ -32,7 +32,7 @@ NAMESPACE             NAME        AGE
 external-secrets      cluster     9m18s
 ----
 
-. Delete the `operatorconfig` by running the following command:
+. Delete the `operatorconfig` custom resrouce (CR) by running the following command:
 +
 [source,terminal]
 ----
@@ -41,7 +41,7 @@ $ oc delete operatorconfig <config_name> -n <operator_namespace>
 
 .Verification
 
-. To verify that the `operatorconfig` is deleted, run the following command:
+. To verify that the `operatorconfig` CR is deleted, run the following command:
 +
 [source,terminal]
 ----

--- a/modules/external-secrets-operator-uninstall-helm.adoc
+++ b/modules/external-secrets-operator-uninstall-helm.adoc
@@ -9,11 +9,17 @@
 [role="_abstract"]
 Remove the community {external-secrets-operator-short} that was installed using Helm. This helps you free up resources and maintain a clean environment for your cluster.
 
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` custom resource (CR).
+
 .Procedure
 
 . Install the {external-secrets-operator}. The `external-secrets-operator` namespace must be null.
 
-. Delete the {external-secrets-short} by running the following command:
+. Delete the {external-secrets-operator-short} by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/external-secrets-operator-uninstall-olm.adoc
+++ b/modules/external-secrets-operator-uninstall-olm.adoc
@@ -10,6 +10,12 @@
 [role="_abstract"]
 Remove the community {external-secrets-operator-short} that was installed by an Operator Lifecycle Manager (OLM) subscription. This helps you free up resources and maintain a clean environment for your cluster.
 
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` CR.
+
 .Procedure
 
 . Find the subscription name by running the following command:

--- a/modules/external-secrets-operator-uninstall-raw-manifests.adoc
+++ b/modules/external-secrets-operator-uninstall-raw-manifests.adoc
@@ -9,6 +9,12 @@
 [role="_abstract"]
 Remove the community {external-secrets-operator-short} that was installed by raw manifests. This helps you free up resources and maintain a clean environment for your cluster.
 
+.Prerequisites
+
+* You must be logged in as a user with the `cluster-admin` role.
+
+* You must have deleted the `operatorconfig` CR.
+
 .Procedure
 
 * To remove the communiity {external-secrets-operator-short} that was installed by raw manifests, run the following command:

--- a/modules/external-secrets-operator-uninstall-upstream-eso.adoc
+++ b/modules/external-secrets-operator-uninstall-upstream-eso.adoc
@@ -2,7 +2,7 @@
 //
 // * security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="external-secrets-operator-uninstall-upstream-eso_{context}"]
 = Uninstalling the community {external-secrets-operator-short}
 
@@ -11,10 +11,5 @@ Uninstall the community {external-secrets-operator-short} to prevent conflicts o
 
 You must uninstall the community {external-secrets-operator-short} to prevent it from being recreated or conflicting with the new one. The steps to uninstall are different based on how the community {external-secrets-operator-short} was installed but the prerequisites are the same for each.
 
-.Prerequisites
-
-* You must be logged in as a user with the `cluster-admin` role.
-
-* You must have deleted the `operatorconfig`.
 
 

--- a/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
+++ b/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="external-secrets-operator-migrate-downstream-upstream"]
-= Migrating from the community {external-secrets-operator-short} to {external-secrets-operator}
+= Migrating from the community External Secrets Operator to the External Secrets Operator for Red Hat OpenShift
 include::_attributes/common-attributes.adoc[]
 :context: external-secrets-operator-migrate-downstream-upstream
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17554

Link to docs preview:
https://103302--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/external_secrets_operator/external-secrets-operator-migrate-downstream-upstream.html


QE review:
- [ ] QE has approved this change.


Additional information:

