### PR TITLE
OSDOCS-16832-416: MWN-1 manual CP

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1452,6 +1452,8 @@ Topics:
   Topics:
   - Name: Understanding multiple networks
     File: understanding-multiple-networks
+  - Name: Additional networks provided
+    File: additional-networks-provided
   - Name: Configuring an additional network
     File: configuring-additional-network
   - Name: About virtual routing and forwarding

--- a/modules/cnf-about-virtual-routing-and-forwarding.adoc
+++ b/modules/cnf-about-virtual-routing-and-forwarding.adoc
@@ -6,11 +6,9 @@
 [id="cnf-about-virtual-routing-and-forwarding_{context}"]
 = About virtual routing and forwarding
 
-Virtual routing and forwarding (VRF) devices combined with IP rules provide the ability to create virtual routing and forwarding domains. VRF reduces the number of permissions needed by CNF, and provides increased visibility of the network topology of secondary networks. VRF is used to provide multi-tenancy functionality, for example, where each tenant has its own unique routing tables and requires different default gateways.
+[role="_abstract"]
+You can use virtual routing and forwarding (VRF) to provide multi-tenancy functionality. For example, where each tenant has its own unique routing tables and requires different default gateways.
 
-Processes can bind a socket to the VRF device. Packets through the binded socket use the routing table associated with the VRF device. An important feature of VRF is that it impacts only OSI model layer 3 traffic and above so L2 tools, such as LLDP, are not affected. This allows higher priority IP rules such as policy based routing to take precedence over the VRF device rules directing specific traffic.
+VRF reduces the number of permissions needed by cloud-native network function (CNF), and provides increased visibility of the network topology of secondary networks. VRF devices combined with IP address rules provide the ability to create virtual routing and forwarding domains.
 
-[id="cnf-benefits-secondary-networks-telecommunications-operators_{context}"]
-== Benefits of secondary networks for pods for telecommunications operators
-
-In telecommunications use cases, each CNF can potentially be connected to multiple different networks sharing the same address space. These secondary networks can potentially conflict with the cluster's main network CIDR. Using the CNI VRF plugin, network functions can be connected to different customers' infrastructure using the same IP address, keeping different customers isolated. IP addresses are overlapped with {product-title} IP space. The CNI VRF plugin also reduces the number of permissions needed by CNF and increases the visibility of network topologies of secondary networks.
+Processes can bind a socket to the VRF device. Packets through the binded socket use the routing table associated with the VRF device. An important feature of VRF is that it impacts only OSI model layer 3 traffic and above so L2 tools, such as LLDP, are not affected. This allows higher priority IP address rules such as policy based routing to take precedence over the VRF device rules directing specific traffic.

--- a/modules/cnf-benefits-secondary-networks-telco-ops.adoc
+++ b/modules/cnf-benefits-secondary-networks-telco-ops.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// networking/multiple_networks/about-virtual-routing-and-forwarding.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cnf-benefits-secondary-networks-telco-ops_{context}"]
+= Benefits of secondary networks for pods for telecommunications operators
+
+[role="_abstract"]
+You can connect network functions to different customers' infrastructure by using the same IP address with the Container Network Interface (CNI) virtual routing and forwarding (VRF) plugin. Using the CNI VRF plugin keeps different customers isolated.
+
+In telecommunications use cases, each CNF can potentially be connected to many different networks sharing the same address space. These secondary networks can potentially conflict with the cluster's main network CIDR.
+
+With the CNI VRF plugin, IP addresses are overlapped with the {product-title} IP address space. The CNI VRF plugin also reduces the number of permissions needed by CNF and increases the visibility of the network topologies of secondary networks.

