### PR TITLE
OSDOCS 17237 Allow MCO to ignore specific non-reconcilable configurations

### DIFF
--- a/machine_configuration/machine-configs-configure.adoc
+++ b/machine_configuration/machine-configs-configure.adoc
@@ -6,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use the tasks in this section to create `MachineConfig` objects that modify files, systemd unit files, and other operating system features running on {product-title} nodes. For more ideas on working with machine configs, see content related to link:https://access.redhat.com/solutions/3868301[updating] SSH authorized keys, xref:../security/container_security/security-container-signature.adoc#security-container-signature[verifying image signatures], link:https://access.redhat.com/solutions/4727321[enabling SCTP], and link:https://access.redhat.com/solutions/5170251[configuring iSCSI initiatornames] for {product-title}.
+[role="_abstract"]
+You can use the tasks in this section to create `MachineConfig` objects that modify files, systemd unit files, and other operating system features running on {product-title} nodes. This allows you to perform such tasks such as disabling chronyd, adding kernel arguments, enabling multipathing, and adding {op-system} extensions.
+
+For more ideas on working with machine configs, see content related to link:https://access.redhat.com/solutions/3868301[updating] SSH authorized keys, xref:../security/container_security/security-container-signature.adoc#security-container-signature[verifying image signatures], link:https://access.redhat.com/solutions/4727321[enabling SCTP], and link:https://access.redhat.com/solutions/5170251[configuring iSCSI initiatornames] for {product-title}.
 
 {product-title} supports link:https://coreos.github.io/ignition/configuration-v3_5/[Ignition specification version 3.5]. You should base all new machine configs you create going forward on Ignition specification version 3.5. If you are upgrading your {product-title} cluster, any existing machine configs with a previous Ignition specification will be translated automatically to specification version 3.5.
 
@@ -19,39 +22,30 @@ Use the following "Configuring chrony time service" procedure as a model for how
 
 include::modules/installation-special-config-chrony.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../installing/install_config/installing-customizing.adoc#installation-special-config-butane_installing-customizing[Creating machine configs with Butane]
-
 include::modules/cnf-disable-chronyd.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+1]
 
 include::modules/rhcos-enabling-multipath-day-2.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
-
-* See xref:../installing/installing_bare_metal/upi/installing-bare-metal.adoc#rhcos-enabling-multipath_installing-bare-metal[Enabling multipathing with kernel arguments on RHCOS] for more information about enabling multipathing during installation time.
-
 include::modules/nodes-nodes-rtkernel-arguments.adoc[leveloffset=+1]
 
 include::modules/machineconfig-modify-journald.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../installing/install_config/installing-customizing.adoc#installation-special-config-butane_installing-customizing[Creating machine configs with Butane]
 
 include::modules/rhcos-add-extensions.adoc[leveloffset=+1]
 
 include::modules/rhcos-load-firmware-blobs.adoc[leveloffset=+1]
 
+include::modules/core-user-password.adoc[leveloffset=+1]
+
+include::modules/machine-config-install-time-configs.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
 * xref:../installing/install_config/installing-customizing.adoc#installation-special-config-butane_installing-customizing[Creating machine configs with Butane]
-
-include::modules/core-user-password.adoc[leveloffset=+1]
+* xref:../installing/installing_bare_metal/upi/installing-bare-metal.adoc#rhcos-enabling-multipath_installing-bare-metal[Enabling multipathing with kernel arguments on RHCOS]
+* xref:../installing/install_config/installing-customizing.adoc#installation-special-config-butane_installing-customizing[Creating machine configs with Butane]
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
 

