### PR TITLE
CNV-73556: Fix hotplug memory default and vale updates

### DIFF
--- a/modules/virt-hot-plugging-memory.adoc
+++ b/modules/virt-hot-plugging-memory.adoc
@@ -12,17 +12,17 @@ You can add or remove the amount of memory allocated to a virtual machine (VM) w
 
 .Procedure
 
-. Navigate to *Virtualization* -> *VirtualMachines*.
+. Go to *Virtualization* -> *VirtualMachines*.
 . Select the required VM to open the *VirtualMachine details* page.
 . On the *Configuration* tab, click *Edit CPU|Memory*.
-. Enter the desired amount of memory and click *Save*.
+. Enter the required amount of memory and click *Save*.
 +
 [NOTE]
 ====
-You can hot plug up to three times the default initial amount of memory of the VM. Exceeding this limit requires a restart.
+You can hot plug up to four times the default initial amount of memory of the VM. Exceeding this limit requires a restart.
 ====
 +
-The system applies these changes immediately. If the VM is migratable, a live migration is triggered. If not, or if the changes cannot be live-updated, a `RestartRequired` condition is added to the VM.
+The system applies these changes immediately. If the VM is able to be migrated, a live migration is triggered. If not, or if the changes cannot be live-updated, a `RestartRequired` condition is added to the VM.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.19+

Issue:
https://issues.redhat.com/browse/CNV-73556

Link to docs preview:
https://104180--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-edit-vms.html#virt-hot-plugging-memory_virt-edit-vms

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
