### PR TITLE
OSDOCS-17582 created zstream RNs for 4-18-30

### DIFF
--- a/modules/zstream-4-18-30-about.adoc
+++ b/modules/zstream-4-18-30-about.adoc
@@ -1,0 +1,27 @@
+
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-18-30-about_{context}"]
+= RHBA-2025:22696 - {product-title} {product-version}.30 bug fix and security update
+
+
+[role="_abstract"]
+Issued: 10 December 2025
+
+
+{product-title} release {product-version}.30, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:22696[RHBA-2025:22696] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:22684[RHBA-2025:22694] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.18.30 --pullspecs
+----

--- a/modules/zstream-4-18-30-bug-fixes.adoc
+++ b/modules/zstream-4-18-30-bug-fixes.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-30-bug-fixes_{context}"]
+= Bug fixes
+
+
+[role=”_abstract”]
+The following bugs are fixed with this release:
+
+* Before this update, the `RevisionController` process in core Operators prevented upgrades to new revisions during a cluster upgrade if the `operator.openshift.io/revision-ready` annotation was missing on the latest available revision ConfigMap. With this release, the `RevisionController` process was updated to upgrade to a new revision even if the `operator.openshift.io/revision-ready` annotation is missing. As a result, core Operators can successfully transition to new revisions regardless of the annotation's presence. (link:https://issues.redhat.com/browse/OCPBUGS-58412[OCPBUGS-58412])
+
+* Before this update, if NetworkManager was restarted or crashed on a node with a `br-ex` interface managed by NMState, the node lost network connectivity. With this release, a fallback check in the dispatcher script was added to detect NMState-managed `br-ex` interfaces by checking for the `br-ex-br` bridge ID when the standard `br-ex` bridge ID is not found. As a result, nodes with this interface type do not lose network connectivity when NetworkManager restarts or crashes. (link:https://issues.redhat.com/browse/OCPBUGS-62169[OCPBUGS-62169])
+
+* Before this update, creating a network bond could hide the original MAC addresses of some interfaces, which caused provisioning to fail. With this release, the `ironic-python-agent` now discovers all MAC addresses within a bond, ensuring nodes can be correctly identified and provisioned no matter which MAC address is used for the `BareMetalHost` `bootMACAddress` value. (link:https://issues.redhat.com/browse/OCPBUGS-62456[OCPBUGS-62456])
+
+* Before this update, the Cloud Credential Operator utility (`ccoctl`) did not support pagination when retrieving `CloudFront` distributions. As a result, if the distribution to be deleted was not included in the first batch of results, the `CloudFront` distribution and its associated origin access identity could not be deleted successfully during the `ccoctl` {aws-first} delete operation. With this release, pagination support is added to the `ccoctl` utility when fetching `CloudFront` distributions, ensuring that the distribution can be located and deleted properly. (link:https://issues.redhat.com/browse/OCPBUGS-65479[OCPBUGS-65479])
+
+* Before this update, during the mirror operation, `oc-mirror` inadvertently set the executable flag on some synchronized files that did not contain executable code or scripts, potentially causing unexpected execution. With this release, unintended executable flags have been removed from the synchronized files. As a result, correct file permissions are set, preventing unintended execution of synchronized files. (link:https://issues.redhat.com/browse/OCPBUGS-65510[OCPBUGS-65510])
+
+* Before this update, a race condition in the Redfish Power interface caused power operations to fail during simultaneous access. As a consequence, users were unable to manage power states reliably. With this release, the race condition in the Redfish Power interface has been resolved, ensuring successful power operations. As a result, users can now manage power states reliably. (link:https://issues.redhat.com/browse/OCPBUGS-65573[OCPBUGS-65573])
+
+* Before this update, the Azure Machine API provider attempted to use the default `platformUpdateDomainCount` of 5 even in regions that are restricted to a single fault domain. This caused machine creation to fail for all node types in affected regions because Azure only supports 1 update domain when the fault domain count is 1. With this release, the logic was updated to explicitly set the `platformUpdateDomainCount` to 1 whenever the `platformFaultDomainCount` is determined to be 1. As a result, Machine Availability Sets are created with valid parameter combinations, allowing machines to successfully provision in Azure regions with a single fault domain. (link:https://issues.redhat.com/browse/OCPBUGS-65882[OCPBUGS-65882])
+
+* Before this update, a rounding error caused metrics charts to display gaps even when the underlying data was continuous. With this release, the rounding error has been corrected, ensuring that charts display without gaps when the data is complete. (link:https://issues.redhat.com/browse/OCPBUGS-65958[OCPBUGS-65958])
+
+*  Before this update, a regression in `runc` prevented pods which had the `shareProcessNamespace` object set to `true` from running properly. With this release, that regression has been corrected. As a result, the underlying issue is resolved, and pods using the `shareProcessNamespace` object can now start and function as expected. (link:https://issues.redhat.com/browse/OCPBUGS-65976[OCPBUGS-65976])

--- a/modules/zstream-4-18-30-enhancements.adoc
+++ b/modules/zstream-4-18-30-enhancements.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-30-enhancements_{context}"]
+= Enhancements
+
+[role="_abstract"]
+This release contains the following enhancements:
+
+* The KubeVirt Container Storage Interface (CSI) driver now supports volume expansion. This means that users can now dynamically increase the size of their persistent volumes in their tenant cluster. This capability greatly simplifies storage management, allowing for a more flexible and scalable infrastructure. (link:https://issues.redhat.com/browse/OCPBUGS-61700[OCPBUGS-61700])

--- a/modules/zstream-4-18-30-updating.adoc
+++ b/modules/zstream-4-18-30-updating.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-30-updating_{context}"]
+= Updating
+
+
+[role="_abstract"]
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3058,7 +3058,19 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
- 
+
+// 4.18.30 about
+include::modules/zstream-4-18-30-about.adoc[leveloffset=+2]
+
+// 4.18.30 enhancements
+include::modules/zstream-4-18-30-enhancements.adoc[leveloffset=+2]
+
+// 4.18.30 bug fixes
+include::modules/zstream-4-18-30-bug-fixes.adoc[leveloffset=+2]
+
+// 4.18.30 updating
+include::modules/zstream-4-18-30-updating.adoc[leveloffset=+2]
+
 //4.18.29 about
 include::modules/zstream-4-18-29-about.adoc[leveloffset=+2]
 
@@ -3179,9 +3191,9 @@ $ oc adm release info 4.18.26 --pullspecs
 
 * Before this update, control plane nodes created before OpenShift Container Platform version 4.12 did not include the `node-role.kubernetes.io/control-plane` label. With this release, the Machine Config Operator (MCO) adds the label whenever it uncordons a control plane node. (link:https://issues.redhat.com/browse/OCPBUGS-62321[OCPBUGS-62321])
 
-* Before this update, visiting the `/auth/error` page could display an improper error. With this release, the page renders a proper error message. (link:https://issues.redhat.com/browse/OCPBUGS-62326[OCPBUGS-62326]) 
+* Before this update, visiting the `/auth/error` page could display an improper error. With this release, the page renders a proper error message. (link:https://issues.redhat.com/browse/OCPBUGS-62326[OCPBUGS-62326])
 
-* Before this update, omitting the `--v1` or `--v2` flags when using oc-mirror could lead to inconsistent behavior. With this release, specifying `--v1` or `--v2` is mandatory. (link:https://issues.redhat.com/browse/OCPBUGS-62432[OCPBUGS-62432]) 
+* Before this update, omitting the `--v1` or `--v2` flags when using oc-mirror could lead to inconsistent behavior. With this release, specifying `--v1` or `--v2` is mandatory. (link:https://issues.redhat.com/browse/OCPBUGS-62432[OCPBUGS-62432])
 
 * Before this update, resizing a PVC immediately after creation could fail because the PV was temporarily not found. With this release, you can resize PVCs immediately after creation without errors. (link:https://issues.redhat.com/browse/OCPBUGS-62467[OCPBUGS-62467])
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-17582

Link to docs preview:
https://103591--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#zstream-4-18-30-about_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
These z-stream RNs are in a new modular format to prepare for DITA migration. Also, there is an xref error below. Ignore that error as it was decided that a special exception would be made for release notes.

To find the Image and RPM IDs, select the following links:

For the Image ID: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/263/diffs#0e7d38e3897bc451547199ecf4f3fae18f82a57b

For the RPM ID: https://errata.devel.redhat.com/advisory/156899

Must be on VPN to view these links.
