### PR TITLE
OSDOCS-17503:Corrected Vale errors in the Intro to OSD book

### DIFF
--- a/modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc
+++ b/modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc
@@ -7,6 +7,7 @@
 [id="how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects_{context}"]
 = How service accounts assume AWS IAM roles in SRE owned projects
 
+[role="_abstract"]
 When you install a {product-title}
 ifdef::openshift-rosa-hcp[]
 cluster,

--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -4,8 +4,12 @@
 // * rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.adoc
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
 
+:_mod-docs-content-type: REFERENCE
 [id="sd-life-cycle-dates_{context}"]
 = Life cycle dates
+
+[role="_abstract"]
+The following table lists the general availability, maintenance support end date, and Extended Update Support Add-On - Term 1 end date for each supported {product-title} version.
 
 [options="header"]
 |===

--- a/modules/life-cycle-definitions.adoc
+++ b/modules/life-cycle-definitions.adoc
@@ -3,8 +3,12 @@
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="rosa-life-cycle-definitions_{context}"]
 = Definitions
+
+[role="_abstract"]
+The following table defines the versioning scheme used for {product-title} releases.
 
 .Version reference
 [options="header"]

--- a/modules/life-cycle-install.adoc
+++ b/modules/life-cycle-install.adoc
@@ -3,8 +3,10 @@
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="rosa-install-policy_{context}"]
 = Installation policy
 
+[role="_abstract"]
 While Red{nbsp}Hat recommends installation of the latest support release, {product-title} supports
 installation of any supported release as covered by the preceding policy.

--- a/modules/life-cycle-limited-support.adoc
+++ b/modules/life-cycle-limited-support.adoc
@@ -8,9 +8,11 @@ ifeval::["{context}" == "rosa-hcp-life-cycle"]
 :rosa-with-hcp:
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="rosa-limited-support_{context}"]
 = Limited support status
 
+[role="_abstract"]
 When a cluster transitions to a _Limited Support_ status, Red{nbsp}Hat no longer proactively monitors the cluster, the SLA is no longer applicable, and credits requested against the SLA are denied. It does not mean that you no longer have product support. In some cases, the cluster can return to a fully-supported status if you remediate the violating factors. However, in other cases, you might have to delete and recreate the cluster.
 
 A cluster might transition to a Limited Support status for many reasons, including the following scenarios:

--- a/modules/life-cycle-major-versions.adoc
+++ b/modules/life-cycle-major-versions.adoc
@@ -3,9 +3,11 @@
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="rosa-major-versions_{context}"]
 = Major versions (X.y.z)
 
+[role="_abstract"]
 Major versions of {product-title}, for example version 4, are supported for one year following the
 release of a subsequent major version or the retirement of the product.
 

--- a/modules/life-cycle-mandatory-upgrades.adoc
+++ b/modules/life-cycle-mandatory-upgrades.adoc
@@ -11,6 +11,7 @@ endif::[]
 [id="rosa-mandatory-upgrades_{context}"]
 = Mandatory upgrades
 
+[role="_abstract"]
 If a critical or important CVE, or other bug identified by Red{nbsp}Hat, significantly impacts the security or stability of the cluster, the customer must upgrade to the next supported patch release within two link:https://access.redhat.com/articles/2623321[business days].
 
 In extreme circumstances and based on Red{nbsp}Hat's assessment of the CVE criticality to the environment, Red{nbsp}Hat will notify customers that they have two link:https://access.redhat.com/articles/2623321[business days] to schedule or manually update their cluster to the latest, secure patch release. In the case that an update is not performed after two link:https://access.redhat.com/articles/2623321[business days], Red{nbsp}Hat will automatically update the

--- a/modules/life-cycle-minor-versions.adoc
+++ b/modules/life-cycle-minor-versions.adoc
@@ -7,9 +7,11 @@ ifeval::["{context}" == "rosa-hcp-life-cycle"]
 :rosa-with-hcp:
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="rosa-minor-versions_{context}"]
 = Minor versions (x.Y.z)
 
