### PR TITLE
OADP-7040: Prepare OADP 1.3 and 1.4 RNs for DITA

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3170,8 +3170,12 @@ Topics:
     Topics:
     - Name: OADP 1.4 release notes
       File: oadp-1-4-release-notes
+    - Name: Upgrading OADP 1.3 to 1.4
+      File: oadp-upgrade-notes-1-4
     - Name: OADP 1.3 release notes
       File: oadp-release-notes-1-3
+    - Name: Upgrading OADP 1.2 to 1.3
+      File: oadp-upgrade-notes-1-3
   - Name: OADP performance
     Dir: oadp-performance
     Topics:

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -8,20 +8,25 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 toc::[]
 
 [role="_abstract"]
-The release notes for {oadp-first} describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
+The release notes for {oadp-first} 1.4 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
 [NOTE]
 ====
-For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
+For additional information about {oadp-short}, see _{oadp-first} FAQ_.
 ====
 
 include::modules/oadp-1-4-8-release-notes.adoc[leveloffset=+1]
 
 include::modules/oadp-1-4-7-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-6-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-5-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-4-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-3-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-2-release-notes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -29,20 +34,10 @@ include::modules/oadp-1-4-2-release-notes.adoc[leveloffset=+1]
 * xref:../../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-deleting-backups.adoc#oadp-about-kopia-repo-maintenance_deleting-backups[About Kopia repository maintenance]
 
 include::modules/oadp-1-4-1-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-0-release-notes.adoc[leveloffset=+1]
-include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+3]
-include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+3]
 
-// TODO: Include this xref when the Operators book is added to the ROSA HCP docs.
-ifndef::openshift-rosa-hcp[]
 [role="_additional-resources"]
-.Additional resources
-* xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
-endif::openshift-rosa-hcp[]
+== Additional resources
 
-[id="oadp-converting-dpa-to-new-version-1-4-0_{context}"]
-=== Converting DPA to the new version
-
-To upgrade from OADP 1.3 to 1.4, no Data Protection Application (DPA) changes are required.
-
-include::modules/oadp-verifying-upgrade-1-4-0.adoc[leveloffset=+2]
+* link:https://access.redhat.com/articles/5456281[{oadp-first} FAQ]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.adoc
@@ -7,26 +7,25 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 The release notes for {oadp-first} 1.3 describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
 include::modules/oadp-release-notes-1-3-9.adoc[leveloffset=+1]
 
 include::modules/oadp-release-notes-1-3-8.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-3-7.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-3-6.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-3-5.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-3-4.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-3-3.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-3-2.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-3-1.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-3-0.adoc[leveloffset=+1]
-include::modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc[leveloffset=+3]
-include::modules/oadp-backing-up-dpa-configuration-1-3-0.adoc[leveloffset=+3]
-include::modules/oadp-upgrading-oadp-operator-1-3-0.adoc[leveloffset=+3]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
-
-include::modules/oadp-converting-dpa-to-new-version-1-3-0.adoc[leveloffset=+3]
-include::modules/oadp-verifying-upgrade-1-3-0.adoc[leveloffset=+3]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-upgrade-notes-1-3.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-upgrade-notes-1-3.adoc
@@ -1,0 +1,33 @@
+:_mod-docs-content-type: ASSEMBLY
+
+[id="oadp-upgrade-notes-1-3"]
+= Upgrading OADP 1.2 to 1.3
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: oadp-upgrade-notes-1-3
+
+toc::[]
+
+[role="_abstract"]
+Learn how to upgrade your existing {oadp-short} 1.2 installation to {oadp-short} 1.3.
+
+[NOTE]
+====
+Always upgrade to the next minor version. *Do not* skip versions. To update to a later version, upgrade only one channel at a time. For example, to upgrade from {oadp-first} 1.1 to 1.3, upgrade first to 1.2, and then to 1.3.
+====
+
+include::modules/oadp-changes-from-oadp-1-2-to-1-3.adoc[leveloffset=+1]
+
+include::modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc[leveloffset=+1]
+
+include::modules/oadp-backing-up-dpa-configuration-1-3-0.adoc[leveloffset=+1]
+
+include::modules/oadp-upgrading-oadp-operator-1-3-0.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
+
+include::modules/oadp-converting-dpa-to-new-version-1-3-0.adoc[leveloffset=+1]
+
+include::modules/oadp-verifying-upgrade-1-3-0.adoc[leveloffset=+1]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-upgrade-notes-1-4.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-upgrade-notes-1-4.adoc
@@ -1,0 +1,34 @@
+:_mod-docs-content-type: ASSEMBLY
+
+[id="upgrade-notes-1-4"]
+= Upgrading OADP 1.3 to 1.4
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: oadp-upgrade-notes-1-4
+
+toc::[]
+
+[role="_abstract"]
+Learn how to upgrade your existing {oadp-short} 1.3 installation to {oadp-short} 1.4.
+
+[NOTE]
+====
+Always upgrade to the next minor version. *Do not* skip versions. To update to a later version, upgrade only one channel at a time. For example, to upgrade from {oadp-first} 1.1 to 1.3, upgrade first to 1.2, and then to 1.3.
+====
+
+include::modules/oadp-changes-from-oadp-1-3-to-1-4.adoc[leveloffset=+1]
+
+include::modules/oadp-backing-up-dpa-configuration-1-4-0.adoc[leveloffset=+1]
+
+include::modules/oadp-upgrading-oadp-operator-1-4-0.adoc[leveloffset=+1]
+
+// TODO: Include this xref when the Operators book is added to the ROSA HCP docs.
+ifndef::openshift-rosa-hcp[]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../operators/admin/olm-upgrading-operators.adoc#olm-changing-update-channel_olm-upgrading-operators[Updating installed Operators]
+endif::openshift-rosa-hcp[]
+
+include::modules/oadp-converting-dpa-to-the-new-version-for-oadp-1-4-0.adoc[leveloffset=+1]
+
+include::modules/oadp-verifying-upgrade-1-4-0.adoc[leveloffset=+1]

--- a/modules/oadp-1-4-0-release-notes.adoc
+++ b/modules/oadp-1-4-0-release-notes.adoc
@@ -9,21 +9,22 @@
 [id="oadp-1-4-0-release-notes_{context}"]
 = OADP 1.4.0 release notes
 
-The {oadp-first} 1.4.0 release notes lists resolved issues and known issues.
+[role="_abstract"]
+The {oadp-first} 1.4.0 release notes list resolved issues and known issues.
 
 [id="resolved-issues-1-4-0_{context}"]
 == Resolved issues
 
-.Restore works correctly in {product-title} 4.16
-
+Restore works correctly in {product-title} 4.16::
 Previously, while restoring the deleted application namespace, the restore operation partially failed with the `resource name may not be empty` error in {product-title} 4.16.
 With this update, restore works as expected in {product-title} 4.16.
++
 link:https://issues.redhat.com/browse/OADP-4075[OADP-4075]
 
-.Data Mover backups work properly in the {product-title} 4.16 cluster
-
-Previously, Velero was using the earlier version of SDK where the `Spec.SourceVolumeMode` field did not exist. As a consequence, Data Mover backups failed in the {product-title} 4.16 cluster on the external snapshotter with version 4.2. 
+Data Mover backups work properly in the {product-title} 4.16 cluster::
+Previously, Velero was using the earlier version of SDK where the `Spec.SourceVolumeMode` field did not exist. As a consequence, Data Mover backups failed in the {product-title} 4.16 cluster on the external snapshotter with version 4.2.
 With this update, external snapshotter is upgraded to version 7.0 and later. As a result, backups do not fail in the {product-title} 4.16 cluster.
++
 link:https://issues.redhat.com/browse/OADP-3922[OADP-3922]
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12438505[OADP 1.4.0 resolved issues] in Jira.
@@ -32,35 +33,10 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-4-0_{context}"]
 == Known issues
 
-.Backup fails when checksumAlgorithm is not set for MCG
-
+Backup fails when checksumAlgorithm is not set for MCG::
 While performing a backup of any application with Noobaa as the backup location, if the `checksumAlgorithm` configuration parameter is not set, backup fails. To fix this problem, if you do not provide a value for `checksumAlgorithm` in the Backup Storage Location (BSL) configuration, an empty value is added.
 The empty value is only added for BSLs that are created using Data Protection Application (DPA) custom resource (CR), and this value is not added if BSLs are created using any other method.
++
 link:https://issues.redhat.com/browse/OADP-4274[OADP-4274]
 
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12438506[OADP 1.4.0 known issues] in Jira.
-
-
-[id="upgrade-notes-1-4-0_{context}"]
-== Upgrade notes
-
-[NOTE]
-====
-Always upgrade to the next minor version. *Do not* skip versions. To update to a later version, upgrade only one channel at a time. For example, to upgrade from {oadp-first} 1.1 to 1.3, upgrade first to 1.2, and then to 1.3.
-====
-
-[id="changes-oadp-1-3-to-1-4_{context}"]
-=== Changes from OADP 1.3 to 1.4
-
-The Velero server has been updated from version 1.12 to 1.14. Note that there are no changes in the Data Protection Application (DPA).
-
-This changes the following:
-
-* The `velero-plugin-for-csi` code is now available in the Velero code, which means an `init` container is no longer required for the plugin.
-
-* Velero changed client Burst and QPS defaults from 30 and 20 to 100 and 100, respectively.
-
-* The `velero-plugin-for-aws` plugin updated default value of the `spec.config.checksumAlgorithm` field in `BackupStorageLocation` objects (BSLs) from `""` (no checksum calculation) to the `CRC32` algorithm. For more information, see link:https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/release-1.10/backupstoragelocation.md[Velero plugins for AWS Backup Storage Location]. The checksum algorithm types are known to work only with AWS. 
-Several S3 providers require the `md5sum` to be disabled by setting the checksum algorithm to `""`. Confirm `md5sum` algorithm support and configuration with your storage provider. 
-+
-In OADP 1.4, the default value for BSLs created within DPA for this configuration is `""`. This default value means that the `md5sum` is not checked, which is consistent with OADP 1.3. For BSLs created within DPA, update it by using the `spec.backupLocations[].velero.config.checksumAlgorithm` field in the DPA. If your BSLs are created outside DPA, you can update this configuration by using `spec.config.checksumAlgorithm` in the BSLs.

