### PR TITLE
CNV#62394: RN 4.18 deprecate RHEL 8 kubevirt-virtctl RPM

### DIFF
--- a/virt/release_notes/virt-4-18-release-notes.adoc
+++ b/virt/release_notes/virt-4-18-release-notes.adoc
@@ -139,6 +139,7 @@ The deprecated and removed features section lists the features that are no longe
 === Deprecated features
 // NOTE: When uncommenting deprecated features list, change the Removed features header level below to ===
 
+* The RHEL 8 `kubevirt-virtctl` RPM is deprecated. Download the `virtctl` binary from the {product-title} web console instead of using the command line. The RPM will be removed in a future release.
 
 //CNV-26316: Release note: Align tekton tasks with instancestypes
 * The `copy-template`, `modify-vm-template`, and `create-vm-from-template` tasks are deprecated.


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/CNV-62394

Link to docs preview:
https://104010--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-18-release-notes.html#virt-4-18-deprecated

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
