### PR TITLE
OBSDOCS-2935 Add docinfo, fix attribute

### DIFF
--- a/modules/support.adoc
+++ b/modules/support.adoc
@@ -33,7 +33,7 @@ From the Customer Portal, you can:
 * Access other product documentation.
 
 ifndef::microshift[]
-To identify issues with your cluster, you can use {red-hat-lightspeed} in {cluster-manager-url}. {red-hat-lightspeed} provides details about issues and, if available, information on how to solve a problem.
+To identify issues with your cluster, you can use {ols-official} in {cluster-manager-url}. {ols-official} provides details about issues and, if available, information on how to solve a problem.
 
 // TODO: verify that these settings apply for Service Mesh and OpenShift virtualization, etc.
 If you have a suggestion for improving this documentation or have found an

--- a/release-notes/docinfo.xml
+++ b/release-notes/docinfo.xml
@@ -1,0 +1,11 @@
+<title>Release notes for Red Hat build of OpenTelemetry</title>
+<productname>{product-title}</productname>
+<productnumber>{product-version}</productnumber>
+<subtitle>New features, enhancements, bug fixes, and technology preview updates</subtitle>
+<abstract>
+    <para>These release notes highlight new features, enhancements, bug fixes, and technology preview updates for Red Hat build of OpenTelemetry.</para>
+</abstract>
+<authorgroup>
+    <orgname>Red Hat OpenShift Documentation Team</orgname>
+</authorgroup>
+<xi:include href="Common_Content/Legal_Notice.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />


### PR DESCRIPTION
Version(s):
standalone-otel-docs-3.8

Issue:
[OBSDOCS-2935](https://issues.redhat.com//browse/OBSDOCS-2935)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
