### PR TITLE
OLS-2290: Update MCP example to show specifying a header for an MCP server

### DIFF
--- a/modules/ols-enabling-custom-mcp-server.adoc
+++ b/modules/ols-enabling-custom-mcp-server.adoc
@@ -45,27 +45,27 @@ spec:
         timeout: 30
         sseReadTimeout: 10
         headers:
-          - Authorization: Bearer <token>
-          - Content-Type: application/json
-          - Accept: application/json
+          - Authorization: kubernetes <4>        
+          - Authorization1: <name_of_the_secret_containing_the_header_content>
         enableSSE: true
     - name: mcp-server-2
       streamableHTTP:
         url: http://localhost:8080/mcp
-        timeout: 30 <4>
-        sseReadTimeout: 10 <5>
+        timeout: 30 <5>
+        sseReadTimeout: 10 <6>
         headers:
-          - <key1>: <value1> <6>
+          - <key1>: <value1> <7>
           - <key2>: <value2>
-        enableSSE: true <7>
+        enableSSE: true <8>
 ----
 <1> Specifies the MCP server functionality.
 <2> Specifies the name of the MCP server.
 <3> Specifies the URL path that the MCP server uses to communicate.
-<4> Specifies the time that the MCP server has to respond to a query. If the client does not receive a query within the time specified, the MCP server times out. In this example, the timeout is 30 seconds.
-<5> Specifies the amount of time a client waits for new data from a Server-Sent Events (SSE) connection. If the client does not receive data within that time, the client closes the connection.
-<6> Specifies the additional header that the HTTP request sends to the MCP server. 
-<7> When you set `enableSSE` to `true`, the MCP server establishes a one-way channel that the MCP server uses to push updates to the client whenever the server has new information. The default setting is `false`. 
+<4> If you want to pass the kubernetes token in the header, specify a string `kubernetes` instead of the secret name.
+<5> Specifies the time that the MCP server has to respond to a query. If the client does not receive a query within the time specified, the MCP server times out. In this example, the timeout is 30 seconds.
+<6> Specifies the amount of time a client waits for new data from a Server-Sent Events (SSE) connection. If the client does not receive data within that time, the client closes the connection.
+<7> Specifies the additional header that the HTTP request sends to the MCP server. 
+<8> When you set `enableSSE` to `true`, the MCP server establishes a one-way channel that the MCP server uses to push updates to the client whenever the server has new information. The default setting is `false`. 
 
 . Click *Save*. 
 +


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue: https://issues.redhat.com/browse/OLS-2290

Link to docs preview:
https://103442--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-enabling-mcp-server_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
