### PR TITLE
OSDOCS-17665: Updating Capacity Reservations docs (ROSA HCP)

### DIFF
--- a/modules/creating-a-machine-pool-cli-capres.adoc
+++ b/modules/creating-a-machine-pool-cli-capres.adoc
@@ -6,16 +6,17 @@
 [id="creating_machine_pools_cli_capres_{context}"]
 = Creating a machine pool with Capacity Reservations using the {rosa-cli}
 
+[role="_abstract"]
 You can create a new machine pool with Capacity Reservations by using the {rosa-cli-first}. Both On-Demand Capacity Reservations and Capacity Blocks for ML are supported.
 
 [NOTE]
 ====
-Currently, upgrading machine pools and enabling autoscaling is not suppored on machine pools with Capacity Reservations.
+Currently, autoscaling is not supported on machine pools with Capacity Reservations.
 ====
 
 .Prerequisites
 
-* You installed and configured the {rosa-cli} version 1.2.57 or above.
+* You installed and configured the latest {rosa-cli}.
 * You logged in to your Red{nbsp}Hat account using the {rosa-cli}.
 * You created a {product-title} cluster version 4.19 or above.
 * The cluster already has a machine pool that is not using a Capacity Reservation or taints. The machine pool must have at least 2 worker nodes.
@@ -23,14 +24,14 @@ Currently, upgrading machine pools and enabling autoscaling is not suppored on m
 
 .Procedure
 
-* Create the machine pool and define the instance type, worker node count, and Capacity Reservation ID by running the following command:
+* Create the machine pool and define the Capacity Reservation preference and ID by running the following command:
 +
---
 [source,terminal]
 ----
-$ rosa create machinepool --cluster=<cluster-name> \
+$ rosa create machinepool --cluster=<cluster_name> \
                           --name=<machine_pool_id> \
                           --replicas=<replica_count> \
+                          --capacity-reservation-preference none | open | capacity-reservations-only \
                           --capacity-reservation-id cr-<capacity_reservation_id> \
                           --instance-type=<instance_type> \
                           --subnet <subnet_id>
@@ -40,9 +41,15 @@ where:
 
 *<machine_pool_id>*:: Specifies the name of the machine pool.
 *<replica_count>*:: Specifies the number of provisioned compute nodes. If you deploy {product-title} using a single AZ, this defines the number of compute nodes provisioned to the machine pool for the AZ. If you deploy your cluster using multiple AZs, this defines the total number of compute nodes provisioned across all AZs. For multi-zone clusters, the compute node count must be a multiple of 3. The `--replicas` argument is required when autoscaling is not configured.
+*<capacity_reservation_preference>*:: Specifies the Capacity Reservation behaviour. Valid preferences include:
+
+* `none`: The instance does not use a Capacity Reservation even if one is available. The instance runs as an EC2 On-Demand instance. Choose this option when you want to avoid consuming purchased reserved capacity and use it for other workloads.
+* `open`: The instance can run in any `open` Capacity Reservation that has matching attributes such as the instance type, platform, AZ, or tenancy. Choose this option for flexibility; if a reservation is not available, the instance can use regular unreserved EC2 capacity.
+* `capacity-reservations-only`: The instance can only run in a Capacity Reservation. If capacity is not available, the instance fails to launch.
+
 *cr-<capacity_reservation_id>*:: Specifies the reservation ID. You get an ID in the `cr-<capacity_reservation_id>` format when you purchase a Capacity Reservation from AWS. The ID can be for both On-Demand Capacity Reservations or Capacity Blocks for ML, you do not need to specify the reservation type.
 *<instance_type>*:: *Optional*: Specifies the instance type for the compute nodes in your machine pool. The instance type defines the vCPU and memory allocation for each compute node in the pool. Replace `<instance_type>` with an instance type. The default is `m5.xlarge`. You cannot change the instance type for a machine pool after the pool is created.
-*<subnet_id>*:: *Optional*: Specifies the subnet ID. For Bring Your Own Virtual Private Cloud (BYO VPC) clusters, you can select a subnet to create a single-AZ machine pool. If you select a subnet that was not specified during the initial cluster creation, you must tag the subnet with the `kubernetes.io/cluster/<infra-id>` key and `shared` value. Customers can obtain the Infra ID by running the following command:
+*<subnet_id>*:: *Optional*: Specifies the subnet ID. For Bring Your Own Virtual Private Cloud (BYO VPC) clusters, you can select a subnet to create a single-AZ machine pool. If you select a subnet that was not specified during the initial cluster creation, you must tag the subnet with the `kubernetes.io/cluster/<infra_id>` key and `shared` value. Customers can obtain the Infra ID by running the following command:
 +
 [source,terminal]
 ----
