### PR TITLE
OSDOCS--16882 Updates short descriptions

### DIFF
--- a/modules/containers-about.adoc
+++ b/modules/containers-about.adoc
@@ -6,7 +6,7 @@
 = Containers
 
 [role="_abstract"]
-The basic units of {product-title} applications are called containers. link:https://www.redhat.com/en/topics/containers#overview[Linux container technologies] are lightweight mechanisms for isolating running processes so that they are limited to interacting with only their designated resources. The word container is defined as _a specific running or paused instance of a container image_.
+Containers are isolated running instances of container images that serve as the basic units of {product-title} applications. By understanding containers, you can work with containerized applications and manage how they run in your cluster.
 
 Many application instances can be running in containers on a single host without visibility into each others' processes, files, network, and so on. Typically, each container provides a single service, often called a micro-service, such as a web server or a database, though containers can be used for arbitrary workloads.
 

--- a/modules/images-about.adoc
+++ b/modules/images-about.adoc
@@ -6,7 +6,7 @@
 = Images
 
 [role="_abstract"]
-Container images are binaries that include all requirements for running a single container. You can use images to package applications and deploy them across multiple containers and hosts in {product-title}.
+Container images are binaries that include all requirements for running a single container. You can use images to package applications and deploy them consistently across multiple containers and hosts in {product-title}.
 
 Containers only have access to resources defined in the image unless you give the container additional access when creating it. By deploying the same image in multiple containers across multiple hosts and load balancing between them, {product-title} can provide redundancy and horizontal scaling for a service packaged into an image.
 

--- a/modules/images-container-repository-about.adoc
+++ b/modules/images-container-repository-about.adoc
@@ -6,7 +6,7 @@
 = Image repository
 
 [role="_abstract"]
-An image repository is a collection of related container images and tags identifying them. You can use image repositories to organize and manage related container images in {product-title}.
+An image repository is a collection of related container images and tags that identify them. You can use image repositories to organize and manage related container images in {product-title}.
 
 For example, the {product-title} Jenkins images are in the following repository:
 

--- a/modules/images-id.adoc
+++ b/modules/images-id.adoc
@@ -6,7 +6,7 @@
 = Image IDs
 
 [role="_abstract"]
-Image IDs are Secure Hash Algorithm (SHA) codes that uniquely identify container images. You can use image IDs to pull specific versions of images that never change. 
+Image IDs are Secure Hash Algorithm (SHA) codes that uniquely identify container images in {product-title}. You can use image IDs to pull specific versions of images that never change. 
 
 For example, the following image ID is for the `docker.io/openshift/jenkins-2-centos7` image:
 

--- a/modules/images-image-registry-about.adoc
+++ b/modules/images-image-registry-about.adoc
@@ -6,7 +6,6 @@
 = Image registry
 
 [role="_abstract"]
-An image registry is a content server that stores and serves container images.
-You can use registries to access container images from external sources or {product-title}'s integrated registry.
+An image registry is a content server that stores and serves container images in {product-title}. You can use registries to access container images from external sources or the integrated registry in {product-title}.
 
 Registries contain a collection of one or more image repositories, which contain one or more tagged images. Red{nbsp}Hat provides a registry at link:https://catalog.redhat.com/en[registry.redhat.io] for subscribers. {product-title} can also supply its own {product-registry} for managing custom container images.

--- a/modules/images-imagestream-image.adoc
+++ b/modules/images-imagestream-image.adoc
@@ -6,5 +6,4 @@
 = Image stream images
 
 [role="_abstract"]
-Image stream images are API resource objects that retrieve specific container images from image streams.
-You can use image stream images to access metadata about particular image SHA identifiers in {product-title}.
+Image stream images are API resource objects in {product-title} that retrieve specific container images from image streams. You can use image stream images to access metadata about particular image SHA identifiers.

--- a/modules/images-imagestream-tag.adoc
+++ b/modules/images-imagestream-tag.adoc
@@ -6,4 +6,4 @@
 = Image stream tags
 
 [role="_abstract"]
-Image stream tags are named pointers to images in image streams. You can configure image stream tags to reference specific versions of container images.
+Image stream tags are named pointers to images in image streams in {product-title}. You can configure image stream tags to reference specific versions of container images.

--- a/modules/images-imagestream-trigger.adoc
+++ b/modules/images-imagestream-trigger.adoc
@@ -6,6 +6,6 @@
 = Image stream triggers
 
 [role="_abstract"]
-Image stream triggers cause specific actions when image stream tags change. You can configure triggers to automatically start builds or deployments when new images are imported.
+Image stream triggers in {product-title} cause specific actions when image stream tags change. You can configure triggers to automatically start builds or deployments when new images are imported.
 
 For example, importing a new image can cause the value of the tag to change, which causes a trigger to fire when there are deployments, builds, or other resources listening for those.

--- a/modules/images-imagestream-use.adoc
+++ b/modules/images-imagestream-use.adoc
@@ -7,7 +7,7 @@
 = Using image streams
 
 [role="_abstract"]
-Image streams provide an abstraction for referencing container images from within {product-title}. You can use image streams to manage image versions and automate builds and deployments.
+Image streams provide an abstraction for referencing container images from within {product-title}. You can use image streams to manage image versions and automate builds and deployments in your cluster.
 
 Image streams do not contain actual image data, but present a single virtual view of related images, similar to an image repository.
 

--- a/modules/images-s2i-build-process-overview.adoc
+++ b/modules/images-s2i-build-process-overview.adoc
@@ -7,8 +7,9 @@
 = Source-to-image build process overview
 
 [role="_abstract"]
-Source-to-image (S2I) is a build process that injects your source code into a container image.
-S2I automates the creation of ready-to-run container images from your application source code. It performs the following steps:
+Source-to-image (S2I) is a build process in {product-title} that injects your source code into a container image. S2I automates the creation of ready-to-run container images from your application source code without manual configuration.
+
+S2I performs the following steps:
 
 . Runs the `FROM <builder image>` command
 . Copies the source code to a defined location in the builder image

--- a/modules/images-using-customizing-s2i-images-scripts-embedded.adoc
+++ b/modules/images-using-customizing-s2i-images-scripts-embedded.adoc
@@ -7,12 +7,12 @@
 = Invoking scripts embedded in an image
 
 [role="_abstract"]
-You invoke embedded S2I image scripts by creating wrapper scripts that run custom logic and default scripts.
-You must do this to extend builder image behavior while preserving supported script logic and upgrade compatibility.
+To extend builder image behavior while preserving supported script logic and upgrade compatibility in {product-title}, you can start embedded S2I image scripts by creating wrapper scripts.
+These wrapper scripts run custom logic and then call the default scripts from the image.
 
 .Procedure
 
-. Look at the value of the `io.openshift.s2i.scripts-url` label to determine the location of the scripts inside of the builder image:
+. Inspect the value of the `io.openshift.s2i.scripts-url` label to determine the location of the scripts inside of the builder image:
 +
 [source,terminal]
 ----
@@ -24,9 +24,7 @@ $ podman inspect --format='{{ index .Config.Labels "io.openshift.s2i.scripts-url
 ----
 image:///usr/libexec/s2i
 ----
-+
-You inspected the `wildfly/wildfly-centos7` builder image and found out that the scripts are in the `/usr/libexec/s2i` directory.
-+
+
 . Create a script that includes an invocation of one of the standard scripts wrapped in other commands:
 +
 .`.s2i/bin/assemble` script

--- a/openshift_images/index.adoc
+++ b/openshift_images/index.adoc
@@ -7,8 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-This section describes the concepts of containers, images, and image streams in {product-title}.
-Use this information to understand how containerized applications work in {product-title}.
+To understand how containerized applications work in {product-title}, you need to know about containers, images, and image streams. This overview explains these core concepts and how they work together in your cluster.
 
 [id="about-containers-images-and-image-streams"]
 == Understanding containers, images, and image streams

--- a/openshift_images/using_images/customizing-s2i-images.adoc
+++ b/openshift_images/using_images/customizing-s2i-images.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Customize source-to-image (S2I) builder images to modify the default assemble and run script behavior.
+To modify the default assemble and run script behavior in {product-title}, you can customize source-to-image (S2I) builder images.
 You can adapt S2I builders to meet your specific application requirements when the default scripts are not suitable.
 
 include::modules/images-using-customizing-s2i-images-scripts-embedded.adoc[leveloffset=+1]

--- a/openshift_images/using_images/using-images-overview.adoc
+++ b/openshift_images/using_images/using-images-overview.adoc
@@ -7,8 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can use Source-to-Image (S2I), database, and other container images that are available for {product-title}.
-You need these images to build and deploy containerized applications on your cluster.
+To build and deploy containerized applications in {product-title}, you can use Source-to-Image (S2I), database, and other container images. These images provide the base components you need to run applications on your cluster.
 
 Red{nbsp}Hat official container images are provided in the Red{nbsp}Hat Registry at link:https://registry.redhat.io[registry.redhat.io]. {product-title}'s supported S2I, database, and Jenkins images are provided in the `openshift4` repository in the {quay} Registry. For example, `quay.io/openshift-release-dev/ocp-v4.0-<address>` is the name of the OpenShift Application Platform image.
 

--- a/openshift_images/using_images/using-s21-images.adoc
+++ b/openshift_images/using_images/using-s21-images.adoc
@@ -7,8 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Source-to-Image (S2I) images are special versions of runtime base images for languages like Node.js, Python, and Java.
-You can insert your code into S2I images to create containerized applications without configuring the runtime environment.
+To create containerized applications in {product-title} without manually configuring runtime environments, you can use Source-to-Image (S2I) images. S2I images are runtime base images for languages like Node.js, Python, and Java that you can insert your code into.
 
 You can use the link:https://access.redhat.com/documentation/en-us/red_hat_software_collections/3/html-single/using_red_hat_software_collections_container_images/index[Red{nbsp}Hat Software Collections] images as a foundation for applications that rely on specific runtime environments such as Node.js, Perl, or Python. 
 

--- a/registry/index.adoc
+++ b/registry/index.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="registry-overview"]
 = {product-registry} overview
-include::_attributes/common-attributes.adoc[]
 :context: registry-overview
 
 toc::[]


### PR DESCRIPTION
Follow up to  https://github.com/openshift/openshift-docs/pull/102855. It just revises some short descriptions. 

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-16882

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