--- a/modules/oadp-1-4-1-release-notes.adoc
+++ b/modules/oadp-1-4-1-release-notes.adoc
@@ -7,98 +7,104 @@
 [id="oadp-1-4-1-release-notes_{context}"]
 = OADP 1.4.1 release notes
 
-The {oadp-first} 1.4.1 release notes lists new features, resolved issues and bugs, and known issues.
+[role="_abstract"]
+The {oadp-first} 1.4.1 release notes list new features, resolved issues, and known issues.
 
 [id="new-features-1-4-1_{context}"]
 == New features
 
-.New DPA fields to update client qps and burst
-
+New DPA fields to update client qps and burst::
 You can now change Velero Server Kubernetes API queries per second and burst values by using the new Data Protection Application (DPA) fields. The new DPA fields are `spec.configuration.velero.client-qps` and `spec.configuration.velero.client-burst`, which both default to 100.
++
 link:https://issues.redhat.com/browse/OADP-4076[OADP-4076]
 
-.Enabling non-default algorithms with Kopia
-
+Enabling non-default algorithms with Kopia::
 With this update, you can now configure the hash, encryption, and splitter algorithms in Kopia to select non-default options to optimize performance for different backup workloads.
-
++
 To configure these algorithms, set the `env` variable of a `velero` pod in the `podConfig` section of the DataProtectionApplication (DPA) configuration. If this variable is not set, or an unsupported algorithm is chosen, Kopia will default to its standard algorithms.
++
 link:https://issues.redhat.com/browse/OADP-4640[OADP-4640]
 
 
 [id="resolved-issues-1-4-1_{context}"]
 == Resolved issues
 
-.Restoring a backup without pods is now successful
-
-Previously, restoring a backup without pods and having `StorageClass VolumeBindingMode` set as `WaitForFirstConsumer`, resulted in the `PartiallyFailed` status with an error: `fail to patch dynamic PV, err: context deadline exceeded`. 
+Restoring a backup without pods is now successful::
+Previously, restoring a backup without pods and having `StorageClass VolumeBindingMode` set as `WaitForFirstConsumer`, resulted in the `PartiallyFailed` status with an error: `fail to patch dynamic PV, err: context deadline exceeded`.
 With this update, patching dynamic PV is skipped and restoring a backup is successful without any `PartiallyFailed` status.
++
 link:https://issues.redhat.com/browse/OADP-4231[OADP-4231]
 
 
-.PodVolumeBackup CR now displays correct message
-
+PodVolumeBackup CR now displays correct message::
 Previously, the `PodVolumeBackup` custom resource (CR) generated an incorrect message, which was: `get a podvolumebackup with status "InProgress" during the server starting, mark it as "Failed"`.
 With this update, the message produced is now:
++
 [source,text]
 ----
 found a podvolumebackup with status "InProgress" during the server starting,
 mark it as "Failed".
 ----
++
 link:https://issues.redhat.com/browse/OADP-4224[OADP-4224]
 
-.Overriding imagePullPolicy is now possible with DPA
-
+Overriding imagePullPolicy is now possible with DPA::
 Previously, {oadp-short} set the `imagePullPolicy` parameter to `Always` for all images.
 With this update, {oadp-short} checks if each image contains `sha256` or `sha512` digest, then it sets `imagePullPolicy` to `IfNotPresent`; otherwise `imagePullPolicy` is set to `Always`. You can now override this policy by using the new `spec.containerImagePullPolicy` DPA field.
++
 link:https://issues.redhat.com/browse/OADP-4172[OADP-4172]
 
-.OADP Velero can now retry updating the restore status if initial update fails
-
+OADP Velero can now retry updating the restore status if initial update fails::
 Previously, {oadp-short} Velero failed to update the restored CR status. This left the status at `InProgress` indefinitely. Components which relied on the backup and restore CR status to determine the completion would fail.
 With this update, the restore CR status for a restore correctly proceeds to the `Completed` or `Failed` status.
++
 link:https://issues.redhat.com/browse/OADP-3227[OADP-3227]
 
-.Restoring BuildConfig Build from a different cluster is successful without any errors
-
+Restoring BuildConfig Build from a different cluster is successful without any errors::
 Previously, when performing a restore of the `BuildConfig` Build resource from a different cluster, the application generated an error on TLS verification to the internal image registry. The resulting error was `failed to verify certificate: x509: certificate signed by unknown authority` error.
 With this update, the restore of the `BuildConfig` build resources to a different cluster can proceed successfully without generating the `failed to verify certificate` error.
++
 link:https://issues.redhat.com/browse/OADP-4692[OADP-4692]
 
-.Restoring an empty PVC is successful
-
+Restoring an empty PVC is successful::
 Previously, downloading data failed while restoring an empty persistent volume claim (PVC). It failed with the following error:
++
 [source,text]
 ----
 data path restore failed: Failed to run kopia restore: Unable to load
     snapshot : snapshot not found
 ----
-With this update, the downloading of data proceeds to correct conclusion when restoring an empty PVC and the error message is not generated. 
++
+With this update, the downloading of data proceeds to correct conclusion when restoring an empty PVC and the error message is not generated.
++
 link:https://issues.redhat.com/browse/OADP-3106[OADP-3106]
 
-.There is no Velero memory leak in CSI and DataMover plugins
-
+There is no Velero memory leak in CSI and DataMover plugins::
 Previously, a Velero memory leak was caused by using the CSI and DataMover plugins. When the backup ended, the Velero plugin instance was not deleted and the memory leak consumed memory until an `Out of Memory` (OOM) condition was generated in the Velero pod. With this update, there is no resulting Velero memory leak when using the CSI and DataMover plugins.
++
 link:https://issues.redhat.com/browse/OADP-4448[OADP-4448]
 
-.Post-hook operation does not start before the related PVs are released
-
+Post-hook operation does not start before the related PVs are released::
 Previously, due to the asynchronous nature of the Data Mover operation, a post-hook might be attempted before the Data Mover persistent volume claim (PVC) releases the persistent volumes (PVs) of the related pods. This problem would cause the backup to fail with a `PartiallyFailed` status.
 With this update, the post-hook operation is not started until the related PVs are released by the Data Mover PVC, eliminating the `PartiallyFailed` backup status.
++
 link:https://issues.redhat.com/browse/OADP-3140[OADP-3140]
 
-.Deploying a DPA works as expected in namespaces with more than 37 characters
-
+Deploying a DPA works as expected in namespaces with more than 37 characters::
 When you install the OADP Operator in a namespace with more than 37 characters to create a new DPA, labeling the "cloud-credentials" Secret fails and the DPA reports the following error:
++
 ----
 The generated label name is too long.
 ----
++
 With this update, creating a DPA does not fail in namespaces with more than 37 characters in the name.
++
 link:https://issues.redhat.com/browse/OADP-3960[OADP-3960]
 
-.Restore is successfully completed by overriding the timeout error
-
+Restore is successfully completed by overriding the timeout error::
 Previously, in a large scale environment, the restore operation would result in a `Partiallyfailed` status with the error: `fail to patch dynamic PV, err: context deadline exceeded`.
 With this update, the `resourceTimeout` Velero server argument is used to override this timeout error resulting in a successful restore.
++
 link:https://issues.redhat.com/browse/OADP-4344[OADP-4344]
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12442016[OADP 1.4.1 resolved issues] in Jira.
@@ -107,17 +113,16 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-4-1_{context}"]
 == Known issues
 
-.Cassandra application pods enter into the `CrashLoopBackoff` status after restoring OADP
-
+Cassandra application pods enter into the `CrashLoopBackoff` status after restoring OADP::
 After {oadp-short} restores, the Cassandra application pods might enter `CrashLoopBackoff` status. To work around this problem, delete the `StatefulSet` pods that are returning the error `CrashLoopBackoff` state after restoring {oadp-short}. The `StatefulSet` controller then recreates these pods and it runs normally.
++
 link:https://issues.redhat.com/browse/OADP-4407[OADP-4407]
 
-.Deployment referencing ImageStream is not restored properly leading to corrupted pod and volume contents
-
+Deployment referencing ImageStream is not restored properly leading to corrupted pod and volume contents::
 During a File System Backup (FSB) restore operation, a `Deployment` resource referencing an `ImageStream` is not restored properly. The restored pod that runs the FSB, and the `postHook` is terminated prematurely.
-
++
 During the restore operation, the {ocp} controller updates the `spec.template.spec.containers[0].image` field in the `Deployment` resource with an updated `ImageStreamTag` hash. The update triggers the rollout of a new pod, terminating the pod on which `velero` runs the FSB along with the post-hook. For more information about image stream trigger, see xref:../../../openshift_images/triggering-updates-on-imagestream-changes.adoc#triggering-updates-on-imagestream-changes[Triggering updates on image stream changes].
-
++
 The workaround for this behavior is a two-step restore process:
 
 . Perform a restore excluding the `Deployment` resources, for example:
@@ -137,4 +142,6 @@ $ velero restore create <RESTORE_NAME> \
   --from-backup <BACKUP_NAME> \
   --include-resources=deployment.apps
 ----
+
++
 link:https://issues.redhat.com/browse/OADP-3954[OADP-3954]

