### PR TITLE
OSDOCS#17581: Update the z-stream RNs for 4.19.21

### DIFF
--- a/modules/zstream-4-19-21-about.adoc
+++ b/modules/zstream-4-19-21-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-29-21-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-19-21-about_{context}"]
+= RHBA-2025:22786 - {product-title} {product-version}.21 bug fix advisory
+
+[role="_abstract"]
+Issued: 10 December 2025
+
+{product-title} release {product-version}.21 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:22786[RHBA-2025:22786] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:22766[RHBA-2025:22766] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.21 --pullspecs
+----

--- a/modules/zstream-4-19-21-bug-fixes.adoc
+++ b/modules/zstream-4-19-21-bug-fixes.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-21-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+There are no notable bug fixes in this release.

--- a/modules/zstream-4-19-21-updating.adoc
+++ b/modules/zstream-4-19-21-updating.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-21-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2949,6 +2949,16 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// 4.19.21 about
+include::modules/zstream-4-19-21-about.adoc[leveloffset=+2]
+
+// 4.19.21 fixes
+include::modules/zstream-4-19-21-bug-fixes.adoc[leveloffset=+2]
+
+// 4.19.21 updating
+include::modules/zstream-4-19-21-updating.adoc[leveloffset=+2]
+
+
 // 4.19.20 about
 include::modules/zstream-4-19-20-about.adoc[leveloffset=+2]
 
@@ -2957,6 +2967,7 @@ include::modules/zstream-4-19-20-bug-fixes.adoc[leveloffset=+2]
 
 // 4.19.20 updating
 include::modules/zstream-4-19-20-updating.adoc[leveloffset=+2]
+
 
 // 4.19.19 about
 include::modules/zstream-4-19-19-about.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.19

Issue:
[OSDOCS-17581](https://issues.redhat.com//browse/OSDOCS-17581)

Link to docs preview:
[4.19.21](https://103698--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-21-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/268)
Art [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19)
