### PR TITLE
OLS-2367: Documentation note about filtering/redaction with introspection

### DIFF
--- a/modules/ols-about-cluster-interaction.adoc
+++ b/modules/ols-about-cluster-interaction.adoc
@@ -9,7 +9,12 @@ The {ols-long} Service uses a large language model (LLM) to generate responses t
 
 The Model Context Protocol (MCP) is an open protocol that standardizes how applications provide context to an LLM. Using the protocol, an MCP server offers a standardized way for an LLM to increase context by requesting and receiving real-time information from external resources.
 
-When you enable cluster interaction, the {ols-long} Operator installs an MCP server. The MCP server provides the {ols-long} Service with access to the {ocp-short-name} API. Through this access, the Service performs read operations to gather more context for the LLM, enabling the service to answer questions about the Kubernetes objects that reside in your {ocp-short-name} cluster.
+[NOTE]
+====
+If you configure filtering or redacting in the `OLSConfig` CR file, and you configure `introspectionEnabled` to enable a Model Context Protocol (MCP) server, any content that the tools return is not filtered and is visible to the LLM.
+====
+
+When you enable cluster interaction, the {ols-long} Operator installs an MCP server. The MCP server provides the {ols-long} Service with access to the {ocp-short-name} API. Through this access, the Service performs read operations to gather more context for the LLM, enabling the Service to generate answers to questions about the Kubernetes objects that reside in your {ocp-short-name} cluster.
 
 [NOTE]
 ====

--- a/modules/ols-filtering-and-redacting-information.adoc
+++ b/modules/ols-filtering-and-redacting-information.adoc
@@ -5,11 +5,18 @@
 [id="ols-filtering-and-redacting-information_{context}"]
 = Filtering and redacting information
 
-You can configure {ols-long} to filter or redact information from being sent to the LLM provider. The following example shows how to modify the `OLSConfig` file to redact IP addresses.   
+Configure {ols-long} to filter or redact sensitive information to prevent the Service sending information to the large language model (LLM) provider. 
 
 [NOTE]
 ====
-You should test your regular expressions against sample data to confirm that they are catching the information you want to filter or redact, and that they are not accidentally catching information you do not want to filter or redact. There are several third-party websites that you can use to test your regular expressions. When using third-party sites, you should practice caution with regards to sharing your private data. Alternatively, you can test the regular expressions locally using Python. In Python, it is possible to design very computationally-expensive regular expressions. Using several complex expressions as query filters can adversely impact the performance of {ols-long}.
+You should test your regular expressions against sample data to confirm that they identify the information you want to filter or redact, and that they do not identify information you want to send to the LLM. There are several third-party websites that you can use to test your regular expressions. When using third-party sites, you should practice caution with regards to sharing your private data. Alternatively, you can test the regular expressions locally using Python. In Python, it is possible to design very computationally-expensive regular expressions. Using several complex expressions as query filters can adversely impact the performance of {ols-long}.
+====
+
+This example shows how to modify the `OLSConfig` custom resource (CR) file to redact IP addresses, but you can also filter or redact other types of sensitive information.   
+
+[NOTE]
+====
+If you configure filtering or redacting in the `OLSConfig` CR file, and you configure `introspectionEnabled` to enable a Model Context Protocol (MCP) server, any content that the tools return is not filtered and is visible to the LLM.
 ====
 
 .Prerequisites
@@ -22,7 +29,7 @@ You should test your regular expressions against sample data to confirm that the
 
 .Procedure
 
-. Modify the `OLSConfig` file and create an entry for each regular expression to filter. The following example redacts IP addresses: 
+. Modify the `OLSConfig` CR file and create an entry for each regular expression to filter. The following example redacts IP addresses: 
 +
 .Example custom resource file
 +


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue: https://issues.redhat.com/browse/OLS-2367

Link to docs preview:
cluster interaction conceptual topic:
https://103658--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#about-cluster-interaction_ols-configuring-openshift-lightspeed

task topic:
https://103658--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-filtering-and-redacting-information_ols-configuring-openshift-lightspeed


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
