### PR TITLE
OSDOCS-17630 [NETOBSERV] Revert space between title and attribute include

### DIFF
--- a/observability/network_observability/configuring-operator.adoc
+++ b/observability/network_observability/configuring-operator.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="configuring-network-observability-operators"]
 = Configuring the Network Observability Operator
-
 include::_attributes/common-attributes.adoc[]
 :context: network_observability
 

--- a/observability/network_observability/flowcollector-api.adoc
+++ b/observability/network_observability/flowcollector-api.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="flowcollector-api"]
 = FlowCollector API reference
-
 include::_attributes/common-attributes.adoc[]
 :context: network_observability
 

--- a/observability/network_observability/flowmetric-api.adoc
+++ b/observability/network_observability/flowmetric-api.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="flowmetric-api"]
 = FlowMetric configuration parameters
-
 include::_attributes/common-attributes.adoc[]
 :context: network_observability
 

--- a/observability/network_observability/installing-operators.adoc
+++ b/observability/network_observability/installing-operators.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-network-observability-operators"]
 = Installing the Network Observability Operator
-
 include::_attributes/common-attributes.adoc[]
 :context: network_observability
 

--- a/observability/network_observability/json-flows-format-reference.adoc
+++ b/observability/network_observability/json-flows-format-reference.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="json-flows-format-reference"]
 = Network flows format reference
-
 include::_attributes/common-attributes.adoc[]
 :context: json_reference
 

--- a/observability/network_observability/metrics-alerts-dashboards.adoc
+++ b/observability/network_observability/metrics-alerts-dashboards.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="metrics-dashboards-alerts"]
 = Using metrics with dashboards and alerts
-
 include::_attributes/common-attributes.adoc[]
 :context: metrics-dashboards-alerts
 

--- a/observability/network_observability/netobserv_cli/netobserv-cli-install.adoc
+++ b/observability/network_observability/netobserv_cli/netobserv-cli-install.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="netobserv-cli-install"]
 = Installing the Network Observability CLI
-
 include::_attributes/common-attributes.adoc[]
 :context: netobserv-cli-install
 

--- a/observability/network_observability/netobserv_cli/netobserv-cli-reference.adoc
+++ b/observability/network_observability/netobserv_cli/netobserv-cli-reference.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="netobserv-cli-reference"]
 = Network Observability CLI (oc netobserv) reference
-
 include::_attributes/common-attributes.adoc[]
 :context: netobserv-cli-reference
 

--- a/observability/network_observability/netobserv_cli/netobserv-cli-using.adoc
+++ b/observability/network_observability/netobserv_cli/netobserv-cli-using.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="netobserv-cli-using"]
 = Using the Network Observability CLI
-
 include::_attributes/common-attributes.adoc[]
 :context: netobserv-cli-using
 

--- a/observability/network_observability/network-observability-alerts.adoc
+++ b/observability/network_observability/network-observability-alerts.adoc
@@ -2,7 +2,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-alerts_{context}"]
 = Network observability alerts
-
 :context: network-observability-alerts
 :toc:
 include::_attributes/common-attributes.adoc[]

--- a/observability/network_observability/network-observability-network-policy.adoc
+++ b/observability/network_observability/network-observability-network-policy.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-network-policy"]
 = Network Policy
-
 include::_attributes/common-attributes.adoc[]
 :context: network_observability
 

--- a/observability/network_observability/network-observability-operator-monitoring.adoc
+++ b/observability/network_observability/network-observability-operator-monitoring.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-operator-monitoring"]
 = Monitoring the Network Observability Operator
-
 include::_attributes/common-attributes.adoc[]
 :context: network_observability
 

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -2,7 +2,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-operator-release-notes"]
 = Network Observability Operator release notes
-
 include::_attributes/common-attributes.adoc[]
 :context: network-observability-operator-release-notes
 

--- a/observability/network_observability/network-observability-overview.adoc
+++ b/observability/network_observability/network-observability-overview.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-overview"]
 = About network observability
-
 include::_attributes/common-attributes.adoc[]
 :context: network-observability-overview
 

--- a/observability/network_observability/network-observability-scheduling-resources.adoc
+++ b/observability/network_observability/network-observability-scheduling-resources.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-scheduling-resources"]
 = Scheduling resources
-
 include::_attributes/common-attributes.adoc[]
 :context: network_observability_scheduling
 

--- a/observability/network_observability/network-observability-secondary-networks.adoc
+++ b/observability/network_observability/network-observability-secondary-networks.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-secondary-networks"]
 = Secondary networks
-
 include::_attributes/common-attributes.adoc[]
 :context: network-observability-secondary-networks
 

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="nw-observe-network-traffic"]
 = Observing the network traffic
-
 include::_attributes/common-attributes.adoc[]
 :context: nw-observe-network-traffic
 

--- a/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+++ b/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
@@ -2,7 +2,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="network-observability-operator-release-notes-archive"]
 = Network Observability Operator release notes archive
-
 :context: network-observability-operator-archived-release-notes
 include::_attributes/common-attributes.adoc[]
 

--- a/observability/network_observability/troubleshooting-network-observability.adoc
+++ b/observability/network_observability/troubleshooting-network-observability.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-troubleshooting"]
 = Troubleshooting network observability
-
 include::_attributes/common-attributes.adoc[]
 :context: network-observability-troubleshooting
 

--- a/observability/network_observability/understanding-network-observability-operator.adoc
+++ b/observability/network_observability/understanding-network-observability-operator.adoc
@@ -1,7 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="nw-network-observability-operator"]
 = Network Observability Operator in {product-title}
-
 include::_attributes/common-attributes.adoc[]
 :context: nw-network-observability-operator
 


### PR DESCRIPTION
[OSDOCS-17630](https://issues.redhat.com//browse/OSDOCS-17630) [NETOBSERV] Revert space between title and attribute include

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-17630

Link to docs preview:

Behind-the-scenes change. Fixes the right-hand nav in previews.

- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/configuring-operator.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/flowcollector-api.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/flowmetric-api.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/json-flows-format-reference.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/metrics-alerts-dashboards.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-install.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-reference.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/netobserv_cli/netobserv-cli-using.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-alerts.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-network-policy.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-monitoring.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-overview.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-scheduling-resources.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-secondary-networks.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/observing-network-traffic.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html
- https://103687--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/understanding-network-observability-operator.html

QE review:
QE is not required for this change.

Additional information:
* See comment: https://github.com/openshift/openshift-docs/pull/103628#discussion_r2603237545

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
