### PR TITLE
[monitoring-docs-4.15] OBSDOCS-2977 Fix the 'key concepts' module to not include any text

### DIFF
--- a/key-concepts/key-concepts.adoc
+++ b/key-concepts/key-concepts.adoc
@@ -9,19 +9,7 @@ toc::[]
 [role="_abstract"]
 Get familiar with the {ocp} monitoring concepts and terms. Learn about how you can improve performance and scale of your cluster, store and record data, manage metrics and alerts, and more.
 
-[id="about-performance-and-scalability_{context}"]
-== About performance and scalability
-
-You can optimize the performance and scale of your clusters.
-You can configure the default monitoring stack by performing any of the following actions:
-
-* Control the placement and distribution of monitoring components:
-** Use node selectors to move components to specific nodes.
-** Assign tolerations to enable moving components to tainted nodes.
-* Use pod topology spread constraints.
-* Set the body size limit for metrics scraping.
-* Manage CPU and memory resources.
-* Use metrics collection profiles.
+include::modules/monitoring-about-performance-and-scalability.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -37,20 +25,7 @@ include::modules/monitoring-about-specifying-limits-and-requests-for-monitoring-
 
 include::modules/monitoring-configuring-metrics-collection-profiles.adoc[leveloffset=+2]
 
-[id="about-storing-and-recording-data_{context}"]
-== About storing and recording data
-
-You can store and record data to help you protect the data and use them for troubleshooting.
-You can configure the default monitoring stack by performing any of the following actions:
-
-* Configure persistent storage:
-** Protect your metrics and alerting data from data loss by storing them in a persistent volume (PV). As a result, they can survive pods being restarted or recreated.
-** Avoid getting duplicate notifications and losing silences for alerts when the Alertmanager pods are restarted.
-* Modify the retention time and size for Prometheus and Thanos Ruler metrics data.
-* Configure logging to help you troubleshoot issues with your cluster:
-** Configure audit logs for Metrics Server.
-** Set log levels for monitoring.
-** Enable the query logging for Prometheus and Thanos Querier.
+include::modules/monitoring-about-storing-and-recording-data.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/monitoring-about-performance-and-scalability.adoc
+++ b/modules/monitoring-about-performance-and-scalability.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * key-concepts/key-concepts.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-performance-and-scalability_{context}"]
+= About performance and scalability
+
+You can optimize the performance and scale of your clusters.
+You can configure the default monitoring stack by performing any of the following actions:
+
+* Control the placement and distribution of monitoring components:
+** Use node selectors to move components to specific nodes.
+** Assign tolerations to enable moving components to tainted nodes.
+* Use pod topology spread constraints.
+* Set the body size limit for metrics scraping.
+* Manage CPU and memory resources.
+* Use metrics collection profiles.

--- a/modules/monitoring-about-storing-and-recording-data.adoc
+++ b/modules/monitoring-about-storing-and-recording-data.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * key-concepts/key-concepts.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-storing-and-recording-data_{context}"]
+= About storing and recording data
+
+You can store and record data to help you protect the data and use them for troubleshooting.
+You can configure the default monitoring stack by performing any of the following actions:
+
+* Configure persistent storage:
+** Protect your metrics and alerting data from data loss by storing them in a persistent volume (PV). As a result, they can survive pods being restarted or recreated.
+** Avoid getting duplicate notifications and losing silences for alerts when the Alertmanager pods are restarted.
+* Modify the retention time and size for Prometheus and Thanos Ruler metrics data.
+* Configure logging to help you troubleshoot issues with your cluster:
+** Configure audit logs for Metrics Server.
+** Set log levels for monitoring.
+** Enable the query logging for Prometheus and Thanos Querier.


### PR DESCRIPTION
manual cherry-pick of https://github.com/openshift/openshift-docs/pull/104375 to 4.15 monitoring