### PR TITLE
[RHDEVDOCS-6794] Add `opc assist` command

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -39,5 +39,8 @@
 
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 
+:ols-official: Red{nbsp}Hat OpenShift Lightspeed
+:ols: OpenShift Lightspeed
+
 // Attributes not present in the main branch
 :OCP: OpenShift Container Platform

--- a/create/creating-applications-with-cicd-pipelines.adoc
+++ b/create/creating-applications-with-cicd-pipelines.adoc
@@ -51,6 +51,8 @@ include::modules/op-mirroring-images-to-run-pipelines-in-restricted-environment.
 
 include::modules/op-running-a-pipeline.adoc[leveloffset=+1]
 
+include::modules/op-diagnosing-a-pipeline-with-opc-assist.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 [id="additional-resources-running_{context}"]
 .Additional resources

--- a/modules/op-diagnosing-a-pipeline-with-opc-assist.adoc
+++ b/modules/op-diagnosing-a-pipeline-with-opc-assist.adoc
@@ -1,0 +1,50 @@
+// This module is included in the following assemblies:
+// * create/creating-applications-with-cicd-pipelines.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="diagnosing-a-pipeline-with-opc-assist_{context}"]
+= Diagnosing pipeline failures with opc assist
+
+If a `PipelineRun` execution fails, you can use the `opc assist` CLI command to help you quickly diagnose the failure and identify corrective steps. This utility leverages {ols-official} to analyze the logs, error messages, and the execution context of the failed object, providing actionable explanations in plain language.
+
+[IMPORTANT]
+====
+To use the `opc assist` CLI command, you must install and configure link:https://docs.redhat.com/en/documentation/red_hat_openshift_lightspeed/latest/html/install/ols-installing-lightspeed[{ols-official}] on your cluster.
+====
+
+:FeatureName: Running {pipelines-title} with the `opc` CLI tool
+include::snippets/technology-preview.adoc[]
+
+.Procedure
+
+. When a `PipelineRun` execution fails, run the following command to retrieve the name of the failed `PipelineRun` object:
++
+[source, terminal]
+----
+$ tkn pipelinerun list
+----
++
+The output lists the pipeline runs, displaying the name and status. The status of the relevant pipeline is `Failed`.
+
+. To obtain a root-cause analysis and suggested remediation steps for the failure, run the following command, replacing `<pipelinerun_name>` and `<namespace>` with the relevant values:
++
+[source, terminal]
+----
+$ opc assist pipelinerun diagnose <pipelinerun_name> -n <namespace>
+----
+where:
+`<pipelinerun_name>`:: Specifies the name of the failed `PipelineRun` object.
+`<namespace>`:: Specifies the name of the project (namespace) where you executed the pipeline.
+
++
+The output displays the {ols} analysis, including a root-cause summary and suggested remediation steps.
+
+. Optional: Run the following command to diagnose a specific step or task directly on the `TaskRun` object:
++
+[source,terminal]
+----
+$ opc assist taskrun diagnose <taskrun_name> -n <namespace>
+----
+where:
+`<taskrun_name>`:: Specifies the name of the failed `TaskRun` object.
+`<namespace>`:: Specifies the name of the project (namespace) where you executed the pipeline.

--- a/modules/op-lightspeed-utility-commands.adoc
+++ b/modules/op-lightspeed-utility-commands.adoc
@@ -1,0 +1,36 @@
+// This module is included in the following assemblies:
+// * tkn_cli/op-tkn-reference.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="op-lightspeed-utility-commands_{context}"]
+= {ols} utility commands
+
+Use the {pipelines-shortname} Client (opc) to access generative AI-powered diagnostics. These commands leverage {ols-official} to analyze pipeline failures and provide actionable troubleshooting guidance.
+
+For installation and configuration of {ols}, see the link:https://docs.redhat.com/en/documentation/red_hat_openshift_lightspeed/latest[{ols-official} documentation].
+
+:FeatureName: Running {pipelines-title} with the `opc` CLI tool
+include::snippets/technology-preview.adoc[]
+
+assist::
+
+[options="header"]
+|===
+
+| Command | Description
+
+| `opc assist pipelinerun diagnose` | Analyze a failed `PipelineRun` execution using {ols} to identify the root cause and display suggested remediation steps.
+| `opc assist taskrun diagnose` | Analyze a failed `TaskRun` execution using {ols} to identify the root cause and display suggested remediation steps.
+
+|===
+
+The `opc assist` command uses the following general syntax:
+
+[source, terminal]
+----
+$ opc assist {pipelinerun | taskrun} diagnose <name> -n <namespace>
+----
+where:
+
+`<name>`:: Specifies the name of the failed `PipelineRun` or `TaskRun` object.
+`<namespace>`:: Specifies the name of the namespace containing the `PipelineRun` or `TaskRun` object.

--- a/modules/op-tkn-utility-commands.adoc
+++ b/modules/op-tkn-utility-commands.adoc
@@ -1,6 +1,7 @@
 // This module is included in the following assemblies:
 // * tkn_cli/op-tkn-reference.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="op-tkn-utility-commands_{context}"]
 = Utility commands
 

--- a/tkn_cli/op-tkn-reference.adoc
+++ b/tkn_cli/op-tkn-reference.adoc
@@ -38,3 +38,6 @@ include::modules/op-tkn-trigger-management.adoc[leveloffset=+1]
 
 // Hub interaction commands
 include::modules/op-tkn-hub-interaction.adoc[leveloffset=+1]
+
+// Lightspeed utility commands
+include::modules/op-lightspeed-utility-commands.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- pipelines-docs-1.21

Issue:
- https://issues.redhat.com/browse/RHDEVDOCS-6794

Link to docs preview:
- [Diagnosing pipeline failures with opc assist](https://103763--ocpdocs-pr.netlify.app/openshift-pipelines/latest/create/creating-applications-with-cicd-pipelines#diagnosing-a-pipeline-with-opc-assist_creating-applications-with-cicd-pipelines)
- [Lightspeed utility commands](https://103763--ocpdocs-pr.netlify.app/openshift-pipelines/latest/tkn_cli/op-tkn-reference.html#op-lightspeed-utility-commands_op-tkn-reference)

QE review:
- [x] QE has approved this change.
