### PR TITLE
OSDOCS-17417: Generate ROSA CLI command ref

### DIFF
--- a/modules/rosa-by-example-content.adoc
+++ b/modules/rosa-by-example-content.adoc
@@ -174,6 +174,21 @@ Create a custom kubeletconfig for a cluster
 
 
 
+== rosa create log-forwarder
+Create a log forwarder for a Hosted Control Plane cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Create a log forwarder using a config file
+  rosa create log-forwarder -c mycluster-hcp --log-fwd-config=s3.yml
+  
+  # Create a log forwarder interactively
+  rosa create log-forwarder -c mycluster-hcp --interactive
+----
+
+
+
 == rosa create machinepool
 Add machine pool to cluster
 
@@ -453,6 +468,18 @@ Delete a kubeletconfig from a cluster
 
 
 
+== rosa delete log-forwarder
+Delete log forwarder
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# Delete log forwarder with ID 'example-id' from a cluster named 'mycluster-hcp'
+  rosa delete log-forwarder --cluster=mycluster-hcp example-id
+----
+
+
+
 == rosa delete machinepool
 Delete machine pool
 
@@ -672,6 +699,17 @@ Show details of a kubeletconfig for a cluster
 
 
 
+== rosa describe log-forwarder
+Show details of a specific log forwarder used by a cluster
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+rosa describe log-forwarder <log_fwd_id> -c mycluster-hcp
+----
+
+
+
 == rosa describe machinepool
 Show details of a machine pool on a cluster
 
@@ -773,9 +811,6 @@ Edit cluster
 ----
 # Edit a cluster named "mycluster" to make it private
   rosa edit cluster -c mycluster --private
-
-  # Edit a cluster named "mycluster" to enable User Workload Monitoring
-  rosa edit cluster -c mycluster --disable-workload-monitoring=false
 
   # Edit all options interactively
   rosa edit cluster -c mycluster --interactive
@@ -1102,6 +1137,17 @@ List kubeletconfigs
 ----
 # List the kubeletconfigs for cluster 'foo'
 rosa list kubeletconfig --cluster foo
+----
+
+
+
+== rosa list log-forwarders
+List cluster log forwarders
+
+.Example usage
+[source,bash,options="nowrap"]
+----
+# List all log forwarders on a cluster named "mycluster": rosa list log-forwarders --cluster=mycluster
 ----
 
 


### PR DESCRIPTION
This updates the ROSA CLI command ref for version 1.2.59.

Version(s):
- enterprise-4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17417

Link to docs preview:
https://104372--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/cli_reference/rosa_cli/rosa-cli-commands.html


QE review:
- N/A
