### PR TITLE
OSDOCS 17046: MACH-6 CQA split CPMS config assemblies

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2444,18 +2444,28 @@ Topics:
   - Name: Configuration options for control plane machines
     Dir: cpmso_provider_configurations
     Topics:
-    - Name: Control plane configuration options for Amazon Web Services
+    - Name: Changing control plane configuration options for Amazon Web Services
       File: cpmso-config-options-aws
-    - Name: Control plane configuration options for Microsoft Azure
+    - Name: Configuring Amazon Web Services features for control plane machines
+      File: cpmso-supported-features-aws
+    - Name: Changing control plane configuration options for Microsoft Azure
       File: cpmso-config-options-azure
-    - Name: Control plane configuration options for Google Cloud
+    - Name: Configuring Microsoft Azure features for control plane machines
+      File: cpmso-supported-features-azure
+    - Name: Changing control plane configuration options for Google Cloud
       File: cpmso-config-options-gcp
-    - Name: Control plane configuration options for Nutanix
+    - Name: Configuring Google Cloud features for control plane machines
+      File: cpmso-supported-features-gcp
+    - Name: Changing control plane configuration options for Nutanix
       File: cpmso-config-options-nutanix
-    - Name: Control plane configuration options for Red Hat OpenStack Platform
+    - Name: Changing control plane configuration options for Red Hat OpenStack Platform
       File: cpmso-config-options-openstack
-    - Name: Control plane configuration options for VMware vSphere
+    - Name: Configuring Red Hat OpenStack Platform features for control plane machines
+      File: cpmso-supported-features-openstack
+    - Name: Changing control plane configuration options for VMware vSphere
       File: cpmso-config-options-vsphere
+    - Name: Configuring VMware vSphere features for control plane machines
+      File: cpmso-supported-features-vsphere
   - Name: Control plane resiliency and recovery
     File: cpmso-resiliency
   - Name: Troubleshooting the control plane machine set

--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc
@@ -47,7 +47,7 @@ include::modules/machine-feature-aws-imds-options.adoc[leveloffset=+2]
 //This link is for a note that does not apply to TP clusters, reassess for Cluster API GA
 [role="_additional-resources"]
 .Additional resources
-* xref:../../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images]
+* xref:../../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Boot image management]
 ////
 
 // Dedicated Instances configuration options

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
@@ -1,58 +1,27 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="cpmso-config-options-aws"]
-= Control plane configuration options for Amazon Web Services
 include::_attributes/common-attributes.adoc[]
+[id="cpmso-config-options-aws"]
+= Changing control plane configuration options for {aws-full}
 :context: cpmso-config-options-aws
 
 toc::[]
 
-You can change the configuration of your {aws-first} control plane machines and enable features by updating values in the control plane machine set.
-When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[update strategy].
+[role="_abstract"]
+You can update your control plane machines to reflect changes in your infrastructure or environment by editing values in the control plane machine set specification.
 
-[id="cpmso-sample-yaml-aws_{context}"]
-== Sample YAML for configuring {aws-full} clusters
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
 
 The following example YAML snippets show provider specification and failure domain configurations for an {aws-short} cluster.
 
 //Sample AWS provider specification
-include::modules/cpmso-yaml-provider-spec-aws.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-provider-spec-aws.adoc[leveloffset=+1]
 
 //Sample AWS failure domain configuration
-include::modules/cpmso-yaml-failure-domain-aws.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-failure-domain-aws.adoc[leveloffset=+1]
 
-[id="cpmso-supported-features-aws_{context}"]
-== Enabling {aws-full} features for control plane machines
-
-You can enable features by updating values in the control plane machine set.
-
-//Restricting the API server to private (AWS control plane machine set version)
-include::modules/private-clusters-setting-api-private.adoc[leveloffset=+2]
-
+[id="additional-resources_{context}"]
 [role="_additional-resources"]
-.Additional resources
-* xref:../../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/nw-configuring-ingress-controller-endpoint-publishing-strategy.adoc#nw-ingresscontroller-change-internal_nw-configuring-ingress-controller-endpoint-publishing-strategy[Configuring the Ingress Controller endpoint publishing scope to Internal]
-
-//Selecting a larger Amazon Web Services instance type for control plane machines
-include::modules/cpms-changing-aws-instance-type.adoc[leveloffset=+2]
-
-//Assigning machines to placement groups by using machine sets
-include::modules/machineset-aws-existing-placement-group.adoc[leveloffset=+2]
-
-//Machine sets that enable the Amazon EC2 Instance Metadata Service
-include::modules/machineset-imds-options.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images]
-
-//Creating machines that use the Amazon EC2 Instance Metadata Service
-include::modules/machineset-creating-imds-options.adoc[leveloffset=+3]
-
-//Machine sets that deploy machines as Dedicated Instances
-include::modules/machineset-dedicated-instances.adoc[leveloffset=+2]
-
-//Creating Dedicated Instances by using machine sets
-include::modules/machineset-creating-dedicated-instances.adoc[leveloffset=+3]
-
-//Configuring Capacity Reservation by using machine sets
-include::modules/machineset-capacity-reservation.adoc[leveloffset=+2,tag=!compute]
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.adoc#cpmso-supported-features-aws[Configuring {aws-full} features for control plane machines]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
@@ -1,74 +1,27 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="cpmso-config-options-azure"]
-= Control plane configuration options for Microsoft Azure
 include::_attributes/common-attributes.adoc[]
