### PR TITLE
CNV-68588: Document preserve-session flag in release notes

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -62,6 +62,14 @@ With this update, the search interface is enhanced, making it more noticeable an
 +
 link:https://issues.redhat.com/browse/CNV-70130[CNV-70130]
 
+New flag introduced to prevent unintentional VNC disconnects:: A new, optional `--preserve-session` flag has been introduced for VMs. This flag prevents an existing VNC console connection from being disconnected if you attempt to start a new session.
++
+If you attempt to create a second connection to the VNC console by using the `virtctl` CLI when this flag is set, an error is displayed and the connection fails.
++
+If you attempt to create a second connection to the VNC console by using the web console, a warning is displayed, and you are prompted to disconnect the existing session before you create the new session.
++
+link:https://issues.redhat.com/browse/CNV-66115[CNV-66115]
+
 // Monitoring
 
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/CNV-68588

Link to docs preview:
https://103444--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html#virt-4-21-new_virt-4-21-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
