### PR TITLE
[enterprise-4.16] OSDOCS-17456 [NETOBSERV] Module short descriptions for Scheduling Resources and Secondary Networks

### DIFF
--- a/modules/network-observability-SRIOV-configuration.adoc
+++ b/modules/network-observability-SRIOV-configuration.adoc
@@ -6,7 +6,10 @@
 [id="network-observability-SR-IOV-config_{context}"]
 = Configuring monitoring for SR-IOV interface traffic
 
-In order to collect traffic from a cluster with a Single Root I/O Virtualization (SR-IOV) device, you must set the `FlowCollector` `spec.agent.ebpf.privileged` field to `true`. Then, the eBPF agent monitors other network namespaces in addition to the host network namespaces, which are monitored by default. When a pod with a virtual functions (VF) interface is created, a new network namespace is created. With `SRIOVNetwork` policy `IPAM` configurations specified, the VF interface is migrated from the host network namespace to the pod network namespace.
+[role="_abstract"]
+Configure the `FlowCollector` resource to monitor traffic on Single Root I/O Virtualization (SR-IOV) device by setting the `spec.agent.ebpf.privileged` field to `true`, which enables the eBPF agent to monitor other network namespaces.
+
+The eBPF agent monitors other network namespaces in addition to the host network namespaces, which are monitored by default. When a pod with a virtual functions (VF) interface is created, a new network namespace is created. With `SRIOVNetwork` policy `IPAM` configurations specified, the VF interface is migrated from the host network namespace to the pod network namespace.
 
 .Prerequisites
 * Access to an {product-title} cluster with a SR-IOV device.

--- a/modules/network-observability-nodes-taints-tolerations.adoc
+++ b/modules/network-observability-nodes-taints-tolerations.adoc
@@ -6,7 +6,10 @@
 [id="network-observability-multi-tenancy_{context}"]
 = Network observability deployment in specific nodes
 
-You can configure the `FlowCollector` to control the deployment of network observability components in specific nodes. The `spec.agent.ebpf.advanced.scheduling`, `spec.processor.advanced.scheduling`, and `spec.consolePlugin.advanced.scheduling` specifications have the following configurable settings:
+[role="_abstract"]
+Configure the `FlowCollector` resource using scheduling specifications, including `NodeSelector`, `Tolerations`, and `Affinity`, to control the deployment of network observability components on specific nodes.
+
+The `spec.agent.ebpf.advanced.scheduling`, `spec.processor.advanced.scheduling`, and `spec.consolePlugin.advanced.scheduling` specifications have the following configurable settings:
 
 * `NodeSelector`
 * `Tolerations`

--- a/modules/network-observability-virtualization-configuration.adoc
+++ b/modules/network-observability-virtualization-configuration.adoc
@@ -6,7 +6,10 @@
 [id="network-observability-virtualization-config_{context}"]
 = Configuring virtual machine (VM) secondary network interfaces for Network Observability
 
-You can observe network traffic on an OpenShift Virtualization setup by identifying eBPF-enriched network flows coming from VMs that are connected to secondary networks, such as through OVN-Kubernetes. Network flows coming from VMs that are connected to the default internal pod network are automatically captured by Network Observability.
+[role="_abstract"]
+Configure the `FlowCollector` to monitor VM secondary network traffic by setting the eBPF agent to `privileged` mode and defining the indexing for secondary networks, enabling the capture and enrichment of flows from {VirtProductName}.
+
+Network flows coming from VMs that are connected to the default internal pod network are automatically captured by network observability.
 
 .Procedure
 . Get information about the virtual machine launcher pod by running the following command. This information is used in Step 5:


### PR DESCRIPTION
Manual cherry-pick: 9a0b19c62d08678271bac3ce258609edf99de343

Original PR: https://github.com/openshift/openshift-docs/pull/103542

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16


QE review:
QE is not required for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
