### PR TITLE
CNV#57055: RN 4.20 - Deprecate syntax - new virtctl port-forward / ssh / scp syntax

### DIFF
--- a/virt/release_notes/virt-4-20-release-notes.adoc
+++ b/virt/release_notes/virt-4-20-release-notes.adoc
@@ -168,6 +168,8 @@ For a complete list of virtualization metrics, see the link:https://github.com/o
 
 Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
 
+* The `virtctl ssh type/name[.namespace]` target syntax is deprecated. Use the `virtctl ssh` `type/name[/namespace]` syntax instead. Scripts and automation that rely on the deprecated syntax might fail after upgrading. (link:https://issues.redhat.com/browse/CNV-71711[*CNV-71711*])
+
 * The `OperatorConditionsUnhealthy` alert is deprecated. You can safely link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/4.20/html/managing_alerts/managing-alerts-as-an-administrator#silencing-alerts_managing-alerts-as-an-administrator[silence] it.
 
 * All hot plugged disks are persistent by default. The use of non-persistent hot plugged disks is deprecated. They will not be supported in future releases.


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/CNV-57055

Link to docs preview:
https://104093--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-20-release-notes.html#virt-4-20-deprecated_virt-4-20-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
