### PR TITLE
OSDOCS-X: Agent link text update

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-using-iscsi.adoc
+++ b/installing/installing_with_agent_based_installer/installing-using-iscsi.adoc
@@ -39,7 +39,7 @@ include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+1]
 * xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#configuring-the-install-config-file_ipi-install-installation-workflow[Configuring the install-config yaml file]
 * xref:../../installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc#installation-three-node-cluster_installing-restricted-networks-bare-metal[Configuring a three-node cluster]
 * xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints]
-* link:https://nmstate.io/examples.html[NMState state examples] (NMState documentation)
+* link:https://nmstate.io/examples.html[NMState state examples (NMState documentation)]
 * xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-opt-manifests_installing-with-agent-based-installer[Optional: Creating additional manifest files]
 * xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#agent-install-verifying-architectures_installing-with-agent-based-installer[Verifying the supported architecture for an Agent-based installation]
 


### PR DESCRIPTION
4.18+

This PR moves some text surrounding an xref to be within the link text, so it's compliant with both our style guides and migration rules.

QE review not required

Preview: