### PR TITLE
OSDOCS-17574:Update the z-stream RNs for 4.15.60

### DIFF
--- a/modules/zstream-4-15-60-about.adoc
+++ b/modules/zstream-4-15-60-about.adoc
@@ -1,0 +1,22 @@
+
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-15-60-about_{context}"]
+= RHBA-2026:23114 - {product-title} {product-version}.60 bug fix advisory
+
+[role="_abstract"]
+Issued: 07 January 2026
+
+{product-title} release {product-version}.60 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:23114[RHBA-2026:23114] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:23112[RHBA-2025:23112] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.60--pullspecs
+----

--- a/modules/zstream-4-15-60-bug-fixes.adoc
+++ b/modules/zstream-4-15-60-bug-fixes.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-15-60-bug-fixes_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issues are fixed with this release:
+
+* Before this update, the router incorrectly assumed that only `SHA1` leaf certificates were rejected by HAProxy. As a consequence, the router failed because it also rejected `SHA1` intermediate certificates. With this release, the router inspects all non-self-signed certificates and rejects any certificates that use `SHA1`. As a result, the router no longer fails. (link:https://issues.redhat.com/browse/OCPBUGS-49392[OCPBUGS-49392])
+
+* Before this update, the `/auth/error` page did not render correctly. As a consequence, the page was empty and error details did not appear. With this release, the front end error page content now renders on the `/auth/error` page. As a result, the expected error content is displayed. (link:https://issues.redhat.com/browse/OCPBUGS-65601[OCPBUGS-65601])
+
+* Before this update, a recent regression in `runc` prevented the successful start of pods when the `shareProcessNamespace` parameter was set to `true`. With this release, a subsequent update to `runc` corrects the regression.  (link:https://issues.redhat.com/browse/OCPBUGS-65979[OCPBUGS-65979])

--- a/modules/zstream-4-15-60-updating.adoc
+++ b/modules/zstream-4-15-60-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-15-60-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2812,6 +2812,15 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//  4.15.60 about
+include::modules/zstream-4-15-60-about.adoc[leveloffset=+2]
+
+//4.15.60 bug fixes
+include::modules/zstream-4-15-60-bug-fixes.adoc[leveloffset=+2]
+
+//4.15.60 bug fixes
+include::modules/zstream-4-15-60-updating.adoc[leveloffset=+2]
+
 // 4.15.59
 [id="ocp-4-15-59_{context}"]
 === RHSA-2025:19306 - {product-title} 4.15.59 bug fix and security update


### PR DESCRIPTION
Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-17574

Link to docs preview:
https://104363--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#zstream-4-15-60-about_release-notes

Additional information:
4.15.60 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/274
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.15
