### PR TITLE
OSDOCS DRA GA, admin access, priority lists

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2682,7 +2682,7 @@ Topics:
     Distros: openshift-enterprise,openshift-origin
   - Name: Placing pods on specific nodes using node selectors
     File: nodes-pods-node-selectors
-  - Name: Allocating GPUs to pods
+  - Name: Allocating GPUs to pods by using DRA
     File: nodes-pods-allocate-dra
     Distros: openshift-enterprise,openshift-origin
   - Name: Run Once Duration Override Operator

--- a/modules/nodes-pods-allocate-dra-about.adoc
+++ b/modules/nodes-pods-allocate-dra-about.adoc
@@ -4,15 +4,13 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nodes-pods-allocate-dra-about_{context}"]
-= About allocating GPUs to workloads
+= About GPU attributes
 
 // Taken from https://issues.redhat.com/browse/OCPSTRAT-1756
-{attribute-based-full} enables pods to request graphics processing units (GPU) based on specific device attributes. This ensures that each pod receives the exact GPU specifications it requires.
+[role="_abstract"]
+You can use {attribute-based-full} to enable pods to be scheduled on nodes that have specific graphics processing units (GPU). These attributes are advertised to the cluster by using a Dynamic Resource Allocation (DRA) driver, a third-party application that runs on each node in your cluster. 
 
-// Hiding until GA. The driver is not integrated in the TP version. 
-// With the NVIDIA Kubernetes DRA driver integrated into OpenShift,by the NVIDIA GPU Operator with a DRA driver
-
-Attribute-based resource allocation requires that you install a Dynamic Resource Allocation (DRA) driver. A DRA driver is a third-party application that runs on each node in your cluster to interface with the hardware of that node. 
+The DRA driver manages and exposes specialized resources within your cluster by interacting with the underlying hardware and advertising it to the {product-title} control plane. You must install a DRA driver in your cluster. Installation of the DRA driver is beyond the scope of this documentation. Some DRA device drivers can also slice GPU memory, making it available to multiple workloads.
 
 The DRA driver advertises several GPU device attributes that {product-title} can use for precise GPU selection, including the following attributes:
 

--- a/modules/nodes-pods-allocate-dra-configure-about.adoc
+++ b/modules/nodes-pods-allocate-dra-configure-about.adoc
@@ -4,20 +4,21 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="nodes-pods-allocate-dra-configure-about_{context}"]
-= About GPU allocation objects
+= About GPU allocation objects and concepts
 
 // Taken from https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#terminology
-{attribute-based-full} uses the following objects to provide the core graphics processing unit (GPU) allocation functionality. All of these API kinds are included in the `resource.k8s.io/v1beta2` API group.
+[role="_abstract"]
+You can use the following {attribute-based-full} objects and concepts to ensure that a workload is scheduled on a node with the graphics processing unit (GPU) specifications it needs. You should be familiar with these objects before proceeding.
 
 Device class::
-A device class is a category of devices that pods can claim and how to select specific device attributes in claims. Some device drivers contain their own device class. Alternatively, an administrator can create device classes. A device class contains a device selector, which is a link:https://cel.dev/[common expression language (CEL)] expression that must evaluate to true if a device satisfies the request.
+A device class is a category of devices that pods can claim. Some device drivers contain their own device class. Alternatively, an administrator can create device classes. A device class contains a device selector, which is a link:https://cel.dev/[common expression language (CEL)] expression that must evaluate to true if a device satisfies the request.
 +
 The following example `DeviceClass` object selects any device that is managed by the `driver.example.com` device driver:
 +
 .Example device class object
 [source,yaml]
 ----
-apiVersion: resource.k8s.io/v1beta1
+apiVersion: resource.k8s.io/v1
 kind: DeviceClass
 metadata:
   name: example-device-class
@@ -27,41 +28,117 @@ spec:
       expression: |-
         device.driver == "driver.example.com"
 ----
++
+--
+where:
+
+`spec.selectors`:: Specifies a CEL expression for selecting a device.
+--
 
 Resource slice::
