### PR TITLE
[prow/ci] JSON payload construction in vale review script

### DIFF
--- a/.vale/templates/bot-comment-output.tmpl
+++ b/.vale/templates/bot-comment-output.tmpl
@@ -29,7 +29,12 @@
         {{- /* Variables setup */ -}}
         {{- $loc := printf "%d" .Line -}}
         {{- $check := printf "%s" .Check -}}
-        {{- $message := printf "%s" .Message -}}
+        {{- /* Escape special characters for valid JSON */ -}}
+        {{- $message := replace "\\" "\\\\" (printf "%s" .Message) -}}
+        {{- $message = replace "\"" "\\\"" $message -}}
+        {{- $message = replace "\n" "\\n" $message -}}
+        {{- $message = replace "\r" "\\r" $message -}}
+        {{- $message = replace "\t" "\\t" $message -}}
         {{- /* Only add a link for RedHat rule errors */ -}}
         {{- $link := "" -}}
         {{- if contains "RedHat." .Check -}}


### PR DESCRIPTION
- Use jq to construct JSON payload for GitHub API review comments
- Escape special characters in Vale template output for valid JSON

FYI @ShaunaDiaz @bergerhoffer @kalexand-rh 

