### PR TITLE
Fix the order of modules for GCP PD CSI Driver content

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc
@@ -22,13 +22,18 @@ To create CSI-provisioned persistent volumes (PVs) that mount to GCP PD storage 
 * *GCP PD driver*: The driver enables you to create and mount GCP PD PVs.
 //
 +
-GCP PD CSI driver supports the C3 instance type for bare metal and N4 machine series. The C3 instance type and N4 machine series support the hyperdisk-balanced disks.
+GCP PD CSI driver supports the C3 instance type for bare metal and N4 machine series. The C3 instance type and N4 machine series support the hyperdisk-balanced disks. For more information, see Section _C3 instance type for bare metal and N4 machine series_.
+
 ifndef::openshift-dedicated[]
 [NOTE]
 ====
 {product-title} provides automatic migration for the GCE Persistent Disk in-tree volume plugin to its equivalent CSI driver. For more information, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
 ====
 endif::openshift-dedicated[]
+
+include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-gcp-pd-storage-class-ref.adoc[leveloffset=+1]
 
 [id="c3-instance-type-for-bare-metal-and-n4-machine-series"]
 == C3 instance type for bare metal and N4 machine series
@@ -47,10 +52,6 @@ ifndef::openshift-dedicated[]
 === Additional resources
 * xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Installing a cluster on GCP with customizations]
 endif::openshift-dedicated[]
-
-include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
-
-include::modules/persistent-storage-csi-gcp-pd-storage-class-ref.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-gcp-pd-encrypted-pv.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.18+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: Correct the order of modules for a more logical flow in the GCP PD CSI driver area
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://103502--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-gcp-pd.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

@gcharot 