-The Dynamic Resource Allocation (DRA) driver on each node creates and manages _resource slices_ in the cluster. A resource slice represents one or more GPU resources that are attached to nodes. When a resource claim is created and used in a pod, {product-title} uses the resource slices to find nodes that have access to the requested resources. After finding an eligible resource slice for the resource claim, the {product-title} scheduler updates the resource claim with the allocation details, allocates resources to the resource claim, and schedules the pod onto a node that can access the resources.
+The DRA driver on each node creates and manages _resource slices_, which describe what resources are available in that cluster. A resource slice represents one or more GPU resources that are attached to nodes. When a resource claim is created and used in a pod, {product-title} uses the resource slices to find nodes that have the requested resources. After finding an eligible resource slice for the resource claim, the {product-title} scheduler updates the resource claim with the allocation details, allocates resources to the resource claim, and schedules the pod onto a node that can access the resources.
++
+.Example resource slice object
+[source,yaml]
+----
+apiVersion: v1
+items:
+- apiVersion: resource.k8s.io/v1
+  kind: ResourceSlice
+# ...
+spec:
+    driver: driver.example.com
+    nodeName: dra-example-driver
+    pool:
+      generation: 0
+      name: dra-example-driver
+      resourceSliceCount: 1
+    devices:
+    - attributes:
+        driverVersion:
+          version: 1.0.0
+        index:
+          int: 0
+        model:
+          string: LATEST-GPU-MODEL
+        uuid:
+          string: gpu-18db0e85-99e9-c746-8531-ffeb86328b39
+      capacity:
+        memory:
+          value: 10Gb
+      name: 2g-10gb
+# ...
+----
++
+--
+where:
+
+`spec.driver`:: Specifies the name of the DRA driver, which you can specify in a device class. 
+
+`spec.devices.attributes`:: Specifies a device that you can allocate by using a resource claim or resource claim template.
+--
 
 Resource claim template::
-Cluster administrators and operators can create a _resource claim template_ to request a GPU from a specific device class. Resource claim templates provide pods with access to separate, similar resources. {product-title} uses a resource claim template to generate a resource claim for the pod. Each resource claim that {product-title} generates from the template is bound to a specific pod. When the pod terminates, {product-title} deletes the corresponding resource claim.
+Cluster administrators and operators can create a _resource claim template_, which describes the GPU resource that a pod requires. The administrator or operator adds the resource claim to a pod specification. {product-title} uses the resource claim template to generate the resource claim for the pod. The {product-title} scheduler then schedules that pod on a node in the cluster that has the requested GPU.  
 +
-The following example resource claim template requests devices in the `example-device-class` device class.
+Each resource claim that {product-title} generates from the template is bound that specific pod. A such, the GPU cannot be used simultaneously by another workload. When the pod terminates, {product-title} deletes the corresponding resource claim.
++
+You must specify either a request for a specific device that the scheduler must meet, or a provide a prioritized list of devices for the scheduler to choose from.
++
+The following example resource claim template contains two sub-requests. Of these sub-requests, only one is selected by the scheduler. The scheduler tries to satisfy the sub-requests in the order in which they are listed. A CEL expression is used inside the sub-request for selecting a device. 
 +
 .Example resource claim template object
 [source,yaml]
 ----
-apiVersion: resource.k8s.io/v1beta1
+apiVersion: resource.k8s.io/v1
 kind: ResourceClaimTemplate
 metadata:
-  namespace: gpu-test1
-  name: gpu-claim-template
+  namespace: gpu-claim
+  name: gpu-devices
 spec:
-# ...
   spec:
     devices:
       requests:
-      - name: gpu
-        deviceClassName: example-device-class
+      - name: req-0
+        firstAvailable:
+        - name: 2g-10gb
+          deviceClassName: example-device-class
+          selectors:
+          - cel:
+              expression: "device.attributes['driver.example.com'].profile == '2g.10gb'"
+        - name: 3g-20gb
+          deviceClassName: example-device-class
+          selectors:
+          - cel:
+              expression: "device.attributes['driver.example.com'].profile == '3g.20gb'"
 ----
