### PR TITLE
OCPBUGS 67311 MachineConfiguration nodeDisruptionPolicy can override mirror-removal policy

### DIFF
--- a/machine_configuration/machine-config-node-disruption.adoc
+++ b/machine_configuration/machine-config-node-disruption.adoc
@@ -47,6 +47,9 @@ For example, if you have a policy for the `/etc/` directory and a policy for the
 
 include::snippets/machine-config-node-disruption-actions.adoc[]
 
-include::modules/machine-config-node-disruption-example.adoc[leveloffset=+1]
+.Additional resources
 
+* xref:../machine_configuration/index.adoc#about-machine-config-operator_machine-config-overview[About the Machine Config Operator]
+
+include::modules/machine-config-node-disruption-example.adoc[leveloffset=+1]
 include::modules/machine-config-node-disruption-config.adoc[leveloffset=+1]

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -67,7 +67,7 @@ Note the following actions and how they affect node drain behavior:
 * If you create an IDMS or ICSP CR object, the MCO does not drain or reboot the node.
 * If you create an ITMS CR object, the MCO drains and reboots the node.
 ifndef::winc[]
-* If you delete an ITMS, IDMS, or ICSP CR object, the MCO drains and reboots the node.
+* If you delete an ITMS, IDMS, or ICSP CR object, the MCO drains and reboots the node, unless you create a node disruption policy to prevent the drain and reboot.
 * If you modify an ITMS, IDMS, or ICSP CR object, the MCO drains and reboots the node.
 +
 [IMPORTANT]

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -66,20 +66,29 @@ Note the following actions and how they affect node drain behavior:
 
 * If you create an IDMS or ICSP CR object, the MCO does not drain or reboot the node.
 * If you create an ITMS CR object, the MCO drains and reboots the node.
-ifndef::winc[]
+ifndef::winc,openshift-rosa,openshift-dedicated[]
 * If you delete an ITMS, IDMS, or ICSP CR object, the MCO drains and reboots the node, unless you create a node disruption policy to prevent the drain and reboot.
 * If you modify an ITMS, IDMS, or ICSP CR object, the MCO drains and reboots the node.
 +
 [IMPORTANT]
 ====
 include::snippets/node-icsp-no-drain.adoc[]
-
 ====
-endif::winc[]
+endif::winc,openshift-rosa,openshift-dedicated[]
 ifdef::winc[]
 * If you delete an ITMS or IDMS CR object, the MCO drains and reboots the node, unless you create a node disruption policy to prevent the drain and reboot.
 * If you modify an ITMS or IDMS CR object, the MCO drains and reboots the node.
 endif::winc[]
+
+ifdef::openshift-rosa,openshift-dedicated[]
+* If you delete an ITMS or IDMS CR object, the MCO drains and reboots the node.
+* If you modify an ITMS or IDMS CR object, the MCO drains and reboots the node.
++
+[IMPORTANT]
+====
+include::snippets/node-icsp-no-drain.adoc[]
+====
+endif::openshift-rosa,openshift-dedicated[]
 
 ifndef::winc[]
 For new clusters, you can use IDMS, ITMS, and ICSP CRs objects as needed. However, using IDMS and ITMS is recommended.

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * openshift_images/image-configuration.adoc
-// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
+// * disconnected/updating/disconnected-update.adoc
 // * windows_containers/enabling-windows-container-workloads.adoc
 
 ifeval::["{context}" == "enabling-windows-container-workloads"]
@@ -77,7 +77,7 @@ include::snippets/node-icsp-no-drain.adoc[]
 ====
 endif::winc[]
 ifdef::winc[]
-* If you delete an ITMS or IDMS CR object, the MCO drains and reboots the node.
+* If you delete an ITMS or IDMS CR object, the MCO drains and reboots the node, unless you create a node disruption policy to prevent the drain and reboot.
 * If you modify an ITMS or IDMS CR object, the MCO drains and reboots the node.
 endif::winc[]
 

--- a/modules/machine-config-node-drain.adoc
+++ b/modules/machine-config-node-drain.adoc
@@ -34,4 +34,4 @@ If the MCO drains pods on the master node, note the following conditions:
 In certain cases the nodes are not drained. For more information, see "About the Machine Config Operator."
 ====
 
-There are ways to mitigate the disruption caused by drain and reboot cycles by using node disruption policies or disabling control plane reboots. For more information, see "Understanding node restart behaviors after machine config changes" and "Disabling the Machine Config Operator from automatically rebooting."
+There are ways to mitigate the disruption caused by drain and reboot cycles by using node disruption policies or disabling control plane reboots. For more information, see "Using node disruption policies to minimize disruption from machine config changes" and "Disabling the Machine Config Operator from automatically rebooting."

--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -78,6 +78,6 @@ Tasks for the MCO configuration that can be done after installation are included
 
 include::snippets/node-icsp-no-drain.adoc[]
 
-In other cases, you can mitigate the disruption to your workload when the MCO makes changes by using _node disruption policies_. For information, see _Understanding node restart behaviors after machine config changes_.  
+In other cases, you can mitigate the disruption to your workload when the MCO makes changes by using _node disruption policies_. For information, see "Using node disruption policies to minimize disruption from machine config changes".  
 
 There might be situations where the configuration on a node does not fully match what the currently-applied machine config specifies. This state is called _configuration drift_. The Machine Config Daemon (MCD) regularly checks the nodes for configuration drift. If the MCD detects configuration drift, the MCO marks the node `degraded` until an administrator corrects the node configuration. A degraded node is online and operational, but, it cannot be updated. For more information on configuration drift, see _Understanding configuration drift detection_.

