### PR TITLE
TELCODOCS-2594: Add a versioned ready label for loaded kmods - OSDOCS

### DIFF
--- a/modules/kmm-customizing-upgrades-for-kernel-modules.adoc
+++ b/modules/kmm-customizing-upgrades-for-kernel-modules.adoc
@@ -6,23 +6,25 @@
 [id="kmm-customizing-upgrades-for-kernel-modules_{context}"]
 = Customizing upgrades for kernel modules
 
-Use this procedure to upgrade the kernel module while running maintenance operations on the node, including rebooting the node, if needed. To minimize the impact on the workloads running in the cluster, run the kernel upgrade process sequentially, one node at a time.
+[role="_abstract"]
+The Kernel Module Management (KMM) Operator periodically upgrades `Module` resources in the cluster, typically during a cluster upgrade.  
 
+Use this procedure to upgrade the kernel module while running maintenance operations on the node, including rebooting the node, if needed. To minimize the impact on the workloads running in the cluster, run the kernel upgrade process sequentially, one node at a time.
 
 [NOTE]
 ====
-This procedure requires knowledge of the workload utilizing the kernel module and must be managed by the cluster administrator.
+This procedure requires knowledge of the workload using the kernel module and must be managed by the cluster administrator.
 ====
 
 .Prerequisites
 
 * Before upgrading, set the `kmm.node.kubernetes.io/version-module.<module_namespace>.<module_name>=$moduleVersion` label on all the nodes that are used by the kernel module.
 
-* Terminate all user application workloads on the node or move them to another node.
+* End all user application workloads on the node or move them to another node.
 
 * Unload the currently loaded kernel module.
 
-* Ensure that the user workload (the application running in the cluster that is accessing kernel module) is not running on the node prior to kernel module unloading and that the workload is back running on the node after the new kernel module version has been loaded.
+* Ensure that the user workload (the application running in the cluster that is accessing kernel module) is not running on the node before the kernel module unloads and that the workload is back running on the node after the new kernel module version has been loaded.
 
 .Procedure
 
@@ -34,7 +36,7 @@ This procedure requires knowledge of the workload utilizing the kernel module an
 +
 The update should be atomic; that is, both the `containerImage` and `version` fields must be updated simultaneously.
 
-. Terminate any workload using the kernel module on the node being upgraded.
+. End any workload using the kernel module on the node being upgraded.
 
 . Remove the `kmm.node.kubernetes.io/version-module.<module_namespace>.<module_name>` label on the node.
 Run the following command to unload the kernel module from the node:
@@ -59,6 +61,14 @@ $ oc label node/<node_name> kmm.node.kubernetes.io/version-module.<module_namesp
 ====
 Because of Kubernetes limitations in label names, the combined length of `Module` name and namespace must not exceed 39 characters.
 ====
++ 
+The Operator labels the node with a `version.ready` label to indicate that the new version of the kernel module is loaded and is ready to be used:
++
+.Example output
+[source,terminal]
+----
+`kmm.node.kubernetes.io/<module-namespace>.<module-name>.version.ready=<module-version>`
+----
 
 . Restore any workload that leverages the kernel module on the node.
 


### PR DESCRIPTION
Document - Add a versioned ready label for loaded kmods

Version: 4.20+

Issue: https://issues.redhat.com/browse/TELCODOCS-2594

Preview: https://103906--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-customizing-upgrades-for-kernel-modules_kernel-module-management-operator

Dev: @yevgeny-shnaidman
QE: @cdvultur