++
+--
+where:
+
+`spec.spec.devices.requests`:: Specifies a list of one or more requests for devices. The sub-request must include either `exactly` or `firstAvailable`.
++
+* `exactly`: Specifies a request for one or more identical devices. The devices must match the request exactly for the request to be satisfied. If the requested device is not available, the scheduler cannot create the pod.  
+* `firstAvailable`: Specifies multiple requests for a device, of which only one device needs to be available before the scheduler can create the requesting pod. The scheduler checks the availability of the devices in the order listed and selects the first available device. The scheduler can create the pod if one requested devices is available.
+
+`spec.devices.requests.exactly.deviceClassName` or `spec.devices.requests.firstAvailable.deviceClassName`:: Specifies which device class to use with this request.
+
+`spec.devices.requests.exactly.selectors` or `spec.devices.requests.firstAvailable.selectors`:: Specifies CEL expressions to request specific devices from the specified device class.
+--
 
 Resource claim::
-Admins and operators can create a _resource claim_ to request a GPU from a specific device class. A resource claim differs from a resource claim template by allowing you to share GPUs with multiple pods. Also, resource claims are not deleted when a requesting pod is terminated. 
+Admins and operators can create a _resource claim_, which describes the GPU resource that a pod requires. The administrator or operator adds the resource claim to a pod specification. The {product-title} scheduler then schedules that pod on a node in the cluster that has the requested GPU. 
 +
-The following example resource claim template uses CEL expressions to request specific devices in the `example-device-class` device class that are of a specific size.
+A resource claim can be used in multiple pod specifications, which allows you to share GPUs with multiple workloads. Resource claims are not deleted when a requesting pod is terminated. 
++
+For the device request in a resource claim, you must specify either a list of one or more device requests that the scheduler must meet, or a provide a prioritized list of requests for the scheduler to choose from.
++
+The following example resource claim uses a CEL expression to request one device in the `example-device-class` device class. Here, the `exactly` parameter indicates that a node with the specific requested device must be available before the scheduler can create the pod.
 +
 .Example resource claim object
 [source,yaml]
 ----
-apiVersion: resource.k8s.io/v1beta1
+apiVersion: resource.k8s.io/v1
 kind: ResourceClaim
 metadata:
   namespace: gpu-claim
@@ -69,28 +146,57 @@ metadata:
 spec:
   devices:
     requests:
-    - name: 1g-5gb
-      deviceClassName: example-device-class
-      selectors:
-      - cel:
-          expression: "device.attributes['driver.example.com'].profile == '1g.5gb'"
-    - name: 1g-5gb-2
-      deviceClassName: example-device-class
-      selectors:
-      - cel:
-          expression: "device.attributes['driver.example.com'].profile == '1g.5gb'"
-    - name: 2g-10gb
-      deviceClassName: example-device-class
-      selectors:
-      - cel:
-          expression: "device.attributes['driver.example.com'].profile == '2g.10gb'"
-    - name: 3g-20gb
-      deviceClassName: example-device-class
-      selectors:
-      - cel:
-          expression: "device.attributes['driver.example.com'].profile == '3g.20gb'"
+    - name: req-0
+      exactly:
+        name: 2g-10gb
+        deviceClassName: example-device-class
+        selectors:
+        - cel:
+            expression: "device.attributes['driver.example.com'].profile == '2g.10gb'"
 ----
 
-For more information on configuring resource claims, resource claim templates, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/["Dynamic Resource Allocation"] (Kubernetes documentation).
+Admin access::
+A cluster administrator can gain privileged access to a device that is in use by other users. This enables administrators to perform tasks such as monitoring the health and status of devices while ensuring that users can continue to use these devices with their workloads.
++
+To gain admin access, an administrator must create a resource claim or resource claim template with the `adminAccess: true` parameter in a namespace that includes the `resource.kubernetes.io/admin-access: "true"` label. Non-administrator users cannot access namespaces with this label. 
++
+.Example namespace with admin access label
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    resource.kubernetes.io/admin-access: "true"
+# ...
+----
++
+In the following example, the administrator is granted access to the `2g-10gb` device:
++
+.Example resource claim object with admin access
+[source,yaml]
+----
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: large-black-cat-claim-template
+spec:
+  devices:
+    requests:
+    - name: req-0
+      exactly:
+        allocationMode: All
+        adminAccess: true
+        deviceClassName: example-device-class
+        selectors:
+        - cel:
+            expression: "device.attributes['driver.example.com'].profile == '2g.10gb'"
+----
++
+--
+where:
+
+`spec.devices.requests.exactly.adminAccess.true` or `spec.devices.requests.firstAvailable.adminAccess.true`:: Specifies that the admin access mode is enabled for the specified device.
+--
 
 For information on adding resource claims to pods, see "Adding resource claims to pods".

