### PR TITLE
OSDOCS-17701: Fix broken link

### DIFF
--- a/modules/kueue-release-notes-1.2.adoc
+++ b/modules/kueue-release-notes-1.2.adoc
@@ -13,7 +13,7 @@
 == New features and enhancements
 
 Monitoring of pending workloads::
-{kueue-name} version 1.2 provides the `VisibilityOnDemand` feature to monitor the pipeline of pending jobs in the cluster queue and the local queue, and help users to estimate when their jobs will start. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ai_workloads/red-hat-build-of-kueue#monitoring-pending-workloads.html[Monitoring pending workloads].
+{kueue-name} version 1.2 provides the `VisibilityOnDemand` feature to monitor the pipeline of pending jobs in the cluster queue and the local queue, and help users to estimate when their jobs will start. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ai_workloads/red-hat-build-of-kueue#monitoring-pending-workloads-install-kueue[Monitoring pending workloads].
 
 [id="release-notes-1.2-fixed-issues_{context}"]
 == Fixed issues


### PR DESCRIPTION
BUG: Fix broken link in Kueue 1.2 RNs

Version: 4.20

Issue: https://issues.redhat.com/browse/OSDOCS-17701

Preview: https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/ai_workloads/red-hat-build-of-kueue#monitoring-pending-workloads-on-demand_monitoring-pending-workloads
