### PR TITLE
OSDOCS 16929 CQA2.0 of NODES-1: Core Node Cluster Resource Configuration

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2883,10 +2883,10 @@ Topics:
   Topics:
   - Name: Viewing system event information in a cluster
     File: nodes-containers-events
-  - Name: Analyzing cluster resource levels
+  - Name: Estimating the number of pods your OpenShift Container Platform nodes can hold
     File: nodes-cluster-resource-levels
     Distros: openshift-enterprise,openshift-origin
-  - Name: Setting limit ranges
+  - Name: Restrict resource consumption with limit ranges
     File: nodes-cluster-limit-ranges
   - Name: Configuring cluster memory to meet container memory and risk requirements
     File: nodes-cluster-resource-configure

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1084,10 +1084,10 @@ Topics:
   Topics:
   - Name: Viewing system event information in a cluster
     File: nodes-containers-events
-  - Name: Analyzing cluster resource levels
+  - Name: Estimating the number of pods your OpenShift Container Platform nodes can hold
     File: nodes-cluster-resource-levels
     Distros: openshift-dedicated
-  - Name: Setting limit ranges
+  - Name: Restrict resource consumption with limit ranges
     File: nodes-cluster-limit-ranges
   - Name: Configuring cluster memory to meet container memory and risk requirements
     File: nodes-cluster-resource-configure

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1413,10 +1413,10 @@ Topics:
   Topics:
   - Name: Viewing system event information in a cluster
     File: nodes-containers-events
-  - Name: Analyzing cluster resource levels
+  - Name: Estimating the number of pods your OpenShift Container Platform nodes can hold
     File: nodes-cluster-resource-levels
     Distros: openshift-rosa
-  - Name: Setting limit ranges
+  - Name: Restrict resource consumption with limit ranges
     File: nodes-cluster-limit-ranges
   - Name: Configuring cluster memory to meet container memory and risk requirements
     File: nodes-cluster-resource-configure

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1263,9 +1263,9 @@ Topics:
   Topics:
   - Name: Viewing system event information in a cluster
     File: nodes-containers-events
-  - Name: Analyzing cluster resource levels
+  - Name: Estimating the number of pods your OpenShift Container Platform nodes can hold
     File: nodes-cluster-resource-levels
-  - Name: Setting limit ranges
+  - Name: Restrict resource consumption with limit ranges
     File: nodes-cluster-limit-ranges
   - Name: Configuring cluster memory to meet container memory and risk requirements
     File: nodes-cluster-resource-configure

--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -6,7 +6,10 @@
 [id="nodes-cluster-enabling-features-about_{context}"]
 = Understanding feature gates
 
-You can use the `FeatureGate` custom resource (CR) to enable specific feature sets in your cluster. A feature set is a collection of {product-title} features that are not enabled by default.
+[role="_abstract"]
+You can use the `FeatureGate` custom resource (CR) to enable specific feature sets so that you can use specific non-default features in your cluster. 
+
+A feature set is a collection of {product-title} features that are not enabled by default.
 
 You can activate the following feature set by using the `FeatureGate` CR:
 
@@ -111,6 +114,8 @@ The following Technology Preview features are enabled by this feature set:
 ** `VSphereMultiVCenters`
 ** `TwoNodeOpenShiftClusterWithFencing`
 --
+
+See the _Additional resources_ sections for information on some of these features. 
 
 ////
 Do not document per Derek Carr: https://github.com/openshift/api/pull/370#issuecomment-510632939

--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -6,17 +6,16 @@
 [id="nodes-cluster-enabling-features-cli_{context}"]
 = Enabling feature sets using the CLI
 
-You can use the OpenShift CLI (`oc`) to enable feature sets for all of the nodes in a cluster by editing the `FeatureGate` custom resource (CR).
+[role="_abstract"]
+You can use the {oc-first} to enable feature sets for all of the nodes in a cluster by editing the `FeatureGate` custom resource (CR). Completing this task enables non-default features in your cluster.
 
 .Prerequisites
 
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 
 .Procedure
 
-To enable feature sets:
-
-. Edit the `FeatureGate` CR named `cluster`:
+* Edit the `FeatureGate` CR named `cluster`:
 +
 [source,terminal]
 ----
@@ -27,7 +26,6 @@ $ oc edit featuregate cluster
 ====
 Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. You should not enable this feature set on production clusters.
 ====
-
 +
 .Sample FeatureGate custom resource
 [source,yaml]
@@ -35,15 +33,17 @@ Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone
 apiVersion: config.openshift.io/v1
 kind: FeatureGate
 metadata:
-  name: cluster <1>
+  name: cluster
 # ...
 spec:
-  featureSet: TechPreviewNoUpgrade <2>
+  featureSet: TechPreviewNoUpgrade
 ----
+where:
 +
 --
-<1> The name of the `FeatureGate` CR must be `cluster`.
-<2> Add the feature set that you want to enable:
+`metadata.name`:: Specifies the name of the `FeatureGate` CR. This must be `cluster`.
+
+`spec.featureSet`:: Specifies the feature set that you want to enable:
 * `TechPreviewNoUpgrade` enables specific Technology Preview features.
 --
 +

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -6,11 +6,10 @@
 [id="nodes-cluster-enabling-features-console_{context}"]
 = Enabling feature sets using the web console
 
-You can use the {product-title} web console to enable feature sets for all of the nodes in a cluster by editing the `FeatureGate` custom resource (CR).
+[role="_abstract"]
+You can use the {product-title} web console to enable feature sets for all of the nodes in a cluster by editing the `FeatureGate` custom resource (CR). Completing this task enables non-default features in your cluster.
 
 .Procedure
-
-To enable feature sets:
 
 . In the {product-title} web console, switch to the *Administration* -> *Custom Resource Definitions* page.
 
@@ -39,10 +38,12 @@ metadata:
 spec:
   featureSet: TechPreviewNoUpgrade <2>
 ----
+where:
 +
 --
-<1> The name of the `FeatureGate` CR must be `cluster`.
-<2> Add the feature set that you want to enable:
+`metadata.name`:: Specifies the name of the `FeatureGate` CR. You must specify `cluster` for the name.
+
+`spec.featureSet`:: Specifies the feature set that you want to enable:
 * `TechPreviewNoUpgrade` enables specific Technology Preview features.
 --
 +

--- a/modules/nodes-cluster-enabling-features-install.adoc
+++ b/modules/nodes-cluster-enabling-features-install.adoc
@@ -6,7 +6,8 @@
 [id="nodes-cluster-enabling-features-install_{context}"]
 = Enabling feature sets at installation
 
-You can enable feature sets for all nodes in the cluster by editing the `install-config.yaml` file before you deploy the cluster.
+[role="_abstract"]
+You can enable feature sets for all nodes in the cluster by editing the `install-config.yaml` file before you deploy the cluster. This allows you to use non-default features in your cluster.
 
 .Prerequisites
 

--- a/modules/nodes-cluster-limit-ranges-about.adoc
+++ b/modules/nodes-cluster-limit-ranges-about.adoc
@@ -6,28 +6,19 @@
 [id="nodes-cluster-limit-ranges-about_{context}"]
 = About limit ranges
 
-A limit range, defined by a `LimitRange` object, restricts resource
-consumption in a project. In the project you can set specific resource
-limits for a pod, container, image, image stream, or
-persistent volume claim (PVC).
+[role="_abstract"]
+You can set specific resource limits for a pod, container, image, image stream, or persistent volume claim (PVC) in a specific project by defining a `LimitRange` object. A limit range allows you to restrict resource consumption in that project. 
 
-All requests to create and modify resources are evaluated against each
-`LimitRange` object in the project. If the resource violates any of the
-enumerated constraints, the resource is rejected.
+All requests to create and modify resources are evaluated against each `LimitRange` object in the project. If the resource violates any of the enumerated constraints, the resource is rejected.
 
 ifdef::openshift-online[]
 [IMPORTANT]
 ====
-For {product-title} Pro, the maximum pod memory is 3Gi. The minimum pod or
-container memory that you can specify is 100Mi.
-
+For {product-title} Pro, the maximum pod memory is 3Gi. The minimum pod or container memory that you can specify is 100Mi.
 ====
 endif::[]
 
-The following shows a limit range object for all components: pod, container,
-image, image stream, or PVC. You can configure limits for any or all of these
-components in the same object. You create a different limit range object for
-each project where you want to control resources.
+The following shows a limit range object for all components: pod, container, image, image stream, or PVC. You can configure limits for any or all of these components in the same object. You create a different limit range object for each project where you want to control resources.
 
 .Sample limit range object for a container
 

--- a/modules/nodes-cluster-limit-ranges-creating.adoc
+++ b/modules/nodes-cluster-limit-ranges-creating.adoc
@@ -6,7 +6,10 @@
 [id="nodes-cluster-limit-creating_{context}"]
 = Creating a Limit Range
 
-To apply a limit range to a project:
+[role="_abstract"]
+You can define `LimitRange` objects to set specific resource limits for a pod, container, image, image stream, or persistent volume claim (PVC) in a specific project. A limit range allows you to restrict resource consumption in that project. 
+
+.Procedure
 
 . Create a `LimitRange` object with your required specifications:
 +
@@ -15,58 +18,67 @@ To apply a limit range to a project:
 apiVersion: "v1"
 kind: "LimitRange"
 metadata:
-  name: "resource-limits" <1>
+  name: "resource-limits"
 spec:
   limits:
-    - type: "Pod" <2>
+    - type: "Pod"
       max:
         cpu: "2"
         memory: "1Gi"
       min:
         cpu: "200m"
         memory: "6Mi"
-    - type: "Container" <3>
+    - type: "Container"
       max:
         cpu: "2"
         memory: "1Gi"
       min:
         cpu: "100m"
         memory: "4Mi"
-      default: <4>
+      default:
         cpu: "300m"
         memory: "200Mi"
-      defaultRequest: <5>
+      defaultRequest:
         cpu: "200m"
         memory: "100Mi"
-      maxLimitRequestRatio: <6>
+      maxLimitRequestRatio:
         cpu: "10"
-    - type: openshift.io/Image <7>
+    - type: openshift.io/Image
       max:
         storage: 1Gi
-    - type: openshift.io/ImageStream <8>
+    - type: openshift.io/ImageStream
       max:
         openshift.io/image-tags: 20
         openshift.io/images: 30
-    - type: "PersistentVolumeClaim" <9>
+    - type: "PersistentVolumeClaim"
       min:
         storage: "2Gi"
       max:
         storage: "50Gi"
 ----
-<1> Specify a name for the `LimitRange` object.
-<2> To set limits for a pod, specify the minimum and maximum CPU and memory requests as needed.
-<3> To set limits for a container, specify the minimum and maximum CPU and memory requests as needed.
-<4> Optional. For a container, specify the default amount of CPU or memory that a container can use, if not specified in the `Pod` spec.
-<5> Optional. For a container, specify the default amount of CPU or memory that a container can request, if not specified in the `Pod` spec.
-<6> Optional. For a container, specify the maximum limit-to-request ratio that can be specified in the `Pod` spec.
-<7> To set limits for an Image object, set the maximum size of an image that can be pushed to an {product-registry}.
-<8> To set limits for an image stream, set the maximum number of image tags and references that can be in the `ImageStream` object file, as needed.
-<9> To set limits for a persistent volume claim, set the minimum and maximum amount of storage that can be requested.
+where:
++
+--
+`metadata.name`:: Specifies a name for the `LimitRange` object.
+`spec.limit.type.Pod`:: Specifies limits for a pod, specify the minimum and maximum CPU and memory requests as needed.
+`spec.limit.type.Container`:: Specifies limits for a container, specify the minimum and maximum CPU and memory requests as needed.
+`spec.limit.type.default`:: For a container, specifies the default amount of CPU or memory that a container can use, if not specified in the `Pod` spec. This parameter is optional.
+`spec.limit.type.defaultRequest`:: For a container, specifies the default amount of CPU or memory that a container can request, if not specified in the `Pod` spec. This parameter is optional.
+`spec.limit.type.maxLimitRequestRatio`:: For a container, specifies the maximum limit-to-request ratio that can be specified in the `Pod` spec. This parameter is optional.
+`spec.limit.type.openshift.io/Image`:: Specifies limits for an image object. Set the maximum size of an image that can be pushed to an {product-registry}.
+`spec.limit.type.openshift.io/ImageStream`:: Specifies limits for an image stream. Set the maximum number of image tags and references that can be in the `ImageStream` object file, as needed.
+`spec.limit.type.openshift.io/PersistentVolueClaim`:: Specifies limits for a persistent volume claim. Set the minimum and maximum amount of storage that can be requested.
+--
 
 . Create the object:
 +
 [source,terminal]
 ----
-$ oc create -f <limit_range_file> -n <project> <1>
+$ oc create -f <limit_range_file> -n <project>
 ----
-<1> Specify the name of the YAML file you created and the project where you want the limits to apply.
+where:
++
+--
+`<limit_range_file>`:: Specifies the name of the YAML file you created.
+`<project>`:: Specifies the project where you want the limits to apply.
+--

--- a/modules/nodes-cluster-limit-ranges-deleting.adoc
+++ b/modules/nodes-cluster-limit-ranges-deleting.adoc
@@ -6,7 +6,10 @@
 [id="nodes-cluster-limit-ranges-deleting_{context}"]
 = Deleting a Limit Range
 
-To remove any active `LimitRange` object to no longer enforce the limits in a project:
+[role="_abstract"]
+You can remove any active `LimitRange` object so that it no longer enforces the limits in a project.
+
+.Procedure
 
 * Run the following command:
 +

--- a/modules/nodes-cluster-limit-ranges-limits.adoc
+++ b/modules/nodes-cluster-limit-ranges-limits.adoc
@@ -2,49 +2,35 @@
 //
 // * nodes/cluster/limit-ranges.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="nodes-cluster-limit-ranges-limits_{context}"]
 = About component limits
 
-The following examples show limit range parameters for each component. The
-examples are broken out for clarity. You can create a single `LimitRange` object
-for any or all components as necessary.
+[role="_abstract"]
+Review the following examples to learn the limit range parameters for each component for when you create or edit a `LimitRange` object. 
 
-[id="nodes-cluster-limit-container-limits"]
-== Container limits
+The examples are broken out for clarity. You can create a single `LimitRange` object for any or all components as necessary.
 
-A limit range allows you to specify the minimum and maximum CPU and memory that each container
-in a pod can request for a specific project. If a container is created in the project,
-the container CPU and memory requests in the `Pod` spec must comply with the values set in the
-`LimitRange` object. If not, the pod does not get created.
-
-* The container CPU or memory request and limit must be greater than or equal to the
-`min` resource constraint for containers that are specified in the `LimitRange` object.
-
-* The container CPU or memory request and limit must be less than or equal to the
-`max` resource constraint for containers that are specified in the `LimitRange` object.
+Container limits::
+A limit range allows you to specify the minimum and maximum CPU and memory that each container in a pod can request for a specific project. If a container is created in the project, the container CPU and memory requests in the `Pod` spec must comply with the values set in the `LimitRange` object. If not, the pod does not get created. The following requirements must hold true:
 +
-If the `LimitRange` object defines a `max` CPU, you do not need to define a CPU
-`request` value in the `Pod` spec. But you must specify a CPU `limit` value that
-satisfies the maximum CPU constraint specified in the limit range.
-
-* The ratio of the container limits to requests must be
-less than or equal to the `maxLimitRequestRatio` value for containers that
-is specified in the `LimitRange` object.
+--
+* The container CPU or memory request and limit must be greater than or equal to the `min` resource constraint for containers that are specified in the `LimitRange` object.
+* The container CPU or memory request and limit must be less than or equal to the `max` resource constraint for containers that are specified in the `LimitRange` object.
+--
 +
-If the `LimitRange` object defines a `maxLimitRequestRatio` constraint, any new
-containers must have both a `request` and a `limit` value. {product-title}
-calculates the limit-to-request ratio by dividing the `limit` by the
-`request`. This value should be a non-negative integer greater than 1.
+If the `LimitRange` object defines a `max` CPU, you do not need to define a CPU `request` value in the `Pod` spec. But you must specify a CPU `limit` value that satisfies the maximum CPU constraint specified in the limit range. The following requirements must hold true:
 +
-For example, if a container has `cpu: 500` in the `limit` value, and
-`cpu: 100` in the `request` value, the limit-to-request ratio for `cpu` is
-`5`. This ratio must be less than or equal to the `maxLimitRequestRatio`.
-
-If the `Pod` spec does not specify a container resource memory or limit,
-the `default` or `defaultRequest` CPU and memory values for containers
-specified in the limit range object are assigned to the container.
-
+--
+* The ratio of the container limits to requests must be less than or equal to the `maxLimitRequestRatio` value for containers that is specified in the `LimitRange` object.
++
+If the `LimitRange` object defines a `maxLimitRequestRatio` constraint, any new containers must have both a `request` and a `limit` value. {product-title} calculates the limit-to-request ratio by dividing the `limit` by the `request`. This value should be a non-negative integer greater than 1.
++
+For example, if a container has `cpu: 500` in the `limit` value, and `cpu: 100` in the `request` value, the limit-to-request ratio for `cpu` is `5`. This ratio must be less than or equal to the `maxLimitRequestRatio`.
+--
++
+If the `Pod` spec does not specify a container resource memory or limit, the `default` or `defaultRequest` CPU and memory values for containers specified in the limit range object are assigned to the container.
++
 .Container `LimitRange` object definition
 
 [source,yaml]
@@ -52,60 +38,55 @@ specified in the limit range object are assigned to the container.
 apiVersion: "v1"
 kind: "LimitRange"
 metadata:
-  name: "resource-limits" <1>
+  name: "resource-limits"
 spec:
   limits:
     - type: "Container"
       max:
-        cpu: "2" <2>
-        memory: "1Gi" <3>
+        cpu: "2"
+        memory: "1Gi"
       min:
-        cpu: "100m" <4>
-        memory: "4Mi" <5>
+        cpu: "100m"
+        memory: "4Mi"
       default:
-        cpu: "300m" <6>
-        memory: "200Mi" <7>
+        cpu: "300m"
+        memory: "200Mi"
       defaultRequest:
-        cpu: "200m" <8>
-        memory: "100Mi" <9>
+        cpu: "200m"
+        memory: "100Mi"
       maxLimitRequestRatio:
-        cpu: "10" <10>
+        cpu: "10"
 ----
-<1> The name of the LimitRange object.
-<2> The maximum amount of CPU that a single container in a pod can request.
-<3> The maximum amount of memory that a single container in a pod can request.
-<4> The minimum amount of CPU that a single container in a pod can request.
-<5> The minimum amount of memory that a single container in a pod can request.
-<6> The default amount of CPU that a container can use if not specified in the `Pod` spec.
-<7> The default amount of memory that a container can use if not specified in the `Pod` spec.
-<8> The default amount of CPU that a container can request if not specified in the `Pod` spec.
-<9> The default amount of memory that a container can request if not specified in the `Pod` spec.
-<10> The maximum limit-to-request ratio for a container.
+where:
++
+--
+`metadata.name`:: Specifies the name of the limit range object.
+`spec.limit.max.cpu`:: Specifies the maximum amount of CPU that a single container in a pod can request.
+`spec.limit.max.memory`:: Specifies the maximum amount of memory that a single container in a pod can request.
+`spec.limit.min.cpu`:: Specifies the minimum amount of CPU that a single container in a pod can request.
+`spec.limit.min.memory`:: Specifies the minimum amount of memory that a single container in a pod can request.
+`spec.limit.default.cpu`:: Specifies the default amount of CPU that a container can use if not specified in the `Pod` spec.
+`spec.limit.default.memory`:: Specifies the default amount of memory that a container can use if not specified in the `Pod` spec.
+`spec.limit.defaultRequest.cpu`:: Specifies the default amount of CPU that a container can request if not specified in the `Pod` spec.
+`spec.limit.defaultRequest.memory`:: Specifies the default amount of memory that a container can request if not specified in the `Pod` spec.
+`spec.limit.maxLimitRequestRatio.cpu`:: Specifies the maximum limit-to-request ratio for a container.
+--
 
+Pod limits::
+A limit range allows you to specify the minimum and maximum CPU and memory limits for all containers across a pod in a given project. To create a container in the project, the container CPU and memory requests in the `Pod` spec must comply with the values set in the `LimitRange` object. If not, the pod does not get created.
++
+If the `Pod` spec does not specify a container resource memory or limit, the `default` or `defaultRequest` CPU and memory values for containers specified in the limit range object are assigned to the container.
++
+Across all containers in a pod, the following requirements must hold true:
++
+--
+* The container CPU or memory request and limit must be greater than or equal to the `min` resource constraints for pods that are specified in the `LimitRange` object.
 
-[id="nodes-cluster-limit-pod-limits"]
-== Pod limits
+* The container CPU or memory request and limit must be less than or equal to the `max` resource constraints for pods that are specified in the `LimitRange` object.
 
-A limit range allows you to specify the minimum and maximum CPU and memory limits for all containers
-across a pod in a given project. To create a container in the project, the container CPU and memory
-requests in the `Pod` spec must comply with the values set in the `LimitRange` object. If not,
-the pod does not get created.
-
-If the `Pod` spec does not specify a container resource memory or limit,
-the `default` or `defaultRequest` CPU and memory values for containers
-specified in the limit range object are assigned to the container.
-
-Across all containers in a pod, the following must hold true:
-
-* The container CPU or memory request and limit must be greater than or equal to the
-`min` resource constraints for pods that are specified in the `LimitRange` object.
-
-* The container CPU or memory request and limit must be less than or equal to the
-`max` resource constraints for pods that are specified in the `LimitRange` object.
-
-* The ratio of the container limits to requests must be less than or equal to
-the `maxLimitRequestRatio` constraint specified in the `LimitRange` object.
-
+* The ratio of the container limits to requests must be less than or equal to the `maxLimitRequestRatio` constraint specified in the `LimitRange` object.
+--
++
 .Pod `LimitRange` object definition
 
 [source,yaml]
@@ -113,153 +94,140 @@ the `maxLimitRequestRatio` constraint specified in the `LimitRange` object.
 apiVersion: "v1"
 kind: "LimitRange"
 metadata:
-  name: "resource-limits" <1>
+  name: "resource-limits"
 spec:
   limits:
     - type: "Pod"
       max:
-        cpu: "2" <2>
-        memory: "1Gi" <3>
+        cpu: "2"
+        memory: "1Gi"
       min:
-        cpu: "200m" <4>
-        memory: "6Mi" <5>
+        cpu: "200m"
+        memory: "6Mi"
       maxLimitRequestRatio:
-        cpu: "10" <6>
+        cpu: "10"
 ----
-<1> The name of the limit range object.
-<2> The maximum amount of CPU that a pod can request across all containers.
-<3> The maximum amount of memory that a pod can request across all containers.
-<4> The minimum amount of CPU that a pod can request across all containers.
-<5> The minimum amount of memory that a pod can request across all containers.
-<6> The maximum limit-to-request ratio for a container.
+where:
++
+--
+`metadata.name`:: Specifies the name of the limit range object.
+`spec.limit.max.cpu`:: Specifies the maximum amount of CPU that a pod can request across all containers.
+`spec.limit.max.memory`:: Specifies the maximum amount of memory that a pod can request across all containers.
+`spec.limit.min.cpu`:: Specifies the minimum amount of CPU that a pod can request across all containers.
+`spec.limit.min.memory`:: Specifies the minimum amount of memory that a pod can request across all containers.
+`spec.limit.maxLimitRequestRatio.cpu`:: Specifies the maximum limit-to-request ratio for a container.
+--
 
-[id="nodes-cluster-limit-image-limits"]
-== Image limits
-
-A `LimitRange` object allows you to specify the maximum size of an image
-that can be pushed to an {product-registry}.
-
-When pushing images to an {product-registry}, the following must hold true:
-
-* The size of the image must be less than or equal to the `max` size for
-images that is specified in the `LimitRange` object.
-
+Image limits::
+A limit range allows you to specify the maximum size of an image that can be pushed to an {product-registry}.
++
+When pushing images to an {product-registry}, the following requirement must hold true:
++
+--
+* The size of the image must be less than or equal to the `max` size for images that is specified in the `LimitRange` object.
+--
++
 .Image `LimitRange` object definition
-
 [source,yaml]
 ----
 apiVersion: "v1"
 kind: "LimitRange"
 metadata:
-  name: "resource-limits" <1>
+  name: "resource-limits"
 spec:
   limits:
     - type: openshift.io/Image
       max:
-        storage: 1Gi <2>
+        storage: 1Gi
 ----
-<1> The name of the `LimitRange` object.
-<2> The maximum size of an image that can be pushed to an {product-registry}.
-
+where:
++
+--
+`metadata.name`:: Specifies the name of the limit range object.
+`spec.limit.max.storage`:: Specifies the maximum size of an image that can be pushed to an {product-registry}.
+--
 ifdef::openshift-enterprise,openshift-origin[]
++
 [NOTE]
 ====
-To prevent blobs that exceed the limit from being uploaded to the registry, the
-registry must be configured to enforce quotas.
+To prevent blobs that exceed the limit from being uploaded to the registry, the registry must be configured to enforce quotas.
 ====
 endif::[]
-
++
 [WARNING]
 ====
-The image size is not always available in the manifest of an uploaded image.
-This is especially the case for images built with Docker 1.10 or higher and
-pushed to a v2 registry. If such an image is pulled with an older Docker daemon,
-the image manifest is converted by the registry to schema v1 lacking all
-the size information. No storage limit set on images prevent it from being
-uploaded.
+The image size is not always available in the manifest of an uploaded image. This is especially the case for images built with Docker 1.10 or higher and pushed to a v2 registry. If such an image is pulled with an older Docker daemon, the image manifest is converted by the registry to schema v1 lacking all the size information. No storage limit set on images prevent it from being uploaded.
 
-link:https://github.com/openshift/origin/issues/7706[The issue] is being
-addressed.
+link:https://github.com/openshift/origin/issues/7706[The issue is being addressed.]
 ====
 
-[id="nodes-cluster-limit-stream-limits"]
-== Image stream limits
+Image stream limits::
+A limit range allows you to specify limits for image streams.
++
+For each image stream, the following requirements must hold true:
++
+--
+* The number of image tags in an `ImageStream` specification must be less than or equal to the `openshift.io/image-tags` constraint in the `LimitRange` object.
 
-A `LimitRange` object allows you to specify limits for image streams.
-
-For each image stream, the following must hold true:
-
-* The number of image tags in an `ImageStream` specification must be less
-than or equal to the `openshift.io/image-tags` constraint in the `LimitRange` object.
-
-* The number of unique references to images in an `ImageStream` specification
-must be less than or equal to the `openshift.io/images` constraint in the limit
-range object.
-
+* The number of unique references to images in an `ImageStream` specification must be less than or equal to the `openshift.io/images` constraint in the limit range object.
+--
++
 .Imagestream `LimitRange` object definition
-
 [source,yaml]
 ----
 apiVersion: "v1"
 kind: "LimitRange"
 metadata:
-  name: "resource-limits" <1>
+  name: "resource-limits"
 spec:
   limits:
     - type: openshift.io/ImageStream
       max:
-        openshift.io/image-tags: 20 <2>
-        openshift.io/images: 30 <3>
+        openshift.io/image-tags: 20
+        openshift.io/images: 30
 ----
-<1> The name of the `LimitRange` object.
-<2> The maximum number of unique image tags in the `imagestream.spec.tags`
-parameter in imagestream spec.
-<3> The maximum number of unique image references in the `imagestream.status.tags`
-parameter in the `imagestream` spec.
+where
++
+--
+`metadata.name`:: Specifies the name of the `LimitRange` object.
+`spec.limit.max.openshift.io/image-tags`:: Specifies the maximum number of unique image tags in the `imagestream.spec.tags` parameter in imagestream spec.
+`spec.limit.max.openshift.io/images`:: Specifies the maximum number of unique image references in the `imagestream.status.tags` parameter in the `imagestream` spec.
+--
++
+The `openshift.io/image-tags` resource represents unique image references. Possible references are an `*ImageStreamTag*`, an `*ImageStreamImage*` and a `*DockerImage*`. Tags can be created using the `oc tag` and `oc import-image` commands. No distinction is made between internal and external references. However, each unique reference tagged in an `ImageStream` specification is counted just once. It does not restrict pushes to an internal container image registry in any way, but is useful for tag restriction.
++
+The `openshift.io/images` resource represents unique image names recorded in image stream status. It allows for restriction of a specific number of images that can be pushed to the {product-registry}. Internal and external references are not distinguished.
 
-The `openshift.io/image-tags` resource represents unique image
-references. Possible references are an `*ImageStreamTag*`, an
-`*ImageStreamImage*` and a `*DockerImage*`. Tags can be created using
-the `oc tag` and `oc import-image` commands. No distinction
-is made between internal and external references. However, each unique reference
-tagged in an `ImageStream` specification is counted just once. It does not
-restrict pushes to an internal container image registry in any way, but is useful for tag
-restriction.
+Persistent volume claim limits::
+A limit range allows you to restrict the storage requested in a persistent volume claim (PVC).
++
+Across all persistent volume claims in a project, the following requirements must hold true:
++
+--
+* The resource request in a persistent volume claim (PVC) must be greater than or equal the `min` constraint for PVCs that is specified in the `LimitRange` object.
 
-The `openshift.io/images` resource represents unique image names recorded in
-image stream status. It allows for restriction of a number of images that can be
-pushed to the {product-registry}. Internal and external references are not
-distinguished.
-
-[id="nodes-cluster-limit-pvc-limits"]
-== Persistent volume claim limits
-
-A `LimitRange` object allows you to restrict the storage requested in a persistent volume claim (PVC).
-
-Across all persistent volume claims in a project, the following must hold true:
-
-* The resource request in a persistent volume claim (PVC) must be greater than or equal
-the `min` constraint for PVCs that is specified in the `LimitRange` object.
-
-* The resource request in a persistent volume claim (PVC) must be less than or equal
-the `max` constraint for PVCs that is specified in the `LimitRange` object.
-
+* The resource request in a persistent volume claim (PVC) must be less than or equal the `max` constraint for PVCs that is specified in the `LimitRange` object.
+--
++
 .PVC `LimitRange` object definition
-
 [source,yaml]
 ----
 apiVersion: "v1"
 kind: "LimitRange"
 metadata:
-  name: "resource-limits" <1>
+  name: "resource-limits"
 spec:
   limits:
     - type: "PersistentVolumeClaim"
       min:
-        storage: "2Gi" <2>
+        storage: "2Gi"
       max:
-        storage: "50Gi" <3>
+        storage: "50Gi"
 ----
-<1> The name of the `LimitRange` object.
-<2> The minimum amount of storage that can be requested in a persistent volume claim.
-<3> The maximum amount of storage that can be requested in a persistent volume claim.
+where:
++
+--
+`metadata.name`:: Specifies the name of the `LimitRange` object.
+`spec.limit.min.storage`:: Specifies the minimum amount of storage that can be requested in a persistent volume claim.
+`spec.limit.max.storage`:: Specifies the maximum amount of storage that can be requested in a persistent volume claim.
+--

--- a/modules/nodes-cluster-limit-ranges-viewing.adoc
+++ b/modules/nodes-cluster-limit-ranges-viewing.adoc
@@ -6,13 +6,14 @@
 [id="nodes-cluster-limit-viewing_{context}"]
 = Viewing a limit
 
-You can view any limits defined in a project by navigating in the web
-console to the project's *Quota* page.
+[role="_abstract"]
+You can view the limits defined in a project by navigating in the web console to the project's *Quota* page. This allows you to see details about each of the limit ranges in a project. 
 
 You can also use the CLI to view limit range details:
 
-. Get the list of `LimitRange` object defined in the project. For example, for a
-project called *demoproject*:
+.Procedure
+
+. Get the list of `LimitRange` objects defined in the project. For example, for a project called *demoproject*:
 +
 [source,terminal]
 ----
@@ -25,8 +26,7 @@ NAME              CREATED AT
 resource-limits   2020-07-15T17:14:23Z
 ----
 
-. Describe the `LimitRange` object you are interested in, for example the
-`resource-limits` limit range:
+. Describe the `LimitRange` object you are interested in, for example the `resource-limits` limit range:
 +
 
 [source,terminal]

--- a/modules/nodes-cluster-node-overcommit.adoc
+++ b/modules/nodes-cluster-node-overcommit.adoc
@@ -7,6 +7,5 @@
 [id="nodes-cluster-node-overcommit_{context}"]
 = Node-level overcommit
 
-You can use various ways to control overcommit on specific nodes, such as quality of service (QOS)
-guarantees, CPU limits, or reserve resources. You can also disable overcommit for specific nodes
-and specific projects.
+[role="_abstract"]
+You can use various ways to control overcommit on specific nodes, such as quality of service (QOS) guarantees, CPU limits, or reserve resources. You can also disable overcommit for specific nodes and specific projects.

--- a/modules/nodes-cluster-overcommit-configure-nodes.adoc
+++ b/modules/nodes-cluster-overcommit-configure-nodes.adoc
@@ -7,20 +7,14 @@
 [id="nodes-cluster-overcommit-configure-nodes_{context}"]
 = Understanding nodes overcommitment
 
-In an overcommitted environment, it is important to properly configure your node to provide best system behavior.
+[role="_abstract"]
+To maintain optimal system performance and stability in an overcommitted environment in {product-title}, configure your nodes to manage resource contention effectively.
 
-When the node starts, it ensures that the kernel tunable flags for memory
-management are set properly. The kernel should never fail memory allocations
-unless it runs out of physical memory.
+When the node starts, it ensures that the kernel tunable flags for memory management are set properly. The kernel should never fail memory allocations unless it runs out of physical memory.
 
-To ensure this behavior, {product-title} configures the kernel to always overcommit
-memory by setting the `vm.overcommit_memory` parameter to `1`, overriding the
-default operating system setting.
+To ensure this behavior, {product-title} configures the kernel to always overcommit memory by setting the `vm.overcommit_memory` parameter to `1`, overriding the default operating system setting.
 
-{product-title} also configures the kernel not to panic when it runs out of memory
-by setting the `vm.panic_on_oom` parameter to `0`. A setting of 0 instructs the
-kernel to call oom_killer in an Out of Memory (OOM) condition, which kills
-processes based on priority.
+{product-title} also configures the kernel to not panic when it runs out of memory by setting the `vm.panic_on_oom` parameter to `0`. A setting of 0 instructs the kernel to call the OOM killer in an Out of Memory (OOM) condition, which kills processes based on priority.
 
 You can view the current setting by running the following commands on your nodes:
 
@@ -52,8 +46,7 @@ vm.panic_on_oom = 0
 
 [NOTE]
 ====
-The above flags should already be set on nodes, and no further action is
-required.
+The previous commands should already be set on nodes, so no further action is required.
 ====
 
 You can also perform the following configurations for each node:

--- a/modules/nodes-cluster-overcommit-node-disable.adoc
+++ b/modules/nodes-cluster-overcommit-node-disable.adoc
@@ -7,12 +7,13 @@
 [id="nodes-cluster-overcommit-node-disable_{context}"]
 = Disabling overcommitment for a node
 
-When enabled, overcommitment can be disabled on each node.
+[role="_abstract"]
+When overcommitment is enabled on a node, you can disable overcommitment on that node. Disabling overcommit can help ensure predictability, stability, and high performance in your cluster.
 
 .Procedure
 
-To disable overcommitment in a node run the following command on that node:
-
+* Run the following command on a node to disable overcommitment on that node:
++
 [source,terminal]
 ----
 $ sysctl -w vm.overcommit_memory=0

--- a/modules/nodes-cluster-overcommit-node-enforcing.adoc
+++ b/modules/nodes-cluster-overcommit-node-enforcing.adoc
@@ -8,7 +8,10 @@
 
 = Disabling or enforcing CPU limits using CPU CFS quotas
 
-Nodes by default enforce specified CPU limits using the Completely Fair Scheduler (CFS) quota support in the Linux kernel.
+[role="_abstract"]
+You can disable the default enforcement of CPU limits for nodes in a machine config pool. 
+
+By default, nodes enforce specified CPU limits using the Completely Fair Scheduler (CFS) quota support in the Linux kernel.
 
 If you disable CPU limit enforcement, it is important to understand the impact on your node:
 
@@ -18,43 +21,7 @@ If you disable CPU limit enforcement, it is important to understand the impact o
 
 .Prerequisites
 
-* Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure by entering the following command:
-+
-[source,terminal]
-----
-$ oc edit machineconfigpool <name>
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ oc edit machineconfigpool worker
-----
-+
-.Example output
-[source,yaml]
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfigPool
-metadata:
-  creationTimestamp: "2022-11-16T15:34:25Z"
-  generation: 4
-  labels:
-    pools.operator.machineconfiguration.openshift.io/worker: "" <1>
-  name: worker
-----
-<1> The label appears under Labels.
-+
-[TIP]
-====
-If the label is not present, add a key/value pair such as:
-
-[source,terminal]
-----
-$ oc label machineconfigpool worker custom-kubelet=small-pods
-----
-====
+* You have the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure.
 
 .Procedure
 
@@ -66,17 +33,21 @@ $ oc label machineconfigpool worker custom-kubelet=small-pods
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
-  name: disable-cpu-units <1>
+  name: disable-cpu-units
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      pools.operator.machineconfiguration.openshift.io/worker: "" <2>
+      pools.operator.machineconfiguration.openshift.io/worker: ""
   kubeletConfig:
-    cpuCfsQuota: false <3>
+    cpuCfsQuota: false
 ----
-<1> Assign a name to CR.
-<2> Specify the label from the machine config pool.
-<3> Set the `cpuCfsQuota` parameter to `false`.
+where:
++
+--
+`metadata.name`:: Specifies a name for the CR.
+`spec.machineConfigPoolSelector.matchLabels`:: Specifies the label from the machine config pool.
+`spec.kubeletConfig.cpuCfsQuota`:: Specifies the `cpuCfsQuota` parameter to `false`.
+--
 
 . Run the following command to create the CR:
 +

--- a/modules/nodes-cluster-overcommit-node-resources.adoc
+++ b/modules/nodes-cluster-overcommit-node-resources.adoc
@@ -3,22 +3,19 @@
 // * nodes/nodes-cluster-overcommit.adoc
 // * post_installation_configuration/node-tasks.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="nodes-cluster-overcommit-node-resources_{context}"]
 
 = Reserving resources for system processes
 
-To provide more reliable scheduling and minimize node resource overcommitment,
-each node can reserve a portion of its resources for use by system daemons
-that are required to run on your node for your cluster to function.
+[role="_abstract"]
+You can explicitly reserve resources for non-pod processes by allocating node resources through specifying resources available for scheduling.
+
+To provide more reliable scheduling and minimize node resource overcommitment, each node can reserve a portion of its resources for use by the system daemons that are required to run on your node for your cluster to function.
 
 [NOTE]
 ====
 It is recommended that you reserve resources for incompressible resources such as memory.
 ====
 
-.Procedure
-
-To explicitly reserve resources for non-pod processes, allocate node resources by specifying resources
-available for scheduling.
-For more details, see Allocating Resources for Nodes.
+For more details, see Allocating Resources for Nodes in the _Additional resources_ section.

--- a/modules/nodes-cluster-overcommit-project-disable.adoc
+++ b/modules/nodes-cluster-overcommit-project-disable.adoc
@@ -7,16 +7,17 @@
 [id="nodes-cluster-overcommit-project-disable_{context}"]
 = Disabling overcommitment for a project
 
+[role="_abstract"]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-When enabled, overcommitment can be disabled per-project. For example, you can allow infrastructure components to be configured independently of overcommitment.
+If overcommitment is enabled on a project, you can disable overcommitment for that projects. This allows infrastructure components to be configured independently of overcommitment.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+If required by your use case, you can disable overcommitment on any project that is not managed by Red Hat. For a list of projects that cannot be modified, see "Red Hat Managed resources" in _Support_.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-If required by your use case, you can disable overcommitment on any project that is not managed by Red Hat. For a list of projects that cannot be modified, see "Red Hat Managed resources" in _Support_.
-
 .Prerequisites
 * You are logged in to the cluster using an account with cluster administrator or cluster editor permissions.
-
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 .Procedure
@@ -60,7 +61,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    quota.openshift.io/cluster-resource-override-enabled: "false" <.>
+    quota.openshift.io/cluster-resource-override-enabled: "false"
 # ...
 ----
-<.> Setting this annotation to `false` disables overcommit for this namespace.
+where:
++
+--
+`metadata.annotations.quota.openshift.io/cluster-resource-override-enabled.false`:: Specifies that overcommit is disabled for this namespace.
+--

--- a/modules/nodes-cluster-overcommit-qos-about.adoc
+++ b/modules/nodes-cluster-overcommit-qos-about.adoc
@@ -7,69 +7,48 @@
 [id="nodes-cluster-overcommit-qos-about_{context}"]
 = Understanding overcommitment and quality of service classes
 
-A node is _overcommitted_ when it has a pod scheduled that makes no request, or
-when the sum of limits across all pods on that node exceeds available machine
-capacity.
+[role="_abstract"]
+You can use Quality of Service (QoS) classes in an overcommitted environment to help you ensure that your cluster is properly configured.
 
-In an overcommitted environment, it is possible that the pods on the node will
-attempt to use more compute resource than is available at any given point in
-time. When this occurs, the node must give priority to one pod over another. The
-facility used to make this decision is referred to as a Quality of Service (QoS)
-Class.
+A node is _overcommitted_ when it has a pod scheduled that makes no request, or when the sum of limits across all pods on that node exceeds available machine capacity.
+
+In an overcommitted environment, the pods on the node might attempt to use more compute resource than is available at any given point in time. When this occurs, the node must give priority to one pod over another. The facility used to make this decision is referred to as a Quality of Service (QoS) class.
 
 A pod is designated as one of three QoS classes with decreasing order of priority:
 
-.Quality of Service Classes
+.Quality of Service classes
 [options="header",cols="1,1,5"]
 |===
 |Priority |Class Name |Description
 
 |1 (highest)
 |*Guaranteed*
-|If limits and optionally requests are set (not equal to 0) for all resources
-and they are equal, then the pod is classified as *Guaranteed*.
+|If limits and optionally requests are set (not equal to 0) for all resources and they are equal, then the pod is classified as *Guaranteed*.
 
 |2
 |*Burstable*
-|If requests and optionally limits are set (not equal to 0) for all resources,
-and they are not equal, then the pod is classified as *Burstable*.
+|If requests and optionally limits are set (not equal to 0) for all resources, and they are not equal, then the pod is classified as *Burstable*.
 
 |3 (lowest)
 |*BestEffort*
-|If requests and limits are not set for any of the resources, then the pod
-is classified as *BestEffort*.
+|If requests and limits are not set for any of the resources, then the pod is classified as *BestEffort*.
 |===
 
-Memory is an incompressible resource, so in low memory situations, containers
-that have the lowest priority are terminated first:
+Memory is an incompressible resource, so in low memory situations, containers that have the lowest priority are terminated first:
 
-- *Guaranteed* containers are considered top priority, and are guaranteed to
-only be terminated if they exceed their limits, or if the system is under memory
-pressure and there are no lower priority containers that can be evicted.
-- *Burstable* containers under system memory pressure are more likely to be
-terminated once they exceed their requests and no other *BestEffort* containers
-exist.
-- *BestEffort* containers are treated with the lowest priority. Processes in
-these containers are first to be terminated if the system runs out of memory.
+- *Guaranteed* containers are considered top priority, and are guaranteed to only be terminated if they exceed their limits, or if the system is under memory pressure and there are no lower priority containers that can be evicted.
+- *Burstable* containers under system memory pressure are more likely to be terminated when they exceed their requests and no other *BestEffort* containers exist.
+- *BestEffort* containers are treated with the lowest priority. Processes in these containers are first to be terminated if the system runs out of memory.
 
 [id="qos-about-reserve_{context}"]
 == Understanding how to reserve memory across quality of service tiers
 
-You can use the `qos-reserved` parameter to specify a percentage of memory to be reserved
-by a pod in a particular QoS level. This feature attempts to reserve requested resources to exclude pods
-from lower OoS classes from using resources requested by pods in higher QoS classes.
+You can use the `qos-reserved` parameter to specify a percentage of memory to be reserved by a pod in a particular QoS level. This feature attempts to reserve requested resources to exclude pods from lower QoS classes from using resources requested by pods in higher QoS classes.
 
 {product-title} uses the `qos-reserved` parameter as follows:
 
-- A value of `qos-reserved=memory=100%` will prevent the `Burstable` and `BestEffort` QoS classes from consuming memory
-that was requested by a higher QoS class. This increases the risk of inducing OOM
-on `BestEffort` and `Burstable` workloads in favor of increasing memory resource guarantees
-for `Guaranteed` and `Burstable` workloads.
+- A value of `qos-reserved=memory=100%` prevents the `Burstable` and `BestEffort` QoS classes from consuming memory that was requested by a higher QoS class. This increases the risk of inducing OOM on `BestEffort` and `Burstable` workloads in favor of increasing memory resource guarantees for `Guaranteed` and `Burstable` workloads.
 
-- A value of `qos-reserved=memory=50%` will allow the `Burstable` and `BestEffort` QoS classes
-to consume half of the memory requested by a higher QoS class.
+- A value of `qos-reserved=memory=50%` allows the `Burstable` and `BestEffort` QoS classes to consume half of the memory requested by a higher QoS class.
 
-- A value of `qos-reserved=memory=0%`
-will allow a `Burstable` and `BestEffort` QoS classes to consume up to the full node
-allocatable amount if available, but increases the risk that a `Guaranteed` workload
-will not have access to requested memory. This condition effectively disables this feature.
+- A value of `qos-reserved=memory=0%` allows a `Burstable` and `BestEffort` QoS classes to consume up to the full node allocatable amount if available, but increases the risk that a `Guaranteed` workload does not have access to requested memory. This condition effectively disables this feature.

--- a/modules/nodes-cluster-overcommit-resource-requests.adoc
+++ b/modules/nodes-cluster-overcommit-resource-requests.adoc
@@ -7,22 +7,11 @@
 [id="nodes-cluster-overcommit-resource-requests_{context}"]
 = Resource requests and overcommitment
 
-For each compute resource, a container may specify a resource request and limit.
-Scheduling decisions are made based on the request to ensure that a node has
-enough capacity available to meet the requested value. If a container specifies
-limits, but omits requests, the requests are defaulted to the limits. A
-container is not able to exceed the specified limit on the node.
+[role="_abstract"]
+You can use resource requests in an overcommitted environment help you ensure that your cluster is properly configured.
 
-The enforcement of limits is dependent upon the compute resource type. If a
-container makes no request or limit, the container is scheduled to a node with
-no resource guarantees. In practice, the container is able to consume as much of
-the specified resource as is available with the lowest local priority. In low
-resource situations, containers that specify no resource requests are given the
-lowest quality of service.
+For each compute resource, a container can specify a resource request and limit. Scheduling decisions are made based on the request to ensure that a node has enough capacity available to meet the requested value. If a container specifies limits, but omits requests, the requests are defaulted to the limits. A container is not able to exceed the specified limit on the node.
 
-Scheduling is based on resources requested, while quota and hard limits refer
-to resource limits, which can be set higher than requested resources. The
-difference between request and limit determines the level of overcommit;
-for instance, if a container is given a memory request of 1Gi and a memory limit
-of 2Gi, it is scheduled based on the 1Gi request being available on the node,
-but could use up to 2Gi; so it is 100% overcommitted.
+The enforcement of limits is dependent upon the compute resource type. If a container makes no request or limit, the container is scheduled to a node with no resource guarantees. In practice, the container is able to consume as much of the specified resource as is available with the lowest local priority. In low resource situations, containers that specify no resource requests are given the lowest quality of service.
+
+Scheduling is based on resources requested, where quota and hard limits refer to resource limits, which can be set higher than requested resources. The difference between the request and the limit determines the level of overcommit. For example, if a container is given a memory request of 1Gi and a memory limit of 2Gi, the container is scheduled based on the 1Gi request being available on the node, but could use up to 2Gi; so it is 100% overcommitted.

--- a/modules/nodes-cluster-overcommit-resources-containers.adoc
+++ b/modules/nodes-cluster-overcommit-resources-containers.adoc
@@ -5,56 +5,27 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nodes-cluster-overcommit-reserving-memory_{context}"]
-= Understanding compute resources and containers
+= Understanding container CPU and memory requests
 
-The node-enforced behavior for compute resources is specific to the resource
-type.
+[role="_abstract"]
+Review the following information to learn about container CPU and memory requests to help you ensure that your cluster is properly configured.
 
-[id="understanding-container-CPU-requests_{context}"]
-== Understanding container CPU requests
+A container is guaranteed the amount of CPU it requests and is additionally able to consume excess CPU available on the node, up to any limit specified by the container. If multiple containers are attempting to use excess CPU, CPU time is distributed based on the amount of CPU requested by each container.
 
-A container is guaranteed the amount of CPU it requests and is additionally able
-to consume excess CPU available on the node, up to any limit specified by the
-container. If multiple containers are attempting to use excess CPU, CPU time is
-distributed based on the amount of CPU requested by each container.
+For example, if one container requested 500m of CPU time and another container requested 250m of CPU time, any extra CPU time available on the node is distributed among the containers in a 2:1 ratio. If a container specified a limit, it will be throttled not to use more CPU than the specified limit. CPU requests are enforced using the CFS shares support in the Linux kernel. By default, CPU limits are enforced using the CFS quota support in the Linux kernel over a 100ms measuring interval, though this can be disabled.
 
-For example, if one container requested 500m of CPU time and another container
-requested 250m of CPU time, then any extra CPU time available on the node is
-distributed among the containers in a 2:1 ratio. If a container specified a
-limit, it will be throttled not to use more CPU than the specified limit.
-CPU requests are enforced using the CFS shares support in the Linux kernel. By
-default, CPU limits are enforced using the CFS quota support in the Linux kernel
-over a 100ms measuring interval, though this can be disabled.
-
-[id="understanding-memory-requests-container_{context}"]
-== Understanding container memory requests
-
-A container is guaranteed the amount of memory it requests. A container can use
-more memory than requested, but once it exceeds its requested amount, it could
-be terminated in a low memory situation on the node.
-If a container uses less memory than requested, it will not be terminated unless
-system tasks or daemons need more memory than was accounted for in the node's
-resource reservation. If a container specifies a limit on memory, it is
-immediately terminated if it exceeds the limit amount.
+A container is guaranteed the amount of memory it requests. A container can use more memory than requested, but once it exceeds its requested amount, it could be terminated in a low memory situation on the node. If a container uses less memory than requested, it will not be terminated unless system tasks or daemons need more memory than was accounted for in the node's resource reservation. If a container specifies a limit on memory, it is immediately terminated if it exceeds the limit amount.
 
 ////
 Not in 4.1
-[id="containers-ephemeral_{context}"]
-== Understanding containers and ephemeral storage
+Containers and ephemeral storage::
 
 [NOTE]
 ====
 The {product-title} cluster uses ephemeral storage to store information that does not have to persist after the cluster is destroyed.
 ====
 
-A container is guaranteed the amount of ephemeral storage it requests. A
-container can use more ephemeral storage than requested, but once it exceeds its
-requested amount, it can be terminated if the available ephemeral disk space gets
-too low.
+A container is guaranteed the amount of ephemeral storage it requests. A container can use more ephemeral storage than requested, but once it exceeds its requested amount, it can be terminated if the available ephemeral disk space gets too low.
 
-If a container uses less ephemeral storage than requested, it will not be
-terminated unless system tasks or daemons need more local ephemeral storage than
-was accounted for in the node's resource reservation. If a container specifies a
-limit on ephemeral storage, it is immediately terminated if it exceeds the limit
-amount.
+If a container uses less ephemeral storage than requested, it is not terminated unless system tasks or daemons need more local ephemeral storage than was accounted for in the node's resource reservation. If a container specifies a limit on ephemeral storage, it is immediately terminated if it exceeds the limit amount.
 ////

--- a/modules/nodes-cluster-project-overcommit.adoc
+++ b/modules/nodes-cluster-project-overcommit.adoc
@@ -7,19 +7,20 @@
 [id="nodes-cluster-project-overcommit_{context}"]
 = Project-level limits
 
+[role="_abstract"]
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-To help control overcommit, you can set per-project resource limit ranges,
-specifying memory and CPU limits and defaults for a project that overcommit
-cannot exceed.
+To help control overcommit, you can set per-project resource limit ranges, specifying memory and CPU limits and defaults for a project that overcommit cannot exceed.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+In {product-title}, because overcommitment of project-level resources is enabled by default, if required by your use case, you can disable overcommitment on projects that are not managed by Red Hat.
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
-For information on project-level resource limits, see Additional resources.
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+For information on project-level resource limits, see the _Additional resources_ section.
 
 Alternatively, you can disable overcommitment for specific projects.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-In {product-title}, overcommitment of project-level resources is enabled by default.
-If required by your use case, you can disable overcommitment on projects that are not managed by Red Hat.
-
 For the list of projects that are managed by Red Hat and cannot be modified, see "Red Hat Managed resources" in _Support_.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]

--- a/modules/nodes-cluster-resource-configure-about.adoc
+++ b/modules/nodes-cluster-resource-configure-about.adoc
@@ -4,28 +4,20 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nodes-cluster-resource-configure-about_{context}"]
-= Understanding managing application memory
+= Understanding how to manage application memory
 
-It is recommended to fully read the overview of how {product-title} manages
-Compute Resources before proceeding.
+[role="_abstract"]
+You can review the following concepts to learn how {product-title} manages compute resources so that you can lean how to keep your cluster running efficiently.
 
-For each kind of resource (memory, CPU, storage), {product-title} allows
-optional *request* and *limit* values to be placed on each container in a
-pod.
+For each kind of resource (memory, CPU, storage), {product-title} allows optional *request* and *limit* values to be placed on each container in a pod.
 
-Note the following about memory requests and memory limits:
+Note the following information about memory requests and memory limits:
 
 * *Memory request*
 
-  - The memory request value, if specified, influences the {product-title}
-    scheduler. The scheduler considers the memory request when scheduling a
-    container to a node, then fences off the requested memory on the chosen node
-    for the use of the container.
+  - The memory request value, if specified, influences the {product-title} scheduler. The scheduler considers the memory request when scheduling a container to a node, then fences off the requested memory on the chosen node for the use of the container.
 
-  - If a node's memory is exhausted, {product-title} prioritizes evicting its
-    containers whose memory usage most exceeds their memory request. In serious
-    cases of memory exhaustion, the node OOM killer may select and kill a
-    process in a container based on a similar metric.
+  - If a node's memory is exhausted, {product-title} prioritizes evicting its containers whose memory usage most exceeds their memory request. In serious cases of memory exhaustion, the node OOM killer might select and kill a process in a container based on a similar metric.
 
   - The cluster administrator can assign quota or assign default values for the memory request value.
 
@@ -33,63 +25,39 @@ Note the following about memory requests and memory limits:
 
 * *Memory limit*
 
-  - The memory limit value, if specified, provides a hard limit on the memory
-    that can be allocated across all the processes in a container.
+  - The memory limit value, if specified, provides a hard limit on the memory that can be allocated across all the processes in a container.
 
-  - If the memory allocated by all of the processes in a container exceeds the
-    memory limit, the node Out of Memory (OOM) killer will immediately select and kill a process in the container.
+  - If the memory allocated by all of the processes in a container exceeds the memory limit, the node Out of Memory (OOM) killer immediately selects and kills a process in the container.
 
-  - If both memory request and limit are specified, the memory limit value must
-    be greater than or equal to the memory request.
+  - If both memory request and limit are specified, the memory limit value must be greater than or equal to the memory request.
 
   - The cluster administrator can assign quota or assign default values for the memory limit value.
 
   - The minimum memory limit is 12 MB. If a container fails to start due to a `Cannot allocate memory` pod event, the memory limit is too low. Either increase or remove the memory limit. Removing the limit allows pods to consume unbounded node resources.
 
-[id="nodes-cluster-resource-configure-about-memory_{context}"]
-== Managing application memory strategy
-
 The steps for sizing application memory on {product-title} are as follows:
 
 . *Determine expected container memory usage*
 +
-Determine expected mean and peak container memory usage, empirically if
-necessary (for example, by separate load testing). Remember to consider all the
-processes that may potentially run in parallel in the container: for example,
-does the main application spawn any ancillary scripts?
+Determine expected mean and peak container memory usage. For example, you could perform separate load testing. Remember to consider all the processes that could potentially run in parallel in the container, such as any ancillary scripts that might be spawned by the main application.
 
 . *Determine risk appetite*
 +
-Determine risk appetite for eviction. If the risk appetite is low, the
-container should request memory according to the expected peak usage plus a
-percentage safety margin. If the risk appetite is higher, it may be more
-appropriate to request memory according to the expected mean usage.
+Determine risk appetite for eviction. If the risk appetite is low, the container should request memory according to the expected peak usage plus a percentage safety margin. If the risk appetite is higher, it might be more appropriate to request memory according to the expected mean usage.
 
 . *Set container memory request*
 +
-Set container memory request based on the above. The more accurately the
-request represents the application memory usage, the better. If the request is
-too high, cluster and quota usage will be inefficient. If the request is too
-low, the chances of application eviction increase.
+Set the container memory request based on the above. The request should represent the application memory usage as accurately as possible. If the request is too high, cluster and quota usage will be inefficient. If the request is too low, the chances of application eviction increase.
 
 . *Set container memory limit, if required*
 +
-Set container memory limit, if required. Setting a limit has the effect of
-immediately killing a container process if the combined memory usage of all
-processes in the container exceeds the limit, and is therefore a mixed blessing.
-On the one hand, it may make unanticipated excess memory usage obvious early
-("fail fast"); on the other hand it also terminates processes abruptly.
+Set the container memory limit, if required. Setting a limit has the effect of immediately killing a container process if the combined memory usage of all processes in the container exceeds the limit. Setting a limit might make unanticipated excess memory usage obvious early (_fail fast_). However, setting a limit also terminates processes abruptly.
 +
-Note that some {product-title} clusters may require a limit value to be set;
-some may override the request based on the limit; and some application images
-rely on a limit value being set as this is easier to detect than a request
-value.
+Note that some {product-title} clusters might require a limit value to be set; some might override the request based on the limit; and some application images rely on a limit value being set as this is easier to detect than a request value.
 +
-If the memory limit is set, it should not be set to less than the expected peak
-container memory usage plus a percentage safety margin.
+If the memory limit is set, it should not be set to less than the expected peak container memory usage plus a percentage safety margin.
 
-. *Ensure application is tuned*
+. *Ensure applications are tuned*
 +
-Ensure application is tuned with respect to configured request and limit values,
-if appropriate. This step is particularly relevant to applications which pool
+Ensure your applications are tuned with respect to configured request and limit values, if appropriate. This step is particularly relevant to applications which pool
 memory, such as the JVM. The rest of this page discusses this.

--- a/modules/nodes-cluster-resource-configure-evicted.adoc
+++ b/modules/nodes-cluster-resource-configure-evicted.adoc
@@ -6,17 +6,12 @@
 [id="nodes-cluster-resource-configure-evicted_{context}"]
 = Understanding pod eviction
 
-{product-title} may evict a pod from its node when the node's memory is
-exhausted. Depending on the extent of memory exhaustion, the eviction may or
-may not be graceful. Graceful eviction implies the main process (PID 1) of each
-container receiving a SIGTERM signal, then some time later a SIGKILL signal if
-the process has not exited already. Non-graceful eviction implies the main
-process of each container immediately receiving a SIGKILL signal.
+[role="_abstract"]
+You can review the following concepts to learn the {product-title} pod eviction policy.
 
-An evicted pod has phase *Failed* and reason *Evicted*. It will not be
-restarted, regardless of the value of `restartPolicy`. However, controllers
-such as the replication controller will notice the pod's failed status and create
-a new pod to replace the old one.
+{product-title} can evict a pod from its node when the node's memory is exhausted. Depending on the extent of memory exhaustion, the eviction might or might not be graceful. Graceful eviction implies the main process (PID 1) of each container receiving a SIGTERM signal, then some time later a SIGKILL signal if the process has not exited already. Non-graceful eviction implies the main process of each container immediately receiving a SIGKILL signal.
+
+An evicted pod has phase *Failed* and reason *Evicted*. It is not restarted, regardless of the value of `restartPolicy`. However, controllers such as the replication controller will notice the pod's failed status and create a new pod to replace the old one.
 
 [source,terminal]
 ----
@@ -38,6 +33,10 @@ $ oc get pod test -o yaml
 .Example output
 [source,terminal]
 ----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
 ...
 status:
   message: 'Pod The node was low on resource: [MemoryPressure].'

--- a/modules/nodes-cluster-resource-configure-jdk.adoc
+++ b/modules/nodes-cluster-resource-configure-jdk.adoc
@@ -6,63 +6,53 @@
 [id="nodes-cluster-resource-configure-jdk_{context}"]
 = Understanding OpenJDK settings for {product-title}
 
+[role="_abstract"]
+You can review the following concepts to learn about how to deploy OpenJDK applications in your cluster effectively.
+
 The default OpenJDK settings do not work well with containerized environments. As a result, some additional Java memory settings must always be provided whenever running the OpenJDK in a container.
 
 The JVM memory layout is complex, version dependent, and describing it in detail is beyond the scope of this documentation. However, as a starting point for running OpenJDK in a container, at least the following three memory-related tasks are key:
 
-. Overriding the JVM maximum heap size.
-
-. Encouraging the JVM to release unused memory to the operating system, if appropriate.
-
-. Ensuring all JVM processes within a container are appropriately configured.
-
-Optimally tuning JVM workloads for running in a container is beyond the scope of this documentation, and may involve setting multiple additional JVM options.
-
-[id="nodes-cluster-resource-configure-jdk-heap_{context}"]
-== Understanding how to override the JVM maximum heap size
-
-OpenJDK defaults to using a maximum of 25% of available memory (recognizing any container memory limits in place) for "heap" memory. This default value is conservative, and, in a properly-configured container environment, this value would result in 75% of the memory assigned to a container being mostly unused. A much higher percentage for the JVM to use for heap memory, such as 80%, is more suitable in a container context where memory limits are imposed on the container level.
-
+Overriding the JVM maximum heap size::
+OpenJDK defaults to using a maximum of 25% of available memory (recognizing any container memory limits in place) for _heap_ memory. This default value is conservative, and, in a properly-configured container environment, would result in 75% of the memory assigned to a container being mostly unused. A much higher percentage for the JVM to use for heap memory, such as 80%, is more suitable in a container context where memory limits are imposed on the container level.
++
 Most of the Red{nbsp}Hat containers include a startup script that replaces the OpenJDK default by setting updated values when the JVM launches.
-
++
 For example, the Red{nbsp}Hat build of OpenJDK containers have a default value of 80%. This value can be set to a different percentage by defining the `JAVA_MAX_RAM_RATIO` environment variable.
-
++
 For other OpenJDK deployements, the default value of 25% can be changed using the following command:
-
++
 .Example
 [source,terminal]
 ----
 $ java -XX:MaxRAMPercentage=80.0
 ----
 
-[id="nodes-cluster-resource-configure-jdk-unused_{context}"]
-== Understanding how to encourage the JVM to release unused memory to the operating system
-
-By default, the OpenJDK does not aggressively return unused memory to the operating system. This may be appropriate for many containerized Java workloads, but notable exceptions include workloads where additional active processes co-exist with a JVM within a container, whether those additional processes are native, additional JVMs, or a combination of the two.
-
+Encouraging the JVM to release unused memory to the operating system, if appropriate::
+By default, the OpenJDK does not aggressively return unused memory to the operating system. This could be appropriate for many containerized Java workloads, but notable exceptions include workloads where additional active processes co-exist with a JVM within a container, whether those additional processes are native, additional JVMs, or a combination of the two.
++
 Java-based agents can use the following JVM arguments to encourage the JVM to release unused memory to the operating system:
-
++
 [source,terminal]
 ----
 -XX:+UseParallelGC
 -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
 -XX:AdaptiveSizePolicyWeight=90
 ----
-
++
 These arguments are intended to return heap memory to the operating system whenever allocated memory exceeds 110% of in-use memory (`-XX:MaxHeapFreeRatio`), spending up to 20% of CPU time in the garbage collector (`-XX:GCTimeRatio`). At no time will the application heap allocation be less than the initial heap allocation (overridden by `-XX:InitialHeapSize` / `-Xms`). Detailed additional information is available link:https://developers.redhat.com/blog/2014/07/15/dude-wheres-my-paas-memory-tuning-javas-footprint-in-openshift-part-1/[Tuning Java's footprint in OpenShift (Part 1)], link:https://developers.redhat.com/blog/2014/07/22/dude-wheres-my-paas-memory-tuning-javas-footprint-in-openshift-part-2/[Tuning Java's footprint in OpenShift (Part 2)], and at link:https://developers.redhat.com/blog/2017/04/04/openjdk-and-containers/[OpenJDK and Containers].
 
-[id="nodes-cluster-resource-configure-jdk-proc_{context}"]
-== Understanding how to ensure all JVM processes within a container are appropriately configured
-
+Ensuring all JVM processes within a container are appropriately configured::
 In the case that multiple JVMs run in the same container, it is essential to ensure that they are all configured appropriately. For many workloads it will be necessary to grant each JVM a percentage memory budget, leaving a perhaps substantial additional safety margin.
-
++
 Many Java tools use different environment variables (`JAVA_OPTS`, `GRADLE_OPTS`, and so on) to configure their JVMs and it can be challenging to ensure that the right settings are being passed to the right JVM.
-
++
 The `JAVA_TOOL_OPTIONS` environment variable is always respected by the OpenJDK, and values specified in `JAVA_TOOL_OPTIONS` will be overridden by other options specified on the JVM command line. By default, to ensure that these options are used by default for all JVM workloads run in the Java-based agent image, the {product-title} Jenkins Maven agent image sets the following variable:
-
++
 [source,terminal]
 ----
 JAVA_TOOL_OPTIONS="-Dsun.zip.disableMemoryMapping=true"
 ----
 
 This does not guarantee that additional options are not required, but is intended to be a helpful starting point.
+Optimally tuning JVM workloads for running in a container is beyond the scope of this documentation, and may involve setting multiple additional JVM options.

--- a/modules/nodes-cluster-resource-configure-oom.adoc
+++ b/modules/nodes-cluster-resource-configure-oom.adoc
@@ -2,23 +2,20 @@
 //
 // * nodes/nodes-cluster-resource-configure.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 [id="nodes-cluster-resource-configure-oom_{context}"]
 = Understanding OOM kill policy
 
-{product-title} can kill a process in a container if the total memory usage of
-all the processes in the container exceeds the memory limit, or in serious cases
-of node memory exhaustion.
+[role="_abstract"]
+{product-title} can kill a process in a container if the total memory usage of all the processes in the container exceeds the memory limit, or in serious cases of node memory exhaustion.
 
-When a process is Out of Memory (OOM) killed, this might result in the container
-exiting immediately. If the container PID 1 process receives the *SIGKILL*, the
-container will exit immediately. Otherwise, the container behavior is
-dependent on the behavior of the other processes.
+If a process is Out of Memory (OOM) killed, the container could exit immediately. If the container PID 1 process receives the *SIGKILL*, the container does exit immediately. Otherwise, the container behavior is dependent on the behavior of the other processes.
 
 For example, a container process exited with code 137, indicating it received a SIGKILL signal.
 
-If the container does not exit immediately, an OOM kill is detectable as
-follows:
+If the container does not exit immediately, use the following stepts to detect if an OOM kill occurred.
+
+.Procedure
 
 . Access the pod using a remote shell:
 +
@@ -66,10 +63,7 @@ $ grep '^oom_kill ' /sys/fs/cgroup/memory/memory.oom_control
 oom_kill 1
 ----
 +
-If one or more processes in a pod are OOM killed, when the pod subsequently
-exits, whether immediately or not, it will have phase *Failed* and reason
-*OOMKilled*. An OOM-killed pod might be restarted depending on the value of
-`restartPolicy`. If not restarted, controllers such as the replication controller will notice the pod's failed status and create a new pod to replace the old one.
+If one or more processes in a pod are OOM killed, when the pod subsequently exits, whether immediately or not, it will have phase *Failed* and reason *OOMKilled*. An OOM-killed pod might be restarted depending on the value of `restartPolicy`. If not restarted, controllers such as the replication controller will notice the pod's failed status and create a new pod to replace the old one.
 +
 Use the following command to get the pod status:
 +
@@ -95,7 +89,11 @@ $ oc get pod test -o yaml
 .Example output
 [source,terminal]
 ----
-...
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+# ...
 status:
   containerStatuses:
   - name: test
@@ -118,7 +116,11 @@ $ oc get pod test -o yaml
 .Example output
 [source,terminal]
 ----
-...
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test
+# ...
 status:
   containerStatuses:
   - name: test

--- a/modules/nodes-cluster-resource-configure-request-limit.adoc
+++ b/modules/nodes-cluster-resource-configure-request-limit.adoc
@@ -6,7 +6,8 @@
 [id="nodes-cluster-resource-configure-request-limit_{context}"]
 = Finding the memory request and limit from within a pod
 
-An application wishing to dynamically discover its memory request and limit from within a pod should use the Downward API.
+[role="_abstract"]
+You can configure your container to use the Downward API to dynamically discover its memory request and limit from within a pod. This allows your applications to better manage these resources without needing to use the API server.  
 
 .Procedure
 
@@ -32,12 +33,12 @@ spec:
     - sleep
     - "3600"
     env:
-    - name: MEMORY_REQUEST # <1>
+    - name: MEMORY_REQUEST
       valueFrom:
         resourceFieldRef:
           containerName: test
           resource: requests.memory
-    - name: MEMORY_LIMIT # <2>
+    - name: MEMORY_LIMIT
       valueFrom:
         resourceFieldRef:
           containerName: test
@@ -52,8 +53,13 @@ spec:
       capabilities:
         drop: [ALL]
 ----
-<1> Add this stanza to discover the application memory request value.
-<2> Add this stanza to discover the application memory limit value.
+where:
++
+--
+`spec.consinters.env.name.MEMORY_REQUEST`:: This stanza discovers the application memory request value.
+
+`spec.consinters.env.name.MEMORY_LIMIT`:: This stanza discovers the application memory limit value.
+--
 
 .. Create the pod by running the following command:
 +

--- a/modules/nodes-cluster-resource-configure.adoc
+++ b/modules/nodes-cluster-resource-configure.adoc
@@ -7,9 +7,10 @@
 [id="nodes-cluster-resource-configure_{context}"]
 = Configuring cluster-level overcommit
 
+[role="_abstract"]
+You can use the OpenShift CLI to configure the Cluster Resource Override Operator to help control overcommit in your cluster.
 
-The Cluster Resource Override Operator requires a `ClusterResourceOverride` custom resource (CR)
-and a label for each project where you want the Operator to control overcommit.
+The Cluster Resource Override Operator requires a `ClusterResourceOverride` custom resource (CR) and a label for each project where you want the Operator to control overcommit.
 
 ifndef::openshift-rosa,openshift-dedicated[]
 By default, the installation process creates two Cluster Resource Override pods on the control plane nodes in the `clusterresourceoverride-operator` namespace. You can move these pods to other nodes, such as infrastructure nodes, as needed. Infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see "Moving the Cluster Resource Override Operator pods".
@@ -17,12 +18,9 @@ endif::openshift-rosa,openshift-dedicated[]
 
 .Prerequisites
 
-* The Cluster Resource Override Operator has no effect if limits have not
-been set on containers. You must specify default limits for a project using a `LimitRange` object or configure limits in `Pod` specs for the overrides to apply.
+* The Cluster Resource Override Operator has no effect if limits have not been set on containers. You must specify default limits for a project using a `LimitRange` object or configure limits in `Pod` specs for the overrides to apply.
 
 .Procedure
-
-To modify cluster-level overcommit:
 
 . Edit the `ClusterResourceOverride` CR:
 +
@@ -35,14 +33,18 @@ metadata:
 spec:
   podResourceOverride:
     spec:
-      memoryRequestToLimitPercent: 50 <1>
-      cpuRequestToLimitPercent: 25 <2>
-      limitCPUToMemoryPercent: 200 <3>
+      memoryRequestToLimitPercent: 50
+      cpuRequestToLimitPercent: 25
+      limitCPUToMemoryPercent: 200
 # ...
 ----
-<1> Optional: Specify the percentage to override the container memory limit, if used, between 1-100. The default is `50`.
-<2> Optional: Specify the percentage to override the container CPU limit, if used, between 1-100. The default is `25`.
-<3> Optional: Specify the percentage to override the container memory limit, if used. Scaling 1Gi of RAM at 100 percent is equal to 1 CPU core. This is processed before overriding the CPU request, if configured. The default is `200`.
+where:
++
+--
+`spec.podResourceOverride.spec.memoryRequestToLimitPercent`:: Specifies the percentage to override the container memory limit, if used, between 1-100. The default is `50`. This parameter is optional.
+`spec.podResourceOverride.spec.cpuRequestToLimitPercent`:: Specifies the percentage to override the container CPU limit, if used, between 1-100. The default is `25`. This parameter is optional.
+`spec.podResourceOverride.spec.limitCPUToMemoryPercent`:: Specifies the percentage to override the container memory limit, if used. Scaling 1Gi of RAM at 100 percent is equal to 1 CPU core. This is processed before overriding the CPU request, if configured. The default is `200`. This parameter is optional.
+--
 
 . Ensure the following label has been added to the Namespace object for each project where you want the Cluster Resource Override Operator to control overcommit:
 +
@@ -55,8 +57,12 @@ metadata:
 # ...
 
   labels:
-    clusterresourceoverrides.admission.autoscaling.openshift.io/enabled: "true" <1>
+    clusterresourceoverrides.admission.autoscaling.openshift.io/enabled: "true"
 
 # ...
 ----
-<1> Add this label to each project.
+where:
++
+--
+`metadata.labels.clusterresourceoverrides.admission.autoscaling.openshift.io/enabled: "true"`:: Specifies that you want to use the Cluster Resource Override Operator with this project.
+--

--- a/modules/nodes-cluster-resource-levels-about.adoc
+++ b/modules/nodes-cluster-resource-levels-about.adoc
@@ -6,23 +6,14 @@
 [id="nodes-cluster-resource-levels-about_{context}"]
 = Understanding the OpenShift Cluster Capacity Tool
 
-The OpenShift Cluster Capacity Tool simulates a sequence of scheduling decisions to
-determine how many instances of an input pod can be scheduled on the cluster
-before it is exhausted of resources to provide a more accurate estimation.
+[role="_abstract"]
+Review the following information to learn how to use the OpenShift Cluster Capacity Tool to simulate a sequence of scheduling decisions that determine how many instances of an input pod can be scheduled on the cluster before the cluster is exhausted of resources.
 
 [NOTE]
 ====
-The remaining allocatable capacity is a rough estimation, because it does not
-count all of the resources being distributed among nodes. It analyzes only the
-remaining resources and estimates the available capacity that is still
-consumable in terms of a number of instances of a pod with given requirements
-that can be scheduled in a cluster.
+The remaining allocatable capacity is a rough estimation, because it does not count all of the resources being distributed among nodes. It analyzes only the remaining resources and estimates the available capacity that is still consumable in terms of the number of instances of a pod with given requirements that can be scheduled in a cluster.
 
-Also, pods might only have scheduling support on particular sets of nodes based
-on its selection and affinity criteria. As a result, the estimation of which
-remaining pods a cluster can schedule can be difficult.
+Also, pods might only have scheduling support on particular sets of nodes based on its selection and affinity criteria. As a result, the estimation of which remaining pods a cluster can schedule can be difficult.
 ====
 
-You can run the OpenShift Cluster Capacity Tool as a stand-alone utility from
-the command line, or as a job in a pod inside an {product-title} cluster.
-Running the tool as job inside of a pod enables you to run it multiple times without intervention.
+You can run the OpenShift Cluster Capacity Tool as a stand-alone utility from the command line, or as a job in a pod inside an {product-title} cluster. Running the tool as job inside of a pod enables you to run it multiple times without intervention.

--- a/modules/nodes-cluster-resource-levels-command.adoc
+++ b/modules/nodes-cluster-resource-levels-command.adoc
@@ -6,16 +6,14 @@
 [id="nodes-cluster-resource-levels-command_{context}"]
 = Running the OpenShift Cluster Capacity Tool on the command line
 
-You can run the OpenShift Cluster Capacity Tool from the command line
-to estimate the number of pods that can be scheduled onto your cluster.
+[role="_abstract"]
+You can run the OpenShift Cluster Capacity Tool from the command line to estimate the number of pods that can be scheduled onto your cluster.
 
-You create a sample pod spec file, which the tool uses for estimating resource usage. The pod spec specifies its resource
-requirements as `limits` or `requests`. The cluster capacity tool takes the
-pod's resource requirements into account for its estimation analysis.
+You create a sample pod spec file, which the tool uses for estimating resource usage. The pod spec specifies its resource requirements as `limits` or `requests`. The cluster capacity tool takes the pod's resource requirements into account for its estimation analysis.
 
 .Prerequisites
 
-. Run the link:https://catalog.redhat.com/software/containers/openshift4/ose-cluster-capacity/5cca0324d70cc57c44ae8eb6?container-tabs=overview[OpenShift Cluster Capacity Tool], which is available as a container image from the Red Hat Ecosystem Catalog.
+. Run the OpenShift Cluster Capacity Tool, which is available as a container image from the Red Hat Ecosystem Catalog. See the link in the "Additional resources" section.
 
 . Create a sample pod spec file:
 
@@ -66,8 +64,6 @@ $ oc create -f pod-spec.yaml
 ----
 
 .Procedure
-
-To use the cluster capacity tool on the command line:
 
 . From the terminal, log in to the Red Hat Registry:
 +

--- a/modules/nodes-cluster-resource-levels-job.adoc
+++ b/modules/nodes-cluster-resource-levels-job.adoc
@@ -6,15 +6,14 @@
 [id="nodes-cluster-resource-levels-job_{context}"]
 = Running the OpenShift Cluster Capacity Tool as a job inside a pod
 
-Running the OpenShift Cluster Capacity Tool as a job inside of a pod allows you to run the tool multiple times without needing user intervention. You run the OpenShift Cluster Capacity Tool as a job by using a `ConfigMap` object.
+[role="_abstract"]
+You can run the OpenShift Cluster Capacity Tool as a job inside of a pod by using a `ConfigMap` object. This allows you to run the tool multiple times without needing user intervention.
 
 .Prerequisites
 
-Download and install link:https://github.com/openshift/cluster-capacity[OpenShift Cluster Capacity Tool].
+* Download and install the OpenShift Cluster Capacity Tool from the `cluster-capacity` repository. See the link in the "Additional resources" section.
 
 .Procedure
-
-To run the cluster capacity tool:
 
 . Create the cluster role:
 
@@ -157,7 +156,7 @@ spec:
           - mountPath: /test-pod
             name: test-volume
           env:
-          - name: CC_INCLUSTER <1>
+          - name: CC_INCLUSTER
             value: "true"
           command:
           - "/bin/sh"
@@ -171,7 +170,9 @@ spec:
           configMap:
             name: cluster-capacity-configmap
 ----
-<1> A required environment variable letting the cluster capacity tool know that it is running inside a cluster as a pod.
+where:
+
+`spec.template.spec.containers.env`:: Specifies a required environment variable that indicates the Cluster Capacity Tool is running inside a cluster as a pod.
  +
 The `pod.yaml` key of the `ConfigMap` object is the same as the `Pod` spec file name, though it is not required. By doing this, the input pod spec file can be accessed inside the pod as `/test-pod/pod.yaml`.
 

--- a/modules/nodes-cluster-resource-override-deploy-cli.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-cli.adoc
@@ -7,7 +7,8 @@
 [id="nodes-cluster-resource-override-deploy-cli_{context}"]
 = Installing the Cluster Resource Override Operator using the CLI
 
-You can use the {product-title} CLI to install the Cluster Resource Override Operator to help control overcommit in your cluster. 
+[role="_abstract"]
+You can use the OpenShift CLI to install the Cluster Resource Override Operator to help you control overcommit in your cluster. 
 
 ifndef::openshift-rosa,openshift-dedicated[]
 By default, the installation process creates a Cluster Resource Override Operator pod on a worker node in the `clusterresourceoverride-operator` namespace. You can move this pod to another node, such as an infrastructure node, as needed. Infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see "Moving the Cluster Resource Override Operator pods".
@@ -18,8 +19,6 @@ endif::openshift-rosa,openshift-dedicated[]
 * The Cluster Resource Override Operator has no effect if limits have not been set on containers. You must specify default limits for a project using a `LimitRange` object or configure limits in `Pod` specs for the overrides to apply.
 
 .Procedure
-
-To install the Cluster Resource Override Operator using the CLI:
 
 . Create a namespace for the Cluster Resource Override Operator:
 
@@ -125,18 +124,22 @@ $ oc project clusterresourceoverride-operator
 apiVersion: operator.autoscaling.openshift.io/v1
 kind: ClusterResourceOverride
 metadata:
-    name: cluster <1>
+    name: cluster
 spec:
   podResourceOverride:
     spec:
-      memoryRequestToLimitPercent: 50 <2>
-      cpuRequestToLimitPercent: 25 <3>
-      limitCPUToMemoryPercent: 200 <4>
+      memoryRequestToLimitPercent: 50
+      cpuRequestToLimitPercent: 25
+      limitCPUToMemoryPercent: 200
 ----
-<1> The name must be `cluster`.
-<2> Optional: Specify the percentage to override the container memory limit, if used, between 1-100. The default is `50`.
-<3> Optional: Specify the percentage to override the container CPU limit, if used, between 1-100. The default is `25`.
-<4> Optional: Specify the percentage to override the container memory limit, if used. Scaling 1 Gi of RAM at 100 percent is equal to 1 CPU core. This is processed before overriding the CPU request, if configured. The default is `200`.
+where
++
+--
+`metadata.name`:: Specifies a name for the CR. The name must be `cluster`.
+`spec.podResourceOverride.spec.memoryRequestToLimitPercent`:: Specifies the percentage to override the container memory limit, if used, between 1-100. The default is `50`. This parameter is optional.
+`spec.podResourceOverride.spec.cpuRequestToLimitPercent`:: Specifies the percentage to override the container CPU limit, if used, between 1-100. The default is `25`. This parameter is optional.
+`spec.podResourceOverride.spec.limitCPUToMemoryPercent`:: Specifies the percentage to override the container memory limit, if used. Scaling 1 Gi of RAM at 100 percent is equal to 1 CPU core. This is processed before overriding the CPU request, if configured. The default is `200`. This parameter is optional.
+--
 
 .. Create the `ClusterResourceOverride` object:
 +
@@ -159,7 +162,7 @@ $ oc create -f cro-cr.yaml
 $ oc get clusterresourceoverride cluster -n clusterresourceoverride-operator -o yaml
 ----
 +
-The `mutatingWebhookConfigurationRef` section appears when the webhook is called.
+The `mutatingWebhookConfigurationRef` section displays when the webhook is called.
 +
 .Example output
 [source,yaml]
@@ -186,7 +189,7 @@ status:
 
 # ...
 
-    mutatingWebhookConfigurationRef: <1>
+    mutatingWebhookConfigurationRef:
       apiVersion: admissionregistration.k8s.io/v1
       kind: MutatingWebhookConfiguration
       name: clusterresourceoverrides.admission.autoscaling.openshift.io
@@ -195,7 +198,11 @@ status:
 
 # ...
 ----
-<1> Reference to the `ClusterResourceOverride` admission webhook.
+where:
++
+--
+`status.mutatingWebhookConfigurationRef`:: Specifies the `ClusterResourceOverride` admission webhook.
+--
 
 ////
 . When the webhook is called, you can add a label to any Namespaces where you want overrides enabled:
@@ -212,8 +219,12 @@ metadata:
 # ...
 
   labels:
-    clusterresourceoverrides.admission.autoscaling.openshift.io: enabled <1>
+    clusterresourceoverrides.admission.autoscaling.openshift.io: enabled
 # ...
 ----
-<1> Add the `clusterresourceoverrides.admission.autoscaling.openshift.io: enabled` label to the Namespace.
+where:	
++
+--
+`metadata.labels.clusterresourceoverrides.admission.autoscaling.openshift.io`:: Add the `clusterresourceoverrides.admission.autoscaling.openshift.io: enabled` label to the namespace.
+--
 ////

--- a/modules/nodes-cluster-resource-override-deploy-console.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-console.adoc
@@ -6,7 +6,8 @@
 [id="nodes-cluster-resource-override-deploy-console_{context}"]
 = Installing the Cluster Resource Override Operator using the web console
 
-You can use the {product-title} CLI to install the Cluster Resource Override Operator to help control overcommit in your cluster. 
+[role="_abstract"]
+You can use the {product-title} web console to install the Cluster Resource Override Operator to help you control overcommit in your cluster. 
 
 ifndef::openshift-rosa,openshift-dedicated[]
 By default, the installation process creates a Cluster Resource Override Operator pod on a worker node in the `clusterresourceoverride-operator` namespace. You can move this pod to another node, such as an infrastructure node, as needed. Infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see "Moving the Cluster Resource Override Operator pods".
@@ -14,12 +15,9 @@ endif::openshift-rosa,openshift-dedicated[]
 
 .Prerequisites
 
-* The Cluster Resource Override Operator has no effect if limits have not
-been set on containers. You must specify default limits for a project using a `LimitRange` object or configure limits in `Pod` specs for the overrides to apply.
+* The Cluster Resource Override Operator has no effect if limits have not been set on containers. You must specify default limits for a project using a `LimitRange` object or configure limits in `Pod` specs for the overrides to apply.
 
 .Procedure
-
-To install the Cluster Resource Override Operator using the {product-title} web console:
 
 . In the {product-title} web console, navigate to *Home* -> *Projects*
 
@@ -52,18 +50,22 @@ To install the Cluster Resource Override Operator using the {product-title} web 
 apiVersion: operator.autoscaling.openshift.io/v1
 kind: ClusterResourceOverride
 metadata:
-  name: cluster <1>
+  name: cluster
 spec:
   podResourceOverride:
     spec:
-      memoryRequestToLimitPercent: 50 <2>
-      cpuRequestToLimitPercent: 25 <3>
-      limitCPUToMemoryPercent: 200 <4>
+      memoryRequestToLimitPercent: 50
+      cpuRequestToLimitPercent: 25
+      limitCPUToMemoryPercent: 200
 ----
-<1> The name must be `cluster`.
-<2> Optional: Specify the percentage to override the container memory limit, if used, between 1-100. The default is `50`.
-<3> Optional: Specify the percentage to override the container CPU limit, if used, between 1-100. The default is `25`.
-<4> Optional: Specify the percentage to override the container memory limit, if used. Scaling 1 Gi of RAM at 100 percent is equal to 1 CPU core. This is processed before overriding the CPU request, if configured. The default is `200`.
+where:
++
+--
+`metadata.name`:: Specifies a name for the CR. The name must be `cluster`.
+`spec.podResourceOverride.spec.memoryRequestToLimitPercent`:: Specifies the percentage to override the container memory limit, if used, between 1-100. The default is `50`. This parameter is optional.
+`spec.podResourceOverride.spec.cpuRequestToLimitPercent`:: Specifies the percentage to override the container CPU limit, if used, between 1-100. The default is `25`. This parameter is optional.
+`spec.podResourceOverride.spec.limitCPUToMemoryPercent`:: Specifies the percentage to override the container memory limit, if used. Scaling 1 Gi of RAM at 100 percent is equal to 1 CPU core. This is processed before overriding the CPU request, if configured. The default is `200`. This parameter is optional.
+--
 
 .. Click *Create*.
 
@@ -71,7 +73,7 @@ spec:
 
 .. On the *ClusterResourceOverride Operator* page, click *cluster*.
 
-.. On the *ClusterResourceOverride Details* page, click *YAML*. The `mutatingWebhookConfigurationRef` section appears when the webhook is called.
+.. On the *ClusterResourceOverride Details* page, click *YAML*. The `mutatingWebhookConfigurationRef` section displays when the webhook is called.
 +
 [source,yaml]
 ----
@@ -97,7 +99,7 @@ status:
 
 # ...
 
-    mutatingWebhookConfigurationRef: <1>
+    mutatingWebhookConfigurationRef:
       apiVersion: admissionregistration.k8s.io/v1
       kind: MutatingWebhookConfiguration
       name: clusterresourceoverrides.admission.autoscaling.openshift.io
@@ -107,7 +109,11 @@ status:
 # ...
 
 ----
-<1> Reference to the `ClusterResourceOverride` admission webhook.
+where:
++
+--
+`status.mutatingWebhookConfigurationRef`:: Specifies the `ClusterResourceOverride` admission webhook.
+--
 
 ////
 . When the webhook is called, you can add a label to any Namespaces where you want overrides enabled:
@@ -126,8 +132,13 @@ metadata:
 # ...
 
   labels:
-    clusterresourceoverrides.admission.autoscaling.openshift.io: enabled <1>
+    clusterresourceoverrides.admission.autoscaling.openshift.io: enabled
 # ...
 ----
-<1> Add the `clusterresourceoverrides.admission.autoscaling.openshift.io: enabled` label to the Namespace.
+where:
++
+--
+`metadata.labels.clusterresourceoverrides.admission.autoscaling.openshift.io`:: Add the `clusterresourceoverrides.admission.autoscaling.openshift.io: enabled` label to the namespace.
+--
+
 ////

--- a/modules/nodes-cluster-resource-override-move-infra.adoc
+++ b/modules/nodes-cluster-resource-override-move-infra.adoc
@@ -11,6 +11,7 @@ endif::[]
 [id="nodes-cluster-resource-override-move-infra_{context}"]
 = Moving the Cluster Resource Override Operator pods
 
+[role="_abstract"]
 By default, the Cluster Resource Override Operator installation process creates an Operator pod and two Cluster Resource Override pods on nodes in the `clusterresourceoverride-operator` namespace. You can move these pods to other nodes, such as infrastructure nodes, as needed.
 
 ifdef::cro[]
@@ -67,10 +68,14 @@ metadata:
 spec:
   config:
     nodeSelector:
-      node-role.kubernetes.io/infra: "" <1>
+      node-role.kubernetes.io/infra: ""
 # ...
 ----
-<1> Specify the role of the node where you want to deploy the Cluster Resource Override Operator pod.
+where
++
+--
+`spec.config.nodeSelector`:: Specifies the role of the node where you want to deploy the Cluster Resource Override Operator pod.
+--
 +
 [NOTE]
 ====
@@ -90,12 +95,16 @@ spec:
   config:
     nodeSelector:
       node-role.kubernetes.io/infra: ""
-    tolerations: <1>
+    tolerations:
     - key: "node-role.kubernetes.io/infra"
       operator: "Exists"
       effect: "NoSchedule"
 ----
-<1> Specifies a toleration for a taint on the infra node.
+where:
+
+--
+`spec.config.tolerations`:: Specifies a toleration for a taint on the infra node.
+--
 ====
 
 . Move the Cluster Resource Override pods by adding a node selector to the `ClusterResourceOverride` custom resource (CR):
@@ -128,8 +137,12 @@ spec:
       node-role.kubernetes.io/infra: "" <2>
 # ...
 ----
-<1> Optional: Specify the number of Cluster Resource Override pods to deploy. The default is `2`. Only one pod is allowed per node.
-<2> Optional: Specify the role of the node where you want to deploy the Cluster Resource Override pods.
+where
++
+--
+`spec.deploymentOverrides.replicas`:: Specifies the number of Cluster Resource Override pods to deploy. The default is `2`. Only one pod is allowed per node. This parameter is optional.
+`spec.deploymentOverrides.nodeSelector`:: Specifies the role of the node where you want to deploy the Cluster Resource Override pods. This parameter is optional.
+--
 +
 [NOTE]
 ====
@@ -160,7 +173,11 @@ spec:
       value: "value"
       effect: "NoSchedule"
 ----
-<1> Specifies a toleration for a taint on the infra node.
+where:
++
+--
+`spec.config.tolerations`:: Specifies a toleration for a taint on the infra node.
+--
 ====
 
 .Verification

--- a/modules/nodes-cluster-resource-override.adoc
+++ b/modules/nodes-cluster-resource-override.adoc
@@ -7,8 +7,8 @@
 [id="nodes-cluster-resource-override_{context}"]
 = Cluster-level overcommit using the Cluster Resource Override Operator
 
-The Cluster Resource Override Operator is an admission webhook that allows you to control the level of overcommit and manage
-container density across all the nodes in your cluster. The Operator controls how nodes in specific projects can exceed defined memory and CPU limits.
+[role="_abstract"]
+You can use the Cluster Resource Override Operator to control the level of overcommit and manage container density across all the nodes in your cluster. The Operator, which is an admission webhook, controls how nodes in specific projects can exceed defined memory and CPU limits.
 
 // Paragraph taken from 3.11 docs and modified. 
 // https://docs.openshift.com/container-platform/3.11/admin_guide/overcommit.html#configuring-masters-for-overcommitment
@@ -16,33 +16,34 @@ The Operator modifies the ratio between the requests and limits that are set on 
 
 You must install the Cluster Resource Override Operator by using the {product-title} console or CLI as shown in the following sections. After you deploy the Cluster Resource Override Operator, the Operator modifies all new pods in specific namespaces. The Operator does not edit pods that existed before you deployed the Operator. 
 
-During the installation, you create a `ClusterResourceOverride` custom resource (CR), where you set the level of overcommit, as shown in the
-following example:
+During the installation, you create a `ClusterResourceOverride` custom resource (CR), where you set the level of overcommit, as shown in the following example:
 
 [source,yaml]
 ----
 apiVersion: operator.autoscaling.openshift.io/v1
 kind: ClusterResourceOverride
 metadata:
-    name: cluster <1>
+    name: cluster
 spec:
   podResourceOverride:
     spec:
-      memoryRequestToLimitPercent: 50 <2>
-      cpuRequestToLimitPercent: 25 <3>
-      limitCPUToMemoryPercent: 200 <4>
+      memoryRequestToLimitPercent: 50
+      cpuRequestToLimitPercent: 25
+      limitCPUToMemoryPercent: 200
 # ...
 ----
-<1> The name must be `cluster`.
-<2> Optional. If a container memory limit has been specified or defaulted, the memory request is overridden to this percentage of the limit, between 1-100. The default is 50.
-<3> Optional. If a container CPU limit has been specified or defaulted, the CPU request is overridden to this percentage of the limit, between 1-100. The default is 25.
-<4> Optional. If a container memory limit has been specified or defaulted, the CPU limit is overridden to a percentage of the memory limit, if specified. Scaling 1Gi of RAM at 100 percent is equal to 1 CPU core. This is processed prior to overriding the CPU request (if configured). The default is 200.
+where:
+
+--
+`metadata.name`:: Specifies a name for the object. The name must be `cluster`.
+`spec.podResourceOverride.spec.memoryRequestToLimitPercent`:: If a container memory limit has been specified or defaulted, the memory request is overridden to this percentage of the limit, between 1-100. The default is 50.
+`spec.podResourceOverride.spec.cpuRequestToLimitPercent`:: If a container CPU limit has been specified or defaulted, the CPU request is overridden to this percentage of the limit, between 1-100. The default is 25.
+`spec.podResourceOverride.spec.limitCPUToMemoryPercent`:: If a container memory limit has been specified or defaulted, the CPU limit is overridden to a percentage of the memory limit, if specified. Scaling 1Gi of RAM at 100 percent is equal to 1 CPU core. This is processed before overriding the CPU request (if configured). The default is 200.
+--
 
 [NOTE]
 ====
-The Cluster Resource Override Operator overrides have no effect if limits have not
-been set on containers. Create a `LimitRange` object with default limits per individual project
-or configure limits in `Pod` specs for the overrides to apply.
+The Cluster Resource Override Operator overrides have no effect if limits have not been set on containers. Create a `LimitRange` object with default limits per individual project or configure limits in `Pod` specs for the overrides to apply.
 ====
 
 When configured, you can enable overrides on a per-project basis by applying the following label to the `Namespace` object for each project where you want the overrides to apply. For example, you can configure override so that infrastructure components are not subject to the overrides.
@@ -101,14 +102,16 @@ spec:
     name: hello-openshift
     resources:
       limits:
-        cpu: "1" <1>
+        cpu: "1"
         memory: 512Mi
       requests:
-        cpu: 250m <2>
+        cpu: 250m
         memory: 256Mi
 # ...
 ----
-<1> The CPU limit has been overridden to `1` because the `limitCPUToMemoryPercent` parameter is set to `200` in the `ClusterResourceOverride` object. As such, 200% of the memory limit, 512Mi in CPU terms, is 1 CPU core. 
-<2> The CPU request is now `250m` because the `cpuRequestToLimit` is set to `25` in the `ClusterResourceOverride` object. As such, 25% of the 1 CPU core is 250m.
+where:
 
-
+--
+`spec.containers.resources.limits.cpu`:: Specifies that the CPU limit has been overridden to `1` because the `limitCPUToMemoryPercent` parameter is set to `200` in the `ClusterResourceOverride` object. As such, 200% of the memory limit, 512Mi in CPU terms, is 1 CPU core. 
+`spec.containers.resources.memory.cpu`:: Specifies that the CPU request is now `250m` because the `cpuRequestToLimit` is set to `25` in the `ClusterResourceOverride` object. As such, 25% of the 1 CPU core is 250m.
+--

--- a/modules/nodes-cluster-worker-latency-profiles-about.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-about.adoc
@@ -6,7 +6,10 @@
 [id="nodes-cluster-worker-latency-profiles-about_{context}"]
 = Understanding worker latency profiles
 
-Worker latency profiles are four different categories of carefully-tuned parameters. The four parameters which implement these values are `node-status-update-frequency`, `node-monitor-grace-period`, `default-not-ready-toleration-seconds` and `default-unreachable-toleration-seconds`. These parameters can use values which allow you to control the reaction of the cluster to latency issues without needing to determine the best values by using manual methods.
+[role="_abstract"]
+Review the following information to learn about worker latency profiles, which allow you to control the reaction of the cluster to latency issues without needing to determine the best values by using manual methods.
+
+Worker latency profiles are four different categories of carefully-tuned parameters. The four parameters which implement these values are `node-status-update-frequency`, `node-monitor-grace-period`, `default-not-ready-toleration-seconds` and `default-unreachable-toleration-seconds`.
 
 [IMPORTANT]
 ====

--- a/modules/nodes-cluster-worker-latency-profiles-using.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-using.adoc
@@ -6,7 +6,8 @@
 [id="nodes-cluster-worker-latency-profiles-using_{context}"]
 = Using and changing worker latency profiles
 
-To change a worker latency profile to deal with network latency, edit the `node.config` object to add the name of the profile. You can change the profile at any time as latency increases or decreases.
+[role="_abstract"]
+You can change a worker latency profile to deal with network latency at any time by editing the `node.config` object. This allows you to ensure that your cluster runs properly if network latency between the control plane and the worker nodes fluctuates.
 
 You must move one worker latency profile at a time. For example, you cannot move directly from the `Default` profile to the `LowUpdateSlowReaction` worker latency profile. You must move from the `Default` worker latency profile to the `MediumUpdateAverageReaction` profile first, then to `LowUpdateSlowReaction`. Similarly, when returning to the `Default` profile, you must move from the low profile to the medium profile first, then to `Default`.
 
@@ -16,8 +17,6 @@ You can also configure worker latency profiles upon installing an {product-title
 ====
 
 .Procedure
-
-To move from the default worker latency profile:
 
 . Move to the medium worker latency profile:
 
@@ -52,11 +51,15 @@ metadata:
   resourceVersion: "1865"
   uid: 0c0f7a4c-4307-4187-b591-6155695ac85b
 spec:
-  workerLatencyProfile: MediumUpdateAverageReaction <1>
+  workerLatencyProfile: MediumUpdateAverageReaction
 
 # ...
 ----
-<1> Specifies the medium worker latency policy.
+where:
++
+--
+`spec.workerLatencyProfile.MediumUpdateAverageReaction`:: Specifies that the medium worker latency policy should be used.
+--
 +
 Scheduling on each worker node is disabled as the change is being applied.
 
@@ -97,8 +100,12 @@ spec:
 
 # ...
 ----
-<1> Specifies use of the low worker latency policy.
-
+where:
++
+--
+`spec.workerLatencyProfile.LowUpdateSlowReaction`:: Specifies that the low worker latency policy should be used.
+--
++
 Scheduling on each worker node is disabled as the change is being applied.
 
 .Verification
@@ -118,7 +125,7 @@ $ oc get KubeControllerManager -o yaml | grep -i workerlatency -A 5 -B 5
       reason: ProfileUpdated
       status: "False"
       type: WorkerLatencyProfileProgressing
-    - lastTransitionTime: "2022-07-11T19:47:10Z" <1>
+    - lastTransitionTime: "2022-07-11T19:47:10Z"
       message: all static pod revision(s) have updated latency profile
       reason: ProfileUpdated
       status: "True"
@@ -131,6 +138,10 @@ $ oc get KubeControllerManager -o yaml | grep -i workerlatency -A 5 -B 5
       status: "False"
 # ...
 ----
-<1> Specifies that the profile is applied and active.
+where:
++
+--
+`status.message: all static pod revision(s) have updated latency profile`:: Specifies that the profile is applied and active.
+--
 
 To change the medium profile to default or change the default to medium, edit the `node.config` object and set the `spec.workerLatencyProfile` parameter to the appropriate value.

--- a/modules/nodes-containers-events-about.adoc
+++ b/modules/nodes-containers-events-about.adoc
@@ -6,18 +6,14 @@
 [id="nodes-containers-events-about_{context}"]
 = Understanding events
 
-Events allow {product-title} to record
-information about real-world events in a resource-agnostic manner. They also
-allow developers and administrators to consume information about system
-components in a unified way.
+[role="_abstract"]
+Review the following information to learn how {product-title} uses _events_ to record information about real-world events in a resource-agnostic manner. Events also allow developers and administrators to consume information about system components in a unified way.
 
 ifdef::openshift-online[]
 [id="event-failure-notifications_{context}"]
 == Failure Notifications
 
-For each of your projects, you can choose to receive email notifications
-about various failures, including dead or failed deployments, dead builds, and
-dead or failed persistent volume claims (PVCs).
+For each of your projects, you can choose to receive email notifications about various failures, including dead or failed deployments, dead builds, and dead or failed persistent volume claims (PVCs).
 
 See Notifications.
 endif::[]

--- a/modules/nodes-containers-events-list.adoc
+++ b/modules/nodes-containers-events-list.adoc
@@ -6,7 +6,8 @@
 [id="nodes-containers-events-list_{context}"]
 = List of events
 
-This section describes the events of {product-title}.
+[role="_abstract"]
+Review the information in this section to learn about {product-title} events.
 
 .Configuration events
 [cols="2,8",options="header"]

--- a/modules/nodes-containers-events-viewing.adoc
+++ b/modules/nodes-containers-events-viewing.adoc
@@ -6,17 +6,22 @@
 [id="nodes-containers-events-viewing-cli_{context}"]
 = Viewing events using the CLI
 
-You can get a list of events in a given project using the CLI.
+[role="_abstract"]
+You can get a list of events in a given project by using the CLI.
 
 .Procedure
 
-* To view events in a project use the following command:
+* View events in a project by using a command similar to the following:
 +
 [source,terminal]
 ----
-$ oc get events [-n <project>] <1>
+$ oc get events [-n <project>]
 ----
-<1> The name of the project.
+where:
++
+--
+`project`:: Specifies the name of the project.
+--
 +
 For example:
 +
@@ -38,8 +43,7 @@ LAST SEEN   TYPE      REASON                   OBJECT                      MESSA
 #...
 ----
 
-
-* To view events in your project from the {product-title} console.
+* View events in your project from the {product-title} console:
 +
 . Launch the {product-title} console.
 +
@@ -47,5 +51,4 @@ LAST SEEN   TYPE      REASON                   OBJECT                      MESSA
 
 . Move to resource that you want to see events. For example: *Home* -> *Projects* -> <project-name> -> <resource-name>.
 +
-Many objects, such as pods and deployments, have their own
-*Events* tab as well, which shows events related to that object.
+Many objects, such as pods and deployments, also have an *Events* tab, which shows events related to that object.

--- a/modules/nodes-qos-about-swap.adoc
+++ b/modules/nodes-qos-about-swap.adoc
@@ -5,28 +5,18 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nodes-qos-about-swap_{context}"]
-= Understanding swap memory and QOS
+= Understanding swap memory and QoS
 
-You can disable swap by default on your nodes to preserve quality of
-service (QOS) guarantees. Otherwise, physical resources on a node can oversubscribe,
-affecting the resource guarantees the Kubernetes scheduler makes during pod
-placement.
+[role="_abstract"]
+Review the following information to learn how swap memory and QoS interact in an overcommitted environment to help you ensure that your cluster is properly configured.
 
-For example, if two guaranteed pods have reached their memory limit, each
-container could start using swap memory. Eventually, if there is not enough swap
-space, processes in the pods can be terminated due to the system being
-oversubscribed.
+You can disable swap by default on your nodes to preserve quality of service (QoS) guarantees. Otherwise, physical resources on a node can oversubscribe, affecting the resource guarantees the Kubernetes scheduler makes during pod placement.
 
-Failing to disable swap results in nodes not recognizing that they are
-experiencing *MemoryPressure*, resulting in pods not receiving the memory they
-made in their scheduling request. As a result, additional pods are placed on the
-node to further increase memory pressure, ultimately increasing your risk of
-experiencing a system out of memory (OOM) event.
+For example, if two guaranteed pods have reached their memory limit, each container could start using swap memory. Eventually, if there is not enough swap space, processes in the pods can be terminated due to the system being oversubscribed.
+
+Failing to disable swap causes nodes to not recognize that they are experiencing *MemoryPressure*, resulting in pods not receiving the memory they made in their scheduling request. As a result, additional pods are placed on the node to further increase memory pressure, ultimately increasing your risk of experiencing a system out of memory (OOM) event.
 
 [IMPORTANT]
 ====
-If swap is enabled, any out-of-resource handling eviction thresholds for available memory will not work as
-expected. Take advantage of out-of-resource handling to allow pods to be evicted
-from a node when it is under memory pressure, and rescheduled on an alternative
-node that has no such pressure.
+If swap is enabled, any out-of-resource handling eviction thresholds for available memory will not work as expected. Out-of-resource handling allows pods to be evicted from a node when it is under memory pressure, and rescheduled on an alternative node that has no such pressure.
 ====

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -6,32 +6,35 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As an administrator, you can use feature gates to enable features that are not part of the default set of features.
+[role="_abstract"]
+As an administrator, you can use feature gates to enable features that are not part of the default set of features so that you can use these non-default features in your cluster.
 
 include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
-
-For more information about the features activated by the `TechPreviewNoUpgrade` feature gate, see the following topics:
-
-** xref:../../cicd/builds/running-entitled-builds.adoc#builds-running-entitled-builds-with-sharedsecret-objects_running-entitled-builds[Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds]
-
-** xref:../../storage/container_storage_interface/ephemeral-storage-csi-inline.adoc#ephemeral-storage-csi-inline[CSI inline ephemeral volumes]
-
-** xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-managing[Swap memory on nodes]
-
-** xref:../../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[Managing machines with the Cluster API]
-
-** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#disabling-insights-operator-gather_using-insights-operator[Disabling the {insights-operator} gather operations]
-
-** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#enabling-insights-operator-gather_using-insights-operator[Enabling the {insights-operator} gather operations]
-
-** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#running-insights-operator-gather_using-insights-operator[Running an {insights-operator} gather operation]
-
-** xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]
-
-** xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement].
 
 include::modules/nodes-cluster-enabling-features-install.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-enabling-features-console.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-enabling-features-cli.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_nodes-cluster-enabling"]
