### PR TITLE
[prow/ci] Address JSON escaping in Vale output template

### DIFF
--- a/.vale/templates/bot-comment-output.tmpl
+++ b/.vale/templates/bot-comment-output.tmpl
@@ -29,7 +29,12 @@
         {{- /* Variables setup */ -}}
         {{- $loc := printf "%d" .Line -}}
         {{- $check := printf "%s" .Check -}}
-        {{- $message := printf "%s" .Message -}}
+        {{- /* Escape special characters for valid JSON */ -}}
+        {{- $message := replace "\\" "\\\\" (printf "%s" .Message) -}}
+        {{- $message = replace "\"" "\\\"" $message -}}
+        {{- $message = replace "\n" "\\n" $message -}}
+        {{- $message = replace "\r" "\\r" $message -}}
+        {{- $message = replace "\t" "\\t" $message -}}
         {{- /* Only add a link for RedHat rule errors */ -}}
         {{- $link := "" -}}
         {{- if contains "RedHat." .Check -}}


### PR DESCRIPTION
I think the recent trouble is due to the Vale output template. Messages that contain double quotes break the JSON output and cause jq to implode.

This is a bit of a stab in the dark at the end of a Friday, though.

Changes to template:
- Backslashes (`\` -> `\\`)
- Double quotes (`"` -> `\"`)
- Newlines, carriage returns, and tabs (do we ever see these? I could reduce change scope.)

@jldohmann Are you able to confirm if this fixes what you were seeing?

As for concerns about rate limiting, I think we could move comment API calls out of the for loop where they live now, but I haven't tested that and I could be wrong. 

This script seems like it's getting a bit hard to maintain--have we considered moving to Python, Ruby, or Node? All seem nicer here, and Ruby + Node are both Octokit languages. 

(Aside: Would also be neat to enable GH Actions in this repo and run some/all CI from there. Aside from a superior maintenance story, that has the potential to speed things up, too. @kalexand-rh) 