### PR TITLE
[DOCS] Update OSSM metrics docs for using PodMonitor

### DIFF
--- a/modules/ossm-config-openshift-monitoring-ambient-mode.adoc
+++ b/modules/ossm-config-openshift-monitoring-ambient-mode.adoc
@@ -21,27 +21,19 @@ You can enable user workload monitoring by applying the `ConfigMap` change for m
 
 .Procedure
 
-. Create a `Service` resource to define a port that uses the metrics exposed by the ztunnel, similar to the following example:
-
+. Create a `Telemetry` resource in the {istio} control plane namespace to ensure that Prometheus is a metrics provider, similar to the following example:
 +
 [source,yaml]
 ----
-apiVersion: v1
-kind: Service
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
 metadata:
-  name: ztunnel
-  namespace: ztunnel
-  labels:
-    app: ztunnel
-    service: ztunnel
+  name: enable-prometheus-metrics
+  namespace: istio-system
 spec:
-  selector:
-    app: ztunnel
-  ports:
-    - name: http-monitoring
-      protocol: TCP
-      port: 15020
-      targetPort: 15020
+  metrics:
+  - providers:
+    - name: prometheus
 ----
 
 . Create a `ServiceMonitor` resource that monitors the {istio} control plane, similar to the following example:
@@ -64,39 +56,79 @@ spec:
     interval: 30s
 ----
 
-. Create a `ServiceMonitor` resource that collects the ztunnel metrics, similar to the following example:
+. Create a `PodMonitor` resource in the `ztunnel` namespace for collecting the ztunnel metrics, similar to the following example:
 +
 [source,yaml]
 ----
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
-  name: ztunnel-monitor
+  name: istio-ztunnel-monitor
   namespace: ztunnel
 spec:
-  targetLabels:
-  - app
   selector:
-    matchLabels:
-      service: ztunnel
-  endpoints:
-  - port: http-monitoring
+    matchExpressions:
+    - key: istio-prometheus-ignore
+      operator: DoesNotExist
+  podMetricsEndpoints:
+  - path: /stats/prometheus
     interval: 30s
