### PR TITLE
Added a section for day2 operator for azure disk encryption sets.

### DIFF
--- a/installing/installing_azure/ipi/installing-azure-preparing-ipi.adoc
+++ b/installing/installing_azure/ipi/installing-azure-preparing-ipi.adoc
@@ -36,6 +36,8 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * For more information about the Telemetry service, see xref:../../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
+include::modules/installation-azure-day2-operations-diskencryptionsets.adoc[leveloffset=+1]
+
 include::modules/installation-azure-preparing-diskencryptionsets.adoc[leveloffset=+1]
 
 .Next steps

--- a/modules/installation-azure-day2-operations-diskencryptionsets.adoc
+++ b/modules/installation-azure-day2-operations-diskencryptionsets.adoc
@@ -1,4 +1,4 @@
-//Module included in the following assemblies:
+// Module included in the following assemblies:
 //
 // * installing/installing_azure/enabling-disk-encryption-sets-azure.adoc
 

--- a/modules/installation-azure-day2-operations-diskencryptionsets.adoc

+++ b/modules/installation-azure-day2-operations-diskencryptionsets.adoc

@@ -1,0 +1,80 @@
+//Module included in the following assemblies:
+//
+// * installing/installing_azure/enabling-disk-encryption-sets-azure.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installation-azure-day2-operations-diskencryptionsets.adoc_{context}"]
+= Preparing an Azure Disk Encryption Set for Day2 Operator
+
+The {product-title} installation program can use an existing Disk Encryption Set with a user-managed key. To enable this feature, create a `DiskEncryptionSet` object in Azure and provide the key to the installation program. 
+
+.Prerequisite
+
+* You enabled the `EncryptionAtHost` feature in your {azure-short} subscription. For more information, see "Use the Azure portal to enable end-to-end encryption using encryption at host".
+.Procedure
+
+. Mark the node from the `encyptionAtHost` cluster resource group as unschedulable by using the following command:
++
+[source,terminal]
+----
+$ oc adm cordon <node_name>
+----
+
+. Evacuate the pods from the compute node. There are several ways to do this. For example, you can evacuate all the pods or the selected pods on a node: 
++
+[source,terminal]
+----
+$ oc adm drain <compute_node> [--pod-selector=<pod_selector>]
+----
++
+[NOTE]
+====
+For other options to evacuate pods from a node, see the "Understanding how to evacuate pods on nodes" section. 
+====
+
+. De-allocate the node by running the following command:
++
+[source,terminal]
+----
+$ az vm deallocate -n <node_name> -g <cluster_resource_group>
+----
+
+. Set the `encryptionAtHost` property to `true` by running the following command:
++
+[source,terminal]
+----
+$ az vm update -n <node_name> -g <cluster_resource_group> --set securityProfile.encryptionAtHost=true
+----
+
+. Start the node by running the following commands:
++
+[source,terminal]
+----
+$ az vm start -n <node_name> -g <cluster_resource_group>
+----
+
+. Mark the node as schedulable by using the following command:
++
+[source,terminal]
+----
+$ oc adm uncordon <node_name>
+----
+
+. Verify that all cluster Operators are available:
++
+[source,terminal]
+----
+$ oc get clusteroperators
+----
++
+All Operators should show `AVAILABLE=True`, `PROGRESSING=False`, and `DEGRADED=False`.
+
+. Repeat the above steps on all the nodes that run `encryptionAtHost`.
+
+[NOTE]
+====
+If you want to enable encryption for your host during cluster installation, specify the following parameters in the `install-config.yaml` file:
+* `compute.platform.azure.encryptionAtHost`
+* `controlPlane.platform.azure.encryptionAtHost`
+* `platform.azure.defaultMachinePlatform.encryptionAtHost`
+====


### PR DESCRIPTION
Started by @subhtk in https://github.com/openshift/openshift-docs/pull/72130. See that PR for dev, QE, and peer review.

Issue: [OCPBUG-26050](https://issues.redhat.com/browse/OCPBUGS-26050)

Link to docs preview: [Preview](https://72130--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/enabling-user-managed-encryption-azure.html#preparing-disk-encryption-sets-day2-operator_enabling-user-managed-encryption-azure)
