### PR TITLE
OSDOCS-17627 [NETOBSERV] Fix 1.10 removed features header

### DIFF
--- a/modules/network-observability-operator-release-notes-1-10-removed-features.adoc
+++ b/modules/network-observability-operator-release-notes-1-10-removed-features.adoc
@@ -3,7 +3,7 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="network-observability-operator-release-notes-1-10-removed-features_{context}"]
-== Network Observability Operator 1.10 removed features
+= Network Observability Operator 1.10 removed features
 
 [role="_abstract"]
 Review the removed features that might affect your use of the Network Observability Operator 1.10 release.

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -26,7 +26,7 @@ include::modules/network-observability-operator-release-notes-1-10-new-features-
 
 include::modules/network-observability-operator-release-notes-1-10-technology-preview-features.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-10-removed-features.adoc[leveloffest=+1]
+include::modules/network-observability-operator-release-notes-1-10-removed-features.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-10-known-issues.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-17627](https://issues.redhat.com//browse/OSDOCS-17627) [NETOBSERV] Fix 1.10 removed features header

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-17627

Link to docs preview:
Network Observability Operator 1.10 removed features: https://103628--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-release-notes-1-10-removed-features_network-observability-operator-release-notes 

QE review:
QE is not required for this PR. This PR fixes a doc formatting issue only.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
