### PR TITLE
OSDOCS-16567: Updated Web Console for DITA migration

### DIFF
--- a/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
+++ b/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
@@ -9,7 +9,7 @@ toc::[]
 The *Developer* perspective in the web console provides you the following options from the *+Add* view to create applications and associated services and deploy them on {product-title}:
 
 ifndef::openshift-enterprise,openshift-webscale[]
-include::snippets/unified-perspective-web-console.adoc[]
+include::snippets/snip-unified-perspective-web-console.adoc[]
 endif::[]
 
 * *Getting started resources*: Use these resources to help you get started with Developer Console. You can choose to hide the header using the Options menu {kebab}.

--- a/modules/about-administrator_web-console.adoc
+++ b/modules/about-administrator_web-console.adoc
@@ -6,6 +6,7 @@
 [id="about-administrator-perspective_{context}"]
 = Administrator role in the web console
 
+[role="_abstract"]
 The cluster administrator role enables you to view the cluster inventory, capacity, general and specific utilization information, and the stream of important events, all of which help you to simplify planning and troubleshooting tasks. Both project administrators and cluster administrators can use all features in the web console.
 
 ifndef::openshift-rosa-hcp[]

--- a/modules/about-developer_web-console.adoc
+++ b/modules/about-developer_web-console.adoc
@@ -6,6 +6,7 @@
 [id="about-developer_web-console_{context}"]
 = Developer role in the web console
 
+[role="_abstract"]
 The developer role in the web console offers several built-in ways to deploy applications, services, and databases. With the developer role, you can:
 
 * View real-time visualization of rolling and recreating rollouts on the component.
@@ -32,5 +33,5 @@ You can use the *Topology* view to display applications, components, and workloa
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 .Additional resources
-See link:https://docs.openshift.com/container-platform/latest/applications/odc-viewing-application-composition-using-topology-view.html[Viewing application composition using the Topology] view for more information on using the *Topology* view in *Developer* perspective.
+* link:https://docs.openshift.com/container-platform/latest/applications/odc-viewing-application-composition-using-topology-view.html[Viewing application composition using the Topology]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/modules/adding-tab-pods-page.adoc
+++ b/modules/adding-tab-pods-page.adoc
@@ -6,6 +6,7 @@
 [id="adding-tab-to-pods-page_{context}"]
 = Adding a tab to the pods page
 
+[role="_abstract"]
 There are different customizations you can make to the {product-title} web console. The following procedure adds a tab to the *Pod details* page as an example extension to your plugin.
 
 [NOTE]
@@ -34,10 +35,10 @@ Custom plugin code is not supported by Red Hat. Only link:https://access.redhat.
 
 ----
 "consolePlugin": {
-  "name": "my-plugin", <1>
-  "version": "0.0.1", <2>
-  "displayName": "My Plugin", <3>
-  "description": "Enjoy this shiny, new console plugin!", <4>
+  "name": "my-plugin",
+  "version": "0.0.1",
+  "displayName": "My Plugin",
+  "description": "Enjoy this shiny, new console plugin!",
   "exposedModules": {
     "ExamplePage": "./components/ExamplePage"
   },
@@ -46,10 +47,15 @@ Custom plugin code is not supported by Red Hat. Only link:https://access.redhat.
   }
 }
 ----
-<1> Update the name of your plugin.
-<2> Update the version.
-<3> Update the display name for your plugin.
-<4> Update the description with a synopsis about your plugin.
++
+--
+where:
+
+`consolePlugin.name.my-plugin`:: Update the name of your plugin.
+`consolePlugin.version.0.0.1`:: Update the version.
+`consolePlugin.displayName.My Plugin`:: Update the display name for your plugin.
+`consolePlugin.description.Enjoy this shiny, new console plugin!`:: Update the description with a synopsis about your plugin.
+--
 
 . Add the following to the `console-extensions.json` file:
 +

--- a/modules/build-image-docker.adoc
+++ b/modules/build-image-docker.adoc
@@ -6,6 +6,7 @@
 [id="build-image-with-docker_{context}"]
 = Build an image with Docker
 
+[role="_abstract"]
 To deploy your plugin on a cluster, you need to build an image and push it to an image registry first.
 
 .Procedure

--- a/modules/csp-overview.adoc
+++ b/modules/csp-overview.adoc
@@ -4,33 +4,26 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="content-security-policy-overview_{context}"]
-= Content Security Policy (CSP) overview
+= Key features of Content Security Policy (CSP)
 
+[role="_abstract"]
 A Content Security Policy (CSP) is delivered to the browser in the `Content-Security-Policy-Report-Only` response header. The policy is specified as a series of directives and values. Each directive type serves a different purpose, and each directive can have a list of values representing allowed sources.
 
-[id="content-security-policy-key-features_{context}"]
-== Key features of `contentSecurityPolicy`
-
-
-=== Directive Types
-
+[id="content-security-policy-directive-types_{context}"]
+== Directive Types
 The supported directive types include `DefaultSrc`, `ScriptSrc`, `StyleSrc`, `ImgSrc`, and `FontSrc`. These directives allow you to specify valid sources for loading different types of content for your plugin. Each directive type serves a different purpose. For example, `ScriptSrc` defines valid JavaScript sources, while `ImgSrc` controls where images can be loaded from.
 
 //backporting the ConnectSrc directive, but that is tbd - openshift/console#14701 and https://github.com/openshift/api/pull/2164
-
-
-
-=== Values
-
+[id="content-security-policy-values_{context}"]
+== Values
 Each directive can have a list of values representing allowed sources. For example, `ScriptSrc` can specify multiple external scripts. These values are restricted to 1024 characters and cannot include whitespace, commas, or semicolons. Additionally, single-quoted strings and wildcard characters (`*`) are disallowed.
 
-
-=== Unified Policy
-
+[id="content-security-policy-unified-policy_{context}"]
+== Unified Policy
 The {product-title} web console aggregates the CSP directives across all enabled `ConsolePlugin` custom resources (CRs) and merges them with its own default policy. The combined policy is then applied with the `Content-Security-Policy-Report-Only` HTTP response header.
 
