### PR TITLE
OSDOCS MCO fix TP table in 4.20 RN

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -2329,23 +2329,32 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.18 |4.19 |4.20
 
-|Improved MCO state reporting (`oc get machineconfignode`)
-|Technology Preview
-|Technology Preview
-|General Availability
-
-|Image mode for OpenShift/On-cluster RHCOS image layering for {aws-short} and {gcp-short}
-|Technology Preview
-|General Availability
-|General Availability
-
-|Image mode for OpenShift/On-cluster RHCOS image layering for {vmw-short}
+|Boot image management for {vmw-short}
 |Not available
 |Not available
 |Technology Preview
+
+|Improved MCO state reporting (oc get machineconfignode)
+|Technology Preview
+|General Availability
+|General Availability
+
+|Pinned Image Sets
+|Technology Preview
+|General Availability ^1^
+|General Availability
+
+|Image mode for OpenShift/On-cluster RHCOS image layering
+|General Availability ^2^
+|General Availability
+|General Availability
 
 |====
-
+[.small]
+--
+. This feature is GA starting in {product-title} 4.19.12. Earlier 4.19.x versions remain in Technology Preview.
+. This feature is GA starting in {product-title} 4.18.20. Earlier 4.18.x versions remain in Technology Preview.
+--
 
 [id="ocp-release-notes-machine-management-tech-preview_{context}"]
 === Machine management Technology Preview features


### PR DESCRIPTION
The Tech Preview table for MCO got out of sync. This PR updates the  table.

Preview: [Machine Config Operator Technology Preview features](https://104027--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-notes-mco-tech-preview_release-notes)

[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/release_notes/ocp-4-20-release-notes#ocp-release-notes-mco-tech-preview_release-notes)