### PR TITLE
PR for SRVLOGIC-752: Update Release Notes content for Serverless Logic 1.37

### DIFF
--- a/modules/serverless-rn-1-37-0.adoc
+++ b/modules/serverless-rn-1-37-0.adoc
@@ -2,7 +2,7 @@
 //
 // * about/serverless-release-notes.adoc
 
-:_content-type: REFERENCE
+:_mod-docs-content-type: REFERENCE
 [id="serverless-rn-1-37-0_{context}"]
 = Red{nbsp}Hat {ServerlessProductName} 1.37
 
@@ -41,6 +41,31 @@
 
 * The Func MCP server is now available as a Developer Preview feature.
 
+[id="new-features-osl-1-37-0_{context}"]
+=== {ServerlessLogicProductName}
+
+* {ServerlessLogicProductName} introduces a new data index mutation named `ExecuteAfter`, which enables you to create and execute a new workflow instance that can reuse the output of a previously completed workflow as its input.
++
+The `ExecuteAfter` mutation accepts the following arguments:
++
+** `processId`: Specifies the process ID of the workflow definition to execute.
+** `processVersion`: Specifies the process version of the workflow definition to execute.
+** `completedInstanceId` (optional): Specifies the ID of a previously completed workflow whose output serves as input for the new workflow instance.
+** `input` (optional): Specifies the additional input data, which the system merges with the output of the `completedInstanceId`, if you provide it.
+** `excludeProperties` (optional): Specifies the list of properties that the system does not copy from the `completedInstanceId` output into the new workflow instance input.
+
+* {ServerlessLogicProductName} container images now use the {op-system-base} UBI 9 parent image, aligning the {ServerlessLogicProductShortName} components with the {op-system-base} 9 runtime environment.
+
+* {ServerlessLogicOperatorName} now uses a simplified `ClusterServiceVersion` (CSV) naming schema that removes the `rhel9` suffix. For example, the CSV name is now `logic-operator.v1.37.0`.
+
+* {ServerlessLogicProductName} now provides a landing web application for the Jobs Service and Data Index services, offering users a centralized entry point to access and explore these services.
+
+* {ServerlessLogicProductName} now supports dynamic URLs and security configurations for OpenAPI function calls in workflows, enabling workflows to adapt securely to different environments and endpoints.
+
+* {ServerlessLogicProductName} now includes a new guide that explains how to configure Maven mirrors in builder and devmode images.
+
+* {ServerlessLogicProductName} now supports token exchange by introducing JSON Web Token (JWT) token parsing for SonataFlow workflows. This feature adds a new Quarkus add-on, `sonataflow-addons-quarkus-jwt-parser`, which enables workflows to parse JWT tokens and extract user claims to generate personalized responses.
+
 [id="fixed-issues-1-37-0_{context}"]
 == Fixed issues
 
@@ -50,6 +75,15 @@
 * Before this update, the `KafkaSource` dispatcher stopped committing offsets when the offsets of produced events were not consecutive integers, for example, when events were produced within a Kafka transaction. This behavior caused the dispatcher to stall and prevented subsequent events from being processed.
 +
 With this update, the `KafkaSource` dispatcher has been fixed to handle such empty offsets correctly. Additionally, the default Kafka consumer configuration for `KafkaSource` has been updated to `isolation.level=read_committed`. When Kafka transactions are used to produce events into a Kafka topic, the `KafkaSource` now processes only the events from committed transactions.
+
+[id="fixed-issues-osl-1-37-0_{context}"]
+=== {ServerlessLogicProductName}
+
+* Before this update, the Sleep state removed tokens from the workflow context when used within a sub-flow. This issue is now fixed, ensuring that tokens remain available throughout the workflow execution.
+
+* Before this update, converting a project to a Quarkus project using the Kn workflow plugin generated incorrect Maven repositories. This issue is now fixed, and the conversion process generates the correct Maven repositories.
+
+* Before this update, the {ServerlessLogicProductName} Builder image downloaded `plexus-utils` version 1.1. This issue is now fixed, and the Builder image no longer downloads this dependency.
 
 [id="known-issues-1-37-0_{context}"]
 == Known issues
@@ -92,3 +126,10 @@ kn: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by kn)
 ----
 
 * As of {ServerlessProductName} 1.37 release, the `kn` client binary downloaded from the *Command Line Tools* page in the {ocp-product-title} web console is not signed with the Red{nbsp}Hat certificate for macOS and Windows platforms. This issue affects the binaries available directly through the {ocp-product-title} console. To obtain properly signed binaries, download them from the link:https://mirror.openshift.com/pub/cgw/serverless/[Official OpenShift Serverless downloads mirror] instead.
+
+[id="known-issues-osl-1-37-0_{context}"]
+=== {ServerlessLogicProductName}
+
+* In disconnected cluster environments, the `logic-swf-builder-rhel9` image attempts to download the `plexus-utils-1.1.jar` dependency during the build process. As external network access is restricted in disconnected setups, this behavior can result in build failures or timeouts. 
+
+* If you apply a `SonataFlow` custom resource (CR) to an OpenShift cluster and the first `SonataFlowBuild` fails for any reason, the Operator does not create the workflow deployment even after the build issue is resolved. As a result, the workflow remains undeployed until you manually reapply or rebuild it.


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.37`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-752

**Doc preview:**

- [Serverless Logic 1.37 release notes](https://103791--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-37-0_serverless-release-notes)

**Reviews:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] Peer has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->