### PR TITLE
[enterprise-4.16] OSDOCS-17457 [NETOBSERV] Module short descriptions for observing-network-traffic.adoc

### DIFF
--- a/modules/network-observability-RTT-overview.adoc
+++ b/modules/network-observability-RTT-overview.adoc
@@ -6,8 +6,10 @@
 [id="network-observability-RTT-overview_{context}"]
 = Round-Trip Time
 
-You can use TCP smoothed Round-Trip Time (sRTT) to analyze network flow latencies. You can use RTT captured from the `fentry/tcp_rcv_established` eBPF hookpoint to read sRTT from the TCP socket to help with the following:
+[role="_abstract"]
+Analyze network flow latencies by using TCP Round-Trip Time (RTT) metrics, which use eBPF hookpoints to identify performance bottlenecks and troubleshoot TCP-related issues through dedicated panels in the Overview view.
 
+You can use TCP smoothed Round-Trip Time (sRTT) to analyze network flow latencies. You can use RTT captured from the `fentry/tcp_rcv_established` eBPF hookpoint to read sRTT from the TCP socket to help with the following:
 
 * Network Monitoring: Gain insights into TCP latencies, helping
   network administrators identify unusual patterns, potential bottlenecks, or

--- a/modules/network-observability-RTT.adoc
+++ b/modules/network-observability-RTT.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-RTT_{context}"]
 = Working with RTT tracing
 
+[role="_abstract"]
+Enable Round Trip Time (RTT) tracing by configuring the `FlowCollector` custom resource to monitor and analyze network latency across your cluster by using the web console.
+
 You can track RTT by editing the `FlowCollector` to the specifications in the following YAML example.
 
 .Procedure

--- a/modules/network-observability-configuring-ipsec-with-flow-collector-resource.adoc
+++ b/modules/network-observability-configuring-ipsec-with-flow-collector-resource.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-configuring-ipsec-with-flow-collector-resource_{context}"]
 = Configuring IPsec with the FlowCollector custom resource
 
+[role="_abstract"]
+Enable IPsec tracking in the `FlowCollector` resource to monitor encrypted traffic, adding an IPsec status column to the traffic flow view and generating a dedicated encryption dashboard.
+
 In {product-title}, IPsec is disabled by default. You can enable IPsec by following the instructions in "Configuring IPsec encryption".
 
 .Prerequisite

--- a/modules/network-observability-configuring-options-overview.adoc
+++ b/modules/network-observability-configuring-options-overview.adoc
@@ -6,7 +6,10 @@
 [id="network-observability-configuring-options-overview_{context}"]
 = Configuring advanced options for the Overview view
 
-You can customize the graphical view by using advanced options. To access the advanced options, click *Show advanced options*. You can configure the details in the graph by using the *Display options* drop-down menu. The options available are as follows:
+[role="_abstract"]
+Customize the network traffic *Overview* view by configuring advanced options, such as graph scope, label truncation, and panel management, to refine the display of flow rate statistics and traffic data.
+
+To access the advanced options, click *Show advanced options*. You can configure the details in the graph by using the *Display options* drop-down menu. The options available are as follows:
 
 * *Scope*: Select to view the components that network traffic flows between. You can set the scope to *Node*, *Namespace*, *Owner*, *Zones*, *Cluster* or *Resource*. *Owner* is an aggregation of resources. *Resource* can be a pod, service, node, in case of host-network traffic, or an unknown IP address. The default value is *Namespace*.
 * *Truncate labels*: Select the required width of the label from the drop-down list. The default value is *M*.

--- a/modules/network-observability-configuring-options-topology.adoc
+++ b/modules/network-observability-configuring-options-topology.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-configuring-options-topology_{context}"]
 = Configuring the advanced options for the Topology view
 
+[role="_abstract"]
+Review the available advanced options in the *Topology* view to customize display settings, configure component grouping and layouts, and export the network graph as an image.
+
 You can customize and export the view by using *Show advanced options*. The advanced options view has the following features:
 
 * *Find in view*: To search the required components in the view.

--- a/modules/network-observability-configuring-options-trafficflow.adoc
+++ b/modules/network-observability-configuring-options-trafficflow.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-configuring-options-trafficflow_{context}"]
 = Configuring advanced options for the Traffic flows view
 