--- a/modules/oadp-1-4-2-release-notes.adoc
+++ b/modules/oadp-1-4-2-release-notes.adoc
@@ -7,42 +7,45 @@
 [id="oadp-1-4-2-release-notes_{context}"]
 = {oadp-short} 1.4.2 release notes
 
-The {oadp-first} 1.4.2 release notes lists new features, resolved issues and bugs, and known issues.
+[role="_abstract"]
+The {oadp-first} 1.4.2 release notes list new features, resolved issues, and known issues.
 
 [id="new-features-1-4-2_{context}"]
 == New features
 
-.Backing up different volumes in the same namespace by using the VolumePolicy feature is now possible
-
+Backing up different volumes in the same namespace by using the VolumePolicy feature is now possible::
 With this release, Velero provides resource policies to back up different volumes in the same namespace by using the `VolumePolicy` feature. The supported `VolumePolicy` feature to back up different volumes includes `skip`, `snapshot`, and `fs-backup` actions.
++
 link:https://issues.redhat.com/browse/OADP-1071[OADP-1071]
 
-.File system backup and data mover can now use short-term credentials
-
+File system backup and data mover can now use short-term credentials::
 File system backup and data mover can now use short-term credentials such as {aws-short} {sts-first} and {gcp-short} WIF. With this support, backup is successfully completed without any `PartiallyFailed` status.
++
 link:https://issues.redhat.com/browse/OADP-5095[OADP-5095]
 
 [id="resolved-issues-1-4-2_{context}"]
 == Resolved issues
 
-.DPA now reports errors if VSL contains an incorrect provider value 
-
+DPA now reports errors if VSL contains an incorrect provider value::
 Previously, if the provider of a Volume Snapshot Location (VSL) spec was incorrect, the Data Protection Application (DPA) reconciled successfully. With this update, DPA reports errors and requests for a valid provider value.
++
 link:https://issues.redhat.com/browse/OADP-5044[OADP-5044]
 
-.Data Mover restore is successful irrespective of using different OADP namespaces for backup and restore
-
+Data Mover restore is successful irrespective of using different OADP namespaces for backup and restore::
 Previously, when backup operation was executed by using {oadp-short} installed in one namespace but was restored by using {oadp-short} installed in a different namespace, the Data Mover restore failed. With this update, Data Mover restore is now successful.
++
 link:https://issues.redhat.com/browse/OADP-5460[OADP-5460]
 
-.SSE-C backup works with the calculated MD5 of the secret key
-
+SSE-C backup works with the calculated MD5 of the secret key::
 Previously, backup failed with the following error:
++
 [source,terminal]
 ----
 Requests specifying Server Side Encryption with Customer provided keys must provide the client calculated MD5 of the secret key.
 ----
++
 With this update, missing Server-Side Encryption with Customer-Provided Keys (SSE-C) base64 and MD5 hash are now fixed. As a result, SSE-C backup works with the calculated MD5 of the secret key. In addition, incorrect `errorhandling` for the `customerKey` size is also fixed.
++
 link:https://issues.redhat.com/browse/OADP-5388[OADP-5388]
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12452476[OADP 1.4.2 resolved issues] in Jira.
@@ -51,17 +54,17 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-4-2_{context}"]
 == Known issues
 
-.The nodeSelector spec is not supported for the Data Mover restore action
-
-When a Data Protection Application (DPA) is created with the `nodeSelector` field set in the `nodeAgent` parameter, Data Mover restore partially fails instead of completing the restore operation. 
+The nodeSelector spec is not supported for the Data Mover restore action::
+When a Data Protection Application (DPA) is created with the `nodeSelector` field set in the `nodeAgent` parameter, Data Mover restore partially fails instead of completing the restore operation.
++
 link:https://issues.redhat.com/browse/OADP-5260[OADP-5260]
 
-.The S3 storage does not use proxy environment when TLS skip verify is specified
-
+The S3 storage does not use proxy environment when TLS skip verify is specified::
 In the image registry backup, the S3 storage does not use the proxy environment when the `insecureSkipTLSVerify` parameter is set to `true`.
++
 link:https://issues.redhat.com/browse/OADP-3143[OADP-3143]
 
-.Kopia does not delete artifacts after backup expiration
-
+Kopia does not delete artifacts after backup expiration::
 Even after you delete a backup, Kopia does not delete the volume artifacts from the `${bucket_name}/kopia/${namespace}` on the S3 location after backup expired. For more information, see "About Kopia repository maintenance".
++
 link:https://issues.redhat.com/browse/OADP-5131[OADP-5131]

--- a/modules/oadp-1-4-3-release-notes.adoc
+++ b/modules/oadp-1-4-3-release-notes.adoc
@@ -7,13 +7,13 @@
 [id="oadp-1-4-3-release-notes_{context}"]
 = {oadp-short} 1.4.3 release notes
 
-The {oadp-first} 1.4.3 release notes lists the following new feature. 
+[role="_abstract"]
+The {oadp-first} 1.4.3 release notes list the following new feature.
 
 [id="new-features-1-4-3_{context}"]
 == New features
 
-.Notable changes in the `kubevirt` velero plugin in version 0.7.1
-
+Notable changes in the `kubevirt` velero plugin in version 0.7.1::
 With this release, the `kubevirt` velero plugin has been updated to version 0.7.1. Notable improvements include the following bug fix and new features:
 
 * Virtual machine instances (VMIs) are no longer ignored from backup when the owner VM is excluded.

--- a/modules/oadp-1-4-4-release-notes.adoc
+++ b/modules/oadp-1-4-4-release-notes.adoc
@@ -7,10 +7,13 @@
 [id="oadp-1-4-4-release-notes_{context}"]
 = {oadp-short} 1.4.4 release notes
 
-{oadp-first} 1.4.4 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.3.
+[role="_abstract"]
+{oadp-first} 1.4.4 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.3. One known issue was identified.
 
 [id="known-issues-1-4-4_{context}"]
 == Known issues
 
-.Issue with restoring stateful applications 
-When you restore a stateful application that uses the `azurefile-csi` storage class, the restore operation remains in the `Finalizing` phase. link:https://issues.redhat.com/browse/OADP-5508[(OADP-5508)]
+Issue with restoring stateful applications::
+When you restore a stateful application that uses the `azurefile-csi` storage class, the restore operation remains in the `Finalizing` phase.
++
+link:https://issues.redhat.com/browse/OADP-5508[OADP-5508]

--- a/modules/oadp-1-4-5-release-notes.adoc
+++ b/modules/oadp-1-4-5-release-notes.adoc
@@ -7,20 +7,22 @@
 [id="oadp-1-4-5-release-notes_{context}"]
 = {oadp-short} 1.4.5 release notes
 
-The {oadp-first} 1.4.5 release notes lists new features and resolved issues.
+[role="_abstract"]
+The {oadp-first} 1.4.5 release notes list new features and resolved issues.
 
 [id="new-features-1-4-5_{context}"]
 == New features
 
-.Collecting logs with the `must-gather` tool has been improved with a Markdown summary
-
+Collecting logs with the `must-gather` tool has been improved with a Markdown summary::
 You can collect logs and information about {oadp-first} custom resources by using the `must-gather` tool. The `must-gather` data must be attached to all customer cases.
-This tool generates a Markdown output file with the collected information, which is located in the clusters directory of the `must-gather` logs.  link:https://issues.redhat.com/browse/OADP-5904[(OADP-5904)]
+This tool generates a Markdown output file with the collected information, which is located in the clusters directory of the `must-gather` logs.
++
+link:https://issues.redhat.com/browse/OADP-5904[OADP-5904]
 
 [id="resolved-issues-1-4-5_{context}"]
 == Resolved issues
 
-{oadp-short} 1.4.5 fixes the following CVEs:: 
+{oadp-short} 1.4.5 fixes the following CVEs::
 
 * link:https://access.redhat.com/security/cve/CVE-2024-45337[CVE-2024-45337] 
 

--- a/modules/oadp-1-4-6-release-notes.adoc
+++ b/modules/oadp-1-4-6-release-notes.adoc
@@ -7,4 +7,5 @@
 [id="oadp-1-4-6-release-notes_{context}"]
 = {oadp-short} 1.4.6 release notes
 
+[role="_abstract"]
 {oadp-first} 1.4.6 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.5.

--- a/modules/oadp-1-4-7-release-notes.adoc
+++ b/modules/oadp-1-4-7-release-notes.adoc
@@ -7,4 +7,5 @@
 [id="oadp-1-4-7-release-notes_{context}"]
 = {oadp-short} 1.4.7 release notes
 
+[role="_abstract"]
 {oadp-first} 1.4.7 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.6.

--- a/modules/oadp-backing-up-dpa-configuration-1-3-0.adoc
+++ b/modules/oadp-backing-up-dpa-configuration-1-3-0.adoc
@@ -7,7 +7,8 @@
 [id="oadp-backing-up-dpa-configuration-1-3-0_{context}"]
 = Backing up the DPA configuration
 
-You must back up your current `DataProtectionApplication` (DPA) configuration.
+[role="_abstract"]
+Save your current `DataProtectionApplication` (DPA) configuration to a file. Backing up your configuration helps ensure you can restore your settings if any issues occur during the upgrade process.
 
 .Procedure
 * Save your current DPA configuration by running the following command:

--- a/modules/oadp-backing-up-dpa-configuration-1-4-0.adoc
+++ b/modules/oadp-backing-up-dpa-configuration-1-4-0.adoc
@@ -7,7 +7,8 @@
 [id="oadp-backing-up-dpa-configuration-1-4-0_{context}"]
 = Backing up the DPA configuration
 
