### PR TITLE
OSSM-11616 [Docs update]: adding a new flag and note for IstioCNI Ambient creation

### DIFF
--- a/modules/ossm-installing-istio-ambient-mode.adoc
+++ b/modules/ossm-installing-istio-ambient-mode.adoc
@@ -83,9 +83,13 @@ metadata:
 spec:
   namespace: istio-cni
   profile: ambient
+  values:
+    cni:
+      ambient:
+        reconcileIptablesOnStartup: true
 ----
 +
-Set the `profile` field to `ambient`.
+Set the `spec.profile` field to `ambient` and `spec.values.cni.ambient.reconcileIptablesOnStartup` field to `true`. `reconcileIptablesOnStartup` field enables the `IstioCNI`` agent to detect and fix incompatible iptables rules in already-running ambient pods when the CNI agent starts up, handling scenarios like upgrades or rule drift.
 
 .. Apply the `IstioCNI` CR by running the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Change type: Doc update; update to Ambient IstioCNI creation for 3.2 documentation

Doc JIRA: https://issues.redhat.com/browse/OSSM-11616

Fix Version: [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Link to docs preview:
https://103468--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-istio-ambient-mode.html

OSSM review: @sridhargaddam

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
