### PR TITLE
OSDOCS-17666: Adding UI procedure for Capacity Reservations (ROSA HCP)

### DIFF
--- a/modules/creating-a-machine-pool-ocm.adoc
+++ b/modules/creating-a-machine-pool-ocm.adoc
@@ -15,6 +15,7 @@ ifdef::openshift-rosa,openshift-rosa-hcp[]
 
 endif::openshift-rosa,openshift-rosa-hcp[]
 
+[role="_abstract"]
 ifndef::openshift-rosa,openshift-rosa-hcp[]
 A machine pool is created when you install an {product-title} cluster. After installation, you can create additional machine pools for your cluster by using {cluster-manager}.
 endif::openshift-rosa,openshift-rosa-hcp[]
@@ -101,6 +102,15 @@ endif::openshift-rosa-hcp[]
 ifdef::openshift-rosa,openshift-rosa-hcp[]
 . Optional: Configure *Root disk size*.
 endif::openshift-rosa,openshift-rosa-hcp[]
+
+ifdef::openshift-rosa-hcp[]
+. Optional: Add reserved capacity to your machine pool.
+.. Select a *Reservation Preference* from the list. Valid preferences include:
+... *None*: The instance does not use a Capacity Reservation even if one is available. The instance runs as an EC2 On-Demand instance. Choose this option when you want to avoid consuming purchased reserved capacity and use it for other workloads.
+... *Open*: The instance can run in any `open` Capacity Reservation that has matching attributes such as the instance type, platform, AZ, or tenancy. Choose this option for flexibility; if a reservation is not available, the instance can use regular unreserved EC2 capacity.
+... *CR only* (capacity reservation only): The instance can only run in a Capacity Reservation. If capacity is not available, the instance fails to launch.
+.. Add a *Reservation ID*. You get an ID in the `cr-<capacity_reservation_id>` format when you purchase a Capacity Reservation from AWS. The ID can be for both On-Demand Capacity Reservations or Capacity Blocks for ML.
+endif::openshift-rosa-hcp[]
 
 . Optional: Add node labels and taints for your machine pool:
 .. Expand the *Edit node labels and taints* menu.

--- a/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
@@ -30,9 +30,9 @@ Using Capacity Reservations on machine pools in {product-title} clusters has the
 * The cluster already has a machine pool that is not using a Capacity Reservation or taints. The machine pool must have at least 2 worker nodes.
 * You have purchased a Capacity Reservation for the instance type required in the AZ of the machine pool that you are creating.
 * You can only add a Capacity Reservation ID to a new machine pool.
-* You cannot use autoscaling on a machine pool with configured Capacity Reservations.
+* You cannot use autoscaling with Capacity Reservations if you create a machine pool using the {rosa-cli}. However, you can enable both autoscaling and Capacity Reservations on machine pools created using {cluster-manager}.
 
-To create a machine pool with a Capacity Reservation, see xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#creating_machine_pools_cli_capres_rosa-managing-worker-nodes[Creating a machine pool with Capacity Reservations using the {rosa-cli}].
+You can create a machine pool with a Capacity Reservation using either xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#creating_machine_pools_ocm_rosa-managing-worker-nodes[{cluster-manager}] or xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#creating_machine_pools_cli_capres_rosa-managing-worker-nodes[the {rosa-cli}].
 endif::openshift-rosa-hcp[]
 
 include::modules/creating-a-machine-pool.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-17666](https://issues.redhat.com/browse/OSDOCS-17666): Adding UI procedure for Capacity Reservations (ROSA HCP)

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17666

Link to docs preview:

- [Creating a machine pool using OCM](https://103902--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#creating_machine_pools_ocm_rosa-managing-worker-nodes) - Added 2 Capacity Reservations fields
- [Managing compute nodes](https://103902--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes#creating_machine_pools_ocm_rosa-managing-worker-nodes) - Added a link to the UI procedure

QE review:

Additional information:
