### PR TITLE
[SRVCOM-4137] Fix link to OCP docs in Functions prereq

### DIFF
--- a/install/configuring-serverless-functions.adoc
+++ b/install/configuring-serverless-functions.adoc
@@ -20,7 +20,7 @@ To enable the use of {FunctionsProductName} on your cluster, you must complete t
 Functions are deployed as a Knative service. If you want to use event-driven architecture with your functions, you must also install Knative Eventing.
 ====
 
-* You have the link:https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-getting-started[`oc` CLI] installed.
+* You have the link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/cli_tools/openshift-cli-oc#cli-getting-started[`oc` CLI] installed.
 
 * You have the xref:../install/installing-kn.adoc#installing-kn[Knative (`kn`) CLI] installed. Installing the Knative CLI enables the use of `kn func` commands which you can use to create and manage functions.
 
@@ -28,10 +28,10 @@ Functions are deployed as a Knative service. If you want to use event-driven arc
 
 * You have access to an available image registry, such as the OpenShift Container Registry.
 
-* If you are using link:https://quay.io/[Quay.io] as the image registry, you must ensure that either the repository is not private, or that you have followed the {ocp-product-title} documentation on link:https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries].
+* If you are using link:https://quay.io/[Quay.io] as the image registry, you must ensure that either the repository is not private, or that you have followed the {ocp-product-title} documentation on link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/images/managing-images#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries].
 
 
-* If you are using the OpenShift Container Registry, a cluster administrator must link:https://docs.openshift.com/container-platform/latest/registry/securing-exposing-registry.html#securing-exposing-registry[expose the registry].
+* If you are using the OpenShift Container Registry, a cluster administrator must link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/registry/securing-exposing-registry[expose the registry].
 
 include::modules/serverless-functions-podman.adoc[leveloffset=+1]
 include::modules/serverless-functions-podman-macos.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- serverless-docs-1.35
- serverless-docs-1.36
- serverless-docs-1.37

Issue:
https://issues.redhat.com/browse/SRVCOM-4137

Link to docs preview:
- [Config Serverless Functions prerequsites](https://104443--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/configuring-serverless-functions.html#prerequisites_configuring-serverless-functions)

QE review:
- [x] QE approval not needed.