+[role="_abstract"]
 Starting with the 4.8 OpenShift Container Platform minor version, Red{nbsp}Hat supports all minor versions for at least a 16 month period following general availability of the given minor version. Patch versions are not affected by the support period.
 
 Customers are notified 60, 30, and 15 days before the end of the support period. Clusters must be upgraded to the latest patch version of the oldest supported minor version before the end of the support period, or

--- a/modules/life-cycle-overview.adoc
+++ b/modules/life-cycle-overview.adoc
@@ -7,6 +7,7 @@
 [id="life-cycle-overview_{context}"]
 = Overview
 
+[role="_abstract"]
 Red{nbsp}Hat provides a published product life cycle for {product-title} in order for customers and partners to effectively plan, deploy, and support their applications running on the platform. Red{nbsp}Hat publishes this life cycle to provide as much transparency as possible and might make exceptions from these policies as conflicts arise.
 
 {product-title} is a managed deployment of Red{nbsp}Hat OpenShift and maintains an independent release schedule. More details about the managed offering can be found in the {product-title} service definition. The availability of Security Advisories and Bug Fix Advisories for a specific version are dependent upon the Red{nbsp}Hat OpenShift Container Platform life cycle policy and subject to the {product-title} maintenance schedule.

--- a/modules/life-cycle-patch-versions.adoc
+++ b/modules/life-cycle-patch-versions.adoc
@@ -3,9 +3,11 @@
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="rosa-patch-versions_{context}"]
 = Patch versions (x.y.Z)
 
+[role="_abstract"]
 During the period in which a minor version is supported, Red{nbsp}Hat supports all OpenShift Container Platform patch versions unless otherwise specified.
 
 For reasons of platform security and stability, a patch release may be deprecated, which would prevent installations of that release and trigger mandatory upgrades off that release.

--- a/modules/life-cycle-supported-versions.adoc
+++ b/modules/life-cycle-supported-versions.adoc
@@ -3,7 +3,9 @@
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="rosa-supported-versions_{context}"]
 = Supported versions exception policy
 
+[role="_abstract"]
 Red{nbsp}Hat reserves the right to add or remove new or existing versions, or delay upcoming minor release versions, that have been identified to have one or more critical production impacting bugs or security issues without advance notice.

--- a/modules/managed-cluster-notification-policy.adoc
+++ b/modules/managed-cluster-notification-policy.adoc
@@ -7,6 +7,7 @@
 [id="managed-cluster-notification-policy_{context}"]
 = Cluster notification policy
 
+[role="_abstract"]
 Cluster notifications are designed to keep you informed about the health of your cluster and high impact events that affect it.
 
 Most cluster notifications are generated and sent automatically to ensure that you are immediately informed of problems or important changes to the state of your cluster.

--- a/modules/osd-intro.adoc
+++ b/modules/osd-intro.adoc
@@ -6,6 +6,7 @@
 [id="osd-intro_{context}"]
 = An overview of {product-title}
 
+[role="_abstract"]
 {product-title} is professionally managed by Red Hat and hosted on {AWS} or {GCP}. Each {product-title} cluster comes with a fully managed link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/architecture/control-plane[control plane] (Control and Infrastructure nodes), application nodes, installation and management by Red Hat Site Reliability Engineers (SRE), premium Red Hat Support, and cluster services such as logging, metrics, monitoring, notifications portal, and a cluster portal.
 
 {product-title} provides enterprise-ready enhancements to Kubernetes, including the following enhancements:

--- a/modules/policy-change-management.adoc
+++ b/modules/policy-change-management.adoc
@@ -6,7 +6,8 @@
 [id="policy-change-management_{context}"]
 = Change management
 
-This section describes the policies about how cluster and configuration changes, patches, and releases are managed.
+[role="_abstract"]
+Manage changes to your cluster and its configuration.
 
 [id="policy-customer-initiated-changes_{context}"]
 == Customer-initiated changes

--- a/modules/policy-customer-responsibility.adoc
+++ b/modules/policy-customer-responsibility.adoc
@@ -6,7 +6,7 @@
 [id="policy-customer-responsibility_{context}"]
 = Customer responsibilities for data and applications
 
-
+[role="_abstract"]
 The customer is responsible for the applications, workloads, and data that they deploy to {product-title}. However, Red Hat provides various tools to help the customer manage data and applications on the platform.
 
 [cols="2a,3a,3a",options="header"]

--- a/modules/policy-disaster-recovery.adoc
+++ b/modules/policy-disaster-recovery.adoc
@@ -6,6 +6,7 @@
 [id="policy-disaster-recovery_{context}"]
 = Disaster recovery
 
+[role="_abstract"]
 {product-title} provides disaster recovery for failures that occur at the pod, worker node, infrastructure node, control plane node, and availability zone levels.
 
 All disaster recovery requires that the customer use best practices for deploying highly available applications, storage, and cluster architecture (for example, single-zone deployment vs. multi-zone deployment) to account for the level of desired availability.

--- a/modules/policy-failure-points.adoc
+++ b/modules/policy-failure-points.adoc
@@ -6,7 +6,7 @@
 [id="policy-failure-points_{context}"]
 = Potential points of failure
 
-
+[role="_abstract"]
 {OCP} provides many features and options for protecting your workloads against downtime, but applications must be architected appropriately to take advantage of these features.
 
 {product-title} can help further protect you against many common Kubernetes issues by adding Red Hat Site Reliability Engineer (SRE) support and the option to deploy a multi-zone cluster, but there are a number of ways in which a container or infrastructure can still fail. By understanding potential points of failure, you can understand risks and appropriately architect both your applications and your clusters to be as resilient as necessary at each specific level.

--- a/modules/policy-identity-access-management.adoc
+++ b/modules/policy-identity-access-management.adoc
@@ -6,6 +6,7 @@
 [id="policy-identity-access-management_{context}"]
 = Identity and access management
 
+[role="_abstract"]
 Most access by Red Hat site reliability engineering (SRE) teams is done by using cluster Operators through automated configuration management.
 
 [NOTE]

--- a/modules/policy-incident.adoc
+++ b/modules/policy-incident.adoc
@@ -6,6 +6,7 @@
 [id="policy-incident_{context}"]
 = Incident and operations management
 
+[role="_abstract"]
 This documentation details the Red{nbsp}Hat responsibilities for the {product-title} managed service.
 The cloud provider is responsible for protecting the hardware infrastructure that runs the services offered by the cloud provider.
 The customer is responsible for incident and operations management of customer application data and any custom networking the customer has configured for the cluster network or virtual network.

--- a/modules/policy-responsibilities.adoc
+++ b/modules/policy-responsibilities.adoc
@@ -6,8 +6,8 @@
 [id="policy-responsibilities_{context}"]
 = Overview of responsibilities for {product-title}
 
-
-While Red Hat manages the {product-title} service, the customer shares responsibility with respect to certain aspects. The {product-title} services are accessed remotely, hosted on public cloud resources, created in either Red Hat or customer-owned cloud service provider accounts, and have underlying platform and data security that is owned by Red Hat.
+[role="_abstract"]
+While Red{nbsp}Hat manages the {product-title} service, the customer shares responsibility with respect to certain aspects. The {product-title} services are accessed remotely, hosted on public cloud resources, created in either Red{nbsp}Hat or customer-owned cloud service provider accounts, and have underlying platform and data security that is owned by Red{nbsp}Hat.
 
 [IMPORTANT]
 ====

--- a/modules/policy-security-regulation-compliance.adoc
+++ b/modules/policy-security-regulation-compliance.adoc
@@ -6,6 +6,7 @@
 [id="policy-security-regulation-compliance_{context}"]
 = Security and regulation compliance
 
+[role="_abstract"]
 Security and regulation compliance includes tasks, such as the implementation of security controls and compliance certification.
 
 [id="data-classification_{context}"]
@@ -22,16 +23,13 @@ When a customer deletes their {product-title} cluster, all cluster data is perma
 == Vulnerability management
 Red Hat performs periodic vulnerability scanning of {product-title} using industry standard tools. Identified vulnerabilities are tracked to their remediation according to timelines based on severity. Vulnerability scanning and remediation activities are documented for verification by third-party assessors in the course of compliance certification audits.
 
-[id="network-security_{context}"]
-== Network security
-
 [id="firewall_{context}"]
-=== Firewall and DDoS protection
+== Network security: Firewall and DDoS protection
 Each {product-title} cluster is protected by a secure network configuration at the cloud infrastructure level using firewall rules (AWS Security Groups or {gcp-full} Compute Engine firewall rules). {product-title} customers on AWS are also protected against DDoS attacks with link:https://docs.aws.amazon.com/waf/latest/developerguide/ddos-overview.html[AWS Shield Standard].
 Similarly, all {gcp-short} load balancers and public IP addresses used by {product-title} on {gcp-short} are protected against DDoS attacks with link:https://cloud.google.com/armor/docs/managed-protection-overview[{gcp-full} Armor Standard].
 
 [id="Component-traffic-flow-encryption_{context}"]
-=== Component and traffic flow encryption
+== Network security: Component and traffic flow encryption
 {product-title} components are configured to use Transport Layer Security (TLS) for secure communication, prioritizing TLS 1.3 for its performance and security enhancements. For components not yet supporting TLS 1.3, robust TLS 1.2 cipher suites are configured. This comprehensive TLS configuration ensures the encryption of various traffic flows within and to the OpenShift Dedicated environment. For more information, refer to link:https://access.redhat.com/articles/5348961#openshift-4-10[TLS configuration on OpenShift] and link:https://www.redhat.com/en/about/appendices[Appendix 4(Online Subscription Services).]
 
 ** Starting with version 4.7, the OpenShift API server (port 6443), kube-controller (port 10257), and kube-scheduler (port 10259) are configured to use TLS 1.3 with a reduced set of secure cipher suites.
@@ -41,13 +39,13 @@ Similarly, all {gcp-short} load balancers and public IP addresses used by {produ
 ** By default, OpenShift 4 enables secure TLS configurations on numerous internal services to protect their communications. These services include the Machine Config Server (ports 22623-22624), Node Exporter (ports 9100-9101), and Kube RBAC Proxy (port 9192).
 
 [id="private-clusters_{context}"]
-=== Private clusters and network connectivity
+== Network security: Private clusters and network connectivity
 Customers can optionally configure their {product-title} cluster endpoints (web console, API, and application router) to be made private so that the cluster control plane or applications are not accessible from the Internet.
 
 For AWS, customers can configure a private network connection to their {product-title} cluster through AWS VPC peering, AWS VPN, or AWS Direct Connect.
 
 [id="network-access-controls_{context}"]
-=== Cluster network access controls
+== Network security: Cluster network access controls
 Fine-grained network access control rules can be configured by customers per project.
 
 [id="penetration-testing_{context}"]
@@ -87,6 +85,6 @@ Any issues that are discovered are prioritized based on severity. Any issues fou
 //This table exists in sdpolicy-security.adoc file also.
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
 
-* See link:https://access.redhat.com/articles/5528091[Red Hat Subprocessor List] for information on SRE residency.
+* link:https://access.redhat.com/articles/5528091[Red Hat Subprocessor List]

--- a/modules/policy-shared-responsibility.adoc
+++ b/modules/policy-shared-responsibility.adoc
@@ -6,8 +6,8 @@
 [id="policy-shared-responsibility_{context}"]
 = Shared responsibility matrix
 
-
-The customer and Red Hat share responsibility for the monitoring and maintenance of an {product-title} cluster. This documentation illustrates the delineation of responsibilities by area and task.
+[role="_abstract"]
+The customer and Red{nbsp}Hat share responsibility for the monitoring and maintenance of an {product-title} cluster. This documentation illustrates the delineation of responsibilities by area and task.
 
 [id="incident-operations-management_{context}"]
 == Incident and operations management

--- a/modules/sdpolicy-am-aws-compute-types-ccs.adoc
+++ b/modules/sdpolicy-am-aws-compute-types-ccs.adoc
@@ -5,6 +5,7 @@
 [id="aws-instance-types-ccs_{context}"]
 = AWS instance types for Customer Cloud Subscription clusters
 
+[role="_abstract"]
 {product-title} offers the following worker node instance types and sizes on AWS:
 
 .General purpose

--- a/modules/sdpolicy-am-aws-compute-types-non-ccs.adoc
+++ b/modules/sdpolicy-am-aws-compute-types-non-ccs.adoc
@@ -5,6 +5,7 @@
 [id="aws-instance-types-non-ccs_{context}"]
 = AWS instance types for non-CCS clusters
 
+[role="_abstract"]
 {product-title} offers the following worker node types and sizes on AWS:
 
 .General purpose

--- a/modules/sdpolicy-am-billing.adoc
+++ b/modules/sdpolicy-am-billing.adoc
@@ -5,6 +5,7 @@
 [id="billing_{context}"]
 = Billing options
 
+[role="_abstract"]
 Customers have the option to purchase annual subscriptions of {product-title} (OSD) or consume on-demand through cloud marketplaces. Customers can decide to bring their own cloud infrastructure account, referred to as Customer Cloud Subscription (CCS), or deploy in cloud provider accounts owned by Red Hat. The table below provides additional information regarding billing, as well as the corresponding supported deployment options.
 [cols="2a,3a,3a",options="header"]
 |===

--- a/modules/sdpolicy-am-cloud-providers.adoc
+++ b/modules/sdpolicy-am-cloud-providers.adoc
@@ -5,6 +5,7 @@
 [id="cloud-providers_{context}"]
 = Cloud providers
 
+[role="_abstract"]
 {product-title} offers OpenShift Container Platform clusters as a managed service on the following cloud providers:
 
 * Amazon Web Services (AWS)

--- a/modules/sdpolicy-am-cluster-self-service.adoc
+++ b/modules/sdpolicy-am-cluster-self-service.adoc
@@ -5,6 +5,7 @@
 [id="cluster-self-service_{context}"]
 = Cluster self-service
 
+[role="_abstract"]
 Customers can create, scale, and delete their clusters from {cluster-manager-url}, provided that they have already purchased the necessary subscriptions.
 
 Actions available in {cluster-manager-first} must not be directly performed from within the cluster as this might cause adverse affects, including having all actions automatically reverted.

--- a/modules/sdpolicy-am-compute.adoc
+++ b/modules/sdpolicy-am-compute.adoc
@@ -5,6 +5,7 @@
 [id="instance-types_{context}"]
 = Instance types
 
+[role="_abstract"]
 Single availability zone clusters require a minimum of 2 worker nodes for Customer Cloud Subscription (CCS) clusters deployed to a single availability zone. A minimum of 4 worker nodes is required for non-CCS clusters. These 4 worker nodes are included in the base subscription.
 
 Multiple availability zone clusters require a minimum of 3 worker nodes for Customer Cloud Subscription (CCS) clusters, 1 deployed to each of 3 availability zones. A minimum of 9 worker nodes are required for non-CCS clusters. These 9 worker nodes are included in the base subscription, and additional nodes must be purchased in multiples of 3 to maintain proper node distribution.

--- a/modules/sdpolicy-am-gcp-compute-types.adoc
+++ b/modules/sdpolicy-am-gcp-compute-types.adoc
@@ -5,6 +5,7 @@
 [id="gcp-compute-types_{context}"]
 = {gcp-full} instance types
 
+[role="_abstract"]
 {product-title} offers the following worker node types and sizes on {gcp-full} that are chosen to have a common CPU and memory capacity that are the same as other cloud instance types:
 [NOTE]
 ====

--- a/modules/sdpolicy-am-limited-support.adoc
+++ b/modules/sdpolicy-am-limited-support.adoc
@@ -5,6 +5,7 @@
 [id="limited-support_{context}"]
 = Limited support status
 
+[role="_abstract"]
 When a cluster transitions to a _Limited Support_ status, Red Hat no longer proactively monitors the cluster, the SLA is no longer applicable, and credits requested against the SLA are denied. It does not mean that you no longer have product support. In some cases, the cluster can return to a fully-supported status if you remediate the violating factors. However, in other cases, you might have to delete and recreate the cluster.
 
 A cluster might transition to a Limited Support status for many reasons, including the following scenarios:

--- a/modules/sdpolicy-am-regions-availability-zones.adoc
+++ b/modules/sdpolicy-am-regions-availability-zones.adoc
@@ -4,7 +4,10 @@
 :_mod-docs-content-type: CONCEPT
 [id="regions-availability-zones_{context}"]
 = Regions and availability zones
+
+[role="_abstract"]
 The following regions are supported by {OCP} 4 and are supported for {product-title}.
+
 [id="aws-regions-availability-zones_{context}"]
 == AWS regions and availability zones
 The following AWS regions are supported by {OCP} 4 and are supported for {product-title}:

--- a/modules/sdpolicy-am-sla.adoc
+++ b/modules/sdpolicy-am-sla.adoc
@@ -4,4 +4,6 @@
 :_mod-docs-content-type: CONCEPT
 [id="sla_{context}"]
 = Service level agreement (SLA)
+
+[role="_abstract"]
 Any SLAs for the service itself are defined in Appendix 4 of the link:https://www.redhat.com/en/about/agreements[Red Hat Enterprise Agreement Appendix 4 (Online Subscription Services)].

--- a/modules/sdpolicy-am-support.adoc
+++ b/modules/sdpolicy-am-support.adoc
@@ -4,6 +4,8 @@
 :_mod-docs-content-type: CONCEPT
 [id="support_{context}"]
 = Support
+
+[role="_abstract"]
 {product-title} includes Red Hat Premium Support, which can be accessed by using the link:https://access.redhat.com/support?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[Red Hat Customer Portal].
 
 See the link:https://access.redhat.com/support/offerings/production/soc[Scope of Coverage Page] for link:https://access.redhat.com/support/offerings/production/scope_moredetail[more details] on what is covered with included support for {product-title}.

--- a/modules/sdpolicy-logging.adoc
+++ b/modules/sdpolicy-logging.adoc
@@ -5,6 +5,8 @@
 :_mod-docs-content-type: CONCEPT
 [id="sdpolicy-logging_{context}"]
 = Logging
+
+[role="_abstract"]
 {product-title} provides optional integrated log forwarding to Amazon CloudWatch (on AWS) or {gcp-full} Logging (on {gcp-short}).
 
 For more information, see link:https://docs.openshift.com/dedicated/observability/logging/log_collection_forwarding/log-forwarding.html[About log collection and forwarding].

--- a/modules/sdpolicy-monitoring.adoc
+++ b/modules/sdpolicy-monitoring.adoc
@@ -6,6 +6,9 @@
 [id="sdpolicy-monitoring_{context}"]
 = Monitoring
 
+[role="_abstract"]
+Review the tools you need to monitor cluster performance and stay informed about your cluster's status.
+
 [id="cluster-metrics_{context}"]
 == Cluster metrics
 

--- a/modules/sdpolicy-networking.adoc
+++ b/modules/sdpolicy-networking.adoc
@@ -6,6 +6,9 @@
 [id="sdpolicy-networking_{context}"]
 = Networking
 
+[role="_abstract"]
+Review the networking aspects of {product-title}.
+
 [id="custom-domains_{context}"]
 == Custom domains for applications
 

--- a/modules/sdpolicy-platform.adoc
+++ b/modules/sdpolicy-platform.adoc
@@ -7,6 +7,9 @@
 [id="sdpolicy-platform_{context}"]
 = Platform
 
+[role="_abstract"]
+This guide outlines the automated backup measures provided by the {product-title} service and clarifies the steps you must take to protect your unique application data.
+
 [id="cluster-backup-policy_{context}"]
 == Cluster backup policy
 

--- a/modules/sdpolicy-security.adoc
+++ b/modules/sdpolicy-security.adoc
@@ -6,7 +6,8 @@
 [id="sdpolicy-security_{context}"]
 = Security
 
-This section provides information about the service definition for {product-title} security.
+[role="_abstract"]
+Review the security features and configurations of {product-title}.
 
 [id="auth-provider_{context}"]
 == Authentication provider

--- a/modules/sdpolicy-storage.adoc
+++ b/modules/sdpolicy-storage.adoc
@@ -7,6 +7,9 @@
 [id="sdpolicy-storage_{context}"]
 = Storage
 
+[role="_abstract"]
+Review the storage options available for {product-title} clusters.
+
 [id="encrypt-rest-node_{context}"]
 == Encrypted-at-rest OS/node storage
 Control plane nodes use encrypted-at-rest-EBS storage.

--- a/modules/sre-cluster-access.adoc
+++ b/modules/sre-cluster-access.adoc
@@ -8,6 +8,7 @@
 [id="sre-cluster-access_{context}"]
 = SRE cluster access
 
+[role="_abstract"]
 Red{nbsp}Hat SRE access to {product-title}
 ifdef::openshift-rosa[]
 (ROSA)

--- a/osd_architecture/osd-understanding.adoc
+++ b/osd_architecture/osd-understanding.adoc
@@ -1,16 +1,19 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="osd-understanding"]
 = Understanding {product-title}
+
 include::_attributes/attributes-openshift-dedicated.adoc[]
+include::_attributes/common-attributes.adoc[]
 :context: osd-understanding
 
 toc::[]
 
+[role="_abstract"]
 With its foundation in Kubernetes, {product-title} is a complete {OCP} cluster provided as a cloud service, configured for high availability, and dedicated to a single customer.
 
 include::modules/osd-intro.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
 
-* For more information about Telemetry and remote health monitoring for {product-title} clusters, see xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]

--- a/osd_architecture/osd_policy/osd-life-cycle.adoc
+++ b/osd_architecture/osd_policy/osd-life-cycle.adoc
@@ -1,10 +1,14 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="osd-life-cycle"]
 = {product-title} update life cycle
+
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: osd-life-cycle
 
 toc::[]
+
+[role="_abstract"]
+Review the life cycle policy for {product-title} versions, including definitions of major, minor, and patch versions, as well as support timelines and upgrade requirements.
 
 include::modules/life-cycle-overview.adoc[leveloffset=+1]
 

--- a/osd_architecture/osd_policy/osd-service-definition.adoc
+++ b/osd_architecture/osd_policy/osd-service-definition.adoc
@@ -2,9 +2,13 @@
 [id="osd-service-definition"]
 = {product-title} service definition
 include::_attributes/attributes-openshift-dedicated.adoc[]
+
 :context: osd-service-definition
 
 toc::[]
+
+[role="_abstract"]
+This document provides you with an overview of the {product-title} service definition, including account management, logging, monitoring, networking, storage, platform, and security aspects.
 
 [id="sdpolicy-account-management_{context}"]
 == Account management
@@ -13,6 +17,7 @@ include::modules/sdpolicy-am-cluster-self-service.adoc[leveloffset=+2]
 include::modules/sdpolicy-am-cloud-providers.adoc[leveloffset=+2]
 include::modules/sdpolicy-am-compute.adoc[leveloffset=+2]
 include::snippets/pid-limits.adoc[]
+
 .Additional resources
 * xref:../../osd_architecture/osd_policy/osd-service-definition.adoc#sdpolicy-red-hat-operator_osd-service-definition[Red Hat Operator Support]
 
@@ -35,7 +40,7 @@ include::modules/sdpolicy-networking.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about the network verification checks, see xref:../../networking/network_security/network-verification.adoc#network-verification[Network verification].
+* xref:../../networking/network_security/network-verification.adoc#network-verification[Network verification]
 
 include::modules/sdpolicy-storage.adoc[leveloffset=+1]
 include::modules/sdpolicy-platform.adoc[leveloffset=+1]

--- a/osd_architecture/osd_policy/osd-sre-access.adoc
+++ b/osd_architecture/osd_policy/osd-sre-access.adoc
@@ -6,6 +6,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+Red Hat Site Reliability Engineers (SREs) require access to {product-title} clusters to perform operational tasks, such as monitoring cluster health, responding to incidents, and performing maintenance activities. This document outlines the identity and access management (IAM) policies and procedures that govern SRE access to {product-title} clusters.
+
 include::modules/policy-identity-access-management.adoc[leveloffset=+1]
 include::modules/sre-cluster-access.adoc[leveloffset=+1]
 include::modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc[leveloffset=+1]
