### PR TITLE
Remove wrong hypen for allow-external-secrets-egress in external-secrets-operator documentation

### DIFF
--- a/modules/external-secrets-operator-egress-specific-provider.adoc
+++ b/modules/external-secrets-operator-egress-specific-provider.adoc
@@ -41,7 +41,7 @@ spec:
           - ports:
               - port: 443   # HTTPS (AWS Secrets Manager)
                 protocol: TCP
-      - name: allow-external-secrets-egress
+        name: allow-external-secrets-egress
 ----
 +
 where:


### PR DESCRIPTION
Version(s):
4.20