-
-=== Validation Rules
+[id="content-security-policy-validation-rules_{context}"]
+== Validation Rules
 * Each directive can have up to 16 unique values.
 * The total size of all values across directives must not exceed 8192 bytes (8KB).
 * Each value must be unique, and additional validation rules are in place to ensure no quotes, spaces, commas, or wildcard symbols are used.

--- a/modules/deployment-plug-in-cluster.adoc
+++ b/modules/deployment-plug-in-cluster.adoc
@@ -6,6 +6,7 @@
 [id="deploy-on-cluster_{context}"]
 = Deploy your plugin on a cluster
 
+[role="_abstract"]
 After pushing an image with your changes to a registry, you can deploy the plugin to a cluster using a Helm chart.
 
 .Prerequisites

--- a/modules/disabling-plug-in-browser.adoc
+++ b/modules/disabling-plug-in-browser.adoc
@@ -6,14 +6,14 @@
 [id="disabling-your-plugin-browser_{context}"]
 = Disabling your plugin in the browser
 
+[role="_abstract"]
 Console users can use the `disable-plugins` query parameter to disable specific or all dynamic plugins that would normally get loaded at run-time.
 
 .Procedure
 
 * To disable a specific plugin(s), remove the plugin you want to disable from the comma-separated list of plugin names.
-
 * To disable all plugins, leave an empty string in the `disable-plugins` query parameter.
-
++
 [NOTE]
 ====
 Cluster administrators can disable plugins in the *Cluster Settings* page of the web console.

--- a/modules/dynamic-plug-in-development.adoc
+++ b/modules/dynamic-plug-in-development.adoc
@@ -6,6 +6,7 @@
 [id="dynamic-plugin-development_{context}"]
 = Dynamic plugin development
 
+[role="_abstract"]
 You can run the plugin using a local development environment. The {product-title} web console runs in a container connected to the cluster you have logged into.
 
 .Prerequisites

--- a/modules/dynamic-plugin-api.adoc
+++ b/modules/dynamic-plugin-api.adoc
@@ -12,9 +12,10 @@
 
 == `useActivePerspective`
 
+[role="_abstract"]
 Hook that provides the currently active perspective and a callback for setting the active perspective. It returns a tuple containing the current active perspective and setter callback.
 