+[id="cpmso-config-options-azure"]
+= Changing control plane configuration options for {azure-full}
 :context: cpmso-config-options-azure
 
 toc::[]
 
-You can change the configuration of your {azure-first} control plane machines and enable features by updating values in the control plane machine set.
-When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[update strategy].
+[role="_abstract"]
+You can update your control plane machines to reflect changes in your infrastructure or environment by editing values in the control plane machine set specification.
 
-[id="cpmso-sample-yaml-azure_{context}"]
-== Sample YAML for configuring {azure-full} clusters
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
 
 The following example YAML snippets show provider specification and failure domain configurations for an {azure-short} cluster.
 
 //Sample Azure provider specification
-include::modules/cpmso-yaml-provider-spec-azure.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-provider-spec-azure.adoc[leveloffset=+1]
 
 //Sample Azure failure domain configuration
-include::modules/cpmso-yaml-failure-domain-azure.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-failure-domain-azure.adoc[leveloffset=+1]
 
-[id="cpmso-supported-features-azure_{context}"]
-== Enabling {azure-full} features for control plane machines
-
-You can enable features by updating values in the control plane machine set.
-
-include::modules/private-clusters-setting-api-private.adoc[leveloffset=+2]
-
+[id="additional-resources_{context}"]
 [role="_additional-resources"]
-.Additional resources
-* xref:../../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/nw-configuring-ingress-controller-endpoint-publishing-strategy.adoc#nw-ingresscontroller-change-internal_nw-configuring-ingress-controller-endpoint-publishing-strategy[Configuring the Ingress Controller endpoint publishing scope to Internal]
-
-//Using the Azure Marketplace offering
-include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+2]
-
-//Enabling Azure boot diagnostics
-include::modules/machineset-azure-boot-diagnostics.adoc[leveloffset=+2]
-
-//Machine sets that deploy machines on ultra disks as data disks
-include::modules/machineset-azure-ultra-disk.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* link:https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#ultra-disks[{azure-full} ultra disks documentation]
-
-//Creating machines on ultra disks by using machine sets
-include::modules/machineset-creating-azure-ultra-disk.adoc[leveloffset=+3]
-
-//Troubleshooting resources for machine sets that enable ultra disks
-include::modules/machineset-troubleshooting-azure-ultra-disk.adoc[leveloffset=+3]
-
-//Enabling customer-managed encryption keys for a machine set
-include::modules/machineset-customer-managed-encryption-azure.adoc[leveloffset=+2]
-
-//Configuring trusted launch for Azure virtual machines by using machine sets
-include::modules/machineset-azure-trusted-launch.adoc[leveloffset=+2]
-
-//Configuring Azure confidential virtual machines by using machine sets
-include::modules/machineset-azure-confidential-vms.adoc[leveloffset=+2]
-
-//Configuring Capacity Reservation by using machine sets
-include::modules/machineset-capacity-reservation.adoc[leveloffset=+2,tag=!compute]
-
-// Accelerated Networking for Microsoft Azure VMs
-include::modules/machineset-azure-accelerated-networking.adoc[leveloffset=+2]
-
-//Not applicable for 4.12, possibly 4.13?
-//[role="_additional-resources"]
-//.Additional resources
-//*  xref:../../../installing/installing_azure/ipi/installing-azure-customizations.adoc#machineset-azure-enabling-accelerated-networking-new-install_installing-azure-customizations[Enabling Accelerated Networking during installation]
-
-// Enabling Accelerated Networking on an existing Microsoft Azure cluster
-include::modules/machineset-azure-enabling-accelerated-networking-existing.adoc[leveloffset=+3]
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-azure.adoc#cpmso-supported-features-azure[Configuring {azure-full} features for control plane machines]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
@@ -1,47 +1,27 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="cpmso-config-options-gcp"]
-= Control plane configuration options for {gcp-full}
+= Changing control plane configuration options for {gcp-full}
 :context: cpmso-config-options-gcp
 
 toc::[]
 
-You can change the configuration of your {gcp-first} control plane machines and enable features by updating values in the control plane machine set.
-When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[update strategy].
+[role="_abstract"]
+You can update your control plane machines to reflect changes in your infrastructure or environment by editing values in the control plane machine set specification.
 
-[id="cpmso-sample-yaml-gcp_{context}"]
-== Sample YAML for configuring {gcp-full} clusters
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
 
 The following example YAML snippets show provider specification and failure domain configurations for a {gcp-short} cluster.
 
 //Sample GCP provider specification
-include::modules/cpmso-yaml-provider-spec-gcp.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-provider-spec-gcp.adoc[leveloffset=+1]
 
 //Sample GCP failure domain configuration
-include::modules/cpmso-yaml-failure-domain-gcp.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-failure-domain-gcp.adoc[leveloffset=+1]
 
-[id="cpmso-supported-features-gcp_{context}"]
-== Enabling {gcp-full} features for control plane machines
-
-You can enable features by updating values in the control plane machine set.
-
-//Note: GCP GPU features should be compatible with CPMS, but dev cannot think of a use case. Leaving them out to keep things less cluttered. If a customer use case emerges, we can just add the necessary modules in here.
-
-//Configuring persistent disk types by using machine sets
-include::modules/machineset-gcp-pd-disk-types.adoc[leveloffset=+2]
-
-//Configuring Confidential VM by using machine sets
-include::modules/machineset-gcp-confidential-vm.adoc[leveloffset=+2]
-
-//Configuring Shielded VM options by using machine sets
-include::modules/machineset-gcp-shielded-vms.adoc[leveloffset=+2]
-
+[id="additional-resources_{context}"]
 [role="_additional-resources"]
-.Additional resources
-* link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm[What is Shielded VM?]
-** link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#secure-boot[Secure Boot]
-** link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#vtpm[Virtual Trusted Platform Module (vTPM)]
-** link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#integrity-monitoring[Integrity monitoring]
-
-//Enabling customer-managed encryption keys for a machine set
-include::modules/machineset-gcp-enabling-customer-managed-encryption.adoc[leveloffset=+2]
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-gcp.adoc#cpmso-supported-features-gcp[Configuring {gcp-full} features for control plane machines]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-nutanix.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-nutanix.adoc
@@ -1,25 +1,27 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="cpmso-config-options-nutanix"]
-= Control plane configuration options for Nutanix
 include::_attributes/common-attributes.adoc[]
+[id="cpmso-config-options-nutanix"]
+= Changing control plane configuration options for Nutanix
 :context: cpmso-config-options-nutanix
 
 toc::[]
 
-You can change the configuration of your Nutanix control plane machines by updating values in the control plane machine set.
-When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[update strategy].
+[role="_abstract"]
+You can update your control plane machines to reflect changes in your infrastructure or environment by editing values in the control plane machine set specification.
 
-[id="cpmso-sample-yaml-nutanix_{context}"]
-== Sample YAML for configuring Nutanix clusters
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
 
-The following example YAML snippet shows a provider specification configuration for a Nutanix cluster.
+The following example YAML snippets show provider specification and failure domain configurations for a Nutanix cluster.
 
 //Sample Nutanix provider specification
-include::modules/cpmso-yaml-provider-spec-nutanix.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-provider-spec-nutanix.adoc[leveloffset=+1]
 
 //Failure domains for Nutanix clusters
-include::modules/mapi-failure-domain-nutanix.adoc[leveloffset=+2]
+include::modules/mapi-failure-domain-nutanix.adoc[leveloffset=+1]
 
+[id="additional-resources_{context}"]
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
 * xref:../../../installing/installing_nutanix/nutanix-failure-domains.adoc#nutanix-failure-domains-adding-to-existing-cluster_nutanix-failure-domains[Adding failure domains to an existing Nutanix cluster]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc
@@ -1,29 +1,27 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="cpmso-config-options-openstack"]
-= Control plane configuration options for Red Hat OpenStack Platform
 include::_attributes/common-attributes.adoc[]
+[id="cpmso-config-options-openstack"]
+= Changing control plane configuration options for {rh-openstack-first}
 :context: cpmso-config-options-openstack
 
 toc::[]
 
-You can change the configuration of your {rh-openstack-first} control plane machines and enable features by updating values in the control plane machine set.
-When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[update strategy].
+[role="_abstract"]
+You can update your control plane machines to reflect changes in your infrastructure or environment by editing values in the control plane machine set specification.
 
-[id="cpmso-sample-yaml-openstack_{context}"]
-== Sample YAML for configuring {rh-openstack-first} clusters
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
 
 The following example YAML snippets show provider specification and failure domain configurations for an {rh-openstack} cluster.
 
 //Sample OpenStack provider specification
-include::modules/cpmso-yaml-provider-spec-openstack.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-provider-spec-openstack.adoc[leveloffset=+1]
 
 //Sample OpenStack failure domain configuration
-include::modules/cpmso-yaml-failure-domain-openstack.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-failure-domain-openstack.adoc[leveloffset=+1]
 
-[id="cpmso-supported-features-openstack_{context}"]
-== Enabling {rh-openstack-first} features for control plane machines
-
-You can enable features by updating values in the control plane machine set.
-
-//Changing the OpenStack Nova flavor by using a control plane machine set
-include::modules/cpms-changing-openstack-flavor-type.adoc[leveloffset=+2]
+[id="additional-resources_{context}"]
+[role="_additional-resources"]
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-openstack.adoc#cpmso-supported-features-openstack[Configuring {rh-openstack} features for control plane machines]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
@@ -1,40 +1,28 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cpmso-config-options-vsphere"]
-= Control plane configuration options for VMware vSphere
+= Changing control plane configuration options for VMware vSphere
 include::_attributes/common-attributes.adoc[]
 :context: cpmso-config-options-vsphere
 
 toc::[]
 
-You can change the configuration of your {vmw-first} control plane machines by updating values in the control plane machine set.
-When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[update strategy].
+[role="_abstract"]
+You can update your control plane machines to reflect changes in your infrastructure or environment by editing values in the control plane machine set specification.
 
-[id="cpmso-sample-yaml-vsphere_{context}"]
-== Sample YAML for configuring {vmw-full} clusters
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
 
 The following example YAML snippets show provider specification and failure domain configurations for a {vmw-short} cluster.
 
 //Sample VMware vSphere provider specification
-include::modules/cpmso-yaml-provider-spec-vsphere.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-provider-spec-vsphere.adoc[leveloffset=+1]
 
 //Sample VMware vSphere failure domain configuration
-include::modules/cpmso-yaml-failure-domain-vsphere.adoc[leveloffset=+2]
+include::modules/cpmso-yaml-failure-domain-vsphere.adoc[leveloffset=+1]
 
+[id="additional-resources_{context}"]
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-vsphere.adoc#cpmso-supported-features-vsphere[Configuring {vmw-full} features for control plane machines]
 * xref:../../../installing/installing_vsphere/post-install-vsphere-zones-regions-configuration.adoc#specifying-regions-zones-infrastructure-vsphere_post-install-vsphere-zones-regions-configuration[Specifying multiple regions and zones for your cluster on {vmw-short}]
-
-[id="cpmso-supported-features-vsphere_{context}"]
-== Enabling {vmw-full} features for control plane machines
-
-You can enable features by updating values in the control plane machine set.
-
-//Adding tags to machines by using machine sets
-include::modules/machine-api-vmw-add-tags.adoc[leveloffset=+2,tag=!compute]
-
-//Configuring multiple NICs by using machine sets
-//pulled from 4.18 GA
-//include::modules/machineset-vsphere-multiple-nics.adoc[leveloffset=+2,tag=!compute]
-
-//Configuring data disks by using machine sets
-include::modules/machineset-vsphere-data-disks.adoc[leveloffset=+2,tag=!compute]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.adoc
@@ -1,0 +1,51 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="cpmso-supported-features-aws"]
+= Configuring {aws-full} features for control plane machines
+:context: cpmso-supported-features-aws
+
+toc::[]
+
+[role="_abstract"]
+You can enable or change the configuration of features for your control plane machines by editing values in the control plane machine set specification.
+
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
+
+//Restricting the API server to private (AWS control plane machine set version)
+include::modules/private-clusters-setting-api-private.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/nw-configuring-ingress-controller-endpoint-publishing-strategy.adoc#nw-ingresscontroller-change-internal_nw-configuring-ingress-controller-endpoint-publishing-strategy[Configuring the Ingress Controller endpoint publishing scope to Internal]
+
+//Selecting a larger Amazon Web Services instance type for control plane machines
+include::modules/cpms-changing-aws-instance-type.adoc[leveloffset=+1]
+
+//Assigning machines to placement groups by using machine sets
+include::modules/machineset-aws-existing-placement-group.adoc[leveloffset=+1]
+
+//Machine sets that enable the Amazon EC2 Instance Metadata Service
+include::modules/machineset-imds-options.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Boot image management]
+
+//Creating machines that use the Amazon EC2 Instance Metadata Service
+include::modules/machineset-creating-imds-options.adoc[leveloffset=+2]
+
+//Machine sets that deploy machines as Dedicated Instances
+include::modules/machineset-dedicated-instances.adoc[leveloffset=+1]
+
+//Creating Dedicated Instances by using machine sets
+include::modules/machineset-creating-dedicated-instances.adoc[leveloffset=+2]
+
+//Configuring Capacity Reservation by using machine sets
+include::modules/machineset-capacity-reservation.adoc[leveloffset=+1,tag=!compute]
+
+[id="additional-resources_{context}"]
+[role="_additional-resources"]
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc#cpmso-config-options-aws[Changing control plane configuration options for {aws-full}]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-azure.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-azure.adoc
@@ -1,0 +1,68 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="cpmso-supported-features-azure"]
+= Configuring {azure-full} features for control plane machines
+:context: cpmso-supported-features-azure
+
+toc::[]
+
+[role="_abstract"]
+You can enable or change the configuration of features for your control plane machines by editing values in the control plane machine set specification.
+
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
+
+
+include::modules/private-clusters-setting-api-private.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/nw-configuring-ingress-controller-endpoint-publishing-strategy.adoc#nw-ingresscontroller-change-internal_nw-configuring-ingress-controller-endpoint-publishing-strategy[Configuring the Ingress Controller endpoint publishing scope to Internal]
+
+//Using the Azure Marketplace offering
+include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]
+
+//Enabling Azure boot diagnostics
+include::modules/machineset-azure-boot-diagnostics.adoc[leveloffset=+1]
+
+//Machine sets that deploy machines on ultra disks as data disks
+include::modules/machineset-azure-ultra-disk.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types#ultra-disks[{azure-full} ultra disks documentation]
+
+//Creating machines on ultra disks by using machine sets
+include::modules/machineset-creating-azure-ultra-disk.adoc[leveloffset=+2]
+
+//Troubleshooting resources for machine sets that enable ultra disks
+include::modules/machineset-troubleshooting-azure-ultra-disk.adoc[leveloffset=+2]
+
+//Enabling customer-managed encryption keys for a machine set
+include::modules/machineset-customer-managed-encryption-azure.adoc[leveloffset=+1]
+
+//Configuring trusted launch for Azure virtual machines by using machine sets
+include::modules/machineset-azure-trusted-launch.adoc[leveloffset=+1]
+
+//Configuring Azure confidential virtual machines by using machine sets
+include::modules/machineset-azure-confidential-vms.adoc[leveloffset=+1]
+
+//Configuring Capacity Reservation by using machine sets
+include::modules/machineset-capacity-reservation.adoc[leveloffset=+1,tag=!compute]
+
+// Accelerated Networking for Microsoft Azure VMs
+include::modules/machineset-azure-accelerated-networking.adoc[leveloffset=+1]
+
+//Not applicable for 4.12, possibly 4.13?
+//[role="_additional-resources"]
+//.Additional resources
+//*  xref:../../../installing/installing_azure/ipi/installing-azure-customizations.adoc#machineset-azure-enabling-accelerated-networking-new-install_installing-azure-customizations[Enabling Accelerated Networking during installation]
+
+// Enabling Accelerated Networking on an existing Microsoft Azure cluster
+include::modules/machineset-azure-enabling-accelerated-networking-existing.adoc[leveloffset=+2]
+
+[id="additional-resources_{context}"]
+[role="_additional-resources"]
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#cpmso-config-options-azure[Changing control plane configuration options for {azure-full}]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-gcp.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-gcp.adoc
@@ -1,0 +1,40 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="cpmso-supported-features-gcp"]
+= Configuring {gcp-full} features for control plane machines
+:context: cpmso-supported-features-gcp
+
+toc::[]
+
+[role="_abstract"]
+You can enable or change the configuration of features for your control plane machines by editing values in the control plane machine set specification.
+
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
+
+//Note: GCP GPU features should be compatible with CPMS, but dev cannot think of a use case. Leaving them out to keep things less cluttered. If a customer use case emerges, we can just add the necessary modules in here.
+
+//Configuring persistent disk types by using machine sets
+include::modules/machineset-gcp-pd-disk-types.adoc[leveloffset=+1]
+
+//Configuring Confidential VM by using machine sets
+include::modules/machineset-gcp-confidential-vm.adoc[leveloffset=+1]
+
+//Configuring Shielded VM options by using machine sets
+include::modules/machineset-gcp-shielded-vms.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm[What is Shielded VM? ({gcp-short} documentation)]
+* link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#secure-boot[Secure Boot ({gcp-short} documentation)]
+* link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#vtpm[Virtual Trusted Platform Module (vTPM) ({gcp-short} documentation)]
+* link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#integrity-monitoring[Integrity monitoring ({gcp-short} documentation)]
+
+//Enabling customer-managed encryption keys for a machine set
+include::modules/machineset-gcp-enabling-customer-managed-encryption.adoc[leveloffset=+1]
+
+[id="additional-resources_{context}"]
+[role="_additional-resources"]
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc#cpmso-config-options-gcp[Changing control plane configuration options for {gcp-full}]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-openstack.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-openstack.adoc
@@ -1,0 +1,22 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="cpmso-supported-features-openstack"]
+= Configuring {rh-openstack-first} features for control plane machines
+:context: cpmso-supported-features-openstack
+
+toc::[]
+
+[role="_abstract"]
+You can enable or change the configuration of features for your control plane machines by editing values in the control plane machine set specification.
+
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
+
+//Changing the OpenStack Nova flavor by using a control plane machine set
+include::modules/cpms-changing-openstack-flavor-type.adoc[leveloffset=+1]
+
+[id="additional-resources_{context}"]
+[role="_additional-resources"]
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc#cpmso-config-options-openstack[Changing control plane configuration options for {rh-openstack-full}]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-vsphere.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-vsphere.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="cpmso-supported-features-vsphere"]
+= Configuring {vmw-first} features for control plane machines
+:context: cpmso-supported-features-vsphere
+
+toc::[]
+
+[role="_abstract"]
+You can enable or change the configuration of features for your control plane machines by editing values in the control plane machine set specification.
+
+When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+For more information, see "Updating the control plane configuration".
+
+//Adding tags to machines by using machine sets
+include::modules/machine-api-vmw-add-tags.adoc[leveloffset=+1,tag=!compute]
+
+//Configuring multiple NICs by using machine sets
+//pulled from 4.18 GA
+//include::modules/machineset-vsphere-multiple-nics.adoc[leveloffset=+1,tag=!compute]
+
+//Configuring data disks by using machine sets
+include::modules/machineset-vsphere-data-disks.adoc[leveloffset=+1,tag=!compute]
+
+[id="additional-resources_{context}"]
+[role="_additional-resources"]
+== Additional resources
+* xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc#cpmso-config-options-vsphere[Changing control plane configuration options for {vmw-full}]

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -32,7 +32,7 @@ include::modules/machineset-imds-options.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Updated boot images]
+* xref:../../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Boot image management]
 
 //Creating machines that use the Amazon EC2 Instance Metadata Service
 include::modules/machineset-creating-imds-options.adoc[leveloffset=+2]