@@ -54,7 +61,6 @@ $ rosa describe cluster --cluster <cluster_name>|grep "Infra ID:"
 ----
 Infra ID:                   mycluster-xqvj7
 ----
---
 
 .Example
 
@@ -94,7 +100,7 @@ $ rosa describe machinepool --cluster <cluster_name> --machinepool <machine_pool
 [source,terminal]
 ----
 ID:                         <machine_pool_name>
-Cluster ID:                 <cluster-id>
+Cluster ID:                 <cluster_id>
 Autoscaling:                No
 Desired replicas:           1
 Current replicas:           1
@@ -103,7 +109,7 @@ Labels:
 Tags:                       red-hat-managed=true, api.openshift.com/environment=production, api.openshift.com/id=<cluster_name>, api.openshift.com/legal-entity-id=<legal_entity_id>, api.openshift.com/name=<cluster_name>, api.openshift.com/nodepool-hypershift=<cluster_name>-<machine_pool_name>, api.openshift.com/nodepool-ocm=<machine_pool_name>, red-hat-clustertype=rosa
 Taints:
 Availability zone:          us-east-1a
-Subnet:                     <subnet-id>
+Subnet:                     <subnet_id>
 Disk Size:                  300 GiB
 Version:                    4.19.10
 EC2 Metadata Http Tokens:   optional
@@ -113,8 +119,9 @@ Kubelet configs:
 Additional security group IDs:
 Node drain grace period:
 Capacity Reservation:
-    - ID:                   <capacity-reservation-id>
+    - ID:                   <capacity_reservation_id>
     - Type:                 OnDemand
+    - Preference:           open
 Management upgrade:
     - Type:                 Replace
     - Max surge:            1
@@ -122,4 +129,4 @@ Management upgrade:
 Message:                    Minimum availability requires 1 replicas, current 1 available
 ----
 +
-The output should include the Capacity Reservation ID and type.
+The output should include the Capacity Reservation ID, type, and preference.

--- a/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
@@ -5,7 +5,8 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-managing-worker-nodes
 toc::[]
 
-This document describes how to manage compute (also known as worker) nodes with {product-title}.
+[role="_abstract"]
+With {product-title}, you can manage compute (also known as worker) nodes to create and configure optimal compute capacity for your workloads.
 
 The majority of changes for compute nodes are configured on machine pools. A machine pool is a group of compute nodes in a cluster that have the same configuration, providing ease of management.
 
@@ -24,13 +25,12 @@ Once you configure Capacity Reservations in {product-title}, you can use your AW
 
 Using Capacity Reservations on machine pools in {product-title} clusters has the following prerequisites and limitations:
 
-* You have installed the {rosa-cli} version 1.2.57 or above.
+* You installed and configured the latest {rosa-cli}.
 * Your {product-title} cluster is version 4.19 or later.
 * The cluster already has a machine pool that is not using a Capacity Reservation or taints. The machine pool must have at least 2 worker nodes.
 * You have purchased a Capacity Reservation for the instance type required in the AZ of the machine pool that you are creating.
 * You can only add a Capacity Reservation ID to a new machine pool.
 * You cannot use autoscaling on a machine pool with configured Capacity Reservations.
-* You cannot upgrade a machine pool with configured Capacity Reservations.
 
 To create a machine pool with a Capacity Reservation, see xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#creating_machine_pools_cli_capres_rosa-managing-worker-nodes[Creating a machine pool with Capacity Reservations using the {rosa-cli}].
 endif::openshift-rosa-hcp[]


### PR DESCRIPTION
[OSDOCS-17665](https://issues.redhat.com/browse/OSDOCS-17665): Updating Capacity Reservations docs (ROSA HCP). The ROSA CLI 1.2.58 release (scheduled on Dec 19th) adds a new field to the `rosa create machinepool` command and removes some limitations.

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17665

Link to docs preview:
Feature overview: [Managing compute nodes](https://103901--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html) - Removing limitations
CLI procedure: [Creating a machine pool with Capacity Reservations](https://103901--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes#creating_machine_pools_cli_capres_rosa-managing-worker-nodes) - Removing limitations, adding a new `capacity-reservation-preference` option, updating example output

QE review:

Additional information: