### PR TITLE
CNV-62285: Removing vTPM note from Release Notes

### DIFF
--- a/virt/release_notes/virt-4-20-release-notes.adoc
+++ b/virt/release_notes/virt-4-20-release-notes.adoc
@@ -217,9 +217,6 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 // CNV-48348
 * The migration controller in the `virt-handler` pod was redesigned to separate source, target, and VM responsibilities, ensure deterministic completion, and use a unified `VirtualMachineInstance` (VMI) cache. (link:https://issues.redhat.com/browse/CNV-48348[*CNV-48348*])
 
-// CNV-36448
-* Virtual Trusted Platform Module (vTPM) persistence is now enabled by default in VM templates. BitLocker system checks in Windows VMs no longer pass with non-persistent vTPM devices. (link:https://issues.redhat.com/browse/CNV-36448[*CNV-36448*])
-
 // CNV-61740
 * On s390x systems, VMs created from a template with the *Boot from CD* option now boot correctly. CD-ROM devices are attached as SCSI instead of SATA, which is not supported on s390x architecture. (link:https://issues.redhat.com/browse/CNV-61740[*CNV-61740*])
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Removing the vTPM note from the Release Notes and moving to the documentation. The PR for putting the note in the documentation is here: [PR 103007](https://github.com/openshift/openshift-docs/pull/103007).
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20

Issue:
[CNV-62285](https://issues.redhat.com/browse/CNV-62285)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