--- a/modules/cpms-changing-aws-instance-type.adoc
+++ b/modules/cpms-changing-aws-instance-type.adoc
@@ -6,7 +6,7 @@
 ifeval::["{context}" == "recommended-control-plane-practices"]
 :scale-host:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-aws"]
+ifeval::["{context}" == "cpmso-supported-features-aws"]
 :cpmso-config-options-aws:
 endif::[]
 
@@ -53,6 +53,6 @@ endif::scale-host[]
 ifeval::["{context}" == "recommended-control-plane-practices"]
 :!scale-host:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-aws"]
+ifeval::["{context}" == "cpmso-supported-features-aws"]
 :!cpmso-config-options-aws:
 endif::[]

--- a/modules/installation-azure-marketplace-subscribe.adoc
+++ b/modules/installation-azure-marketplace-subscribe.adoc
@@ -15,7 +15,7 @@ endif::[]
 ifeval::["{context}" == "creating-machineset-azure"]
 :mapi:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :mapi:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
@@ -228,7 +228,7 @@ endif::[]
 ifeval::["{context}" == "creating-machineset-azure"]
 :!mapi:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :!mapi:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]

--- a/modules/machine-feature-aws-imds-options.adoc
+++ b/modules/machine-feature-aws-imds-options.adoc
@@ -13,8 +13,8 @@ Machines can require the use of link:https://docs.aws.amazon.com/AWSEC2/latest/U
 This is true but does not apply to TP clusters, reassess for Cluster API GA
 [NOTE]
 ====
