### PR TITLE
OBSDOCS-2449 Remove callouts from the monitoring documentation.

### DIFF
--- a/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
+++ b/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
@@ -64,12 +64,23 @@ metadata:
 data:
   config.yaml: |
     {component}:
-      secrets: # <1>
-      - <secret_name_1> # <2>
+      secrets:
+      - <secret_name_1>
       - <secret_name_2>
 ----
-<1> This section contains the secrets to be mounted into Alertmanager. The secrets must be located within the same namespace as the Alertmanager object.
-<2> The name of the `Secret` object that contains authentication credentials for the receiver. If you add multiple secrets, place each one on a new line.
++
+--
+where:
+
+`secrets`::
+Defines the secrets to be mounted into Alertmanager. The secrets must be located within the same namespace as the Alertmanager object.
+
+`<secret_name_1>`:: 
+Specifies the name of the `Secret` object that contains authentication credentials for the receiver.
+
+`<secret_name_2>`::
+Optional: Specifies additional secrets. If you add additional secrets, place each one on a new line.
+--
 +
 The following sample config map settings configure Alertmanager to use two `Secret` objects named `test-secret-basic-auth` and `test-secret-api-token`:
 +

--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -62,9 +62,15 @@ data:
   config.yaml: |
     {component}:
       externalLabels:
-        <key>: <value> # <1>
+        <key>: <value>
 ----
-<1> Substitute `<key>: <value>` with key-value pairs where `<key>` is a unique name for the new label and `<value>` is its value.
++
+--
+where:
+
+`<key>: <value>`::
+Specifies key-value pairs where `<key>` is a unique name for the new label and `<value>` is its value.
+--
 +
 [WARNING]
 ====

--- a/modules/monitoring-choosing-a-metrics-collection-profile.adoc
+++ b/modules/monitoring-choosing-a-metrics-collection-profile.adoc
@@ -36,12 +36,15 @@ metadata:
 data:
   config.yaml: |
     prometheusK8s:
-      collectionProfile: <metrics_collection_profile_name> <1>
+      collectionProfile: <metrics_collection_profile_name>
 ----
 +
-<1> The name of the metrics collection profile.
-The available values are `full` or `minimal`.
-If you do not specify a value or if the `collectionProfile` key name does not exist in the config map, the default setting of `full` is used.
+--
+where:
+
+`<metrics_collection_profile_name>`::
+Specifies the name of the metrics collection profile. The available values are `full` or `minimal`. If you do not specify a value or if the `collectionProfile` key name does not exist in the config map, the default setting of `full` is used.
+--
 +
 The following example sets the metrics collection profile to `minimal` for the core platform instance of Prometheus:
 +

--- a/modules/monitoring-configuring-a-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-persistent-volume-claim.adoc
@@ -60,17 +60,27 @@ metadata:
   namespace: {namespace-name}
 data:
   config.yaml: |
-    <component>: # <1>
+    <component>:
       volumeClaimTemplate:
         spec:
-          storageClassName: <storage_class> # <2>
+          storageClassName: <storage_class>
           resources:
             requests:
-              storage: <amount_of_storage> # <3>
+              storage: <amount_of_storage>
 ----
-<1> Specify the monitoring component for which you want to configure the PVC.
-<2> Specify an existing storage class. If a storage class is not specified, the default storage class is used.
-<3> Specify the amount of required storage.
++
+--
+where:
+
+`<component>`::
+Specifies the monitoring component for which you want to configure the PVC.
+
+`<storage_class>`::
+Specifies an existing storage class. If a storage class is not specified, the default storage class is used.
+
+`<amount_of_storage>`::
+Specifies the amount of required storage.
+--
 +
 The following example configures a PVC that claims persistent storage for 
 // tag::CPM[]

--- a/modules/monitoring-configuring-alert-routing-default-platform-alerts.adoc
+++ b/modules/monitoring-configuring-alert-routing-default-platform-alerts.adoc
@@ -40,11 +40,11 @@ $ oc -n openshift-monitoring get secret alertmanager-main --template='{{ index .
 global:
   resolve_timeout: 5m
   http_config:
-    proxy_from_environment: true # <1>
+    proxy_from_environment: true
 route:
-  group_wait: 30s # <2>
-  group_interval: 5m # <3>
-  repeat_interval: 12h # <4>
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 12h
   receiver: default
   routes:
   - matchers:
@@ -55,12 +55,20 @@ receivers:
 - name: default
 - name: watchdog
 ----
-<1> If you configured an HTTP cluster-wide proxy, set the `proxy_from_environment` parameter to `true` to enable proxying for all alert receivers.
-<2> Specify how long Alertmanager waits while collecting initial alerts for a group of alerts before sending a notification.
-<3> Specify how much time must elapse before Alertmanager sends a notification about new alerts added to a group of alerts for which an initial notification was already sent.
-<4> Specify the minimum amount of time that must pass before an alert notification is repeated.
-If you want a notification to repeat at each group interval, set the `repeat_interval` value to less than the `group_interval` value.
-The repeated notification can still be delayed, for example, when certain Alertmanager pods are restarted or rescheduled.
++
+where:
+
+`proxy_from_environment`::
+Specifies whether to enable proxying for all alert receivers. If you configured an HTTP cluster-wide proxy, set this parameter to `true` to enable proxying for all alert receivers.
+
+`group_wait`::
+Specifies how long Alertmanager waits while collecting initial alerts for a group of alerts before sending a notification.
+
+`group_interval`::
+Specifies how much time must elapse before Alertmanager sends a notification about new alerts added to a group of alerts for which an initial notification was already sent.
+
+`repeat_interval`::
+Specifies the minimum amount of time that must pass before an alert notification is repeated. If you want a notification to repeat at each group interval, set the `repeat_interval` value to less than the `group_interval` value. The repeated notification can still be delayed, for example, when certain Alertmanager pods are restarted or rescheduled.
 
 .. Add your alert receiver configuration:
 +
@@ -70,12 +78,20 @@ The repeated notification can still be delayed, for example, when certain Alertm
 receivers:
 - name: default
 - name: watchdog
-- name: <receiver> # <1>
-  <receiver_configuration> # <2>
+- name: <receiver>
+  <receiver_configuration>
 # ...
 ----
-<1> The name of the receiver.
-<2> The receiver configuration. The supported receivers are PagerDuty, webhook, email, Slack, and Microsoft Teams.
++
+--
+where:
+
+`<receiver>`::
+Specifies the name of the receiver.
+
+`<receiver_configuration>`::
+Specifies the receiver configuration. The supported receivers are PagerDuty, webhook, email, Slack, and Microsoft Teams.
+--
 +
 .Example of configuring PagerDuty as an alert receiver
 [source,yaml]
@@ -86,17 +102,24 @@ receivers:
 - name: watchdog
 - name: team-frontend-page
   pagerduty_configs:
-  - routing_key: xxxxxxxxxx # <1>
-    http_config: # <2> 
+  - routing_key: xxxxxxxxxx
+    http_config:
       proxy_from_environment: true
       authorization:
         credentials: xxxxxxxxxx
 # ...
 ----
-<1> Defines the PagerDuty integration key.
-<2> Optional: Add the custom HTTP configuration for a specific receiver. That receiver does not inherit the global HTTP configuration settings.
 +
 --
+where:
+
+`routing_key`::
+Specifies the PagerDuty integration key.
+
+`http_config`::
+(Optional) Adds the custom HTTP configuration for a specific receiver. That receiver does not inherit the global HTTP configuration settings.
+--
++
 .Example of configuring email as an alert receiver
 [source,yaml]
 ----
@@ -106,19 +129,32 @@ receivers:
 - name: watchdog
 - name: team-frontend-page
   email_configs:
-    - to: myemail@example.com # <1>
-      from: alertmanager@example.com # <2>
-      smarthost: 'smtp.example.com:587' # <3>
-      auth_username: alertmanager@example.com  # <4>
+    - to: myemail@example.com
+      from: alertmanager@example.com
+      smarthost: 'smtp.example.com:587'
+      auth_username: alertmanager@example.com
       auth_password: password
-      hello: alertmanager # <5>
+      hello: alertmanager
 # ...
 ----
-<1> Specify an email address to send notifications to.
-<2> Specify an email address to send notifications from.
-<3> Specify the SMTP server address used for sending emails, including the port number.
-<4> Specify the authentication credentials that Alertmanager uses to connect to the SMTP server. This example uses username and password.
-<5> Specify the hostname to identify to the SMTP server. If you do not include this parameter, the hostname defaults to `localhost`.
++
+--
+where:
+
+`to`::
+Specifies an email address to send notifications to.
+
+`from`::
+Specifies an email address to send notifications from.
+
+`smarthost`::
+Specifies the SMTP server address used for sending emails, including the port number.
+
+`auth_username`, `auth_password`::
+Specify the authentication credentials that Alertmanager uses to connect to the SMTP server. This example uses username and password.
+
+`hello`::
+Specifies the hostname to identify to the SMTP server. If you do not include this parameter, the hostname defaults to `localhost`.
 --
 +
 [IMPORTANT]
@@ -150,22 +186,30 @@ route:
     - "alertname=Watchdog"
     repeat_interval: 2m
     receiver: watchdog
-  - matchers: # <1>
-    - "<your_matching_rules>" # <2>
-    receiver: <receiver> # <3>
+  - matchers:
+    - "<your_matching_rules>"
+    receiver: <receiver>
 # ...
 ----
-<1> Use the `matchers` key name to specify the matching rules that an alert has to fulfill to match the node.
-If you define inhibition rules, use `target_matchers` key name for target matchers and `source_matchers` key name for source matchers.
-<2> Specify labels to match your alerts.
-<3> Specify the name of the receiver to use for the alerts.
++
+--
+where:
+
+`matchers`::
+Defines the matching rules that an alert has to fulfill to match the node. If you define inhibition rules, use `target_matchers` key name for target matchers and `source_matchers` key name for source matchers.
+
+`<your_matching_rules>`::
+Specifies labels to match your alerts.
+
+`<receiver>`::
+Specifies the name of the receiver to use for the alerts.
+--
 +
 [WARNING]
 ====
 Do not use the `match`, `match_re`, `target_match`, `target_match_re`, `source_match`, and `source_match_re` key names, which are deprecated and planned for removal in a future release.
 ====
 +
