### PR TITLE
OSDOCS-17623:Update Google Cloud firewall prereqs.

### DIFF
--- a/cloud_experts_osd_tutorials/cloud-experts-osd-create-new-limit-egress.adoc
+++ b/cloud_experts_osd_tutorials/cloud-experts-osd-create-new-limit-egress.adoc
@@ -10,11 +10,6 @@ toc::[]
 [role="_abstract"]
 Use this guide to implement egress restrictions for {product-title} on {GCP} by using {GCP}'s Next Generation Firewall (NGFW). NGFW is a fully distributed firewall service that allows fully qualified domain name (FQDN) objects in firewall policy rules. This is necessary for many of the external endpoints that {product-title} relies on.
 
-[IMPORTANT]
-====
-The ability to restrict egress traffic using a firewall or other network device is only supported with {product-title} clusters deployed using Private Service Connect (PSC). Clusters that do not use PSC require a support exception to use this functionality. For additional assistance, please open a link:https://access.redhat.com/support/cases/?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#/case/new/get-support?caseCreate=true[support case].
-====
-
 include::modules/cloud-experts-osd-limit-egress-ngfw-prereqs.adoc[leveloffset=+1]
 
 include::modules/cloud-experts-osd-limit-egress-ngfw-setup-environ.adoc[leveloffset=+1]

--- a/modules/osd-gcp-psc-firewall-prerequisites.adoc
+++ b/modules/osd-gcp-psc-firewall-prerequisites.adoc
@@ -8,11 +8,6 @@
 
 If you are using a firewall to control egress traffic from {product-title} on {GCP}, you must configure your firewall to grant access to certain domains and port combinations listed in the tables below. {product-title} requires this access to provide a fully managed OpenShift service.
 
-[IMPORTANT]
-====
-Only {product-title} on {GCP} clusters deployed with Private Service Connect can use a firewall to control egress traffic.
-====
-
 // .Prerequisites
 // Per SMEs, no prereqs. Will confirm with QE when ticket is reviewed.
 
@@ -69,10 +64,6 @@ Only {product-title} on {GCP} clusters deployed with Private Service Connect can
 |`console.redhat.com`
 |443
 |Required. Allows interactions between the cluster and {cluster-manager-first} to enable functionality, such as scheduling upgrades.
-
-|`sso.redhat.com`
-|443
-|The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`.
 
 |`catalog.redhat.com`
 |443


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17623](https://issues.redhat.com//browse/OSDOCS-17623)

Link to docs preview:

- [Tutorial: Limit egress with Google Cloud Next Generation Firewall](https://104053--ocpdocs-pr.netlify.app/openshift-dedicated/latest/cloud_experts_osd_tutorials/cloud-experts-osd-create-new-limit-egress.html)
- [Google Cloud firewall prerequisites](https://104053--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
