### PR TITLE
For OSDOCS#17480: Added a note and hyperlink to Network Connectivity …

### DIFF
--- a/installing/installing_two_node_cluster/about-two-node-arbiter-installation.adoc
+++ b/installing/installing_two_node_cluster/about-two-node-arbiter-installation.adoc
@@ -14,3 +14,9 @@ You can install a cluster with two control plane nodes and one local arbiter nod
 * Installing on bare metal: xref:../installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#ipi-install-config-local-arbiter-node_ipi-install-installation-workflow[Configuring a local arbiter node]
 
 * Installing with the Agent-based Installer: xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-local-arbiter-node_installing-with-agent-based-installer[Configuring a local arbiter node]
+
+[NOTE]
+====
+For a cluster with an arbiter, the same networking requirements as a regular cluster for connectivity between machines apply. For more information, see xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installation-network-connectivity-user-infra_installing-platform-agnostic[Network connectivity requirements].
+====
+

--- a/modules/installation-complete-user-infra.adoc
+++ b/modules/installation-complete-user-infra.adoc
@@ -94,11 +94,11 @@ kube-storage-version-migrator              {product-version}.0    True        Fa
 machine-api                                {product-version}.0    True        False         False      29m
 machine-approver                           {product-version}.0    True        False         False      37m
 machine-config                             {product-version}.0    True        False         False      36m
-marketplace                                {product-version}.0    True        False         False      37m
+marketplace                                {product-version}.0    True        False         False      37muser
 monitoring                                 {product-version}.0    True        False         False      29m
 network                                    {product-version}.0    True        False         False      38m
 node-tuning                                {product-version}.0    True        False         False      37m
-openshift-apiserver                        {product-version}.0    True        False         False      32m
+openshift-apiserver                        {product-version}.0    True        False         False      32muser
 openshift-controller-manager               {product-version}.0    True        False         False      30m
 openshift-samples                          {product-version}.0    True        False         False      32m
 operator-lifecycle-manager                 {product-version}.0    True        False         False      37m


### PR DESCRIPTION
Version(s):
4.20, 4.21, 4.22

Issue:
https://issues.redhat.com/browse/OSDOCS-17480

Link to docs preview:
https://103913--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/about-two-node-arbiter-installation
https://103913--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic#installation-network-connectivity-user-infra_installing-platform-agnostic

QE review:
- [x] QE has approved this change.

