### PR TITLE
OLS-2318: Add resource utilization content to OLS doc

### DIFF
--- a/about/ols-about-openshift-lightspeed.adoc
+++ b/about/ols-about-openshift-lightspeed.adoc
@@ -11,6 +11,7 @@ The following topics provide an overview of {ols-official} and discuss functiona
 include::modules/ols-openshift-lightspeed-overview.adoc[leveloffset=+1]
 include::modules/ols-about-product-coverage.adoc[leveloffset=+2]
 include::modules/ols-openshift-requirements.adoc[leveloffset=+1]
+include::modules/ols-minimum-cluster-resource-requirements.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/ols-minimum-cluster-resource-requirements.adoc
+++ b/modules/ols-minimum-cluster-resource-requirements.adoc
@@ -1,0 +1,36 @@
+// This module is used in the following assemblies:
+
+// * about/ols-about-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-cluster-minimum-resource-requirements_{context}"]
+
+= Cluster resource requirements
+
+[role="_abstract"]
+{ols-long} requires access to the following resources to ensure that the service operates efficiently without affecting other cluster workloads.
+
+[cols="1,1,1,1"]
+|===
+| Component | Minimum CPU (Cores) | Minimum Memory | Maximum Memory
+
+| Application server
+| 0.5 
+| 1 GB
+| 4 Gi
+
+| Postgres database
+| 0.3 
+| 300 Mi
+| 2 Gi
+
+| {ocp-product-title} web console
+| 0.1 
+| 50 Mi
+| 100 Mi
+
+| {ols-long} operator
+| 0.1 
+| 64 Mi
+| 256 Mi
+|===


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue: https://issues.redhat.com/browse/OLS-2318

Link to docs preview:
https://103500--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/about/ols-about-openshift-lightspeed.html#ols-cluster-minimum-resource-requirements_ols-about-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