--- a/modules/understanding-machine-config-operator.adoc
+++ b/modules/understanding-machine-config-operator.adoc
@@ -44,7 +44,7 @@ When you perform node management operations, you create or modify a
 ====
 When changes are made to a machine configuration, the Machine Config Operator (MCO) automatically reboots all corresponding nodes in order for the changes to take effect.
 
-You can mitigate the disruption caused by some machine config changes by using a node disruption policy. See _Understanding node restart behaviors after machine config changes_.
+You can mitigate the disruption caused by some machine config changes by using a node disruption policy. See "Using node disruption policies to minimize disruption from machine config changes".
 
 Alternatively, you can prevent the nodes from automatically rebooting after machine configuration changes before making the changes. Pause the autoreboot process by setting the `spec.paused` field to `true` in the corresponding machine config pool. When paused, machine configuration changes are not applied until you set the `spec.paused` field to `false` and the nodes have rebooted into the new configuration.
 

--- a/openshift_images/image-configuration.adoc
+++ b/openshift_images/image-configuration.adoc
@@ -38,10 +38,12 @@ include::modules/images-configuration-cas.adoc[leveloffset=+2]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 

--- a/openshift_images/image-configuration.adoc
+++ b/openshift_images/image-configuration.adoc
@@ -38,6 +38,11 @@ include::modules/images-configuration-cas.adoc[leveloffset=+2]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes]
+
 include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 
 include::modules/images_configuring_registry_mirror_config_params.adoc[leveloffset=+2]

--- a/snippets/node-icsp-no-drain.adoc
+++ b/snippets/node-icsp-no-drain.adoc
@@ -12,8 +12,12 @@
 ** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
 ** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
 
-* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as editing an `ImageDigestMirrorSet`, `ImageTagMirrorSet`, or `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes. The node drain does not happen for the following changes:
-
+* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as editing or deleting an `ImageDigestMirrorSet`, `ImageTagMirrorSet`, or `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes. The node drain does not happen for the following changes:
++
+--
 ** The addition of a registry with the `pull-from-mirror = "digest-only"` parameter set for each mirror.
 ** The addition of a mirror with the `pull-from-mirror = "digest-only"` parameter set in a registry.
 ** The addition of items to the `unqualified-search-registries` list.
+--
++
+You can create a node disruption policy to prevent the MCO from the draining and rebooting nodes upon the deletion of these objects.

--- a/snippets/node-icsp-no-drain.adoc
+++ b/snippets/node-icsp-no-drain.adoc
@@ -12,6 +12,7 @@
 ** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
 ** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * When the MCO detects changes to the `/etc/containers/registries.conf` file, such as editing or deleting an `ImageDigestMirrorSet`, `ImageTagMirrorSet`, or `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes. The node drain does not happen for the following changes:
 +
 --
@@ -21,3 +22,12 @@
 --
 +
 You can create a node disruption policy to prevent the MCO from the draining and rebooting nodes upon the deletion of these objects.
+endif::openshift-rosa,openshift-dedicated[]
+
+ifdef::openshift-rosa,openshift-dedicated[]
+* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as editing or deleting an `ImageDigestMirrorSet`, `ImageTagMirrorSet`, or `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes. The node drain does not happen for the following changes:
+
+** The addition of a registry with the `pull-from-mirror = "digest-only"` parameter set for each mirror.
+** The addition of a mirror with the `pull-from-mirror = "digest-only"` parameter set in a registry.
+** The addition of items to the `unqualified-search-registries` list.
+endif::openshift-rosa,openshift-dedicated[]

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -72,6 +72,11 @@ include::modules/wmco-disconnected-cluster.adoc[leveloffset=+1]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes]
+
 include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -75,7 +75,7 @@ include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes]
+* xref:../machine_configuration/machine-config-node-disruption.adoc#machine-config-node-disruption[Using node disruption policies to minimize disruption from machine config changes]
 
 include::modules/images-configuration-registry-mirror-configuring.adoc[leveloffset=+2]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-67311

Link to docs preview:
* Machine configuration -> [Using node disruption policies to minimize disruption from machine config changes](https://104292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-config-node-disruption) -- Added link (before Example node disruption policies)
* Images ->  Image configuration resources -> [Understanding image registry repository mirroring](https://104292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-registry-mirror_image-configuration) -- Added to the _If you delete an ITMS, IDMS, or ICSP CR object_ bullet
* Disconnected environments -> Updating a cluster in a disconnected environment -> Updating a cluster in a disconnected environment without OSUS -> [Understanding  image registry repository mirroring](https://104292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/updating/disconnected-update#images-configuration-registry-mirror_updating-disconnected-cluster) -- Added to the _If you delete an ITMS, IDMS, or ICSP CR object_ bullet.
* Windows Container Support for OpenShift -> Enabling Windows container workloads -> [Understanding image registry repository mirroring](https://104292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads#images-configuration-registry-mirror_enabling-windows-container-workloads) -- Added to the _If you delete an ITMS, IDMS, or ICSP CR object_ bullet.
* Machine configuration -> Machine configuration overview -> [Understanding the Machine Config Operator node drain behavior](https://104292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#machine-config-node-drain_machine-config-overview) -- Added link (before Configuring image registry repository mirroring).
* Machine configuration -> Machine configuration overview -> About the Machine Config Operator -> [What can you change with machine configs?](https://104292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#what-can-you-change-with-machine-configs) -- Updated _For information_ reference in penultimate paragraph.
* Machine configuration -> Machine configuration overview -> [About the Machine Config Operator](https://104292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/index.html#about-machine-config-operator_machine-config-overview) -- Updated _For information_ reference in Important note. Added final sentence in Important note.
* Images -> [Image configuration resources](https://104292--ocpdocs-pr.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration) -- Added link (before _Configuring image registry repository mirroring_)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
