### PR TITLE
OCPNAS#294: RN - Update CNSA to v5.2.3.5

### DIFF
--- a/modules/virt-fusion-access-san-release-updates.adoc
+++ b/modules/virt-fusion-access-san-release-updates.adoc
@@ -12,20 +12,34 @@ Release updates for IBM Fusion Access for SAN, including new features, bug fixes
 [id="virt-fusion-access-san-new-changes_{context}"]
 == New and changed features
 
+Fusion Access for SAN 1.1.0 includes Spectrum Scale 5.2.3.5::
+
+Fusion Access for SAN 1.1.0 uses Spectrum Scale version 5.2.3.5. When you upgrade to Fusion Access for SAN 1.1.0, Spectrum Scale is automatically upgraded to version 5.2.3.5.
++
+link:https://issues.redhat.com/browse/OCPNAS-294[OCPNAS-294]
++
+link:https://issues.redhat.com/browse/OCPNAS-279[OCPNAS-279]
+
 Image registry requirements for kernel module management::
 
-{IBMFusionFirst} uses the {product-title} image registry to manage the kernel module. Do not configure the registry to use `emptyDir` storage because it provides only temporary storage and is not suitable for production use. Configure {IBMFusionFirst} to use a different image registry by creating a config map and secret after installing the Operator and before creating the `FusionAccess` CR. (link:https://issues.redhat.com/browse/OCPNAS-213[*OCPNAS-213*])
+{IBMFusionFirst} uses the {product-title} image registry to manage the kernel module. Do not configure the registry to use `emptyDir` storage because it provides only temporary storage and is not suitable for production use. Configure {IBMFusionFirst} to use a different image registry by creating a config map and secret after installing the Operator and before creating the `FusionAccess` CR.
++
+link:https://issues.redhat.com/browse/OCPNAS-213[OCPNAS-213]
 
 [id="virt-fusion-access-san-bug-fixes_{context}"]
 == Bug fixes
 
 Filesystem creation button stays disabled until daemons are ready::
 
-The {IBMFusionFirst} Operator was updated to check the readiness of filesystem daemons before allowing a filesystem to be created. The **Create file system** button in the web console now stays disabled with a tooltip explaining the condition until the environment is ready. This change prevents filesystems from appearing stuck during creation. (link:https://issues.redhat.com/browse/OCPNAS-184[*OCPNAS-184*])
+The {IBMFusionFirst} Operator was updated to check the readiness of filesystem daemons before allowing a filesystem to be created. The **Create file system** button in the web console now stays disabled with a tooltip explaining the condition until the environment is ready. This change prevents filesystems from appearing stuck during creation.
++
+link:https://issues.redhat.com/browse/OCPNAS-184[OCPNAS-184]
 
 Filesystems cannot be deleted from the user interface::
 
-The {product-title} web console does not support deleting filesystems. To delete a filesystem, use the {oc-first}. (link:https://issues.redhat.com/browse/OCPNAS-217[*OCPNAS-217*])
+The {product-title} web console does not support deleting filesystems. To delete a filesystem, use the {oc-first}.
++
+link:https://issues.redhat.com/browse/OCPNAS-217[OCPNAS-217]
 
 [id="virt-fusion-access-san-known-issues_{context}"]
 == Known issues
@@ -39,4 +53,6 @@ Filesystem creation might fail if core pods are deleted at the same time. The fi
 Disk <ID> may still belong to an active file system
 ----
 +
-No workaround is available. Contact IBM Support for assistance. (link:https://issues.redhat.com/browse/OCPNAS-233[*OCPNAS-233*])
+No workaround is available. Contact IBM Support for assistance.
++
+link:https://issues.redhat.com/browse/OCPNAS-233[OCPNAS-233]


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OCPNAS-294

Link to docs preview:
https://103884--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/install-configure-fusion-access-san.html#virt-fusion-access-san-release-updates_install-configure-fusion-access-san

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Added RN for CSNA but also made the rest of the file consistent with recent style compliance changes.
