### PR TITLE
OSDOCS-17657: Removing GovCloud Life cycle dates from OSD documentation.

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -36,7 +36,7 @@ Before upgrading your cluster from version 4.16 to version 4.18, confirm that yo
 See _Upgrade options for {product-title} clusters_ in the _Additional resources_ section for more information.
 =====
 endif::openshift-rosa-hcp[]
-
+ifdef::openshift-rosa-hcp,openshift-rosa[]
 [id="govcloud-life-cycle-dates_{context}"]
 = Life cycle dates for {product-title} GovCloud
 
@@ -48,3 +48,4 @@ endif::openshift-rosa-hcp[]
 |4.15       |May 9, 2025           |Dec 1, 2025
 |4.16       |Oct 20, 2025           |Dec 27, 2025
 |===
+endif::openshift-rosa-hcp,openshift-rosa[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
[OSDOCS-17657](https://issues.redhat.com/browse/OSDOCS-17657)

Link to docs preview:
[OSD:](https://103828--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-life-cycle#sd-life-cycle-dates_osd-life-cycle) Table no longer exists.
[HCP:](https://103828--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle#govcloud-life-cycle-dates_rosa-hcp-life-cycle) Table exists
[Classic: ](https://103828--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle#govcloud-life-cycle-dates_rosa-life-cycle) Table exists


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