-You must back up your current `DataProtectionApplication` (DPA) configuration.
+[role="_abstract"]
+Save your current `DataProtectionApplication` (DPA) configuration to a file. Backing up your configuration helps ensure you can restore your settings if any issues occur during the upgrade process.
 
 .Procedure
 * Save your current DPA configuration by running the following command:

--- a/modules/oadp-changes-from-oadp-1-2-to-1-3.adoc
+++ b/modules/oadp-changes-from-oadp-1-2-to-1-3.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes-1-3.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-changes-from-oadp-1-2-to-1-3_{context}"]
+= Changes from OADP 1.2 to 1.3
+
+[role="_abstract"]
+The Velero server has been updated from version 1.11 to 1.12. {oadp-first} 1.3 uses the Velero built-in Data Mover instead of the VolumeSnapshotMover (VSM) or the Volsync Data Mover. To ensure your upgrade succeeds, update your `DataProtectionApplication` (DPA) to align with these changes.
+
+The changes are as follows:
+
+* The `spec.features.dataMover` field and the VSM plugin are not compatible with OADP 1.3, and you must remove the configuration from the `DataProtectionApplication` (DPA) configuration.
+
+* The Volsync Operator is no longer required for Data Mover functionality, and you can remove it.
+
+* The custom resource definitions `volumesnapshotbackups.datamover.oadp.openshift.io` and `volumesnapshotrestores.datamover.oadp.openshift.io` are no longer required, and you can remove them.
+
+* The secrets used for the OADP-1.2 Data Mover are no longer required, and you can remove them.
+
+OADP 1.3 supports Kopia, which is an alternative file system backup tool to Restic.
+
+* To employ Kopia, use the new `spec.configuration.nodeAgent` field as shown in the following example:
++
+.Example
+[source,yaml]
+----
+spec:
+  configuration:
+    nodeAgent:
+      enable: true
+      uploaderType: kopia
+# ...
+----
+
+* The `spec.configuration.restic` field is deprecated in OADP 1.3 and will be removed in a future version of OADP. To avoid seeing deprecation warnings, remove the `restic` key and its values, and use the following new syntax:
++
+.Example
+[source,yaml]
+----
+spec:
+  configuration:
+    nodeAgent:
+      enable: true
+      uploaderType: restic
+# ...
+----
+
+[NOTE]
+====
+In a future OADP release, it is planned that the `kopia` tool will become the default `uploaderType` value.
+====

--- a/modules/oadp-changes-from-oadp-1-3-to-1-4.adoc
+++ b/modules/oadp-changes-from-oadp-1-3-to-1-4.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-changes-from-oadp-1-3-to-1-4_{context}"]
+= Changes from OADP 1.3 to 1.4
+
+[role="_abstract"]
+The Velero server has been updated from version 1.12 to 1.14. Although the Data Protection Application (DPA) remains unchanged, several plugins and default configuration values were updated.
+
+The changes are as follows:
+
+* The `velero-plugin-for-csi` code is now available in the Velero code, which means an `init` container is no longer required for the plugin.
+
+* Velero changed the client Burst default from 30 to 100 and the QPS default from 20 to 100.
+
+* The `velero-plugin-for-aws` plugin updated default value of the `spec.config.checksumAlgorithm` field in `BackupStorageLocation` objects (BSLs) from `""` (no checksum calculation) to the `CRC32` algorithm. For more information, see link:https://github.com/vmware-tanzu/velero-plugin-for-aws/blob/release-1.10/backupstoragelocation.md[Velero plugins for AWS Backup Storage Location]. The checksum algorithm types are known to work only with AWS.
+Several S3 providers require the `md5sum` to be disabled by setting the checksum algorithm to `""`. Confirm `md5sum` algorithm support and configuration with your storage provider.
++
+In OADP 1.4, the default value for BSLs created within DPA for this configuration is `""`. This default value means that the `md5sum` is not checked, which is consistent with OADP 1.3. For BSLs created within DPA, update it by using the `spec.backupLocations[].velero.config.checksumAlgorithm` field in the DPA. If your BSLs are created outside DPA, you can update this configuration by using `spec.config.checksumAlgorithm` in the BSLs.

--- a/modules/oadp-converting-dpa-to-new-version-1-3-0.adoc
+++ b/modules/oadp-converting-dpa-to-new-version-1-3-0.adoc
@@ -7,7 +7,8 @@
 [id="oadp-converting-dpa-to-new-version-1-3-0_{context}"]
 = Converting DPA to the new version
 
-If you need to move backups off cluster with the Data Mover, reconfigure the `DataProtectionApplication` (DPA) manifest as follows.
+[role="_abstract"]
+Reconfigure your `DataProtectionApplication` (DPA) manifest to move to the built-in Velero Data Mover. With this change, you can move volume snapshots to off-cluster object storage for disaster recovery.
 
 .Procedure
 . Click *Operators* → *Installed Operators* and select the OADP Operator.
@@ -36,6 +37,7 @@ spec:
 * Remove the `features.dataMover` key and values from the DPA.
 * Remove the VolumeSnapshotMover (VSM) plugin.
 * Add the `nodeAgent` key and values.
+
 +
 .Example updated DPA
 [source,yaml]

--- a/modules/oadp-converting-dpa-to-the-new-version-for-oadp-1-4-0.adoc
+++ b/modules/oadp-converting-dpa-to-the-new-version-for-oadp-1-4-0.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-converting-dpa-to-the-new-version-for-oadp-1-4-0_{context}"]
+= Converting DPA to the new version for OADP 1.4.0
+
+[role="_abstract"]
+To upgrade from OADP 1.3 to 1.4, no Data Protection Application (DPA) changes are required.

--- a/modules/oadp-release-notes-1-3-0.adoc
+++ b/modules/oadp-release-notes-1-3-0.adoc
@@ -6,67 +6,70 @@
 [id="oadp-release-notes-1-3-0_{context}"]
 = OADP 1.3.0 release notes
 
-The {oadp-first} 1.3.0 release notes lists new features, resolved issues and bugs, and known issues.
+[role="_abstract"]
+The {oadp-first} 1.3.0 release notes list new features, resolved issues, and known issues.
 
 [id="new-features-1-3-0_{context}"]
 == New features
 
-.Velero built-in DataMover
-
+Velero built-in DataMover::
++
+--
 :FeatureName: Velero built-in DataMover
 include::snippets/technology-preview.adoc[]
-
+--
++
 OADP 1.3 includes a built-in Data Mover that you can use to move Container Storage Interface (CSI) volume snapshots to a remote object store. The built-in Data Mover allows you to restore stateful applications from the remote object store if a failure, accidental deletion, or corruption of the cluster occurs. It uses Kopia as the uploader mechanism to read the snapshot data and to write to the Unified Repository.
 
 
-.Backing up applications with File System Backup: Kopia or Restic
-
+Backing up applications with File System Backup: Kopia or Restic::
 Velero’s File System Backup (FSB) supports two backup libraries: the Restic path and the Kopia path.
-
++
 Velero allows users to select between the two paths.
-
++
 For backup, specify the path during the installation through the `uploader-type` flag. The valid value is either `restic` or `kopia`. This field defaults to `kopia` if the value is not specified. The selection cannot be changed after the installation.
 
-.{gcp-first} authentication
-
+{gcp-first} authentication::
 {gcp-first} authentication enables you to use short-lived Google credentials.
-
++
 {gcp-short} with Workload Identity Federation enables you to use Identity and Access Management (IAM) to grant external identities IAM roles, including the ability to impersonate service accounts. This eliminates the maintenance and security risks associated with service account keys.
 
-.AWS ROSA STS authentication
-
+AWS ROSA STS authentication::
 You can use {oadp-first} with {product-rosa} (ROSA) clusters to backup and restore application data.
-
++
 ROSA provides seamless integration with a wide range of AWS compute, database, analytics, machine learning, networking, mobile, and other services to speed up the building and delivering of differentiating experiences to your customers.
-
++
 You can subscribe to the service directly from your AWS account.
-
++
 After the clusters are created, you can operate your clusters by using the OpenShift web console. The ROSA service also uses OpenShift APIs and command-line interface (CLI) tools.
 
 [id="resolved-issues-1-3-0_{context}"]
 == Resolved issues
 
-.ACM applications were removed and re-created on managed clusters after restore
+ACM applications were removed and re-created on managed clusters after restore::
 Applications on managed clusters were deleted and re-created upon restore activation. {oadp-full} (OADP 1.2) backup and restore process is faster than the older versions. The OADP performance change caused this behavior when restoring ACM resources. Therefore, some resources were restored before other resources, which caused the removal of the applications from managed clusters.
++
 link:https://issues.redhat.com/browse/OADP-2686[OADP-2686]
 
 
-.Restic restore was partially failing due to Pod Security standard
+Restic restore was partially failing due to Pod Security standard::
+During interoperability testing, {product-title} 4.14 had the pod Security mode set to `enforce`, which caused the pod to be denied. This was caused due to the restore order. The pod was getting created before the security context constraints (SCC) resource, since the pod violated the `podSecurity` standard, it denied the pod. When setting the restore priority field on the Velero server, restore is successful.
++
+link:https://issues.redhat.com/browse/OADP-2688[OADP-2688]
 
-During interoperability testing, {product-title} 4.14 had the pod Security mode set to `enforce`, which caused the pod to be denied. This was caused due to the restore order. The pod was getting created before the security context constraints (SCC) resource, since the pod violated the `podSecurity` standard, it denied the pod. When setting the restore priority field on the Velero server, restore is successful. link:https://issues.redhat.com/browse/OADP-2688[OADP-2688]
-
-.Possible pod volume backup failure if Velero is installed in several namespaces
-
+Possible pod volume backup failure if Velero is installed in several namespaces::
 There was a regression in Pod Volume Backup (PVB) functionality when Velero was installed in several namespaces. The PVB controller was not properly limiting itself to PVBs in its own namespace.
