### PR TITLE
OSDOCS-17746 updated zero-trust modules

### DIFF
--- a/modules/zero-trust-manager-configure-azure.adoc
+++ b/modules/zero-trust-manager-configure-azure.adoc
@@ -25,55 +25,63 @@ $ az login
 +
 [source,terminal]
 ----
-$ export SUBSCRIPTION_ID=$(az account list --query "[?isDefault].id" -o tsv) <1>
+$ export SUBSCRIPTION_ID=$(az account list --query "[?isDefault].id" -o tsv)
 ----
 +
 [source,terminal]
 ----
-$ export TENANT_ID=$(az account list --query "[?isDefault].tenantId" -o tsv) <2>
+$ export TENANT_ID=$(az account list --query "[?isDefault].tenantId" -o tsv)
 ----
 +
 [source,terminal]
 ----
-$ export LOCATION=centralus <3>
+$ export LOCATION=centralus
 ----
-+
-<1> Your unique subscription identifier.
-<2> The ID for your Azure Active Directory instance.
-<3> The Azure region where your resource is created.
+where:
+
+`SUBSCRIPTION_ID`:: Specifies your unique subscription identifier.
+
+`TENANT_ID`:: Specifies the ID for your Azure Active Directory instance.
+
+`LOCATION`:: The Azure region where your resource is created.
 
 . Define resource variable names by running the following commands:
 +
 [source,terminal]
 ----
-$ export NAME=ztwim <1>
+$ export NAME=ztwim
 ----
 +
 [source,terminal]
 ----
-$ export RESOURCE_GROUP="${NAME}-rg" <2>
+$ export RESOURCE_GROUP="${NAME}-rg"
 ----
 +
 [source,terminal]
 ----
-$ export STORAGE_ACCOUNT="${NAME}storage" <3>
+$ export STORAGE_ACCOUNT="${NAME}storage"
 ----
 +
 [source,terminal]
 ----
-$ export STORAGE_CONTAINER="${NAME}storagecontainer" <4>
+$ export STORAGE_CONTAINER="${NAME}storagecontainer"
 ----
 +
 [source,terminal]
 ----
-$ export USER_ASSIGNED_IDENTITY_NAME="${NAME}-identity" <5>
+$ export USER_ASSIGNED_IDENTITY_NAME="${NAME}-identity"
 ----
-+
-<1> A base name for all resources.
-<2> The name of the resource group.
-<3> The name for the storage account.
-<4> The name for the storage container.
-<5> The name for a managed identity.
+where:
+
+`NAME`:: Specifies A base name for all resources.
+
+`RESOURCE_GROUP`:: Specifies the name of the resource group.
+
+`STORAGE_ACCOUNT`:: Specifies the name for the storage account.
+
+`STORAGE_CONTAINER`:: Specifies the name for the storage container.
+
+`USER_ASSIGNED_IDENTITY_NAME`:: Specifies the name for a managed identity.
 
 . Create the resource group by running the following command:
 +

--- a/modules/zero-trust-manager-federation-configuration.adoc
+++ b/modules/zero-trust-manager-federation-configuration.adoc
@@ -225,7 +225,7 @@ You should receive a JSON response containing the trust bundle.
 [source,terminal]
 ----
 $ oc logs -n zero-trust-workload-identity-manager \
-    deployment/spire-server -c spire-server --tail=50
+    statefulset/spire-server -c spire-server --tail=50
 ----
 +
 Look for log messages indicating successful bundle synchronization with federated trust domains.

--- a/modules/zero-trust-manager-oidc-config.adoc
+++ b/modules/zero-trust-manager-oidc-config.adoc
@@ -41,21 +41,21 @@ spec:
 ----
 where:
 
-name:: Specifies that the value must be 'cluster'.
+`metadata.name`:: Specifies that the value must be `cluster`.
 
-logLevel:: Specifies the logging level for the SPIRE Server. The valid options are `debug`, `info`, `warn`, and `error`.
+`spec.logLevel`:: Specifies the logging level for the SPIRE Server. The valid options are `debug`, `info`, `warn`, and `error`.
 
-logFormat:: Specifies the logging format for the SPIRE Server. The valid options are `text` and `json`.
+`spec.logFormat`:: Specifies the logging format for the SPIRE Server. The valid options are `text` and `json`.
 
-csiDriverName:: Specifies the name of the CSI driver to use for mounting the Workload API socket. This must match the `SpiffeCSIDriver.spec.pluginName` value for the OIDC provider to access SPIFFE identities. Must be a valid DNS subdomain format (for example, `csi.spiffe.io`) with a maximum length of 127 characters.
+`spec.csiDriverName`:: Specifies the name of the CSI driver to use for mounting the Workload API socket. This must match the `SpiffeCSIDriver.spec.pluginName` value for the OIDC provider to access SPIFFE identities. Must be a valid DNS subdomain format (for example, `csi.spiffe.io`) with a maximum length of 127 characters.
 
-jwtIssuer:: Specifies the JWT issuer URL. Must be a valid HTTPS or HTTP URL with a maximum length of 512 characters. This value must match the `SpireServer.spec.jwtIssuer` value.
+`spec.jwtIssuer`:: Specifies the JWT issuer URL. Must be a valid HTTPS or HTTP URL with a maximum length of 512 characters. This value must match the `SpireServer.spec.jwtIssuer` value.
 
-replicaCount:: Specifies the number of replicas for the OIDC Discovery Provider deployment. Must be between 1 and 5.
+`spec.replicaCount`:: Specifies the number of replicas for the OIDC Discovery Provider deployment. Must be between 1 and 5.
 
-managedRoute:: Specifies  whether the Operator automatically creates an OpenShift route for the OIDC Discovery Provider endpoints. Set to `true` to have the Operator automatically create and maintain an OpenShift route for OIDC discovery endpoints (`*.apps.`). Set to `false` for administrators to manually configure routes or ingress.
+`spec.managedRoute`:: Specifies  whether the Operator automatically creates an OpenShift route for the OIDC Discovery Provider endpoints. Set to `true` to have the Operator automatically create and maintain an OpenShift route for OIDC discovery endpoints (`*.apps.`). Set to `false` for administrators to manually configure routes or ingress.
 
-externalSecretRef:: Specifies a reference to an externally managed secret that contains the TLS certificate for the OIDC Discovery Provider route host. Must be a valid Kubernetes secret reference name with a maximum length of 253 characters. This field is optional.
+`spec.ternalSecretRef`:: Specifies a reference to an externally managed secret that contains the TLS certificate for the OIDC Discovery Provider route host. Must be a valid Kubernetes secret reference name with a maximum length of 253 characters. This field is optional.
 
 .. Apply the configuration by running the following command:
 +

--- a/modules/zero-trust-manager-spiffe-csidriver-config.adoc
+++ b/modules/zero-trust-manager-spiffe-csidriver-config.adoc
@@ -35,11 +35,11 @@ spec:
 ----
 where:
 
-name:: Specifies that the name must be 'cluster'.
+`metadata.name`:: Specifies that the name must be `cluster`.
 
-agentSocketPath:: Specifies the path to the directory containing the SPIRE agent's Workload API socket. This directory is bind-mounted into workload containers by the CSI driver. The directory is shared between the SPIRE agent and CSI driver via a `hostPath` volume. Must be an absolute path with a maximum length of 256 characters. This value must match `SpireAgent.spec.socketPath` for workloads to access the socket.
+`spec.agentSocketPath`:: Specifies the path to the directory containing the SPIRE agent's Workload API socket. This directory is bind-mounted into workload containers by the CSI driver. The directory is shared between the SPIRE agent and CSI driver via a `hostPath` volume. Must be an absolute path with a maximum length of 256 characters. This value must match `SpireAgent.spec.socketPath` for workloads to access the socket.
 
-pluginName:: Specifies the name of the CSI plugin. This sets the CSI driver name that is deployed to the cluster and used in `VolumeMount` configurations. Must match the driver name referenced in the workload pods. Must be a valid domain name format (for example, `csi.spiffe.io`) with a maximum length of 127 characters.
+`spec.pluginName`:: Specifies the name of the CSI plugin. This sets the CSI driver name that is deployed to the cluster and used in `VolumeMount` configurations. Must match the driver name referenced in the workload pods. Must be a valid domain name format (for example, `csi.spiffe.io`) with a maximum length of 127 characters.
 
 .. Apply the configuration by running the following command:
 +

--- a/modules/zero-trust-manager-spire-agent-config.adoc
+++ b/modules/zero-trust-manager-spire-agent-config.adoc
@@ -47,27 +47,27 @@ spec:
 ----
 where:
 
-name:: Must be named 'cluster'.
+`metadata.name`:: Specifies that the value must be `cluster`.
 
-socketPath:: Specifies the directory on the host where the SPIRE agent socket is created. This directory is shared with the SPIFFE CSI driver via the `hostPath` volume. Must match the `SpiffeCSIDriver.spec.agentSocketPath` for workloads to access the socket. Must be an absolute path with a maximum length of 256 characters.
+`spec.socketPath`:: Specifies the directory on the host where the SPIRE agent socket is created. This directory is shared with the SPIFFE CSI driver via the `hostPath` volume. Must match the `SpiffeCSIDriver.spec.agentSocketPath` for workloads to access the socket. Must be an absolute path with a maximum length of 256 characters.
 
-logLevel:: Specifies the logging level for the SPIRE Server. The valid options are `debug`, `info`, `warn`, and `error`.
+`spec.logLevel`:: Specifies the logging level for the SPIRE Server. The valid options are `debug`, `info`, `warn`, and `error`.
 
-logFormat:: Specifies the logging format for the SPIRE Server. The valid options are `text` and `json`.
+`spec.logFormat`:: Specifies the logging format for the SPIRE Server. The valid options are `text` and `json`.
 
-k8sPSATEnabled:: Specifies whether Kubernetes Projected Service Account Token (PSAT) node attestation is enabled. When enabled, the SPIRE agent uses K8s PSATs to prove its identity to the SPIRE server during node attestation. The valid options are `true` and `false`.
+`spec.nodeAttestor.k8sPSATEnabled`:: Specifies whether Kubernetes Projected Service Account Token (PSAT) node attestation is enabled. When enabled, the SPIRE agent uses K8s PSATs to prove its identity to the SPIRE server during node attestation. The valid options are `true` and `false`.
 
-k8sEnabled:: Specifies whether the Kubernetes workload attestor is enabled. When enabled, the SPIRE agent can verify workload identities using Kubernetes pod information and service account tokens. The valid options are `true` and `false`.
+`spec.workloadAttestors.k8sEnabled`:: Specifies whether the Kubernetes workload attestor is enabled. When enabled, the SPIRE agent can verify workload identities using Kubernetes pod information and service account tokens. The valid options are `true` and `false`.
 
-type:: Specifies the kubelet certificate verification mode. The valid options are `auto`, `hostCert`, and `skip`.
+`spec.workloadAttestors.workloadAttestorsVerification.type`:: Specifies the kubelet certificate verification mode. The valid options are `auto`, `hostCert`, and `skip`.
 
-hostCertBasePath:: Specifies the directory containing the kubelet CA certificate. Required when type is `hostCert`. Optional when type is `auto` (defaults to /etc/kubernetes if not specified).
+`spec.workloadAttestors.workloadAttestorsVerification.hostCertBasePath`:: Specifies the directory containing the kubelet CA certificate. Required when type is `hostCert`. Optional when type is `auto` (defaults to /etc/kubernetes if not specified).
 
-hostCertFileName:: Specifies the file name for the kubelet's CA certificate. When combined with `hostCertBasePath`, forms the full path. Required when type is `hostCert`. Optional when type is `auto`. Defaults to `kubelet-ca.crt` if not specified.
+`spec.workloadAttestors.workloadAttestorsVerification.hostCertFileName`:: Specifies the file name for the kubelet's CA certificate. When combined with `hostCertBasePath`, forms the full path. Required when type is `hostCert`. Optional when type is `auto`. Defaults to `kubelet-ca.crt` if not specified.
 
-disableContainerSelectors:: Specifies whether to disable container selectors in the Kubernetes workload attestor. Set to `true` if using `holdApplicationUntilProxyStarts` in Istio. The valid options are `true` and `false`.
+`spec.workloadAttestors.disableContainerSelectors`:: Specifies whether to disable container selectors in the Kubernetes workload attestor. Set to `true` if using `holdApplicationUntilProxyStarts` in Istio. The valid options are `true` and `false`.
 
-useNewContainerLocator:: Specifies enabling the new container locator algorithm that has support for cgroups v2. The valid options are `true` and `false`.
+`spec.workloadAttestors.useNewContainerLocator`:: Specifies enabling the new container locator algorithm that has support for cgroups v2. The valid options are `true` and `false`.
 
 .. Apply the configuration by running the following command:
 +

--- a/modules/zero-trust-manager-spire-server-config.adoc
+++ b/modules/zero-trust-manager-spire-server-config.adoc
@@ -25,7 +25,7 @@ Deploy the SPIRE Server by configuring the `SpireServer` custom resource (CR). T
 +
 [source,yaml]
 ----
-aapiVersion: operator.openshift.io/v1alpha1
+apiVersion: operator.openshift.io/v1alpha1
 kind: SpireServer
 metadata:
  name: cluster
@@ -36,7 +36,7 @@ spec:
   caValidity: "24h"
   defaultX509Validity: "1h"
   defaultJWTValidity: "5m"
-  jwtKeyType: "rsa-248"
+  jwtKeyType: "rsa-2048"
   caSubject:
     country: "US"
     organization: "Example Corporation"
@@ -53,64 +53,50 @@ spec:
     maxIdleConns: 10
     connMaxLifetime: 0
     disableMigration: "false"
-  federation:
-    bundleEndpoint:
-      profile: "https_spiffe"
-      refreshHint: 300
-    federatesWith: []
-    managedRoute: "true"
 ----
 where:
 
-name:: Specifies that the value mmust be 'cluster'.
+`metadata.name`:: Specifies that the value must be `cluster`.
 
-logLevel:: Specifies the logging level for the SPIRE Server. The valid options are `debug`, `info`, `warn`, and `error`.
+`spec.logLevel`:: Specifies the logging level for the SPIRE Server. The valid options are `debug`, `info`, `warn`, and `error`.
 
-logFormat:: Specifies the logging format for the SPIRE Server. The valid options are `text` and `json`.
+`spec.logFormat`:: Specifies the logging format for the SPIRE Server. The valid options are `text` and `json`.
 
-jwtIssuer:: Specifies the JWT issuer URL. Must be a valid HTTPS or HTTP URL with a maximum length of 512 characters.
+`spec.jwtIssuer`:: Specifies the JWT issuer URL. Must be a valid HTTPS or HTTP URL with a maximum length of 512 characters.
 
-caValidity:: Specifies the validity period (Time to Live (TTL)) for the SPIRE Server's CA certificate. This determines how long the server's root or intermediate certificate is valid. The format is a duration string (for example, `24h`, `168h`).
+`spec.caValidity`:: Specifies the validity period (Time to Live (TTL)) for the SPIRE Server's CA certificate. This determines how long the server's root or intermediate certificate is valid. The format is a duration string (for example, `24h`, `168h`).
 
-defaultX509Validity:: Specifies the default validity period (TTL) for X.509 SVIDs issued to workloads. This value is used if a specific TTL is not configured for a registration entry.
+`spec.defaultX509Validity`:: Specifies the default validity period (TTL) for X.509 SVIDs issued to workloads. This value is used if a specific TTL is not configured for a registration entry.
 
-defaultJWTValidity:: Specifies thedefault validity period (TTL) for JWT SVIDs issued to workloads. This value is used if a specific TTL is not configured for a registration entry.
+`spec.defaultJWTValidity`:: Specifies thedefault validity period (TTL) for JWT SVIDs issued to workloads. This value is used if a specific TTL is not configured for a registration entry.
 
-jwtKeyType:: Specifies the key type used for JWT signing. The valid options are `rsa-2048`, `rsa-4096`, `ec-p256`, and `ec-p384`. This field is optional.
+`spec.wtKeyType`:: Specifies the key type used for JWT signing. The valid options are `rsa-2048`, `rsa-4096`, `ec-p256`, and `ec-p384`. This field is optional.
 
-country:: Specifies the country for the SPIRE Server certificate authority (CA). Must be an ISO 3166-1 alpha-2 country code (2 characters).
+`spec.caSubject.country`:: Specifies the country for the SPIRE Server certificate authority (CA). Must be an ISO 3166-1 alpha-2 country code (2 characters).
 
-organization:: Specifies the organization for the SPIRE Server CA. Maximum length is 64 characters.
+`spec.caSubject.organization`:: Specifies the organization for the SPIRE Server CA. Maximum length is 64 characters.
 
-commonName:: Specifies the common name for the SPIRE Server CA. Maximum length is 255 characters.
+`spec.caSubject.commonName`:: Specifies the common name for the SPIRE Server CA. Maximum length is 255 characters.
 
-size:: Specifies the size of the persistent volume (for example, `1Gi`, `5Gi`). Once set, this field is immutable.
+`spec.persistence.size`:: Specifies the size of the persistent volume (for example, `1Gi`, `5Gi`). Once set, this field is immutable.
 
-accessMode:: Specifies the access mode for the persistent volume. The valid options are `ReadWriteOnce`, `ReadWriteOncePod`, and `ReadWriteMany`. Once set, this field is immutable.
+`spec.persistence.accessMode`:: Specifies the access mode for the persistent volume. The valid options are `ReadWriteOnce`, `ReadWriteOncePod`, and `ReadWriteMany`. Once set, this field is immutable.
 
-storageClass::  Specifies the storage class to be used for the PVC. Once set, this field is immutable.
+`spec.persistence.storageClass`::  Specifies the storage class to be used for the PVC. Once set, this field is immutable.
 
-databaseType:: Specifies the type of database to use for the datastore. The valid options are `sql`, `sqlite3`, `postgres`, `mysql`, `aws_postgresql`, and `aws_mysql`.
+`spec.datastore.databaseType`:: Specifies the type of database to use for the datastore. The valid options are `sql`, `sqlite3`, `postgres`, `mysql`, `aws_postgresql`, and `aws_mysql`.
 
-connectionString:: Specifies the connection string for the database. For PostgreSQL with SSL, include `sslmode` and certificate paths (for example, `dbname=spire user=spire host=postgres.example.com sslmode=verify-full`).
+`spec.datastore.connectionString`:: Specifies the connection string for the database. For PostgreSQL with SSL, include `sslmode` and certificate paths (for example, `dbname=spire user=spire host=postgres.example.com sslmode=verify-full`).
 
-tlsSecretName::  Specifies the name of a Kubernetes Secret containing TLS certificates for database connections. The Secret will be mounted at `/run/spire/db/certs`. This field is optional.
+`spec.datastore.tlsSecretName`::  Specifies the name of a Kubernetes Secret containing TLS certificates for database connections. The Secret will be mounted at `/run/spire/db/certs`. This field is optional.
 
-maxOpenConns:: Specifies the maximum number of open database connections. Must be between 1 and 10000.
+`spec.datastore.maxOpenConns`:: Specifies the maximum number of open database connections. Must be between 1 and 10000.
 
-maxIdleConns:: Specifies the maximum number of idle database connections in the pool. Must be between 0 and 10000.
+`spec.datastore.maxIdleConns`:: Specifies the maximum number of idle database connections in the pool. Must be between 0 and 10000.
 
-connMaxLifetime:: Specifies the maximum lifetime of a database connection in seconds. A value of 0 means connections are not closed due to age.
+`spec.datastore.connMaxLifetime`:: Specifies the maximum lifetime of a database connection in seconds. A value of 0 means connections are not closed due to age.
 
-disableMigration:: Specifies whether to disable automatic database migration. The valid options are `true` and `false`.
-
-profile:: Specifies the bundle endpoint authentication profile for federation. The valid options are `https_spiffe` and `https_web`.
-
-refreshHint:: Specifies the hint for bundle refresh interval in seconds. Must be between 60 and 3600.
-
-federatesWith:: Specifies the list of trust domains this cluster federates with. Each entry requires `trustDomain`, `bundleEndpointUrl`, and `bundleEndpointProfile`.
-
-managedRoute::  Specifies either enabling or disabling automatic route creation for the federation endpoint. Set to `true` to allow automatic exposure through a managed OpenShift Route, or `false` to manually configure routing.
+`spec.datastore.disableMigration`:: Specifies whether to disable automatic database migration. The valid options are `true` and `false`.
 
 .. Apply the configuration by running the following command:
 +

--- a/modules/zero-trust-manager-uninstall-resources.adoc
+++ b/modules/zero-trust-manager-uninstall-resources.adoc
@@ -27,7 +27,7 @@ $ oc delete SpireOIDCDiscoveryProvider cluster
 +
 [source,terminal]
 ----
-$ oc delete SpiffeCSIDriver cluster -l=app.kubernetes.io/name=zero-trust-workload-identity-manager
+$ oc delete SpiffeCSIDriver cluster -l
 ----
 
 .. Delete the `SpireAgent` cluster by running the following command:

--- a/modules/zero-trust-manager-ztwim-cr.adoc
+++ b/modules/zero-trust-manager-ztwim-cr.adoc
@@ -28,11 +28,11 @@ spec:
 ----
 where:
 
-trustDomain:: Specifies tThe trust domain to be used for the SPIFFE identifiers. Must be a valid SPIFFE trust domain (lowercase alphanumeric, hyphens, and dots). Maximum length is 255 characters. Once set, this field is immutable.
+`spec.trustDomain`:: Specifies the trust domain to be used for the SPIFFE identifiers. Must be a valid SPIFFE trust domain (lowercase alphanumeric, hyphens, and dots). Maximum length is 255 characters. After setting a value for the field, the field is immutable. Red{nbsp}Hat highly recommends to set this value to match your the base application URL (for example, `apps.mycluster.example.com`) of your {product-title} cluster. Using a different value might cause automatically generated OpenShift Routes or federation endpoints to be created with incorrect or mismatched hostnames later in the configuration process.
 
-clusterName:: Specifies tThe name that identifies this cluster within the trust domain. Must be a valid DNS-1123 subdomain with a maximum length of 63 characters. Once set, this field is immutable.
+`spec.clusterName`:: Specifies the name that identifies this cluster within the trust domain. Must be a valid DNS-1123 subdomain with a maximum length of 63 characters. Once set, this field is immutable.
 
-bundleConfigMap:: Specifies the name of the ConfigMap that stores the SPIRE trust bundle. This ConfigMap contains the root certificates for the trust domain and is created and maintained by the Operator. Must be a valid Kubernetes name with a maximum length of 253 characters. This field is optional (defaults to `spire-bundle`) and once set, is immutable.
+`spec.bundleConfigMap`:: Specifies the name of the ConfigMap that stores the SPIRE trust bundle. This ConfigMap contains the root certificates for the trust domain and is created and maintained by the Operator. Must be a valid Kubernetes name with a maximum length of 253 characters. This field is optional (defaults to `spire-bundle`) and once set, is immutable.
 
 
 

--- a/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
+++ b/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.adoc
@@ -2,10 +2,14 @@
 [id="zero-trust-manager-configuration"]
 = Deploying Zero Trust Workload Identity Manager operands
 
+include::_attributes/common-attributes.adoc[]
+:context: zero-trust-manager-configuration
+
+
 toc::[]
 
 [role="_abstract"]
-Deploy the {zero-trust-full} operands by creating their custom resources in a specific order. Adhering to the sequence helps ensure the successful installation of components, such as the SPIRE Server, SPIRE Agent, and SPIFFE CSI driver.
+Deploy the {zero-trust-full} operands by creating their custom resources in a specific order. Adhering to the sequence ensures the successful installation of components, such as the SPIRE Server, SPIRE Agent, and SPIFFE CSI driver.
 
 You must deploy the operands in the following sequence to ensure successful installation:
 


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17746

Link to docs preview:
https://104453--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-configuration.html
https://104453--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/zero_trust_workload_identity_manager/zero-trust-manager-oidc-federation.html


QE review:
- [ ] QE has approved this change.


Additional information:

