### PR TITLE
[RHDEVDOCS-7013] Release notes for Pipelines 1.19.4

### DIFF
--- a/modules/op-release-notes-1-19-4.adoc
+++ b/modules/op-release-notes-1-19-4.adoc
@@ -1,0 +1,60 @@
+// This module is included in the following assemblies:
+// * release_notes/op-release-notes-1-19.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-release-notes-1-19-4_{context}"]
+= Release notes for {pipelines-title} 1.19.4
+
+With this update, {pipelines-title} General Availability (GA) 1.19.4 is available on {OCP} 4.16 and later versions.
+
+[id="fixed-issues-1-19-4_{context}"]
+== Fixed issues
+
+.Pipelines
+
+Git resolver no longer ignores certificates in the cluster custom PKI::
+Before this update, a regression error caused the Git resolver to no longer use the OpenShift Proxy custom-configured PKIs. This prevented the Git resolver from resolving references to a self-hosted Git provider. With this update, the full certificate authority (CA) bundle configured in the OpenShift Proxy is trusted by the system in all components, including the Git resolver.
+
+Operator no longer panics when validating Pipelines with invalid matrix variable substitutions::
+Before this update, a `Pipeline` resource using the `v1beta1` API that included a matrixed task with an invalid variable or result reference caused the Operator validation webhook to panic. This occurred because the `v1beta1` validation logic attempted to resolve malformed result substitutions inside `matrix` parameters, leading to an out-of-range index error and a webhook crash. As a result, `Pipeline` creation failed with an internal error instead of returning a proper validation error. With this update, the validation logic correctly detects invalid result references and rejects `Pipeline` resources with a standard validation error, preventing the Operator from panicking.
+
+
+.Operator
+
+Webhook validation no longer disrupts control-plane namespaces::
+Before this update, the `tekton-operator-proxy-webhook` admission webhook validated all namespaces, including control-plane namespaces (`kube-\*`, `openshift-*`). This behavior could cause webhook certificate issues to affect unrelated system components, such as the Network Operator, during namespace reconciliation. With this update, the webhook excludes control-plane namespaces from validation. This change prevents certificate issues from impacting other cluster operators, keeps the existing certificate renewal logic intact, and improves isolation between Tekton and system components.
+
+
+.{pac}
+
+The revision variable no longer returns the incorrect commit SHA::
+Before this update, the {pac} dynamic variable `revision` returned the SHA of the original commit instead of the latest HEAD merge commit after upgrading to {pipelines-shortname} 1.19. With this update, the `revision` variable always fetches the SHA of the HEAD merge commit as expected.
+
+Bitbucket Data Center no longer incorrectly reports running status for unauthorized users::
+Before this update, when a pull request was opened by an unauthorized user on Bitbucket Data Center, the CI status incorrectly reported the status as `Running` instead of `Pending`. With this update, the status correctly reports `Pending` while awaiting administrator approval.
+
+
+Parser no longer causes false failure reports for non-Tekton resources::
+Before this update, non-Tekton resources stored in the `.tekton` directory caused false-positive failure reports. The parser attempted to unmarshal all files, and when it encountered unrecognized resources (such as `ImageDigestMirrorSet`), it produced errors that led to misleading "PipelineRun failure" comments on otherwise successful pull requests. With this update, the parser correctly ignores unmarshalling errors for **non-Tekton resources**. This prevents unrelated files from triggering false failures, which reduces noise on pull requests.
+
+
+prioritySemaphore implementation no longer stalls concurrent pipeline executions::
+Before this update, flaws in the priority-based semaphore mechanism could cause concurrent pipelines to hang, fail, or behave unpredictably under load. These issues were triggered by incorrect lock handling, access to shared data, and improperly managed queue operations. With this update, the locking model has been strengthened, shared data access is fully synchronized, and queue operations are handled safely. The semaphore mechanism now manages concurrent pipeline execution reliably, avoiding deadlocks, race conditions, and runtime errors.
+
+
+.User interface
+
+Incorrect sorting logic no longer affects PipelineRun duration display::
+Before this update, sorting `PipelineRuns` by duration used a string sort instead of actual duration values, which caused misleading results. With this update, the logic is updated to sort the duration in seconds, using the difference between `status.completionTime` and `status.startTime`.
+
+Task parameters with empty default arrays no longer trigger validation::
+Before this update, a validation check incorrectly triggered for `task` parameters where the default was `['']`. This caused issues in the Pipeline builder UI, such as preventing saving of `Buildah` tasks with the default `BUILD_ARGS` parameter. With this update, the check is removed, and tasks can now save correctly even with empty default arrays.
+
+Console UI no longer incorrectly displays PipelineRun status as cancelling::
+Before this update, when a `PipelineRun` had the status reason `CancelledRunFinally` and included multiple `finally` tasks, a failure in any `finally` task caused the console UI to incorrectly show the `PipelineRun` status as `Cancelling` instead of `Cancelled`. With this update, the issue is fixed.
+
+Pipeline Builder UI no longer displays stale task parameters across namespaces::
+Before this update, the Pipeline Builder UI could show stale or incorrect parameter data for tasks that share the same name across different namespaces. This could cause you to unintentionally save pipelines with invalid configurations, causing potential pipeline failures. With this update, the Pipeline Builder side panel correctly displays the parameters for the task in the selected namespace, matching the data shown in the YAML editor. Cross-namespace task references are now safely resolved, helping to prevent conflicts and ensure consistent, accurate task parameter display.
+
+YAML view in {pipelines-shortname} Console no longer fails to update::
+Before this update, changes made in the YAML editor of the {pipelines-shortname} Console were not properly synchronized. Updating the YAML did not reflect the changes immediately, and the pipeline could only be created after remounting the component or switching views. With this update, the YAML editor now correctly synchronizes changes using the `useEffect` hook, helping you to create pipelines directly from the YAML editor without workarounds.

--- a/release_notes/op-release-notes-1-19.adoc
+++ b/release_notes/op-release-notes-1-19.adoc
@@ -39,3 +39,6 @@ include::modules/op-release-notes-1-19-2.adoc[leveloffset=+1]
 
 // Release notes for Red Hat OpenShift Pipelines 1.19.3 
 include::modules/op-release-notes-1-19-3.adoc[leveloffset=+1]
+
+// Release notes for Red Hat OpenShift Pipelines 1.19.3 
+include::modules/op-release-notes-1-19-4.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- _none for cherry-pick_

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-7013

Link to docs preview:
- [1.19.4 RNs](https://103405--ocpdocs-pr.netlify.app/openshift-pipelines/latest/release_notes/op-release-notes-1-19.html#op-release-notes-1-19-4_op-release-notes)

QE review:
- [x] QE has approved this change.
