### PR TITLE
OSDOCS-17673-1:Update the z-stream RNs for 4.17.46

### DIFF
--- a/modules/zstream-4-17-46-about.adoc
+++ b/modules/zstream-4-17-46-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-17-46-about_{context}"]
+= RHBA-2026:23120 - {product-title} {product-version}.46 bug fix advisory
+
+[role="_abstract"]
+Issued: 06 January 2026
+
+{product-title} release {product-version}.46 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:23120[RHBA-2026:23120] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:23118[RHBA-2025:23118] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.46--pullspecs
+----

--- a/modules/zstream-4-17-46-fixed-issues.adoc
+++ b/modules/zstream-4-17-46-fixed-issues.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-46-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issues are fixed with this release:
+
+* Before this update, when an IDMS or ICSP in the management cluster defined a source that pointed to `registry.redhat.io` or `registry.redhat.io/redhat`, and the mirror registry did not contain the required OLM catalog images, the provisioning of the `HostedCluster` object stalled due to unauthorized image pulls. As a consequence, the `HostedCluster` object was not deployed, and was blocked from pulling essential catalog images from the mirrored registry. With this release, the provisioning explicitly fails and blocks if a required image cannot be pulled due to authorization errors. In addition, the logic for registry overrides is improved to allow matches on the root of the registry, such as `registry.redhat.io`, for OLM CatalogSource image resolution. Also, a fallback mechanism is introduced to use the original image reference if the registry override does not yield a working image. As a result, the `HostedCluster` object is deployed, even in scenarios where the mirror registry lacks the required OLM catalog images, because the system correctly falls back to pull from the original source when appropriate. (link:https://issues.redhat.com/browse/OCPBUGS-57123[OCPBUGS-57123]).
+
+* Before this update, a bug on `oc adm inspect --all-namespaces` command construction meant that must-gather was not correctly gathering information about leases, `csistoragecapacities`, and the assisted-installer namespace. With this release, the issue is fixed and must-gather gathers the information correctly. (link:https://issues.redhat.com/browse/OCPBUGS-60607[OCPBUGS-60607])
+
+* Before this update, when network interfaces were bonded, the bond interface presented itself using the MAC address of one of the interfaces that it used. The other interface in the bond also presented itself using that MAC address, but also retained its permanent MAC address. With this release, this permanent MAC address is reported and discovered by ironic-python-agent, so that if it is used as a boot MAC address, the ironic agent can look up the node that contains the MAC address. (link:https://issues.redhat.com/browse/OCPBUGS-62490[OCPBUGS-62490])
+
+* Before this update, when you directly navigated to a page created by a web console dynamic plugin, the web console might have redirected you to a different URL. With this release, the URL redirect is removed. (link:https://issues.redhat.com/browse/OCPBUGS-65933[OCPBUGS-65933])
+
+* Before this update, the {azure-short} Machine API provider attempted to use the default `platformUpdateDomainCount` of `5` even in regions that are restricted to a single fault domain. This caused machine creation to fail for all node types in affected regions because {azure-short} only supports one update domain when the fault domain count is `1`. With this release, the logic was updated to explicitly set the `platformUpdateDomainCount` parameter to `1` whenever the `platformFaultDomainCount` parameter is determined to be `1`. As a result, Machine Availability Sets are created with valid parameter combinations, which allows machines to successfully provision in {azure-short} regions with a single fault domain. (link:https://issues.redhat.com/browse/OCPBUGS-65954[OCPBUGS-65954])

--- a/modules/zstream-4-17-46-updating.adoc
+++ b/modules/zstream-4-17-46-updating.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-46-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2942,6 +2942,15 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//  4.17.46 about
+include::modules/zstream-4-17-46-about.adoc[leveloffset=+2]
+
+//4.17.46 bug fixes
+include::modules/zstream-4-17-46-fixed-issues.adoc[leveloffset=+2]
+
+//4.17.46 bug fixes
+include::modules/zstream-4-17-46-updating.adoc[leveloffset=+2]
+
 //  4.17.45 about
 include::modules/zstream-4-17-45-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-17673

Link to docs preview:
https://104400--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#zstream-4-17-46-about_release-notes

Additional information:
4.17.46 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/275
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.17