### PR TITLE
OSDOCS-16989_3#AWS_prep

### DIFF
--- a/installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc
+++ b/installing/installing_aws/ipi/ipi-aws-preparing-to-install.adoc
@@ -15,7 +15,7 @@ The following list outlines in detail the steps to prepare to install an {produc
 
 * Verifying internet connectivity for your cluster.
 
-* xref:../../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an aws-short} account].
+* xref:../../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an {aws-short} account].
 
 * Downloading the installation program.
 +

--- a/modules/installation-aws-permissions-iam-roles.adoc
+++ b/modules/installation-aws-permissions-iam-roles.adoc
@@ -7,13 +7,13 @@
 = Default permissions for IAM instance profiles
 
 [role="_abstract"]
-By default, the installation program creates IAM instance profiles for the bootstrap, control plane and worker instances with the necessary permissions for the cluster to operate.
+To ensure your cluster operates with the correct security permissions in {product-title}, review the default IAM instance profiles created by the installation program.
+
+By default, the installation program creates IAM instance profiles for the bootstrap, control plane, and compute instances with the necessary permissions for the cluster to operate.
 
 The following lists specify the default permissions for control plane and compute machines:
 
 .Default IAM role permissions for control plane instance profiles
-[%collapsible]
-====
 * `ec2:AttachVolume`
 * `ec2:AuthorizeSecurityGroupIngress`
 * `ec2:CreateSecurityGroup`
@@ -52,11 +52,7 @@ The following lists specify the default permissions for control plane and comput
 * `elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer`
 * `elasticloadbalancing:SetLoadBalancerPoliciesOfListener`
 * `kms:DescribeKey`
-====
 
 .Default IAM role permissions for compute instance profiles
-[%collapsible]
-====
 * `ec2:DescribeInstances`
 * `ec2:DescribeRegions`
-====

--- a/modules/installation-three-node-cluster-cloud-provider.adoc
+++ b/modules/installation-three-node-cluster-cloud-provider.adoc
@@ -91,6 +91,8 @@ endif::vsphere[]
 
 
 ifndef::nutanix,openstack[]
++
+--
 .Example `cluster-scheduler-02-config.yml` file for a three-node cluster
 [source,yaml]
 ----
@@ -105,6 +107,7 @@ spec:
     name: ""
 status: {}
 ----
+--
 endif::nutanix,openstack[]
 
 ifeval::["{context}" == "installing-aws-three-node"]

--- a/modules/nw-endpoint-route53.adoc
+++ b/modules/nw-endpoint-route53.adoc
@@ -7,7 +7,9 @@
 = Ingress Operator endpoint configuration for {aws-short} Route 53
 
 [role="_abstract"]
-If you install in either {aws-first} GovCloud (US) US-West or US-East region, the Ingress Operator uses `us-gov-west-1` region for Route53 and tagging API clients.
+Configure Ingress Operator endpoints for {product-title} clusters in {aws-first} GovCloud (US) regions. Verifying these settings helps to ensure that your cluster connects to the correct API endpoints.
+
+If you install in either {aws-short} GovCloud (US) US-West or US-East region, the Ingress Operator uses `us-gov-west-1` region for Route53 and tagging API clients.
 
 The Ingress Operator uses `https://tagging.us-gov-west-1.amazonaws.com` as the tagging API endpoint if a tagging custom endpoint is configured that includes the string 'us-gov-east-1'.
 
@@ -34,8 +36,9 @@ platform:
     - name: tagging
       url: https://tagging.us-gov-west-1.amazonaws.com
 ----
-+
+++
 where:
+++
 
 `https://route53.us-gov.amazonaws.com`:: Defaults to `https://route53.us-gov.amazonaws.com` for both {aws-short} GovCloud (US) regions.
 `https://tagging.us-gov-west-1.amazonaws.com`:: Only the US-West region has endpoints for tagging. Omit this parameter if your cluster is in another region.


### PR DESCRIPTION
Versions:
4.16+


Issue:
https://issues.redhat.com/browse/OSDOCS-16989

Link to docs preview:
[Preparing to install a cluster on AWS](https://104332--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/ipi/ipi-aws-preparing-to-install)
[Default permissions for IAM instance profiles](https://104332--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions-iam-roles_installing-aws-account)
[Configuring a three-node cluster](https://104332--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-three-node#installation-three-node-cluster_installing-aws-three-node)
[Ingress Operator endpoint configuration for AWS Route 53](https://104332--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account#nw-endpoint-route53_installing-aws-account)

QE review:
No content changes, so QE approval is not required.

Additional information:
This PR applies small fixes identified in the final review of https://github.com/openshift/openshift-docs/pull/103257.
