### PR TITLE
TRACING-5814 | RHOSDT 3.9 Document google managed prometheus

### DIFF
--- a/modules/otel-extensions-googleauth-extension.adoc
+++ b/modules/otel-extensions-googleauth-extension.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-collector/otel-collector-extensions.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="otel-extensions-googleauth-extension_{context}"]
+= Google Client Authentication Extension
+
+[role="_abstract"]
+
+The Google Client Authentication extension provides Google OAuth2 Client Credentials and Metadata for gRPC and http based exporters.
+
+.OpenTelemetry Collector custom resource with the configured Google Client Auth Extension
+[source,yaml]
+----
+# ...
+  config:
+    extensions:
+      googleclientauth:
+        project: "my-project" # <1>
+
+    exporters:
+      otlphttp:
+        encoding: json
+        endpoint: https://telemetry.googleapis.com
+        auth:
+          authenticator: googleclientauth
+
+    service:
+      extensions: [googleclientauth]
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug]
+# ...
+----
+
+<1> The Google Cloud Project telemetry is sent to if the `gcp.project.id` resource attribute is not set. If unspecified, this is determined using application default credentials.

--- a/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
+++ b/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
@@ -89,3 +89,6 @@ The OTLP exporter should be configured with Google Client Auth extension, which 
 <3> The path to the service account token used by WIF. In this case `/var/run/secrets/otel/serviceaccount/token`.
 <4> The `subtract_initial_point` strategy is stateful, requiring the Collector to run as a sidecar to maintain per-pod state. Alternative strategies available; choose the one that best fits your use case.
 <5> Replace with your GCP project ID.
+
+
+Other resources: https://docs.cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes

--- a/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
+++ b/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
@@ -14,6 +14,27 @@ To forward metrics to the Google Managed Prometheus, use the OpenTelemetry Colle
 ----
 # ...
   mode: sidecar
+  env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS # <1>
+      value: "/etc/workload-identity/credential-configuration.json"
+  volumes:
+    - name: workload-identity-credential-configuration
+      configMap:
+        name: gcp-wif-credentials # <2>
+     - name: service-account-token-volume
+       projected:
+         sources:
+         - serviceAccountToken:
+             audience: openshift
+             expirationSeconds: 3600
+             path: token
+  volumeMounts:
+    - name: workload-identity-credential-configuration
+      mountPath: "/etc/workload-identity"
+      readOnly: true
+    - name: service-account-token-volume
+      mountPath: "/var/run/secrets/otel/serviceaccount" <3>
+      readOnly: true
   config:
     extensions:
       googleclientauth: {}
@@ -27,12 +48,12 @@ To forward metrics to the Google Managed Prometheus, use the OpenTelemetry Colle
 
     processors:
       metricstarttime:
-        strategy: subtract_initial_point # <1>
+        strategy: subtract_initial_point # <4>
 
       resource/gcp_project_id:
         attributes:
         - action: insert
-          value: project_id # <2>
+          value: project_id # <5>
           key: gcp.project_id
 
       k8sattributes: {}
@@ -62,5 +83,8 @@ To forward metrics to the Google Managed Prometheus, use the OpenTelemetry Colle
           exporters: [otlphttp]
 # ...
 ----
-<1> The `subtract_initial_point` strategy is stateful, requiring the Collector to run as a sidecar to maintain per-pod state. Alternative strategies available; choose the one that best fits your use case.
-<2> Replace with your GCP project ID.
+<1> The environment variable `GOOGLE_APPLICATION_CREDENTIALS` can be configured to use the traditional secret or use the workload identity federation (WIF). This specific example uses WIF.
+<2> Config map contains the Google WIF configuration file `credential-configuration.json`.
+<3> The path to the service account token used by WIF. In this case `/var/run/secrets/otel/serviceaccount/token`.
+<4> The `subtract_initial_point` strategy is stateful, requiring the Collector to run as a sidecar to maintain per-pod state. Alternative strategies available; choose the one that best fits your use case.
+<5> Replace with your GCP project ID.

--- a/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
+++ b/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * observability/otel/otel-forwarding-telemetry-data.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="otel-forwarding-data-to-google-managed-prometheus_{context}"]
+= Forwarding telemetry data to Google Managed Prometheus
+
+[role="_abstract"]
+To forward metrics to the Google Managed Prometheus, use the OpenTelemetry Collector with the OTLP exporter, metricstarttime processor and googleclientauth extension.
+
+.OpenTelemetry Collector custom resource with a configured File Storage Extension that persists an OTLP sending queue
+[source,yaml]
+----
+# ...
+  config:
+    extensions:
+      file_storage/all_settings:
+        directory: /var/lib/otelcol/mydir # <1>
+        timeout: 1s # <2>
+        compaction:
+          on_start: true # <3>
+          directory: /tmp/ # <4>
+          max_transaction_size: 65_536 # <5>
+        fsync: false # <6>
+    processors:
+   transform/collision:
+     metric_statements:
+     - context: datapoint
+       statements:
+       - set(attributes["exported_location"], attributes["location"])
+       - delete_key(attributes, "location")
+       - set(attributes["exported_cluster"], attributes["cluster"])
+       - delete_key(attributes, "cluster")
+       - set(attributes["exported_namespace"], attributes["namespace"])
+       - delete_key(attributes, "namespace")
+       - set(attributes["exported_job"], attributes["job"])
+       - delete_key(attributes, "job")
+       - set(attributes["exported_instance"], attributes["instance"])
+       - delete_key(attributes, "instance")
+       - set(attributes["exported_project_id"], attributes["project_id"])
+       - delete_key(attributes, "project_id")
+
+    exporters:
+      otlp:
+        sending_queue:
+          storage: file_storage/all_settings # <7>
+
+    service:
+      extensions: [file_storage/all_settings] # <8>
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [otlp]
+# ...

--- a/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
+++ b/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
@@ -7,9 +7,10 @@
 = Forwarding telemetry data to Google Managed Prometheus
 
 [role="_abstract"]
-To forward metrics to the Google Managed Prometheus, use the OpenTelemetry Collector with the OTLP exporter, metricstarttime processor and googleclientauth extension.
+To forward metrics to the Google Managed Prometheus, use the OpenTelemetry Collector with the OTLP exporter, Metric Start Time processor and Google Client Auth extension.
+The OTLP exporter should be configured with Google Client Auth extension, which can use standard secret authentication or Workload Identity Federation (WIF).
 
-.OpenTelemetry Collector custom resource with a configured File Storage Extension that persists an OTLP sending queue
+.OpenTelemetry Collector custom resource with configured OTLP exporter and Google WIF authentication.
 [source,yaml]
 ----
 # ...

--- a/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
+++ b/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
@@ -21,18 +21,18 @@ To forward metrics to the Google Managed Prometheus, use the OpenTelemetry Colle
     exporters:
       otlphttp:
         encoding: json
-          endpoint: https://telemetry.googleapis.com
+        endpoint: https://telemetry.googleapis.com
         auth:
           authenticator: googleclientauth
 
     processors:
       metricstarttime:
-        strategy: subtract_initial_point # <2>
+        strategy: subtract_initial_point # <1>
 
       resource/gcp_project_id:
         attributes:
         - action: insert
-          value: project_id # <1>
+          value: project_id # <2>
           key: gcp.project_id
 
       k8sattributes: {}

--- a/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
+++ b/modules/otel-forwarding-data-to-google-managed-prometheus.adoc
@@ -13,43 +13,54 @@ To forward metrics to the Google Managed Prometheus, use the OpenTelemetry Colle
 [source,yaml]
 ----
 # ...
+  mode: sidecar
   config:
     extensions:
-      file_storage/all_settings:
-        directory: /var/lib/otelcol/mydir # <1>
-        timeout: 1s # <2>
-        compaction:
-          on_start: true # <3>
-          directory: /tmp/ # <4>
-          max_transaction_size: 65_536 # <5>
-        fsync: false # <6>
-    processors:
-   transform/collision:
-     metric_statements:
-     - context: datapoint
-       statements:
-       - set(attributes["exported_location"], attributes["location"])
-       - delete_key(attributes, "location")
-       - set(attributes["exported_cluster"], attributes["cluster"])
-       - delete_key(attributes, "cluster")
-       - set(attributes["exported_namespace"], attributes["namespace"])
-       - delete_key(attributes, "namespace")
-       - set(attributes["exported_job"], attributes["job"])
-       - delete_key(attributes, "job")
-       - set(attributes["exported_instance"], attributes["instance"])
-       - delete_key(attributes, "instance")
-       - set(attributes["exported_project_id"], attributes["project_id"])
-       - delete_key(attributes, "project_id")
+      googleclientauth: {}
 
     exporters:
-      otlp:
-        sending_queue:
-          storage: file_storage/all_settings # <7>
+      otlphttp:
+        encoding: json
+          endpoint: https://telemetry.googleapis.com
+        auth:
+          authenticator: googleclientauth
+
+    processors:
+      metricstarttime:
+        strategy: subtract_initial_point # <2>
+
+      resource/gcp_project_id:
+        attributes:
+        - action: insert
+          value: project_id # <1>
+          key: gcp.project_id
+
+      k8sattributes: {}
+
+      transform/collision:
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["exported_location"], attributes["location"])
+          - delete_key(attributes, "location")
+          - set(attributes["exported_cluster"], attributes["cluster"])
+          - delete_key(attributes, "cluster")
+          - set(attributes["exported_namespace"], attributes["namespace"])
+          - delete_key(attributes, "namespace")
+          - set(attributes["exported_job"], attributes["job"])
+          - delete_key(attributes, "job")
+          - set(attributes["exported_instance"], attributes["instance"])
+          - delete_key(attributes, "instance")
+          - set(attributes["exported_project_id"], attributes["project_id"])
+          - delete_key(attributes, "project_id")
 
     service:
-      extensions: [file_storage/all_settings] # <8>
+      extensions: [googleclientauth]
       pipelines:
-        traces:
-          receivers: [otlp]
-          exporters: [otlp]
+        metrics:
+          processors: [k8sattributes, resource/gcp_project_id, transform/collision, metricstarttime]
+          exporters: [otlphttp]
 # ...
+----
+<1> The `subtract_initial_point` strategy is stateful, requiring the Collector to run as a sidecar to maintain per-pod state. Alternative strategies available; choose the one that best fits your use case.
+<2> Replace with your GCP project ID.

--- a/observability/otel/otel-collector/otel-collector-extensions.adoc
+++ b/observability/otel/otel-collector/otel-collector-extensions.adoc
@@ -23,6 +23,8 @@ include::modules/otel-extensions-jaegerremotesampling-extension.adoc[leveloffset
 
 include::modules/otel-extensions-pprof-extension.adoc[leveloffset=+1]
 
+include::modules/otel-extensions-googleauth-extension.adoc[leveloffset=+1]
+
 include::modules/otel-extensions-healthcheck-extension.adoc[leveloffset=+1]
 
 include::modules/otel-extensions-zpages-extension.adoc[leveloffset=+1]

--- a/observability/otel/otel-forwarding-telemetry-data.adoc
+++ b/observability/otel/otel-forwarding-telemetry-data.adoc
@@ -32,6 +32,7 @@ include::modules/otel-forwarding-data-to-google-managed-prometheus.adoc[leveloff
 .Additional resources
 * xref:../../observability/otel/otel-collector/otel-collector-processors.adoc#otel-collector-processors[Processors]
 * xref:../../observability/otel/otel-collector/otel-collector-extensions.adoc#otel-collector-extensions[Extensions]
+* https://docs.cloud.google.com/stackdriver/docs/managed-prometheus
 
 [role="_additional-resources"]
 [id="additional-resources_{context}"]

--- a/observability/otel/otel-forwarding-telemetry-data.adoc
+++ b/observability/otel/otel-forwarding-telemetry-data.adoc
@@ -29,6 +29,11 @@ include::modules/otel-forwarding-data-to-google-cloud.adoc[leveloffset=+1]
 include::modules/otel-forwarding-data-to-google-managed-prometheus.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+.Additional resources
+* xref:../../observability/otel/otel-collector/otel-collector-processors.adoc#otel-collector-processors[Processors]
+* xref:../../observability/otel/otel-collector/otel-collector-extensions.adoc#otel-collector-extensions[Extensions]
+
+[role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources
 * link:https://opentelemetry.io/docs/specs/otlp/[OpenTelemetry Protocol (OTLP)]

--- a/observability/otel/otel-forwarding-telemetry-data.adoc
+++ b/observability/otel/otel-forwarding-telemetry-data.adoc
@@ -26,6 +26,8 @@ include::modules/otel-forwarding-data-to-google-cloud.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../observability/otel/otel-collector/otel-collector-exporters.adoc#otel-collector-exporters[Exporters]
 
+include::modules/otel-forwarding-data-to-google-managed-prometheus.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

RHOSDT 3.9
OCP 4.12-4.21 (all supported OCP versions at the merge time)


Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/TRACING-5814

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

* GMP OTLP metrics ingestion user facing doc https://docs.google.com/document/d/1FCHI6Qwv5F522j2ajd6Nhoq8FRTPutoVYDMYgZqagcw/edit?tab=t.0
* https://docs.google.com/document/d/1-C2Fx9BV58t7iyEQhWItBzO_3vC3HAM0_5hEfYLCM4o/edit?tab=t.0
* sample https://github.com/GoogleCloudPlatform/opentelemetry-operator-sample/blob/main/recipes/host-and-kubelet-metrics/collector-config.yaml 

OTELcol 0.142.0

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CHANGELOG.md#-breaking-changes-
```
receiver/prometheus: Promote the receiver.prometheusreceiver.RemoveStartTimeAdjustment feature gate to stable and remove in-receiver metric start time adjustment in favor of the metricstarttime processor, including disabling the created-metric feature gate. (#44180) Previously, users could disable the RemoveStartTimeAdjustment feature gate to temporarily keep the legacy start time adjustment behavior in the Prometheus receiver. With this promotion to stable and bounded registration, that gate can no longer be disabled; the receiver will no longer set StartTime on metrics based on process_start_time_seconds, and users should migrate to the metricstarttime processor for equivalent functionality. This change also disables the receiver.prometheusreceiver.UseCreatedMetric feature gate, which previously used the <metric>_created series to derive start timestamps for counters, summaries, and histograms when scraping non OpenMetrics protocols. However, this does not mean that the _created series is always ignored: when using the OpenMetrics 1.0 protocol, Prometheus itself continues to interpret the _created series as the start timestamp, so only the receiver-side handling for other scrape protocols has been removed.
```