### PR TITLE
[service-mesh-docs-3.1] [DOCS] OSSM-11427 3.1.4 Release notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,7 +17,7 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.1.3
+:SMProductVersion: 3.1.4
 //service mesh v2
 //Update when there is a new 2.6.z release
 :SMv2Version: 2.6.10

--- a/modules/ossm-release-notes-3-1-4.adoc
+++ b/modules/ossm-release-notes-3-1-4.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-1-4_{context}"]
+= {SMProductName} version 3.1.4
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.1.4 and is supported on {ocp-product-title} 4.16 and later. This release addresses enhancements and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.1.4, see "Service Mesh version support tables".
+
+[id="ossm-enhancements-3-1-4_{context}"]
+== Enhancements
+
+* This enhancement updates {istio} to version 1.26.6.
+
+* This enhancement updates Kiali Operator to version 2.17.2.
+
+* This enhancement updates Kiali server to version 2.11.5.
+
+* This enhancement updates Envoy to version 1.34.10.

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,6 +7,36 @@
 = {SMProduct} supported versions
 
 [role="_abstract"]
+See the following table for information about {SMProduct} 3.1.4 supported versions.
+
+== {SMProduct} 3.1.4 supported versions
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.1.4
+
+|{SMProduct} `Istio` control plane resource
+|1.26.6
+
+|{ocp-product-title}
+|4.16-4.20
+
+| Envoy proxy
+| 1.34.10
+
+| `IstioCNI` resource
+| 1.26.6
+
+|Kiali Operator
+|2.17.2
+
+|Kiali control plane resource
+|2.11.5
+
+|===
+
 See the following table for information about {SMProduct} 3.1.3 supported versions.
 
 == {SMProduct} 3.1.3 supported versions

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -13,6 +13,8 @@ The {SMProductName} release notes provide details about new features and enhance
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[{ocp-short-name} Operator Life Cycles].
 ====
 
+include::modules/ossm-release-notes-3-1-4.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-1-3.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-1-2.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 3.1.4 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-11427

Fix Version: [service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

Doc Previews:

- Release notes: https://103596--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes#ossm-release-3-1-4_ossm-release-notes

- Version support table: https://103596--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-1-4-supported-versions

QE Review: @mkralik3 @ctartici 
Peer Review: