### PR TITLE
[enterprise-4.18] Adding a empty .claude folder and updating gitignore with same

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ commercial_package
 .vale/styles/AsciiDoc
 .vale/styles/OpenShiftAsciiDoc
 .vale/styles/RedHat
-.vale/styles/AsciiDocDITA/
+.vale/styles/AsciiDocDITA
+.claude


### PR DESCRIPTION
In order to facilitate the use of claude code tools I wish to have this PR submitted to the OCP repo. Only noticeable change is to the .gitignore

Version: 4.18 

NOTES: This a manual CP from https://github.com/openshift/openshift-docs/pull/104063 and merge commit https://github.com/openshift/openshift-docs/commit/548816ce0392d933f46f15c3dc627861fbf0b397
