### PR TITLE
Logging is not "A high scale log collection system" is not longer true

### DIFF
--- a/about/cluster-logging-support.adoc
+++ b/about/cluster-logging-support.adoc
@@ -14,7 +14,6 @@ include::snippets/logging-loki-statement-snip.adoc[]
 
 {logging-uc} is not:
 
-* A high scale log collection system
 * Security Information and Event Monitoring (SIEM) compliant
 * A "bring your own" (BYO) log collector configuration
 * Historical or long term log retention or storage


### PR DESCRIPTION
[OBSDOCS-2884](https://issues.redhat.com//browse/OBSDOCS-2884) - Removes A high scale log collection system

Version(s):
standalone-logging-docs-6.0
standalone-logging-docs-6.1
standalone-logging-docs-6.2
standalone-logging-docs-6.3
standalone-logging-docs-6.4

Issue:
https://issues.redhat.com/browse/OBSDOCS-2884

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [N/A] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
