### PR TITLE
Oadp 7033 dita errors self service

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-cluster-admin-use-cases.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-cluster-admin-use-cases.adoc
@@ -6,11 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can use the Self-Service feature in the following scenarios:
-
-* Enable or disable {oadp-short} Self-Service.
-* Approve or reject the NABSL custom resource (CR).
-* Enforce template policies in the `DataProtectionApplication` (DPA) CR.
+[role="_abstract"]
+Configure and manage {oadp-short} Self-Service by enabling the feature, reviewing backup storage location requests, and enforcing policy templates. This helps you provide Self-Service backup capabilities while maintaining administrative control.
 
 include::modules/oadp-self-service-admin-enable-disable.adoc[leveloffset=+1]
 

--- a/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-namespace-admin-use-cases.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-namespace-admin-use-cases.adoc
@@ -6,12 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a namespace admin user, you can use the Self-Service feature in the following scenarios:
-
-* Create a backup storage location in your authorized namespace.
-* Create a `NonAdminBackup` (NAB) custom resource (CR).
-* Create a `NonAdminRestore` (NAR) CR.
-* Review NAB and NAR logs.
+[role="_abstract"]
+Use {oadp-short} Self-Service as a namespace administrator to create backup storage locations, perform backup and restore operations, and review operation logs for your authorized namespaces. This helps you to manage data protection independently without cluster admin access.
 
 include::modules/oadp-self-service-creating-nabsl.adoc[leveloffset=+1]
 

--- a/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-troubleshooting.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
  
-You can use the following sections to troubleshoot common errors when using {oadp-short} Self-Service.
+[role="_abstract"]
+Resolve common errors and issues when using {oadp-short} Self-Service by following troubleshooting procedures for backup storage locations and backup operations. This helps you quickly identify and fix problems independently.
 
 include::modules/oadp-self-service-troubleshoot-nabsl-same-ns.adoc[leveloffset=+1]
 

--- a/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{oadp-full} ({oadp-short}) 1.5.0 introduces a new feature named {oadp-short} Self-Service, enabling namespace admin users to back up and restore applications on {product-title}.
+[role="_abstract"]
+Use {oadp-short} Self-Service to enable namespace administrators to back up and restore their applications without cluster admin privileges. This helps you delegate backup operations while maintaining administrative control.
 
 include::modules/oadp-self-service-overview.adoc[leveloffset=+1]
 

--- a/modules/oadp-self-service-about-nabsl.adoc
+++ b/modules/oadp-self-service-about-nabsl.adoc
@@ -6,7 +6,8 @@
 [id="oadp-self-service-about-nabsl_{context}"]
 = About NonAdminBackupStorageLocation CR
 
-A namespace administrator can create a `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) to store the backup data.
+[role="_abstract"]
+Review the `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) workflows to understand how namespace administrators define backup storage locations through administrator creation, approval, or automatic processes. This helps you choose the appropriate workflow based on security requirements.
 
 To ensure that the NABSL CR is created and used securely, use cluster administrator controls. The cluster administrator manages the NABSL CR to comply with company policies, and compliance requirements.
 

--- a/modules/oadp-self-service-about-nadr.adoc
+++ b/modules/oadp-self-service-about-nadr.adoc
@@ -6,9 +6,10 @@
 [id="oadp-self-service-about-nadr_{context}"]
 = About NonAdminDownloadRequest CR
 
-As a namespace admin user, you can use the `NonAdminDownloadRequest` (NADR) custom resource (CR) to access detailed information about your backups and restores for troubleshooting. 
+[role="_abstract"]
+Review backup and restore logs by using the `NonAdminDownloadRequest` (NADR) custom resource (CR). This helps you troubleshoot backup and restore issues without cluster administrator assistance. 
 
-This CR provides information that is equivalent to what a cluster administrator can access by using the `velero backup describe --details` command.
+The NADR CR provides information that is equivalent to what a cluster administrator can access by using the `velero backup describe --details` command.
 
 After the NADR CR request is validated, a secure download URL is generated to access the requested information.
 

--- a/modules/oadp-self-service-admin-enable-disable.adoc
+++ b/modules/oadp-self-service-admin-enable-disable.adoc
@@ -6,15 +6,13 @@
 [id="oadp-self-service-admin-enable-disable_{context}"]
 = Enabling and disabling {oadp-short} Self-Service
 
-You must be a cluster administrator to enable the {oadp-short} Self-Service feature. You can use the `spec.nonAdmin.enable` section of the `DataProtectionApplication` (DPA) custom resource (CR) to enable and disable the Self-Service feature. 
-
-Enabling the Self-Service feature installs the `NonAdminController` (NAC) CR in the {oadp-short} Operator namespace.
+[role="_abstract"]
+Enable or disable the {oadp-short} Self-Service feature to allow namespace administrators to manage their own backup and restore operations without cluster admin privileges. This helps you delegate backup responsibilities while maintaining administrative control.
 
 [NOTE]
 ====
 You can install only one instance of the `NonAdminController` (NAC) CR in the cluster. If you install multiple instances of the NAC CR, you get the following error:
 
-.Example error
 [source,terminal]
 ----
 message: only a single instance of Non-Admin Controller can be installed across the entire cluster. Non-Admin controller is already configured and installed in openshift-adp namespace.
@@ -50,8 +48,8 @@ spec:
         - openshift
         - csi
       defaultSnapshotMoveData: true
-  nonAdmin: # <1>
-    enable: true # <2>
+  nonAdmin:
+    enable: true
   backupLocations:
     - velero:
         config:
@@ -69,8 +67,11 @@ spec:
           bucket: <bucket_name> 
           prefix: oadp  
 ----
-<1> Add the `nonAdmin.enable` section in the `spec` section of the DPA.
-<2> Set the `enable` field to `true`. To disable the Self-Service feature, set the `enable` field to `false`.
++
+where:
++
+`nonAdmin`:: Specifies the section in the `spec` section of the DPA to enable or disable the Self-Service feature.
+`enable`:: Specifies whether to enable the Self-Service feature. Set to `true` to enable the feature. Set to `false` to disable the feature.
 
 .Verification
 
@@ -82,7 +83,6 @@ $ oc get pod -n openshift-adp -l control-plane=non-admin-controller
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 NAME                                  READY   STATUS    RESTARTS   AGE

