### PR TITLE
OSDOCS-16614: Documented VIP optional with user-managed LB feature

### DIFF
--- a/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
@@ -69,6 +69,8 @@ include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 * xref:../../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installation-user-provisioned-validating-dns_installing-bare-metal-network-customizations[Validating DNS resolution for user-provisioned infrastructure]
 
+include::modules/installation-bare-metal-dns-record-type.adoc[leveloffset=+2]
+
 include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
 
 // Creating a manifest object that includes a customized `br-ex` bridge

--- a/installing/installing_bare_metal/upi/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/upi/installing-bare-metal.adoc
@@ -74,6 +74,8 @@ include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 * xref:../../../installing/installing_bare_metal/upi/installing-bare-metal.adoc#installation-user-provisioned-validating-dns_installing-bare-metal[Validating DNS resolution for user-provisioned infrastructure]
 
+include::modules/installation-bare-metal-dns-record-type.adoc[leveloffset=+2]
+
 // Load balancing requirements for user-provisioned infrastructure
 include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
@@ -84,6 +84,8 @@ include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 * xref:../../../installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc#installation-user-provisioned-validating-dns_installing-restricted-networks-bare-metal[Validating DNS resolution for user-provisioned infrastructure]
 
+include::modules/installation-bare-metal-dns-record-type.adoc[leveloffset=+2]
+
 include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
 
 // Creating a manifest object that includes a customized `br-ex` bridge

--- a/modules/installation-bare-metal-dns-record-type.adoc
+++ b/modules/installation-bare-metal-dns-record-type.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc
+// * installing/installing_bare_metal/upi/installing-bare-metal.adoc
+// * installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-bare-metal-dns-record-type_{context}"]
+= Configuring the dnsRecordsType parameter
+
+[role="_abstract"]
+During cluster installation, you can specify the `dnsRecordsType` parameter in the `install-config.yaml` file to set if the internal DNS service or an external source provides the necessary records for `api`, `api-int`, and `ingress` DNS records.
+
+:FeatureName: Configuring the dnsRecordsType parameter
+include::snippets/technology-preview.adoc[]
+
+The `dnsRecordsType` parameter supports the following values:
+
+* `Internal`: The default value. Setting this value causes the cluster infrastructure to automatically create and maintain the necessary DNS records.
+* `External`: You can use this value only if you set the `loadBalancer.type` parameter to `UserManaged`. The cluster does not manage the DNS records. You must manually configure DNS records on an external DNS server.
+
+.Prerequisites
+
+* You created DNS records, such as `api`, `api-int`, or `\*.apps`.
+* You configured a user-managed load balancer for your cluster. 
+* If you intend on setting `dnsRecordsType.External` in the `infrastructure.config.openshift.io` CR , you must initially configure cluster nodes to use the specific external server for DNS resolution.
+
+.Procedure
+
+* During cluster installation, specify `TechPreviewNoUpgrade` for the `featureSet` parameter and specify `External` for the `dnsRecordsType` parameter in the `install-config.yaml` file:
++
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com
+metadata:
+  name: dev-cluster
+# ...
+platform:
+  baremetal:
+# ...
+    loadBalancer:
+      type: UserManaged
+    dnsRecordsType: External
+# ...
+featureSet: TechPreviewNoUpgrade
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}'
+sshKey: 'ssh-ed25519 AAAA...'
+# ...
+----
++
+where:
++
+`type.UserManaged`:: Specifies an external load balancer for your cluster.
+`dnsRecordsType.External`:: Specifies that the cluster does not create internal DNS records for the core infrastructure.
+`featureSet.TechPreviewNoUpgrade`:: Specifies the enablement of non-default features for your cluster.

--- a/modules/nw-dns-forward.adoc
+++ b/modules/nw-dns-forward.adoc
@@ -20,9 +20,11 @@ endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * Provide a list of upstream DNS servers (`spec.upstreamResolvers`).
 * Change the default forwarding policy.
 
-[NOTE]
-====
 A DNS forwarding configuration for the default domain can have both the default servers specified in the `/etc/resolv.conf` file and the upstream DNS servers.
+
+[IMPORTANT]
+====
+During pod creation, Kubernetes uses the `/etc/resolv.conf` file that exists on a node. If you modify the `/etc/resolv.conf` file on a host node, the changes do not propagate to the `/etc/resolv.conf` file that exists in a container. You must recreate the container for changes to take effect.
 ====
 
 .Procedure

--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -139,6 +139,11 @@ The following example shows a default situation that stores DNS values globally:
 
 * Configure a static DNS without a network interface. Note that when updating the `/etc/resolv.conf` file on a host node, you do not need to specify an interface, IPv4 or IPv6, in the `NodeNetworkConfigurationPolicy` (NNCP) manifest.
 +
+[IMPORTANT]
+====
+During pod creation, Kubernetes uses the `/etc/resolv.conf` file that exists on a node. If you modify the `/etc/resolv.conf` file on a host node, the changes do not propagate to the `/etc/resolv.conf` file that exists in a container. You must recreate the container for changes to take effect.
+====
++
 Example of a DNS configuration for a network interface that globally stores DNS values:
 +
 [source,yaml]


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-16614](https://issues.redhat.com/browse/OSDOCS-16614)

Link to docs preview:

* https://104065--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html#installation-bare-metal-dns-record-type_installing-bare-metal
* https://104065--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html#installation-bare-metal-dns-record-type_installing-bare-metal-network-customizations
* https://104065--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html#installation-bare-metal-dns-record-type_installing-restricted-networks-bare-metal

- [x] SME has approved this change.
- [x] QE has approved this change.

https://github.com/openshift/api/pull/2460
