### PR TITLE
CNV-71950: Remove references to RHEL 8 (deprecated) from docs

### DIFF
--- a/modules/virt-rhel-9.adoc
+++ b/modules/virt-rhel-9.adoc
@@ -7,9 +7,7 @@
 = {op-system-base} 9 compatibility
 
 [role="_abstract"]
-{VirtProductName} {VirtVersion} is based on {op-system-base-full} 9. You can update to {VirtProductName} {VirtVersion} from a version that was based on {op-system-base} 8 by following the standard {VirtProductName} update procedure. No additional steps are required.
-
-As in previous versions, you can perform the update without disrupting running workloads. {VirtProductName} {VirtVersion} supports live migration from {op-system-base} 8 nodes to {op-system-base} 9 nodes.
+{VirtProductName} {VirtVersion} is based on {op-system-base-full} 9.
 
 [id="rhel-9-machine-type_{context}"]
 == {op-system-base} 9 machine type

--- a/virt/getting_started/virt-using-the-cli-tools.adoc
+++ b/virt/getting_started/virt-using-the-cli-tools.adoc
@@ -16,11 +16,7 @@ You can access and modify virtual machine (VM) disk images by using the link:htt
 
 To install `virtctl` on {op-system-base-full} 9 or later, Linux, Windows, and MacOS operating systems, you can download and install the `virtctl` binary file.
 
-To install `virtctl` on {op-system-base} 8, you can enable the {VirtProductName} repository and then install the `kubevirt-virtctl` RPM package.
-
 include::modules/virt-installing-virtctl-binary.adoc[leveloffset=+2]
-
-include::modules/virt-installing-virtctl-rhel8-rpm.adoc[leveloffset=+2]
 
 [id="virtctl-commands_virt-using-the-cli-tools"]
 == virtctl commands


### PR DESCRIPTION
Version(s):
Main, 4.21

Issue: [CNV-71950](https://issues.redhat.com/browse/CNV-71950)

Link to docs preview:

- https://104051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-using-the-cli-tools.html

- https://104051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-edit-vms.html

- https://104051--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/virt/getting_started/virt-using-the-cli-tools.html
- https://104051--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt.html

QE review:
- [x] QE has approved this change.