--- a/modules/oadp-self-service-admin-spec-enforce-nab.adoc
+++ b/modules/oadp-self-service-admin-spec-enforce-nab.adoc
@@ -6,7 +6,10 @@
 [id="oadp-self-service-admin-spec-enforce-nab_{context}"]
 = Self-Service administrator spec enforcement for NAB
 
-As a cluster administrator, you can enforce the following fields for a `NonAdminBackup` (NAB) CR:
+[role="_abstract"]
+Enforce specific fields in `NonAdminBackup` (NAB) custom resource (CR) to control timeout settings, resource policies, label selectors, snapshot configurations, and time-to-live values used by namespace administrators. This helps you maintain backup standards.
+
+You can enforce the following fields for a NAB CR:
 
 * `csiSnapshotTimeout`
 * `itemOperationTimeout`
@@ -36,12 +39,15 @@ kind: DataProtectionApplication
 spec:
   nonAdmin:
     enable: true
-    enforceBackupSpec: # <1>
-      snapshotMoveData: true # <2>
-      ttl: 158h0m0s # <3>
+    enforceBackupSpec:
+      snapshotMoveData: true
+      ttl: 158h0m0s
 ----
-<1> Add the `enforceBackupSpec` section.
-<2> Enforce Data Mover by setting the `snapshotMoveData` field to `true`. 
-<3> Enforce the `ttl` value by setting the field to `158h0m0s`.
+
+where:
+
+`enforceBackupSpec`:: Specifies the section to enforce policies for the `NonAdminBackup` CR.
+`snapshotMoveData`:: Specifies whether to enforce Data Mover. Set to `true` to enforce Data Mover backups.
+`ttl`:: Specifies the time-to-live value to enforce for backups. In this example, it is set to `158h0m0s`.
 
 When a namespace admin user creates a NAB CR, they must follow the template set up in the DPA. Otherwise, the `status.phase` field on the NAB CR is set to `BackingOff` and the NAB CR fails to create.

--- a/modules/oadp-self-service-admin-spec-enforce-nabsl.adoc
+++ b/modules/oadp-self-service-admin-spec-enforce-nabsl.adoc
@@ -6,7 +6,10 @@
 [id="oadp-self-service-admin-spec-enforce-nabsl_{context}"]
 = Self-Service administrator spec enforcement for NABSL
 
-As a cluster administrator, you can enforce the following fields for a `NonAdminBackupStorageLocation` (NABSL) custom resource (CR):
+[role="_abstract"]
+Enforce specific fields in `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) to control storage bucket, credentials, configuration, access mode, and validation settings used by namespace administrators. This helps you maintain organizational policies.
+
+You can enforce the following fields for a NABSL:
 
 * `objectStorage`
 * `credential`
@@ -25,18 +28,21 @@ kind: DataProtectionApplication
 spec:
   nonAdmin:
     enable: true
-    enforceBSLSpec: # <1>
-      config: # <2>
+    enforceBSLSpec:
+      config:
         checksumAlgorithm: ""
         profile: default
         region: us-west-2
-      objectStorage: # <3>
+      objectStorage:
         bucket: my-company-bucket
-        prefix: velero 
+        prefix: velero
       provider: aws  
 ----
-<1> Add the `enforceBSLSpec` section.
-<2> Enforce the `config` section of a NABSL to use an {aws-short} S3 bucket in the `us-west-2` region. 
-<3> Enforce the `objectStorage` section of a NABSL to use a company bucket named `my-company-bucket`.
+
+where:
+
+`enforceBSLSpec`:: Specifies the section to enforce policies for the `NonAdminBackupStorageLocation` CR.
+`config`:: Specifies the configuration to enforce for the NABSL. In this example, it enforces the use of an {aws-short} S3 bucket in the `us-west-2` region.
+`objectStorage`:: Specifies the object storage settings to use a company bucket named `my-company-bucket`.
 
 When a namespace admin user creates a NABSL, they must follow the template set up in the DPA. Otherwise, the `status.phase` field on the NABSL CR is set to `BackingOff` and the NABSL fails to create.

--- a/modules/oadp-self-service-admin-spec-enforce-nar.adoc
+++ b/modules/oadp-self-service-admin-spec-enforce-nar.adoc
@@ -6,7 +6,10 @@
 [id="oadp-self-service-admin-spec-enforce-nar_{context}"]
 = Self-Service administrator spec enforcement for NAR
 
-As a cluster administrator, you can enforce the following fields for a `NonAdminRestore` (NAR) custom resource (CR):
+[role="_abstract"]
+Enforce specific fields in `NonAdminRestore` (NAR) custom resource (CR) to control timeout settings, resource policies, label selectors, persistent volume restoration, and node port configurations used by namespace administrators. This helps you maintain restore standards.
+
+You can enforce the following fields for a NAR CR:
 
 * `itemOperationTimeout`
 * `uploaderConfig`

--- a/modules/oadp-self-service-admin-spec-enforcement.adoc
+++ b/modules/oadp-self-service-admin-spec-enforcement.adoc
@@ -6,7 +6,8 @@
 [id="oadp-self-service-admin-spec-enforcement_{context}"]
 = {oadp-short} Self-Service administrator DPA spec enforcement
 
-As a cluster administrator, you can enforce policies in the `DataProtectionApplication` (DPA) spec template. The spec enforcement applies to Self-Service custom resources (CRs) such as `NonAdminBackup`, `NonAdminRestore`, and `NonAdminBackupStorageLocation`. 
+[role="_abstract"]
+Enforce policy templates in the `DataProtectionApplication` (DPA) custom resource (CR) to control `NonAdminBackup`, `NonAdminRestore`, and `NonAdminBackupStorageLocation` custom resources created by namespace administrators. This helps you maintain compliance standards. 
 
 The cluster administrator can enforce a company, or a compliance policy by using the following fields in the `DataProtectionApplication` (DPA) CR:
 

--- a/modules/oadp-self-service-approving-nabsl.adoc
+++ b/modules/oadp-self-service-approving-nabsl.adoc
@@ -6,7 +6,8 @@
 [id="oadp-self-service-approving-nabsl_{context}"]
 = Approving a NonAdminBackupStorageLocation request
 
-As a cluster administrator, to approve a `NonAdminBackupStorageLocation` (NABSL) CR request, you can edit the `NonAdminBackupStorageLocationRequest` CR and set the `approvalDecision` field to `approve`.
+[role="_abstract"]
+Approve `NonAdminBackupStorageLocation` (NABSL) custom resource requests from namespace administrators to grant access to their specified backup storage locations. This enables self-service backup and restore operations for namespace resources.
 
 .Prerequisites
 
@@ -38,9 +39,9 @@ non-admin-bsl-test-.....5e0   Pending         non-admin-bsl-test    waitingappro
 +
 [source,terminal]
 ----
-$ oc patch nabslrequest <nabsl_name> -n openshift-adp --type=merge -p '{"spec": {"approvalDecision": "approve"}}' # <1>
+$ oc patch nabslrequest <nabsl_name> -n openshift-adp --type=merge -p '{"spec": {"approvalDecision": "approve"}}'
 ----
-<1> Specify the name of the `NonAdminBackupStorageLocationRequest` CR.
+Replace `<nabsl_name>` with the name of the `NonAdminBackupStorageLocationRequest` CR.
 
 
 .Verification

--- a/modules/oadp-self-service-components.adoc
+++ b/modules/oadp-self-service-components.adoc
@@ -6,6 +6,9 @@
 [id="oadp-self-service-custom-resources_{context}"]
 = {oadp-short} Self-Service custom resources
 
+[role="_abstract"]
+Use {oadp-short} Self-Service custom resources to control backup, restore, storage location, and download operations for namespace-scoped applications. This provides namespace administrators with self-service data protection tools.
+
 The {oadp-short} Self-Service feature has the following new custom resources (CRs) to perform the backup and restore operations for a namespace admin user:
 
 .Custom resources

--- a/modules/oadp-self-service-creating-nab.adoc
+++ b/modules/oadp-self-service-creating-nab.adoc
@@ -6,7 +6,8 @@
 [id="oadp-self-service-creating-nab_{context}"]
 = Creating a NonAdminBackup CR
 
-As a namespace admin user, you can create a `NonAdminBackup` (NAB) custom resource (CR) to back up your application from your authorized namespace. NAB is an {product-title} CR that securely facilitates the creation of a `Velero` backup object. The `Velero` backup object reports the status back to the NAB CR that ultimately updates the `status.phase` field.
+[role="_abstract"]
+Create a `NonAdminBackup` (NAB) custom resource (CR) to back up application resources in your authorized namespace. This helps you to protect your application data and configuration without requiring cluster administrator privileges.
 
 After you create a NAB CR, the CR undergoes the following phases:
 
@@ -37,25 +38,28 @@ Review the following important points when creating a NAB CR:
 apiVersion: oadp.openshift.io/v1alpha1
 kind: NonAdminBackup
 metadata:
-  name: test-nab # <1>
+  name: test-nab
 spec:
   backupSpec:
-    defaultVolumesToFsBackup: true # <2>
-    snapshotMoveData: false # <3>
-    storageLocation: test-bsl # <4>
+    defaultVolumesToFsBackup: true
+    snapshotMoveData: false
+    storageLocation: test-bsl
 ----
-<1> Specify a name for the NAB CR, for example, `test-nab`.
-<2> To use File System Backup (FSB), set `defaultVolumesToFsBackup` to `true`.
-<3> If you want to backup your data volumes by using the Data Mover, set the `snapshotMoveData` to `true`. This example uses the FSB for backup.
-<4> Optionally, set a NABSL CR as a storage location. If you do not set a `storageLocation`, then the default backup storage location configured in the DPA is used.
++
+where:
+
+`name`:: Specifies a name for the NAB CR. For example, `test-nab`.
+`defaultVolumesToFsBackup`:: Specifies whether to use File System Backup (FSB). Set to `true` to use FSB.
+`snapshotMoveData`:: Specifies whether to back up data volumes by using the Data Mover. Set to `true` to use Data Mover. This example uses FSB for backup.
+`storageLocation`:: Specifies a NABSL CR as a storage location. If you do not set a `storageLocation`, then the default backup storage location configured in the DPA is used.
 
 . To apply the NAB CR configuration, run the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f <nab_cr_filename> # <1>
+$ oc apply -f <nab_cr_filename>
 ----
-<1> Specify the file name containing the NAB CR configuration.
+Replace `<nab_cr_filename>` with the file name containing the NAB CR configuration.
 
 .Verification
 
@@ -67,8 +71,6 @@ $ oc get nab test-nab -o yaml
 ----
 +
 .Example output
-
-+
 [source,yaml]
 ----
 apiVersion: oadp.openshift.io/v1alpha1
@@ -78,8 +80,8 @@ metadata:
   finalizers:
   - nonadminbackup.oadp.openshift.io/finalizer
   generation: 2
-  name: test-nab 
-  namespace: test-nac-ns # <1>
+  name: test-nab
+  namespace: test-nac-ns
   resourceVersion: "134316"
   uid: c5...4c8a8
 spec:
@@ -94,7 +96,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "202...56Z"
-    message: backup accepted # <2>
+    message: backup accepted
     reason: BackupAccepted
     status: "True"
     type: Accepted
@@ -104,15 +106,15 @@ status:
     status: "True"
     type: Queued
   dataMoverDataUploads: {}
-  fileSystemPodVolumeBackups: # <3>
+  fileSystemPodVolumeBackups:
     completed: 2
     total: 2
-  phase: Created # <4>
+  phase: Created
   queueInfo:
-    estimatedQueuePosition: 0 # <5>
+    estimatedQueuePosition: 0
   veleroBackup:
-    nacuuid: test-nac-test-nab-d2...a9b14 # <6>
-    name: test-nac-test-nab-d2...b14 # <7>
+    nacuuid: test-nac-test-nab-d2...a9b14
+    name: test-nac-test-nab-d2...b14
     namespace: openshift-adp
     spec:
       csiSnapshotTimeout: 10m0s
@@ -136,12 +138,12 @@ status:
       snapshotMoveData: false
       storageLocation: test-nac-test-bsl-bf..02b70a
       ttl: 720h0m0s
-    status: # <8>
+    status:
       completionTimestamp: "2025-0..3:13Z"
       expiration: "2025..2:56Z"
       formatVersion: 1.1.0
       hookStatus: {}
-      phase: Completed # <9>
+      phase: Completed
       progress:
         itemsBackedUp: 46
         totalItems: 46
@@ -149,12 +151,15 @@ status:
       version: 1
       warnings: 1
 ----
-<1> The namespace name that the `NonAdminController` CR sets on the `Velero` backup object to back up.
-<2> The NAC has reconciled and validated the NAB CR and has created the `Velero` backup object.
-<3> The `fileSystemPodVolumeBackups` field indicates the number of volumes that are backed up by using FSB.
-<4> The NAB CR is in the `Created` phase.
-<5> This field indicates the queue position of the backup object. There can be multiple backups in process, and each backup object is assigned a queue position. When the backup is complete, the queue position is set to `0`.
-<6> The NAC creates the `Velero` backup object and sets the value for the `nacuuid` field.
-<7> The name of the associated `Velero` backup object.
-<8> The status of the `Velero` backup object.
-<9> The `Velero` backup object is in the `Completed` phase and the backup is successful.
++
+where:
+
+`namespace`:: Specifies the namespace name that the `NonAdminController` CR sets on the `Velero` backup object to back up.
+`message: backup accepted`:: Specifies that the NAC has reconciled and validated the NAB CR and has created the `Velero` backup object.
+`fileSystemPodVolumeBackups`:: Specifies the number of volumes that are backed up by using FSB.
+`phase: Created`:: Specifies that the NAB CR is in the `Created` phase.
+`estimatedQueuePosition`:: Specifies the queue position of the backup object. There can be multiple backups in process, and each backup object is assigned a queue position. When the backup is complete, the queue position is set to `0`.
+`nacuuid`:: Specifies that the NAC creates the `Velero` backup object and sets the value for the `nacuuid` field.
+`name`:: Specifies the name of the associated `Velero` backup object.
+`status`:: Specifies the status of the `Velero` backup object.
+`phase: Completed`:: Specifies that the `Velero` backup object is in the `Completed` phase and the backup is successful.

--- a/modules/oadp-self-service-creating-nabsl.adoc
+++ b/modules/oadp-self-service-creating-nabsl.adoc
@@ -6,7 +6,8 @@
 [id="oadp-self-service-creating-nabsl_{context}"]
 = Creating a NonAdminBackupStorageLocation CR
 
-You can create a `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) in your authorized namespace. After the cluster administrator approves the NABSL CR request, you can use the NABSL CR in the `NonAdminBackup` CR spec.
+[role="_abstract"]
+Create a `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) to define backup storage locations in your authorized namespace. With this feature, you can store backups in a cloud storage that meets your application requirements.
 
 .Prerequisites
 
@@ -21,9 +22,14 @@ You can create a `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) in
 +
 [source,terminal]
 ----
-$ oc create secret generic cloud-credentials -n test-nac-ns --from-file <cloud_key_name>=<cloud_credentials_file> # <1>
+$ oc create secret generic cloud-credentials -n test-nac-ns --from-file <cloud_key_name>=<cloud_credentials_file>
 ----
-<1> In this example, the `Secret` name is `cloud-credentials` and the authorized namespace name is `test-nac-ns`. Replace `<cloud_key_name>` and `<cloud_credentials_file>` with your cloud key name and the cloud credentials file name, respectively.
++
+where:
++
+`<cloud_key_name>`:: Specifies the cloud provider key name. In this example, the `Secret` name is `cloud-credentials` and the authorized namespace name is `test-nac-ns`.
+
+`<cloud_credentials_file>`:: Specifies the cloud credentials file name.
 
 . To create a `NonAdminBackupStorageLocation` CR, create a YAML manifest file with the following configuration:
 +
@@ -34,31 +40,36 @@ apiVersion: oadp.openshift.io/v1alpha1
 kind: NonAdminBackupStorageLocation
 metadata:
   name: test-nabsl 
-  namespace: test-nac-ns # <1>
-spec: 
+  namespace: test-nac-ns
+spec:
   backupStorageLocationSpec:
     config:
       profile: default
-      region: <region_name> # <2>
+      region: <region_name>
     credential:
       key: cloud
       name: cloud-credentials
     objectStorage:
-      bucket: <bucket_name> # <3>
+      bucket: <bucket_name>
       prefix: velero
-    provider: aws  
+    provider: aws
 ----
-<1> Specify the namespace you are authorized to operate from. For example, `test-nac-ns`.
-<2> Replace `<region_name>` with a region name.
-<3> Replace `<bucket_name>` with a bucket name.
++
+where:
++
+`namespace`:: Specifies the namespace you are authorized to operate from. For example, `test-nac-ns`.
+`<region_name>`:: Specifies the region name for your cloud provider.
+`<bucket_name>`:: Specifies the bucket name for storing backups.
 
++
 . To apply the NABSL CR configuration, run the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f <nabsl_cr_filename> # <1>
+$ oc apply -f <nabsl_cr_filename>
 ----
-<1> Replace `<nabsl_cr_filename>` with the file name containing the NABSL CR configuration.
++
+Replace `<nabsl_cr_filename>` with the file name containing the NABSL CR configuration.
 
 
 .Verification
@@ -71,7 +82,6 @@ $ oc get nabsl test-nabsl -o yaml
 ----
 +
 .Example output
-
 [source,yaml]
 ----
 apiVersion: oadp.openshift.io/v1alpha1
@@ -85,18 +95,21 @@ status:
     status: "True"
     type: Accepted
   - lastTransitionTime: "2025-02-26T09:07:15Z"
-    message: NonAdminBackupStorageLocationRequest approval pending # <1>
+    message: NonAdminBackupStorageLocationRequest approval pending
     reason: BslSpecApprovalPending
     status: "False"
     type: ClusterAdminApproved
-  phase: New # <2>
+  phase: New
   veleroBackupStorageLocation:
     nacuuid: test-nac-test-bsl-c...d4389a1930
     name: test-nac-test-bsl-cd....1930
     namespace: openshift-adp
 ----
-<1> Defines that the `status.conditions.message` field contains the `NonAdminBackupStorageLocationRequest approval pending` message .
-<2> Defines that the status of a phase is `New`.
++
+where:
+
+`message`:: Contains the `NonAdminBackupStorageLocationRequest approval pending` message.
+`phase`:: Specifies the status of the phase. In this example, the phase is `New`.
 
 . After the cluster administrator approves the `NonAdminBackupStorageLocationRequest` CR request, verify that the NABSL CR is successfully created by running the following command:
 +
@@ -106,8 +119,6 @@ $ oc get nabsl test-nabsl -o yaml
 ----
 +
 .Example output
-
-+
 [source,yaml]
 ----
 apiVersion: oadp.openshift.io/v1alpha1
@@ -133,33 +144,36 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025-02-19T09:30:34Z"
-    message: NonAdminBackupStorageLocation spec validation successful # <1>
+    message: NonAdminBackupStorageLocation spec validation successful
     reason: BslSpecValidation
     status: "True"
     type: Accepted
   - lastTransitionTime: "2025-02-19T09:30:34Z"
-    message: Secret successfully created in the OADP namespace # <2>
+    message: Secret successfully created in the OADP namespace
     reason: SecretCreated
     status: "True"
     type: SecretSynced
   - lastTransitionTime: "2025-02-19T09:30:34Z"
-    message: BackupStorageLocation successfully created in the OADP namespace # <3>
+    message: BackupStorageLocation successfully created in the OADP namespace
     reason: BackupStorageLocationCreated
     status: "True"
     type: BackupStorageLocationSynced
   phase: Created
   veleroBackupStorageLocation:
-    nacuuid: test-nac-..f933a-4ec1-4f6a-8099-ee...b8b26 # <4>
-    name: test-nac-test-nabsl-36...11ab8b26 # <5>
+    nacuuid: test-nac-..f933a-4ec1-4f6a-8099-ee...b8b26
+    name: test-nac-test-nabsl-36...11ab8b26
     namespace: openshift-adp
     status:
       lastSyncedTime: "2025-02-19T11:47:10Z"
       lastValidationTime: "2025-02-19T11:47:31Z"
-      phase: Available # <6>
+      phase: Available
 ----
-<1> The NABSL `spec` is validated and approved by the cluster administrator.
-<2> The `secret` object is successfully created in the `openshift-adp` namespace.
-<3> The associated `Velero` `BackupStorageLocation` is successfully created in the `openshift-adp` namespace.
-<4> The `nacuuid` NAC is orchestrating the NABSL CR.
-<5> The name of the associated `Velero` backup storage location object.
-<6> The `Available` phase indicates that the NABSL is ready for use.
++
+where:
+
+`message: NonAdminBackupStorageLocation spec validation successful`:: Specifies that the NABSL `spec` is validated and approved by the cluster administrator.
+`message: Secret successfully created in the OADP namespace`:: Specifies that the `secret` object is successfully created in the `openshift-adp` namespace.
+`message: BackupStorageLocation successfully created in the OADP namespace`:: Specifies that the associated `Velero` `BackupStorageLocation` is successfully created in the `openshift-adp` namespace.
+`nacuuid`:: Specifies the NAC that is orchestrating the NABSL CR.
+`name`:: Specifies the name of the associated `Velero` backup storage location object.
+`phase: Available`:: Specifies that the NABSL is ready for use.

--- a/modules/oadp-self-service-creating-nar.adoc
+++ b/modules/oadp-self-service-creating-nar.adoc
@@ -6,7 +6,8 @@
 [id="oadp-self-service-creating-nar_{context}"]
 = Creating a NonAdminRestore CR
 
-As a namespace admin user, to restore a backup, you can create a `NonAdminRestore` (NAR) custom resource (CR). The backup is restored to your authorized namespace.
+[role="_abstract"]
+Create a `NonAdminRestore` (NAR) custom resource (CR) to restore application resources from a backup to your authorized namespace. This provides an ability to recover your application data and configuration without requiring cluster administrator privileges.
 
 .Prerequisites
 
@@ -26,21 +27,24 @@ As a namespace admin user, to restore a backup, you can create a `NonAdminRestor
 apiVersion: oadp.openshift.io/v1alpha1
 kind: NonAdminRestore
 metadata:
-  name: test-nar # <1>
+  name: test-nar
 spec:
   restoreSpec:
-    backupName: test-nab # <2>
+    backupName: test-nab
 ----
-<1> Defines a name for the NAR CR, for example, `test-nar`.
-<2> Defines the name of the NAB CR you want to restore from. For example, `test-nab`.
++
+where:
+
+`name`:: Specifies a name for the NAR CR. For example, `test-nar`.
+`backupName`:: Specifies the name of the NAB CR you want to restore from. For example, `test-nab`.
 
 . To apply the NAR CR configuration, run the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f <nar_cr_filename> # <1>
+$ oc apply -f <nar_cr_filename>
 ----
-<1> Replace `<nar_cr_filename>` with the file name containing the NAR CR configuration.
+Replace `<nar_cr_filename>` with the file name containing the NAR CR configuration.
 
 .Verification
 
@@ -52,8 +56,6 @@ $ oc get nar test-nar -o yaml
 ----
 +
 .Example output
-
-+
 [source,yaml]
 ----
 apiVersion: oadp.openshift.io/v1alpha1
@@ -75,7 +77,7 @@ spec:
 status:
   conditions:
   - lastTransitionTime: "2025..15Z"
-    message: restore accepted # <1>
+    message: restore accepted
     reason: RestoreAccepted
     status: "True"
     type: Accepted
@@ -85,30 +87,33 @@ status:
     status: "True"
     type: Queued
   dataMoverDataDownloads: {}
-  fileSystemPodVolumeRestores: # <2>
+  fileSystemPodVolumeRestores:
     completed: 2
     total: 2
-  phase: Created # <3>
+  phase: Created
   queueInfo:
-    estimatedQueuePosition: 0 # <4>
+    estimatedQueuePosition: 0
   veleroRestore:
-    nacuuid: test-nac-test-nar-c...1ba # <5>
-    name: test-nac-test-nar-c7...1ba # <6>
+    nacuuid: test-nac-test-nar-c...1ba
+    name: test-nac-test-nar-c7...1ba
     namespace: openshift-adp
     status:
       completionTimestamp: "2025...22:44Z"
       hookStatus: {}
-      phase: Completed # <7>
+      phase: Completed
       progress:
         itemsRestored: 28
         totalItems: 28
       startTimestamp: "2025..15Z"
       warnings: 7
 ----
-<1> The `NonAdminController` (NAC) CR has reconciled and validated the NAR CR.
-<2> The `fileSystemPodVolumeRestores` field indicates the number of volumes that are restored.
-<3> The NAR CR is in the `Created` phase.
-<4> This field indicates the queue position of the restore object. There can be multiple restores in process, and each restore is assigned a queue position. When the restore is complete, the queue position is set to `0`.
-<5> The NAC creates the `Velero` restore object and sets the value as `nacuuid`.
-<6> The name of the associated `Velero` restore object.
-<7> The `Velero` restore object is in the `Completed` phase and the restore is successful.
++
+where:
+
+`message: restore accepted`:: Specifies that the `NonAdminController` (NAC) CR has reconciled and validated the NAR CR.
+`fileSystemPodVolumeRestores`:: Specifies the number of volumes that are restored.
+`phase: Created`:: Specifies that the NAR CR is in the `Created` phase.
+`estimatedQueuePosition`:: Specifies the queue position of the restore object. There can be multiple restores in process, and each restore is assigned a queue position. When the restore is complete, the queue position is set to `0`.
+`nacuuid`:: Specifies that the NAC creates the `Velero` restore object and sets the `nacuuid` value.
+`name`:: Specifies the name of the associated `Velero` restore object.
+`phase: Completed`:: Specifies that the `Velero` restore object is in the `Completed` phase and the restore is successful.

--- a/modules/oadp-self-service-enabling-nabsl-approval.adoc
+++ b/modules/oadp-self-service-enabling-nabsl-approval.adoc
@@ -6,9 +6,8 @@
 [id="oadp-self-service-enabling-nabsl-approval_{context}"]
 = Enabling NonAdminBackupStorageLocation administrator approval workflow
 
-The `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) administrator approval workflow is an opt-in feature. As a cluster administrator, you must explicitly enable the feature in the `DataProtectionApplication` (DPA) CR by setting the `nonAdmin.requireApprovalForBSL` field to `true`.
-
-You also need to set the `noDefaultBackupLocation` field in the DPA CR to `true`. This setting indicates that, there is no default backup storage location configured in the DPA CR and the namespace admin user can create a NABSL CR and send the CR request for approval.
+[role="_abstract"]
+Enable the administrator approval workflow for `NonAdminBackupStorageLocation` custom resource to review backup storage location requests from namespace administrators before they are applied. This helps you maintain control over backup storage configurations.
 
 .Prerequisites
 
@@ -38,10 +37,13 @@ spec:
         - aws
         - openshift
         - csi
-      noDefaultBackupLocation: true # <1>
+      noDefaultBackupLocation: true
   nonAdmin:
     enable: true
-    requireApprovalForBSL: true # <2> 
+    requireApprovalForBSL: true 
 ----
-<1> Add the `noDefaultBackupLocation` field and set it to `true`.
-<2> Add the `requireApprovalForBSL` field and set it to `true`.
++
+where:
++
+`noDefaultBackupLocation`:: Specifies that there is no default backup storage location configured in the DPA CR. Set to `true` to enable the namespace admin user to create a NABSL CR and send the CR request for approval.
+`requireApprovalForBSL`:: Specifies whether the NABSL administrator approval workflow is enabled. Set to `true` to enable the approval workflow.

--- a/modules/oadp-self-service-how-it-works.adoc
+++ b/modules/oadp-self-service-how-it-works.adoc
@@ -6,7 +6,10 @@
 [id="oadp-self-service-how-it-works_{context}"]
 = How {oadp-short} Self-Service works
 
-The following diagram describes how {oadp-short} Self-Service works at a high level. The diagram describes the following workflow:
+[role="_abstract"]
+Review how {oadp-short} Self-Service processes backup requests through the `NonAdminController` (NAC) custom resource, which validates namespace administrator requests and creates corresponding `Velero` backup objects.
+
+The diagram describes the following workflow:
 
 . A namespace admin user creates a `NonAdminBackup` (NAB) custom resource (CR) request.
 . The `NonAdminController` (NAC) CR receives the NAB CR request.

--- a/modules/oadp-self-service-nab-nar-logs.adoc
+++ b/modules/oadp-self-service-nab-nar-logs.adoc
@@ -6,7 +6,8 @@
 [id="oadp-self-service-nab-nar-logs_{context}"]
 = Reviewing NAB and NAR logs
 
-As a namespace admin user, you can review the logs for the `NonAdminBackup` (NAB) and `NonAdminRestore` (NAR) custom resources (CRs) by creating a `NonAdminDownloadRequest` (NADR) CR.
+[role="_abstract"]
+Create a `NonAdminDownloadRequest` (NADR) custom resource (CR) to access and review detailed logs for `NonAdminBackup` (NAB) and `NonAdminRestore` (NAR) operations. This helps you troubleshoot backup and restore issues independently.
 
 [NOTE]
 ====
@@ -35,13 +36,16 @@ metadata:
   name: test-nadr-backup
 spec:
   target:
-    kind: BackupLog # <1>
-    name: test-nab # <2>
+    kind: BackupLog
+    name: test-nab
 ----
-<1> Specify `BackupLog` as the value for the `kind` field of the NADR CR.
-<2> Specify the name of the NAB CR.
++
+where:
 
-. Verify that the NADR CR is processed by running the following command.
+`kind`:: Specifies `BackupLog` as the value for the `kind` field of the NADR CR.
+`name`:: Specifies the name of the NAB CR.
+
+. Verify that the NADR CR is processed by running the following command:
 +
 [source,terminal]
 ----
@@ -75,12 +79,15 @@ status:
   phase: Created
   velero:
     status:
-      downloadURL: https://... # <1>
+      downloadURL: https://...
       expiration: "202...22Z"
-      phase: Processed # <2>
+      phase: Processed
 ----
-<1> The `status.downloadURL` field contains the download URL of the NAB logs. You can use the `downloadURL` to download and review the NAB logs.
-<2> The `status.phase` is `Processed`.
++
+where:
+
+`downloadURL`:: The `status.downloadURL` field contains the download URL of the NAB logs. You can use the `downloadURL` to download and review the NAB logs.
+`phase`:: The `status.phase` is `Processed`.
 
 . Download and analyze the backup information by using the `status.downloadURL` URL.
 
