### PR TITLE
RHDEVDOCS-7045: Bug in Builds for OpenShift Operator documentation

### DIFF
--- a/work_with_shared_resources/docinfo.xml
+++ b/work_with_shared_resources/docinfo.xml
@@ -1,7 +1,7 @@
 <title>Work with shared resources</title>
 <productname>{product-title}</productname>
 <productnumber>{product-version}</productnumber>
-<subtitle>Using Shared Resources CSI Driver Operator</subtitle>
+<subtitle>Using Shared Resources CSI Driver</subtitle>
 <abstract>
     <para>This document provides procedural examples for using Shared Resources CSI Driver.
     </para>

--- a/work_with_shared_resources/using-shared-resource-csi-driver.adoc
+++ b/work_with_shared_resources/using-shared-resource-csi-driver.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="shared-resource-csi-driver"]
-= Shared Resource CSI Driver Operator
+= Shared Resource CSI Driver
 
 include::_attributes/common-attributes.adoc[]
 :context: shared-resource-csi-driver


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): build-docs-1.5, 1.6, 1.7
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/RHDEVDOCS-7045
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://104217--ocpdocs-pr.netlify.app/openshift-builds/latest/work_with_shared_resources/using-shared-resource-csi-driver.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Builds does not have QE
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: Anchita bora
- [ ] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
