### PR TITLE
OSDOCS-17741:Update the z-stream RNs for 4.12.84

### DIFF
--- a/modules/zstream-4-12-84-about.adoc
+++ b/modules/zstream-4-12-84-about.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-84-about_{context}"]
+= RHBA-2026:0317 - {product-title} {product-version}.84 bug fix and security update
+
+[role="_abstract"]
+Issued: 15 January 2026
+
+{product-title} release {product-version}.84, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:0317[RHBA-2026:0317] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:0315[RHSA-2026:0315] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.12.84 --pullspecs
+----

--- a/modules/zstream-4-12-84-bug-fixes.adoc
+++ b/modules/zstream-4-12-84-bug-fixes.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-84-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issue is fixed with this release:
+
+* Before this update, a recent regression in `runc` prevented the successful start of pods when the `shareProcessNamespace` parameter was set to `true`. With this release, a subsequent update to `runc` corrects the regression. (link:https://issues.redhat.com/browse/OCPBUGS-65982[OCPBUGS-65982])

--- a/modules/zstream-4-12-84-updating.adoc
+++ b/modules/zstream-4-12-84-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-84-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5348,3 +5348,12 @@ include::modules/zstream-4-12-83-bug-fixes.adoc[leveloffset=+2]
 
 // 4.12.83 updating
 include::modules/zstream-4-12-83-updating.adoc[leveloffset=+2]
+
+// 4.12.84 about
+include::modules/zstream-4-12-84-about.adoc[leveloffset=+2]
+
+// 4.12.84 fixes
+include::modules/zstream-4-12-84-bug-fixes.adoc[leveloffset=+2]
+
+// 4.12.84 updating
+include::modules/zstream-4-12-84-updating.adoc[leveloffset=+2]


### PR DESCRIPTION
<Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-17741

Link to docs preview:
https://104369--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#zstream-4-12-84-about_release-notes

Additional information:
4.12.84 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/285
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.12