---
 .Example of alert routing 
 [source,yaml]
 ----
@@ -176,23 +220,18 @@ route:
   repeat_interval: 12h
   receiver: default
   routes:
+  # ...
   - matchers:
-    - "alertname=Watchdog"
-    repeat_interval: 2m
-    receiver: watchdog
-  - matchers: # <1>
     - "service=example-app"
-    routes: # <2>
+    routes:
     - matchers:
       - "severity=critical"
       receiver: team-frontend-page
 # ...
 ----
-<1>  This example matches alerts from the `example-app` service.
-<2> You can create routes within other routes for more complex alert routing. 
---
-+
-The previous example routes alerts of `critical` severity that are fired by the `example-app` service to the `team-frontend-page` receiver. Typically, these types of alerts are paged to an individual or a critical response team.
+
+* `"service=example-app"` matching rule matches alerts from the `example-app` service.
+* You can specify routes within other routes for more complex alert routing. In this example, `route.routes.matchers.routes` matches alerts of `critical` severity that are fired by the `example-app` service to the `team-frontend-page` receiver. Typically, these types of alerts are paged to an individual or a critical response team.
 
 . Apply the new configuration in the file:
 +

--- a/modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc
+++ b/modules/monitoring-configuring-alert-routing-user-defined-alerts-secret.adoc
@@ -33,32 +33,42 @@ endif::[]
 ----
 $ oc -n openshift-user-workload-monitoring get secret alertmanager-user-workload --template='{{ index .data "alertmanager.yaml" }}' | base64 --decode > alertmanager.yaml
 ----
-+
+
 . Edit the configuration in `alertmanager.yaml`:
 +
 [source,yaml]
 ----
 global:
   http_config:
-    proxy_from_environment: true # <1>
+    proxy_from_environment: true
 route:
   receiver: Default
   group_by:
   - name: Default
   routes:
   - matchers:
-    - "service = prometheus-example-monitor" # <2>
-    receiver: <receiver> # <3>
+    - "service = prometheus-example-monitor"
+    receiver: <receiver>
 receivers:
 - name: Default
 - name: <receiver>
-  <receiver_configuration> # <4>
+  <receiver_configuration>
 ----
-<1> If you configured an HTTP cluster-wide proxy, set the `proxy_from_environment` parameter to `true` to enable proxying for all alert receivers.
-<2> Specify labels to match your alerts. This example targets all alerts that have the `service="prometheus-example-monitor"` label.
-<3> Specify the name of the receiver to use for the alerts group.
-<4> Specify the receiver configuration.
 +
+where:
+
+`proxy_from_environment`::
+Specifies whether to enable proxying for all alert receivers. If you configured an HTTP cluster-wide proxy, set this parameter to `true` to enable proxying for all alert receivers.
+
+`matchers`::
+Specifies labels to match your alerts. This example targets all alerts that have the `service="prometheus-example-monitor"` label.
+
+`<receiver>`::
+Specifies the name of the receiver to use for the alerts group.
+
+`<receiver_configuration>`::
+Specifies the receiver configuration.
+
 . Apply the new configuration in the file:
 +
 [source,terminal]

--- a/modules/monitoring-configuring-audit-logs-for-metrics-server.adoc
+++ b/modules/monitoring-configuring-audit-logs-for-metrics-server.adoc
@@ -45,9 +45,13 @@ data:
   config.yaml: |
     metricsServer:
       audit:
-        profile: <audit_log_profile> # <1>
+        profile: <audit_log_profile>
 ----
-<1> Specify the audit profile for Metrics Server.
++
+where:
+
+`<audit_log_profile>`::
+Specifies the audit profile for Metrics Server.
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
 

--- a/modules/monitoring-configuring-external-alertmanagers.adoc
+++ b/modules/monitoring-configuring-external-alertmanagers.adoc
@@ -81,16 +81,23 @@ data:
     prometheusK8s:
 # end::CPM[]
 # tag::UWM[]
-    <component>: # <2>
+    <component>:
 # end::UWM[]
       additionalAlertmanagerConfigs:
-      - <alertmanager_specification> # <1>
+      - <alertmanager_specification>
 ----
-<1> Substitute `<alertmanager_specification>` with authentication and other configuration details for additional Alertmanager instances.
-Currently supported authentication methods are bearer token (`bearerToken`) and client TLS (`tlsConfig`).
++
+--
+where:
+
 // tag::UWM[]
-<2> Substitute `<component>` for one of two supported external Alertmanager components: `prometheus` or `thanosRuler`.
+`<component>`::
+Specifies one of two supported external Alertmanager components: `prometheus` or `thanosRuler`.
 // end::UWM[]
+
+`<alertmanager_specification>`::
+Specifies authentication and other configuration details for additional Alertmanager instances. Currently supported authentication methods are bearer token (`bearerToken`) and client TLS (`tlsConfig`).
+--
 +
 The following sample config map configures an additional Alertmanager for {component-name} by using a bearer token with client TLS authentication:
 +

--- a/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
+++ b/modules/monitoring-configuring-pod-topology-spread-constraints.adoc
@@ -76,25 +76,33 @@ metadata:
   namespace: {namespace-name}
 data:
   config.yaml: |
-    <component>: # <1>
+    <component>:
       topologySpreadConstraints:
-      - maxSkew: <n> # <2>
-        topologyKey: <key> # <3>
-        whenUnsatisfiable: <value> # <4>
-        labelSelector: # <5>
+      - maxSkew: <n>
+        topologyKey: <key>
+        whenUnsatisfiable: <value>
+        labelSelector:
           <match_option>
 ----
-<1> Specify a name of the component for which you want to set up pod topology spread constraints.
-<2> Specify a numeric value for `maxSkew`, which defines the degree to which pods are allowed to be unevenly distributed.
-<3> Specify a key of node labels for `topologyKey`.
-Nodes that have a label with this key and identical values are considered to be in the same topology.
-The scheduler tries to put a balanced number of pods into each domain.
-<4> Specify a value for `whenUnsatisfiable`.
-Available options are `DoNotSchedule` and `ScheduleAnyway`.
-Specify `DoNotSchedule` if you want the `maxSkew` value to define the maximum difference allowed between the number of matching pods in the target topology and the global minimum.
-Specify `ScheduleAnyway` if you want the scheduler to still schedule the pod but to give higher priority to nodes that might reduce the skew.
-<5> Specify `labelSelector` to find matching pods. 
-Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
++
+--
+where:
+
+`<component>`::
+Specifies a name of the component for which you want to set up pod topology spread constraints.
+
+`<n>`::
+Specifies a numeric value for `maxSkew`, which defines the degree to which pods are allowed to be unevenly distributed.
+
+`<key>`::
+Specifies a key of node labels for `topologyKey`. Nodes that have a label with this key and identical values are considered to be in the same topology. The scheduler tries to put a balanced number of pods into each domain.
+
+`<value>`::
+Specifies a value for `whenUnsatisfiable`. Available options are `DoNotSchedule` and `ScheduleAnyway`. Specify `DoNotSchedule` if you want the `maxSkew` value to define the maximum difference allowed between the number of matching pods in the target topology and the global minimum. Specify `ScheduleAnyway` if you want the scheduler to still schedule the pod but to give higher priority to nodes that might reduce the skew.
+
+`<match_option>`::
+Specifies `labelSelector` to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
+--
 +
 .Example configuration for {component-name}
 [source,yaml,subs="attributes+"]

--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -73,13 +73,17 @@ data:
   config.yaml: |
     {component}:
       remoteWrite:
-      - url: "https://remote-write-endpoint.example.com" # <1>
-        <endpoint_authentication_credentials> # <2>
+      - url: "https://remote-write-endpoint.example.com"
+        <endpoint_authentication_credentials>
 ----
-<1> The URL of the remote write endpoint.
-<2> The authentication method and credentials for the endpoint.
-Currently supported authentication methods are AWS Signature Version 4, authentication using HTTP in an `Authorization` request header, Basic authentication, OAuth 2.0, and TLS client.
-See _Supported remote write authentication settings_ for sample configurations of supported authentication methods.
++
+where:
+
+`url`::
+Defines the URL of the remote write endpoint.
+
+`<endpoint_authentication_credentials>`::
+Specifies the authentication method and credentials for the endpoint. Currently supported authentication methods are AWS Signature Version 4, authentication using HTTP in an `Authorization` request header, Basic authentication, OAuth 2.0, and TLS client. See _Supported remote write authentication settings_ for sample configurations of supported authentication methods.
 
 . Add write relabel configuration values after the authentication credentials:
 +
@@ -97,9 +101,15 @@ data:
       - url: "https://remote-write-endpoint.example.com"
         <endpoint_authentication_credentials>
         writeRelabelConfigs:
-        - <your_write_relabel_configs> #<1>
+        - <your_write_relabel_configs>
 ----
-<1> Add configuration for metrics that you want to send to the remote endpoint.
++
+--
+where:
+
+`<your_write_relabel_configs>`::
+Specifies configuration for metrics that you want to send to the remote endpoint.
+--
 +
 .Example of forwarding a single metric called `my_metric`
 [source,yaml,subs="attributes+"]

--- a/modules/monitoring-configuring-shiftstack-remotewrite.adoc
+++ b/modules/monitoring-configuring-shiftstack-remotewrite.adoc
@@ -70,7 +70,7 @@ $ oc -n openstack edit openstackcontrolplane/controlplane
           prometheusConfig:
             scrapeInterval: 30s
             remoteWrite:
-            - url: https://external-prometheus.example.com/api/v1/write # <1>
+            - url: https://external-prometheus.example.com/api/v1/write
               tlsConfig:
                 ca:
                   secret:
@@ -94,14 +94,21 @@ $ oc -n openstack edit openstackcontrolplane/controlplane
             requests:
               cpu: 100m
               memory: 256Mi
-          retention: 1d # <2>
+          retention: 1d
         dashboardsEnabled: false
         dataplaneNetwork: ctlplane
         enabled: true
         prometheusTls: {}
 ----
-<1> Replace this URL with the URL of your Prometheus instance.
-<2> Set a retention period. Optionally, you can reduce retention for local metrics because of external collection.
++
+where:
+
+`url`::
+Specifies the URL of your Prometheus instance.
+
+`retention`::
+Sets a retention period. Optionally, you can reduce retention for local metrics because of external collection.
+
 // run on tenant's openshift cluster
 . Configure the tenant cluster on which your workloads run to send metrics to Prometheus:
 
@@ -117,7 +124,7 @@ metadata:
 data:
   config.yaml: |
     prometheusK8s:
-      retention: 1d # <1>
+      retention: 1d
       remoteWrite:
       - url: "https://external-prometheus.example.com/api/v1/write"
         writeRelabelConfigs:
@@ -138,7 +145,11 @@ data:
             name: mtls-bundle
             key: ocp-client.key
 ----
-<1> Set a retention period. Optionally, you can reduce retention for local metrics because of external collection.
++
+where:
+
+`retention`::
+Sets a retention period. Optionally, you can reduce retention for local metrics because of external collection.
 
 .. Save the config map as a file called `cluster-monitoring-config.yaml`.
 

--- a/modules/monitoring-configuring-shiftstack-scraping.adoc
+++ b/modules/monitoring-configuring-shiftstack-scraping.adoc
@@ -56,23 +56,33 @@ metadata:
 spec:
   params:
     'match[]':
-    - '{__name__=~"kube_node_info|kube_persistentvolume_info|cluster:master_nodes"}' # <1>
+    - '{__name__=~"kube_node_info|kube_persistentvolume_info|cluster:master_nodes"}'
   metricsPath: '/federate'
   authorization:
     type: Bearer
     credentials:
-      name: ocp-federated # <2>
+      name: ocp-federated
       key: token
   scheme: HTTPS # or HTTP
-  scrapeInterval: 30s # <3>
+  scrapeInterval: 30s
   staticConfigs:
   - targets:
-    - prometheus-k8s-federate-openshift-monitoring.apps.openshift.example # <4>
+    - prometheus-k8s-federate-openshift-monitoring.apps.openshift.example
 ----
-<1> Add metrics here. In this example, only the metrics `kube_node_info`, `kube_persistentvolume_info`, and `cluster:master_nodes` are requested.
-<2> Insert the previously generated secret name here.
-<3> Limit scraping to fewer than 1000 samples for each request with a maximum frequency of once every 30 seconds.
-<4> Insert the URL you fetched previously here. If the endpoint is HTTPS and uses a custom certificate authority, add a `tlsConfig` section after it.
++
+where:
+
+`'match[]'`::
+Defines requested metrics. In this example, only the metrics `kube_node_info`, `kube_persistentvolume_info`, and `cluster:master_nodes` are requested.
+
+`spec.authorization.credentials.name`::
+Defines the previously generated secret name.
+
+`scrapeInterval`::
+Limits scraping to fewer than 1000 samples for each request with a maximum frequency of once every 30 seconds.
+
+`targets`::
+Defines the URL you fetched previously. If the endpoint is HTTPS and uses a custom certificate authority, add a `tlsConfig` section after it.
 
 . While connected to the {rhoso} management cluster, apply the manifest by running the following command:
 +

--- a/modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc
@@ -38,19 +38,31 @@ spec:
   groups:
   - name: example
     rules:
-    - alert: VersionAlert # <1>
-      for: 1m # <2>
-      expr: version{job="prometheus-example-app"} == 0 # <3>
+    - alert: VersionAlert
+      for: 1m
+      expr: version{job="prometheus-example-app"} == 0
       labels:
-        severity: warning # <4>
+        severity: warning
       annotations:
-        message: This is an example alert. # <5>
+        message: This is an example alert.
 ----
-<1> The name of the alerting rule you want to create.
-<2> The duration for which the condition should be true before an alert is fired.
-<3> The PromQL query expression that defines the new rule.
-<4> The severity that alerting rule assigns to the alert.
-<5> The message associated with the alert.
++
+where:
+
+`alert`::
+Specifies the name of the alerting rule you want to create.
+
+`for`::
+Specifies the duration for which the condition should be true before an alert is fired.
+
+`expr`::
+Specifies the PromQL query expression that defines the new rule.
+
+`labels.severity`::
+Specifies the severity that alerting rule assigns to the alert.
+
+`annotations.message`::
+Specifies the message associated with the alert.
 
 . Apply the configuration file to the cluster:
 +

--- a/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
+++ b/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
@@ -77,11 +77,19 @@ data:
       remoteWrite:
       - url: "https://remote-write-endpoint.example.com"
         <endpoint_authentication_credentials>
-        writeRelabelConfigs: # <1>
-          - <relabel_config> # <2>
+        writeRelabelConfigs:
+          - <relabel_config>
 ----
-<1> Add a list of write relabel configurations for metrics that you want to send to the remote endpoint.
-<2> Substitute the label configuration for the metrics sent to the remote write endpoint.
++
+--
+where:
+
+`writeRelabelConfigs`::
+Specifies a list of write relabel configurations for metrics that you want to send to the remote endpoint.
+
+`<relabel_config>`::
+Specifies the label configuration for the metrics sent to the remote write endpoint.
+--
 +
 The following sample shows how to forward a metric with the cluster ID label `cluster_id`:
 +
@@ -99,16 +107,21 @@ data:
       - url: "https://remote-write-endpoint.example.com"
         writeRelabelConfigs:
         - sourceLabels:
-          - __tmp_openshift_cluster_id__ # <1>
-          targetLabel: cluster_id # <2>
-          action: replace # <3>
+          - __tmp_openshift_cluster_id__
+          targetLabel: cluster_id
+          action: replace
 ----
-<1> The system initially applies a temporary cluster ID source label named `+++__tmp_openshift_cluster_id__+++`. This temporary label gets replaced by the cluster ID label name that you specify.
-<2> Specify the name of the cluster ID label for metrics sent to remote write storage.
-If you use a label name that already exists for a metric, that value is overwritten with the name of this cluster ID label.
-For the label name, do not use `+++__tmp_openshift_cluster_id__+++`. The final relabeling step removes labels that use this name.
-<3> The `replace` write relabel action replaces the temporary label with the target label for outgoing metrics.
-This action is the default and is applied if no action is specified.
++
+where:
+
+`__tmp_openshift_cluster_id__`::
+Is a temporarily applied cluster ID source label. This temporary label gets replaced by the cluster ID label name that you specify.
+
+`targetLabel`::
+Specifies the name of the cluster ID label for metrics sent to remote write storage. If you use a label name that already exists for a metric, that value is overwritten with the name of this cluster ID label. For the label name, do not use `+++__tmp_openshift_cluster_id__+++`. The final relabeling step removes labels that use this name.
+
+`action`::
+Specifies the write relabel action. The `replace` write relabel action replaces the temporary label with the target label for outgoing metrics. This action is the default and is applied if no action is specified.
 
 . Save the file to apply the changes. The new configuration is applied automatically.
 

--- a/modules/monitoring-creating-cross-project-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-creating-cross-project-alerting-rules-for-user-defined-projects.adoc
@@ -51,10 +51,14 @@ metadata:
   namespace: openshift-user-workload-monitoring
 data:
   config.yaml: |
-    namespacesWithoutLabelEnforcement: [ <namespace1>, <namespace2> ] # <1>
+    namespacesWithoutLabelEnforcement: [ <namespace1>, <namespace2> ]
     # ...
 ----
-<1> Specify one or more projects in which you want to create cross-project alerting rules. Prometheus and Thanos Ruler for user-defined monitoring do not enforce the `namespace` label in `PrometheusRule` objects created in these projects, making the `PrometheusRule` objects applicable to all projects.
++
+where:
+
+`namespacesWithoutLabelEnforcement`::
+Specifies one or more projects in which you want to create cross-project alerting rules. Prometheus and Thanos Ruler for user-defined monitoring do not enforce the `namespace` label in `PrometheusRule` objects created in these projects, making the `PrometheusRule` objects applicable to all projects.
 
 . Create a YAML file for alerting rules. In this example, it is called `example-cross-project-alerting-rule.yaml`.
 
@@ -68,25 +72,41 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: example-security
-  namespace: ns1 #<1>
+  namespace: ns1
 spec:
   groups:
     - name: pod-security-policy
       rules:
-        - alert: "ProjectNotEnforcingRestrictedPolicy" # <2>
-          for: 5m # <3>
-          expr: kube_namespace_labels{namespace!~"(openshift|kube).*|default",label_pod_security_kubernetes_io_enforce!="restricted"} # <4>
+        - alert: "ProjectNotEnforcingRestrictedPolicy"
+          for: 5m
+          expr: kube_namespace_labels{namespace!~"(openshift|kube).*|default",label_pod_security_kubernetes_io_enforce!="restricted"}
           annotations:
-            message: "Restricted policy not enforced. Project {{ $labels.namespace }} does not enforce the restricted pod security policy." #<5>
+            message: "Restricted policy not enforced. Project {{ $labels.namespace }} does not enforce the restricted pod security policy."
           labels:
-            severity: warning # <6>
+            severity: warning
 ----
