### PR TITLE
OSDOCS-17573: Added cluster-wide egress IP considerations

### DIFF
--- a/modules/nw-egress-ips-object.adoc
+++ b/modules/nw-egress-ips-object.adoc
@@ -6,7 +6,20 @@
 [id="nw-egress-ips-object_{context}"]
 = EgressIP object
 
+[role="_abstract"]
 View the following YAML files to better understand how you can effectively configure an `EgressIP` object to better meet your needs.
+
+When the `EgressIP` namespace selector matches the label on multiple namespaces, consider the following behaviors:
+
+* All traffic for selected pods must pass through a single node. During times of high traffic, the network interface of the node might experience performance issues.
+* An error in a label selector might change the outbound IP address for many cluster namespaces.
+* Only a cluster administrator can create or change cluster-scoped objects.
+* Packets must move from a pod that exists in a node to the named host node that is referenced in the `EgressIP` object. This approach adds a network hop.
+
+[IMPORTANT]
+====
+Do not create egress rules, such as a single label selector, that forces all namespaces that exist in a cluster to use the same outbound IP address. This configuration can cause the node that hosts the IP address to crash during times of high network traffic.
+====
 
 The following YAML describes the API for the `EgressIP` object. The scope of the object is cluster-wide and is not created in a namespace.
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-17573](https://issues.redhat.com/browse/OSDOCS-17573)

Link to docs preview:
* [EgressIP object - core](https://104446--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-object_configuring-egress-ips-ovn)
* [EgressIP object - ROSA](https://104446--ocpdocs-pr.netlify.app/openshift-rosa/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-object_configuring-egress-ips-ovn)

- [x] SME has approved this change.
- [x] QE has approved this change (Huiran Wang or Qiong Wang).
