### PR TITLE
OCPBUGS-64636 added note to document

### DIFF
--- a/modules/installation-two-node-ingress-lb-configuration.adoc
+++ b/modules/installation-two-node-ingress-lb-configuration.adoc
@@ -2,27 +2,32 @@
 [id="two-node-ingress-lb-configuration_{context}"]
 = Configuring an Ingress load balancer for a two-node cluster with fencing
 
-You must configure an external Ingress load balancer (LB) before you install a two-node OpenShift cluster with fencing. The Ingress LB forwards external application traffic to the Ingress Controller pods that run on the control plane nodes. Both nodes can actively receive traffic.
+[role="_abstract"]
+Configure an external Ingress load balancer to forward application traffic to Ingress Controller pods on control plane nodes. You must configure this load balancer before installing a two-node OpenShift cluster with fencing to allow both nodes to actively receive traffic.
+
+[NOTE]
+====
+An external load balancer is recommended for production deployments but is not required.
+====
 
 .Prerequisites
 
-* You have two control plane nodes with fencing enabled.  
-* You have network connectivity from the load balancer to both control plane nodes.  
-* You created DNS records for `api.<cluster_name>.<base_domain>` and `*.apps.<cluster_name>.<base_domain>`.  
-* You have an external load balancer that supports health checks on endpoints.  
+* You have two control plane nodes with fencing enabled.
+* You have network connectivity from the load balancer to both control plane nodes.
+* You created DNS records for `api.<cluster_name>.<base_domain>` and `*.apps.<cluster_name>.<base_domain>`.
 
 .Procedure
 
 . Configure the load balancer to forward traffic for the following ports:
 +
-* `6443`: Kubernetes API server  
+* `6443`: Kubernetes API server
 * `80` and `443`: Application ingress
 +
 You must forward traffic to both control plane nodes.
 
 . Configure health checks on the load balancer. You must monitor the backend endpoints so that the load balancer only sends traffic to nodes that respond.
 
-. Configure the load balancer to forward traffic to both control plane nodes. The following example shows how to configure two control plane nodes:  
+. Configure the load balancer to forward traffic to both control plane nodes. The following example shows how to configure two control plane nodes:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OCPBUGS-64636

Link to docs preview:
https://104233--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_two_node_cluster/installing_tnf/installing-two-node-fencing.html#two-node-ingress-lb-configuration_installing-two-node-fencing

QE review:
- [ ] QE has approved this change.


Additional information:

