### PR TITLE
OBSDOCS-2909 Fix oversized refresh image

### DIFF
--- a/modules/coo-troubleshooting-ui-plugin-using.adoc
+++ b/modules/coo-troubleshooting-ui-plugin-using.adoc
@@ -45,7 +45,7 @@ image::coo-troubleshooting-panel-link.png[Open panel]
 image::coo-troubleshooting-panel-graph.png[Troubleshooting Panel]
 +
 .. Click **Focus** to re-calculate the graph from the main console at any time.
-.. Click {sync} to refresh the graph that is currently displayed.
+.. Click the refresh icon to update the graph that is currently displayed.
 .. The root (top) node represents the resource in the main console window.
 .. First-degree neighbors are directly related to the initial resource.
 .. Second-degree neighbors are indirectly related via first-degree neighbors.


### PR DESCRIPTION

Version(s):
standalone-coo-docs-1-latest

Issue:
[OBSDOCS-2909](https://issues.redhat.com//browse/OBSDOCS-2909)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
