### PR TITLE
OSDOCS#17676: Update the z-stream RNs for 4.20.8

### DIFF
--- a/modules/zstream-4-20-8-about.adoc
+++ b/modules/zstream-4-20-8-about.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-20-8-about_{context}"]
+= RHBA-2025:23103 - {product-title} {product-version}.8 fixed issues advisory
+
+[role="_abstract"]
+Issued: 16 December 2025
+
+{product-title} release {product-version}.5 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:23103[RHBA-2025:23103] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:23101[RHBA-2025:23101] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.8 --pullspecs
+----

--- a/modules/zstream-4-20-8-fixed-issues.adoc
+++ b/modules/zstream-4-20-8-fixed-issues.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-58-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issues are fixed for this release:
+
+* Before this update, resizing or cloning small {gcp-first} hyperdisk volumes failed due to an input/output operations per second (IOPS) validation error from the {gcp-first} Application Programming Interface (API). This occurred because the Container Storage Interface (CSI) driver did not automatically adjust the provisioned IOPS to meet the minimum requirements of the new volume size. With this release, the driver is updated to correctly calculate and provide the required IOPS during volume expansion operations. (link:https://issues.redhat.com/browse/OCPBUGS-62117[OCPBUGS-62117])
+
+* Before this update, when a `MachineDeployment` controller upgraded its machines and the cluster autoscaler was also scaling the `MachineDeployment` controller, it was possible for the cluster autoscaler to remove new machines by scaling down the `MachineDeployment` controller for underused nodes. With this release, scaling down machines does not occur when a `MachineDeployment` controller is in the process of upgrading its machines. (link:https://issues.redhat.com/browse/OCPBUGS-63495[OCPBUGS-63495])
+
+* Before this update, the filtering mechanism was not handling the scenario where a range was a specific version, which resulted in the system mirroring more Operator versions than the customer requested. With this release, the logic is fixed to ignore a range when only one version is required, ensuring that only the specific requested version is mirrored. (link:https://issues.redhat.com/browse/OCPBUGS-64647[OCPBUGS-64647])
+
+* Before this update, `AdminNetworkPolicy`, `AdminPolicyBasedRouteListers`, `EgressFirewall`, `EgressQoS`, and `NetworkQoS` objects retained `managedFields` status entries for nodes that were deleted, leading to a buildup of stale data in etcd for large clusters with frequent node churn. With this version, the cleanup logic is fixed for all the resource types. (link:https://issues.redhat.com/browse/OCPBUGS-65514[OCPBUGS-65514])
+
+* Before this update, the Ingress Operator failed to set the `ingress_controller_conditions` metric during a restart with degraded Ingress Controller resources. As a consequence, the Ingress Controller metrics were unavailable after the Operator pod restarted. With this release, the Ingress Operator sets the `ingress_controller_conditions` metrics, which are available after a restart. (link:https://issues.redhat.com/browse/OCPBUGS-65664[OCPBUGS-65664])
+
+* Before this update, the console relied on the full name for user identification, which created potential ambiguity when users shared similar names. With this release, the display logic to prioritize unique identifiers. As a result, the console shows the user name instead of the full name as the display name. (link:https://issues.redhat.com/browse/OCPBUGS-65793[OCPBUGS-65793])
+
+* Before this update, when opening a terminal to a running pod, the session disconnected whenever the annotations of the pod changed. With this release, the terminal session does not disconnect when the annotations are changed. (link:https://issues.redhat.com/browse/OCPBUGS-65900[OCPBUGS-65900])
+
+* Before this update, unit conversion formulas were missing, which resulted in units showing `undefined` when one of the missing formulas was selected. With this release, the missing unit conversion formulas are added, ensuring that results show the correct units rather than showing an `undefined` state. (link:https://issues.redhat.com/browse/OCPBUGS-65947[OCPBUGS-65947])

--- a/modules/zstream-4-20-x-updating.adoc
+++ b/modules/zstream-4-20-x-updating.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-x-updating_{context}"]
+= Updating
+
+
+[role="_abstract"]
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -2989,30 +2989,29 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
-// About 4-20-6 release notes
-include::modules/zstream-4-20-6-about.adoc[leveloffset=+2]
+// About 4-20-8 release notes
+include::modules/zstream-4-20-8-about.adoc[leveloffset=+2]
 
-// 4-20-6 release notes bug fixes
-include::modules/zstream-4-20-6-bug-fixes.adoc[leveloffset=+2]
+// 4-20-8 release notes fixed issues
+include::modules/zstream-4-20-8-fixed-issues.adoc[leveloffset=+3]
 
-// 4-20-6 release notes updating
-include::modules/zstream-4-20-6-updating.adoc[leveloffset=+2]
-
+// 4-20-8 release notes updating
+include::modules/zstream-4-20-x-updating.adoc[leveloffset=+3]
 
 // About 4-20-5 release notes
 include::modules/zstream-4-20-5-about.adoc[leveloffset=+2]
 
 // 4-20-5 release notes enhancements
-include::modules/zstream-4-20-5-enhancements.adoc[leveloffset=+2]
+include::modules/zstream-4-20-5-enhancements.adoc[leveloffset=+3]
 
 // 4-20-5 release notes known issues
-include::modules/zstream-4-20-5-known-issues.adoc[leveloffset=+2]
+include::modules/zstream-4-20-5-known-issues.adoc[leveloffset=+3]
 
 // 4-20-5 release notes bug fixes
-include::modules/zstream-4-20-5-bug-fixes.adoc[leveloffset=+2]
+include::modules/zstream-4-20-5-bug-fixes.adoc[leveloffset=+3]
 
 // 4-20-5 release notes updating
-include::modules/zstream-4-20-5-updating.adoc[leveloffset=+2]
+include::modules/zstream-4-20-5-updating.adoc[leveloffset=+3]
 
 //4.20.4
 [id="ocp-4-20-4_{context}"]


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-17676](https://issues.redhat.com//browse/OSDOCS-17676)

Link to docs preview:
[4.20.8](https://104039--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-8-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/273#0ffb01e9e0596ef6f1712717d8948b04c353e63c)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20)