@@ -95,13 +102,16 @@ metadata:
   name: test-nadr-restore
 spec:
   target:
-    kind: RestoreLog # <1>
-    name: test-nar # <2>
+    kind: RestoreLog
+    name: test-nar
 ----
-<1> Specify `RestoreLog` as the value for the `kind` field of the NADR CR.
-<2> Defines the name of the NAR CR.
++
+where:
 
-. Verify that the NADR CR is processed by running the following command.
+`kind`:: Specifies `RestoreLog` as the value for the `kind` field of the NADR CR.
+`name`:: Specifies the name of the NAR CR.
+
+. Verify that the NADR CR is processed by running the following command:
 +
 [source,terminal]
 ----
@@ -135,12 +145,14 @@ status:
   phase: Created
   velero:
     status:
-      downloadURL: https://... # <1>
+      downloadURL: https://...
       expiration: "202..:01Z"
-      phase: Processed # <2>
-
+      phase: Processed
 ----
-<1> The `status.downloadURL` field contains the download URL of the NAR logs. You can use the `downloadURL` to download and review the NAR logs.
-<2> The `status.phase` is `Processed`.
++
+where:
+
+`downloadURL`:: The `status.downloadURL` field contains the download URL of the NAR logs. You can use the `downloadURL` to download and review the NAR logs.
+`phase`:: The `status.phase` is `Processed`.
 
 . Download and analyze the restore information by using the `status.downloadURL` URL.

--- a/modules/oadp-self-service-namespace-permissions.adoc
+++ b/modules/oadp-self-service-namespace-permissions.adoc
@@ -6,7 +6,10 @@
 [id="oadp-self-service-namespace-permissions_{context}"]
 = {oadp-short} Self-Service namespace permissions
 
-As a cluster administrator, ensure that a namespace admin user has editor roles assigned for the following list of objects in their namespace. These objects ensure that a namespace admin user can perform the backup and restore operations in their namespace.
+[role="_abstract"]
+Assign namespace permissions to namespace administrators to create and manage backup, restore, and storage location resources in their assigned namespaces. This grants namespace administrators the required access for Self-Service data protection operations.
+
+As a cluster administrator, ensure that a namespace admin user has editor roles assigned for the following list of objects in their namespace.
 
 * `nonadminbackups.oadp.openshift.io`
 * `nonadminbackupstoragelocations.oadp.openshift.io`

--- a/modules/oadp-self-service-namespace-scoped.adoc
+++ b/modules/oadp-self-service-namespace-scoped.adoc
@@ -6,6 +6,7 @@
 [id="oadp-self-service-overview-namespace-scope_{context}"]
 = What namespace-scoped backup and restore means
 
+[role="_abstract"]
 {oadp-short} Self-Service ensures that namespace admin users can only operate within their authorized namespace. For example, if you do not have access to a namespace, as a namespace admin user, you cannot back up that namespace.
 
 A namespace admin user cannot access backup and restore data of other users.

--- a/modules/oadp-self-service-overview.adoc
+++ b/modules/oadp-self-service-overview.adoc
@@ -6,6 +6,7 @@
 [id="oadp-self-service-overview_{context}"]
 = About {oadp-short} Self-Service
 
+[role="_abstract"]
 From {oadp-short} 1.5.0 onward, you do not need the `cluster-admin` role to perform the backup and restore operations. You can use {oadp-short} with the namespace `admin` role. The namespace `admin` role has administrator access only to the namespace the user is assigned to.
 
 You can use the Self-Service feature only after the cluster administrator installs the {oadp-short} Operator and provides the necessary permissions.

--- a/modules/oadp-self-service-phases.adoc
+++ b/modules/oadp-self-service-phases.adoc
@@ -6,7 +6,8 @@
 [id="oadp-self-service-phases_{context}"]
 = {oadp-short} Self-Service backup and restore phases
 
-The `status.phase` field of a `NonAdminBackup` (NAB) custom resource (CR) and a `NonAdminRestore` (NAR) CR provide an overview of the current state of the CRs. Review the values for the NAB and NAR phases in the following table.
+[role="_abstract"]
+Review the status phases of `NonAdminBackup` (NAB) and `NonAdminRestore` (NAR) custom resources to track the progress and state of backup and restore operations. This helps you monitor and troubleshoot Self-Service backup and restore requests.
 
 The phase of the CRs only progress forward. Once a phase transitions to the next phase, it cannot revert to a previous phase.
 

--- a/modules/oadp-self-service-prerequisites.adoc
+++ b/modules/oadp-self-service-prerequisites.adoc
@@ -6,7 +6,8 @@
 [id="oadp-self-service-prerequisites_{context}"]
 = {oadp-short} Self-Service prerequisites
 
-Before you start using {oadp-short} Self-Service as a namespace `admin` user, ensure you meet the following prerequisites:
+[role="_abstract"]
+Configure your cluster environment to enable {oadp-short} Self-Service backup and restore operations by meeting the following prerequisites. This helps namespace administrators perform data protection tasks in their assigned namespaces.
 
 * The cluster administrator has configured the {oadp-short} `DataProtectionApplication` (DPA) CR to enable Self-Service. 
 * The cluster administrator has completed the following tasks:

--- a/modules/oadp-self-service-rejecting-nabsl.adoc
+++ b/modules/oadp-self-service-rejecting-nabsl.adoc
@@ -6,7 +6,8 @@
 [id="oadp-self-service-rejecting-nabsl_{context}"]
 = Rejecting a NonAdminBackupStorageLocation request
 
-As a cluster administrator, to reject a `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) request, you can edit the `NonAdminBackupStorageLocationRequest` CR and set the `approvalDecision` field to `reject`.
+[role="_abstract"]
+Reject `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) requests from namespace administrators to deny access to backup storage locations that do not meet requirements. This helps you maintain security and compliance standards.
 
 .Prerequisites
 
@@ -40,6 +41,6 @@ non-admin-bsl-test-.....5e0   Pending         non-admin-bsl-test    waitingappro
 +
 [source,terminal]
 ----
-$ oc patch nabslrequest <nabsl_name> -n openshift-adp --type=merge -p '{"spec": {"approvalDecision": "reject"}}' # <1>
+$ oc patch nabslrequest <nabsl_name> -n openshift-adp --type=merge -p '{"spec": {"approvalDecision": "reject"}}'
 ----
