### PR TITLE
[monitoring-docs-4.16] OBSDOCS-2915 Release notes - move async updates to separate module

### DIFF
--- a/modules/monitoring-async-updates.adoc
+++ b/modules/monitoring-async-updates.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assembly:
+//
+// * release-notes/monitoring-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="monitoring-asynchronous-errata-updates_{context}"]
+= Asynchronous errata updates
+
+[role="_abstract"]
+Security, fixed issues, and enhancement updates for {ocp} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. This includes updates for the monitoring stack and other components.
+
+For more information about monitoring updates, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/release_notes/ocp-4-16-release-notes#ocp-4-16-asynchronous-errata-updates_release-notes[Asynchronous errata updates].

--- a/release-notes/monitoring-release-notes.adoc
+++ b/release-notes/monitoring-release-notes.adoc
@@ -2,6 +2,7 @@
 include::_attributes/common-attributes.adoc[]
 [id="monitoring-release-notes"]
 = {product-title} release notes
+
 :context: monitoring-release-notes
 
 toc::[]
@@ -17,9 +18,5 @@ include::modules/monitoring-support-version-matrix-for-monitoring-components.ado
 //{ocp} {product-version} monitoring release notes
 include::modules/monitoring-4-16-release-notes.adoc[leveloffset=+1]
 
-[id="monitoring-asynchronous-errata-updates_{context}"]
-== Asynchronous errata updates
-
-Security, fixed issues, and enhancement updates for {ocp} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. This includes updates for the monitoring stack and other components.
-
-For more information about monitoring updates, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/release_notes/ocp-4-16-release-notes#ocp-4-16-asynchronous-errata-updates_release-notes[Asynchronous errata updates].
+//Asynchronous errata updates
+include::modules/monitoring-async-updates.adoc[leveloffset=+1]


### PR DESCRIPTION
manual cherry-pick of https://github.com/openshift/openshift-docs/pull/103447 to 4.16 standalone