+[role="_abstract"]
+Customize the *Traffic flows* view by adjusting row density, selecting specific data columns, and exporting filtered flow data for external analysis.
+
 You can customize and export the view by using *Show advanced options*.
 You can set the row size by using the *Display options* drop-down menu. The default value is *Normal*.
 

--- a/modules/network-observability-dns-overview.adoc
+++ b/modules/network-observability-dns-overview.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-dns-overview_{context}"]
 = DNS tracking
 
+[role="_abstract"]
+Monitor DNS activity by using eBPF-based DNS tracking to gain insights into query patterns, detect security threats, and troubleshoot latency issues through dedicated graphical panels in the *Overview* view.
+
 You can configure graphical representation of Domain Name System (DNS) tracking of network flows in the *Overview* view. Using DNS tracking with extended Berkeley Packet Filter (eBPF) tracepoint hooks can serve various purposes:
 
 * Network Monitoring: Gain insights into DNS queries and responses, helping network administrators identify unusual patterns, potential bottlenecks, or performance issues.

--- a/modules/network-observability-dns-tracking.adoc
+++ b/modules/network-observability-dns-tracking.adoc
@@ -6,12 +6,16 @@
 [id="network-observability-dns-tracking_{context}"]
 = Working with DNS tracking
 
-Using DNS tracking, you can monitor your network, conduct security analysis, and troubleshoot DNS issues. You can track DNS by editing the `FlowCollector` to the specifications in the following YAML example.
+[role="_abstract"]
+Configure the `FlowCollector` custom resource to enable DNS tracking for monitoring network performance, security analysis, and DNS troubleshooting in the web console.
+
+You can track DNS by editing the `FlowCollector` to the specifications in the following YAML example.
 
 [IMPORTANT]
 ====
 CPU and memory usage increases are observed in the eBPF agent when this feature is enabled.
 ====
+
 .Procedure
 . In the web console, navigate to *Operators* -> *Installed Operators*.
 . Under the *Provided APIs* heading for *Network Observability*, select *Flow Collector*.

--- a/modules/network-observability-ebpf-rule-flow-filter.adoc
+++ b/modules/network-observability-ebpf-rule-flow-filter.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-ebpf-flow-rule-filter_{context}"]
 = eBPF flow rule filter
 
+[role="_abstract"]
+Control packet capture volume by using eBPF flow rule filtering to specify capture criteria based on ports and CIDR notation, while monitoring filter performance through dedicated health dashboards and Prometheus metrics.
+
 You can use rule-based filtering to control the volume of packets cached in the eBPF flow table. For example, a filter can specify that only packets coming from port 100 should be captured. Then only the packets that match the filter are captured and the rest are dropped.
 
 You can apply multiple filter rules.

--- a/modules/network-observability-filtering-ebpf-rule.adoc
+++ b/modules/network-observability-filtering-ebpf-rule.adoc
@@ -5,7 +5,8 @@
 [id="network-observability-filtering-ebpf-rule_{context}"]
 = Filtering eBPF flow data using multiple rules
 
-You can configure the `FlowCollector` custom resource to filter eBPF flows using multiple rules to control the flow of packets cached in the eBPF flow table.
+[role="_abstract"]
+Configure multiple filtering rules in the `FlowCollector` custom resource to refine network traffic data collection by accepting or rejecting specific eBPF flows based on IP addresses and packet conditions.
 
 [IMPORTANT]
 ====

--- a/modules/network-observability-flow-filter-parameters.adoc
+++ b/modules/network-observability-flow-filter-parameters.adoc
@@ -6,7 +6,8 @@
 [id="network-observability-flowcollector-flowfilter-parameters_{context}"]
 = Flow filter configuration parameters
 
-The flow filter rules consist of required and optional parameters.
+[role="_abstract"]
+Reference the required and optional parameters for configuring flow filter rules in the `FlowCollector` resource, including CIDR ranges, filter actions, protocols, and specific port configurations.
 
 .Required configuration parameters
 [cols="3a,8a",options="header"]

--- a/modules/network-observability-histogram-trafficflow.adoc
+++ b/modules/network-observability-histogram-trafficflow.adoc
@@ -4,6 +4,9 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="network-observability-histogram-trafficflow_{context}"]
-== Using the histogram
+= Using the histogram
+
+[role="_abstract"]
+The histogram provides a visualization of network flow logs that you can use to analyze traffic volume trends and filter flow data by specific time intervals.
 
 You can click *Show histogram* to display a toolbar view for visualizing the history of flows as a bar chart. The histogram shows the number of logs over time. You can select a part of the histogram to filter the network flow data in the table that follows the toolbar.

--- a/modules/network-observability-network-traffic-overview-view.adoc
+++ b/modules/network-observability-network-traffic-overview-view.adoc
@@ -6,4 +6,9 @@
 [id="network-observability-network-traffic-overview-view_{context}"]
 = Observing the network traffic from the Overview view
 
-The *Overview* view displays the overall aggregated metrics of the network traffic flow on the cluster. As an administrator, you can monitor the statistics with the available display options.
+[role="_abstract"]
+The Network Traffic *Overview* view provides aggregated flow metrics and visual insights into application communications. Administrators can use the metrics to monitor data volume, troubleshoot connectivity, and detect unusual traffic patterns across the cluster.
+
+The *Overview* view shows aggregate network traffic in your {product-title} cluster, allowing you to see which applications are communicating and the volume of data being transferred. It provides detailed insights by source, destination, and flow type, along with the top traffic flows and average byte rates.
+
+As an administrator, you can troubleshoot connectivity issues, detect unusual traffic patterns, and optimize application performance. It provides a quick overview of network behavior, making it easier to prioritize actions and ensure efficient resource usage.

--- a/modules/network-observability-packet-drops.adoc
+++ b/modules/network-observability-packet-drops.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-packet-drops_{context}"]
 = Working with packet drops
 
+[role="_abstract"]
+Enable packet drop tracking in the Network Observability Operator by configuring the `FlowCollector` resource to monitor and visualize network data loss in the web console.
+
 Packet loss occurs when one or more packets of network flow data fail to reach their destination. You can track these drops by editing the `FlowCollector` to the specifications in the following YAML example.
 
 [IMPORTANT]

--- a/modules/network-observability-packet-translation-overview.adoc
+++ b/modules/network-observability-packet-translation-overview.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-packet-translation-overview_{context}"]
 = Endpoint translation (xlat)
 
+[role="_abstract"]
+Endpoint translation (xlat) uses eBPF to enrich network flow logs with translated pod-level metadata, providing visibility into the specific backend pods serving traffic behind services or load balancers.
+
 You can gain visibility into the endpoints serving traffic in a consolidated view using network observability and extended Berkeley Packet Filter (eBPF). Typically, when traffic flows through a service, egressIP, or load balancer, the traffic flow information is abstracted as it is routed to one of the available pods. If you try to get information about the traffic, you can only view service related info, such as service IP and port, and not information about the specific pod that is serving the request. Often the information for both the service traffic and the virtual service endpoint is captured as two separate flows, which complicates troubleshooting.
 
 To solve this, endpoint xlat can help in the following ways:

--- a/modules/network-observability-packet-translation.adoc
+++ b/modules/network-observability-packet-translation.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-packet-translation_{context}"]
 = Working with endpoint translation (xlat)
 
+[role="_abstract"]
+Enable endpoint translation (xlat) in the `FlowCollector` resource to enrich network flows with translated packet information. You can use this information to identify the specific pods and objects serving service traffic through dedicated xlat columns.
+
 You can use network observability and eBPF to enrich network flows from a Kubernetes service with translated endpoint information, gaining insight into the endpoints serving traffic.
 
 .Procedure

--- a/modules/network-observability-pktdrop-overview.adoc
+++ b/modules/network-observability-pktdrop-overview.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-pktdrop-overview_{context}"]
 = Packet drop tracking
 
+[role="_abstract"]
+Monitor and analyze network packet loss by using eBPF-based packet drop tracking, which identifies drop locations, detects host or OVS-specific drop reasons, and provides dedicated graphical panels in the *Overview* view.
+
 You can configure graphical representation of network flow records with packet loss in the *Overview* view. By employing eBPF tracepoint hooks, you can gain valuable insights into packet drops for TCP, UDP, SCTP, ICMPv4, and ICMPv6 protocols, which can result in the following actions:
 
 * Identification: Pinpoint the exact locations and network paths where packet drops are occurring. Determine whether specific devices, interfaces, or routes are more prone to drops.
