### PR TITLE
OSDOCS-16862-1:CQA2.0 of CORE-3: Ingress Controllers and Load Balancin

### DIFF
--- a/modules/creating-a-custom-ingress-controller.adoc
+++ b/modules/creating-a-custom-ingress-controller.adoc
@@ -6,6 +6,7 @@
 [id="creating-a-custom-ingress-controller_{context}"]
 = Creating an Ingress Controller for manual DNS management
 
+[role="_abstract"]
 As a cluster administrator, you can create a new custom Ingress Controller with the Unmanaged DNS management policy.
 
 .Prerequisites
@@ -23,20 +24,22 @@ apiVersion: operator.openshift.io/v1
 kind: IngressController
 metadata:
   namespace: openshift-ingress-operator
-  name: <name> <1>
+  name: <name>
 spec:
-  domain: <domain> <2>
+  domain: <domain>
   endpointPublishingStrategy:
     type: LoadBalancerService
     loadBalancer:
-      scope: External <3>
-      dnsManagementPolicy: Unmanaged <4>
+      scope: External
+      dnsManagementPolicy: Unmanaged
 ----
-<1> Specify the `<name>` with a name for the `IngressController` object.
-<2> Specify the `domain` based on the DNS record that was created as a prerequisite.
-<3> Specify the `scope` as `External` to expose the load balancer externally.
-<4> `dnsManagementPolicy` indicates if the Ingress Controller is managing the lifecycle of the wildcard DNS record associated with the load balancer.
-The valid values are `Managed` and `Unmanaged`. The default value is `Managed`.
++
+where:
++
+`metadata.name`:: Specify the `<name>` with a name for the `IngressController` object.
+`spec.domain`:: Specify the `domain` based on the DNS record that was created as a prerequisite.
+`loadBalancer.scope`:: Specify the `scope` as `External` to expose the load balancer externally.
+`loadBalancer.dnsManagementPolicy`: Specifies if the Ingress Controller is managing the lifecycle of the wildcard DNS record associated with the load balancer. The valid values are `Managed` and `Unmanaged`. The default value is `Managed`.
 
 . Apply the manifest to create the `IngressController` object:
 +

--- a/modules/modifying-an-existing-ingress-controller.adoc
+++ b/modules/modifying-an-existing-ingress-controller.adoc
@@ -6,6 +6,7 @@
 [id="modifying-an-existing-ingress-controller_{context}"]
 = Modifying an existing Ingress Controller for manual DNS management
 
+[role="_abstract"]
 As a cluster administrator, you can modify an existing Ingress Controller to manually manage the DNS record lifecycle.
 
 .Prerequisites

--- a/modules/nw-configuring-lb-allowed-source-ranges-migration.adoc
+++ b/modules/nw-configuring-lb-allowed-source-ranges-migration.adoc
@@ -6,11 +6,14 @@
 [id="nw-configuring-lb-allowed-source-ranges-migration_{context}"]
 = Migrating to load balancer allowed source ranges
 
-If you have already set the annotation `service.beta.kubernetes.io/load-balancer-source-ranges`, you can migrate to load balancer allowed source ranges. When you set the `AllowedSourceRanges`, the Ingress Controller sets the `spec.loadBalancerSourceRanges` field based on the `AllowedSourceRanges` value and unsets the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation.
+[role="_abstract"]
+To ensure long-term compatibility and use stable API parameters in {product-title}, migrate from the legacy `service.beta.kubernetes.io/load-balancer-source-ranges` annotation to load balancer allowed source ranges.
+
+When you set the `AllowedSourceRanges`, the Ingress Controller sets the `spec.loadBalancerSourceRanges` parameter based on the `AllowedSourceRanges` value and unsets the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation.
 
 [NOTE]
 ====
