### PR TITLE
OCPNAS#293: RN - Missing SnapshotClass when creating filesystem

### DIFF
--- a/modules/virt-fusion-access-san-release-updates.adoc
+++ b/modules/virt-fusion-access-san-release-updates.adoc
@@ -24,9 +24,17 @@ Backend redesign for `FileSystemClaim` resources::
 
 {IBMFusionFirst} updates the backend to use `FileSystemClaim` resources for managing filesystem related objects. Previously, filesystem creation could fail if the process was interrupted. With this update, backend handling improves reliability while keeping the user interface flow and appearance unchanged.
 +
-After upgrading to {IBMFusionFirst} 1.1.0, resources that were created by using the 1.0 user interface are automatically migrated and associated with a `FileSystemClaim` resource.
+After you upgrade to {IBMFusionFirst} 1.1.0, resources that were created by using the 1.0 user interface are automatically migrated and associated with a `FileSystemClaim` resource.
 +
 link:https://issues.redhat.com/browse/OCPNAS-241[OCPNAS-241]
+
+Automatic creation of `VolumeSnapshotClass` resources for filesystems::
+
+{IBMFusionFirst} now creates a `VolumeSnapshotClass` resource alongside the `StorageClass` resource for each filesystem. This ensures that snapshot support is consistently available for newly created filesystems.
++
+After upgrading from {IBMFusionFirst} 1.0 to 1.1.0, a `VolumeSnapshotClass` resource is automatically created for existing filesystems that did not previously have one.
++
+link:https://issues.redhat.com/browse/OCPNAS-293[OCPNAS-293]
 
 Image registry requirements for kernel module management::
 


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/OCPNAS-293

Link to docs preview:
https://103942--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/install-configure-fusion-access-san.html#virt-fusion-access-san-new-changes_install-configure-fusion-access-san

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