@@ -28,7 +31,7 @@ Other packet drop panels are available to add in *Manage panels*:
 
 == Types of packet drops
 
-Two kinds of packet drops are detected by Network Observability: host drops and OVS drops. Host drops are prefixed with `SKB_DROP` and OVS drops are prefixed with `OVS_DROP`. Dropped flows are shown in the side panel of the *Traffic flows* table along with a link to a description of each drop type. Examples of host drop reasons are as follows:
+Two kinds of packet drops are detected by network observability: host drops and OVS drops. Host drops are prefixed with `SKB_DROP` and OVS drops are prefixed with `OVS_DROP`. Dropped flows are shown in the side panel of the *Traffic flows* table along with a link to a description of each drop type. Examples of host drop reasons are as follows:
 
 * `SKB_DROP_REASON_NO_SOCKET`: the packet dropped due to a missing socket.
 * `SKB_DROP_REASON_TCP_CSUM`: the packet dropped due to a TCP checksum error.

--- a/modules/network-observability-quickfilter.adoc
+++ b/modules/network-observability-quickfilter.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-quickfilter_{context}"]
 = Filtering the network traffic
 
+[role="_abstract"]
+Review the available query options and filtering parameters in the *Network Traffic* view to optimize data searches, analyze specific log types, and manage directional traffic visibility.
+
 By default, the *Network Traffic* page displays the traffic flow data in the cluster based on the default filters configured in the `FlowCollector` instance. You can use the filter options to observe the required data by changing the preset filter.
 
 Alternatively, you can access the traffic flow data in the *Network Traffic* tab of the *Namespaces*, *Services*, *Routes*, *Nodes*, and *Workloads* pages which provide the filtered data of the corresponding aggregations.

--- a/modules/network-observability-topology.adoc
+++ b/modules/network-observability-topology.adoc
@@ -6,4 +6,11 @@
 [id="network-observability-topology_{context}"]
 = Observing the network traffic from the Topology view
 
-The *Topology* view provides a graphical representation of the network flows and the amount of traffic. As an administrator, you can monitor the traffic data across the application by using the *Topology* view.
+[role="_abstract"]
+The *Topology* view in the *Network Traffic* page provides a graphical representation of network flows and traffic volume across your {product-title} cluster. As an administrator, you can use this view to monitor application traffic data and visualize the relationships between various network components.
+
+The visualization represents network entities as nodes and traffic flows as edges. By selecting individual components within the graph, you can access a side panel containing specific metrics and health details for that resource. This interactive approach allows for rapid identification of traffic patterns and connectivity issues within the cluster.
+
+To manage complex environments, the *Topology* view includes advanced configuration options that allow you to customize the layout and data density. You can adjust the *Scope* of the view, apply *Groups* to represent resource ownership, and choose different *Layout* algorithms to optimize the graphical display. Additionally, you can enable *Edge labels* to show real-time measurements, such as the average byte rate, directly on the flow lines.
+
+For reporting or external analysis, the *Topology* view provides an export feature. You can download the current graphical representation as a PNG image or generate a direct link to the specific view configuration to share with other administrators. These tools ensure that network insights are both accessible and easily documented.

--- a/modules/network-observability-trafficflow.adoc
+++ b/modules/network-observability-trafficflow.adoc
@@ -6,4 +6,11 @@
 [id="network-observability-trafficflow_{context}"]
 = Observing the network traffic from the Traffic flows view
 
-The *Traffic flows* view displays the data of the network flows and the amount of traffic in a table. As an administrator, you can monitor the amount of traffic across the application by using the traffic flow table.
+[role="_abstract"]
+Use the *Traffic flows* view to monitor real-time and historical network communication between cluster components. By analyzing granular flow data collected via eBPF, you can audit network traffic, validate network policies, and export data for external reporting and analysis.
+
+The *Traffic flows* view in the Network Observability Operator provides a granular, tabular representation of network activity across a {product-title} cluster. By leveraging eBPF technology to collect flow data, this view allows administrators to monitor real-time and historical communication between pods, services, and nodes. This visibility is essential for auditing network traffic, validating network policies, and identifying unexpected communication patterns within the cluster infrastructure.
+
+In the *Traffic flows* interface, you can analyze specific connection details by interacting with individual rows to retrieve detailed flow information. The view supports advanced customization through the *Display options* menu, where you can adjust row density and manage columns. By selecting and reordering specific columns, you can tailor the table to highlight the most relevant data points for your environment, such as source and destination endpoints or traffic volume.
+
+To support external analysis and reporting, the *Traffic flows* view includes data export capabilities. You can export the entire data set or select specific fields to generate a targeted report of network activity. This functionality ensures that network flow data is accessible for long-term auditing or for use in third-party monitoring tools, providing a flexible way to document and analyze the network health of your {product-title} environment.