--- a/modules/machine-config-install-time-configs.adoc
+++ b/modules/machine-config-install-time-configs.adoc
@@ -1,0 +1,218 @@
+// Module included in the following assemblies:
+//
+// * machine_configuration/machine-configs-configure.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="machine-config-install-time-configs_{context}"]
+= Overriding storage or partition setup
+
+[role="_abstract"]
+You can use a `MachineConfig` object to change the disk partition schema, file systems, and RAID configurations that were established during the cluster installation. This allows you to make specific configuration changes that are different from the initial cluster state.
+
+If you specified storage and partition configuration upon cluster installation by using a Butane config, Ignition config, or machine config, those configurations become defaults within your cluster. If you create new nodes, those nodes automatically use those default configurations. 
+
+You cannot change these components directly. By default, the Machine Config Operator (MCO) reviews changes in `MachineConfig` objects for specific fields and blocks some changes for security reasons. However, you can override this restriction for disk partition schema, file systems, and RAID configurations by adding the `irreconcilableValidationOverrides` parameter to the `MachineConfiguration` object. Then, you can create a new machine config to make the necessary changes for new nodes.
+
+[NOTE]
+====
+Configuration changes made through this process apply to new nodes only.
+====
+
+For example, you might want to override your default storage configuration to add new hardware that uses a different storage partitioning schema or storage file system to your cluster. In this case, you can modify the storage configuration for any new nodes in your cluster.
+
+Or, if you used Ignition to modify the storage configuration as a post-installation task, your cluster might be reporting an `irreconcilableChanges` status in the `MachineConfigNode` object status fields. This messaging can alert you to these differences, so that you can determine if you want new hardware with the new configurations.  
+
+:FeatureName: Overriding irreconcilable fields
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You enabled the required Technology Preview features for your cluster by adding the `TechPreviewNoUpgrade` feature set to the `FeatureGate` CR named `cluster`. For information about enabling Feature Gates, see _Enabling features using feature gates_.
++
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them. Do not enable this feature set on production clusters.
+====
+
+.Procedure
+
+. Edit the `MachineConfiguration` object by using the following command:
++
+[source,terminal]
+----
+$ oc edit machineconfiguration
+----
+
+. Add the `irreconcilableValidationOverrides` stanza to the `MachineConfiguration` object.
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: MachineConfiguration
+# ...
+spec:
+  irreconcilableValidationOverrides:
+    storage:
+    - Disks
+    - Raid
+    - FileSystems
+# ...
+----
+where:
++
+--
+`spec.irreconcilableValidationOverrides.storage.Disks`:: Allows you to modify the installed storage disk configuration to be used with new nodes. This field is optional.
+
+`spec.irreconcilableValidationOverrides.storage.Raid`:: Allows you to modify the installed RAID configuration to be used with new nodes. This field is optional.
+
+`spec.irreconcilableValidationOverrides.storage.FileSystems`:: Allows you to modify the installed file system configuration to be used with new nodes. This field is optional.
+--
+
+. Create a YAML file for a `MachineConfig` object with the changes that you need, similar to the following:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: extra-disks
+spec:
+  config:
+    ignition:
+      version: "3.5.0"
+    storage:
+      disks:
+      - device: "/dev/sdb"
+        wipeTable: true
+        partitions:
+        - label: raid.1.1
+          number: 1
+          sizeMiB: 1024
+          startMiB: 0
+      - device: "/dev/sdc"
+        wipeTable: true
+        partitions:
+        - label: raid.1.2
+          number: 1
+          sizeMiB: 1024
+          startMiB: 0
+      raid:
+      - devices:
+        - "/dev/disk/by-partlabel/raid.1.1"
+        - "/dev/disk/by-partlabel/raid.1.2"
+        level: stripe
+        name: data
+      filesystems:
+      - device: "/dev/md/data"
+        path: "/var/lib/data"
+        format: ext4
+        label: DATA
+----
+where:
+
+`spec.config.storage.disks`:: Specifies changes to the installed storage disk configuration in Ignition format. This field is optional.
+
+`spec.config.storage.raid`:: Specifies changes to the installed RAID configuration in Ignition format. This field is optional.
+
+`spec.config.storage.filesystems`:: Specifies changes to the installed file system configuration in Ignition format. This field is optional.
+
+. Create the `MachineConfig` object by using a command similar to the following:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
++
+When you create a new node from a machine set with the associated label, the new configurations are applied to the node. 
+
+
+
+////
+Hide for the GA release. Need to verify the verification.
+.Verification
+
+. View the changes in the created machine set by using a command similar to the following:
++
+[source,terminal]
+----
+$ oc edit mc 
+----
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: rendered-worker-b640f52876a9bf7fe636fee0a0164ae1
+# ...
+spec
+  config
+# ...
+    storage:
+      disks:
+      - device: /dev/sdb
+        partitions:
+        - label: raid.1.1
+          number: 1
+          sizeMiB: 1024
+          startMiB: 0
+        wipeTable: true
+      - device: /dev/sdc
+        partitions:
+        - label: raid.1.2
+          number: 1
+          sizeMiB: 1024
+          startMiB: 0
+        wipeTable: true
+     files:
+# ...
+      filesystems:
+      - device: /dev/md/data
+        format: ext4
+        label: DATA
+        path: /var/lib/data
+      raid:
+      - devices:
+        - /dev/disk/by-partlabel/raid.1.1
+        - /dev/disk/by-partlabel/raid.1.2
+        level: stripe
+        name: data
+# ...
+----
+
+. Open an `oc debug` session to a node by running a command similar to the following:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
++
+. Set `/host` as the root directory within the debug shell by running the following command:
++
+[source,terminal]
+----
+sh-5.1# chroot /host
+----
++
+. Ensure the raid exists and that the file system can be mounted by using commands similar to the following:
++
+[source,terminal]
+----
+sh-5.1# mount /dev/md/data /var/lib/data
+----
++
+[source,terminal]
+----
+sh-5.1# mdadm --detail --scan
+----
++
+.Example output
+[source,terminal]
+----
+ARRAY /dev/md/data metadata=1.2 UUID=9989eb57:2fa9774c:b57cc2cc:70ac303e
+----
+////
+
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17237
https://github.com/openshift/machine-config-operator/pull/5223

Link to docs preview:
[Overriding storage or partition setup](https://103894--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-configure.html#machine-config-install-time-configs_machine-configs-configure)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
