### PR TITLE
[enterprise-4.19] OCPBUGS-59577 Correcting inaccurate description

### DIFF
--- a/modules/nw-multus-bond-cni-object.adoc
+++ b/modules/nw-multus-bond-cni-object.adoc
@@ -18,7 +18,7 @@ The following table describes the configuration parameters for the Bond CNI plug
 
 |`name`
 |`string`
-|Specifies the name given to this CNI network attachment definition. This name is used to identify and reference the interface within the container.
+|The mandatory, unique identifier assigned to this CNI network attachment definition. It is used by the container runtime to select the correct network configuration and serves as the key for persistent resource state management, such as IP address allocations.
 
 |`cniVersion`
 |`string`
@@ -34,7 +34,7 @@ The following table describes the configuration parameters for the Bond CNI plug
 
 |`mtu`
 |`integer`
-|Optional: Specifies the maximum transmission unit (MTU) of the bond. The default is `1500`. 
+|Optional: Specifies the maximum transmission unit (MTU) of the bond. The default is `1500`.
 
 |`failOverMac`
 |`integer`
@@ -42,7 +42,7 @@ The following table describes the configuration parameters for the Bond CNI plug
 
 |`mode`
 |`string`
-|Specifies the bonding policy. 
+|Specifies the bonding policy.
 
 |`linksInContainer`
 |`boolean`
@@ -66,15 +66,15 @@ The following example configures a secondary network named `bond-net1`:
 [source,json]
 ----
 {
- "type": "bond", 
+ "type": "bond",
  "cniVersion": "0.3.1",
  "name": "bond-net1",
- "mode": "active-backup", 
- "failOverMac": 1, 
- "linksInContainer": true, 
+ "mode": "active-backup",
+ "failOverMac": 1,
+ "linksInContainer": true,
  "miimon": "100",
  "mtu": 1500,
- "links": [ 
+ "links": [
        {"name": "net1"},
        {"name": "net2"}
    ],

--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -21,7 +21,8 @@ ifndef::microshift[]
 
 |`name`
 |`string`
-|The value for the `name` parameter you provided previously for the CNO configuration.
+|The mandatory, unique identifier assigned to this CNI network attachment definition. It is used by the container runtime to select the correct network configuration and serves as the key for persistent resource state management, such as IP address allocations.
+
 endif::microshift[]
 
 ifdef::microshift[]

--- a/modules/nw-multus-dummy-device-object.adoc
+++ b/modules/nw-multus-dummy-device-object.adoc
@@ -6,7 +6,7 @@
 [id="nw-multus-dummy-device-object_{context}"]
 = Configuration for a dummy device additional network
 
-[role="_abstract"] 
+[role="_abstract"]
 The dummy CNI plugin functions like a loopback device. The plugin is a virtual interface, and you can use the plugin to route the packets to a designated IP address. Unlike a loopback device, the IP address is arbitrary and is not restricted to the `127.0.0.0/8` address range.
 
 The dummy device CNI plugin JSON configuration object describes the configuration parameters for the dummy CNI plugin. The following table details these parameters:
@@ -21,7 +21,7 @@ The dummy device CNI plugin JSON configuration object describes the configuratio
 
 |`name`
 |`string`
-|The value for the `name` parameter that you previously specified for the CNO configuration.
+|The mandatory, unique identifier assigned to this CNI network attachment definition. It is used by the container runtime to select the correct network configuration and serves as the key for persistent resource state management, such as IP address allocations.
 
 |`type`
 |`string`

--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -26,7 +26,7 @@ The following table details the configuration parameters:
 
 |`name`
 |`string`
-|The value for the `name` parameter you provided previously for the CNO configuration.
+|The mandatory, unique identifier assigned to this CNI network attachment definition. It is used by the container runtime to select the correct network configuration and serves as the key for persistent resource state management, such as IP address allocations.
 
 |`type`
 |`string`

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -23,7 +23,7 @@ The IPVLAN CNI plugin JSON configuration object describes the configuration para
 
 |`name`
 |`string`
-|The value for the `name` parameter you provided previously for the CNO configuration.
+|The mandatory, unique identifier assigned to this CNI network attachment definition. It is used by the container runtime to select the correct network configuration and serves as the key for persistent resource state management, such as IP address allocations.
 
 |`type`
 |`string`

--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -20,7 +20,7 @@ The MACVLAN CNI plugin JSON configuration object describes the configuration par
 
 |`name`
 |`string`
-|The value for the `name` parameter you provided previously for the CNO configuration.
+|The mandatory, unique identifier assigned to this CNI network attachment definition. It is used by the container runtime to select the correct network configuration and serves as the key for persistent resource state management, such as IP address allocations.
 
 |`type`
 |`string`

--- a/modules/nw-multus-tap-object.adoc
+++ b/modules/nw-multus-tap-object.adoc
@@ -19,7 +19,7 @@ The TAP CNI plugin JSON configuration object describes the configuration paramet
 
 |`name`
 |`string`
-|The value for the `name` parameter you provided previously for the CNO configuration.
+|The mandatory, unique identifier assigned to this CNI network attachment definition. It is used by the container runtime to select the correct network configuration and serves as the key for persistent resource state management, such as IP address allocations.
 
 |`type`
 |`string`

--- a/modules/nw-multus-vlan-object.adoc
+++ b/modules/nw-multus-vlan-object.adoc
@@ -21,7 +21,7 @@ The VLAN CNI plugin JSON configuration object describes the configuration parame
 
 |`name`
 |`string`
-|The value for the `name` parameter you provided previously for the CNO configuration.
+|The mandatory, unique identifier assigned to this CNI network attachment definition. It is used by the container runtime to select the correct network configuration and serves as the key for persistent resource state management, such as IP address allocations.
 
 |`type`
 |`string`


### PR DESCRIPTION
[OCPBUGS-59577]: Update all descriptions for CNIs 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.19
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-59577
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://104224--ocpdocs-pr.netlify.app/microshift/latest/microshift_networking/microshift_multiple_networks/microshift-cni-multus.html
https://104224--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/creating-secondary-nwt-other-cni.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: A manual CP of PR https://github.com/openshift/openshift-docs/pull/102078 adding updates section into 4.19 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