@@ -13,4 +16,4 @@ include::modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects
 [id="additional-resources_{context}"]
 == Additional resources
 
-For more information about WIF configuration and SRE access roles, see xref:../../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-cluster-cli_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a WIF configuration].
+* xref:../../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-cluster-cli_osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a WIF configuration]

--- a/osd_architecture/osd_policy/policy-process-security.adoc
+++ b/osd_architecture/osd_policy/policy-process-security.adoc
@@ -9,10 +9,11 @@ toc::[]
 [id="review-action-notifications_{context}"]
 == Review and action cluster notifications
 
-include::snippets/managed-openshift-about-cluster-notifications.adoc[leveloffset=+0]
-include::modules/managed-cluster-notification-policy.adoc[leveloffset=+2]
+[role="_abstract"]
 
-//---
+include::snippets/managed-openshift-about-cluster-notifications.adoc[leveloffset=+0]
+
+include::modules/managed-cluster-notification-policy.adoc[leveloffset=+2]
 
 include::modules/policy-incident.adoc[leveloffset=+1]
 include::modules/policy-change-management.adoc[leveloffset=+1]
@@ -22,4 +23,4 @@ include::modules/policy-disaster-recovery.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information about Red Hat site reliability engineering (SRE) teams access, see xref:../../osd_architecture/osd_policy/osd-sre-access.adoc#policy-identity-access-management_osd-sre-access[Identity and access management].
+* xref:../../osd_architecture/osd_policy/osd-sre-access.adoc#policy-identity-access-management_osd-sre-access[Identity and access management]

--- a/osd_architecture/osd_policy/policy-responsibility-matrix.adoc
+++ b/osd_architecture/osd_policy/policy-responsibility-matrix.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="policy-responsibility-matrix"]
 = Responsibility assignment matrix
+
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: policy-responsibility-matrix
 

--- a/osd_architecture/osd_policy/policy-understand-availability.adoc
+++ b/osd_architecture/osd_policy/policy-understand-availability.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="policy-understand-availability"]
 = Understanding availability for {product-title}
+
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: policy-understand-availability
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17503](https://issues.redhat.com//browse/OSDOCS-17503)

Description:
This PR addresses the Vale errors in the Intro to OSD book. It also fixes an issue where the {quay} attribute was not rendering correctly.

Link to docs preview:

- https://104416--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-life-cycle.html
-https://104416--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html
- https://104416--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-sre-access.html
- https://104416--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/policy-process-security.html
- https://104416--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/policy-responsibility-matrix.html
- https://104416--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/policy-understand-availability.html
- https://104416--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd-understanding.html
- https://104416--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_cluster_admin/osd-cluster-notifications.html
- https://104416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/assuming-an-aws-iam-role-for-a-service-account.html
- https://104416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html
- https://104416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html
- https://104416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.html
- https://104416--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_cluster_admin/rosa-cluster-notifications.html
- https://104416--ocpdocs-pr.netlify.app/openshift-rosa/latest/authentication/assuming-an-aws-iam-role-for-a-service-account.html
- https://104416--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html
- https://104416--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html
- https://104416--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.html
- https://104416--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-cluster-notifications.html
 
Peer review:
- [x] Peer reviewer has approved this change.

QE review:
-  QE approval is not required to merge this PR 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