-To use IMDSv2 on AWS clusters that were created with {product-title} version 4.6 or earlier, you must update your boot image. 
-For more information, see "Updated boot images".
+To use IMDSv2 on AWS clusters that were created with {product-title} version 4.6 or earlier, you must update your boot image.
+For more information, see "Boot image management".
 ====
 ////
 
@@ -51,8 +51,8 @@ The following values are valid:
 
 [NOTE]
 ====
-The Machine API does not support the `httpEndpoint`, `httpPutResponseHopLimit`, and `instanceMetadataTags` fields. 
-If you migrate a Cluster API machine template that uses this feature to a Machine API compute machine set, any Machine API machines that it creates will not have these fields and the underlying instances will not use these settings. 
+The Machine API does not support the `httpEndpoint`, `httpPutResponseHopLimit`, and `instanceMetadataTags` fields.
+If you migrate a Cluster API machine template that uses this feature to a Machine API compute machine set, any Machine API machines that it creates will not have these fields and the underlying instances will not use these settings.
 Any existing machines that the migrated machine set manages will retain these fields and the underlying instances will continue to use these settings.
 ====
 

--- a/modules/machineset-aws-existing-placement-group.adoc
+++ b/modules/machineset-aws-existing-placement-group.adoc
@@ -3,7 +3,7 @@
 // * machine_management/creating-machinesets/creating-machineset-aws.adoc
 // * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
 
-ifeval::["{context}" == "cpmso-config-options-aws"]
+ifeval::["{context}" == "cpmso-supported-features-aws"]
 :cpmso:
 endif::[]
 
@@ -63,7 +63,7 @@ spec:
 <3> Specify the zone, for example, `us-east-1a`.
 <4> Specify the region, for example, `us-east-1`.
 <5> Specify the name of the existing AWS placement group to deploy machines in.
-<6> Optional: Specify the partition number of the existing AWS placement group to deploy machines in. 
+<6> Optional: Specify the partition number of the existing AWS placement group to deploy machines in.
 
 .Verification
 
@@ -75,6 +75,6 @@ spec:
 
 ** The interface type field indicates that it uses an EFA.
 
