### PR TITLE
OSDOCS#17587: Update the z-stream RNs for 4.14.60

### DIFF
--- a/modules/zstream-4-14-60-about.adoc
+++ b/modules/zstream-4-14-60-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-60-about_{context}"]
+= RHBA-2025:22733 - {product-title} 4.14.60 bug fix and security update
+
+[role="_abstract"]
+Issued: 11 December 2025
+
+{product-title} release 4.14.60, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:22733[RHBA-2025:22733] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:22731[RHBA-2025:22731] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.60 --pullspecs
+----

--- a/modules/zstream-4-14-60-bug-fixes.adoc
+++ b/modules/zstream-4-14-60-bug-fixes.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-60-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+The following bug is fixed with this release:
+
+* Before this update, an unsafe process file system in a container prevented a process from starting, and caused network issues. With this release, the unsafe issue in a container is fixed,  and the pods start. As a result, the pods do not stay in the initial startup state, and the Border Gateway Protocol (BGP) operation continues. (link:https://issues.redhat.com/browse/OCPBUGS-58892[OCPBUGS-58892])

--- a/modules/zstream-4-14-x-updating.adoc
+++ b/modules/zstream-4-14-x-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-x-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3426,14 +3426,23 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//4.14.60 about
+include::modules/zstream-4-14-60-about.adoc[leveloffset=+2]
+
+//4.14.60 bug fixes
+include::modules/zstream-4-14-60-bug-fixes.adoc[leveloffset=+3]
+
+//4.14.60 updating
+include::modules/zstream-4-14-x-updating.adoc[leveloffset=+3]
+
 //4.14.59 about
 include::modules/zstream-4-14-59-about.adoc[leveloffset=+2]
 
-// 4.14.59 fixes
-include::modules/zstream-4-14-59-bug-fixes.adoc[leveloffset=+2]
+// 4.14.59 bug fixes
+include::modules/zstream-4-14-59-bug-fixes.adoc[leveloffset=+3]
 
 // 4.14.59 updating
-include::modules/zstream-4-14-59-updating.adoc[leveloffset=+2]
+include::modules/zstream-4-14-59-updating.adoc[leveloffset=+3]
 
 // 4.14.58
 [id="ocp-4-14-58_{context}"]


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-17587](https://issues.redhat.com//browse/OSDOCS-17587)

Link to docs preview:
[4.14.60](https://103827--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#zstream-4-14-60-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/265)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.14)
