### PR TITLE
[service-mesh-docs-3.2] [DOCS] OSSM-11427 3.2.1 Release notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.2.0
+:SMProductVersion: 3.2.1
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.10

--- a/install/ossm-supported-platforms-configurations.adoc
+++ b/install/ossm-supported-platforms-configurations.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Before you can install {SMProductName} {SMProductVersion}, you must subscribe to {ocp-product-title} and install {ocp-product-title} in a supported configuration. If you do not have a subscription on your Red Hat account, contact your sales representative for more information.
 
 [id="ossm-supported-platforms_{context}"]
@@ -14,10 +15,10 @@ Before you can install {SMProductName} {SMProductVersion}, you must subscribe to
 The following platform versions support {SMProductShortName} control plane version {SMProductVersion}:
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat OpenShift Container Platform version 4.16 or later
+* Red Hat OpenShift Container Platform version 4.18 or later
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* Red Hat {ocp-product-title} version 4.16 or later
+* Red Hat {ocp-product-title} version 4.18 or later
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * {product-dedicated} version 4
 * Azure Red Hat OpenShift (ARO) version 4

--- a/modules/ossm-release-notes-3-2-1.adoc
+++ b/modules/ossm-release-notes-3-2-1.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-2-1_{context}"]
+= {SMProductName} version 3.2.1
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.2.1 and is supported on {ocp-product-title} 4.18 and later. This release addresses enhancements and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.2.1, see "Service Mesh version support tables".
+
+[id="ossm-enhancements-3-2-1_{context}"]
+== Enhancements
+
+* This enhancement updates Kiali Operator to version 2.17.2.
+
+* This enhancement updates Kiali control plane resource to version 2.4.11.
+
+[id="ossm-fixed-issues-3-2-1_{context}"]
+== Fixed issues
+
+* Before this update, the `ZTunnel` custom resource definition (CRD) version was not updated in the 3.2.0 release, resulting in a `v1alpha1` CRD being deployed. As a consequence, users may encounter compatibility issues with existing `v1alpha1` `ZTunnel` CRD instances in the 3.2.0 release. With this release, the `ZTunnel` CRD has been updated to `v1`. As a result, end users can now use the updated `ZTunnel` CRD `v1`, ensuring compatibility and avoiding confusion in deployments.
++
+link:https://issues.redhat.com/browse/OSSM-11377[OSSM-11377]

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,6 +7,40 @@
 = {SMProduct} supported versions
 
 [role="_abstract"]
+See the following table for information about {SMProduct} 3.2.1 supported versions.
+
+== {SMProduct} 3.2.1 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.2.1
+
+|{SMProduct} `Istio` control plane resource
+|1.27.3
+
+|{ocp-product-title}
+|4.18-4.20
+
+| Envoy proxy
+| 1.35.6
+
+| `IstioCNI` resource
+| 1.27.3
+
+| `Ztunnel` resource
+| 1.27.3
+
+|Kiali Operator
+|2.17.2
+
+|Kiali control plane resource
+|2.4.11
+
+|===
+
 See the following table for information about {SMProduct} 3.2.0 supported versions.
 
 == {SMProduct} 3.2.0 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -14,6 +14,8 @@ toc::[]
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[{ocp-short-name} Operator Life Cycles].
 ====
 
+include::modules/ossm-release-notes-3-2-1.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-2-new-features-enhancements.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-2-known-issues.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 3.2.1 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-11427

Fix Version: [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Doc Previews:

- Release notes: https://103595--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes#ossm-release-3-2-1_ossm-release-notes

- Version support table: https://103595--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-2-1-supported-versions

QE Review: @mkralik3 @ctartici
Peer Review: 