### PR TITLE
OSDOCS-17459 [NETOBSERV] Module short descriptions for understanding-network-observability-operator.adoc

### DIFF
--- a/modules/network-observability-architecture.adoc
+++ b/modules/network-observability-architecture.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-architecture_{context}"]
 = Network Observablity Operator architecture
 
+[role="_abstract"]
+Review the Network Observability Operator architecture, detailing how the `FlowCollector` resource manages the `eBPF agent`, which collects and enriches flows, sending the data to Loki for storage or Prometheus for metrics.
+
 The Network Observability Operator provides the `FlowCollector` API, which is instantiated at installation and configured to reconcile the `eBPF agent`, the `flowlogs-pipeline`, and the `netobserv-plugin` components. Only a single `FlowCollector` per cluster is supported.
 
 The `eBPF agent` runs on each cluster node with some privileges to collect network flows. The `flowlogs-pipeline` receives the network flows data and enriches the data with Kubernetes identifiers. If you choose to use Loki, the `flowlogs-pipeline` sends flow logs data to Loki for storing and indexing. The `netobserv-plugin`, which is a dynamic {product-title} web console plugin, queries Loki to fetch network flows data. Cluster-admins can view the data in the web console.

--- a/modules/nw-network-observability-operator.adoc
+++ b/modules/nw-network-observability-operator.adoc
@@ -5,6 +5,9 @@
 [id="nw-network-observability-operator_{context}"]
 = Viewing statuses
 
+[role="_abstract"]
+View the operational status of the Network Observability Operator by using the `oc get` command to check the `FlowCollector` resource status, as well as the status of the `eBPF agent`, `flowlogs-pipeline`, and console plugin Pods.
+
 The Network Observability Operator provides the Flow Collector API. When a Flow Collector resource is created, it deploys pods and services to create and store network flows in the Loki log store, as well as to display dashboards, metrics, and flows in the {product-title} web console.
 
 .Procedure

--- a/modules/nw-view-status-configuration-network-observability-operator.adoc
+++ b/modules/nw-view-status-configuration-network-observability-operator.adoc
@@ -5,7 +5,8 @@
 [id="nw-status-configuration-network-observability-operator_{context}"]
 = Viewing Network Observability Operator status and configuration
 
-You can inspect the status and view the details of the `FlowCollector` using the `oc describe` command.
+[role="_abstract"]
+Inspect the current status, configuration details, and generated resources of the Network Observability Operator by using the `oc describe flowcollector/cluster` command.
 
 .Procedure
 


### PR DESCRIPTION
[OSDOCS-17459](https://issues.redhat.com//browse/OSDOCS-17459) [NETOBSERV] Module short descriptions for understanding-network-observability-operator.adoc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+ since migration-related. Follow Networking Pod review process.

Issue:
https://issues.redhat.com/browse/OSDOCS-17459

Link to docs preview:
* Viewing statuses: https://103572--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/understanding-network-observability-operator.html#nw-network-observability-operator_nw-network-observability-operator
* Network Observability Operator architecture: https://103572--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/understanding-network-observability-operator.html#network-observability-architecture_nw-network-observability-operator
* Viewing Network Observability Operator status and configuration: https://103572--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/understanding-network-observability-operator.html#nw-status-configuration-network-observability-operator_nw-network-observability-operator

QE review:
QE approval is not required for this PR.

Additional information:
* This PR only adds `[role="_abstract"]`.
* All other migration issues are being addressed in separate Jiras and corresponding PRs.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