-If you have already set the `spec.loadBalancerSourceRanges` field or the load balancer service anotation `service.beta.kubernetes.io/load-balancer-source-ranges` in a previous version of {product-title}, the Ingress Controller starts reporting `Progressing=True` after an upgrade. To fix this, set `AllowedSourceRanges` that overwrites the `spec.loadBalancerSourceRanges` field and clears the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation. The Ingress Controller starts reporting `Progressing=False` again.
+If you have already set the `spec.loadBalancerSourceRanges` parameter or the load balancer service anotation `service.beta.kubernetes.io/load-balancer-source-ranges` in a previous version of {product-title}, the Ingress Controller starts reporting `Progressing=True` after an upgrade. To fix this, set `AllowedSourceRanges` that overwrites the `spec.loadBalancerSourceRanges` parameter and clears the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation. The Ingress Controller starts reporting `Progressing=False` again.
 ====
 
 .Prerequisites
@@ -19,7 +22,7 @@ If you have already set the `spec.loadBalancerSourceRanges` field or the load ba
 
 .Procedure
 
-. Ensure that the `service.beta.kubernetes.io/load-balancer-source-ranges` is set:
+. Check that the `service.beta.kubernetes.io/load-balancer-source-ranges` is set by entering the following command:
 +
 [source,terminal]
 ----
@@ -36,7 +39,7 @@ metadata:
     service.beta.kubernetes.io/load-balancer-source-ranges: 192.168.0.1/32
 ----
 
-. Ensure that the `spec.loadBalancerSourceRanges` field is unset:
+. Check that the `spec.loadBalancerSourceRanges` parameter is unset by entering the following command:
 +
 [source,terminal]
 ----
@@ -61,6 +64,9 @@ spec:
 ----
 $ oc -n openshift-ingress-operator patch ingresscontroller/default \
     --type=merge --patch='{"spec":{"endpointPublishingStrategy": \
-    {"loadBalancer":{"allowedSourceRanges":["0.0.0.0/0"]}}}}' <1>
+    {"loadBalancer":{"allowedSourceRanges":["0.0.0.0/0"]}}}}'
 ----
-<1> The example value `0.0.0.0/0` specifies the allowed source range.
++
+where:
++
+`allowedSourceRanges`:: The example value `0.0.0.0/0` specifies the allowed source range.

--- a/modules/nw-configuring-lb-allowed-source-ranges.adoc
+++ b/modules/nw-configuring-lb-allowed-source-ranges.adoc
@@ -6,11 +6,14 @@
 [id="nw-configuring-lb-allowed-source-ranges_{context}"]
 = Configuring load balancer allowed source ranges
 
-You can enable and configure the `spec.endpointPublishingStrategy.loadBalancer.allowedSourceRanges` field. By configuring load balancer allowed source ranges, you can limit the access to the load balancer for the Ingress Controller to a specified list of IP address ranges. The Ingress Operator reconciles the load balancer Service and sets the `spec.loadBalancerSourceRanges` field based on `AllowedSourceRanges`.
+[role="_abstract"]
+You can enable and configure the `spec.endpointPublishingStrategy.loadBalancer.allowedSourceRanges` parameter. By configuring load balancer allowed source ranges, you can limit the access to the load balancer for the Ingress Controller to a specified list of IP address ranges. 
+
+The Ingress Operator reconciles the load balancer Service and sets the `spec.loadBalancerSourceRanges` parameter based on `AllowedSourceRanges`.
 
 [NOTE]
 ====
-If you have already set the `spec.loadBalancerSourceRanges` field or the load balancer service anotation `service.beta.kubernetes.io/load-balancer-source-ranges` in a previous version of {product-title}, Ingress Controller starts reporting `Progressing=True` after an upgrade. To fix this, set `AllowedSourceRanges` that overwrites the `spec.loadBalancerSourceRanges` field and clears the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation. Ingress Controller starts reporting `Progressing=False` again.
+If you have already set the `spec.loadBalancerSourceRanges` parameter or the load balancer service anotation `service.beta.kubernetes.io/load-balancer-source-ranges` in a previous version of {product-title}, Ingress Controller starts reporting `Progressing=True` after an upgrade. To fix this, set `AllowedSourceRanges` that overwrites the `spec.loadBalancerSourceRanges` parameter and clears the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation. Ingress Controller starts reporting `Progressing=False` again.
 ====
 
 .Prerequisites
@@ -26,6 +29,9 @@ If you have already set the `spec.loadBalancerSourceRanges` field or the load ba
 $ oc -n openshift-ingress-operator patch ingresscontroller/default \
     --type=merge --patch='{"spec":{"endpointPublishingStrategy": \
     {"type":"LoadBalancerService", "loadbalancer": \
-    {"scope":"External", "allowedSourceRanges":["0.0.0.0/0"]}}}}' <1>
+    {"scope":"External", "allowedSourceRanges":["0.0.0.0/0"]}}}}'
 ----
-<1> The example value `0.0.0.0/0` specifies the allowed source range.
++
+where:
++
+`allowedSourceRanges`:: The example value `0.0.0.0/0` specifies the allowed source range.

--- a/modules/nw-create-load-balancer-service.adoc
+++ b/modules/nw-create-load-balancer-service.adoc
@@ -6,7 +6,8 @@
 [id="nw-create-load-balancer-service_{context}"]
 = Creating a load balancer service
 
-Use the following procedure to create a load balancer service.
+[role="_abstract"]
+To distribute incoming traffic efficiently and ensure high availability for your applications in {product-title}, create a load balancer service.
 
 .Prerequisites
 
@@ -15,55 +16,58 @@ Use the following procedure to create a load balancer service.
 
 .Procedure
 
-To create a load balancer service:
-
-. Log in to  {product-title}.
+. Log in to {product-title}.
 
 . Load the project where the service you want to expose is located.
 +
+.Example command
 [source,terminal]
 ----
 $ oc project project1
 ----
 
-. Open a text file on the control plane node and paste the following text, editing the
-file as needed:
+. Open a text file on the control plane node and paste the following text into the file. Edit the file as needed.
 +
 .Sample load balancer configuration file
+[source,yaml]
 ----
 apiVersion: v1
 kind: Service
 metadata:
-  name: egress-2 <1>
+  name: egress-2
 spec:
   ports:
   - name: db
-    port: 3306 <2>
+    port: 3306
   loadBalancerIP:
-  loadBalancerSourceRanges: <3>
+  loadBalancerSourceRanges:
   - 10.0.0.0/8
   - 192.168.0.0/16
-  type: LoadBalancer <4>
+  type: LoadBalancer
   selector:
-    name: mysql <5>
+    name: mysql
 ----
-<1> Enter a descriptive name for the load balancer service.
-<2> Enter the same port that the service you want to expose is listening on.
-<3> Enter a list of specific IP addresses to restrict traffic through the load balancer. This field is ignored if the cloud-provider does not support the feature.
-<4> Enter `Loadbalancer` as the type.
-<5> Enter the name of the service.
++
+where:
++
+`metadata.name`:: Specifies a descriptive name for the load balancer service.
+`ports.port`:: Specifies the same port that the service you want to expose is listening on.
+`loadBalancerSourceRanges`:: Specifies a list of specific IP addresses to restrict traffic through the load balancer. The parameter is ignored if the cloud provider does not support the feature.
+`type`:: Specifies `Loadbalancer` as the type.
+`selector.name`:: Specifies the name of the service.
 +
 [NOTE]
 ====
-To restrict the traffic through the load balancer to specific IP addresses, it is recommended to use the Ingress Controller field `spec.endpointPublishingStrategy.loadBalancer.allowedSourceRanges`. Do not set the `loadBalancerSourceRanges` field.
+To restrict the traffic through the load balancer to specific IP addresses, use the `spec.endpointPublishingStrategy.loadBalancer.allowedSourceRanges` Ingress Controller parameter. Do not set the `loadBalancerSourceRanges` parameter.
 ====
+
 . Save and exit the file.
 
 . Run the following command to create the service:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>
+$ oc create -f <file_name>
 ----
 +
 For example:
@@ -87,15 +91,13 @@ NAME       TYPE           CLUSTER-IP      EXTERNAL-IP                           
 egress-2   LoadBalancer   172.30.22.226   ad42f5d8b303045-487804948.example.com   3306:30357/TCP   15m
 ----
 +
-The service has an external IP address automatically assigned if there is a cloud
-provider enabled.
+The service has an external IP address automatically assigned if there is a cloud provider enabled.
 
-. On the master, use a tool, such as cURL, to make sure you can reach the service
-using the public IP address:
+. On the master, use a tool, such as `curl`, to make sure you can reach the service by using the public IP address:
 +
 [source,terminal]
 ----
-$ curl <public-ip>:<port>
+$ curl <public_ip>:<port>
 ----
 +
 For example:
@@ -105,9 +107,7 @@ For example:
 $ curl 172.29.121.74:3306
 ----
 +
-The examples in this section use a MySQL service, which requires a client application.
-If you get a string of characters with the `Got packets out of order` message,
-you are connecting with the service:
+The examples in this section use a MySQL service, which requires a client application. If you get a string of characters with the `Got packets out of order` message, you are connecting with the service:
 +
 If you have a MySQL client, log in with the standard CLI command:
 +

--- a/modules/nw-exposing-service.adoc
+++ b/modules/nw-exposing-service.adoc
@@ -10,7 +10,8 @@ endif::[]
 [id="nw-exposing-service_{context}"]
 = Exposing the service by creating a route
 
-You can expose the service as a route by using the `oc expose` command.
+[role="_abstract"]
+To enable external access to your application that runs on {product-title}, you can expose the service as a route by using the `oc expose` command.
 
 .Prerequisites
 
@@ -28,7 +29,6 @@ $ oc project <project_name>
 ifndef::nodeport[]
 . Run the `oc expose service` command to expose the route:
 +
-
 [source,terminal]
 ----
 $ oc expose service nodejs-ex
@@ -41,7 +41,7 @@ route.route.openshift.io/nodejs-ex exposed
 ----
 
 . To verify that the service is exposed, you can use a tool, such as `curl` to check that the service is accessible from outside the cluster.
-
++
 .. To find the hostname of the route, enter the following command:
 +
 [source,terminal]
@@ -55,7 +55,7 @@ $ oc get route
 NAME        HOST/PORT                        PATH   SERVICES    PORT       TERMINATION   WILDCARD
 nodejs-ex   nodejs-ex-myproject.example.com         nodejs-ex   8080-tcp                 None
 ----
-
++
 .. To check that the host responds to a GET request, enter the following command:
 +
 .Example `curl` command
@@ -86,15 +86,16 @@ $ oc edit svc <service_name>
 spec:
   ports:
   - name: 8443-tcp
-    nodePort: 30327 <1>
+    nodePort: 30327
     port: 8443
     protocol: TCP
     targetPort: 8443
   sessionAffinity: None
-  type: NodePort <2>
+  type: NodePort
 ----
-<1> Optional: Specify the node port range for the application. By default, {product-title} selects an available port in the `30000-32767` range.
-<2> Define the service type.
++
+* `nodePort`: Optional parameter. Specifies the node port range for the application. By default, {product-title} selects an available port in the `30000-32767` range.
+* `type`: Specifies the service type.
 
 . Optional: To confirm the service is available with a node port exposed, enter the following command:
 +
@@ -136,10 +137,6 @@ NAME    TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
 httpd   NodePort   172.xx.xx.xx    <none>        8443:30327/TCP   109s
 ----
 endif::nodeport[]
-
-//Potentially add verification step, "If a verification step is needed, it would
-//look something like oc get route mysql-55-rhel7 and curl with the host from the
-//output of the oc get route command."
 
 ifdef::nodeport[]
 :!nodeport:

--- a/modules/nw-service-externalip-create.adoc
+++ b/modules/nw-service-externalip-create.adoc
@@ -6,7 +6,10 @@
 [id="nw-service-externalip-create_{context}"]
 = Attaching an ExternalIP to a service
 
-You can attach an ExternalIP resource to a service. If you configured your cluster to automatically attach the resource to a service, you might not need to manually attach an ExternalIP to the service.
+[role="_abstract"]
+To route traffic from external networks to your applications in {product-title}, attach an ExternalIP resource to a service. 
+
+If you configured your cluster to automatically attach the resource to a service, you might not need to manually attach an ExternalIP to the service.
 
 The examples in the procedure use a scenario that manually attaches an ExternalIP resource to a service in a cluster with an IP failover configuration. 
 
