### PR TITLE
OSDOCS-17586 created 4-20-7 zstream RNs

### DIFF
--- a/modules/zstream-4-20-7-about.adoc
+++ b/modules/zstream-4-20-7-about.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-20-7-about_{context}"]
+= RHSA-2025:22257 - {product-title} {product-version}.7 bug fix advisory
+
+[role="_abstract"]
+Issued: 09 December 2025
+
+{product-title} release {product-version}.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2025:22770[RHSA-2025:22770] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2025:22768[RHSA-2025:22768] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.7 --pullspecs
+----

--- a/modules/zstream-4-20-7-bug-fixes.adoc
+++ b/modules/zstream-4-20-7-bug-fixes.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-7-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bugs are fixed for this release:
+
+* Before this update, when a `MachineDeployment` was in the process of upgrading its machines and the Cluster Autoscaler was also scaling the `MachineDeployment`, it was possible for the Cluster Autoscaler to remove new machines by scaling down the `MachineDeployment` for under-utilized nodes. With this release, scale down does not occur when a `MachineDeployment` is in the process of upgrading its machines. (link:https://issues.redhat.com/browse/OCPBUGS-63495[OCPBUGS-63495])
+
+* Before this update, the filtering mechanism was not handling the scenario where a range was actually a specific version, which resulted in the system mirroring more Operator versions than requested by the customer. With this release, we have fixed the logic to ignore a range when only one version is required, ensuring that only the specific requested version is mirrored. (link:https://issues.redhat.com/browse/OCPBUGS-64647[OCPBUGS-64647])
+
+* Before this update, the console relied on the full name for user identification, which created potential ambiguity when users shared similar names. With this release, the display logic has been updated to prioritize unique identifiers. As a result, the console now shows the user name instead of the full name as the display name. (link:https://issues.redhat.com/browse/OCPBUGS-65793[OCPBUGS-65793])
+
+* Before this update, when opening a terminal to a running pod, the session disconnected whenever the annotations of the pod changed. With this release, the terminal session no longer disconnects when the annotations are changed. (link:https://issues.redhat.com/browse/OCPBUGS-65900[OCPBUGS-65900])
+
+* Before this update, there were missing unit conversion formulas, which resulted in units displaying as "undefined" when one of the missing formulas was selected. With this release, the missing unit conversion formulas have been added, ensuring that results now show the correct units rather than appearing as "undefined". (link:https://issues.redhat.com/browse/OCPBUGS-65947[OCPBUGS-65947])

--- a/modules/zstream-4-20-7-updating.adoc
+++ b/modules/zstream-4-20-7-updating.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-7-updating_{context}"]
+= Updating
+
+
+[role="_abstract"]
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -2975,6 +2975,16 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// About 4-20-7 release notes
+include::modules/zstream-4-20-7-about.adoc[leveloffset=+2]
+
+// 4-20-7 release notes bug fixes
+include::modules/zstream-4-20-7-bug-fixes.adoc[leveloffset=+2]
+
+// 4-20-7 release notes updating
+include::modules/zstream-4-20-7-updating.adoc[leveloffset=+2]
+
+
 // About 4-20-6 release notes
 include::modules/zstream-4-20-6-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-17586

Link to docs preview:
https://103541--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-7-about_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
These z-stream RNs are in a new modular format to prepare for DITA migration. Also, there is an xref error below. Ignore that error as it was decided that a special exception would be made for release notes.

To find the Image and RPM IDs, select the following links:

For the Image ID: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/266/diffs#7289c45fb2e747c38c13d8b1fa9de32d6b695250

For the RPM ID: https://errata.devel.redhat.com/advisory/156944

Must be on VPN to view these links.
