### PR TITLE
Update documentation for External Secrets Operator

### DIFF
--- a/modules/eso-external-secrets-list.adoc
+++ b/modules/eso-external-secrets-list.adoc
@@ -25,7 +25,7 @@ The `externalSecretsConfigList` object fetches the list of `externalSecretsConfi
 
 | `kind`
 | _string_
-| `kind` specifies the type of the object, which is `externalSecretsList` for this API.
+| `kind` specifies the type of the object, which is `externalSecretsConfigList` for this API.
 |
 |
 
@@ -37,7 +37,7 @@ The `externalSecretsConfigList` object fetches the list of `externalSecretsConfi
 
 | `items`
 | _array_
-| `Items` contains a list of `externalSecrets` objects.
+| `Items` contains a list of `externalSecretsConfig` objects.
 |
 |
 |===

--- a/modules/eso-external-secrets.adoc
+++ b/modules/eso-external-secrets.adoc
@@ -27,7 +27,7 @@ Creating an `externalSecretsConfig` object triggers the deployment of the `exter
 
 | `kind`
 | _string_
-| `kind` specifies the type of the object, which is `externalSecrets` for this object.
+| `kind` specifies the type of the object, which is `externalSecretsConfig` for this object.
 |
 |
 
@@ -39,13 +39,13 @@ Creating an `externalSecretsConfig` object triggers the deployment of the `exter
 
 | `spec`
 | _object_
-| `spec` contains the specifications of the desired behavior of the `externalSecrets` object.
+| `spec` contains the specifications of the desired behavior of the `externalSecretsConfig` object.
 |
 |
 
 | `status`
 | _object_
-| `status` displays the most recently observed status of the `externalSecrets` object.
+| `status` displays the most recently observed status of the `externalSecretsConfig` object.
 |
 |
 

--- a/modules/external-secrets-operand-install-cli.adoc
+++ b/modules/external-secrets-operand-install-cli.adoc
@@ -14,27 +14,25 @@ You can use the command-line interface (CLI) to install the External Secrets ope
 
 .Procedure
 
-. Create a `externalsecrets.openshift.operator.io` object by defining a YAML file with the following content:
+. Create an `externalsecretsconfig.operator.openshift.io` object by defining a YAML file with the following content:
 +
-.Example `externalsecrets.yaml` file
+.Example `externalsecretsconfig.yaml` file
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1alpha1
-kind: ExternalSecrets
+kind: ExternalSecretsConfig
 metadata:
-  labels:
-    app.kubernetes.io/name: external-secrets-operator
   name: cluster
 spec: {}
 ----
 +
 For more information on spec configuration, see "External Secrets Operator for Red Hat OpenShift APIs".
 
-. Create the `externalsecrets.openshift.operator.io` object by running the following command:
+. Create the `externalsecretsconfig.operator.openshift.io` object by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f externalsecrets.yaml
+$ oc create -f externalsecretsconfig.yaml
 ----
 
 .Verification
@@ -59,7 +57,7 @@ external-secrets-webhook-b566658ff-7m4d5            1/1     Running   0         
 +
 [source,terminal]
 ----
-$ oc get externalsecrets.operator.openshift.io cluster -n external-secrets-operator -o jsonpath='{.status.conditions}' | jq .
+$ oc get externalsecretsconfigs.operator.openshift.io cluster -o jsonpath='{.status.conditions}' | jq .
 ----
 +
 .Example output

--- a/modules/external-secrets-operator-install-cli.adoc
+++ b/modules/external-secrets-operator-install-cli.adoc
@@ -53,7 +53,7 @@ metadata:
   name: openshift-external-secrets-operator
   namespace: external-secrets-operator
 spec:
-  channel: tech-preview-v0.1
+  channel: stable-v1
   name: openshift-external-secrets-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
@@ -79,8 +79,8 @@ $ oc get subscription -n external-secrets-operator
 .Example output
 [source,terminal]
 ----
-NAME                                  PACKAGE                               SOURCE          CHANNEL
-openshift-external-secrets-operator   openshift-external-secrets-operator   eso-010-index   tech-preview-v0.1
+NAME                                  PACKAGE                               SOURCE             CHANNEL
+openshift-external-secrets-operator   openshift-external-secrets-operator   redhat-operators   stable-v1
 ----
 
 . Verify whether the Operator is successfully installed by running the following command:
@@ -94,7 +94,7 @@ $ oc get csv -n external-secrets-operator
 [source,terminal]
 ----
 NAME                               DISPLAY                                           VERSION   REPLACES   PHASE
-external-secrets-operator.v0.1.0   External Secrets Operator for Red Hat OpenShift   0.1.0                Succeeded
+external-secrets-operator.v1.0.0   External Secrets Operator for Red Hat OpenShift   1.0.0                Succeeded
 ----
 
 . Verify that the status of the {external-secrets-operator-short} is Running by entering the following command:

--- a/modules/external-secrets-operator-install-console.adoc
+++ b/modules/external-secrets-operator-install-console.adoc
@@ -29,7 +29,7 @@ You can use the web console to install the {external-secrets-operator}.
 //====
 . On the *Install Operator* page:
 
-.. Update the *Update channel*, if necessary. The channel defaults to *tech-preview-v0.1*, which installs the latest stable release of the {external-secrets-operator-short}.
+.. Update the *Update channel*, if necessary. The channel defaults to *stable-v1*, which installs the latest stable release of the {external-secrets-operator-short}.
 
 .. Select the version from *Version* drop-down list.
 


### PR DESCRIPTION
Update documentation for External Secrets Operator: corrected object names and updated installation instructions to reflect changes from `externalSecrets` to `externalSecretsConfig`, and modified the update channel from `tech-preview-v0.1` to `stable-v1`.

Version(s):
4.20