+    relabelings:
+    - action: keep
+      sourceLabels: [__meta_kubernetes_pod_container_name]
+      regex: "istio-proxy"
+    - action: keep
+      sourceLabels: [__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape]
+    - action: replace
+      regex: (\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+      replacement: '[\$2]:\$1'
+      sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+      targetLabel: __address__
+    - action: replace
+      regex: (\\d+);((([0-9]+?)(\.|$)){4})
+      replacement: \$2:\$1
+      sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+      targetLabel: __address__
+    # Set the 'app' label from 'app.kubernetes.io/name' or fallback to 'app'
+    - sourceLabels: ["__meta_kubernetes_pod_label_app_kubernetes_io_name", "__meta_kubernetes_pod_label_app"]
+      separator: ";"
+      targetLabel: "app"
+      action: replace
+      regex: "(.+);.*|.*;(.+)"
+      replacement: "\${1}\${2}"  # Use the first non-empty value
+    # Set the 'version' label from 'app.kubernetes.io/version' or fallback to 'version'
+    - sourceLabels: ["__meta_kubernetes_pod_label_app_kubernetes_io_version", "__meta_kubernetes_pod_label_version"]
+      separator: ";"
+      targetLabel: "version"
+      action: replace
+      regex: "(.+);.*|.*;(.+)"
+      replacement: "\${1}\${2}"  # Use the first non-empty value
+    # additional labels
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - action: replace
+      replacement: "mesh_id"
+      targetLabel: mesh_id
 ----
++
+where:
+
+`mesh_id`:: Specify the actual mesh ID.
+`\\d+`:: The additional backslash is only used when you apply this replacement from a command line via heredoc. If you apply this from a yaml file, replace `\\d+` with `\d+`.
+`\$`:: The backslash is only used when you apply this replacement from a command line via heredoc. If you apply this from a yaml file, replace `\$` with `$`.
 
 . Optional: Deploy a waypoint proxy to enable the Layer 7 (L7) {SMProduct} features in ambient mode:
 
-.. Deploy a custom waypoint proxy with additional labels and ports for the `bookinfo` namespace, similar to the following example:
+.. Deploy a waypoint proxy for the `bookinfo` namespace, similar to the following example:
 +
 [source,yaml]
 ----
- apiVersion: gateway.networking.k8s.io/v1
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   labels:
     istio.io/waypoint-for: service
-    app: waypoint
-    service: waypoint
   name: waypoint
   namespace: bookinfo
 spec:
@@ -105,11 +137,7 @@ spec:
   - name: mesh
     port: 15008
     protocol: HBONE
-  - name: http-monitoring
-    protocol: TCP
-    port: 15020
 ----
-`<http-monitoring>`:: Specifies an additional port that exposes the metrics used by the waypoint proxy.
 
 .. Enroll the namespace to use the waypoint by running the following command:
 +
@@ -118,25 +146,68 @@ spec:
 $ oc label namespace bookinfo istio.io/use-waypoint=waypoint
 ----
 
-.. Create a `ServiceMonitor` resource that collects the waypoint proxy metrics for the `bookinfo` namespace, similar to the following example:
+.. Create a `PodMonitor` resource for collecting waypoint proxies metrics in an application namespace such as `bookinfo`, similar to the following example:
 +
 [source,yaml]
 ----
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
-  name: waypoint-monitor
+  name: istio-waypoint-monitor
   namespace: bookinfo
 spec:
-  targetLabels:
-  - app
   selector:
-    matchLabels:
-      service: waypoint
-  endpoints:
-  - port: http-monitoring
+    matchExpressions:
+    - key: istio-prometheus-ignore
+      operator: DoesNotExist
+  podMetricsEndpoints:
+  - path: /stats/prometheus
     interval: 30s
+    relabelings:
+    - action: keep
+      sourceLabels: [__meta_kubernetes_pod_container_name]
+      regex: "istio-proxy"
+    - action: keep
+      sourceLabels: [__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape]
+    - action: replace
+      regex: (\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+      replacement: '[\$2]:\$1'
+      sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+      targetLabel: __address__
+    - action: replace
+      regex: (\\d+);((([0-9]+?)(\.|$)){4})
+      replacement: \$2:\$1
+      sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+      targetLabel: __address__
+    # Set the 'app' label from 'app.kubernetes.io/name' or fallback to 'app'
+    - sourceLabels: ["__meta_kubernetes_pod_label_app_kubernetes_io_name", "__meta_kubernetes_pod_label_app"]
+      separator: ";"
+      targetLabel: "app"
+      action: replace
+      regex: "(.+);.*|.*;(.+)"
+      replacement: "\${1}\${2}"  # Use the first non-empty value
+    # Set the 'version' label from 'app.kubernetes.io/version' or fallback to 'version'
+    - sourceLabels: ["__meta_kubernetes_pod_label_app_kubernetes_io_version", "__meta_kubernetes_pod_label_version"]
+      separator: ";"
+      targetLabel: "version"
+      action: replace
+      regex: "(.+);.*|.*;(.+)"
+      replacement: "\${1}\${2}"  # Use the first non-empty value
+    # additional labels
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - action: replace
+      replacement: "mesh_id"
+      targetLabel: mesh_id
 ----
++
+where:
+
+`mesh_id`:: Specify the actual mesh ID.
+`\\d+`:: The additional backslash is only used when you apply this replacement from a command line via heredoc. If you apply this from a yaml file, replace `\\d+` with `\d+`.
+`\$`:: The backslash is only used when you apply this replacement from a command line via heredoc. If you apply this from a yaml file, replace `\$` with `$`.
+
 +
 [NOTE]
 ====

--- a/modules/ossm-config-openshift-monitoring-only.adoc
+++ b/modules/ossm-config-openshift-monitoring-only.adoc
@@ -22,6 +22,21 @@ You can enable user-workload monitoring by applying the `ConfigMap` change for m
 
 .Procedure
 
+. Create a `Telemetry` resource in the {istio} control plane namespace to ensure that Prometheus is a metrics provider, similar to the following example:
++
+[source,yaml]
+----
+apiVersion: telemetry.istio.io/v1
+kind: Telemetry
+metadata:
+  name: enable-prometheus-metrics
+  namespace: istio-system
+spec:
+  metrics:
+  - providers:
+    - name: prometheus
+----
+
 . Create a `ServiceMonitor` resource that monitors the {istio} control plane, similar to the following example:
 +
 [source,yaml]
@@ -42,7 +57,70 @@ spec:
     interval: 30s
 ----
 
-. To validate that the `ServiceMonitor` resource is monitoring the {istio} control plane, go to the {ocp-short-name} Console, navigate to *Observe* -> *Metrics*, and run the query `istio_requests_total`. Confirm that the metrics for the {istio} request are displayed.
+. Create a `PodMonitor` resource that collects metrics from the {istio} proxies, similar to the following example:
++
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: istio-proxies-monitor
+  namespace: istio-system
+spec:
+  selector:
+    matchExpressions:
+    - key: istio-prometheus-ignore
+      operator: DoesNotExist
+  podMetricsEndpoints:
+  - path: /stats/prometheus
+    interval: 30s
+    relabelings:
+    - action: keep
+      sourceLabels: [__meta_kubernetes_pod_container_name]
+      regex: "istio-proxy"
+    - action: keep
+      sourceLabels: [__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape]
+    - action: replace
+      regex: (\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
+      replacement: '[\$2]:\$1'
+      sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+      targetLabel: __address__
+    - action: replace
+      regex: (\\d+);((([0-9]+?)(\.|$)){4})
+      replacement: \$2:\$1
+      sourceLabels: [__meta_kubernetes_pod_annotation_prometheus_io_port, __meta_kubernetes_pod_ip]
+      targetLabel: __address__
+    # Set the 'app' label from 'app.kubernetes.io/name' or fallback to 'app'
+    - sourceLabels: ["__meta_kubernetes_pod_label_app_kubernetes_io_name", "__meta_kubernetes_pod_label_app"]
+      separator: ";"
+      targetLabel: "app"
+      action: replace
+      regex: "(.+);.*|.*;(.+)"
+      replacement: "\${1}\${2}"  # Use the first non-empty value
+    # Set the 'version' label from 'app.kubernetes.io/version' or fallback to 'version'
+    - sourceLabels: ["__meta_kubernetes_pod_label_app_kubernetes_io_version", "__meta_kubernetes_pod_label_version"]
+      separator: ";"
+      targetLabel: "version"
+      action: replace
+      regex: "(.+);.*|.*;(.+)"
+      replacement: "\${1}\${2}"  # Use the first non-empty value
+    # additional labels
+    - sourceLabels: [__meta_kubernetes_namespace]
+      action: replace
+      targetLabel: namespace
+    - action: replace
+      replacement: "mesh_id"
+      targetLabel: mesh_id
+----
++
+where:
+
+`istio-system`:: Specifies that the `PodMonitor` object must be applied in all mesh namespaces, including the {istio} control plane namespace, because {ocp-product-title} monitoring ignores the `namespaceSelector` spec in `ServiceMonitor` and `PodMonitor` objects.
+`mesh_id`:: Specify the actual mesh ID.
+`\\d+`:: The additional backslash is only used when you apply this replacement from a command line via heredoc. If you apply this from a yaml file, replace `\\d+` with `\d+`.
+`\$`:: The backslash is only used when you apply this replacement from a command line via heredoc. If you apply this from a yaml file, replace `\$` with `$`.
+
+. To validate that the `ServiceMonitor` and `PodMonitor` resources are monitoring the {istio} control plane, go to the {ocp-short-name} Console, navigate to *Observe* -> *Metrics*, and run the query `istio_requests_total`. Confirm that the metrics for the {istio} request are displayed.
 +
 [NOTE]
 ====

--- a/modules/ossm-verifying-metrics-ambient-mode.adoc
+++ b/modules/ossm-verifying-metrics-ambient-mode.adoc
@@ -17,7 +17,7 @@ You can verify that the metrics for your application available in the OpenShift 
 
 . On the {ocp-short-name} Console go to *Observe* -> *Targets*.
 
-. Find the status of `Metrics Targets` by searching for targets such as `istiod-monitor`, `ztunnel-monitor`, and `waypoint-monitor`. `waypoint-monitor` is created only when the waypoint proxy is created to use Layer 7 (L7) {SMProduct} features.
+. Find the status of `Metrics Targets` by searching for targets such as `istiod-monitor`, `istio-ztunnel-monitor`, and `istio-waypoint-monitor`. `istio-waypoint-monitor` is created only when the waypoint proxy is created to use Layer 7 (L7) {SMProduct} features.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Change type: Doc update; Update OSSM metrics docs for sidecar and ambient modes

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main) and [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Doc Preview:

- https://104365--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/observability/metrics/ossm-metrics.html