### PR TITLE
OSDOCS-17628: Kueue 1.2 RNs

### DIFF
--- a/ai_workloads/kueue/release-notes.adoc
+++ b/ai_workloads/kueue/release-notes.adoc
@@ -10,6 +10,8 @@ toc::[]
 
 include::modules/kueue-compatible-environments.adoc[leveloffset=+1]
 
+include::modules/kueue-release-notes-1.2.adoc[leveloffset=+1]
+
 include::modules/kueue-release-notes-1.1.adoc[leveloffset=+1]
 
 include::modules/kueue-release-notes-1.0.1.adoc[leveloffset=+1]

--- a/modules/kueue-release-notes-1.2.adoc
+++ b/modules/kueue-release-notes-1.2.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="release-notes-1.2_{context}"]
+= Release notes for {kueue-name} version 1.2
+
+[role="_abstract"]
+{kueue-name} version 1.2 is a generally available release that is supported on {product-title} versions 4.18 and later. {kueue-name} version 1.2 uses link:https://kueue.sigs.k8s.io/docs/overview/[Kueue] version 0.14.
+
+[id="release-notes-1.2-new-features_{context}"]
+== New features and enhancements
+
+Monitoring of pending workloads::
+{kueue-name} version 1.2 provides the `VisibilityOnDemand` feature to monitor the pipeline of pending jobs in the cluster queue and the local queue, and help users to estimate when their jobs will start. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ai_workloads/red-hat-build-of-kueue#monitoring-pending-workloads.html[Monitoring pending workloads].
+
+[id="release-notes-1.2-fixed-issues_{context}"]
+== Fixed issues
+
+Custom resources are not deleted properly when you uninstall {kueue-name}::
+After you uninstall the {kueue-op} using the *Delete all operand instances for this operator* option in the {product-title} web console, {kueue-name} custom resources were attempted to be deleted. With this release, they are not considered for deletion.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-62254[OCPBUGS-62254])
+
+Documentation error in previous versions of {kueue-name}::
+In link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ai_workloads/red-hat-build-of-kueue#create-kueue-cr_install-kueue[Creating a Kueue custom resource], the optional workload types `Pod`, `Deployment`, `StatefulSet` were omitted. They are now included. 
++
+(link:https://issues.redhat.com/browse/OCPBUGS-62877[OCPBUGS-62877])
+
+{kueue-name} metrics were not being exposed to Prometheus from version 1.1::
+Prometheus was not scraping metrics from the Operator's controller, even though the ServiceMonitor and RBAC resources were successfully created as part of the Operator installation. As a result, none of the Kueue metrics were available in the cluster monitoring stack. 
++
+The metrics service added during the installation was configured with an incorrect port reference, causing Prometheus to fail in scraping metrics from the Kueue endpoint. The port name has been updated with the correct port name.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-63441[OCPBUGS-63441])
+
+
+[id="release-notes-1.2-known-issues_{context}"]
+== Known issues
+
+Reconcile jobs only in opt-in namespaces::
+{product-title} allows reconciliation of `Job` resources that have the `kueue.x-k8s.io/queue-name` label, even if these resources are in namespaces which are not configured to opt in to being managed by {product-title}. This is inconsistent with the behavior for other core integrations like pods, deployments, and stateful sets, which are only reconciled if they are in namespaces which have been configured to opt in to being managed by {product-title} by adding the `kueue.openshift.io/managed=true`.
++
+(link:https://issues.redhat.com/browse/OCPBUGS-58205[OCPBUGS-58205])
+
+`Kueue` CR description reads as "Not available" in the {product-title} web console:: 
+After installing {kueue-name}, in the *Operator details* view, the description for the `Kueue` CR reads as "Not available". This issue does not affect or degrade the {kueue-name} Operator functionality. 
++
+(link:https://issues.redhat.com/browse/OCPBUGS-62185[OCPBUGS-62185])


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-17628

Link to docs preview:
https://103685--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/release-notes.html#release-notes-1.2_release-notes


QE review: @anahas-redhat

    QE has approved this change.