-<1> Ensure that you specify the project that you defined in the `namespacesWithoutLabelEnforcement` field.
-<2> The name of the alerting rule you want to create.
-<3> The duration for which the condition should be true before an alert is fired.
-<4> The PromQL query expression that defines the new rule. You can use label matchers on the `namespace` label to filter which projects are included or excluded from the alerting rule.
-<5> The message associated with the alert.
-<6> The severity that alerting rule assigns to the alert.
++
+--
+where:
+
+`namespace`::
+Specifies the project. Ensure that you specify the project that you defined in the `namespacesWithoutLabelEnforcement` field.
+
+`alert`::
+Specifies the name of the alerting rule you want to create.
+
+`for`::
+Specifies the duration for which the condition should be true before an alert is fired.
+
+`expr`::
+Specifies the PromQL query expression that defines the new rule. You can use label matchers on the `namespace` label to filter which projects are included or excluded from the alerting rule.
+
+`annotations.message`::
+Specifies the message associated with the alert.
+
+`labels.severity`::
+Specifies the severity that alerting rule assigns to the alert.
+--
 +
 [IMPORTANT]
 ====

--- a/modules/monitoring-creating-new-alerting-rules.adoc
+++ b/modules/monitoring-creating-new-alerting-rules.adoc
@@ -35,25 +35,41 @@ apiVersion: monitoring.openshift.io/v1
 kind: AlertingRule
 metadata:
   name: example
-  namespace: openshift-monitoring # <1>
+  namespace: openshift-monitoring
 spec:
   groups:
   - name: example-rules
     rules:
-    - alert: ExampleAlert # <2>
-      for: 1m # <3>
-      expr: vector(1) # <4>
+    - alert: ExampleAlert
+      for: 1m
+      expr: vector(1)
       labels:
-        severity: warning # <5>
+        severity: warning
       annotations:
-        message: This is an example alert. # <6>
+        message: This is an example alert.
 ----
-<1> Ensure that the namespace is `openshift-monitoring`.
-<2> The name of the alerting rule you want to create.
-<3> The duration for which the condition should be true before an alert is fired.
-<4> The PromQL query expression that defines the new rule.
-<5> The severity that alerting rule assigns to the alert.
-<6> The message associated with the alert.
++
+--
+where:
+
+`namespace`::
+Specifies the project. Ensure that the namespace is `openshift-monitoring`.
+
+`alert`::
+Specifies the name of the alerting rule you want to create.
+
+`for`::
+Specifies the duration for which the condition should be true before an alert is fired.
+
+`expr`::
+Specifies the PromQL query expression that defines the new rule.
+
+`labels.severity`::
+Specifies the severity that alerting rule assigns to the alert.
+
+`annotations.message`::
+Specifies the message associated with the alert.
+--
 +
 [IMPORTANT]
 ====

--- a/modules/monitoring-creating-scrape-sample-alerts.adoc
+++ b/modules/monitoring-creating-scrape-sample-alerts.adoc
@@ -31,40 +31,56 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: monitoring-stack-alerts #<1>
-  namespace: ns1 #<2>
+  name: monitoring-stack-alerts
+  namespace: ns1
 spec:
   groups:
   - name: general.rules
     rules:
-    - alert: TargetDown #<3>
+    - alert: TargetDown
       annotations:
         message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service
-          }} targets in {{ $labels.namespace }} namespace are down.' #<4>
+          }} targets in {{ $labels.namespace }} namespace are down.'
       expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job,
         namespace, service)) > 10
-      for: 10m #<5>
+      for: 10m
       labels:
-        severity: warning #<6>
-    - alert: ApproachingEnforcedSamplesLimit #<7>
+        severity: warning
+    - alert: ApproachingEnforcedSamplesLimit
       annotations:
-        message: '{{ $labels.container }} container of the {{ $labels.pod }} pod in the {{ $labels.namespace }} namespace consumes {{ $value | humanizePercentage }} of the samples limit budget.' #<8>
-      expr: (scrape_samples_post_metric_relabeling / (scrape_sample_limit > 0)) > 0.9 #<9>
-      for: 10m #<10>
+        message: '{{ $labels.container }} container of the {{ $labels.pod }} pod in the {{ $labels.namespace }} namespace consumes {{ $value | humanizePercentage }} of the samples limit budget.'
+      expr: (scrape_samples_post_metric_relabeling / (scrape_sample_limit > 0)) > 0.9
+      for: 10m
       labels:
-        severity: warning #<11>
+        severity: warning
 ----
-<1> Defines the name of the alerting rule.
-<2> Specifies the user-defined project where the alerting rule is deployed.
-<3> The `TargetDown` alert fires if the target cannot be scraped and is not available for the `for` duration.
-<4> The message that is displayed when the `TargetDown` alert fires.
-<5> The conditions for the `TargetDown` alert must be true for this duration before the alert is fired.
-<6> Defines the severity for the `TargetDown` alert.
-<7> The `ApproachingEnforcedSamplesLimit` alert fires when the defined scrape sample threshold is exceeded and lasts for the specified `for` duration.
-<8> The message that is displayed when the `ApproachingEnforcedSamplesLimit` alert fires.
-<9> The threshold for the `ApproachingEnforcedSamplesLimit` alert. In this example, the alert fires when the number of ingested samples exceeds 90% of the configured limit.
-<10> The conditions for the `ApproachingEnforcedSamplesLimit` alert must be true for this duration before the alert is fired.
-<11> Defines the severity for the `ApproachingEnforcedSamplesLimit` alert.
++
+where:
+
+`metadata.name`::
+Specifies the name of the alerting rule.
+
+`metadata.namespace`::
+Specifies the user-defined project where the alerting rule is deployed.
+
+`TargetDown`::
+Specifies an alert that fires if the target cannot be scraped and is not available for the `for` duration.
+
+`ApproachingEnforcedSamplesLimit`::
+Specifies an alert that fires when the defined scrape sample threshold is exceeded and lasts for the specified `for` duration.
+
+`annotations.message`::
+Specifies the message that is displayed when the alert fires.
+
+`expr`::
+Specifies the PromQL query expression that defines the new rule. For example, the `ApproachingEnforcedSamplesLimit` alert fires when the number of ingested samples exceeds 90% of the configured limit.
+
+`for`::
+Specifies that the conditions for the alert must be true for this duration before the alert is fired.
+
+`labels.severity`::
+Specifies the severity for the alert.
+
 
 . Apply the configuration to the user-defined project:
 +

--- a/modules/monitoring-disabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-disabling-monitoring-for-user-defined-projects.adoc
@@ -22,8 +22,8 @@ Alternatively, you can remove `enableUserWorkload: true` to disable monitoring f
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
-+
-.. Set `enableUserWorkload:` to `false` under `data/config.yaml`:
+
+. Set `enableUserWorkload:` to `false` under `data/config.yaml`:
 +
 [source,yaml]
 ----

--- a/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
@@ -36,7 +36,7 @@ endif::[]
 ----
 $ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
 ----
-+
+
 . Add `enabled: true` and `enableAlertmanagerConfig: true` in the `alertmanager` section under `data/config.yaml`:
 +
 [source,yaml]
@@ -49,13 +49,18 @@ metadata:
 data:
   config.yaml: |
     alertmanager:
-      enabled: true # <1>
-      enableAlertmanagerConfig: true # <2>
+      enabled: true
+      enableAlertmanagerConfig: true
 ----
-<1> Set the `enabled` value to `true` to enable a dedicated instance of the Alertmanager for user-defined projects in a cluster. Set the value to `false` or omit the key entirely to disable the Alertmanager for user-defined projects.
-If you set this value to `false` or if the key is omitted, user-defined alerts are routed to the default platform Alertmanager instance.
-<2> Set the `enableAlertmanagerConfig` value to `true` to enable users to define their own alert routing configurations with `AlertmanagerConfig` objects.
 +
+where:
+
+`alertmanager.enabled`::
+Defines whether to enable a dedicated instance of the Alertmanager for user-defined projects in a cluster. Set the value to `true` to enable or `false` to disable. If you set this value to `false` or if the key is omitted, user-defined alerts are routed to the default platform Alertmanager instance.
+
+`alertmanager.enableAlertmanagerConfig`::
+Defines whether to enable users to define their own alert routing configurations with `AlertmanagerConfig` objects. Set the value to `true` to enable or `false` to disable.
+
 . Save the file to apply the changes. The dedicated instance of Alertmanager for user-defined projects starts automatically.
 
 .Verification

