### PR TITLE
OBSDOCS-2938: Error in clusterlogforwarder CR filters code

### DIFF
--- a/modules/logging-content-filter-drop-records.adoc
+++ b/modules/logging-content-filter-drop-records.adoc
@@ -55,11 +55,11 @@ spec:
   - name: drop-filter
     type: drop # <1>
     drop: # <2>
-    - test: # <3>
-      - field: .kubernetes.labels."app.version-1.2/beta" # <4>
-        matches: .+ # <5>
-      - field: .kubernetes.pod_name
-        notMatches: "my-pod" # <6>
+      - test: # <3>
+        - field: .kubernetes.labels."app.version-1.2/beta" # <4>
+          matches: .+ # <5>
+        - field: .kubernetes.pod_name
+          notMatches: "my-pod" # <6>
   pipelines:
   - name: my-pipeline # <7>
     filterRefs:
@@ -91,11 +91,11 @@ filters:
 - name: important
   type: drop
   drop:
-  - test:
-    - field: .message
-      notMatches: "(?i)critical|error"
-    - field: .level
-      matches: "info|warning"
+    - test:
+      - field: .message
+        notMatches: "(?i)critical|error"
+      - field: .level
+        matches: "info|warning"
 # ...
 ----
 +
@@ -107,14 +107,14 @@ filters:
 - name: important
   type: drop
   drop:
-  - test: # <1>
-    - field: .kubernetes.namespace_name
-      matches: "openshift.*"
-  - test: # <2>
-    - field: .log_type
-      matches: "application"
-    - field: .kubernetes.pod_name
-      notMatches: "my-pod"
+    - test: # <1>
+      - field: .kubernetes.namespace_name
+        matches: "openshift.*"
+    - test: # <2>
+      - field: .log_type
+        matches: "application"
+      - field: .kubernetes.pod_name
+        notMatches: "my-pod"
 # ...
 ----
 <1> The filter drops logs that contain a namespace that starts with `openshift`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 6.4
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2938

Link to docs preview: https://103830--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-log-forwarding.html#logging-content-filter-drop-records_configuring-log-forwarding
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
