### PR TITLE
OSDOCS-15995 - Hiding content from ROSA HCP

### DIFF
--- a/web_console/customizing-the-web-console.adoc
+++ b/web_console/customizing-the-web-console.adoc
@@ -28,18 +28,18 @@ This is especially helpful if you need to tailor the web console to meet specifi
 include::modules/adding-a-custom-logo.adoc[leveloffset=+1]
 
 // Hiding in ROSA/OSD, as dedicated-admins cannot create resource "consolelinks"
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
 include::modules/creating-custom-links.adoc[leveloffset=+1]
 
 // Hiding in ROSA/OSD, as dedicated-admins cannot patch resource "ingresses"
 include::modules/customizing-the-web-console-URL.adoc[leveloffset=+1]
 
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
 
 // moved _Recognizing resource and project limits and quotas_ to modules/recognize-resource-limits-quotas.adoc in web-console.adoc
 
 // Hiding in ROSA/OSD, as dedicated-admins cannot create resource "secrets" in openshift-config
-ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]
 include::modules/customizing-the-login-page.adoc[leveloffset=+1]
 
 // Hiding in ROSA/OSD, as dedicated-admins cannot create resource "consoleexternalloglinks"
@@ -63,25 +63,16 @@ include::modules/odc-customizing-a-perspective-using-YAML-view.adoc[leveloffset=
 // Hiding in ROSA/OSD, as dedicated-admins do not have sufficient permissions to read any cluster configuration
 include::modules/odc-customizing-a-perspective-using-form-view.adoc[leveloffset=+2]
 
-endif::openshift-rosa,openshift-dedicated[]
-
 // Hiding in ROSA/OSD, as Hive overwrites changes to console config
-ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/odc_con_customizing-a-developer-catalog-or-its-sub-catalogs.adoc[leveloffset=+1]
 
-endif::openshift-rosa,openshift-dedicated[]
-
 // Hiding in ROSA/OSD, as Hive overwrites changes to console config
-ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-yaml-view.adoc[leveloffset=+2]
 
-endif::openshift-rosa,openshift-dedicated[]
-
 // Hiding in ROSA/OSD, as dedicated-admins do not have sufficient permissions to read any cluster configuration
-ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-form-view.adoc[leveloffset=+2]
 
 // Hiding in ROSA/OSD, as dedicated-admins cannot patch resource "consoles"
 include::modules/odc_con_example-yaml-file-changes.adoc[leveloffset=+3]
 
-endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-rosa-hcp,openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
[OSDOCS-15995](https://issues.redhat.com/browse/OSDOCS-15995) - Hiding web console content from ROSA HCP

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-15995

Link to docs preview:
https://104290--ocpdocs-pr.netlify.app/openshift-dedicated/latest/web_console/customizing-the-web-console.html
https://104290--ocpdocs-pr.netlify.app/openshift-enterprise/latest/web_console/customizing-the-web-console.html
https://104290--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/web_console/customizing-the-web-console.html
https://104290--ocpdocs-pr.netlify.app/openshift-rosa/latest/web_console/customizing-the-web-console.html

QE review:
N/A

Additional information:
