### PR TITLE
OSSM-11752 Remove "tech preview" call out on cert-manager doc

### DIFF
--- a/modules/ossm-about-cert-manager.adoc
+++ b/modules/ossm-about-cert-manager.adoc
@@ -6,8 +6,7 @@
 [id="ossm-cert-manager-integration-istio_{context}"]
 = About the cert-manager Operator istio-csr agent
 
-include::snippets/technology-preview-istiocsr.adoc[]
-
+[role="_abstract"]
 The {cert-manager-operator} enhances certificate management for securing workloads and control plane components in {SMProductName} and {istio}. It supports issuing, delivering, and renewing certificates used for mutual Transport Layer Security (mTLS) through cert-manager issuers.
 
 By integrating {istio} with the `istio-csr` agent that is managed by the cert-manager Operator, you enable {istio} to request and manage the certificates directly. The integration simplifies security configuration and centralizes certificate management within the cluster.


### PR DESCRIPTION
Change type: Doc update; Remove "tech preview" call out on cert-manager doc

Doc JIRA: https://issues.redhat.com/browse/OSSM-11752

Fix versions:

- [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
- [service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)
- [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Doc Preview: https://104062--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/install/ossm-cert-manager.html

SME Review/QE Review: @fjglira @FilipB 

Peer Review: @kaldesai 