### PR TITLE
OSDOCS#17590:Removed duplicate Compliance table with partial info from OSD service def

### DIFF
--- a/modules/sdpolicy-security.adoc
+++ b/modules/sdpolicy-security.adoc
@@ -56,25 +56,7 @@ $ oc adm policy add-cluster-role-to-group self-provisioner system:authenticated:
 
 [id="regulatory-compliance_{context}"]
 == Regulatory compliance
-{product-title} follows common industry best practices for security and controls. The certifications are outlined in the following table.
-
-.Security and control certifications for {product-title}
-[cols= "3,3,3",options="header"]
-|===
-| Compliance | {product-title} on AWS | {product-title} on {gcp-short}
-
-| HIPAA Qualified | Yes (Only Customer Cloud Subscriptions) | Yes (Only Customer Cloud Subscriptions)
-
-| ISO 27001 | Yes | Yes
-
-| PCI DSS | Yes | Yes
-
-| SOC 2 Type 2 | Yes | Yes
-
-|===
-
-//This table exists in policy-security-regulation-compliance.adoc file also.
-
+See the _Security and control certifications for {product-title}_ table in _Understanding process and security for {product-title}_ for the latest compliance information.
 
 [id="network-security_{context}"]
 == Network security


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17590

Link to docs preview:
[Regulatory compliance](https://103450--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#regulatory-compliance_osd-service-definition)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
