### PR TITLE
OCPBUGS-66340: Removed Both OpenShift Logging and Red Hat OpenShift S…

### DIFF
--- a/installing/installing_vsphere/post-install-vsphere-zones-regions-configuration.adoc
+++ b/installing/installing_vsphere/post-install-vsphere-zones-regions-configuration.adoc
@@ -42,7 +42,6 @@ include::modules/vsphere-enabling-multiple-layer2-networks.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../installing/installing_vsphere/upi/installing-vsphere-network-customizations.adoc#installing-vsphere-network-customizations[Installing a cluster on vSphere with network customizations]
-* xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets-production[Creating infrastructure machine sets for production environments]
 * xref:../../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#machineset-creating_creating-machineset-vsphere[Creating a compute machine set]
 
 include::modules/references-regions-zones-infrastructure-vsphere.adoc[leveloffset=+1]

--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -10,18 +10,11 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 You can use infrastructure machine sets to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
 
-In a production deployment, it is recommended that you deploy at least three machine sets to hold infrastructure components. {SMProductName} deploys Elasticsearch, which requires three instances to be installed on different nodes. Each of these nodes can be deployed to different availability zones for high availability. This configuration requires three different machine sets, one for each availability zone. In global Azure regions that do not have multiple availability zones, you can use availability sets to ensure high availability.
-
 include::modules/infrastructure-components.adoc[leveloffset=+1]
 
 For information about infrastructure nodes and which components can run on infrastructure nodes, see the "Red Hat OpenShift control plane and infrastructure nodes" section in the link:https://www.redhat.com/en/resources/openshift-subscription-sizing-guide[OpenShift sizing and subscription guide for enterprise Kubernetes] document.
 
 To create an infrastructure node, you can xref:../machine_management/creating-infrastructure-machinesets.adoc#machineset-creating_creating-infrastructure-machinesets[use a machine set], xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-an-infra-node_creating-infrastructure-machinesets[label the node], or xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infra-machines_creating-infrastructure-machinesets[use a machine config pool].
-
-[id="creating-infrastructure-machinesets-production"]
-== Creating infrastructure machine sets for production environments
-
-In a production deployment, it is recommended that you deploy at least three compute machine sets to hold infrastructure components. {SMProductName} deploys Elasticsearch, which requires three instances to be installed on different nodes. Each of these nodes can be deployed to different availability zones for high availability. A configuration like this requires three different compute machine sets, one for each availability zone. In global Azure regions that do not have multiple availability zones, you can use availability sets to ensure high availability.
 
 [id="creating-infrastructure-machinesets-clouds"]
 === Creating infrastructure machine sets for different clouds

--- a/modules/dr-scenario-cluster-state-issues.adoc
+++ b/modules/dr-scenario-cluster-state-issues.adoc
@@ -8,7 +8,7 @@
 [id="dr-scenario-cluster-state-issues_{context}"]
 = Issues and workarounds for restoring a persistent storage state
 
-If your {product-title} cluster uses persistent storage of any form, a state of the cluster is typically stored outside etcd. It might be an Elasticsearch cluster running in a pod or a database running in a `StatefulSet` object. When you restore from an etcd backup, the status of the workloads in {product-title} is also restored. However, if the etcd snapshot is old, the status might be invalid or outdated.
+If your {product-title} cluster uses persistent storage of any form, a state of the cluster is typically stored outside etcd. When you restore from an etcd backup, the status of the workloads in {product-title} is also restored. However, if the etcd snapshot is old, the status might be invalid or outdated.
 
 [IMPORTANT]
 ====

--- a/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc
+++ b/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc
@@ -11,8 +11,6 @@ include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 You can use infrastructure machine sets to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
 
-In a production deployment, it is recommended that you deploy at least three machine sets to hold infrastructure components. Both OpenShift Logging and {SMProductName} deploy Elasticsearch, which requires three instances to be installed on different nodes. Each of these nodes can be deployed to different availability zones for high availability. This configuration requires three different machine sets, one for each availability zone. In global Azure regions that do not have multiple availability zones, you can use availability sets to ensure high availability.
-
 [NOTE]
 ====
 After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].

--- a/nodes/pods/nodes-pods-vertical-autoscaler.adoc
+++ b/nodes/pods/nodes-pods-vertical-autoscaler.adoc
@@ -41,10 +41,6 @@ include::modules/nodes-pods-vertical-autoscaler-install.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc[leveloffset=+1]
 
-.Additional resources
-
-* xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets-production[Creating infrastructure machine sets]
-
 include::modules/nodes-pods-vertical-autoscaler-using-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-vertical-autoscaler-tuning.adoc[leveloffset=+2]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -241,8 +241,6 @@ include::modules/creating-control-plane-node.adoc[leveloffset=+2]
 
 You can create a compute machine set to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
 
-In a production deployment, it is recommended that you deploy at least three compute machine sets to hold infrastructure components. Both OpenShift Logging and {SMProductName} deploy Elasticsearch, which requires three instances to be installed on different nodes. Each of these nodes can be deployed to different availability zones for high availability. A configuration like this requires three different compute machine sets, one for each availability zone. In global Azure regions that do not have multiple availability zones, you can use availability sets to ensure high availability.
-
 For information on infrastructure nodes and which components can run on infrastructure nodes, see xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets].
 
 To create an infrastructure node, you can xref:../post_installation_configuration/cluster-tasks.adoc#machineset-creating_post-install-cluster-tasks[use a machine set], xref:../post_installation_configuration/cluster-tasks.adoc#creating-an-infra-node_post-install-cluster-tasks[assign a label to the nodes], or xref:../post_installation_configuration/cluster-tasks.adoc#creating-infra-machines_post-install-cluster-tasks[use a machine config pool].


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-66340](https://issues.redhat.com/browse/OCPBUGS-66340)

Link to docs preview:

* [Creating infrastructure machine sets](https://103344--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html)
* [Creating infrastructure nodes](https://103344--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.html)
* [Creating infrastructure machine sets for production environments](https://103344--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html)
* [About using the Vertical Pod Autoscaler Operator](https://103344--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-using-about_nodes-pods-vertical-autoscaler)

Topic map has the following file commented out:

<img width="1087" height="469" alt="Screenshot From 2025-12-03 15-02-16" src="https://github.com/user-attachments/assets/6a08d306-38a2-4ef3-9d73-9041443635f1" />

- [x] SME has approved this change (Francesco Minafra/Jeff Cantrill).
- [x] QE has approved this change (Kabir Bharti/ Anping Li).