-<1> Specify the name of the `NonAdminBackupStorageLocationRequest` CR.
+Replace `<nabsl_name>` with the name of the `NonAdminBackupStorageLocationRequest` CR.

--- a/modules/oadp-self-service-troubleshoot-nabsl-default.adoc
+++ b/modules/oadp-self-service-troubleshoot-nabsl-default.adoc
@@ -2,49 +2,43 @@
 //
 // backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-troubleshooting.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 [id="oadp-self-service-troubleshoot-nabsl-default_{context}"]
-= NonAdminBackupStorageLocation cannot be set as default
+= Resolving error NonAdminBackupStorageLocation cannot be set as default
 
-As a non-admin user, if you have created a `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) in your authorized namespace, you cannot set the NABSL CR as the default backup storage location.
+[role="_abstract"]
+Resolve the error that occurs when you set a `NonAdminBackupStorageLocation` (NABSL) custom resource (CR) as the default backup storage location. This helps you resolve validation errors and configure backup storage locations correctly.
 
-In such a scenario, the NABSL CR fails to validate and the `NonAdminController` (NAC) gives an error message.
+As a non-admin user, if you have created a NABSL CR in your authorized namespace, you cannot set the NABSL CR as the default backup storage location.
 
-.Example NABSL error
+If you set the NABSL CR as the default backup storage location, the NABSL CR fails to validate and the `NonAdminController` (NAC) gives an error message.
 
+[source,text]
+----
+NonAdminBackupStorageLocation cannot be used as a default BSL
+---- 
+
+.Procedure
+
+* To successfully validate and reconcile the NABSL CR, set the `default` field to `false` in the NABSL CR:
++
 [source, yaml]
 ----
 apiVersion: oadp.openshift.io/v1alpha1
 kind: NonAdminBackupStorageLocation
-metadata:
-  creationTimestamp: "20...:03Z"
-  generation: 1
-  name: nabsl1
-  namespace: test-nac-1
-  resourceVersion: "11...9"
-  uid: 8d2fc....c9b6c4401
+...
 spec:
   backupStorageLocationSpec:
     credential:
       key: cloud
       name: cloud-credentials-gcp
-    default: true # <1>
+    default: false
     objectStorage:
       bucket: oad..7l8
       prefix: velero
     provider: gcp
-status:
-  conditions:
-  - lastTransitionTime: "20...:27:03Z"
-    message: NonAdminBackupStorageLocation cannot be used as a default BSL # <2>
-    reason: BslSpecValidation
-    status: "False"
-    type: Accepted
-  phase: BackingOff
 ----
-<1> The value of the `default` field is set to `true`.
-<2> The error message reported by NAC.
++
+where:
 
-.Solution
-
-To successfully validate and reconcile the NABSL CR, ensure that the `default` field is set to `false` in the NABSL CR.
+`default` :: Specifies that the `default` backup storage location is set to `false`.

--- a/modules/oadp-self-service-troubleshoot-nabsl-same-ns.adoc
+++ b/modules/oadp-self-service-troubleshoot-nabsl-same-ns.adoc
@@ -2,25 +2,19 @@
 //
 // backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-troubleshooting.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 [id="oadp-self-service-troubleshoot-nabsl-same-ns_{context}"]
-= Error NonAdminBackupStorageLocation not found in the namespace
+= Resolving error NonAdminBackupStorageLocation not found in the namespace
+
+[role="_abstract"]
+Resolve the `NonAdminBackupStorageLocation not found in the namespace` error by using a backup storage location that belongs to the same namespace as your backup. This helps ensure successful backup operations.
 
 Consider the following scenario of a namespace `admin` backup:
 
 * You have created two `NonAdminBackupStorageLocations` (NABLs) custom resources (CRs) in two different namespaces, for example, `nabsl-1` in `namespace-1` and `nabsl-2` in `namespace-2`.
 * You are taking a backup of `namespace-1` and use `nabsl-2` in the `NonAdminBackup` (NAB) CR.
 
-In this scenario, after creating the NAB CR, you get the following error:
-
-[source,text]
-----
-NonAdminBackupStorageLocation not found in the namespace: NonAdminBackupStorageLocation.oadp.openshift.io
----- 
-
-The cause of the error is that the NABSL CR does not belong to the namespace that you are trying to back up. 
-
-.Error
+In this scenario, after creating the NAB CR, you get the following error. The cause of the error is that the NABSL CR does not belong to the namespace that you are trying to back up. 
 
 [source, yaml]
 ----
@@ -38,9 +32,9 @@ status:
   phase: BackingOff
 ----
 
-.Solution
+.Procedure
 
-Use the NABSL that belongs to the same namespace that you are trying to back up. 
-
+* Use the NABSL that belongs to the same namespace that you are trying to back up. 
++
 In this scenario, you must use `nabsl-1` in the NAB CR to back up `namespace-1`.
  

--- a/modules/oadp-self-service-unsupported-features.adoc
+++ b/modules/oadp-self-service-unsupported-features.adoc
@@ -6,6 +6,9 @@
 [id="oadp-self-service-unsupported-features_{context}"]
 = {oadp-short} Self-Service limitations
 
+[role="_abstract"]
+Review the limitations and unsupported features of {oadp-short} Self-Service to understand which operations are restricted for namespace administrators. This helps you plan appropriate backup and restore strategies within the supported functionality.
+
 The following features are not supported by {oadp-short} Self-Service:
 
 * Cross cluster backup and restore, or migrations are not supported. These {oadp-short} operations are supported for the cluster administrator.


### PR DESCRIPTION
## Jira 

* [OADP-7033](https://issues.redhat.com/browse/OADP-7033)

Fix callouts and DITA errors for OADP self-service

##  Version

* OCP 4.19, 4.20, 4.21

## Preview

*  [Self-Service](https://104314--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service.html)
* [Self-Service cluster admin](https://104314--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-cluster-admin-use-cases.html)
* [Self-Service namespace admin](https://104314--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-namespace-admin-use-cases.html)
* [Self-Service troubleshooting](https://104314--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-self-service/oadp-self-service-troubleshooting.html)

## QE Review

* No content changes. By-passing QE review
