### PR TITLE
OSDOCS MCO fix TP table in 4.19 RN

### DIFF
--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -1419,7 +1419,7 @@ In the following tables, features are marked with the following statuses:
 |====
 
 
-=== Storage deprecated and removed features
+=== Storage deprecated and removed featuresmco-rn-tp-fix
 
 .Storage deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
@@ -2383,20 +2383,21 @@ In the following tables, features are marked with the following statuses:
 |Improved MCO state reporting (`oc get machineconfignode`)
 |Technology Preview
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Image mode for OpenShift/On-cluster RHCOS image layering
 |Technology Preview
-|Technology Preview
+|General Availability ^1^
 |General Availability
 
 |Pinned Image Sets
 |Technology Preview
 |Technology Preview
-|General Availability ^1^
+|General Availability ^2^
 
 |====
 [.small]
+. This feature is GA starting in {product-title} 4.18.20. Earlier 4.18.x versions remain in Technology Preview.
 . This feature is GA starting in {product-title} 4.19.12. Earlier 4.19.x versions remain in Technology Preview.
 
 [id="ocp-release-notes-machine-management-tech-preview_{context}"]


### PR DESCRIPTION
The Tech Preview table for MCO got out of sync. This PR updates the table.

[Preview](https://104142--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#ocp-release-notes-mco-tech-preview_release-notes)

[Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/release_notes/ocp-4-19-release-notes#ocp-release-notes-mco-tech-preview_release-notes)