--- a/modules/nw-additional-network-considerations.adoc
+++ b/modules/nw-additional-network-considerations.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/understanding-multiple-networks-con.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-additional-network-considerations_{context}"]
+= Usage scenarios for an additional network
+
+[role="_abstract"]
+You can use an additional network in situations where you require network isolation, including for data plane and control plane separation.
+
+Isolating network traffic is useful for the following performance and security reasons:
+
+Performance:: You can send traffic on two different planes to manage how much traffic is along each plane.
+Security:: You can send sensitive traffic onto a network plane that is managed specifically for security considerations, and you can separate private data that must not be shared between tenants or customers.
+
+All of the pods in the cluster still use the cluster-wide default network to maintain connectivity across the cluster. Every pod has an `eth0` interface that is attached to the cluster-wide pod network. You can view the interfaces for a pod by using the `oc exec -it <pod_name> \-- ip a` command. If you add additional network interfaces that use Multus CNI, they are named `net1`, `net2`, ..., `netN`.
+
+To attach additional network interfaces to a pod, you must create configurations that define how the interfaces are attached. You specify each interface by using a `NetworkAttachmentDefinition` custom resource (CR). A CNI configuration inside each of these CRs defines how that interface is created.

--- a/modules/nw-multus-understanding-con.adoc
+++ b/modules/nw-multus-understanding-con.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/understanding-multiple-networks.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nw-multus-understanding-con_{context}"]
+= About using multiple networks with the OVN-K CNI
+
+[role="_abstract"]
+You can define more than one _additional network_ for your cluster. This gives you flexibility when you configure pods that deliver network functionality, such as switching or routing.
+
+By default, OVN-Kubernetes serves as the Container Network Interface (CNI) of an {product-title} cluster. This network interface is what administrators use to create default networks. During cluster installation, you configure your _default_ pod network. The default network handles all ordinary network traffic for the cluster.
+
+{product-title} uses the Multus CNI plugin to allow chaining of CNI plugins. You can define an _additional network_ based on the available CNI plugins and attach one or more of these networks to your pods.

--- a/networking/multiple_networks/about-virtual-routing-and-forwarding.adoc
+++ b/networking/multiple_networks/about-virtual-routing-and-forwarding.adoc
@@ -7,3 +7,5 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 include::modules/cnf-about-virtual-routing-and-forwarding.adoc[leveloffset=+1]
+
+include::modules/cnf-benefits-secondary-networks-telco-ops.adoc[leveloffset=+2]

--- a/networking/multiple_networks/additional-networks-provided.adoc
+++ b/networking/multiple_networks/additional-networks-provided.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="additional-networks-provided"]
+= Additional networks in {product-title}
+include::_attributes/common-attributes.adoc[]
+:context: additional-networks-provided
+
+toc::[]
+
+[role="_abstract"]
+You can use the following Container Network Interface (CNI) plugins for creating additional networks in your {product-title} cluster.
+
+* *bridge*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-bridge-object_configuring-additional-network[Configure a bridge-based additional network]
+ to allow pods on the same host to communicate with each other and the host.
+
+* *bond-cni*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-bond-cni-object_configuring-additional-network[Configure a Bond CNI secondary network] to provide a method for aggregating multiple network interfaces into a single logical _bonded_ interface.
+
+* *host-device*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-host-device-object_configuring-additional-network[Configure a host-device additional network] to allow pods access to a physical Ethernet network device on the host system.
+
+* *ipvlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[Configure an ipvlan-based additional network] to allow pods on a host to communicate with other hosts and pods on those hosts, similar to a macvlan-based additional network. Unlike a macvlan-based additional network, each pod shares the same MAC address as the parent physical network interface.
+
+* *vlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-vlan-object_configuring-additional-network[Configure a vlan-based additional network] to allow VLAN-based network isolation and connectivity for pods.
+
+* *macvlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[Configure a macvlan-based additional network] to allow pods on a host to communicate with other hosts and pods on those hosts by using a physical network interface. Each pod that is attached to a macvlan-based additional network is provided a unique MAC address.
+
+* *TAP*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-tap-object_configuring-additional-network[Configure a tap-based additional network] to create a tap device inside the container namespace. A tap device enables user space programs to send and receive network packets.
+
+* *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configure an SR-IOV based additional network] to allow pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.
+
+* *route-override*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-route-override-cni_configuring-additional-network[Configure a `route-override` based additional network] to allow pods to override and set routes.

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -6,61 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In Kubernetes, container networking is delegated to networking plugins that
-implement the Container Network Interface (CNI).
+[role="_abstract"]
+{product-title} administrators and users can use user-defined networks (UDNs) or `NetworkAttachmentDefinition` (NADs) to define the networks that handle all of the ordinary network traffic of the cluster.
 