++
 link:https://issues.redhat.com/browse/OADP-2308[OADP-2308]
 
-.OADP Velero plugins returning "received EOF, stopping recv loop" message
+OADP Velero plugins returning "received EOF, stopping recv loop" message::
+In OADP, Velero plugins were started as separate processes. When the Velero operation completes, either successfully or not, they exit. Therefore, if you see a `received EOF, stopping recv loop` messages in debug logs, it does not mean an error occurred, it means that a plugin operation has completed.
++
+link:https://issues.redhat.com/browse/OADP-2176[OADP-2176]
 
-In OADP, Velero plugins were started as separate processes. When the Velero operation completes, either successfully or not, they exit. Therefore, if you see a `received EOF, stopping recv loop` messages in debug logs, it does not mean an error occurred, it means that a plugin operation has completed. link:https://issues.redhat.com/browse/OADP-2176[OADP-2176]
-
-.CVE-2023-39325 Multiple HTTP/2 enabled web servers are vulnerable to a DDoS attack (Rapid Reset Attack)
+CVE-2023-39325 Multiple HTTP/2 enabled web servers are vulnerable to a DDoS attack (Rapid Reset Attack)::
 In previous releases of OADP, the HTTP/2 protocol was susceptible to a denial of service attack because request cancellation could reset multiple streams quickly. The server had to set up and tear down the streams while not hitting any server-side limit for the maximum number of active streams per connection. This resulted in a denial of service due to server resource consumption.
-
++
 For more information, see link:https://access.redhat.com/security/cve/cve-2023-39325[CVE-2023-39325 (Rapid Reset Attack)]
 
 
@@ -75,79 +78,25 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-3-0_{context}"]
 == Known issues
 
-.CSI plugin errors on nil pointer when csiSnapshotTimeout is set to a short duration
+CSI plugin errors on nil pointer when csiSnapshotTimeout is set to a short duration::
 The CSI plugin errors on nil pointer when `csiSnapshotTimeout` is set to a short duration. Sometimes it succeeds to complete the snapshot within a short duration, but often it panics with the backup `PartiallyFailed` with the following error: `plugin panicked: runtime error: invalid memory address or nil pointer dereference`.
 
-.Backup is marked as PartiallyFailed when volumeSnapshotContent CR has an error
-If any of the `VolumeSnapshotContent` CRs have an error related to removing the `VolumeSnapshotBeingCreated` annotation, it moves the backup to the `WaitingForPluginOperationsPartiallyFailed` phase. link:https://issues.redhat.com/browse/OADP-2871[OADP-2871]
+Backup is marked as PartiallyFailed when volumeSnapshotContent CR has an error::
+If any of the `VolumeSnapshotContent` CRs have an error related to removing the `VolumeSnapshotBeingCreated` annotation, it moves the backup to the `WaitingForPluginOperationsPartiallyFailed` phase.
++
+link:https://issues.redhat.com/browse/OADP-2871[OADP-2871]
 
-.Performance issues when restoring 30,000 resources for the first time
-When restoring 30,000 resources for the first time, without an existing-resource-policy, it takes twice as long to restore them, than it takes during the second and third try with an existing-resource-policy set to `update`. link:https://issues.redhat.com/browse/OADP-3071[OADP-3071]
+Performance issues when restoring 30,000 resources for the first time::
+When restoring 30,000 resources for the first time, without an existing-resource-policy, it takes twice as long to restore them, than it takes during the second and third try with an existing-resource-policy set to `update`.
++
+link:https://issues.redhat.com/browse/OADP-3071[OADP-3071]
 
-.Post restore hooks might start running before Datadownload operation has released the related PV
+Post restore hooks might start running before Datadownload operation has released the related PV::
 Due to the asynchronous nature of the Data Mover operation, a post-hook might be attempted before the related pods persistent volumes (PVs) are released by the Data Mover persistent volume claim (PVC).
 
 
-.{gcp-first} Workload Identity Federation VSL backup PartiallyFailed
+{gcp-first} Workload Identity Federation VSL backup PartiallyFailed::
 VSL backup `PartiallyFailed` when {gcp-first} workload identity is configured on {gcp-short}.
 
 
 For a complete list of all known issues in this release, see the list of link:https://issues.redhat.com/issues/?filter=12422838[OADP 1.3.0 known issues] in Jira.
-
-[id="upgrade-notes-1-3-0_{context}"]
-== Upgrade notes
-
-[NOTE]
-====
-Always upgrade to the next minor version. *Do not* skip versions. To update to a later version, upgrade only one channel at a time. For example, to upgrade from {oadp-first} 1.1 to 1.3, upgrade first to 1.2, and then to 1.3.
-====
-
-[id="changes-oadp-1-2-to-1-3_{context}"]
-=== Changes from OADP 1.2 to 1.3
-
-The Velero server has been updated from version 1.11 to 1.12.
-
-{oadp-first} 1.3 uses the Velero built-in Data Mover instead of the VolumeSnapshotMover (VSM) or the Volsync Data Mover.
-
-This changes the following:
-
-* The `spec.features.dataMover` field and the VSM plugin are not compatible with OADP 1.3, and you must remove the configuration from the `DataProtectionApplication` (DPA) configuration.
-
-* The Volsync Operator is no longer required for Data Mover functionality, and you can remove it.
-
-* The custom resource definitions `volumesnapshotbackups.datamover.oadp.openshift.io` and `volumesnapshotrestores.datamover.oadp.openshift.io` are no longer required, and you can remove them.
-
-* The secrets used for the OADP-1.2 Data Mover are no longer required, and you can remove them.
-
-OADP 1.3 supports Kopia, which is an alternative file system backup tool to Restic.
-
-* To employ Kopia, use the new `spec.configuration.nodeAgent` field as shown in the following example:
-+
-.Example
-[source,yaml]
-----
-spec:
-  configuration:
-    nodeAgent:
-      enable: true
-      uploaderType: kopia
-# ...
-----
-
-* The `spec.configuration.restic` field is deprecated in OADP 1.3 and will be removed in a future version of OADP. To avoid seeing deprecation warnings, remove the `restic` key and its values, and use the following new syntax:
-+
-.Example
-[source,yaml]
-----
-spec:
-  configuration:
-    nodeAgent:
-      enable: true
-      uploaderType: restic
-# ...
-----
-
-[NOTE]
-====
-In a future OADP release, it is planned that the `kopia` tool will become the default `uploaderType` value.
-====

--- a/modules/oadp-release-notes-1-3-1.adoc
+++ b/modules/oadp-release-notes-1-3-1.adoc
@@ -6,60 +6,53 @@
 [id="oadp-release-notes-1-3-1_{context}"]
 = OADP 1.3.1 release notes
 
-The {oadp-first} 1.3.1 release notes lists new features and resolved issues.
+[role="_abstract"]
+The {oadp-first} 1.3.1 release notes list new features and resolved issues.
 
 [id="new-features-1-3-1_{context}"]
 == New features
 
-.OADP 1.3.0 Data Mover is now fully supported
-
+OADP 1.3.0 Data Mover is now fully supported::
 The OADP built-in Data Mover, introduced in OADP 1.3.0 as a Technology Preview, is now fully supported for both containerized and virtual machine workloads.
 
 [id="resolved-issues-1-3-1_{context}"]
 == Resolved issues
 
-.{ibm-cloud-name} Object Storage is now supported as a backup storage provider
-
+{ibm-cloud-name} Object Storage is now supported as a backup storage provider::
 {ibm-cloud-name} Object Storage is one of the AWS S3 compatible backup storage providers, which was unsupported previously.
 With this update, {ibm-cloud-name} Object Storage is now supported as an AWS S3 compatible backup storage provider.
-
++
 link:https://issues.redhat.com/browse/OADP-3788[OADP-3788]
 
-.OADP operator now correctly reports the missing region error
-
-Previously, when you specified `profile:default` without specifying the `region` in the AWS Backup Storage Location (BSL) configuration, the OADP operator failed to report the `missing region` error on the Data Protection Application (DPA) custom resource (CR). This update corrects validation of DPA BSL specification for AWS. As a result, the OADP Operator reports the `missing region` error.
-
+OADP Operator now correctly reports the missing region error::
+Previously, when you specified `profile:default` without specifying the `region` in the AWS Backup Storage Location (BSL) configuration, the OADP Operator failed to report the `missing region` error on the Data Protection Application (DPA) custom resource (CR). This update corrects validation of DPA BSL specification for AWS. As a result, the OADP Operator reports the `missing region` error.
++
 link:https://issues.redhat.com/browse/OADP-3044[OADP-3044]
 
-.Custom labels are not removed from the openshift-adp namespace
-
+Custom labels are not removed from the openshift-adp namespace::
 Previously, the `openshift-adp-controller-manager` pod would reset the labels attached to the `openshift-adp` namespace. This caused synchronization issues for applications requiring custom labels such as Argo CD, leading to improper functionality. With this update, this issue is fixed and custom labels are not removed from the `openshift-adp` namespace.
-
++
 link:https://issues.redhat.com/browse/OADP-3189[OADP-3189]
 
-.OADP must-gather image collects CRDs
-
+OADP must-gather image collects CRDs::
 Previously, the OADP `must-gather` image did not collect the custom resource definitions (CRDs) shipped by OADP. Consequently, you could not use the `omg` tool to extract data in the support shell.
 With this fix, the `must-gather` image now collects CRDs shipped by OADP and can use the `omg` tool to extract data.
 
 // RH employee only - link:https://issues.redhat.com/browse/OADP-3229[OADP-3229]
 