@@ -26,7 +29,7 @@ If `autoAssignCIDRs` is set and you did not specify a value for `spec.externalIP
 
 . Choose one of the following options to attach an ExternalIP resource to the service:
 +
-.. If you are creating a new service, specify a value in the `spec.externalIPs` field and array of one or more valid IP addresses in the `allowedCIDRs` parameter.
+.. If you are creating a new service, specify a value in the `spec.externalIPs` parameter and array of one or more valid IP addresses in the `allowedCIDRs` parameter.
 +
 .Example of service YAML configuration file that supports an ExternalIP resource
 [source,yaml]
@@ -40,6 +43,7 @@ spec:
     policy:
       allowedCIDRs:
       - 192.168.123.0/28
+# ...
 ----
 +
 .. If you are attaching an ExternalIP to an existing service, enter the following command. Replace `<name>` with the service name. Replace `<ip_address>` with a valid ExternalIP address. You can provide multiple IP addresses separated by commas.

--- a/modules/nw-using-load-balancer-getting-traffic.adoc
+++ b/modules/nw-using-load-balancer-getting-traffic.adoc
@@ -6,15 +6,12 @@
 [id="nw-using-load-balancer-getting-traffic_{context}"]
 = Using a load balancer to get traffic into the cluster
 
-If you do not need a specific external IP address, you can configure a load
-balancer service to allow external access to an {product-title} cluster.
+[role="_abstract"]
+If you do not need a specific external IP address, you can configure a load balancer service to allow external access to an {product-title} cluster.
 
-A load balancer service allocates a unique IP. The load balancer has a single
-edge router IP, which can be a virtual IP (VIP), but is still a single machine
-for initial load balancing.
+A load balancer service allocates a unique IP. The load balancer has a single edge router IP, which can be a virtual IP (VIP), but is still a single machine for initial load balancing.
 
 [NOTE]
 ====
-If a pool is configured, it is done at the infrastructure level, not by a cluster
-administrator.
+A pool gets configured at the infrastructure level and not the cluster administrator level.
 ====

--- a/modules/nw-using-nodeport.adoc
+++ b/modules/nw-using-nodeport.adoc
@@ -6,21 +6,18 @@
 [id="nw-using-nodeport_{context}"]
 = Using a NodePort to get traffic into the cluster
 
-Use a `NodePort`-type `Service` resource to expose a service on a specific port
-on all nodes in the cluster. The port is specified in the `Service` resource's
-`.spec.ports[*].nodePort` field.
+[role="_abstract"]
+Use a `NodePort`-type `Service` resource to expose a service on a specific port on all nodes in the cluster. 
+
+The port is specified in the `Service` resource's `.spec.ports[*].nodePort` parameter
 
 [IMPORTANT]
 ====
 Using a node port requires additional port resources.
 ====
 
-A `NodePort` exposes the service on a static port on the node's IP address.
-``NodePort``s are in the `30000` to `32767` range by default, which means a
-`NodePort` is unlikely to match a service's intended port. For example, port
-`8080` may be exposed as port `31020` on the node.
+A `NodePort` exposes the service on a static port on the IP address of a node. A `NodePort` spans the `30000` to `32767` IP address ranges by default, which means a `NodePort` is unlikely to match the intended port of a service. For example, port `8080` might be exposed as port `31020` on the node.
 
 The administrator must ensure the external IP addresses are routed to the nodes.
 
-``NodePort``s and external IPs are independent and both can be used
-concurrently.
+A `NodePort` and external IPs are independent and both can be used concurrently.

--- a/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.adoc
+++ b/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can specify a list of IP address ranges for the `IngressController`. This restricts access to the load balancer service when the `endpointPublishingStrategy` is `LoadBalancerService`.
+[role="_abstract"]
+You can specify a list of IP address ranges for the Ingress Controller. This action restricts access to the load balancer service when you specify the `LoadBalancerService` value for the `endpointPublishingStrategy` parameter.
 
 include::modules/nw-configuring-lb-allowed-source-ranges.adoc[leveloffset=+1]
 

--- a/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc
+++ b/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc
@@ -6,37 +6,23 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} provides methods for communicating from
-outside the cluster with services running in the cluster. This method uses a
-load balancer.
+[role="_abstract"]
+{product-title} provides methods for communicating from outside the cluster with services running in the cluster. This method uses a load balancer.
 
-include::modules/nw-using-load-balancer-getting-traffic.adoc[leveloffset=+1]
+Before starting the following procedures, the administrator must complete the following prerequisite tasks:
 
-[NOTE]
-====
-The procedures in this section require prerequisites performed by the cluster
-administrator.
-====
+* Set up the external port to the cluster networking environment so that requests can reach the cluster.
 
-== Prerequisites
+* Have an {product-title} cluster with at least one control plane node, at least one compute node, and a system outside the cluster that has network access to the cluster. This procedure assumes that the external system is on the same subnet as the cluster. The additional networking required for external systems on a different subnet is out-of-scope for this topic.
 
-Before starting the following procedures, the administrator must:
-
-* Set up the external port to the cluster networking environment so that requests
-can reach the cluster.
-
-* Make sure there is at least one user with cluster admin role. To add this role
-to a user, run the following command:
+* Make sure there is at least one user with cluster admin role. To add this role to a user, run the following command:
 +
+[source,terminal]
 ----
 $ oc adm policy add-cluster-role-to-user cluster-admin username
 ----
 
-* Have an {product-title} cluster with at least one master and at least one node
-and a system outside the cluster that has network access to the cluster. This
-procedure assumes that the external system is on the same subnet as the cluster.
-The additional networking required for external systems on a different subnet is
-out-of-scope for this topic.
+include::modules/nw-using-load-balancer-getting-traffic.adoc[leveloffset=+1]
 
 include::modules/nw-creating-project-and-service.adoc[leveloffset=+1]
 

--- a/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc
+++ b/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc
@@ -6,37 +6,26 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} provides methods for communicating from
-outside the cluster with services running in the cluster. This method uses a
-`NodePort`.
+[role="_abstract"]
+To enable external access to your application for specific networking requirements, expose a service by using a `NodePort`. 
 
-include::modules/nw-using-nodeport.adoc[leveloffset=+1]
+This configuration opens a specific port on every node in the cluster, allowing external traffic to reach your workloads by using an IP address of any node.
 
-[NOTE]
-====
-The procedures in this section require prerequisites performed by the cluster
-administrator.
-====
+{product-title} provides methods for communicating from outside the cluster with services running in the cluster. This method uses a `NodePort`.
 
-== Prerequisites
+Before starting the following procedures, the administrator must complete the following prerequisite tasks:
 
-Before starting the following procedures, the administrator must:
+* Set up the external port to the cluster networking environment so that requests can reach the cluster.
 
-* Set up the external port to the cluster networking environment so that requests
-can reach the cluster.
+* Have an {product-title} cluster with at least one control plane node, at least one compute node, and a system outside the cluster that has network access to the cluster. This procedure assumes that the external system is on the same subnet as the cluster. The additional networking required for external systems on a different subnet is out-of-scope for this topic.
 
-* Make sure there is at least one user with cluster admin role. To add this role
-to a user, run the following command:
+* Make sure there is at least one user with cluster admin role. To add this role to a user, run the following command:
 +
 ----
 $ oc adm policy add-cluster-role-to-user cluster-admin <user_name>
 ----
 
-* Have an {product-title} cluster with at least one master and at least one node
-and a system outside the cluster that has network access to the cluster. This
-procedure assumes that the external system is on the same subnet as the cluster.
-The additional networking required for external systems on a different subnet is
-out-of-scope for this topic.
+include::modules/nw-using-nodeport.adoc[leveloffset=+1]
 
 // Creating a project and service
 include::modules/nw-creating-project-and-service.adoc[leveloffset=+1]

--- a/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.adoc
+++ b/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.adoc
@@ -6,15 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use either a MetalLB implementation or an IP failover deployment to attach an ExternalIP resource to a service so that the service is available to traffic outside your {product-title} cluster. Hosting an external IP address in this way is only applicable for a cluster installed on bare-metal hardware.
+[role="_abstract"]
+You can use either a MetalLB implementation or an IP failover deployment to attach an ExternalIP resource to a service so that the service is available to traffic outside your {product-title} cluster. 
+
+Hosting an external IP address in this way is only applicable for a cluster installed on bare-metal hardware.
 
 You must ensure that you correctly configure the external network infrastructure to route traffic to the service.
 
-[id="configuring-ingress-cluster-traffic-service-external-ip-prerequisites"]
-== Prerequisites
+Before you begin the procedure, ensure that you meet the following prerequisite:
 
-* Your cluster is configured with ExternalIPs enabled. For more information, read xref:../../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-externalip.adoc#configuring-externalip[Configuring ExternalIPs for services].
-+
+* You configured your cluster with ExternalIPs enabled. For more information, see "Configuring ExternalIPs for services" in the _Additional resources_ section.
+
 [NOTE]
 ====
 Do not use the same ExternalIP for the egress IP.
@@ -25,6 +27,8 @@ include::modules/nw-service-externalip-create.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="configuring-ingress-cluster-traffic-service-external-ip-additional-resources"]
 == Additional resources
+
+xref:../../../networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-externalip.adoc#configuring-externalip[Configuring ExternalIPs for services]
 
 * xref:../../../networking/networking_operators/metallb-operator/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator]
 

--- a/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-controller-dnsmgt.adoc
+++ b/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-controller-dnsmgt.adoc
@@ -6,19 +6,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+To ensure application accessiblity across external networks in {product-title}, you can manually configure DNS records for an Ingress Controller.
+
 As a cluster administrator, when you create an Ingress Controller, the Operator manages the DNS records automatically. This has some limitations when the required DNS zone is different from the cluster DNS zone or when the DNS zone is hosted outside the cloud provider.
 
-== Managed DNS management policy
+The following list details key aspects for a managed DNS management policy:
 
-The Managed DNS management policy for Ingress Controllers ensures that the lifecycle of the wildcard DNS record on the cloud provider is automatically managed by the Operator. This is the default behavior.
+* The Managed DNS management policy for Ingress Controllers ensures that the lifecycle of the wildcard DNS record on the cloud provider is automatically managed by the Operator. This is the default behavior.
 
-When you change an Ingress Controller from `Managed` to `Unmanaged` DNS management policy, the Operator does not clean up the previous wildcard DNS record provisioned on the cloud.
+* When you change an Ingress Controller from `Managed` to `Unmanaged` DNS management policy, the Operator does not clean up the previous wildcard DNS record provisioned on the cloud.
 
-When you change an Ingress Controller from `Unmanaged` to `Managed` DNS management policy, the Operator attempts to create the DNS record on the cloud provider if it does not exist or updates the DNS record if it already exists.
+* When you change an Ingress Controller from `Unmanaged` to `Managed` DNS management policy, the Operator attempts to create the DNS record on the cloud provider if it does not exist or updates the DNS record if it already exists.
 
-== Unmanaged DNS management policy
+The following list details key aspects for a unmanaged DNS management policy:
 
-The Unmanaged DNS management policy for Ingress Controllers ensures that the lifecycle of the wildcard DNS record on the cloud provider is not automatically managed; instead, it becomes the responsibility of the cluster administrator.
+* The Unmanaged DNS management policy for Ingress Controllers ensures that the lifecycle of the wildcard DNS record on the cloud provider is not automatically managed; instead, it becomes the responsibility of the cluster administrator.
 
 include::modules/creating-a-custom-ingress-controller.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.16+ 

Issue:
[OSDOCS-16862](https://issues.redhat.com/browse/OSDOCS-16862)

Link to docs preview:

* https://104379--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html
* https://104379--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer-allowed-source-ranges.html
* https://104379--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.html
* https://104379--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.html
* https://104379--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-service-external-ip.html
* https://104379--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-controller-dnsmgt.html


Next PR starts from openshift-docs/networking/ingress_load_balancing/configuring_ingress_cluster_traffic/ingress-gateway-api.adoc