-{product-title} uses the Multus CNI plugin to allow chaining of CNI plugins.
-During cluster installation, you configure your _default_ pod network. The
-default network handles all ordinary network traffic for the cluster. You can
-define an _additional network_ based on the available CNI plugins and attach
-one or more of these networks to your pods. You can define more than one
-additional network for your cluster, depending on your needs. This gives you
-flexibility when you configure pods that deliver network functionality, such as
-switching or routing.
+include::modules/nw-multus-understanding-con.adoc[leveloffset=+1]
 
-[id="additional-network-considerations"]
-== Usage scenarios for an additional network
+include::modules/nw-additional-network-considerations.adoc[leveloffset=+1]
 
-You can use an additional network in situations where network isolation is
-needed, including data plane and control plane separation. Isolating network
-traffic is useful for the following performance and security reasons:
+[id="additional-resources_nw-multus-understanding"]
+[role="_additional-resources"]
+== Additional resources
 
-Performance:: You can send traffic on two different planes to manage
-how much traffic is along each plane.
-Security:: You can send sensitive traffic onto a network plane that is managed
-specifically for security considerations, and you can separate private data that
-must not be shared between tenants or customers.
-
-All of the pods in the cluster still use the cluster-wide default network
-to maintain connectivity across the cluster. Every pod has an `eth0` interface
-that is attached to the cluster-wide pod network. You can view the interfaces
-for a pod by using the `oc exec -it <pod_name> \-- ip a` command. If you
-add additional network interfaces that use Multus CNI, they are named `net1`,
-`net2`, ..., `netN`.
-
-To attach additional network interfaces to a pod, you must create configurations that define how the interfaces are attached. You specify each interface by using a `NetworkAttachmentDefinition` custom resource (CR). A CNI configuration inside each of these CRs defines how that interface is created.
-
-[id="additional-networks-provided"]
-== Additional networks in {product-title}
-
-{product-title} provides the following CNI plugins for creating additional
-networks in your cluster:
-
- * *bridge*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-bridge-object_configuring-additional-network[Configure a bridge-based additional network]
- to allow pods on the same host to communicate with each other and the host.
-
-* *bond-cni*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-bond-cni-object_configuring-additional-network[Configure a Bond CNI secondary network] to provide a method for aggregating multiple network interfaces into a single logical _bonded_ interface.
-
-* *host-device*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-host-device-object_configuring-additional-network[Configure a host-device additional network] to allow pods access to a physical Ethernet network device on the host system.
-
- * *ipvlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[Configure an ipvlan-based additional network] to allow pods on a host to communicate with other hosts and pods on those hosts, similar to a macvlan-based additional network. Unlike a macvlan-based additional network, each pod shares the same MAC address as the parent physical network interface.
-
-* *vlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-vlan-object_configuring-additional-network[Configure a vlan-based additional network] to allow VLAN-based network isolation and connectivity for pods.
-
- * *macvlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[Configure a macvlan-based additional network] to allow pods on a host to communicate with other hosts and pods on those hosts by using a physical network interface. Each pod that is attached to a macvlan-based additional network is provided a unique MAC address.
-
-  * *tap*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-tap-object_configuring-additional-network[Configure a tap-based additional network] to create a tap device inside the container namespace. A tap device enables user space programs to send and receive network packets.
-
- * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configure an SR-IOV based additional network] to allow pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.
-
- * *route-override*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-route-override-cni_configuring-additional-network[Configure a `route-override` based additional network] to allow pods to override and set routes.
+* xref:../../networking/multiple_networks/additional-networks-provided.adoc#additional-networks-provided[Additional networks in {product-title}]


### PR DESCRIPTION
Version(s):
4.16

Issue:
[OSDOCS-16832](https://issues.redhat.com/browse/OSDOCS-16832)

Link to docs preview:
https://103948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/about-virtual-routing-and-forwarding.html
https://103948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/additional-networks-provided.html
https://103948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks.html

QE review:
N/A internal docs work only

Manual CP of https://github.com/openshift/openshift-docs/pull/103471
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
