### PR TITLE
OSDOCS-17704 updated create-only mode

### DIFF
--- a/modules/zero-trust-manager-pause-reconciliation.adoc
+++ b/modules/zero-trust-manager-pause-reconciliation.adoc
@@ -4,10 +4,15 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="zero-trust-manager-pause-reconciliation_{context}"]
+= Pausing Operator reconciliation
 
-= Pausing Operator reconciliation by annotation
+[role="_abstract"]
+Pause reconciliation of the operands by enabling `create-only` mode. This setting prevents the Operator from automatically reverting your manual changes to the desired state. You can enable this mode by updating the Operator's subscription object.
 
-Reconciliation by annotation supports the `SpireServer`, `SpireAgent`, `SpiffeCSIDriver`, `SpireOIDCDiscoveryProvider`, and the `ZeroTrustWorkloadIdentityManager` custom resources. You can pause the reconciliation process by adding an annotation.
+[IMPORTANT]
+====
+When `create-only` mode is disabled, the Operator overwrites the resources if any conflicts exist.
+====
 
 .Prerequisites
 
@@ -17,11 +22,11 @@ Reconciliation by annotation supports the `SpireServer`, `SpireAgent`, `SpiffeCS
 
 .Procedure
 
-* To pause reconciling the `SpireServer` custom resource, add the `create-only` annotation to the named `cluster` by running the following command:
+* To pause reconciling the operands resources managed by the Operator, add the environment variable `CREATE_ONLY_MODE`: `true` in the subscription object by running the following command:
 +
 [source,terminal]
 ----
-$ oc annotate SpireServer cluster -n zero-trust-workload-identity-manager ztwim.openshift.io/create-only=true
+$ oc -n $OPERATOR_NAMESPACE patch subscription openshift-zero-trust-workload-identity-manager --type='merge' -p '{"spec":{"config":{"env":[{"name":"CREATE_ONLY_MODE","value":"true"}]}}}'
 ----
 
 .Verification
@@ -32,15 +37,30 @@ $ oc annotate SpireServer cluster -n zero-trust-workload-identity-manager ztwim.
 $ oc get SpireServer cluster -o yaml
 ----
 
-.Example output
+The following is an example that confirms that the 'create-only' mode is active.
 [source,yaml]
 ----
 status:
   conditions:
-  - lastTransitionTime: "2025-09-03T12:13:39Z"
-    message: Create-only mode is enabled via ztwim.openshift.io/create-only annotation
+  - lastTransitionTime: "2025-12-23T11:36:58Z"
+    message: All components are ready
+    reason: Ready
+    status: "True"
+    type: Ready
+  - lastTransitionTime: "2025-12-23T11:36:58Z"
+    message: All operand CRs are ready
+    reason: Ready
+    status: "True"
+    type: OperandsAvailable
+  - lastTransitionTime: "2025-12-23T11:36:58Z"
+    message: create-only mode enabled
     reason: CreateOnlyModeEnabled
     status: "True"
     type: CreateOnlyMode
 ----
+
+[IMPORTANT]
+====
+The Operator updates the upgradeable condition to `false` in the `operatorCondition` resource. You might not be able to upgrade the Operator when in `create-only` mode.
+====
 

--- a/modules/zero-trust-manager-restart-reconciliation.adoc
+++ b/modules/zero-trust-manager-restart-reconciliation.adoc
@@ -5,44 +5,18 @@
 :_mod-docs-content-type: PROCEDURE
 [id="zero-trust-manager-restart-reconciliation_{context}"]
 
-= Resuming Operator reconciliation by annotation
+= Resuming Operator reconciliation
+
+[role="_abstract"]
+To pause Operator reconciliation for manual configuration or debugging, enable the `create-only`` mode. This prevents the controller from overwriting your changes. You can enable this mode by setting the environment variable in the subscription object.
 
 .Procedure
 
-Follow these steps to restart the reconciliation process:
-
-. Run the `oc annotate` command, adding a hyphen (`-`) at the end of the annotation name. This removes the annotation from the cluster resource.
+* To restart reconciling the Operator-managed resources, add the environment variable `CREATE_ONLY_MODE`: `false` in the subscription object by running the following command:
 +
 [source,terminal]
 ----
-$ oc annotate SpireServer cluster -n zero-trust-workload-identity-manager ztwim.openshift.io/create-only-
+$ oc -n $OPERATOR_NAMESPACE patch subscription openshift-zero-trust-workload-identity-manager --type='merge' -p '{"spec":{"config":{"env":[{"name":"CREATE_ONLY_MODE","value":"false"}]}}}'
 ----
 
-. Restart the controller by running the following command:
-+
-[source,terminal]
-----
-$ oc rollout restart deploy/zero-trust-workload-identity-manager-controller-manager -n zero-trust-workload-identity-manager
-----
 
-.Verification
-* Check the status of the `SpireServer` resource to confirm that the `create-only` mode is disabled. The `status` must be `false` and the `reason` must be `CreateOnlyModeDisabled`.
-+
-[source,terminal]
-----
-$ oc get SpireServer cluster -o yaml
-----
-
-.Example output
-[source,yaml]
-----
-status:
-  conditions:
-  - lastTransitionTime: "2025-09-03T12:13:39Z"
-    message: Create-only mode is enabled via ztwim.openshift.io/create-only annotation
-    reason: CreateOnlyModeDisabled
-    status: "False"
-    type: CreateOnlyMode
-----
-
-Once `create-only` mode is enabled, it persists until the Operator pod restarts, even if the annotation is removed. To exit this mode, you might need to remove or unset the annotation and restart the Operator pod.

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.adoc
@@ -6,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-By enabling the `create-only` mode, you can pause the Operator reconciliation, which allows you to perform manual configurations or debug without the controller overwriting your changes. This is done by annotating the API resources which are managed by the Operator. The following scenarios are examples of when the `create-only` mode might be of use:
+[role="_abstract"]
+To pause Operator reconciliation, enable `create-only` mode by setting an environment variable in the subscription object. By setting this value, you can perform manual configurations or debug the operator without the controller overwriting your changes.
+
+The following scenarios are examples of when the `create-only` mode might be of use:
 
 **Manual Customization Required**: You need to customize operator-managed resources (ConfigMaps, Deployments, DaemonSets, etc.) with specific configurations that differ from the operator's defaults
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17704

Link to docs preview:
https://104178--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-reconciliation.html


QE review:
- [x] QE has approved this change.


Additional information:

