### PR TITLE
CNV-71950-RN: Moved RHEL 8 RPM from deprecated to removed

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -109,6 +109,9 @@ Removed features are no longer supported in {VirtProductName}.
 Legacy virtctl ssh target syntax removed::
 With this release, support for the `virtctl ssh type/name[.namespace]` target syntax has been removed. You must specify the target by using an explicit resource type, such as `vmi/<name>` or `vm/<name>`. Scripts and automation that rely on the removed syntax must be updated.
 
+// CNV-71950
+Support for `kubevirt-virtctl` RPM removed::
+With this release, support for the RHEL 8 `kubevirt-virtctl` RPM is removed and no longer supported.
 
 [id="virt-4-21-technology-preview_{context}"]
 == Technology Preview features


### PR DESCRIPTION
Version(s):
4.21

Issue: [CNV-71950](https://issues.redhat.com/browse/CNV-71950)

Link to docs preview

QE review:
- [x] QE has approved this change.