### PR TITLE
Update-gitignore: Updating gitignore with .claude so folder contents are ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ commercial_package
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat
 .vale/styles/AsciiDocDITA
+.claude


### PR DESCRIPTION
In order to facilitate the use of claude code tools I wish to have this PR submitted to the OCP repo. Only noticeable change is to the .gitignore 

Version: 4.12 and greater 