+== Additional resources
+
+* xref:../../cicd/builds/running-entitled-builds.adoc#builds-running-entitled-builds-with-sharedsecret-objects_running-entitled-builds[Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds]
+
+* xref:../../storage/container_storage_interface/ephemeral-storage-csi-inline.adoc#ephemeral-storage-csi-inline[CSI inline ephemeral volumes]
+
+* xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-managing[Swap memory on nodes]
+
+* xref:../../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[Managing machines with the Cluster API]
+
+* xref:../../support/remote_health_monitoring/using-insights-operator.adoc#disabling-insights-operator-gather_using-insights-operator[Disabling the {insights-operator} gather operations]
+
+* xref:../../support/remote_health_monitoring/using-insights-operator.adoc#enabling-insights-operator-gather_using-insights-operator[Enabling the {insights-operator} gather operations]
+
+* xref:../../support/remote_health_monitoring/using-insights-operator.adoc#running-insights-operator-gather_using-insights-operator[Running an {insights-operator} gather operation]
+
+* xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]
+
+* xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement]

--- a/nodes/clusters/nodes-cluster-limit-ranges.adoc
+++ b/nodes/clusters/nodes-cluster-limit-ranges.adoc
@@ -6,32 +6,28 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can use limit ranges to restrict resource consumption for specific objects in a project.
 
-By default, containers run with unbounded compute resources on an {product-title}
-cluster. With limit ranges, you can restrict resource consumption for specific
-objects in a project:
+By default, containers run with unbounded compute resources on an {product-title} cluster. 
 
-* pods and containers: You can set minimum and maximum requirements for CPU and
-memory for pods and their containers.
-* Image streams: You can set limits on the number of images and tags in an
-`ImageStream` object.
-* Images: You can limit the size of images that can be pushed to an internal
-registry.
-* Persistent volume claims (PVC): You can restrict the size of the PVCs that can
-be requested.
+You can configure resource consumption for the following objects:
 
-If a pod does not meet the constraints imposed by the limit
-range, the pod cannot be created in the namespace.
+* pods and containers: You can set minimum and maximum requirements for CPU and memory for pods and their containers.
+* Image streams: You can set limits on the number of images and tags in an `ImageStream` object.
+* Images: You can limit the size of images that can be pushed to an internal registry.
+* Persistent volume claims (PVC): You can restrict the size of the PVCs that can be requested.
+
+If a pod does not meet the constraints imposed by the limit range, the pod cannot be created in the namespace.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-
 include::modules/nodes-cluster-limit-ranges-about.adoc[leveloffset=+1]
 
-include::modules/nodes-cluster-limit-ranges-limits.adoc[leveloffset=+2]
+include::modules/nodes-cluster-limit-ranges-limits.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-limit-ranges-creating.adoc[leveloffset=+1]
 

--- a/nodes/clusters/nodes-cluster-overcommit.adoc
+++ b/nodes/clusters/nodes-cluster-overcommit.adoc
@@ -6,39 +6,31 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In an _overcommitted_ state, the sum of the container compute resource requests
-and limits exceeds the resources available on the system. For example, you might
-want to use overcommitment in development environments where a trade-off of
-guaranteed performance for capacity is acceptable.
-
-Containers can specify compute resource requests and limits. Requests are used
-for scheduling your container and provide a minimum service guarantee. Limits
-constrain the amount of compute resource that can be consumed on your node.
-
-The scheduler attempts to optimize the compute resource use across all nodes
-in your cluster. It places pods onto specific nodes, taking the pods' compute
-resource requests and nodes' available capacity into consideration.
-
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-{product-title} administrators can control the level of overcommit and manage
-container density on developer containers by using
-the xref:#nodes-cluster-resource-override_nodes-cluster-overcommit[ClusterResourceOverride Operator].
+[role="_abstract"]
+{product-title} administrators can control the level of overcommit and manage container density on developer containers by using the ClusterResourceOverride Operator.
 
 [NOTE]
 ====
 In {product-title}, you must enable cluster-level overcommit. Node overcommitment is enabled by default.
-See xref:#nodes-cluster-overcommit-node-disable_nodes-cluster-overcommit[Disabling overcommitment for a node].
 ====
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 //ROSA and Dedicated intro
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+[role="_abstract"]
 {product-title} administrators can manage container density on nodes by configuring pod placement behavior and per-project resource limits that overcommit cannot exceed.
 
 Alternatively, administrators can disable project-level resource overcommitment on customer-created namespaces that are not managed by Red Hat.
 
 For more information about container resource management, see Additional resources.
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+
+In an _overcommitted_ state, the sum of the container compute resource requestsand limits exceeds the resources available on the system. For example, you might want to use overcommitment in development environments where a trade-off of guaranteed performance for capacity is acceptable.
+
+Containers can specify compute resource requests and limits. Requests are used for scheduling your container and provide a minimum service guarantee. Limits constrain the amount of compute resource that can be consumed on your node.
+
+The scheduler attempts to optimize the compute resource use across all nodes in your cluster. It places pods onto specific nodes, taking the pods' compute resource requests and nodes' available capacity into consideration.
 
 //core openshift content
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
@@ -49,30 +41,12 @@ include::modules/nodes-cluster-resource-override.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-resource-override-deploy-console.adoc[leveloffset=+2]
 
-ifndef::openshift-rosa,openshift-dedicated[]
-.Additional resources
-* xref:../../machine_management/creating-infrastructure-machinesets.adoc#nodes-cluster-resource-override-move-infra_creating-infrastructure-machinesets[Moving the Cluster Resource Override Operator pods]
-endif::openshift-rosa,openshift-dedicated[]
-
 include::modules/nodes-cluster-resource-override-deploy-cli.adoc[leveloffset=+2]
-
-ifndef::openshift-rosa,openshift-dedicated[]
-.Additional resources
-* xref:../../machine_management/creating-infrastructure-machinesets.adoc#nodes-cluster-resource-override-move-infra_creating-infrastructure-machinesets[Moving the Cluster Resource Override Operator pods]
-endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/nodes-cluster-resource-configure.adoc[leveloffset=+2]
 
 ifndef::openshift-rosa,openshift-dedicated[]
-.Additional resources
-* xref:../../machine_management/creating-infrastructure-machinesets.adoc#nodes-cluster-resource-override-move-infra_creating-infrastructure-machinesets[Moving the Cluster Resource Override Operator pods]
-endif::openshift-rosa,openshift-dedicated[]
-
-ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/nodes-cluster-resource-override-move-infra.adoc[leveloffset=+2]
-
-.Additional resources
-* xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets]
 endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/nodes-cluster-node-overcommit.adoc[leveloffset=+1]
@@ -85,22 +59,9 @@ include::modules/nodes-qos-about-swap.adoc[leveloffset=+2]
 
 include::modules/nodes-cluster-overcommit-configure-nodes.adoc[leveloffset=+2]
 
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-overcommit-node-enforcing_nodes-cluster-overcommit[Disabling or enforcing CPU limits using CPU CFS quotas]
-* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-overcommit-node-resources_nodes-cluster-overcommit[Reserving resources for system processes]
-* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#qos-about-reserve_nodes-cluster-overcommit[Understanding how to reserve memory across quality of service tiers]
-
 include::modules/nodes-cluster-overcommit-node-enforcing.adoc[leveloffset=+2]
 
 include::modules/nodes-cluster-overcommit-node-resources.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
-* xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring[Allocating resources for nodes]
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
 include::modules/nodes-cluster-overcommit-node-disable.adoc[leveloffset=+2]
 
@@ -115,7 +76,13 @@ include::modules/nodes-cluster-overcommit-project-disable.adoc[leveloffset=+2]
 [id="nodes-cluster-overcommit-addtl-resources"]
 == Additional resources
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#nodes-cluster-resource-override-move-infra_creating-infrastructure-machinesets[Moving the Cluster Resource Override Operator pods]
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets]
 * xref:../../applications/deployments/managing-deployment-processes.adoc#deployments-triggers_deployment-operations[Setting deployment resources]
+* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-overcommit-node-enforcing_nodes-cluster-overcommit[Disabling or enforcing CPU limits using CPU CFS quotas]
+* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-overcommit-node-resources_nodes-cluster-overcommit[Reserving resources for system processes]
+* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#qos-about-reserve_nodes-cluster-overcommit[Understanding how to reserve memory across quality of service tiers]
+* xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring[Allocating resources for nodes]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ifdef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../nodes/clusters/nodes-cluster-limit-ranges.adoc#nodes-cluster-limit-ranges[Restrict resource consumption with limit ranges]

--- a/nodes/clusters/nodes-cluster-resource-configure.adoc
+++ b/nodes/clusters/nodes-cluster-resource-configure.adoc
@@ -6,13 +6,16 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can help your clusters operate efficiently through managing application memory by:
+[role="_abstract"]
+As a cluster administrator, you can manage application memory usage to help your clusters operate more efficiently. 
 
-* Determining the memory and risk requirements of a containerized application component and configuring the container memory parameters to suit those requirements.
+You can perform any of the following tasks to manage application memory:
 
-* Configuring containerized application runtimes (for example, OpenJDK) to adhere optimally to the configured container memory parameters.
+* Determine the memory and risk requirements of a containerized application component and configuring the container memory parameters to suit those requirements.
 
-* Diagnosing and resolving memory-related error conditions associated with running in a container.
+* Configure containerized application runtimes (for example, OpenJDK) to adhere optimally to the configured container memory parameters.
+
+* Diagnose and resolve memory-related error conditions associated with running in a container.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
@@ -21,12 +24,6 @@ As a cluster administrator, you can help your clusters operate efficiently throu
 
 include::modules/nodes-cluster-resource-configure-about.adoc[leveloffset=+1]
 
-ifdef::openshift-origin,openshift-online,openshift-webscale,openshift-enterprise[]
-[role="_additional-resources"]
-.Additional resources
-* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-overcommit-reserving-memory_nodes-cluster-overcommit[Understanding compute resources and containers]
-endif::[]
-
 include::modules/nodes-cluster-resource-configure-jdk.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-resource-configure-request-limit.adoc[leveloffset=+1]
@@ -34,3 +31,9 @@ include::modules/nodes-cluster-resource-configure-request-limit.adoc[leveloffset
 include::modules/nodes-cluster-resource-configure-oom.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-resource-configure-evicted.adoc[leveloffset=+1]
+
+ifdef::openshift-origin,openshift-online,openshift-webscale,openshift-enterprise[]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-overcommit-reserving-memory_nodes-cluster-overcommit[Understanding compute resources and containers]
+endif::[]

--- a/nodes/clusters/nodes-cluster-resource-levels.adoc
+++ b/nodes/clusters/nodes-cluster-resource-levels.adoc
@@ -7,8 +7,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-
-As a cluster administrator, you can use the OpenShift Cluster Capacity Tool to view the number of pods that can be scheduled to increase the current resources before they become exhausted, and to ensure any future pods can be scheduled. This capacity comes from an individual node host in a cluster, and includes CPU, memory, disk space, and others.
+[role="_abstract"]
+As a cluster administrator, you can use the OpenShift Cluster Capacity Tool to view the number of pods that can be scheduled in your cluster. This allows you to increase the current resources before they become exhausted and to ensure any future pods can be scheduled. This capacity comes from an individual node host in a cluster, and includes CPU, memory, disk space, and others.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
@@ -21,4 +21,9 @@ include::modules/nodes-cluster-resource-levels-command.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-resource-levels-job.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+[id="nodes-cluster-resource-levels_additional-resources"]
+== Additional resources
 
+* link:https://catalog.redhat.com/software/containers/openshift4/ose-cluster-capacity/5cca0324d70cc57c44ae8eb6?container-tabs=overview[OpenShift Cluster Capacity Tool]
+* link:https://github.com/openshift/cluster-capacity[cluster-capacity repository]

--- a/nodes/clusters/nodes-cluster-worker-latency-profiles.adoc
+++ b/nodes/clusters/nodes-cluster-worker-latency-profiles.adoc
@@ -7,12 +7,13 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
+[role="_abstract"]
+Review the following information to learn about _worker latency profiles_, which adjust the frequency that the Kubelet and the Kubernetes Controller Manager wait for status updates before taking action if a pod is unreachable.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
 // assemblies.
-
 
 include::snippets/worker-latency-profile-intro.adoc[]
 

--- a/nodes/clusters/nodes-containers-events.adoc
+++ b/nodes/clusters/nodes-containers-events.adoc
@@ -6,12 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
-
-
-
-Events in {product-title} are modeled based on events that happen to API objects
-in an {product-title} cluster.
+[role="_abstract"]
+You can view events in {product-title}, which are based on events that happen to API objects in an {product-title} cluster.
 
 
 // The following include statements pull in the module files that comprise


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16929

* [Viewing system event information in OpenShift Container Platform clusters](https://104371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-containers-events#nodes-containers-events-viewing-cli_nodes-containers-events)
* [Estimating the number of pods your OpenShift Container Platform nodes can hold](https://104371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-levels)
* [Restrict resource consumption with limit ranges](https://104371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-limit-ranges)
* [Configuring cluster memory to meet container memory and risk requirements](https://104371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-configure.html)
* [Configuring your cluster to place pods on overcommitted nodes](https://104371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit)
* [Enabling features using feature gates](https://104371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features)
* [Improving cluster stability in high latency environments using worker latency profiles](https://104371--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-worker-latency-profiles)