### PR TITLE
OSDOCS#17726: Update the 4.20.6 z-stream RN information in the assembly file

### DIFF
--- a/modules/zstream-4-20-8-about.adoc
+++ b/modules/zstream-4-20-8-about.adoc
@@ -10,7 +10,7 @@
 [role="_abstract"]
 Issued: 16 December 2025
 
-{product-title} release {product-version}.5 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:23103[RHBA-2025:23103] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:23101[RHBA-2025:23101] advisory.
+{product-title} release {product-version}.8 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2025:23103[RHBA-2025:23103] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:23101[RHBA-2025:23101] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3017,6 +3017,15 @@ include::modules/zstream-4-20-8-fixed-issues.adoc[leveloffset=+3]
 // 4-20-8 release notes updating
 include::modules/zstream-4-20-x-updating.adoc[leveloffset=+3]
 
+// About 4-20-6 release notes
+include::modules/zstream-4-20-6-about.adoc[leveloffset=+2]
+
+// 4-20-6 release notes bug fixes
+include::modules/zstream-4-20-6-bug-fixes.adoc[leveloffset=+3]
+
+// 4-20-6 release notes updating
+include::modules/zstream-4-20-6-updating.adoc[leveloffset=+3]
+
 // About 4-20-5 release notes
 include::modules/zstream-4-20-5-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-17726](https://issues.redhat.com//browse/OSDOCS-17726)

Link to docs preview:
[4.20.6](https://104272--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-6-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream release notes

Additional information:
The 4.20.6 release notes were removed from the z-stream releases in error. This PR adds this information back and also corrects a typo in 4.20.8.