--- a/modules/nodes-pods-allocate-dra-configure.adoc
+++ b/modules/nodes-pods-allocate-dra-configure.adoc
@@ -6,34 +6,64 @@
 [id="nodes-pods-allocate-dra-configure_{context}"]
 = Adding resource claims to pods
 
-{attribute-based-full} uses resource claims and resource claim templates to allow you to request specific graphics processing units (GPU) for the containers in your pods. Resource claims can be used with multiple containers, but resource claim templates can be used with only one container. For more information, see "About configuring device allocation by using device attributes" in the _Additional Resources_ section.
+[role="_abstract"]
+You can use resource claims and resource claim templates with {attribute-based-full} to allow you to request your workloads to be scheduled on nodes with specific graphics processing units (GPU). 
 
-The example in the following procedure creates a resource claim template to assign a specific GPU to `container0` and a resource claim to share a GPU between `container1` and `container2`.
+Resource claims can be used with multiple pods, but resource claim templates can be used with only one pod. For more information, see "About GPU allocation objects and concepts".
+
+The example in the following procedure creates a resource claim to schedule a pod on a node with the assign a specific GPU to  and a resource claim to share a GPU between `container1` and `container2`.
 
 .Prerequisites
 
 * A Dynamic Resource Allocation (DRA) driver is installed. For more information on DRA, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/["Dynamic Resource Allocation"] (Kubernetes documentation).
-//Remove for TP * The Nvidia GPU Operator is installed. For more information see "Adding Operators to a cluster" in the _Additional Resources_ section.
 * A resource slice has been created.
 * A resource claim and/or resource claim template has been created.
