### PR TITLE
OCPBUGS-71207: Fixed the typo in Manually creating IAM

### DIFF
--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -100,7 +100,7 @@ $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}'
 $ oc adm release extract \
   --from=$RELEASE_IMAGE \
   --credentials-requests \
-  --include \
+  --included \
   --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \
   --to=<path_to_directory_for_credentials_requests>
 ----


### PR DESCRIPTION
Fixed a typo. I got an SME approval as David pinged me about the issue. 

Version(s):
4.16+

Issue:
[OCPBUGS-71207](https://issues.redhat.com/browse/OCPBUGS-71207)

Link to docs preview:

* https://104454--ocpdocs-pr.netlify.app/
* https://104454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/installing-ibm-cloud-customizations.html
* https://104454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/installing-ibm-cloud-private.html
* https://104454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/installing-ibm-cloud-restricted.html
* https://104454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/installing-ibm-cloud-vpc.html
* https://104454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.html
* https://104454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.html
* https://104454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-powervs-vpc.html
* https://104454--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.html


- [x] SME has approved this change.