-.Example
+**Example**
 [source,tsx]
 ----
 const Component: React.FC = (props) => {
@@ -35,7 +36,7 @@ const Component: React.FC = (props) => {
 
 Component for displaying a green check mark circle icon.
 
-.Example
+**Example**
 [source,tsx]
 ----
 <GreenCheckCircleIcon title="Healthy" />
@@ -54,7 +55,7 @@ Component for displaying a green check mark circle icon.
 
 Component for displaying a red exclamation mark circle icon.
 
-.Example
+**Example**
 [source,tsx]
 ----
 <RedExclamationCircleIcon title="Failed" />
@@ -73,7 +74,7 @@ Component for displaying a red exclamation mark circle icon.
 
 Component for displaying a yellow triangle exclamation icon.
 
-.Example
+**Example**
 [source,tsx]
 ----
 <YellowExclamationTriangleIcon title="Warning" />
@@ -92,7 +93,7 @@ Component for displaying a yellow triangle exclamation icon.
 
 Component for displaying a blue info circle icon.
 
-.Example
+**Example**
 [source,tsx]
 ----
 <BlueInfoCircleIcon title="Info" />
@@ -111,7 +112,7 @@ Component for displaying a blue info circle icon.
 
 Component for displaying an error status popover.
 
-.Example
+**Example**
 [source,tsx]
 ----
 <ErrorStatus title={errorMsg} />
@@ -132,7 +133,7 @@ Component for displaying an error status popover.
 
 Component for displaying an information status popover.
 
-.Example
+**Example**
 [source,tsx]
 ----
 <InfoStatus title={infoMsg} />
@@ -153,7 +154,7 @@ Component for displaying an information status popover.
 
 Component for displaying a progressing status popover.
 
-.Example
+**Example**
 [source,tsx]
 ----
 <ProgressStatus title={progressMsg} />
@@ -174,7 +175,7 @@ Component for displaying a progressing status popover.
 
 Component for displaying a success status popover.
 
-.Example
+**Example**
 [source,tsx]
 ----
 <SuccessStatus title={successMsg} />
@@ -223,7 +224,7 @@ Initially, the hook returns an empty array. After the resolution is complete, th
 
 The hook's result elements are guaranteed to be referentially stable across re-renders. It returns a tuple containing a list of adapted extension instances with resolved code references, a boolean flag indicating whether the resolution is complete, and a list of errors detected during the resolution.
 
-.Example
+**Example**
 [source,ts]
 ----
 const [navItemExtensions, navItemsResolved] = useResolvedExtensions<NavItem>(isNavItem);
@@ -243,7 +244,7 @@ not the extension meets desired type constraints
 
 A component that creates a Navigation bar for a page. Routing is handled as part of the component. `console.tab/horizontalNav` can be used to add additional content to any horizontal navigation.
 
-.Example
+**Example**
 
 [source,jsx]
 ----
@@ -273,7 +274,7 @@ K8sResourceCommon type
 
 Component for displaying table data within a table row.
 
-.Example
+**Example**
 [source,jsx]
 
 ----
@@ -304,7 +305,7 @@ const PodRow: React.FC<RowProps<K8sResourceCommon>> = ({ obj, activeColumnIDs })
 
 A hook that provides a list of user-selected active TableColumns.
 
-.Example
+**Example**
 [source,text]
 ----
 // See implementation for more details on TableColumn type
@@ -340,7 +341,7 @@ A tuple containing the current user selected active columns (a subset of options
 
 Component for generating a page header.
 
-.Example
+**Example**
 [source,jsx]
 ----
 const exampleList: React.FC = () => {
@@ -365,7 +366,7 @@ const exampleList: React.FC = () => {
 
 Component for adding a create button for a specific resource kind that automatically generates a link to the create YAML for this resource.
 
-.Example
+**Example**
 [source,jsx]
 ----
 const exampleList: React.FC<MyProps> = () => {
@@ -390,7 +391,7 @@ const exampleList: React.FC<MyProps> = () => {
 
 Component for creating a stylized link.
 
-.Example
+**Example**
 [source,jsx]
 ----
 const exampleList: React.FC<MyProps> = () => {
@@ -420,7 +421,7 @@ determine access
 
 Component for creating button.
 
-.Example
+**Example**
 [source,jsx]
 ----
 const exampleList: React.FC<MyProps> = () => {
@@ -448,7 +449,7 @@ determine access
 
 Component for creating a dropdown wrapped with permissions check.
 
-.Example
+**Example**
 [source,jsx]
 ----
 const exampleList: React.FC<MyProps> = () => {
@@ -484,7 +485,7 @@ determine access
 
 Component that creates a link to a specific resource type with an icon badge.
 
-.Example
+**Example**
 [source,tsx]
 ----
   <ResourceLink
@@ -532,7 +533,7 @@ link to
 
 Component that creates an icon badge for a specific resource type.
 
-.Example
+**Example**
 [source,tsx]
 ----
 <ResourceIcon kind="Pod"/>
@@ -551,7 +552,7 @@ Component that creates an icon badge for a specific resource type.
 
 Hook that retrieves the k8s model for provided K8sGroupVersionKind from redux. It returns an array with the first item as k8s model and second item as `inFlight` status.
 
-.Example
+**Example**
 [source,ts]
 ----
 const Component: React.FC = () => {
@@ -573,7 +574,7 @@ group, version, kind which is deprecated, i.e, group/version/kind (GVK) K8sResou
 
 Hook that retrieves all current k8s models from redux. It returns an array with the first item as the list of k8s model and second item as `inFlight` status.
 
-.Example
+**Example**
 [source,ts]
 ----
 const Component: React.FC = () => {
@@ -587,7 +588,7 @@ const Component: React.FC = () => {
 
 Hook that retrieves the k8s resource along with status for loaded and error. It returns an array with first item as resource(s), second item as loaded status and third item as error state if any.
 
-.Example
+**Example**
 [source,ts]
 ----
 const Component: React.FC = () => {
@@ -610,7 +611,7 @@ const Component: React.FC = () => {
 
 Hook that retrieves the k8s resources along with their respective status for loaded and error. It returns a map where keys are as provided in initResouces and value has three properties data, loaded and error.
 
-.Example
+**Example**
 [source,tsx]
 ----
 const Component: React.FC = () => {
@@ -797,7 +798,7 @@ URL.
 
 It deletes resources from the cluster, based on the provided model, resource. The garbage collection works based on `Foreground`|`Background` can be configured with propagationPolicy property in provided model or passed in json. It returns a promise that resolves to the response of kind Status. In case of failure promise gets rejected with HTTP error response.
 
-.Example
+**Example**
 `kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy`
 
 
@@ -885,7 +886,7 @@ Provides a group, version, and kind for a k8s model. This returns the group, ver
 
 Component that shows the status in a popup window. Helpful component for building `console.dashboards/overview/health/resource` extensions.
 
-.Example
+**Example**
 [source,tsx]
 ----
   <StatusPopupSection
@@ -914,7 +915,7 @@ Component that shows the status in a popup window. Helpful component for buildin
 
 Status element used in status popup; used in `StatusPopupSection`.
 
-.Example
+**Example**
 [source,text]
 ----
 <StatusPopupSection
@@ -1431,7 +1432,7 @@ const PodAnnotationsButton = ({ pod }) => {
 |`resource` |The resource to edit annotations for an object of K8sResourceCommon type.
 |===
 
-.Returns
+**Returns**
 A function which launches a modal for editing a resource's annotations.
 
 
@@ -1459,7 +1460,7 @@ const DeletePodButton = ({ pod }) => {
 |`deleteAllResources` |(optional) A function to delete all resources of the same kind.
 |===
 
-.Returns
+**Returns**
 A function which launches a modal for deleting a resource.
 
 
@@ -1483,7 +1484,7 @@ const PodLabelsButton = ({ pod }) => {
 |`resource` |The resource to edit labels for, an object of K8sResourceCommon type.
 |===
 
-.Returns
+**Returns**
 A function which launches a modal for editing a resource's labels.
 
 
@@ -1507,7 +1508,7 @@ const Component: React.FC = (props) => {
 }
 ----
 
-.Returns
+**Returns**
 A tuple containing the current active namespace and setter callback.
 
 
@@ -1530,7 +1531,7 @@ const Component: React.FC = (props) ++=>++ {
 };
 ----
 
-.Returns
+**Returns**
 A tuple containing the user setting vauel, a setter callback, and a loaded boolean.
 
 
@@ -1550,7 +1551,7 @@ const OpenQuickStartButton ++= ({ quickStartId }) => {++
 };
 ----
 
-.Reterns
+**Returns**
 Quick start context values object.
 
 

--- a/modules/dynamic-plugin-localization.adoc
+++ b/modules/dynamic-plugin-localization.adoc
@@ -6,6 +6,7 @@
 [id="dynamic-plugin-api_{context}"]
 = Translating messages with react-i18next
 
+[role="_abstract"]
 The link:https://github.com/openshift/console-plugin-template[plugin template] demonstrates how you can translate messages with link:https://www.i18next.com/[react-i18next].
 
 .Prerequisites
@@ -32,9 +33,8 @@ You must match the `i18n` namespace with the name of the `ConsolePlugin` resourc
 
 . Set the `spec.i18n.loadType` field based on needed behavior.
 +
-.`plugin__console-demo-plugin`
-[example]
-====
+`plugin__console-demo-plugin` **Example**
++
 [source,yaml,subs="+quotes,+macros"]
 ----
 spec:
@@ -47,10 +47,12 @@ spec:
     type: Service
   displayName: OpenShift Console Demo Plugin
   i18n:
-    loadType: Preload <1>
+    loadType: Preload
 ----
-<1> Loads all the plugin's localization resources from the `i18n` namespace after the dynamic plugin during loading.
-====
++
+--
+`loadType: Preload`:: Loads all the plugin's localization resources from the `i18n` namespace after the dynamic plugin during loading.
+--
 
 . Use the format `++%plugin__console-plugin-template~My Label%++` for labels in `console-extensions.json`. The console replaces the value with the message for the current language from the `plugin__console-plugin-template` namespace. For example:
 +

--- a/modules/dynamic-plugin-proxy-service.adoc
+++ b/modules/dynamic-plugin-proxy-service.adoc
@@ -6,6 +6,7 @@
 [id="dynamic-plugin-proxy-service_{context}"]
 = Plugin service proxy
 
+[role="_abstract"]
 If you need to make HTTP requests to an in-cluster service from your plugin, you can declare a service proxy in its `ConsolePlugin` resource by using the `spec.proxy` array field. The console backend exposes the `/api/proxy/plugin/<plugin-name>/<proxy-alias>/<request-path>++?++<optional-query-parameters>` endpoint to proxy the communication between the plugin and the service. A proxied request uses a _service CA bundle_ by default. The service must use HTTPS.
 
 [NOTE]
@@ -24,22 +25,26 @@ metadata:
   name:<plugin-name>
 spec:
   proxy:
-  - alias: helm-charts <1>
-    authorization: UserToken <2>
-    caCertificate: +'-----BEGIN CERTIFICATE-----\nMIID....'en+ <3>
-    endpoint: <4>
+  - alias: helm-charts
+    authorization: UserToken
+    caCertificate: +'-----BEGIN CERTIFICATE-----\nMIID....'en+
+    endpoint:
       service:
         name: <service-name>
         namespace: <service-namespace>
         port: <service-port>
       type: Service
 ----
-<1> Alias of the proxy.
-<2> If the service proxy request must contain the logged-in user's {product-title} access token, you must set the authorization field to `UserToken`.
+-- 
+where:
+
+`spec.proxy.alias.helm-charts`:: Alias of the proxy.
+`spec.proxy.authorization.UserToken`:: If the service proxy request must contain the logged-in user's {product-title} access token, you must set the authorization field to `UserToken`.
 +
 [NOTE]
 ====
 If the service proxy request does not contain the logged-in user's {product-title} access token, set the authorization field to `None`.
 ====
-<3> If the service uses a custom service CA, the `caCertificate` field must contain the certificate bundle.
-<4> Endpoint of the proxy.
+`spec.proxy.caCertificate.+'-----BEGIN CERTIFICATE-----\nMIID....'en+`:: If the service uses a custom service CA, the `caCertificate` field must contain the certificate bundle.
+`spec.proxy.endpoint`:: Endpoint of the proxy.
+--

--- a/modules/dynamic-plugin-sdk-extensions.adoc
+++ b/modules/dynamic-plugin-sdk-extensions.adoc
@@ -9,6 +9,7 @@
 
 == `console.action/filter`
 
+[role="_abstract"]
 `ActionFilter` can be used to filter an action.
 
 [cols=",,,",options="header",]

--- a/modules/enabling-developer-perspective_web-console.adoc
+++ b/modules/enabling-developer-perspective_web-console.adoc
@@ -6,6 +6,7 @@
 [id="enabling-developer-perspective_web-console_{context}"]
 = Enabling the *Developer* perspective in the web console
 
+[role="_abstract"]
 ifndef::openshift-rosa-hcp[]
 Starting with {product-title} 4.19, the perspectives in the web console have unified. There is no longer a *Developer* perspective by default; however, cluster administrators can enable the *Developer* perspective for developers to use.
 endif::openshift-rosa-hcp[]

--- a/modules/monitoring-about-monitoring-dashboards.adoc
+++ b/modules/monitoring-about-monitoring-dashboards.adoc
@@ -8,7 +8,7 @@
 
 {product-title} provides a set of monitoring dashboards that help you understand the state of cluster components and user-defined workloads.
 
-include::snippets/unified-perspective-web-console.adoc[]
+include::snippets/snip-unified-perspective-web-console.adoc[]
 
 As an administrator, you can access dashboards for the core {product-title} components, including the following items:
 

--- a/modules/monitoring-reviewing-monitoring-dashboards-admin.adoc
+++ b/modules/monitoring-reviewing-monitoring-dashboards-admin.adoc
@@ -8,7 +8,7 @@
 
 As an administrator, you can view dashboards relating to core {product-title} cluster components.
 
-include::snippets/unified-perspective-web-console.adoc[]
+include::snippets/snip-unified-perspective-web-console.adoc[]
 
 .Prerequisites
 

--- a/modules/monitoring-reviewing-monitoring-dashboards-developer.adoc
+++ b/modules/monitoring-reviewing-monitoring-dashboards-developer.adoc
@@ -8,7 +8,7 @@
 
 As a developer, you can view dashboards relating to projects you have permissions for.
 
-include::snippets/unified-perspective-web-console.adoc[]
+include::snippets/snip-unified-perspective-web-console.adoc[]
 
 .Prerequisites
 

--- a/modules/odc-access-web-terminal.adoc
+++ b/modules/odc-access-web-terminal.adoc
@@ -6,6 +6,7 @@
 [id="odc-access-web-terminal_{context}"]
 = Accessing the web terminal
 
+[role="_abstract"]
 After the {web-terminal-op} is installed, you can access the web terminal. After the web terminal is initialized, you can use the preinstalled CLI tools like `oc`, `kubectl`, `odo`, `kn`, `tkn`, `helm`, and `subctl` in the web terminal.
 You can re-run commands by selecting them from the list of commands you have run in the terminal. These commands persist across multiple terminal sessions.
 The web terminal remains open until you close it or until you close the browser window or tab.

--- a/modules/odc-setting-user-preferences.adoc
+++ b/modules/odc-setting-user-preferences.adoc
@@ -5,6 +5,7 @@
 [id="odc-setting-user-preferences_{context}"]
 = Setting user preferences
 
+[role="_abstract"]
 You can set the default user preferences for your cluster.
 
 .Procedure

--- a/modules/openshift-lightspeed-web-console.adoc
+++ b/modules/openshift-lightspeed-web-console.adoc
@@ -6,6 +6,7 @@
 [id="openshift-lightspeed-web-console_{context}"]
 = {ols-official} in the web console
 
+[role="_abstract"]
 {ols-official} is a generative artificial intelligence-powered virtual assistant for {product-title}. {ols} functionality uses a natural-language interface in the {product-title} web console.
 
 This early access program exists so that customers can provide feedback on the user experience, features and capabilities, issues encountered, and any other aspects of the product so that {ols} can become more aligned with your needs when it is released and made generally available.

--- a/modules/optional-capabilities-operators.adoc
+++ b/modules/optional-capabilities-operators.adoc
@@ -6,4 +6,5 @@
 [id="optional-capabilities-operators_{context}"]
 =  Enhancing the {product-title} web console with Operators
 
+[role="_abstract"]
 Cluster administrators can install Operators on clusters in the {product-title} web console by using the software catalog to provide customization outside of layered products for developers. For example, the Web Terminal Operator allows you to start a web terminal in your browser with common CLI tools for interacting with the cluster.

--- a/modules/pipelines-web-console.adoc
+++ b/modules/pipelines-web-console.adoc
@@ -6,4 +6,5 @@
 [id="pipelines-web-console_{context}"]
 = {pipelines-title} in the web console
 
+[role="_abstract"]
 {pipelines-title} is a cloud-native, continuous integration and continuous delivery (CI/CD) solution based on Kubernetes resources. Install the {pipelines-title} Operator using the software catalog in the {product-title} web console. Once the Operator is installed, you can create and modify pipeline objects on *Pipelines* page.

--- a/modules/quick-start-components.adoc
+++ b/modules/quick-start-components.adoc
@@ -6,6 +6,7 @@
 [id="quick-start-components_{context}"]
 = Quick start components
 
+[role="_abstract"]
 A quick start consists of the following sections:
 
 * *Card*: The catalog tile that provides the basic information of the quick start, including title, description, time commitment, and completion status

--- a/modules/quick-start-user-workflow.adoc
+++ b/modules/quick-start-user-workflow.adoc
@@ -6,6 +6,7 @@
 [id="quick-start-user-workflow_{context}"]
 = Quick start user workflow
 
+[role="_abstract"]
 When you interact with an existing quick start tutorial, this is the expected workflow experience:
 
 . In the *Administrator* or *Developer* perspective, click the *Help icon* and select *Quick Starts*.

--- a/modules/recognize-resource-limits-quotas.adoc
+++ b/modules/recognize-resource-limits-quotas.adoc
@@ -5,6 +5,7 @@
 [id="recognize-resource-limits-quotas"]
 = Recognizing resource and project limits and quotas
 
+[role="_abstract"]
 You can view a graphical representation of available resources in the *Topology* view of the web console *Developer* perspective.
 
 If a resource has a message about resource limitations or quotas being reached, a yellow border appears around the resource name. Click the resource to open a side panel to see the message. If the *Topology* view has been zoomed out, a yellow dot indicates that a message is available.

--- a/modules/red-hat-marketplace-features.adoc
+++ b/modules/red-hat-marketplace-features.adoc
@@ -32,7 +32,7 @@ For example, after a database Operator is installed, a developer can create an i
 
 Cluster administrators can access Operator installation and application usage information. They can also launch application instances by browsing custom resource definitions (CRDs) in the *Installed Operators* list.
 
-include::snippets/unified-perspective-web-console.adoc[]
+include::snippets/snip-unified-perspective-web-console.adoc[]
 
 
 

--- a/modules/removing-devworkspace-operator.adoc
+++ b/modules/removing-devworkspace-operator.adoc
@@ -6,6 +6,7 @@
 [id="removing-devworkspace-operator_{context}"]
 = Removing the {devworkspace-op}
 
+[role="_abstract"]
 To completely uninstall the web terminal, you must also remove the {devworkspace-op} and custom resources used by the Operator.
 
 [IMPORTANT]

--- a/modules/removing-web-terminal-operator.adoc
+++ b/modules/removing-web-terminal-operator.adoc
@@ -6,6 +6,7 @@
 [id="removing-web-terminal-operator_{context}"]
 = Removing the {web-terminal-op}
 
+[role="_abstract"]
 You can uninstall the web terminal by removing the {web-terminal-op} and custom resources used by the Operator.
 
 .Prerequisites

--- a/modules/rhdh-install-web-console.adoc
+++ b/modules/rhdh-install-web-console.adoc
@@ -6,6 +6,7 @@
 [id="rhdh-install-web-console_{context}"]
 =  Installing the {rh-dev-hub} using the {product-title} web console
 
+[role="_abstract"]
 The web console provides a quick start with instructions on how to install the {rh-dev-hub} Operator.
 
 .Prerequisites

--- a/modules/rhdh-web-console.adoc
+++ b/modules/rhdh-web-console.adoc
@@ -6,4 +6,5 @@
 [id="rhdh-web-console_{context}"]
 = {rh-dev-hub} in the {product-title} web console
 
+[role="_abstract"]
 The {rh-dev-hub} is a platform you can use to experience a streamlined development environment. {rh-dev-hub} is driven by a centralized software catalog, providing efficiency to your microservices and infrastructure. It enables your product team to deliver quality code without any compromises. A quick start is available for you to learn more about how to install the developer hub.

--- a/modules/serverless-web-console.adoc
+++ b/modules/serverless-web-console.adoc
@@ -6,4 +6,5 @@
 [id="using-serverless-with-openshift_{context}"]
 = Red Hat {serverlessproductname} in the web console
 
+[role="_abstract"]
 Red Hat {serverlessproductname} enables developers to create and deploy serverless, event-driven applications on {product-title}. You can use the {product-title} web console software catalog to install the {serverlessproductname} Operator.

--- a/modules/troubleshooting-dynamic-plugin.adoc
+++ b/modules/troubleshooting-dynamic-plugin.adoc
@@ -6,6 +6,7 @@
 [id="troubleshooting-dynamic-plugin_{context}"]
 = Troubleshooting your dynamic plugin
 
+[role="_abstract"]
 Refer to this list of troubleshooting tips if you run into issues loading your plugin.
 
 * Verify that you have enabled your plugin in the console Operator configuration and your plugin name is the output by running the following command:

--- a/modules/understanding-quick-starts.adoc
+++ b/modules/understanding-quick-starts.adoc
@@ -6,6 +6,7 @@
 [id="understanding-quick-starts_{context}"]
 = Understanding quick starts
 
+[role="_abstract"]
 A quick start is a guided tutorial with user tasks. In the web console, you can access quick starts under the *Help* menu. They are especially useful for getting oriented with an application, Operator, or other product offering.
 
 A quick start primarily consists of tasks and steps. Each task has multiple steps, and each quick start has multiple tasks. For example:

--- a/modules/viewing-a-project-using-the-web-console.adoc
+++ b/modules/viewing-a-project-using-the-web-console.adoc
@@ -8,7 +8,7 @@
 
 You can view the projects that you have access to by using the {product-title} web console.
 
-include::snippets/unified-perspective-web-console.adoc[]
+include::snippets/snip-unified-perspective-web-console.adoc[]
 
 .Procedure
 

--- a/modules/viewing-stats-collected-kubernetes-nmtate-op.adoc
+++ b/modules/viewing-stats-collected-kubernetes-nmtate-op.adoc
@@ -58,7 +58,7 @@ kubernetes_nmstate_features_applied{name="dhcpv4-custom-hostname"} 1
 * You have deployed a service in a user-defined project.
 * You have created a `NodeNetworkConfigurationPolicy` manifest and applied it to your cluster.
 
-include::snippets/unified-perspective-web-console.adoc[]
+include::snippets/snip-unified-perspective-web-console.adoc[]
 
 .Procedure
 

--- a/modules/web-console-disable.adoc
+++ b/modules/web-console-disable.adoc
@@ -6,9 +6,10 @@
 [id="web-console-disable_{context}"]
 = Disabling the web console
 
-You can disable the web console by editing the
-`consoles.operator.openshift.io` resource.
+[role="_abstract"]
+You can disable the web console by editing the `consoles.operator.openshift.io` resource.
 
+.Procedure
 * Edit the `consoles.operator.openshift.io` resource:
 +
 [source,terminal]
@@ -26,9 +27,11 @@ kind: Console
 metadata:
   name: cluster
 spec:
-  managementState: Removed <1>
+  managementState: Removed
 ----
-<1> Set the `managementState` parameter value to `Removed` to disable the web
-console. The other valid values for this parameter are `Managed`, which enables
-the console under the cluster's control, and `Unmanaged`, which means that you
-are taking control of web console management.
++
+--
+where:
+
+`spec.managementState.Removed`:: Set the `managementState` parameter value to `Removed` to disable the web console. The other valid values for this parameter are `Managed`, which enables the console under the cluster's control, and `Unmanaged`, which means that you are taking control of web console management.
+--

--- a/modules/web-console-overview.adoc
+++ b/modules/web-console-overview.adoc
@@ -1,17 +1,18 @@
 // Module included in the following assemblies:
 // * web_console/web-console.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 [id="web-console-overview_{context}"]
 = Understanding and accessing the web console
 
+[role="_abstract"]
 The web console runs as a pod on the control plane node. The static assets required to run the web console are served by the pod. 
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 After you install {product-title} using the `openshift-install create cluster` command, you can find the web console URL and login credentials for the installed cluster in the CLI output of the installation program. For example:
 
 [source,terminal]
-.Example output
+**Example output**:
 ----
 INFO Install complete!
 INFO Run 'export KUBECONFIG=<your working directory>/auth/kubeconfig' to manage the cluster with 'oc', the OpenShift CLI.
@@ -35,8 +36,7 @@ ifdef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 .Procedure
 
 . Log in to {cluster-manager-url} and click the name of your cluster.
-
 . On the cluster *Overview* tab, click *Open console*, and log in with your credentials.
-
++
 Alternatively, use the `oc whoami --show-console` command to get the web console URL.
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]

--- a/observability/monitoring/managing-alerts/managing-alerts-as-a-developer.adoc
+++ b/observability/monitoring/managing-alerts/managing-alerts-as-a-developer.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 In {product-title}, the Alerting UI enables you to manage alerts, silences, and alerting rules.
 
-include::snippets/unified-perspective-web-console.adoc[]
+include::snippets/snip-unified-perspective-web-console.adoc[]
 
 [NOTE]
 ====

--- a/observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc
+++ b/observability/monitoring/managing-alerts/managing-alerts-as-an-administrator.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 In {product-title}, the Alerting UI enables you to manage alerts, silences, and alerting rules.
 
-include::snippets/unified-perspective-web-console.adoc[]
+include::snippets/snip-unified-perspective-web-console.adoc[]
 
 [NOTE]
 ====

--- a/snippets/snip-unified-perspective-web-console.adoc
+++ b/snippets/snip-unified-perspective-web-console.adoc
@@ -8,6 +8,7 @@
 
 :_mod-docs-content-type: SNIPPET
 
+[role="_abstract"]
 [IMPORTANT]
 ====
 Starting with {product-title} 4.19, the perspectives in the web console have unified. The *Developer* perspective is no longer enabled by default.

--- a/web_console/adding-user-preferences.adoc
+++ b/web_console/adding-user-preferences.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="adding-user-preferences"]
 = Adding user preferences
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: adding-user-preferences

--- a/web_console/capabilities_products-web-console.adoc
+++ b/web_console/capabilities_products-web-console.adoc
@@ -1,53 +1,36 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="capabilities-products-web-console"]
 = Optional capabilities and products in the web console
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: capabilities-web-console
 
 toc::[]
 
+[role="_abstract"]
 You can further customize the {product-title} web console by adding additional capabilities to your existing workflows and integrations through products.
 
-//Note to think about as this section is built- plan to make this a landing page for all capabilities related to the web console. Will include others such as Observability, Logging, Monitoring, Networking etc.
-
 include::modules/optional-capabilities-operators.adoc[leveloffset=+1]
+//OpenShift LightSpeed
+include::modules/openshift-lightspeed-web-console.adoc[leveloffset=+1]
+//pipelines
+include::modules/pipelines-web-console.adoc[leveloffset=+1]
+//serverless
+include::modules/serverless-web-console.adoc[leveloffset=+1]
+//RHDH
+include::modules/rhdh-web-console.adoc[leveloffset=+1]
+include::modules/rhdh-install-web-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../operators/understanding/olm-understanding-software-catalog.adoc#olm-understanding-software-catalog[Understanding the software catalog]
 * xref:../web_console/web_terminal/installing-web-terminal.adoc#installing-web-terminal[Installing the web terminal]
-
-//OpenShift LightSpeed
-include::modules/openshift-lightspeed-web-console.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_lightspeed/1.0tp1/html/about/ols-about-openshift-lightspeed#ols-openshift-lightspeed-overview[{ols} overview]
 * link:https://docs.redhat.com/en/documentation/red_hat_openshift_lightspeed/1.0tp1/html/install/ols-installing-lightspeed[Installing {ols}]
-
-//pipelines
-include::modules/pipelines-web-console.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
 * link:https://docs.openshift.com/pipelines/1.14/create/working-with-pipelines-web-console.html[Working with {pipelines-title} in the web console]
 * link:https://docs.openshift.com/pipelines/1.14/create/working-with-pipelines-web-console.html#op-console-statistics_working-with-pipelines-web-console[Pipeline execution statistics in the web console]
-
-//serverless
-include::modules/serverless-web-console.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_serverless/1.31/html/installing_serverless/install-serverless-operator#serverless-install-web-console_install-serverless-operator[Installing the {ServerlessProductName} Operator from the web console].
-
-//RHDH
-include::modules/rhdh-web-console.adoc[leveloffset=+1]
-
-include::modules/rhdh-install-web-console.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_serverless/1.31/html/installing_serverless/install-serverless-operator#serverless-install-web-console_install-serverless-operator[Installing the {ServerlessProductName} Operator from the web console]
 * link:https://access.redhat.com/documentation/en-us/red_hat_developer_hub/1.0[Product Documentation for {rh-dev-hub}]
 
 //RHTaP

--- a/web_console/creating-quick-start-tutorials.adoc
+++ b/web_console/creating-quick-start-tutorials.adoc
@@ -2,6 +2,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 :_mod-docs-content-type: ASSEMBLY
 [id="creating-quick-start-tutorials"]
 = Creating quick start tutorials in the web console
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: creating-quick-start-tutorials
@@ -10,6 +11,7 @@ ifdef::openshift-rosa,openshift-dedicated[]
 :_mod-docs-content-type: ASSEMBLY
 [id="creating-quick-start-tutorials"]
 = About quick start tutorials
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: creating-quick-start-tutorials
@@ -17,6 +19,7 @@ endif::openshift-rosa,openshift-dedicated[]
 
 toc::[]
 
+[role="_abstract"] 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 If you are creating quick start tutorials for the {product-title} web console, follow these guidelines to maintain a consistent user experience across all quick starts.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
@@ -51,6 +54,6 @@ include::modules/quick-start-content-guidelines.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For voice and tone requirements, refer to link:https://www.patternfly.org/ux-writing/brand-voice-and-tone[PatternFly's brand voice and tone guidelines].
-* For other UX content guidance, refer to all areas of link:https://www.patternfly.org/ux-writing/about[PatternFly's UX writing style guide].
+* link:https://www.patternfly.org/ux-writing/brand-voice-and-tone[PatternFly's brand voice and tone guidelines]
+* link:https://www.patternfly.org/ux-writing/about[PatternFly's UX writing style guide]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/web_console/disabling-web-console.adoc
+++ b/web_console/disabling-web-console.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="disabling-web-console"]
 = Disabling the web console in {product-title}
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: disabling-web-console
 
 toc::[]
 
+[role="_abstract"]
 You can disable the {product-title} web console.
 
 == Prerequisites

--- a/web_console/dynamic-plugin/content-security-policy.adoc
+++ b/web_console/dynamic-plugin/content-security-policy.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="content-security-policy_{context}"]
 = Content Security Policy (CSP)
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: content-security-policy
 
 toc::[]
 
+[role="_abstract"]
 You can specify Content Security Policy (CSP) directives for your dynamic plugin using the `contentSecurityPolicy` field in the `ConsolePluginSpec` file. This field helps mitigate potential security risks by specifying which sources are allowed for fetching content like scripts, styles, images, and fonts. For dynamic plugins that require loading resources from external sources, defining custom CSP rules ensures secure integration into the {product-title} console.
 
 [IMPORTANT]

--- a/web_console/dynamic-plugin/deploy-plugin-cluster.adoc
+++ b/web_console/dynamic-plugin/deploy-plugin-cluster.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="deploy-plugin-cluster_{context}"]
 = Deploy your plugin on a cluster
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: deploy-plugin-cluster
 
 toc::[]
 
+[role="_abstract"]
 You can deploy the plugin to  
 ifndef::openshift-rosa-hcp,openshift-rosa[]
 an {product-title} 

--- a/web_console/dynamic-plugin/dynamic-plugin-example.adoc
+++ b/web_console/dynamic-plugin/dynamic-plugin-example.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="dynamic-plugin-example_{context}"]
 = Dynamic plugin example
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: dynamic-plugin-example
 
 toc::[]
 
+[role="_abstract"]
 Before working through the example, verify that the plugin is working by following the steps in xref:../../web_console/dynamic-plugin/dynamic-plugins-get-started.adoc#dynamic-plugin-development_dynamic-plugins-get-started[Dynamic plugin development]
 
 include::modules/adding-tab-pods-page.adoc[leveloffset=+1]

--- a/web_console/dynamic-plugin/dynamic-plugins-get-started.adoc
+++ b/web_console/dynamic-plugin/dynamic-plugins-get-started.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="getting-started-with-dynamic-plugins_{context}"]
 = Getting started with dynamic plugins
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: dynamic-plugins-get-started
 
 toc::[]
 
+[role="_abstract"]
 To get started using the dynamic plugin, you must set up your environment to write a new {product-title} dynamic plugin. For an example of how to write a new plugin, see xref:../../web_console/dynamic-plugin/dynamic-plugin-example.adoc#adding-tab-to-pods-page_dynamic-plugin-example[Adding a tab to the pods page].
 
 include::modules/dynamic-plug-in-development.adoc[leveloffset=+1]

--- a/web_console/dynamic-plugin/dynamic-plugins-reference.adoc
+++ b/web_console/dynamic-plugin/dynamic-plugins-reference.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="dynamic-plugins-reference_{context}"]
 = Dynamic plugin reference
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: dynamic-plugins-reference
 
 toc::[]
 
+[role="_abstract"]
 You can add extensions that allow you to customize your plugin. Those extensions are then loaded to the console at run-time.
 
 include::modules/dynamic-plugin-sdk-extensions.adoc[leveloffset=+1]

--- a/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
+++ b/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="overview-of-dynamic-plugins_{context}"]
 = Overview of dynamic plugins
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: overview-of-dynamic-plugins
@@ -10,6 +11,7 @@ toc::[]
 [id="dynamic-plug-in-overview"]
 == About dynamic plugins
 
+[role="_abstract"]
 Dynamic plugins are loaded and interpreted from remote sources at runtime. One way to deliver and expose dynamic plugins to the console is through OLM Operators. The Operator creates a deployment on the platform with an HTTP server to host the plugin and exposes it using a Kubernetes service.
 
 Dynamic plugins allow you to add custom pages and other extensions to your console user interface at runtime. The `ConsolePlugin` custom resource registers plugins with the console, and a cluster administrator enables plugins in the console Operator configuration.

--- a/web_console/using-dashboard-to-get-cluster-information.adoc
+++ b/web_console/using-dashboard-to-get-cluster-information.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="using-dashboard-to-get-cluster-info"]
 = Using the {product-title} dashboard to get cluster information
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: using-dashboard-to-get-cluster-info
 
 toc::[]
 
+[role="_abstract"]
 The {product-title} web console captures high-level information about the cluster.
 
 include::modules/virt-about-the-overview-dashboard.adoc[leveloffset=+1]

--- a/web_console/web-console-overview.adoc
+++ b/web_console/web-console-overview.adoc
@@ -1,16 +1,18 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="web-console-overview"]
 = Web Console Overview
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: web-console-overview
 
 toc::[]
 
+[role="_abstract"]
 The {product-title} web console provides a graphical user interface to visualize your project data and perform administrative, management, and troubleshooting tasks. The web console runs as pods on the control plane nodes in the openshift-console project. It is managed by a `console-operator` pod.
 
 ifndef::openshift-rosa-hcp[]
-include::snippets/unified-perspective-web-console.adoc[]
+include::snippets/snip-unified-perspective-web-console.adoc[]
 
 endif::openshift-rosa-hcp[]
 

--- a/web_console/web-console.adoc
+++ b/web_console/web-console.adoc
@@ -2,12 +2,14 @@
 
 [id="web-console"]
 = Accessing the web console
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: web-console
 
 toc::[]
 
+[role="_abstract"]
 The {product-title} web console is a user interface accessible from a web browser. You can use the web console to visualize, browse, and manage the contents of projects.
 
 == Prerequisites

--- a/web_console/web_terminal/installing-web-terminal.adoc
+++ b/web_console/web_terminal/installing-web-terminal.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="installing-web-terminal"]
 = Installing the web terminal
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: installing-web-terminal
 
 toc::[]
 
+[role="_abstract"]
 You can install the web terminal by using the {web-terminal-op} listed in the {product-title} software catalog. When you install the {web-terminal-op}, the custom resource definitions (CRDs) that are required for the command line configuration, such as the `DevWorkspace` CRD, are automatically installed. The web console creates the required resources when you open the web terminal.
 
 

--- a/web_console/web_terminal/odc-using-web-terminal.adoc
+++ b/web_console/web_terminal/odc-using-web-terminal.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="odc-using-web-terminal"]
 = Using the web terminal
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: odc-using-web-terminal
 
 toc::[]
 
+[role="_abstract"]
 You can launch an embedded command-line terminal instance in the web console. This terminal instance is preinstalled with common CLI tools for interacting with the cluster, such as `oc`, `kubectl`,`odo`, `kn`, `tkn`, `helm`, and `subctl`. It also has the context of the project you are working on and automatically logs you in using your credentials.
 
 include::modules/odc-access-web-terminal.adoc[leveloffset=+1]

--- a/web_console/web_terminal/troubleshooting-web-terminal.adoc
+++ b/web_console/web_terminal/troubleshooting-web-terminal.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="troubleshooting-web-terminal"]
 = Troubleshooting the web terminal
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: troubleshooting-web-terminal
@@ -10,6 +11,7 @@ toc::[]
 [id="troubleshooting-web-terminal-network-policies"]
 == Web terminal and network policies
 
+[role="_abstract"]
 The web terminal might fail to start if the cluster has network policies configured. To start a web terminal instance, the {web-terminal-op} must communicate with the web terminal's pod to verify it is running, and the {product-title} web console needs to send information to automatically log in to the cluster within the terminal. If either step fails, the web terminal fails to start and the terminal panel is in a loading state until a `context deadline exceeded error` occurs.
 
 To avoid this issue, ensure that the network policies for namespaces that are used for terminals allow ingress from the `openshift-console` and `openshift-operators` namespaces.

--- a/web_console/web_terminal/uninstalling-web-terminal.adoc
+++ b/web_console/web_terminal/uninstalling-web-terminal.adoc
@@ -1,12 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="uninstalling-web-terminal"]
 = Uninstalling the web terminal
+
 include::_attributes/common-attributes.adoc[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: uninstalling-web-terminal
 
 toc::[]
 
+[role="_abstract"]
 Uninstalling the {web-terminal-op} does not remove any of the custom resource definitions (CRDs) or managed resources that are created when the Operator is installed. For security purposes, you must manually uninstall these components. By removing these components, you save cluster resources because terminals do not idle when the Operator is uninstalled.
 
 Uninstalling the web terminal is a two-step process:


### PR DESCRIPTION
Version(s):
`enterprise-4.20+`

Issue:
**[OSDOCS-16567](https://issues.redhat.com/browse/OSDOCS-16567)**

Link to docs preview:
* [Web Console](https://104179--ocpdocs-pr.netlify.app/openshift-rosa/latest/web_console/web-console-overview.html) (ROSA Classic)
* [Web Console](https://104179--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/web_console/web-console-overview.html) (ROSA with HCP)
* [Web Console](https://104179--ocpdocs-pr.netlify.app/openshift-dedicated/latest/web_console/web-console-overview.html) (OpenShift Dedicated)
* [Web Console](https://104179--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/web-console-overview.html) (OpenShift Core Platform)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updated the Web Console book for ROSA, ROSA Classic, and Dedicated to meet DITA compliance.