### PR TITLE
OSDOCS-14725: moving link in install file

### DIFF
--- a/installing/overview/index.adoc
+++ b/installing/overview/index.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 include::modules/installation-overview.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/installing-ove.adoc#installing-ove[Installing a cluster without an external registry]
+
 include::modules/install-openshift-common-terms.adoc[leveloffset=+2]
 
 include::modules/installation-process.adoc[leveloffset=+2]
@@ -58,5 +63,3 @@ include::modules/supported-platforms-for-openshift-clusters.adoc[leveloffset=+1]
 * See xref:../../installing/overview/installing-preparing.adoc#installing-preparing[Selecting a cluster installation method and preparing it for users] for information about choosing an installation method and preparing the required resources.
 
 * link:https://access.redhat.com/labs/ocpnc/[Red Hat OpenShift Network Calculator] can help you design your cluster network during both the deployment and expansion phases. It addresses common questions related to the cluster network and provides output in a convenient JSON format.
-
-* xref:../../installing/installing_with_agent_based_installer/installing-ove.adoc#installing-ove[Installing a cluster without an external registry]


### PR DESCRIPTION
Versions: 4.20+

This PR simply moves an additional resources link closer to the content the link is referenced in.

No QE required.

Preview: [Glossary of common terms for OpenShift Container Platform installing](https://104284--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/index.html#install-openshift-common-terms_ocp-installation-overview) (additional resources section right above heading)