-ifeval::["{context}" == "cpmso-config-options-aws"]
+ifeval::["{context}" == "cpmso-supported-features-aws"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-azure-accelerated-networking.adoc
+++ b/modules/machineset-azure-accelerated-networking.adoc
@@ -6,7 +6,7 @@
 ifeval::["{context}" == "creating-machineset-azure"]
 :compute:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :cpmso:
 endif::[]
 
@@ -38,6 +38,6 @@ endif::compute[]
 ifeval::["{context}" == "creating-machineset-azure"]
 :!compute:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-azure-confidential-vms.adoc
+++ b/modules/machineset-azure-confidential-vms.adoc
@@ -3,7 +3,7 @@
 // * machine_management/creating_machinesets/creating-machineset-azure.adoc
 // * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
 
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :cpmso:
 endif::[]
 
@@ -83,6 +83,6 @@ spec:
 
 * On the Azure portal, review the details for a machine deployed by the machine set and verify that the confidential VM options match the values that you configured.
 
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-azure-enabling-accelerated-networking-existing.adoc
+++ b/modules/machineset-azure-enabling-accelerated-networking-existing.adoc
@@ -6,7 +6,7 @@
 ifeval::["{context}" == "creating-machineset-azure"]
 :compute:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :cpmso:
 endif::[]
 
@@ -78,6 +78,6 @@ endif::compute[]
 ifeval::["{context}" == "creating-machineset-azure"]
 :!compute:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-azure-trusted-launch.adoc
+++ b/modules/machineset-azure-trusted-launch.adoc
@@ -3,7 +3,7 @@
 // * machine_management/creating_machinesets/creating-machineset-azure.adoc
 // * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
 
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :cpmso:
 endif::[]
 
@@ -104,6 +104,6 @@ spec:
 
 * On the Azure portal, review the details for a machine deployed by the machine set and verify that the trusted launch options match the values that you configured.
 
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-azure-ultra-disk.adoc
+++ b/modules/machineset-azure-ultra-disk.adoc
@@ -8,7 +8,7 @@
 ifeval::["{context}" == "creating-machineset-azure"]
 :mapi:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :cpmso:
 endif::[]
 ifeval::["{context}" == "persistent-storage-azure"]
@@ -41,7 +41,7 @@ endif::pvc[]
 ifeval::["{context}" == "creating-machineset-azure"]
 :!mapi:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :!cpmso:
 endif::[]
 ifeval::["{context}" == "persistent-storage-azure"]

--- a/modules/machineset-capacity-reservation.adoc
+++ b/modules/machineset-capacity-reservation.adoc
@@ -1,18 +1,20 @@
 // Module included in the following assemblies:
 //
 // * machine_management/creating_machinesets/creating-machineset-azure.adoc
-// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-azure.adoc
+// * machine_management/creating_machinesets/creating-machineset-aws.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.adoc
 
 ifeval::["{context}" == "creating-machineset-azure"]
 :azure:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :azure:
 endif::[]
 ifeval::["{context}" == "creating-machineset-aws"]
 :aws:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-aws"]
+ifeval::["{context}" == "cpmso-supported-features-aws"]
 :aws:
 endif::[]
 
@@ -26,23 +28,23 @@ ifdef::azure[on-demand Capacity Reservation with Capacity Reservation groups on 
 ifdef::aws[Capacity Reservations on {aws-full} clusters, including On-Demand Capacity Reservations and Capacity Blocks for ML.]
 
 You can configure a machine set to deploy machines on any available resources that match the parameters of a capacity request that you define.
-These parameters specify the 
+These parameters specify the
 ifdef::azure[VM size,]
 ifdef::aws[instance type,]
 region, and number of instances that you want to reserve.
-If your 
+If your
 ifdef::azure[{azure-short} subscription quota]
 ifdef::aws[Capacity Reservation]
 can accommodate the capacity request, the deployment succeeds.
 
-For more information, including limitations and suggested use cases for this 
+For more information, including limitations and suggested use cases for this
 ifdef::azure[{azure-short} offering, see link:https://learn.microsoft.com/en-us/azure/virtual-machines/capacity-reservation-overview[On-demand Capacity Reservation] in the {azure-full} documentation.]
 ifdef::aws[{aws-short} offering, see link:https://docs.aws.amazon.com/en_us/AWSEC2/latest/UserGuide/capacity-reservation-overview.html[On-Demand Capacity Reservations and Capacity Blocks for ML] in the {aws-short} documentation.]
 
 ifdef::azure[]
 [NOTE]
 ====
-You cannot change an existing Capacity Reservation configuration for a machine set. 
+You cannot change an existing Capacity Reservation configuration for a machine set.
 To use a different Capacity Reservation group, you must replace the machine set and the machines that the previous machine set deployed.
 ====
 endif::azure[]
@@ -108,7 +110,7 @@ endif::aws[]
 end::controlplane[]
 # ...
 ----
-<1> Specify the ID of the 
+<1> Specify the ID of the
 ifdef::azure[Capacity Reservation group]
 ifdef::aws[Capacity Block for ML or On-Demand Capacity Reservation]
 that you want the machine set to deploy machines on.
@@ -146,19 +148,19 @@ tag::compute[]
 where `<machine_set_name>` is the name of the compute machine set.
 end::compute[]
 +
-In the output, verify that the characteristics of the listed machines match the parameters of your 
+In the output, verify that the characteristics of the listed machines match the parameters of your
 ifdef::azure[Capacity Reservation.]
 ifdef::aws[Capacity Reservation.]
 
 ifeval::["{context}" == "creating-machineset-azure"]
 :!azure:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :!azure:
 endif::[]
 ifeval::["{context}" == "creating-machineset-aws"]
 :!aws:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-aws"]
+ifeval::["{context}" == "cpmso-supported-features-aws"]
 :!aws:
 endif::[]

--- a/modules/machineset-creating-azure-ultra-disk.adoc
+++ b/modules/machineset-creating-azure-ultra-disk.adoc
@@ -8,7 +8,7 @@
 ifeval::["{context}" == "creating-machineset-azure"]
 :mapi:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :cpmso:
 endif::[]
 ifeval::["{context}" == "persistent-storage-azure"]
@@ -343,7 +343,7 @@ endif::cpmso[]
 ifeval::["{context}" == "creating-machineset-azure"]
 :!mapi:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :!cpmso:
 endif::[]
 ifeval::["{context}" == "persistent-storage-azure"]

--- a/modules/machineset-gcp-confidential-vm.adoc
+++ b/modules/machineset-gcp-confidential-vm.adoc
@@ -3,7 +3,7 @@
 // * machine_management/creating_machinesets/creating-machineset-gcp.adoc
 // * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
 
-ifeval::["{context}" == "cpmso-config-options-gcp"]
+ifeval::["{context}" == "cpmso-supported-features-gcp"]
 :cpmso:
 endif::[]
 
@@ -85,6 +85,6 @@ The use of Confidential Computing with AMD Secure Encrypted Virtualization (AMD 
 
 * On the {gcp-full} console, review the details for a machine deployed by the machine set and verify that the Confidential VM options match the values that you configured.
 
-ifeval::["{context}" == "cpmso-config-options-gcp"]
+ifeval::["{context}" == "cpmso-supported-features-gcp"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-gcp-enabling-customer-managed-encryption.adoc
+++ b/modules/machineset-gcp-enabling-customer-managed-encryption.adoc
@@ -3,7 +3,7 @@
 // * machine_management/creating_machinesets/creating-machineset-gcp.adoc
 // * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
 
-ifeval::["{context}" == "cpmso-config-options-gcp"]
+ifeval::["{context}" == "cpmso-supported-features-gcp"]
 :cpmso:
 endif::[]
 
@@ -69,6 +69,6 @@ spec:
 +
 When a new machine is created by using the updated `providerSpec` object configuration, the disk encryption key is encrypted with the KMS key.
 
-ifeval::["{context}" == "cpmso-config-options-gcp"]
+ifeval::["{context}" == "cpmso-supported-features-gcp"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-gcp-pd-disk-types.adoc
+++ b/modules/machineset-gcp-pd-disk-types.adoc
@@ -3,7 +3,7 @@
 // * machine_management/creating_machinesets/creating-machineset-gcp.adoc
 // * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
 
-ifeval::["{context}" == "cpmso-config-options-gcp"]
+ifeval::["{context}" == "cpmso-supported-features-gcp"]
 :cpmso:
 endif::[]
 
@@ -56,6 +56,6 @@ endif::cpmso[]
 
 * Using the {gcp-full} console, review the details for a machine deployed by the machine set and verify that the `Type` field matches the configured disk type.
 
-ifeval::["{context}" == "cpmso-config-options-gcp"]
+ifeval::["{context}" == "cpmso-supported-features-gcp"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-gcp-shielded-vms.adoc
+++ b/modules/machineset-gcp-shielded-vms.adoc
@@ -3,7 +3,7 @@
 // * machine_management/creating_machinesets/creating-machineset-gcp.adoc
 // * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
 
-ifeval::["{context}" == "cpmso-config-options-gcp"]
+ifeval::["{context}" == "cpmso-supported-features-gcp"]
 :cpmso:
 endif::[]
 
@@ -61,6 +61,6 @@ When integrity monitoring is enabled, you must not disable virtual trusted platf
 
 * Using the {gcp-full} console, review the details for a machine deployed by the machine set and verify that the Shielded VM options match the values that you configured.
 
-ifeval::["{context}" == "cpmso-config-options-gcp"]
+ifeval::["{context}" == "cpmso-supported-features-gcp"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-imds-options.adoc
+++ b/modules/machineset-imds-options.adoc
@@ -3,7 +3,7 @@
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
 // * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
 
-ifeval::["{context}" == "cpmso-config-options-aws"]
+ifeval::["{context}" == "cpmso-supported-features-aws"]
 :cpmso:
 endif::[]
 
@@ -15,11 +15,11 @@ You can use machine sets to create machines that use a specific version of the A
 
 [NOTE]
 ====
-To use IMDSv2 on AWS clusters that were created with {product-title} version 4.6 or earlier, you must update your boot image. For more information, see "Updated boot images".
+To use IMDSv2 on AWS clusters that were created with {product-title} version 4.6 or earlier, you must update your boot image. For more information, see "Boot image management".
 ====
 
 ifndef::cpmso[]
-To deploy new compute machines with your preferred IMDS configuration, create a compute machine set YAML file with the appropriate values. You can also edit an existing machine set to create new machines with your preferred IMDS configuration when the machine set is scaled up. 
+To deploy new compute machines with your preferred IMDS configuration, create a compute machine set YAML file with the appropriate values. You can also edit an existing machine set to create new machines with your preferred IMDS configuration when the machine set is scaled up.
 endif::cpmso[]
 
 [IMPORTANT]
@@ -27,6 +27,6 @@ endif::cpmso[]
 Before configuring a machine set to create machines that require IMDSv2, ensure that any workloads that interact with the AWS metadata service support IMDSv2.
 ====
 
-ifeval::["{context}" == "cpmso-config-options-aws"]
+ifeval::["{context}" == "cpmso-supported-features-aws"]
 :!cpmso:
 endif::[]

--- a/modules/machineset-troubleshooting-azure-ultra-disk.adoc
+++ b/modules/machineset-troubleshooting-azure-ultra-disk.adoc
@@ -8,7 +8,7 @@
 ifeval::["{context}" == "creating-machineset-azure"]
 :mapi:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :mapi:
 endif::[]
 ifeval::["{context}" == "persistent-storage-azure"]
@@ -82,7 +82,7 @@ endif::mapi[]
 ifeval::["{context}" == "creating-machineset-azure"]
 :!mapi:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :!mapi:
 endif::[]
 ifeval::["{context}" == "persistent-storage-azure"]

--- a/modules/private-clusters-setting-api-private.adoc
+++ b/modules/private-clusters-setting-api-private.adoc
@@ -7,10 +7,10 @@
 ifeval::["{context}" == "configuring-private-cluster"]
 :post-install:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-aws"]
+ifeval::["{context}" == "cpmso-supported-features-aws"]
 :cpmso-using-aws:
 endif::[]
-ifeval::["{context}" == "cpmso-config-options-azure"]
+ifeval::["{context}" == "cpmso-supported-features-azure"]
 :cpmso-using-azure:
 endif::[]
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-17046](https://issues.redhat.com//browse/OSDOCS-17046)

Link to docs preview:
All assemblies in the _Configuration options for control plane machines_ subdirectory. The first one is [Changing control plane configuration options for Amazon Web Services](https://103702--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws).

QE review:
N/A, no technical changes in this PR

Additional information:
Splitting CPMS YAML config assemblies into one for basic options and one for feature options, all platforms