### PR TITLE
OBSDOCS-2911 Add docinfo for OTEL standalone

### DIFF
--- a/about/docinfo.xml
+++ b/about/docinfo.xml
@@ -1,0 +1,11 @@
+<title>About Red Hat build of OpenTelemetry</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Understanding the OpenTelemetry Collector architecture and features</subtitle>
+<abstract>
+    <para>This document provides an overview of Red Hat build of OpenTelemetry, including the OpenTelemetry Collector for unified telemetry data collection and processing. Learn about deploying and managing the Collector, workload instrumentation capabilities, and use cases for metrics, traces, and logs in cloud-native environments.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/config-collector-metrics/docinfo.xml
+++ b/config-collector-metrics/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Configuring the Collector metrics</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Monitoring OpenTelemetry Collector performance and resource usage</subtitle>
+<abstract>
+    <para>This document describes how to configure and monitor the OpenTelemetry Collector's internal metrics. Learn how to enable metrics collection for monitoring Collector performance, including memory usage, CPU utilization, trace and span processing statistics, and dropped telemetry data. Includes configuration for automatic ServiceMonitor and PodMonitor creation, Prometheus integration, and verification procedures using the web console.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/config-instrumentation/docinfo.xml
+++ b/config-instrumentation/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Configuring the instrumentation</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Setting up auto-instrumentation for application telemetry collection</subtitle>
+<abstract>
+    <para>This document describes how to configure OpenTelemetry instrumentation for applications. Learn about auto-instrumentation capabilities that inject telemetry libraries without code changes, configuring the Instrumentation custom resource, and setting up language-specific instrumentation for Go, Java, Node.js, Python, .NET, and Apache HTTP Server. Includes exporter configuration with TLS/mTLS support, SDK environment variables, and multi-container pod scenarios.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/config-monitoring/docinfo.xml
+++ b/config-monitoring/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Configuring metrics for the monitoring stack</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Integrating the OpenTelemetry Collector with Prometheus monitoring</subtitle>
+<abstract>
+    <para>This document describes how to configure metrics integration between the OpenTelemetry Collector and the OpenShift monitoring stack. Learn how to send Collector metrics to Prometheus using ServiceMonitor and PodMonitor custom resources, and how to receive metrics from the in-cluster monitoring stack using the Prometheus receiver. Includes configuration for scraping internal Collector metrics, Prometheus exporter endpoints, RBAC setup, TLS configuration, and accessing the federation endpoint.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/forwarding/docinfo.xml
+++ b/forwarding/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Forwarding telemetry data</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Exporting traces, logs, and metrics to observability backends and cloud platforms</subtitle>
+<abstract>
+    <para>This document describes how to forward telemetry data from the OpenTelemetry Collector to various destinations. Learn how to export traces to TempoStack, logs to LokiStack, and telemetry data to third-party systems. Includes configuration procedures for cloud platform integrations with AWS services (CloudWatch Logs, EMF, X-Ray) and Google Cloud Operations Suite (Cloud Monitoring, Cloud Logging, Cloud Trace). Covers service account setup, RBAC configuration, OTLP protocol usage, and custom Collector deployments.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/installing/docinfo.xml
+++ b/installing/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Installing Red Hat build of OpenTelemetry</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Deploying the OpenTelemetry Operator and Collector instances</subtitle>
+<abstract>
+    <para>This document describes how to install Red Hat build of OpenTelemetry on OpenShift. Learn how to deploy the OpenTelemetry Operator, create namespaces, and configure OpenTelemetry Collector instances using either the web console or the CLI. Includes procedures for setting up RBAC resources and configuring node scheduling options.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/migrating/docinfo.xml
+++ b/migrating/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Migrating to the Red Hat build of OpenTelemetry</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Transitioning from Jaeger to OpenTelemetry for distributed tracing</subtitle>
+<abstract>
+    <para>This document describes how to migrate from Red Hat build of Jaeger to Red Hat build of OpenTelemetry. Learn about two migration approaches: migrating with sidecars by replacing Jaeger Agent sidecars with OpenTelemetry Collector sidecars, and migrating without sidecars using standalone Collector deployments. Includes procedures for configuring the Jaeger receiver to maintain protocol compatibility, setting up service accounts and RBAC permissions, enabling sidecar injection, and updating application tracing endpoints to export traces to TempoStack.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/otel-collector/docinfo.xml
+++ b/otel-collector/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Configuring the Collector</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Setting up telemetry data pipelines with receivers, processors, exporters, connectors, and extensions</subtitle>
+<abstract>
+    <para>This document describes how to configure the OpenTelemetry Collector using custom resource definitions. Learn about configuring receivers to ingest telemetry data, processors to transform and filter data, exporters to send data to monitoring backends, connectors to link pipelines, and extensions to add capabilities like authentication. Includes deployment modes, configuration options, and RBAC setup.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/receiving/docinfo.xml
+++ b/receiving/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Receiving telemetry data</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Connecting instrumented applications and configuring multi-cluster telemetry collection</subtitle>
+<abstract>
+    <para>This document describes how to configure the OpenTelemetry Collector to receive telemetry data from instrumented applications. Learn how to set up multi-cluster telemetry collection by deploying Collectors in edge clusters and forwarding data to a central Collector instance. Includes procedures for certificate management using cert-manager, TLS/mTLS configuration for secure communication, service account and RBAC setup, and integration with TempoStack for trace storage.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/removing/docinfo.xml
+++ b/removing/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Removing the Red Hat build of OpenTelemetry</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Uninstalling Collector instances and the OpenTelemetry Operator</subtitle>
+<abstract>
+    <para>This document describes how to remove Red Hat build of OpenTelemetry from an OpenShift cluster. Learn the proper sequence for removal: shutting down OpenTelemetry pods, removing OpenTelemetryCollector and OpenTelemetryInstrumentation instances, and uninstalling the OpenTelemetry Operator. Includes procedures for removing instances using both the web console Administrator view and the command-line interface, with verification steps to confirm successful removal.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/sending/docinfo.xml
+++ b/sending/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Sending traces, logs, and metrics to the Collector</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Configuring applications to send telemetry data with and without sidecar injection</subtitle>
+<abstract>
+    <para>This document describes how to send traces, logs, and metrics from applications to the OpenTelemetry Collector or TempoStack instance. Learn about two deployment approaches: using sidecar injection for automatic configuration, and manual configuration without sidecars. Includes procedures for setting up service accounts, configuring RBAC permissions, deploying the Collector in different modes, and configuring environment variables for telemetry data export.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/troubleshooting/docinfo.xml
+++ b/troubleshooting/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Troubleshooting the Red Hat build of OpenTelemetry</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Diagnosing and resolving Collector and instrumentation issues</subtitle>
+<abstract>
+    <para>This document provides troubleshooting procedures for the OpenTelemetry Collector and instrumentation. Learn how to collect diagnostic data using must-gather, configure and retrieve Collector logs, expose and monitor internal metrics for data processing, use the debug exporter, and troubleshoot network issues. Includes procedures for diagnosing instrumentation injection problems, verifying pod annotations, checking init-containers, inspecting Operator logs, and resolving telemetry data generation issues.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/updating/docinfo.xml
+++ b/updating/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Upgrading the Red Hat build of OpenTelemetry</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>Managing Operator and Collector version upgrades</subtitle>
+<abstract>
+    <para>This document describes how version upgrades are managed for Red Hat build of OpenTelemetry. Learn about the Operator Lifecycle Manager (OLM) that controls installation, upgrades, and RBAC for the OpenTelemetry Operator. Understand the automatic upgrade process where the Operator upgrades all OpenTelemetryCollector custom resources during startup, reconciles managed instances, and handles upgrade failures with exponential backoff retry mechanisms. Includes information about version synchronization between the Operator and Collector instances.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION

Version(s):
standalone-otel-docs-3.8

Issue:
[OBSDOCS-2911](https://issues.redhat.com//browse/OBSDOCS-2911)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
