### PR TITLE
OBSDOCS-2968 Warning for UWM pods on infra nodes - fix tags

### DIFF
--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -17,23 +17,23 @@
 // end::UWM[]
 
 [role="_abstract"]
-// tag::CPM[]
-To specify the nodes in your cluster on which monitoring stack components will run, configure the `nodeSelector` constraint for the components in the `cluster-monitoring-config` config map to match labels assigned to the nodes.
+ifndef::openshift-dedicated,openshift-rosa[]
+To specify the nodes in your cluster on which monitoring stack components will run, configure the `nodeSelector` constraint for the components in the `{configmap-name}` config map to match labels assigned to the nodes.
 
 [NOTE]
 ====
 You cannot add a node selector constraint directly to an existing scheduled pod.
 ====
-// end::CPM[]
+endif::openshift-dedicated,openshift-rosa[]
 
-// tag::UWM[]
+ifdef::openshift-dedicated,openshift-rosa[]
 You can move any of the components that monitor workloads for user-defined projects to specific worker nodes. 
 
 [WARNING]
 ====
 It is not permitted to move components to control plane or infrastructure nodes.
 ====
-// end::UWM[]
+endif::openshift-dedicated,openshift-rosa[]
 
 .Prerequisites
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2968
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

* Core platform monitoring: https://104315--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-core-platform-monitoring/configuring-performance-and-scalability.html#moving-monitoring-components-to-different-nodes_configuring-performance-and-scalability
* UWM: https://104315--ocpdocs-pr.netlify.app/openshift-monitoring/latest/configuring-user-workload-monitoring/configuring-performance-and-scalability-uwm.html#moving-monitoring-components-to-different-nodes_configuring-performance-and-scalability-uwm
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

By accident, I have previously added this note:
```
It is not permitted to move components to control plane or infrastructure nodes.
```
to the UWM section, although it was only relevant for rosa and osd distros. This PR fixes that issue.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
