### PR TITLE
TELCODOCS-2590: KMM 2.5 Release Notes OSDOCS

### DIFF
--- a/hardware_enablement/kmm-release-notes.adoc
+++ b/hardware_enablement/kmm-release-notes.adoc
@@ -4,6 +4,9 @@
 include::_attributes/common-attributes.adoc[]
 :context: kmm-release-notes
 
+[role="_abstract"]
+Use the release notes to learn what is new or changed in Kernel Module Management (KMM).
+
 toc::[]
 
 [id="kmm-2-2-RN"]
@@ -315,3 +318,81 @@ For more information, see xref:../hardware_enablement/kmm-kernel-module-manageme
 // TELCODOCS-2390
 // MGMT-21050
 If you are running KMM-hub version 2.3.0 or earlier and you are not running KMM, the upgrade to KMM-hub 2.4.0 is not reliable. Instead, you must upgrade to KMM-hub 2.4.1. KMM is not affected by this issue. For more information, see link:https://access.redhat.com/errata/RHEA-2025:10778[RHEA-2025:10778 - Product Enhancement Advisory].
+
+[id="kmm-2-5-RN"]
+== Release notes for Kernel Module Management Operator 2.5
+=== New features and enhancements
+
+// MGMT-21653, TELCODOCS-2595
+* Starting with this version, you can use the KMM Operator to manage the lifecycle of kmod images that you installed by using the Day 1 utility. When a Day 1 kmod image is transitioned to the KMM Operator by using a `Module`, a `BootMachineConfig` (BMC) CRD is also created in the cluster. The BMC CRD fixes sudden reboot issues by ensuring that the `MachineConfig` gets updated with the correct values without triggering a node reboot. For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-customizing-upgrades-for-kernel-modules_kernel-module-management-operator[Managing Day 1 kmod images].
+
+// MGMT-22178, TELCODOCS-2594
+* The Kernel Module Management Operator (KMMO) 2.5 provides a `version.ready` label to indicate that the new version of the kernel module is loaded and is ready to use. For more information, see xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-customizing-upgrades-for-kernel-modules_kernel-module-management-operator[Customizing upgrades for kernel modules].
+
+// MGMT-22368, MGMT-21602 
+* KMM Operator support on {ibm-power-title} architecture
++
+RHEL does not provide a real-time Kernel for {ibm-power-title}, so do not deploy or validate any real-time features for KMM 2.5 on {ibm-power-title} compute nodes.
+
+// MGMT-22367, MGMT-21601
+* KMM Operator support on {ibm-z-title} architecture
++
+Kernel Module Management (KMM) 2.5 is now supported on {ibm-z-title} architecture. However, RHEL does not provide a real-time Kernel for {ibm-z-title}. Therefore, you should not deploy or validate any real-time features for KMM 2.5 on {ibm-z-title} worker nodes.
+
+=== Bug fixes
+
+// MGMT-20925
+* `PreflightValidationOCP` from KMM 2.4 does not synchronize status between v1beta1 and v1beta2.
+
+** *Cause*: This happens because the `v1beta1` --> `v1beta2` conversion webhook was not well defined in the CRD.
+
+** *Consequence*: The status only shows in v1beta2 and not in v1beta1. 
+
+** *Fix*:  A conversion between v1beta1 and v1beta2 has been added into the `PreflightValidationOCP` CRD. 
+
+** *Result*: The `PreflightValidationOCP` status is now shown in v1beta1 and v1beta2. 
+
+// MGMT-20900
+* `PreflightValidationOCP` in KMM 2.4 incorrectly pushes images to registry.
+
+** *Cause*: `PreflightValidationOCP` in KMM 2.4 version is pushing images to the registry despite the `pushBuiltImage: false` setting. 
+
+** *Consequence*: The new `PreflightValidationOCP` for KMM 2.4 ignores the `pushBuiltImage: false` and pushes it to registry.  
+
+** *Fix*: The internal logic has been updated to ensure the push behavior for built images is correctly propagated across all relevant workflows. 
+
+** *Result*: Built images are no longer incorrectly pushed to the registry when `pushBuiltImage: false`.
+
+// OCPBUGS-57167
+* The `kmm-operator-controller` pod encounters `OOMKilled` errors. 
+
+** *Cause*:  The `kmm-operator-controller` pod repeatedly encounters `OOMKilled` errors despite having a 1Gi memory limit. This issue occurs during cycles of installing and uninstalling the x100 Operator and associated kernel modules, suggesting a potential memory leak related to module management.
+
+ ** *Consequence*: This issue occurs even though the container has both `resources.limits.memory` and `resources.requests.memory` set to 1Gi. After several cycles, the manager container is repeatedly terminated by `OOMKilled`, despite having a 1Gi memory limit. The pod status shows `Running` with a 0/1 `ready` state, and the restart count grows continuously.
+
+** *Fix*: A fix that completely removes all code and configuration related to managing Cluster and Service CA ConfigMaps has been implemented. Update to KMM 2.4 or higher.
+
+** *Result*: Installing and uninstalling the x100 operator and associated kernel modules runs as expected. 
+
+// MGMT-21610, MGMT-22453
+* OpenShift 4.20 includes Kernel Module Management (KMM) Operator version 2.3.0 
+
+** *Cause*: The OpenShift 4.20 catalog includes Kernel Module Management (KMM) Operator version 2.3.0 as the latest version instead of the required KMM versions 2.4.0 and 2.4.1.
+
+** *Consequence*: The documentation was outdated and required an update.
+
+** *Fix*: The 4.20 catalogues have been updated to include KMM Operator versions 2.4.0 and 2.4.1. 
+
+** *Result*: The catalogues are now up-to-date.
+
+// MGMT-20954, MGMT-22454 
+* `HashAnnotationDiffer` function could produce unexpected results
+
+** *Cause*: A potential bug in the `HashAnnotationDiffer` function within the Kernel Module Management (KMM) could be exposed by a change in implementation. 
+
+** *Consequence*: While this potential bug is currently mitigated by the NMC logic, a change in implementation could expose this bug in real-time. 
+
+** *Fix*: The `HashAnnotationDiffer` method in `internal/pod/workerpodmanager.go` was updated to correctly handle cases where both input pods are nil or only one is nil. The logic now returns `false` (no difference) when both are nil, and `true` (difference) when only one is nil.
+
+** *Result*: The `HashAnnotationDiffer` function runs as expected. 
+


### PR DESCRIPTION
KMM 2.5 Release Notes

Version: 4.20+

Issue: https://issues.redhat.com/browse/TELCODOCS-2590

Preview: https://103905--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-release-notes.html#kmm-2-5-RN

Dev: @yevgeny-shnaidman
QE: @cdvultur 