-.Garbage collection has the correct description for the default frequency value
-
+Garbage collection has the correct description for the default frequency value::
 Previously, the `garbage-collection-frequency` field had a wrong description for the default frequency value. With this update, `garbage-collection-frequency` has a correct value of one hour for the `gc-controller` reconciliation default frequency.
-
++
 link:https://issues.redhat.com/browse/OADP-3486[OADP-3486]
 
-.FIPS Mode flag is available in OperatorHub
-
+FIPS Mode flag is available in OperatorHub::
 By setting the `fips-compliant` flag to `true`, the FIPS mode flag is now added to the OADP Operator listing in OperatorHub. This feature was enabled in OADP 1.3.0 but did not show up in the Red Hat Container catalog as being FIPS enabled.
-
++
 link:https://issues.redhat.com/browse/OADP-3495[OADP-3495]
 
-.CSI plugin does not panic with a nil pointer when csiSnapshotTimeout is set to a short duration
-
+CSI plugin does not panic with a nil pointer when csiSnapshotTimeout is set to a short duration::
 Previously, when the `csiSnapshotTimeout` parameter was set to a short duration, the CSI plugin encountered the following error: `plugin panicked: runtime error: invalid memory address or nil pointer dereference`.
-
++
 With this fix, the backup fails with the following error: `Timed out awaiting reconciliation of volumesnapshot`.
 
 // RH employee only - link:https://issues.redhat.com/browse/OADP-3069[OADP-3069]
@@ -70,17 +63,16 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-3-1_{context}"]
 == Known issues
 
-.Backup and storage restrictions for {sno-caps} clusters deployed on {ibm-power-name} and {ibm-z-name} platforms
-
+Backup and storage restrictions for {sno-caps} clusters deployed on {ibm-power-name} and {ibm-z-name} platforms::
 Review the following backup and storage related restrictions for {sno-caps} clusters that are deployed on {ibm-power-name} and {ibm-z-name} platforms:
 
-Storage:: Only NFS storage is currently compatible with {sno} clusters deployed on {ibm-power-name} and {ibm-z-name} platforms.
-Backup:: Only the backing up applications with File System Backup such as `kopia` and `restic` are supported for backup and restore operations.
+* Storage: Only NFS storage is currently compatible with {sno} clusters deployed on {ibm-power-name} and {ibm-z-name} platforms.
+* Backup: Only the backing up applications with File System Backup such as `kopia` and `restic` are supported for backup and restore operations.
 
++
 link:https://issues.redhat.com/browse/OADP-3787[OADP-3787]
 
-.Cassandra application pods enter in the CrashLoopBackoff status after restoring OADP
-
+Cassandra application pods enter in the CrashLoopBackoff status after restoring OADP::
 After OADP restores, the Cassandra application pods might enter in the `CrashLoopBackoff` status. To work around this problem, delete the `StatefulSet` pods with any error or the `CrashLoopBackoff` state after restoring OADP. The `StatefulSet` controller recreates these pods and it runs normally.
-
++
 link:https://issues.redhat.com/browse/OADP-3767[OADP-3767]

--- a/modules/oadp-release-notes-1-3-2.adoc
+++ b/modules/oadp-release-notes-1-3-2.adoc
@@ -6,6 +6,7 @@
 [id="oadp-release-notes-1-3-2_{context}"]
 = {oadp-short} 1.3.2 release notes
 
+[role="_abstract"]
 The {oadp-first} 1.3.2 release notes list resolved issues and known issues.
 
 //[id="new-features-1-3-2_{context}"]
@@ -15,40 +16,34 @@ The {oadp-first} 1.3.2 release notes list resolved issues and known issues.
 [id="resolved-issues-1-3-2_{context}"]
 == Resolved issues
 
-.DPA fails to reconcile if a valid custom secret is used for BSL
-
+DPA fails to reconcile if a valid custom secret is used for BSL::
 DPA fails to reconcile if a valid custom secret is used for Backup Storage Location (BSL), but the default secret is missing. The workaround is to create the required default `cloud-credentials` initially. When the custom secret is re-created, it can be used and checked for its existence. 
-
++
 link:https://issues.redhat.com/browse/OADP-3193[OADP-3193]
 
-.CVE-2023-45290: `oadp-velero-container`: Golang `net/http`: Memory exhaustion in `Request.ParseMultipartForm`
-
+CVE-2023-45290: `oadp-velero-container`: Golang `net/http`: Memory exhaustion in `Request.ParseMultipartForm`::
 A flaw was found in the `net/http` Golang standard library package, which impacts previous versions of {oadp-short}. When parsing a `multipart` form, either explicitly with `Request.ParseMultipartForm` or implicitly with `Request.FormValue`, `Request.PostFormValue`, or `Request.FormFile`, limits on the total size of the parsed form are not applied to the memory consumed while reading a single form line. This permits a maliciously crafted input containing long lines to cause the allocation of arbitrarily large amounts of memory, potentially leading to memory exhaustion. This flaw has been resolved in {oadp-short} 1.3.2.
-
++
 For more details, see link:https://access.redhat.com/security/cve/cve-2023-45290[CVE-2023-45290].
 
-.CVE-2023-45289: `oadp-velero-container`: Golang `net/http/cookiejar`: Incorrect forwarding of sensitive headers and cookies on HTTP redirect
-
+CVE-2023-45289: `oadp-velero-container`: Golang `net/http/cookiejar`: Incorrect forwarding of sensitive headers and cookies on HTTP redirect::
 A flaw was found in the `net/http/cookiejar` Golang standard library package, which impacts previous versions of {oadp-short}. When following an HTTP redirect to a domain that is not a subdomain match or exact match of the initial domain, an `http.Client` does not forward sensitive headers such as `Authorization` or `Cookie`. A maliciously crafted HTTP redirect could cause sensitive headers to be unexpectedly forwarded. This flaw has been resolved in {oadp-short} 1.3.2.
-
++
 For more details, see link:https://access.redhat.com/security/cve/cve-2023-45289[CVE-2023-45289].
 
-.CVE-2024-24783: `oadp-velero-container`: Golang `crypto/x509`: Verify panics on certificates with an unknown public key algorithm
-
+CVE-2024-24783: `oadp-velero-container`: Golang `crypto/x509`: Verify panics on certificates with an unknown public key algorithm::
 A flaw was found in the `crypto/x509` Golang standard library package, which impacts previous versions of {oadp-short}. Verifying a certificate chain that contains a certificate with an unknown public key algorithm causes `Certificate.Verify` to panic. This affects all `crypto/tls` clients and servers that set `Config.ClientAuth` to `VerifyClientCertIfGiven` or `RequireAndVerifyClientCert`. The default behavior is for TLS servers to not verify client certificates. This flaw has been resolved in {oadp-short} 1.3.2.
-
++
 For more details, see link:https://access.redhat.com/security/cve/cve-2024-24783[CVE-2024-24783].
 
-.CVE-2024-24784: `oadp-velero-plugin-container`: Golang `net/mail`: Comments in display names are incorrectly handled
-
+CVE-2024-24784: `oadp-velero-plugin-container`: Golang `net/mail`: Comments in display names are incorrectly handled::
 A flaw was found in the `net/mail` Golang standard library package, which impacts previous versions of {oadp-short}. The `ParseAddressList` function incorrectly handles comments, text in parentheses, and display names. Because this is a misalignment with conforming address parsers, it can result in different trust decisions being made by programs using different parsers. This flaw has been resolved in {oadp-short} 1.3.2.
-
++
 For more details, see link:https://access.redhat.com/security/cve/cve-2024-24784[CVE-2024-24784].
 
-.CVE-2024-24785: `oadp-velero-container`: Golang: html/template: errors returned from `MarshalJSON` methods may break template escaping
-
+CVE-2024-24785: `oadp-velero-container`: Golang: html/template: errors returned from `MarshalJSON` methods may break template escaping::
 A flaw was found in the `html/template` Golang standard library package, which impacts previous versions of {oadp-short}. If errors returned from `MarshalJSON` methods contain user-controlled data, they may be used to break the contextual auto-escaping behavior of the HTML/template package, allowing subsequent actions to inject unexpected content into the templates. This flaw has been resolved in {oadp-short} 1.3.2.
-
++
 For more details, see link:https://access.redhat.com/security/cve/cve-2024-24785[CVE-2024-24785].
 
 For a complete list of all issues resolved in this release, see the list of link:https://issues.redhat.com/issues/?filter=12436254[OADP 1.3.2 resolved issues] in Jira.
@@ -57,8 +52,7 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-3-2_{context}"]
 == Known issues
 
-.Cassandra application pods enter into the `CrashLoopBackoff` status after restoring OADP
-
+Cassandra application pods enter into the `CrashLoopBackoff` status after restoring OADP::
 After {oadp-short} restores, the Cassandra application pods might enter in the `CrashLoopBackoff` status. To work around this problem, delete the `StatefulSet` pods that are returning an error or the `CrashLoopBackoff` state after restoring {oadp-short}. The `StatefulSet` controller recreates these pods and it runs normally.
-
++
 link:https://issues.redhat.com/browse/OADP-3767[OADP-3767]

--- a/modules/oadp-release-notes-1-3-3.adoc
+++ b/modules/oadp-release-notes-1-3-3.adoc
@@ -6,17 +6,18 @@
 [id="oadp-release-notes-1-3-3_{context}"]
 = {oadp-short} 1.3.3 release notes
 
+[role="_abstract"]
 The {oadp-first} 1.3.3 release notes list resolved issues and known issues.
 
 [id="resolved-issues-1-3-3_{context}"]
 == Resolved issues
 
