### PR TITLE
OSDOCS-17572: adding agent network note

### DIFF
--- a/modules/agent-install-networking.adoc
+++ b/modules/agent-install-networking.adoc
@@ -12,6 +12,12 @@ In an environment without a DHCP server, you can define IP addresses statically.
 
 In addition to static IP addresses, you can apply any network configuration that is in NMState format. This includes VLANs and NIC bonds.
 
+[NOTE]
+====
+By default, Podman uses a subnet of `10.88.0.0/16` as a bridge network.
+Do not set the `network.machineNetwork.cidr` parameter to include this address range, otherwise a conflict causes the cluster installation to fail.
+====
+
 [id="agent-install-networking-DHCP_{context}"]
 == DHCP
 


### PR DESCRIPTION
[OSDOCS-17572](https://issues.redhat.com/browse/OSDOCS-17572)

Version(s): 4.12+

This PR adds a note to the Agent networking docs, warning users not to use a subnet that is already used by Podman.

QE review:
- [x] QE has approved this change.

Preview: [About networking](https://103688--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-install-networking_preparing-to-install-with-agent-based-installer)