### PR TITLE
OLS-2401: Create OLS 1.0.9 release notes

### DIFF
--- a/modules/ols-1-0-9-fixed-issues.adoc
+++ b/modules/ols-1-0-9-fixed-issues.adoc
@@ -1,0 +1,32 @@
+// This module is used in the following assemblies:
+
+// * lightspeed-docs-main/release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-1-0-9-fixed-issues_{context}"]
+= Fixed issues
+
+{ols-official} 1.0.9 fixes the following issues:
+
+[NOTE]
+====
+Some linked Jira tickets are accessible only with {red-hat} credentials.
+====
+
+* Previously, you defined replicas in the `DeploymentConfig` and it was not obvious which pod each replica referred to. As a result, when you changed the replica count it was not clear which pod should be scaled. With this release, you configure replica count with each specific component's deployments: `APIContainer`, `ConsoleContainer`, and `DatabaseContainer`. This change allows you to specify the number of replicas for each pod. Note that the value for the number of replicas can only be changed for `APIContainer`. For all other containers, the number of replicas is fixed to `1`.
++
+https://issues.redhat.com/browse/OLS-2322[OLS-2322]
+
+
+* Previously, support for custom HTTPS credentials for UI to backend communications was spread between two configurations: `UIDeployment` and `TLSConfig`. As a result, you had to ensure that both places are configured, which was error prone. With this release, support for custom HTTPS credentials for UI to backend communications is consolidated in one place, `TLSConfig`.
++
+[NOTE]
+====
+If you do not provide `ca.crt` in the current implementation, the {ocp-product-title} Console proxy uses the default system trust store.
+====
++
+https://issues.redhat.com/browse/OLS-2322[OLS-2322]
+
+* Before this update, {ols-long} failed to handle unreachable MCP servers, resulting in loss of all tool functionality. With this release, {ols-long} isolates the failing MCP server, keeping other tools operational and preserving full assistant capabilities.
++
+https://issues.redhat.com/browse/OLS-2322[OLS-2393]

--- a/modules/ols-1-0-9-release-notes.adoc
+++ b/modules/ols-1-0-9-release-notes.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-1-9-release-notes_{context}"]
+= {ols-long} version 1.0.9
+
+{ols-official} 1.0.9 is now available on {ocp-product-title} 4.16 and later.
+
+[id="ols-1-0-9-enhancements_{context}"]
+== Enhancements
+
+The following enhancements have been made with {ols-official} 1.0.9:
+
+* With this update, {ols-long} supports automatic updates of BYO Knowledge images that use floating tags, such as `latest`. If over time a BYO Knowledge image tag points to different underlying images, {ols-long} detects those changes and updates the corresponding BYO Knowledge database accordingly. This feature is built using {red-hat} OpenShift `ImageStream` objects. {ocp-product-title} clusters check for updates to `ImageStream` objects every 15 minutes.
+
+* Starting with this release, you can specify an array of image pull secrets in the `OLSConfig` Custom Resource (CR) file. Pull secrets contain authentication credentials for remote image registries and are used to pull RAG BYO Knowledge images from image registries requiring authentication.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -13,6 +13,8 @@ The release notes highlight what is new and what has changed with each {ols-offi
 {ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
 ====
 
+include::modules/ols-1-0-9-release-notes.adoc[leveloffset=+1]
+include::modules/ols-1-0-9-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-8-release-notes.adoc[leveloffset=+1]
 include::modules/ols-1-0-8-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-7-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue: https://issues.redhat.com/browse/OLS-2401

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