-.{oadp-short} fails when its namespace name is longer than 37 characters
+{oadp-short} fails when its namespace name is longer than 37 characters::
+When installing the {oadp-short}  Operator in a namespace with more than 37 characters and when creating a new DPA, labeling the `cloud-credentials` secret fails. With this release, the issue has been fixed.
++
+link:https://issues.redhat.com/browse/OADP-4211[{oadp-short}-4211]
 
-When installing the {oadp-short}  Operator in a namespace with more than 37 characters and when creating a new DPA, labeling the `cloud-credentials` secret fails. With this release, the issue has been fixed. link:https://issues.redhat.com/browse/OADP-4211[{oadp-short}-4211]
-
-.{oadp-short} image PullPolicy set to `Always`
-
+{oadp-short} image PullPolicy set to `Always`::
 In previous versions of {oadp-short}, the image PullPolicy of the adp-controller-manager and Velero pods was set to `Always`. This was problematic in edge scenarios where there could be limited network bandwidth to the registry, resulting in slow recovery time following a pod restart. In {oadp-short} 1.3.3, the image PullPolicy of the `openshift-adp-controller-manager` and Velero pods is set to `IfNotPresent`.
 
 The list of security fixes that are included in this release is documented in the link:https://access.redhat.com/errata/RHSA-2024:4982[RHSA-2024:4982] advisory.
@@ -26,8 +27,7 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-3-3_{context}"]
 == Known issues
 
-.Cassandra application pods enter into the `CrashLoopBackoff` status after restoring OADP
-
+Cassandra application pods enter into the `CrashLoopBackoff` status after restoring OADP::
 After {oadp-short} restores, the Cassandra application pods might enter in the `CrashLoopBackoff` status. To work around this problem, delete the `StatefulSet` pods that are returning an error or the `CrashLoopBackoff` state after restoring {oadp-short}. The `StatefulSet` controller recreates these pods and it runs normally.
-
++
 link:https://issues.redhat.com/browse/OADP-3767[OADP-3767]

--- a/modules/oadp-release-notes-1-3-4.adoc
+++ b/modules/oadp-release-notes-1-3-4.adoc
@@ -6,40 +6,45 @@
 [id="oadp-release-notes-1-3-4_{context}"]
 = {oadp-short} 1.3.4 release notes
 
+[role="_abstract"]
 The {oadp-first} 1.3.4 release notes list resolved issues and known issues.
 
 [id="resolved-issues-1-3-4_{context}"]
 == Resolved issues
 
-.The backup spec.resourcepolicy.kind parameter is now case-insensitive
+The backup spec.resourcepolicy.kind parameter is now case-insensitive::
+Previously, the `backup spec.resourcepolicy.kind` parameter was only supported with a lower-level string. With this fix, it is now case-insensitive.
++
+link:https://issues.redhat.com/browse/OADP-2944[{oadp-short}-2944]
 
-Previously, the `backup spec.resourcepolicy.kind` parameter was only supported with a lower-level string. With this fix, it is now case-insensitive. link:https://issues.redhat.com/browse/OADP-2944[{oadp-short}-2944]
+Use olm.maxOpenShiftVersion to prevent cluster upgrade to OCP 4.16 version::
+The cluster `operator-lifecycle-manager` Operator must not be upgraded between minor {OCP} versions. Using the `olm.maxOpenShiftVersion` parameter prevents upgrading to {OCP} 4.16 version when {oadp-short} 1.3 is installed.
+To upgrade to {OCP} 4.16 version, upgrade {oadp-short} 1.3 on OCP 4.15 version to {oadp-short} 1.4.
++
+link:https://issues.redhat.com/browse/OADP-4803[{oadp-short}-4803]
 
-.Use olm.maxOpenShiftVersion to prevent cluster upgrade to OCP 4.16 version
-
-The cluster `operator-lifecycle-manager` operator must not be upgraded between minor {OCP} versions. Using the `olm.maxOpenShiftVersion` parameter prevents upgrading to {OCP} 4.16 version when {oadp-short} 1.3 is installed. 
-To upgrade to {OCP} 4.16 version, upgrade {oadp-short} 1.3 on OCP 4.15 version to {oadp-short} 1.4. link:https://issues.redhat.com/browse/OADP-4803[{oadp-short}-4803]
-
-.BSL and VSL are removed from the cluster
-
+BSL and VSL are removed from the cluster::
 Previously, when any Data Protection Application (DPA) was modified to remove the Backup Storage Locations (BSL) or Volume Snapshot Locations (VSL) from the `backupLocations` or `snapshotLocations` section, BSL or VSL were not removed from the cluster until the DPA was deleted.
-With this update, BSL/VSL are removed from the cluster. link:https://issues.redhat.com/browse/OADP-3050[{oadp-short}-3050]
+With this update, BSL/VSL are removed from the cluster.
++
+link:https://issues.redhat.com/browse/OADP-3050[{oadp-short}-3050]
 
-.DPA reconciles and validates the secret key
-
+DPA reconciles and validates the secret key::
 Previously, the Data Protection Application (DPA) reconciled successfully on the wrong Volume Snapshot Locations (VSL) secret key name.
-With this update, DPA validates the secret key name before reconciling on any VSL. link:https://issues.redhat.com/browse/OADP-3052[{oadp-short}-3052]
+With this update, DPA validates the secret key name before reconciling on any VSL.
++
+link:https://issues.redhat.com/browse/OADP-3052[{oadp-short}-3052]
 
 
-.Velero's cloud credential permissions are now restrictive
-
+Velero's cloud credential permissions are now restrictive::
 Previously, Velero's cloud credential permissions were mounted with the 0644 permissions. As a consequence, any one could read the `/credentials/cloud` file apart from the owner and group making it easier to access sensitive information such as storage access keys.
 With this update, the permissions of this file are updated to 0640, and this file cannot be accessed by other users except the owner and group.
 
 
-.Warning is displayed when ArgoCD managed namespace is included in the backup
-
-A warning is displayed during the backup operation when ArgoCD and Velero manage the same namespace. link:https://issues.redhat.com/browse/OADP-4736[{oadp-short}-4736]
+Warning is displayed when ArgoCD managed namespace is included in the backup::
+A warning is displayed during the backup operation when ArgoCD and Velero manage the same namespace.
++
+link:https://issues.redhat.com/browse/OADP-4736[{oadp-short}-4736]
 
 
 The list of security fixes that are included in this release is documented in the link:https://access.redhat.com/errata/RHSA-2024:9960[RHSA-2024:9960] advisory.
@@ -49,20 +54,23 @@ For a complete list of all issues resolved in this release, see the list of link
 [id="known-issues-1-3-4_{context}"]
 == Known issues
 
-.Cassandra application pods enter into the `CrashLoopBackoff` status after restore
-
-After {oadp-short} restores, the Cassandra application pods might enter the `CrashLoopBackoff` status. To work around this problem, delete the `StatefulSet` pods that are returning an error or the `CrashLoopBackoff` state after restoring {oadp-short}. The `StatefulSet` controller recreates these pods and it runs normally. 
+Cassandra application pods enter into the `CrashLoopBackoff` status after restore::
+After {oadp-short} restores, the Cassandra application pods might enter the `CrashLoopBackoff` status. To work around this problem, delete the `StatefulSet` pods that are returning an error or the `CrashLoopBackoff` state after restoring {oadp-short}. The `StatefulSet` controller recreates these pods and it runs normally.
++
 link:https://issues.redhat.com/browse/OADP-3767[OADP-3767]
 
-.defaultVolumesToFSBackup and defaultVolumesToFsBackup flags are not identical 
+defaultVolumesToFSBackup and defaultVolumesToFsBackup flags are not identical::
+The `dpa.spec.configuration.velero.defaultVolumesToFSBackup` flag is not identical to the `backup.spec.defaultVolumesToFsBackup` flag, which can lead to confusion.
++
+link:https://issues.redhat.com/browse/OADP-3692[OADP-3692]
 
-The `dpa.spec.configuration.velero.defaultVolumesToFSBackup` flag is not identical to the `backup.spec.defaultVolumesToFsBackup` flag, which can lead to confusion. link:https://issues.redhat.com/browse/OADP-3692[OADP-3692]
+PodVolumeRestore works even though the restore is marked as failed::
+The `podvolumerestore` continues the data transfer even though the restore is marked as failed.
++
+link:https://issues.redhat.com/browse/OADP-3039[OADP-3039]
 
-.PodVolumeRestore works even though the restore is marked as failed
-
-The `podvolumerestore` continues the data transfer even though the restore is marked as failed. link:https://issues.redhat.com/browse/OADP-3039[OADP-3039]
-
-.Velero is unable to skip restoring of initContainer spec
-
-Velero might restore the `restore-wait init` container even though it is not required. link:https://issues.redhat.com/browse/OADP-3759[OADP-3759]
+Velero is unable to skip restoring of initContainer spec::
+Velero might restore the `restore-wait init` container even though it is not required.
++
+link:https://issues.redhat.com/browse/OADP-3759[OADP-3759]
 

--- a/modules/oadp-release-notes-1-3-5.adoc
+++ b/modules/oadp-release-notes-1-3-5.adoc
@@ -6,4 +6,5 @@
 [id="oadp-release-notes-1-3-5_{context}"]
 = {oadp-short} 1.3.5 release notes
 
+[role="_abstract"]
 {oadp-first} 1.3.5 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.3.4.

--- a/modules/oadp-release-notes-1-3-6.adoc
+++ b/modules/oadp-release-notes-1-3-6.adoc
@@ -6,4 +6,5 @@
 [id="oadp-release-notes-1-3-6_{context}"]
 = {oadp-short} 1.3.6 release notes
 
+[role="_abstract"]
 {oadp-first} 1.3.6 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.3.5.

--- a/modules/oadp-release-notes-1-3-7.adoc
+++ b/modules/oadp-release-notes-1-3-7.adoc
@@ -6,9 +6,10 @@
 [id="oadp-release-notes-1-3-7_{context}"]
 = {oadp-short} 1.3.7 release notes
 