--- a/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
@@ -40,7 +40,7 @@ Every time you save configuration changes to the `user-workload-monitoring-confi
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
 
-. Add `enableUserWorkload: true` under `data/config.yaml`:
+. Add `enableUserWorkload: true` under `data/config.yaml` to enable monitoring for user-defined projects in a cluster:
 +
 [source,yaml]
 ----
@@ -51,9 +51,8 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
-    enableUserWorkload: true <1>
+    enableUserWorkload: true
 ----
-<1> When set to `true`, the `enableUserWorkload` parameter enables monitoring for user-defined projects in a cluster.
 
 . Save the file to apply the changes. Monitoring for user-defined projects is then enabled automatically.
 +

--- a/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
+++ b/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
@@ -28,7 +28,7 @@ Because log rotation is not supported, only enable this feature temporarily when
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
-+
+
 . Add a `thanosQuerier` section under `data/config.yaml` and add values as shown in the following example:
 +
 [source,yaml]
@@ -41,12 +41,18 @@ metadata:
 data:
   config.yaml: |
     thanosQuerier:
-      enableRequestLogging: <value> <1>
-      logLevel: <value> <2>
+      enableRequestLogging: <enable_logging>
+      logLevel: <log_level>
 ----
-<1> Set the value to `true` to enable logging and `false` to disable logging. The default value is `false`.
-<2> Set the value to `debug`, `info`, `warn`, or `error`. If no value exists for `logLevel`, the log level defaults to `error`.
 +
+where:
+
+`<enable_logging>`::
+Specifies whether to enable logging. Set it to `true` to enable and `false` to disable. The default value is `false`.
+
+`<log_level>`::
+Specifies the log level. Supported values are `debug`, `info`, `warn`, and `error`. If no value exists for `logLevel`, it defaults to `error`.
+
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
 
 .Verification
@@ -79,4 +85,3 @@ Because the `thanos-querier` pods are highly available (HA) pods, you might be a
 ====
 
 . After you examine the logged query information, disable query logging by changing the `enableRequestLogging` value to `false` in the config map.
-

--- a/modules/monitoring-enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing.adoc
@@ -23,7 +23,7 @@ You can allow users to create user-defined alert routing configurations that use
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
-+
+
 . Add `enableUserAlertmanagerConfig: true` in the `alertmanagerMain` section under `data/config.yaml`:
 +
 [source,yaml]
@@ -37,9 +37,10 @@ data:
   config.yaml: |
     # ...
     alertmanagerMain:
-      enableUserAlertmanagerConfig: true # <1>
+      enableUserAlertmanagerConfig: true
     # ...
 ----
-<1> Set the `enableUserAlertmanagerConfig` value to `true` to allow users to create user-defined alert routing configurations that use the main platform instance of Alertmanager.
 +
+Setting the `enableUserAlertmanagerConfig` value to `true` allows users to create user-defined alert routing configurations that use the main platform instance of Alertmanager.
+
 . Save the file to apply the changes. The new configuration is applied automatically.

--- a/modules/monitoring-example-remote-write-authentication-settings.adoc
+++ b/modules/monitoring-example-remote-write-authentication-settings.adoc
@@ -43,12 +43,18 @@ metadata:
   name: sigv4-credentials
   namespace: {namespace-name}
 stringData:
-  accessKey: <AWS_access_key> <1>
-  secretKey: <AWS_secret_key> <2>
+  accessKey: <AWS_access_key>
+  secretKey: <AWS_secret_key>
 type: Opaque
 ----
-<1> The AWS API access key.
-<2> The AWS API secret key.
+
+where:
+
+`<AWS_access_key>`::
+Specifies the AWS API access key.
+
+`<AWS_secret_key>`::
+Specifies the AWS API secret key.
 
 The following shows sample AWS Signature Version 4 remote write authentication settings that use a `Secret` object named `sigv4-credentials` in the `{namespace-name}` namespace:
 
@@ -65,22 +71,36 @@ data:
       remoteWrite:
       - url: "https://authorization.example.com/api/write"
         sigv4:
-          region: <AWS_region> <1>
+          region: <AWS_region>
           accessKey:
-            name: sigv4-credentials <2>
-            key: accessKey <3>
+            name: sigv4-credentials
+            key: accessKey
           secretKey:
-            name: sigv4-credentials <2>
-            key: secretKey <4>
-          profile: <AWS_profile_name> <5>
-          roleArn: <AWS_role_arn> <6>
+            name: sigv4-credentials
+            key: secretKey
+          profile: <AWS_profile_name>
+          roleArn: <AWS_role_arn>
 ----
-<1> The AWS region.
-<2> The name of the `Secret` object containing the AWS API access credentials.
-<3> The key that contains the AWS API access key in the specified `Secret` object.
-<4> The key that contains the AWS API secret key in the specified `Secret` object.
-<5> The name of the AWS profile that is being used to authenticate.
-<6> The unique identifier for the Amazon Resource Name (ARN) assigned to your role.
+
+where:
+
+`<AWS_region>`::
+Specifies the AWS region.
+
+`accessKey.name`, `secretKey.name`::
+Define the name of the `Secret` object containing the AWS API access credentials.
+
+`accessKey.key`::
+Defines the key that contains the AWS API access key in the specified `Secret` object.
+
+`secretKey.key`::
+Defines the key that contains the AWS API secret key in the specified `Secret` object.
+
+`<AWS_profile_name>`::
+Specifies the name of the AWS profile that is being used to authenticate.
+
+`<AWS_role_arn>`::
+Specifies the unique identifier for the Amazon Resource Name (ARN) assigned to your role.
 
 [id="remote-write-sample-yaml-basic-auth_{context}"]
 == Sample YAML for Basic authentication
@@ -95,12 +115,18 @@ metadata:
   name: rw-basic-auth
   namespace: {namespace-name}
 stringData:
-  user: <basic_username> <1>
-  password: <basic_password> <2>
+  user: <basic_username>
+  password: <basic_password>
 type: Opaque
 ----
-<1> The username.
-<2> The password.
+
+where:
+
+`<basic_username>`::
+Specifies the username.
+
+`<basic_password>`::
+Specifies the password.
 
 The following sample shows a `basicAuth` remote write configuration that uses a `Secret` object named `rw-basic-auth` in the `{namespace-name}` namespace.
 It assumes that you have already set up authentication credentials for the endpoint.
@@ -119,15 +145,23 @@ data:
       - url: "https://basicauth.example.com/api/write"
         basicAuth:
           username:
-            name: rw-basic-auth <1>
-            key: user <2>
+            name: rw-basic-auth
+            key: user
           password:
-            name: rw-basic-auth <1>
-            key: password <3>
+            name: rw-basic-auth
+            key: password
 ----
-<1> The name of the `Secret` object that contains the authentication credentials.
-<2> The key that contains the username  in the specified `Secret` object.
-<3> The key that contains the password in the specified `Secret` object.
+
+where:
+
+`username.name`, `password.name`::
+Define the name of the `Secret` object that contains the authentication credentials.
+
+`username.key`::
+Defines the key that contains the username in the specified `Secret` object.
+
+`password.key`::
+Defines the key that contains the password in the specified `Secret` object.
 
 [id="remote-write-sample-yaml-bearer-token_{context}"]
 == Sample YAML for authentication with a bearer token using a `Secret` Object
@@ -142,10 +176,14 @@ metadata:
   name: rw-bearer-auth
   namespace: {namespace-name}
 stringData:
-  token: <authentication_token> <1>
+  token: <authentication_token>
 type: Opaque
 ----
-<1> The authentication token.
+
+where:
+
+`<authentication_token>`::
+Specifies the authentication token.
 
 The following shows sample bearer token config map settings that use a `Secret` object named `rw-bearer-auth` in the `{namespace-name}` namespace:
 
@@ -162,14 +200,22 @@ data:
       remoteWrite:
       - url: "https://authorization.example.com/api/write"
         authorization:
-          type: Bearer <1>
+          type: Bearer
           credentials:
-            name: rw-bearer-auth <2>
-            key: token <3>
+            name: rw-bearer-auth
+            key: token
 ----
-<1> The authentication type of the request. The default value is `Bearer`.
-<2> The name of the `Secret` object that contains the authentication credentials.
-<3> The key that contains the authentication token in the specified `Secret` object.
+
+where:
+
+`authorization.type`::
+Defines the authentication type of the request. The default value is `Bearer`.
+
+`credentials.name`::
+Defines the name of the `Secret` object that contains the authentication credentials.
+
+`credentials.key`::
+Defines the key that contains the authentication token in the specified `Secret` object.
 
 [id="remote-write-sample-yaml-oauth-20_{context}"]
 == Sample YAML for OAuth 2.0 authentication
@@ -184,12 +230,18 @@ metadata:
   name: oauth2-credentials
   namespace: {namespace-name}
 stringData:
-  id: <oauth2_id> <1>
-  secret: <oauth2_secret> <2>
+  id: <oauth2_id>
+  secret: <oauth2_secret>
 type: Opaque
 ----
-<1> The Oauth 2.0 ID.
-<2> The OAuth 2.0 secret.
+
+where:
+
+`<oauth2_id>`::
+Specifies the Oauth 2.0 ID.
+
+`<oauth2_secret>`::
+Specifies the OAuth 2.0 secret.
 
 The following shows an `oauth2` remote write authentication sample configuration that uses a `Secret` object named `oauth2-credentials` in the `{namespace-name}` namespace:
 
@@ -208,24 +260,36 @@ data:
         oauth2:
           clientId:
             secret:
-              name: oauth2-credentials <1>
-              key: id <2>
+              name: oauth2-credentials
+              key: id
           clientSecret:
-            name: oauth2-credentials <1>
-            key: secret <2>
-          tokenUrl: https://example.com/oauth2/token <3>
-          scopes: <4>
+            name: oauth2-credentials
+            key: secret
+          tokenUrl: https://example.com/oauth2/token
+          scopes:
           - <scope_1>
           - <scope_2>
-          endpointParams: <5>
+          endpointParams:
             param1: <parameter_1>
             param2: <parameter_2>
 ----
-<1> The name of the corresponding `Secret` object. Note that `ClientId` can alternatively refer to a `ConfigMap` object, although `clientSecret` must refer to a `Secret` object.
-<2> The key that contains the OAuth 2.0 credentials in the specified `Secret` object.
-<3> The URL used to fetch a token with the specified `clientId` and `clientSecret`.
-<4> The OAuth 2.0 scopes for the authorization request. These scopes limit what data the tokens can access.
-<5> The OAuth 2.0 authorization request parameters required for the authorization server.
+
+where:
+
+`oauth2.clientId.secret.name`, `oauth2.clientSecret.name`::
+Define the name of the corresponding `Secret` object. Note that `ClientId` can alternatively refer to a `ConfigMap` object, although `clientSecret` must refer to a `Secret` object.
+
+`oauth2.clientId.secret.key`, `oauth2.clientSecret.key`::
+Define the key that contains the OAuth 2.0 credentials in the specified `Secret` object.
+
+`tokenUrl`::
+Defines the URL used to fetch a token with the specified `clientId` and `clientSecret`.
+
+`scopes`::
+Defines the OAuth 2.0 scopes for the authorization request. These scopes limit what data the tokens can access.
+
+`endpointParams`::
+Defines the OAuth 2.0 authorization request parameters required for the authorization server.
 
 [id="remote-write-sample-yaml-tls_{context}"]
 == Sample YAML for TLS client authentication
@@ -240,14 +304,22 @@ metadata:
   name: mtls-bundle
   namespace: {namespace-name}
 data:
-  ca.crt: <ca_cert> <1>
-  client.crt: <client_cert> <2>
-  client.key: <client_key> <3>
+  ca.crt: <ca_cert>
+  client.crt: <client_cert>
+  client.key: <client_key>
 type: tls
 ----
-<1> The CA certificate in the Prometheus container with which to validate the server certificate.
-<2> The client certificate for authentication with the server.
-<3> The client key.
+
+where:
+
+`<ca_cert>`::
+Specifies the CA certificate in the Prometheus container with which to validate the server certificate.
+
+`<client_cert>`::
+Specifies the client certificate for authentication with the server.
+
+`<client_key>`::
+Specifies the client key.
 
 The following sample shows a `tlsConfig` remote write authentication configuration that uses a TLS `Secret` object named `mtls-bundle`.
 
@@ -266,20 +338,30 @@ data:
         tlsConfig:
           ca:
             secret:
-              name: mtls-bundle <1>
-              key: ca.crt <2>
+              name: mtls-bundle
+              key: ca.crt
           cert:
             secret:
-              name: mtls-bundle <1>
-              key: client.crt <3>
+              name: mtls-bundle
+              key: client.crt
           keySecret:
-            name: mtls-bundle <1>
-            key: client.key <4>
+            name: mtls-bundle
+            key: client.key
 ----
-<1> The name of the corresponding `Secret` object that contains the TLS authentication credentials. Note that `ca` and `cert` can alternatively refer to a `ConfigMap` object, though `keySecret` must refer to a `Secret` object.
-<2> The key in the specified `Secret` object that contains the CA certificate for the endpoint.
-<3> The key in the specified `Secret` object that contains the client certificate for the endpoint.
-<4> The key in the specified `Secret` object that contains the client key secret.
+
+where:
+
+`ca.secret.name`, `cert.secret.name`, `keySecret.name`::
+Define the name of the corresponding `Secret` object that contains the TLS authentication credentials. Note that `ca` and `cert` can alternatively refer to a `ConfigMap` object, though `keySecret` must refer to a `Secret` object.
+
+`ca.secret.key`::
+Defines the key in the specified `Secret` object that contains the CA certificate for the endpoint.
+
+`cert.secret.key`::
+Defines the key in the specified `Secret` object that contains the client certificate for the endpoint.
+
+`keySecret.key`::
+Defines the key in the specified `Secret` object that contains the client key secret.
 
 // Unset the source code block attributes just to be safe.
 :!configmap-name:

--- a/modules/monitoring-example-remote-write-queue-configuration.adoc
+++ b/modules/monitoring-example-remote-write-queue-configuration.adoc
@@ -43,28 +43,47 @@ data:
       - url: "https://remote-write-endpoint.example.com" 
         <endpoint_authentication_credentials>
         queueConfig:
-          capacity: 10000 #<1>
-          minShards: 1 #<2>
-          maxShards: 50 #<3>
-          maxSamplesPerSend: 2000 #<4>
-          batchSendDeadline: 5s #<5>
-          minBackoff: 30ms #<6>
-          maxBackoff: 5s #<7>
-          retryOnRateLimit: false #<8>
-          sampleAgeLimit: 0s #<9>
+          capacity: 10000
+          minShards: 1
+          maxShards: 50
+          maxSamplesPerSend: 2000
+          batchSendDeadline: 5s
+          minBackoff: 30ms
+          maxBackoff: 5s
+          retryOnRateLimit: false
+          sampleAgeLimit: 0s
 ----
-<1> The number of samples to buffer per shard before they are dropped from the queue.
-<2> The minimum number of shards.
-<3> The maximum number of shards.
-<4> The maximum number of samples per send.
-<5> The maximum time for a sample to wait in buffer.
-<6> The initial time to wait before retrying a failed request. The time gets doubled for every retry up to the `maxbackoff` time.
-<7> The maximum time to wait before retrying a failed request.
-<8> Set this parameter to `true` to retry a request after receiving a 429 status code from the remote write storage.
-<9> The samples that are older than the `sampleAgeLimit` limit are dropped from the queue. If the value is undefined or set to `0s`, the parameter is ignored.
+
+where:
+
+`capacity`::
+Defines the number of samples to buffer per shard before they are dropped from the queue.
+
+`minShards`::
+Defines the minimum number of shards.
+
+`maxShards`::
+Defines the maximum number of shards.
+
+`maxSamplesPerSend`::
+Defines the maximum number of samples per send.
+
+`batchSendDeadline`::
+Defines the maximum time for a sample to wait in buffer.
+
+`minBackoff`::
+Defines the initial time to wait before retrying a failed request. The time gets doubled for every retry up to the `maxbackoff` time.
+
+`maxBackoff`::
+Defines the maximum time to wait before retrying a failed request.
+
+`retryOnRateLimit`::
+When set to `true`, retries a request after receiving a 429 status code from the remote write storage.
+
+`sampleAgeLimit`::
+Specifies that samples older than the `sampleAgeLimit` limit are dropped from the queue. If the value is undefined or set to `0s`, the parameter is ignored.
 
 // Unset the source code block attributes just to be safe.
 :!configmap-name:
 :!namespace-name:
 :!component:
-

--- a/modules/monitoring-example-service-endpoint-authentication-settings.adoc
+++ b/modules/monitoring-example-service-endpoint-authentication-settings.adoc
@@ -25,9 +25,13 @@ metadata:
   name: example-bearer-auth
   namespace: ns1
 stringData:
-  token: <authentication_token> #<1>
+  token: <authentication_token>
 ----
-<1> Specify an authentication token.
+
+where:
+
+`<authentication_token>`::
+Specifies an authentication token.
 
 The following sample shows bearer token authentication settings for a `ServiceMonitor` CRD. The example uses a `Secret` object named `example-bearer-auth`:
 
@@ -44,15 +48,21 @@ spec:
   endpoints: 
   - authorization:
       credentials:
-        key: token #<1>
-        name: example-bearer-auth #<2>
+        key: token
+        name: example-bearer-auth
     port: web
-  selector: 
+  selector:
     matchLabels:
       app: prometheus-example-app
 ----
-<1> The key that contains the authentication token in the specified `Secret` object.
-<2> The name of the `Secret` object that contains the authentication credentials.
+
+where:
+
+`credentials.key`::
+Defines the key that contains the authentication token in the specified `Secret` object.
+
+`credentials.name`::
+Defines the name of the `Secret` object that contains the authentication credentials.
 
 [IMPORTANT]
 =====
@@ -73,11 +83,17 @@ metadata:
   name: example-basic-auth
   namespace: ns1
 stringData:
-  user: <basic_username> #<1>
-  password: <basic_password>  #<2>
+  user: <basic_username>
+  password: <basic_password>
 ----
-<1> Specify a username for authentication.
-<2> Specify a password for authentication.
+
+where:
+
+`<basic_username>`::
+Specifies a username for authentication.
+
+`<basic_password>`::
+Specifies a password for authentication.
 
 The following sample shows Basic authentication settings for a `ServiceMonitor` CRD. The example uses a `Secret` object named `example-basic-auth`:
 
@@ -93,19 +109,27 @@ spec:
   endpoints: 
   - basicAuth:
       username:
-        key: user #<1>
-        name: example-basic-auth #<2>
+        key: user
+        name: example-basic-auth
       password:
-        key: password #<3>
-        name: example-basic-auth #<2>
+        key: password
+        name: example-basic-auth
     port: web
-  selector: 
+  selector:
     matchLabels:
       app: prometheus-example-app
 ----
-<1> The key that contains the username in the specified `Secret` object.
-<2> The name of the `Secret` object that contains the Basic authentication.
-<3> The key that contains the password in the specified `Secret` object.
+
+where:
+
+`username.key`::
+Defines the key that contains the username in the specified `Secret` object.
+
+`username.name`, `password.name`::
+Define the name of the `Secret` object that contains the Basic authentication.
+
+`password.key`::
+Defines the key that contains the password in the specified `Secret` object.
 
 [id="sample-yaml-oauth-20_{context}"]
 == Sample YAML authentication with OAuth 2.0
@@ -121,11 +145,17 @@ metadata:
   name: example-oauth2
   namespace: ns1
 stringData:
-  id: <oauth2_id> #<1>
-  secret: <oauth2_secret> #<2>
+  id: <oauth2_id>
+  secret: <oauth2_secret>
 ----
-<1> Specify an Oauth 2.0 ID.
-<2> Specify an Oauth 2.0 secret.
+
+where:
+
+`<oauth2_id>`::
+Specifies an Oauth 2.0 ID.
+
+`<oauth2_secret>`::
+Specifies an Oauth 2.0 secret.
 
 The following sample shows OAuth 2.0 authentication settings for a `ServiceMonitor` CRD. The example uses a `Secret` object named `example-oauth2`:
 
@@ -140,20 +170,30 @@ metadata:
 spec:
   endpoints: 
   - oauth2:
-      clientId: 
+      clientId:
         secret:
-          key: id #<1>
-          name: example-oauth2 #<2>
+          key: id
+          name: example-oauth2
       clientSecret:
-        key: secret #<3>
-        name: example-oauth2 #<2>
-      tokenUrl: https://example.com/oauth2/token #<4>
+        key: secret
+        name: example-oauth2
+      tokenUrl: https://example.com/oauth2/token
     port: web
-  selector: 
+  selector:
     matchLabels:
       app: prometheus-example-app
 ----
-<1> The key that contains the OAuth 2.0 ID in the specified `Secret` object.
-<2> The name of the `Secret` object that contains the OAuth 2.0 credentials.
-<3> The key that contains the OAuth 2.0 secret in the specified `Secret` object.
-<4> The URL used to fetch a token with the specified `clientId` and `clientSecret`.
+
+where:
+
+`clientId.secret.key`::
+Defines the key that contains the OAuth 2.0 ID in the specified `Secret` object.
+
+`clientId.secret.name`, `clientSecret.name`::
+Define the name of the `Secret` object that contains the OAuth 2.0 credentials.
+
+`clientSecret.key`::
+Defines the key that contains the OAuth 2.0 secret in the specified `Secret` object.
+
+`tokenUrl`::
+Defines the URL used to fetch a token with the specified `clientId` and `clientSecret`.

--- a/modules/monitoring-granting-user-permissions-using-the-cli.adoc
+++ b/modules/monitoring-granting-user-permissions-using-the-cli.adoc
@@ -33,14 +33,34 @@ Whichever role or cluster role you choose, you must bind it against a specific p
 +
 [source,terminal]
 ----
-$ oc adm policy add-role-to-user <role> <user> -n <namespace> --role-namespace <namespace> <1>
+$ oc adm policy add-role-to-user <role> <user> -n <namespace> --role-namespace <namespace>
 ----
-<1> Substitute `<role>` with the wanted monitoring role, `<user>` with the user to whom you want to assign the role, and `<namespace>` with the project where you want to grant the access.
++
+where:
+
+`<role>`::
+Specifies the wanted monitoring role.
+
+`<user>`::
+Specifies the user to whom you want to assign the role.
+
+`<namespace>`::
+Specifies the project where you want to grant the access.
 
 * To assign a monitoring cluster role to a user for a project, enter the following command:
 +
 [source,terminal]
 ----
-$ oc adm policy add-cluster-role-to-user <cluster-role> <user> -n <namespace> <1>
+$ oc adm policy add-cluster-role-to-user <cluster-role> <user> -n <namespace>
 ----
-<1> Substitute `<cluster-role>` with the wanted monitoring cluster role, `<user>` with the user to whom you want to assign the cluster role, and `<namespace>` with the project where you want to grant the access.
++
+where:
+
+`<cluster-role>`::
+Specifies the wanted monitoring cluster role.
+
+`<user>`::
+Specifies the user to whom you want to assign the cluster role.
+
+`<namespace>`::
+Specifies the project where you want to grant the access.

--- a/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
@@ -28,6 +28,13 @@ endif::[]
 +
 [source,terminal]
 ----
-$ oc -n <namespace> adm policy add-role-to-user alert-routing-edit <user> <1>
+$ oc -n <namespace> adm policy add-role-to-user alert-routing-edit <user>
 ----
-<1> For `<namespace>`, substitute the namespace for the user-defined project, such as `ns1`. For `<user>`, substitute the username for the account to which you want to assign the role.
++
+where:
+
+`<namespace>`::
+Specifies the namespace for the user-defined project.
+
+`<user>`::
+Specifies the username for the account to which you want to assign the role.

--- a/modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc
@@ -53,6 +53,7 @@ Role:
 Subjects:
   Kind  Name  Namespace
   ----  ----  ---------
-  User  user1           <1>
+  User  user1
 ----
-<1> In this example, `user1` is assigned to the `user-workload-monitoring-config-edit` role.
++
+In this example, `user1` is assigned to the `user-workload-monitoring-config-edit` role.

--- a/modules/monitoring-modifying-core-platform-alerting-rules.adoc
+++ b/modules/monitoring-modifying-core-platform-alerting-rules.adoc
@@ -28,23 +28,37 @@ apiVersion: monitoring.openshift.io/v1
 kind: AlertRelabelConfig
 metadata:
   name: watchdog
-  namespace: openshift-monitoring # <1>
+  namespace: openshift-monitoring
 spec:
   configs:
-  - sourceLabels: [alertname,severity] # <2>
-    regex: "Watchdog;none" # <3>
-    targetLabel: severity # <4>
-    replacement: critical # <5>
-    action: Replace # <6>
+  - sourceLabels: [alertname,severity]
+    regex: "Watchdog;none"
+    targetLabel: severity
+    replacement: critical
+    action: Replace
 ----
-<1> Ensure that the namespace is `openshift-monitoring`.
-<2> The source labels for the values you want to modify.
-<3> The regular expression against which the value of `sourceLabels` is matched.
-<4> The target label of the value you want to modify.
-<5> The new value to replace the target label.
-<6> The relabel action that replaces the old value based on regex matching.
-The default action is `Replace`.
-Other possible values are `Keep`, `Drop`, `HashMod`, `LabelMap`, `LabelDrop`, and `LabelKeep`.
++
+--
+where:
+
+`namespace`::
+Must be set to `openshift-monitoring`.
+
+`sourceLabels`::
+Defines the source labels for the values you want to modify.
+
+`regex`::
+Defines the regular expression against which the value of `sourceLabels` is matched.
+
+`targetLabel`::
+Defines the target label of the value you want to modify.
+
+`replacement`::
+Defines the new value to replace the target label.
+
+`action`::
+Defines the relabel action that replaces the old value based on regex matching. The default action is `Replace`. Other possible values are `Keep`, `Drop`, `HashMod`, `LabelMap`, `LabelDrop`, and `LabelKeep`.
+--
 +
 [IMPORTANT]
 ====

--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -76,11 +76,19 @@ metadata:
 data:
   config.yaml: |
     {component}:
-      retention: <time_specification> # <1>
-      retentionSize: <size_specification> # <2>
+      retention: <time_specification>
+      retentionSize: <size_specification>
 ----
-<1> The retention time: a number directly followed by `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), or `y` (years). You can also combine time values for specific times, such as `1h30m15s`.
-<2> The retention size: a number directly followed by `B` (bytes), `KB` (kilobytes), `MB` (megabytes), `GB` (gigabytes), `TB` (terabytes), `PB` (petabytes), and `EB` (exabytes).
++
+--
+where:
+
+`<time_specification>`::
+Specifies the retention time. The number is directly followed by `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), or `y` (years). You can also combine time values for specific times, such as `1h30m15s`.
+
+`<size_specification>`::
+Specifies the retention size. The number is directly followed by `B` (bytes), `KB` (kilobytes), `MB` (megabytes), `GB` (gigabytes), `TB` (terabytes), `PB` (petabytes), and `EB` (exabytes).
+--
 +
 The following example sets the retention time to 24 hours and the retention size to 10 gigabytes for the Prometheus instance:
 +

--- a/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
+++ b/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
@@ -47,12 +47,15 @@ metadata:
 data:
   config.yaml: |
     thanosRuler:
-      retention: <time_specification> <1>
+      retention: <time_specification>
 ----
 +
-<1> Specify the retention time in the following format: a number directly followed by `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), or `y` (years).
-You can also combine time values for specific times, such as `1h30m15s`.
-The default is `24h`.
+--
+where:
+
+`<time_specification>`::
+Specifies the retention time. The number is directly followed by `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks), or `y` (years). You can also combine time values for specific times, such as `1h30m15s`. The default is `24h`.
+--
 +
 The following example sets the retention time to 10 days for Thanos Ruler data:
 +

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -61,10 +61,16 @@ endif::openshift-dedicated,openshift-rosa[]
 +
 [source,terminal]
 ----
-$ oc label nodes <node_name> <node_label> <1>
+$ oc label nodes <node_name> <node_label>
 ----
-<1> Replace `<node_name>` with the name of the node where you want to add the label. 
-Replace `<node_label>` with the name of the wanted label.
++
+where:
+
+`<node_name>`::
+Specifies the name of the node where you want to add the label.
+
+`<node_label>`::
+Specifies the name of the wanted label.
 
 . Edit the `{configmap-name}` `ConfigMap` object in the `{namespace-name}` project:
 +
@@ -85,16 +91,25 @@ metadata:
 data:
   config.yaml: |
     # ...
-    <component>: #<1>
+    <component>:
       nodeSelector:
-        <node_label_1> #<2>
-        <node_label_2> #<3>
+        <node_label_1>
+        <node_label_2>
     # ...
 ----
-<1> Substitute `<component>` with the appropriate monitoring stack component name.
-<2> Substitute `<node_label_1>` with the label you added to the node.
-<3> Optional: Specify additional labels.
-If you specify additional labels, the pods for the component are only scheduled on the nodes that contain all of the specified labels.
++
+--
+where:
+
+`<component>`::
+Specifies the monitoring stack component.
+
+`<node_label_1>`::
+Specifies the label you added to the node.
+
+`<node_label_2>`::
+Optional: Specifies additional labels. If you specify additional labels, the pods for the component are only scheduled on the nodes that contain all of the specified labels.
+--
 +
 [NOTE]
 ====

--- a/modules/monitoring-resizing-a-persistent-volume.adoc
+++ b/modules/monitoring-resizing-a-persistent-volume.adoc
@@ -68,15 +68,23 @@ metadata:
   namespace: {namespace-name}
 data:
   config.yaml: |
-    <component>: # <1>
+    <component>:
       volumeClaimTemplate:
         spec:
           resources:
             requests:
-              storage: <amount_of_storage> # <2>
+              storage: <amount_of_storage>
 ----
-<1> The component for which you want to change the storage size.
-<2> Specify the new size for the storage volume. It must be greater than the previous value.
++
+--
+where:
+
+`<component>`::
+Specifies the component for which you want to change the storage size.
+
+`<amount_of_storage>`::
+Specifies the new size for the storage volume. It must be greater than the previous value.
+--
 +
 The following example sets the new PVC request to 
 // tag::CPM[]

--- a/modules/monitoring-resolving-the-kubepersistentvolumefillingup-alert-firing-for-prometheus.adoc
+++ b/modules/monitoring-resolving-the-kubepersistentvolumefillingup-alert-firing-for-prometheus.adoc
@@ -38,12 +38,13 @@ endif::openshift-dedicated,openshift-rosa-hcp,openshift-rosa[]
 +
 [source,terminal]
 ----
-$ oc debug <prometheus_k8s_pod_name> -n openshift-monitoring \// <1>
--c prometheus --image=$(oc get po -n openshift-monitoring <prometheus_k8s_pod_name> \// <1>
+$ oc debug <prometheus_k8s_pod_name> -n openshift-monitoring \
+-c prometheus --image=$(oc get po -n openshift-monitoring <prometheus_k8s_pod_name> \
 -o jsonpath='{.spec.containers[?(@.name=="prometheus")].image}') \
 -- sh -c 'cd /prometheus/;du -hs $(ls -dtr */ | grep -Eo "[0-9|A-Z]{26}")'
 ----
-<1> Replace `<prometheus_k8s_pod_name>` with the pod mentioned in the `KubePersistentVolumeFillingUp` alert description.
++
+Replace `<prometheus_k8s_pod_name>` with the pod mentioned in the `KubePersistentVolumeFillingUp` alert description.
 +
 .Example output
 [source,terminal]
@@ -77,11 +78,12 @@ while read BLOCK; do rm -r /prometheus/$BLOCK; done'
 +
 [source,terminal]
 ----
-$ oc debug <prometheus_k8s_pod_name> -n openshift-monitoring \// <1>
---image=$(oc get po -n openshift-monitoring <prometheus_k8s_pod_name> \// <1>
+$ oc debug <prometheus_k8s_pod_name> -n openshift-monitoring \
+--image=$(oc get po -n openshift-monitoring <prometheus_k8s_pod_name> \
 -o jsonpath='{.spec.containers[?(@.name=="prometheus")].image}') -- df -h /prometheus/
 ----
-<1> Replace `<prometheus_k8s_pod_name>` with the pod mentioned in the `KubePersistentVolumeFillingUp` alert description.
++
+Replace `<prometheus_k8s_pod_name>` with the pod mentioned in the `KubePersistentVolumeFillingUp` alert description.
 +
 The following example output shows the mounted PV claimed by the `prometheus-k8s-0` pod that has 63% of space remaining:
 +

--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -80,24 +80,26 @@ metadata:
   namespace: {namespace-name}
 data:
   config.yaml: |
-    <component>: # <1>
-      logLevel: <log_level> # <2>
+    <component>:
+      logLevel: <log_level>
 # tag::CPM[]
     metricsServer:
-      verbosity: <value> # <3>
+      verbosity: <verbosity>
 # end::CPM[]
     # ...
 ----
-<1> Specify the monitoring stack component for which you are setting a log level.
-Available component values are `{prometheus}`, `{alertmanager}`, `prometheusOperator`, and `{thanos}`.
-<2> Specify the log level for the component.
-The available values are `error`, `warn`, `info`, and `debug`.
-The default value is `info`.
++
+where:
+
+`<component>`::
+Specifies the monitoring stack component for which you are setting a log level. Available component values are `{prometheus}`, `{alertmanager}`, `prometheusOperator`, and `{thanos}`.
+
+`<log_level>`::
+Specifies the log level for the component. The available values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
+
 // tag::CPM[]
-<3> Specify the verbosity for Metrics Server.
-Valid values are positive integers.
-Increasing the number increases the amount of logged events, values over `10` are usually unnecessary.
-The default value is `0`.
+`<verbosity>`::
+Specifies the verbosity for Metrics Server. Valid values are positive integers. Increasing the number increases the amount of logged events, values over `10` are usually unnecessary. The default value is `0`.
 // end::CPM[]
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.

--- a/modules/monitoring-setting-query-log-file-for-prometheus.adoc
+++ b/modules/monitoring-setting-query-log-file-for-prometheus.adoc
@@ -69,9 +69,13 @@ metadata:
 data:
   config.yaml: |
     {component}:
-      queryLogFile: <path> # <1>
+      queryLogFile: <path>
 ----
-<1> Add the full path to the file in which queries will be logged.
++
+where:
+
+`<path>`::
+Specifies the full path to the file in which queries will be logged.
 
 . Save the file to apply the changes. The pods affected by the new configuration are automatically redeployed.
 

--- a/modules/monitoring-setting-scrape-and-evaluation-intervals-limits-for-user-defined-projects.adoc
+++ b/modules/monitoring-setting-scrape-and-evaluation-intervals-limits-for-user-defined-projects.adoc
@@ -53,24 +53,35 @@ metadata:
 data:
   config.yaml: |
     prometheus:
-      enforcedSampleLimit: 50000 # <1>
-      enforcedLabelLimit: 500 # <2>
-      enforcedLabelNameLengthLimit: 50 # <3>
-      enforcedLabelValueLengthLimit: 600 # <4>
-      scrapeInterval: 1m30s # <5>
-      evaluationInterval: 1m15s # <6>
+      enforcedSampleLimit: 50000
+      enforcedLabelLimit: 500
+      enforcedLabelNameLengthLimit: 50
+      enforcedLabelValueLengthLimit: 600
+      scrapeInterval: 1m30s
+      evaluationInterval: 1m15s
 ----
-<1> A value is required if this parameter is specified. This `enforcedSampleLimit` example limits the number of samples that can be accepted per target scrape in user-defined projects to 50,000.
-<2> Specifies the maximum number of labels per scrape.
-The default value is `0`, which specifies no limit.
-<3> Specifies the maximum character length for a label name.
-The default value is `0`, which specifies no limit.
-<4> Specifies the maximum character length for a label value.
-The default value is `0`, which specifies no limit.
-<5> Specifies the interval between consecutive scrapes. The interval must be set between 5 seconds and 5 minutes.
-The default value is `30s`.
-<6> Specifies the interval between Prometheus rule evaluations. The interval must be set between 5 seconds and 5 minutes.
-The default value for Prometheus is `30s`.
++
+--
+where:
+
+`enforcedSampleLimit`::
+Defines the maximum number of samples that can be accepted per target scrape. A value is required if this parameter is specified. This example limits the number to 50,000.
+
+`enforcedLabelLimit`::
+Defines the maximum number of labels per scrape. The default value is `0`, which specifies no limit.
+
+`enforcedLabelNameLengthLimit`::
+Defines the maximum character length for a label name. The default value is `0`, which specifies no limit.
+
+`enforcedLabelValueLengthLimit`::
+Defines the maximum character length for a label value. The default value is `0`, which specifies no limit.
+
+`scrapeInterval`::
+Defines the interval between consecutive scrapes. The interval must be set between 5 seconds and 5 minutes. The default value is `30s`.
+
+`evaluationInterval`::
+Defines the interval between Prometheus rule evaluations. The interval must be set between 5 seconds and 5 minutes. The default value for Prometheus is `30s`.
+--
 +
 [NOTE]
 ====

--- a/modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.adoc
+++ b/modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.adoc
@@ -46,12 +46,16 @@ metadata:
 data:
   config.yaml: |-
     prometheusK8s:
-      enforcedBodySizeLimit: 40MB <1>
+      enforcedBodySizeLimit: 40MB
 ----
-<1> Specify the maximum body size for scraped metrics targets.
-This `enforcedBodySizeLimit` example limits the uncompressed size per target scrape to 40 megabytes.
++
+where:
+
+`enforcedBodySizeLimit`::
+Defines the maximum body size for scraped metrics targets. This example limits the uncompressed size per target scrape to 40 megabytes.
++
 Valid numeric values use the Prometheus data size format: B (bytes), KB (kilobytes), MB (megabytes), GB (gigabytes), TB (terabytes), PB (petabytes), and EB (exabytes).
-The default value is `0`, which specifies no limit.
-You can also set the value to `automatic` to calculate the limit automatically based on cluster capacity.
++ 
+The default value is `0`, which specifies no limit. You can also set the value to `automatic` to calculate the limit automatically based on cluster capacity.
 
 . Save the file to apply the changes. The new configuration is applied automatically.

--- a/modules/monitoring-specifying-how-a-service-is-monitored.adoc
+++ b/modules/monitoring-specifying-how-a-service-is-monitored.adoc
@@ -41,19 +41,29 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: prometheus-example-monitor
-  namespace: ns1 #<1>
+  namespace: ns1
 spec:
   endpoints:
   - interval: 30s
-    port: web #<2>
+    port: web
     scheme: http
-  selector: #<3>
+  selector:
     matchLabels:
       app: prometheus-example-app
 ----
-<1> Specify a user-defined namespace where your service runs.
-<2> Specify endpoint ports to be scraped by Prometheus.
-<3> Configure a selector to match your service based on its metadata labels.
++
+--
+where:
+
+`namespace`::
+Defines a user-defined namespace where your service runs.
+
+`port`::
+Defines endpoint ports to be scraped by Prometheus.
+
+`selector`::
+Defines a selector to match your service based on its metadata labels.
+--
 +
 [NOTE]
 ====

--- a/modules/monitoring-viewing-a-list-of-available-metrics.adoc
+++ b/modules/monitoring-viewing-a-list-of-available-metrics.adoc
@@ -33,6 +33,7 @@ $ oc get routes -n openshift-monitoring thanos-querier -o jsonpath='{.status.ing
 +
 [source,terminal]
 ----
-$ curl -k -H "Authorization: Bearer $(oc whoami -t)" https://<thanos_querier_route>/api/v1/metadata <1>
+$ curl -k -H "Authorization: Bearer $(oc whoami -t)" https://<thanos_querier_route>/api/v1/metadata
 ----
-<1> Replace `<thanos_querier_route>` with the {ocp} API route for Thanos Querier.
++
+Replace `<thanos_querier_route>` with the {ocp} API route for Thanos Querier.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2449
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-core-platform-monitoring/preparing-to-configure-the-monitoring-stack
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-core-platform-monitoring/configuring-performance-and-scalability
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-core-platform-monitoring/storing-and-recording-data
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-core-platform-monitoring/configuring-metrics
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-core-platform-monitoring/configuring-alerts-and-notifications
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-user-workload-monitoring/preparing-to-configure-the-monitoring-stack-uwm
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-user-workload-monitoring/storing-and-recording-data-uwm
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-user-workload-monitoring/configuring-metrics-uwm
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-user-workload-monitoring/configuring-alerts-and-notifications-uwm
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/shiftstack-prometheus/shiftstack-prometheus-configuration
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/accessing-metrics/accessing-metrics-as-an-administrator#viewing-a-list-of-available-metrics_accessing-metrics-as-an-administrator
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/managing-alerts/managing-alerts-as-an-administrator
* https://103907--ocpdocs-pr.netlify.app/openshift-monitoring/latest/troubleshooting/troubleshooting-monitoring-issues#resolving-the-kubepersistentvolumefillingup-alert-firing-for-prometheus_troubleshooting-monitoring-issues
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: `n/a`
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