-* You enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`:
 +
-.Example `FeatureGate` CR
+.Example resource claim object
 [source,yaml]
 ----
-apiVersion: config.openshift.io/v1
-kind: FeatureGate
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
 metadata:
-  name: cluster
+  namespace: gpu-claim
+  name: gpu-devices
 spec:
-  featureSet: TechPreviewNoUpgrade <1>
+  devices:
+    requests:
+    - name: req-0
+      exactly:
+        name: 2g-10gb
+        deviceClassName: example-device-class
+        selectors:
+        - cel:
+            expression: "device.attributes['driver.example.com'].profile == '2g.10gb'"
 ----
-<1> Enables the required features.
 +
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
-====
+.Example resource claim template object
+[source,yaml]
+----
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  namespace: gpu-claim
+  name: gpu-devices
+spec:
+  spec:
+    devices:
+      requests:
+      - name: req-0
+        firstAvailable:
+        - name: 2g-10gb
+          deviceClassName: example-device-class
+          selectors:
+          - cel:
+              expression: "device.attributes['driver.example.com'].profile == '2g.10gb'"
+        - name: 3g-20gb
+          deviceClassName: example-device-class
+          selectors:
+          - cel:
+              expression: "device.attributes['driver.example.com'].profile == '3g.20gb'"
+----
 
 .Procedure
 
@@ -56,7 +86,7 @@ spec:
     image: ubuntu:24.04
     command: ["sleep", "9999"]
     resources:
-      claims: <1>
+      claims:
       - name: gpu-claim-template
   - name: container1
     image: ubuntu:24.04
@@ -70,14 +100,20 @@ spec:
     resources:
       claims:
       - name: gpu-claim
-  resourceClaims: <2>
+  resourceClaims:
   - name: gpu-claim-template
-    resourceClaimTemplateName: example-resource-claim-template
+    resourceClaimTemplateName: gpu-devices-template
   - name: gpu-claim
-    resourceClaimName: example-resource-claim
+    resourceClaimName: gpu-devices
 ----
-<1> Specifies one or more resource claims to use with this container.
-<2> Specifies the resource claims that are required for the containers to start. Include an arbitrary name for the resource claim request and the resource claim and/or resource claim template. 
++
+--
+where:
+
+`spec.container.resource.claims`:: Specifies one or more resource claims to use with this container.
+
+`spec.resourceClaims`:: Specifies the resource claims that are required for the containers to start. Include an arbitrary name for the resource claim request and a resource claim, resource claim template, or both. 
+--
 
 . Create the CRD object:
 +

--- a/nodes/pods/nodes-pods-allocate-dra.adoc
+++ b/nodes/pods/nodes-pods-allocate-dra.adoc
@@ -1,20 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 :context: nodes-pods-allocate-dra
 [id="nodes-pods-allocate-dra"]
-= Allocating GPUs to pods
+= Allocating GPUs to pods by using DRA
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
 // Taken from https://issues.redhat.com/browse/OCPSTRAT-1756
 // Naming taken from https://issues.redhat.com/browse/OCPSTRAT-2384. Is this correct?
-{attribute-based-full} enables fine-tuned control over graphics processing unit (GPU) resource allocation in {product-title}, allowing pods to request GPUs based on specific device attributes, including product name, GPU memory capacity, compute capability, vendor name and driver version. These attributes are exposed by a third-party Dynamic Resource Allocation (DRA) driver.
 
-// Hiding until GA. The driver is not integrated in the TP version
-// This attribute-based resource allocation is achieved through the integration of the NVIDIA Kubernetes DRA driver into OpenShift. 
+[role="_abstract"]
+You can use {attribute-based-full} to enable fine-tuned control over graphics processing unit (GPU) resource allocation in {product-title}, allowing pods to request GPUs based on specific device attributes, including product name, GPU memory capacity, compute capability, vendor name and driver version. Having access to these attributes, which are exposed by a third-party Dynamic Resource Allocation (DRA) driver, allows {product-title} to schedule a pod on a node that has the specific devices that the workload needs. 
 
-:FeatureName: {attribute-based-full}
-include::snippets/technology-preview.adoc[]
+This workflow provides significant improvement in the device allocation workflow when compared to device plugins, which require per-container device requests, do not support device sharing, and do not support expression-based device filtering.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
@@ -25,13 +23,4 @@ include::modules/nodes-pods-allocate-dra-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-allocate-dra-configure-about.adoc[leveloffset=+1]
 
-.Next steps
-* xref:../../nodes/pods/nodes-pods-allocate-dra.adoc#nodes-pods-allocate-dra-configure_nodes-pods-allocate-dra[Adding resource claims to pods]
-
 include::modules/nodes-pods-allocate-dra-configure.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-// Hiding until GA link:https://catalog.ngc.nvidia.com/orgs/nvidia/helm-charts/nvidia-dra-driver-gpu?version=25.3.2[NVIDIA DRA Driver for GPUs]
-// Hiding until GA * xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
-* xref:../../nodes/pods/nodes-pods-allocate-dra.adoc#nodes-pods-allocate-dra-configure-about_nodes-pods-allocate-dra[About configuring device allocation by using device attributes]


### PR DESCRIPTION
Promoting the [DRA/Allocating GPUs feature](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/nodes/working-with-pods#nodes-pods-allocate-dra) to GA.

Added information on admin access and priority lists. 
Updated the API from resource.k8s.io/v1beta1 to resource.k8s.io/v1
Added that exactly or firstAvailable is required in the resource claim or template.   
Removed TP references.

[OSDOCS-17427](https://issues.redhat.com/browse/OSDOCS-17427)
[OSDOCS-17430](https://issues.redhat.com/browse/OSDOCS-17430)
[OSDOCS-17431](https://issues.redhat.com/browse/OSDOCS-17431)

Link to docs preview:
[Allocating GPUs to pods by using DRA](https://103484--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-allocate-dra) -- Updated title, various edits, removed TP.
[About GPU attributes](https://103484--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-allocate-dra.html#nodes-pods-allocate-dra-about_nodes-pods-allocate-dra) -- Edits
[About GPU allocation objects and concepts](https://103484--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-allocate-dra.html#nodes-pods-allocate-dra-configure-about_nodes-pods-allocate-dra) --  Various edits. New section "Admin Access"
Adding resource claims to pods -- Removed TP. Added example ResourceClaim. 

QE review:
- [x] QE has approved this change in a [private Slack](https://redhat-internal.slack.com/archives/D06QR9JRFRV/p1768470773552179).
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

