### PR TITLE
CNV#62394: RN 4.14 deprecate RHEL 8 kubevirt-virtctl RPM

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -176,6 +176,8 @@ For more information, see xref:../../virt/install/preparing-cluster-for-virt.ado
 
 Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
 
+* The RHEL 8 `kubevirt-virtctl` RPM is deprecated. Download the `virtctl` binary from the {product-title} web console instead of using the command line. The RPM will be removed in a future release.
+
 //CNV-26426 [DOCS] Release note: Deprecate TTO
 * The `tekton-tasks-operator` is deprecated and Tekton tasks and example pipelines are now deployed by the `ssp-operator`.
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/CNV-62394

Link to docs preview:
https://104006--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes.html#virt-4-14-deprecated

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
