### PR TITLE
[OSDOCS#17643]Add ap-southeast-6 region to ROSA HCP docs

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -98,6 +98,11 @@ ifdef::openshift-rosa-hcp[]
 |4.16.34; 4.17.15
 |Yes
 
+|ap-southeast-6
+|Auckland
+|4.19.18
+|Yes
+
 |ap-southeast-7
 |Thailand
 |4.18


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17643

Link to docs preview:
[Regions and availability zones](https://104064--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-service-definition.html#rosa-sdpolicy-regions-az_rosa-hcp-service-definition)

Peer review:
- [ ] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- QE approval is not required for this PR as no no procedural changes involved.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
