### PR TITLE
OSDOCS-17536 [NETOBSERV] Add storageClass recommendation for LokiStack

### DIFF
--- a/modules/network-observability-lokistack-create.adoc
+++ b/modules/network-observability-lokistack-create.adoc
@@ -46,7 +46,7 @@ spec:
 ====
 It is not possible to change the number `1x` for the deployment size.
 ====
-<3> Use a storage class name that is available on the cluster for `ReadWriteOnce` access mode. You can use `oc get storageclasses` to see what is available on your cluster.
+<3> Use a storage class name that is available on the cluster for `ReadWriteOnce` access mode. For best performance, specify a storage class that allocates block storage. You can use `oc get storageclasses` to see what is available on your cluster.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
[OSDOCS-17536](https://issues.redhat.com//browse/OSDOCS-17536) [NETOBSERV] Add storageClass recommendation for LokiStack

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-17536

Link to docs preview:
* https://103731--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/installing-operators.html#network-observability-lokistack-create_network_observability

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Pre-migration issues, like callouts, are being addressed separately.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
