### PR TITLE
OSDOCS#17556: Update the z-stream RNs for 4.13.62

### DIFF
--- a/modules/zstream-4-13-62-about.adoc
+++ b/modules/zstream-4-13-62-about.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-13-62-about_{context}"]
+= RHSA-2025:22284 - {product-title} 4.13.62 bug fix and security update
+
+
+[role="_abstract"]
+Issued: 04 December 2025
+
+
+{product-title} release 4.13.62, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:22284[RHSA-2025:22284] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:22274[RHBA-2025:22274] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.13.62 --pullspecs
+----

--- a/modules/zstream-4-13-62-bug-fixes.adoc
+++ b/modules/zstream-4-13-62-bug-fixes.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-62-bug-fixes_{context}"]
+= Bug fixes
+
+[role=”_abstract”]
+There are no notable bug fixes in this release.

--- a/modules/zstream-4-13-62-updating.adoc
+++ b/modules/zstream-4-13-62-updating.adoc
@@ -1,0 +1,6 @@
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-13-62-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -4632,3 +4632,10 @@ $ oc adm release info 4.13.61 --pullspecs
 [id="ocp-4-13-61-updating_{context}"]
 ==== Updating
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+//4.13.62
+include::modules/zstream-4-13-62-about.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-62-bug-fixes.adoc[leveloffset=+2]
+
+include::modules/zstream-4-13-62-updating.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-17556](https://issues.redhat.com//browse/OSDOCS-17556)

Link to docs preview:
[4.13.62](https://103369--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#zstream-4-13-62-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/260#0d69888c5414df22dcd03c8208dadf0e3ddaf3a3)
Art [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.13)