--- a/modules/network-observability-working-with-conversations.adoc
+++ b/modules/network-observability-working-with-conversations.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-working-with-conversations_{context}"]
 = Working with conversation tracking
 
+[role="_abstract"]
+Configure the `FlowCollector` custom resource to enable conversation tracking for grouping and analyzing related network flows in the web console.
+
 As an administrator, you can group network flows that are part of the same conversation. A conversation is defined as a grouping of peers that are identified by their IP addresses, ports, and protocols, resulting in an unique *Conversation Id*. You can query conversation events in the web console. These events are represented in the web console as follows:
 
 ** *Conversation start*: This event happens when a connection is starting or TCP flag intercepted

--- a/modules/network-observability-working-with-overview.adoc
+++ b/modules/network-observability-working-with-overview.adoc
@@ -6,7 +6,11 @@
 [id="network-observability-working-with-overview_{context}"]
 = Working with the Overview view
 
-As an administrator, you can navigate to the *Overview* view to see the graphical representation of the flow rate statistics.
+[role="_abstract"]
+Navigate to the network traffic *Overview* view in the {product-title} console to see graphical representations of flow rate statistics and configure the display scope using available options.
+
+.Prerequisite
+* Access to the cluster with administrator rights.
 
 .Procedure
 . Navigate to *Observe* → *Network Traffic*.

--- a/modules/network-observability-working-with-topology.adoc
+++ b/modules/network-observability-working-with-topology.adoc
@@ -6,7 +6,13 @@
 [id="network-observability-working-with-topology_{context}"]
 = Working with the Topology view
 
+[role="_abstract"]
+Access the *Topology* view to visually inspect cluster network relationships and select individual components to view detailed traffic metrics and metadata.
+
 As an administrator, you can navigate to the *Topology* view to see the details and metrics of the component.
+
+.Prerequisites
+* You have administrator access.
 
 .Procedure
 . Navigate to *Observe* → *Network Traffic*.

--- a/modules/network-observability-working-with-trafficflow.adoc
+++ b/modules/network-observability-working-with-trafficflow.adoc
@@ -6,7 +6,13 @@
 [id="network-observability-working-with-trafficflow_{context}"]
 = Working with the Traffic flows view
 
+[role="_abstract"]
+View and analyze detailed network flow information by using the *Traffic flows* table.
+
 As an administrator, you can navigate to *Traffic flows* table to see network flow information.
+
+.Prerequisite
+* You have administrator access.
 
 .Procedure
 

--- a/modules/network-observability-working-with-zones.adoc
+++ b/modules/network-observability-working-with-zones.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-zones_{context}"]
 = Working with availability zones
 
+[role="_abstract"]
+Configure the `FlowCollector` custom resource to collect availability zone data, enabling the visualization and analysis of network traffic across different cluster zones in the web console.
+
 You can configure the `FlowCollector` to collect information about the cluster availability zones. This allows you to enrich network flow data with the link:https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone[`topology.kubernetes.io/zone`] label value applied to the nodes.
 
 .Procedure

--- a/observability/network_observability/observing-network-traffic.adoc
+++ b/observability/network_observability/observing-network-traffic.adoc
@@ -53,7 +53,7 @@ include::modules/network-observability-working-with-trafficflow.adoc[leveloffset
 
 include::modules/network-observability-configuring-options-trafficflow.adoc[leveloffset=+2]
 
-include::modules/network-observability-proc_configuring-ipsec-with-flow-collector-resource.adoc[leveloffset=+2]
+include::modules/network-observability-configuring-ipsec-with-flow-collector-resource.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Cherry-pick: 2119bb24060ec4b4a2b7f42657fdc0b8cad3221d

Original PR: https://github.com/openshift/openshift-docs/pull/104309/

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16

QE review:
QE is not required for this PR.

Additional information:
* 26 files because there were modules that do not apply to enterprise-4.16.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
