### PR TITLE
OSDOCS 17653 GA-BYOPKI for image verification in OCP

### DIFF
--- a/modules/nodes-sigstore-configure-cluster-policy.adoc
+++ b/modules/nodes-sigstore-configure-cluster-policy.adoc
@@ -21,7 +21,7 @@ The default `ClusterImagePolicy` object, named `openshift`, provides sigstore su
 * You have a sigstore-supported public key infrastructure (PKI) key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or provide a link:https://docs.sigstore.dev/cosign/signing/overview/[Cosign public and private key pair] for signing operations.
 * You have a signing process in place to sign your images.
 * You have access to a registry that supports Cosign signatures, if you are using Cosign signatures.
-* If registry mirrors are configured for the {product-title} release image repositories, `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev`, before enabling the Technology Preview feature set, you must mirror the sigstore signatures for the {product-title} release images into your mirror registry. Otherwise, the default `openshift` cluster image policy, which enforces signature verification for the release repository, blocks the ability of the Cluster Version Operator to move the CVO pod to new nodes, preventing the node update that results from the feature set change.
+* If a mirror registry is configured for the {product-title} release image repositories, `quay.io/openshift-release-dev/ocp-release` and `quay.io/openshift-release-dev/ocp-v4.0-art-dev`, you must mirror the sigstore signatures for the {product-title} release images into your mirror registry. Otherwise, the default `openshift` cluster image policy, which enforces signature verification for the release repository, blocks the ability of the Cluster Version Operator to move the CVO pod to new nodes, preventing the node update.
 +
 You can use the `oc image mirror` command to mirror the signatures. For example:
 +
@@ -30,30 +30,6 @@ You can use the `oc image mirror` command to mirror the signatures. For example:
 $ oc image mirror quay.io/openshift-release-dev/ocp-release:sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sig \
 mirror.com/image/repo:sha256-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sig
 ----
-
-* If you are using a BYOPKI certificate as the root of trust, you enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`.
-+
-[source,terminal]
-----
-$ oc edit featuregate cluster
-----
-+
-.Example `FeatureGate` CR
-[source,yaml]
-----
-apiVersion: config.openshift.io/v1
-kind: FeatureGate
-metadata:
-  name: cluster
-spec:
-  featureSet: TechPreviewNoUpgrade <1>
-----
-<1> Enables the required `SigstoreImageVerificationPKI` feature.
-+
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
-====
 
 .Procedure
 

--- a/modules/nodes-sigstore-configure-image-policy.adoc
+++ b/modules/nodes-sigstore-configure-image-policy.adoc
@@ -20,29 +20,6 @@ The following example shows general guidelines on how to configure an `ImagePoli
 * You have a sigstore-supported public key infrastructure (PKI) key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or provide a link:https://docs.sigstore.dev/cosign/signing/overview/[Cosign public and private key pair] for signing operations.
 * You have a signing process in place to sign your images.
 * You have access to a registry that supports Cosign signatures, if you are using Cosign signatures.
-* If you are using a BYOPKI certificate as the root of trust, you enabled the required Technology Preview features for your cluster by editing the `FeatureGate` CR named `cluster`:
-+
-[source,terminal]
-----
-$ oc edit featuregate cluster
-----
-+
-.Example `FeatureGate` CR
-[source,yaml]
-----
-apiVersion: config.openshift.io/v1
-kind: FeatureGate
-metadata:
-  name: cluster
-spec:
-  featureSet: TechPreviewNoUpgrade <1>
-----
-<1> Enables the required `SigstoreImageVerification` feature.
-+
-[WARNING]
-====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
-====
 
 .Procedure
 

--- a/modules/nodes-sigstore-configure.adoc
+++ b/modules/nodes-sigstore-configure.adoc
@@ -58,11 +58,6 @@ If a scoped image or repository in an image policy is nested under one of the sc
 * `rootOfTrust`: Specifies the root of trust for the policy. Configure either a public key, a Bring Your Own Public Key Infrastructure (BYOPKI) certificate, or a link:https://docs.sigstore.dev/certificate_authority/overview/[Fulcio certificate].
 ** `publicKey`: Indicates that the policy relies on a sigstore public key. You must specify a base64-encoded PEM format public key. You can optionally include link:https://docs.sigstore.dev/logging/overview/[Rekor verification].
 ** `PKI` Indicates that the policy relies on a certificate from your own public key infrastructure (PKI) that is compatible with Cosign Bring Your Own Public Key Infrastructure (BYOPKI) verification. You must specify a base64-encoded PEM format public key. BYOPKI enables you to validate container images using an existing X.509 certificate while aligning with Cosign's bring-your-own PKI signing workflow.
-+
---
-:FeatureName: sigstore BYOPKI support
-include::snippets/technology-preview.adoc[]
---
 ** `FulcioCAWithRekor`: Indicates that the policy is based on a Fulcio certificate. You must specify the following parameters:
 *** A base64-encoded PEM-format Fulcio CA
 *** An OpenID Connect (OIDC) issuer


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17653

Link to docs preview:
[Creating a cluster image policy CR](https://103803--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#nodes-sigstore-configure-cluster-policy_nodes-sigstore-using) -- Reworded prerequisite 4, Removed TP feature gate prereq.
[Creating an image policy CR](https://103803--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#nodes-sigstore-configure-image-policy_nodes-sigstore-using) -- Removed TP feature gate prereq.
[About cluster and image policy parameters](https://103803--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#nodes-sigstore-configure-parameters_nodes-sigstore-using) -- Removed TP snippet. 
 
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

