### PR TITLE
OSDOCAS-17575 created zstream RNs for 4-16-54

### DIFF
--- a/modules/zstream-4-16-54-about.adoc
+++ b/modules/zstream-4-16-54-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-16-54-about_{context}"]
+= RHBA-2025:22725 - {product-title} {product-version}.54 bug fix advisory
+
+
+[role="_abstract"]
+Issued: 10 December 2025
+
+{product-title} release {product-version}.54 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:22725[RHBA-2025:22725] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:22723[RHBA-2025:22723] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.54 --pullspecs
+----

--- a/modules/zstream-4-16-54-bug-fixes.adoc
+++ b/modules/zstream-4-16-54-bug-fixes.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-54-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bugs are fixed for this release:
+
+* Before this update, a Kube State Metrics (KSM) deny-list had typographical errors as demonstrated in the following example:
++
+[source,terminal,subs=""verbatim""]
+----
+--metric-denylist=
+          ^kube_secret_labels$,
+          ^kube_.+_annotations$
+          ^kube_customresource_.+_annotations_info$,
+          ^kube_customresource_.+_labels_info$,
+----
++
+With this release, a missing comma is now included as shown in the following example:
++
+[source,terminal,subs=""verbatim""]
+----
+--metric-denylist=
+          ^kube_secret_labels$,
+          ^kube_.+_annotations$,
+          ^kube_customresource_.+_annotations_info$,
+          ^kube_customresource_.+_labels_info$,
+----
++
+As a result, the entries are correctly separated. (link:https://issues.redhat.com/browse/OCPBUGS-64581[OCPBUGS-64581])
+
+ * Before this update, the `must-gather` pod could be scheduled on a node marked with a `NotReady` taint, resulting in deployment to an unavailable node and subsequent log collection failures. With this release, the scheduler now accounts for node taints and automatically applies a node selector to the pod specification. This change ensures that `must-gather` pods are not scheduled on tainted nodes, thereby preventing log collection failures. (link:https://issues.redhat.com/browse/OCPBUGS-64616[OCPBUGS-64616])
+
+* Before this update, gRPC connection logs were set at a highly verbose log level. This generated an excessive number of messages, which caused the logs to overflow. With this release, the gRPC connection logs have been moved to the V(4) log level. As a result, the logs no longer overflow, as these specific messages are now less verbose by default. (link:https://issues.redhat.com/browse/OCPBUGS-64632[OCPBUGS-64632])
+
+*   Before this update, a regression in `runc` prevented pods which had the `shareProcessNamespace` object set to `true` from running properly. With this release,that regression has been corrected. As a result, the underlying issue is resolved, and pods using the `shareProcessNamespace` object can now start and function as expected. (link:https://issues.redhat.com/browse/OCPBUGS-65978[OCPBUGS-65978])
+
+* Before this update, the Azure Machine API provider attempted to use the default `platformUpdateDomainCount` of 5 even in regions that are restricted to a single fault domain. This caused machine creation to fail for all node types in affected regions because Azure only supports 1 update domain when the fault domain count is 1. With this release, the logic was updated to explicitly set the `platformUpdateDomainCount` to 1 whenever the `platformFaultDomainCount` is determined to be 1. As a result, machine availability sets are created with valid parameter combinations, allowing machines to successfully provision in Azure regions with a single fault domain. (link:https://issues.redhat.com/browse/OCPBUGS-66044[OCPBUGS-66044])

--- a/modules/zstream-4-16-54-updating.adoc
+++ b/modules/zstream-4-16-54-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-54-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3396,6 +3396,15 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// About 4-16-54 release notes
+include::modules/zstream-4-16-54-about.adoc[leveloffset=+2]
+
+// 4-16-54 release notes bug fixes
+include::modules/zstream-4-16-54-bug-fixes.adoc[leveloffset=+2]
+
+// 4-16-54 release notes updating
+include::modules/zstream-4-16-54-updating.adoc[leveloffset=+2]
+
 // About 4-16-53 release notes
 include::modules/zstream-4-16-53-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-17575

Link to docs preview:
https://103561--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-54-about_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
These z-stream RNs are in a new modular format to prepare for DITA migration. Also, there is an xref error below. Ignore that error as it was decided that a special exception would be made for release notes.

To find the Image and RPM IDs, select the following links:

For the Image ID: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/264/diffs#6460d3efa2dddc1ce2306dd02f06cc4439f964ff

For the RPM ID: https://errata.devel.redhat.com/advisory/156901

Must be on VPN to view these links.
