### PR TITLE
OSDOCS-17013-bm-upi-re

### DIFF
--- a/modules/cli-installing-cli-linux.adoc
+++ b/modules/cli-installing-cli-linux.adoc
@@ -56,7 +56,7 @@ endif::[]
 = Installing the OpenShift CLI on Linux
 
 [role="_abstract"]
-You can install the {oc-first} binary on Linux by using the following procedure.
+You can install the {oc-first} binary on Linux.
 
 [IMPORTANT]
 ====
@@ -79,18 +79,25 @@ endif::microshift[]
 
 ifdef::openshift-origin[]
 . Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/[https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/] and choose the folder for your operating system and architecture.
+
 . Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin,microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Navigate to the link:https://access.redhat.com/downloads/content/290[Download {product-title}] page on the Red{nbsp}Hat Customer Portal.
+
 . Select the architecture from the *Product Variant* list.
+
 . Select the appropriate version from the *Version* list.
+
 . Click *Download Now* next to the *OpenShift v{product-version} Linux Clients* entry and save the file.
 endif::openshift-origin,microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifdef::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Navigate to the link:https://access.redhat.com/downloads/content/290[Download {OCP}] page on the Red{nbsp}Hat Customer Portal.
+
 . Select the architecture from the *Product Variant* list.
+
 . Select the appropriate version from the *Version* list.
+
 . Click *Download Now* next to the *OpenShift v{product-version} Linux Clients* entry and save the file.
 endif::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Unpack the archive:
@@ -99,6 +106,7 @@ endif::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ----
 $ tar xvf <file>
 ----
+
 . Place the `oc` binary in a directory that is on your `PATH`.
 +
 To check your `PATH`, execute the following command:

--- a/modules/cli-installing-cli-macos.adoc
+++ b/modules/cli-installing-cli-macos.adoc
@@ -56,7 +56,7 @@ endif::[]
 = Installing the OpenShift CLI on macOS
 
 [role="_abstract"]
-You can install the {oc-first} binary on macOS by using the following procedure.
+You can install the {oc-first} binary on macOS.
 
 [IMPORTANT]
 ====
@@ -83,7 +83,11 @@ ifdef::openshift-origin[]
 endif::[]
 ifndef::openshift-origin,microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Navigate to the link:https://access.redhat.com/downloads/content/290[Download {product-title}] page on the Red{nbsp}Hat Customer Portal.
-. Select the appropriate version from the *Version* drop-down list.
+
+. Select the architecture from the *Product Variant* list.
+
+. Select the appropriate version from the *Version* list.
+
 . Click *Download Now* next to the *OpenShift v{product-version} macOS Clients* entry and save the file.
 +
 [NOTE]
@@ -94,12 +98,15 @@ endif::openshift-origin,microshift,openshift-rosa,openshift-rosa-hcp,openshift-d
 ifdef::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Navigate to the link:https://access.redhat.com/downloads/content/290[Download {OCP}] on the Red{nbsp}Hat Customer Portal.
 . Select the appropriate version from the *Version* drop-down list.
+
 . Click *Download Now* next to the *OpenShift v{product-version} macOS Clients* entry and save the file.
+
 endif::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Unpack and unzip the archive.
-. Move the `oc` binary to a directory on your PATH.
+
+. Move the `oc` binary to a directory on your `PATH` variable.
 +
-To check your `PATH`, open a terminal and execute the following command:
+To check your `PATH` variable, open a terminal and execute the following command:
 +
 [source,terminal]
 ----

--- a/modules/cli-installing-cli-windows.adoc
+++ b/modules/cli-installing-cli-windows.adoc
@@ -56,7 +56,7 @@ endif::[]
 = Installing the OpenShift CLI on Windows
 
 [role="_abstract"]
-You can install the {oc-first} binary on Windows by using the following procedure.
+You can install the {oc-first} binary on Windows.
 
 [IMPORTANT]
 ====
@@ -83,18 +83,23 @@ ifdef::openshift-origin[]
 endif::[]
 ifndef::openshift-origin,microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Navigate to the link:https://access.redhat.com/downloads/content/290[Download {product-title}] page on the Red{nbsp}Hat Customer Portal.
+
 . Select the appropriate version from the *Version* list.
+
 . Click *Download Now* next to the *OpenShift v{product-version} Windows Client* entry and save the file.
 endif::openshift-origin,microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifdef::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Navigate to the link:https://access.redhat.com/downloads/content/290[Download {OCP}] page on the Red Hat Customer Portal.
+
 . Select the appropriate version from the *Version* list.
+
 . Click *Download Now* next to the *OpenShift v{product-version} Windows Client* entry and save the file.
 endif::microshift,openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 . Extract the archive with a ZIP program.
-. Move the `oc` binary to a directory that is on your `PATH`.
+
+. Move the `oc` binary to a directory that is on your `PATH` variable.
 +
-To check your `PATH`, open the command prompt and execute the following command:
+To check your `PATH` variable, open the command prompt and execute the following command:
 +
 [source,terminal]
 ----

--- a/openshift_images/samples-operator-alt-registry.adoc
+++ b/openshift_images/samples-operator-alt-registry.adoc
@@ -15,13 +15,13 @@ include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 //Incorrect rendering of ROSA attributes discovered during Pruning HCP task. I believe some of the following content is not correct for managed OpenShift. I have created JIRA issue to investigate further.
 
 // Installing the OpenShift CLI on Linux
-include::modules/cli-installing-cli-linux.adoc[leveloffset=+1]
+include::modules/cli-installing-cli-linux.adoc[leveloffset=+2]
 
 // Installing the OpenShift CLI on Windows
-include::modules/cli-installing-cli-windows.adoc[leveloffset=+1]
+include::modules/cli-installing-cli-windows.adoc[leveloffset=+2]
 
 // Installing the OpenShift CLI on macOS
-include::modules/cli-installing-cli-macos.adoc[leveloffset=+1]
+include::modules/cli-installing-cli-macos.adoc[leveloffset=+2]
 
 include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Continue from include::modules/installation-user-infra-machines-pxe.adoc

Version(s):
4.16+

Issue:
[OSDOCS-17013](https://issues.redhat.com/browse/OSDOCS-17013)

Link to docs preview:

* https://103618--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/upi/installing-restricted-networks-azure-user-provisioned.html
* https://103618--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installation-config-parameters-bare-metal.html
* https://103618--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html
* https://103618--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html
* https://103618--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html


- [ ] SME has approved this change.
- [ ] QE has approved this change.

