### PR TITLE
CNV#57055: RN 4.21 - Deprecate syntax - new virtctl port-forward / ssh / scp syntax

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -89,11 +89,16 @@ link:https://issues.redhat.com/browse/CNV-66115[CNV-66115]
 [id="virt-4-21-deprecated_{context}"]
 == Deprecated features
 
+
 [id="virt-4-21-removed_{context}"]
 == Removed features
 
 [role="_abstract"]
 Removed features are no longer supported in {VirtProductName}.
+
+Legacy virtctl ssh target syntax removed::
+With this release, support for the `virtctl ssh type/name[.namespace]` target syntax has been removed. You must specify the target by using an explicit resource type, such as `vmi/<name>` or `vm/<name>`. Scripts and automation that rely on the removed syntax must be updated.
+
 
 [id="virt-4-21-technology-preview_{context}"]
 == Technology Preview features


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/CNV-57055

Link to docs preview:
https://104094--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html#virt-4-21-removed_virt-4-21-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