-{oadp-first} 1.3.7 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.3.6.
+[role="_abstract"]
+{oadp-first} 1.3.7 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.3.6. Some Common Vulnerabilities and Exposures (CVEs) have been fixed, and a new feature has been added.
 
-The following Common Vulnerabilities and Exposures (CVEs) have been fixed in {oadp-short} 1.3.7
+The following Common Vulnerabilities and Exposures (CVEs) have been fixed in {oadp-short} 1.3.7::
 
 * link:https://access.redhat.com/security/cve/cve-2024-45338[CVE-2024-45338]
 
@@ -19,6 +20,7 @@ The following Common Vulnerabilities and Exposures (CVEs) have been fixed in {oa
 [id="new-features-1-3-7_{context}"]
 == New features
 
-.Collecting logs with the `must-gather` tool has been improved with a Markdown summary
-
-You can collect logs and information about {oadp-short} custom resources by using the `must-gather` tool. The `must-gather` data must be attached to all customer cases. This tool generates a Markdown output file with the collected information, which is located in the `must-gather` logs clusters directory. link:https://issues.redhat.com/browse/OADP-5384[OADP-5384]
+Collecting logs with the `must-gather` tool has been improved with a Markdown summary::
+You can collect logs and information about {oadp-short} custom resources by using the `must-gather` tool. The `must-gather` data must be attached to all customer cases. This tool generates a Markdown output file with the collected information, which is located in the `must-gather` logs clusters directory.
++
+link:https://issues.redhat.com/browse/OADP-5384[OADP-5384]

--- a/modules/oadp-release-notes-1-3-8.adoc
+++ b/modules/oadp-release-notes-1-3-8.adoc
@@ -6,4 +6,5 @@
 [id="oadp-release-notes-1-3-8_{context}"]
 = {oadp-short} 1.3.8 release notes
 
+[role="_abstract"]
 {oadp-first} 1.3.8 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.3.7.

--- a/modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc
+++ b/modules/oadp-upgrade-from-oadp-data-mover-1-2-0.adoc
@@ -7,22 +7,23 @@
 [id="oadp-upgrade-from-oadp-data-mover-1-2-0_{context}"]
 = Upgrading from OADP 1.2 Technology Preview Data Mover
 
-{oadp-first} 1.2 Data Mover backups *cannot* be restored with OADP 1.3. To prevent a gap in the data protection of your applications, complete the following steps before upgrading to OADP 1.3:
+[role="_abstract"]
+Backups created with the {oadp-first} 1.2 Data Mover are not compatible with OADP 1.3. Before upgrading to OADP 1.3, create a CSI or a file system backup to help ensure continuous data protection for your applications.
 
-.Procedure
-
-. If your cluster backups are sufficient and Container Storage Interface (CSI) storage is available,
-back up the applications with a CSI backup.
-. If you require off cluster backups:
-.. Back up the applications with a file system backup that uses the `--default-volumes-to-fs-backup=true or backup.spec.defaultVolumesToFsBackup` options.
-.. Back up the applications with your object storage plugins, for example, `velero-plugin-for-aws`.
+[IMPORTANT]
+====
+To restore OADP 1.2 Data Mover backup, you must uninstall OADP, and install and configure OADP 1.2.
+====
 
 [NOTE]
 ====
 The default timeout value for the Restic file system backup is one hour. In OADP 1.3.1 and later, the default timeout value for Restic and Kopia is four hours.
 ====
 
-[IMPORTANT]
-====
-To restore OADP 1.2 Data Mover backup, you must uninstall OADP, and install and configure OADP 1.2.
-====
+.Procedure
+
+. If your cluster backups are sufficient and Container Storage Interface (CSI) storage is available,
+back up the applications with a CSI backup.
+. If you require off cluster backups:
+.. Back up the applications with a file system backup that uses the `--default-volumes-to-fs-backup=true` or `backup.spec.defaultVolumesToFsBackup` options.
+.. Back up the applications with your object storage plugins, for example, `velero-plugin-for-aws`.

--- a/modules/oadp-upgrading-oadp-operator-1-3-0.adoc
+++ b/modules/oadp-upgrading-oadp-operator-1-3-0.adoc
@@ -7,7 +7,8 @@
 [id="oadp-upgrading-dpa-operator-1-3-0_{context}"]
 = Upgrading the OADP Operator
 
-Use the following sequence when upgrading the {oadp-first} Operator.
+[role="_abstract"]
+Upgrade the {oadp-first} Operator to ensure your installation has the latest enhancements and bug fixes.
 
 .Procedure
 

--- a/modules/oadp-upgrading-oadp-operator-1-4-0.adoc
+++ b/modules/oadp-upgrading-oadp-operator-1-4-0.adoc
@@ -7,7 +7,8 @@
 [id="oadp-upgrading-dpa-operator-1-4-0_{context}"]
 = Upgrading the OADP Operator
 
-Use the following procedure when upgrading the {oadp-first} Operator.
+[role="_abstract"]
+Upgrade the {oadp-first} Operator to ensure your installation has the latest enhancements and bug fixes.
 
 .Procedure
 

--- a/modules/oadp-verifying-upgrade-1-3-0.adoc
+++ b/modules/oadp-verifying-upgrade-1-3-0.adoc
@@ -7,7 +7,8 @@
 [id="verifying-upgrade-1-3-0_{context}"]
 = Verifying the upgrade
 
-Use the following procedure to verify the upgrade.
+[role="_abstract"]
+Verify the upgrade to ensure the integrity of the installation and the availability of backup storage locations.
 
 .Procedure
 . Verify the installation by viewing the {oadp-first} resources by running the following command:
@@ -18,7 +19,7 @@ $ oc get all -n openshift-adp
 ----
 +
 .Example output
-+
+[source,terminal]
 ----
 NAME                                                     READY   STATUS    RESTARTS   AGE
 pod/oadp-operator-controller-manager-67d9494d47-6l8z8    2/2     Running   0          2m8s
@@ -49,9 +50,9 @@ replicaset.apps/velero-588db7f655                              1         1      
 ----
 $ oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
 ----
++
 .Example output
 [source,yaml]
-+
 ----
 {"conditions":[{"lastTransitionTime":"2023-10-27T01:23:57Z","message":"Reconcile complete","reason":"Complete","status":"True","type":"Reconciled"}]}
 ----
@@ -64,22 +65,22 @@ $ oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
 ----
 $ oc get backupstoragelocations.velero.io -n openshift-adp
 ----
++
 .Example output
 [source,yaml]
-+
 ----
 NAME           PHASE       LAST VALIDATED   AGE     DEFAULT
 dpa-sample-1   Available   1s               3d16h   true
 ----
 
-In OADP 1.3 you can start data movement off cluster per backup versus creating a `DataProtectionApplication` (DPA) configuration.
-
+. Start data movement off cluster per backup compared to creating a `DataProtectionApplication` (DPA) configuration:
++
 .Example command
 [source,terminal]
 ----
 $ velero backup create example-backup --include-namespaces mysql-persistent --snapshot-move-data=true
 ----
-
++
 .Example configuration file
 [source,yaml]
 ----
@@ -96,3 +97,5 @@ spec:
   ttl: 720h0m0s
 # ...
 ----
+
+//The last step doesn't really fit here but I'm hesitant to separate it out right now. It cannot be floating because of DITA requirements.

--- a/modules/oadp-verifying-upgrade-1-4-0.adoc
+++ b/modules/oadp-verifying-upgrade-1-4-0.adoc
@@ -7,7 +7,8 @@
 [id="verifying-upgrade-1-2-0_{context}"]
 = Verifying the upgrade
 
-Use the following procedure to verify the upgrade.
+[role="_abstract"]
+Verify the upgrade to ensure the integrity of the installation and the availability of backup storage locations.
 
 .Procedure
 
@@ -19,7 +20,7 @@ $ oc get all -n openshift-adp
 ----
 +
 .Example output
-+
+[source,terminal]
 ----
 NAME                                                     READY   STATUS    RESTARTS   AGE
 pod/oadp-operator-controller-manager-67d9494d47-6l8z8    2/2     Running   0          2m8s
@@ -49,9 +50,9 @@ replicaset.apps/velero-588db7f655                              1         1      
 ----
 $ oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
 ----
++
 .Example output
 [source,yaml]
-+
 ----
 {"conditions":[{"lastTransitionTime":"2023-10-27T01:23:57Z","message":"Reconcile complete","reason":"Complete","status":"True","type":"Reconciled"}]}
 ----
@@ -64,9 +65,9 @@ $ oc get dpa dpa-sample -n openshift-adp -o jsonpath='{.status}'
 ----
 $ oc get backupstoragelocations.velero.io -n openshift-adp
 ----
++
 .Example output
 [source,yaml]
-+
 ----
 NAME           PHASE       LAST VALIDATED   AGE     DEFAULT
 dpa-sample-1   Available   1s               3d16h   true


### PR DESCRIPTION
Summary:
Rewrite OADP 1.3 and 1.4 Release Notes in accordance with DITA (add abstracts, definition lists, split assemblies, etc.).

Version(s):
OCP 4.14-4.15

Issue:
[OADP-7040](https://issues.redhat.com/browse/OADP-7040)

Link to docs preview:

- [OADP 1.4 release notes](https://103873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html)
- [Upgrading OADP 1.3 to 1.4](https://103873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-upgrade-notes-1-4.html)
- [OADP 1.3 release notes](https://103873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-release-notes-1-3.html)
- [Upgrading OADP 1.2 to 1.3](https://103873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-upgrade-notes-1-3.html)

Bypassing QE review as this is markup changes only.