### PR TITLE
DOCPLAN-92: Update callout formatting for migration

### DIFF
--- a/modules/nw-sriov-network-attachment.adoc
+++ b/modules/nw-sriov-network-attachment.adoc
@@ -29,6 +29,7 @@ ifdef::ocp-sriov-net[]
 [id="nw-sriov-network-attachment_{context}"]
 = Configuring SR-IOV additional network
 
+[role="_abstract"]
 You can configure an additional network that uses SR-IOV hardware by creating an `{rs}` object.
 When you create an `{rs}` object, the SR-IOV Network Operator automatically creates a `NetworkAttachmentDefinition` object.
 
@@ -39,7 +40,7 @@ Do not modify or delete an `{rs}` object if it is attached to any {object} in a 
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
@@ -75,7 +76,7 @@ $ oc create -f <name>.yaml
 +
 where `<name>` specifies the name of the additional network.
 
-. Optional: To confirm that the `NetworkAttachmentDefinition` object that is associated with the `{rs}` object that you created in the previous step exists, enter the following command. Replace `<namespace>` with the networkNamespace you specified in the `{rs}` object.
+. Optional: To confirm that the `NetworkAttachmentDefinition` object that is associated with the `{rs}` object that you created in the previous step exists, enter the following command. Replace `<namespace>` with the `networkNamespace` value you specified in the `{rs}` object.
 +
 [source,terminal]
 ----
@@ -99,72 +100,72 @@ Do not modify or delete an `{rs}` object if it is attached to {object} in a `run
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
 
 . Create the following `SriovNetwork` object, and then save the YAML in the `<name>-sriov-network.yaml` file. Replace `<name>` with a name for this additional network.
-
-// The list breaks because of the [NOTE]
++
 [source,yaml]
 ----
 apiVersion: sriovnetwork.openshift.io/v1
 kind: SriovNetwork
 metadata:
-  name: <name> <1>
-  namespace: openshift-sriov-network-operator <2>
+  name: <name>
+  namespace: openshift-sriov-network-operator
 spec:
-  resourceName: <sriov_resource_name> <3>
-  networkNamespace: <target_namespace> <4>
-  vlan: <vlan> <5>
-  spoofChk: "<spoof_check>" <6>
-  linkState: <link_state> <7>
-  maxTxRate: <max_tx_rate> <8>
-  minTxRate: <min_rx_rate> <9>
-  vlanQoS: <vlan_qos> <10>
-  trust: "<trust_vf>" <11>
-  capabilities: <capabilities> <12>
+  resourceName: <sriov_resource_name>
+  networkNamespace: <target_namespace>
+  vlan: <vlan>
+  spoofChk: "<spoof_check>"
+  linkState: <link_state>
+  maxTxRate: <max_tx_rate>
+  minTxRate: <min_rx_rate>
+  vlanQoS: <vlan_qos>
+  trust: "<trust_vf>"
+  capabilities: <capabilities>
 ifdef::ocp-sriov-net[]
-  ipam: {} <7>
-  linkState: <link_state> <8>
-  maxTxRate: <max_tx_rate> <9>
-  minTxRate: <min_tx_rate> <10>
-  vlanQoS: <vlan_qos> <11>
-  trust: "<trust_vf>" <12>
-  capabilities: <capabilities> <13>
+  ipam: {}
+  linkState: <link_state>
+  maxTxRate: <max_tx_rate>
+  minTxRate: <min_tx_rate>
+  vlanQoS: <vlan_qos>
+  trust: "<trust_vf>"
+  capabilities: <capabilities>
 endif::ocp-sriov-net[]
 ----
-<1> Replace `<name>` with a name for the object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with same name.
-<2> Specify the namespace where the SR-IOV Network Operator is installed.
-<3> Replace `<sriov_resource_name>` with the value for the `.spec.resourceName` parameter from the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
-<4> Replace `<target_namespace>` with the target namespace for the SriovNetwork. Only {object} in the target namespace can attach to the SriovNetwork.
-<5> Optional: Replace `<vlan>` with a Virtual LAN (VLAN) ID for the additional network. The integer value must be from `0` to `4095`. The default value is `0`.
-<6> Optional: Replace `<spoof_check>` with the spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
++
+`metadata.name`:: Specify a name for the `SriovNetwork` object. The SR-IOV Network Operator creates a `NetworkAttachmentDefinition` object with same name.
+`metadata.namespace`:: Specify the namespace where the SR-IOV Network Operator is installed.
+`spec.resourceName`:: Specify the value of the `.spec.resourceName` parameter in the `SriovNetworkNodePolicy` object that defines the SR-IOV hardware for this additional network.
+`spec.networkNamespace`:: Specify the target namespace for the `SriovNetwork` object. Only {object} in the target namespace can attach to the `SriovNetwork` object.
+`spec.vlan`:: Optional: Specify a Virtual LAN (VLAN) ID for the additional network. The integer value must be from `0` to `4095`. The default value is `0`.
+`spec.spoofChk`:: Optional: Specify the spoof check mode of the VF. The allowed values are the strings `"on"` and `"off"`.
 +
 [IMPORTANT]
 ====
 You must enclose the value you specify in quotes or the CR is rejected by the SR-IOV Network Operator.
 ====
-<7> Optional: Replace `<link_state>` with the link state of virtual function (VF). Allowed value are `enable`, `disable` and `auto`.
-<8> Optional: Replace `<max_tx_rate>` with a maximum transmission rate, in Mbps, for the VF.
-<9> Optional: Replace `<min_tx_rate>` with a minimum transmission rate, in Mbps, for the VF. This value should always be less than or equal to Maximum transmission rate.
+`spec.linkState`:: Optional: Specify the link state of virtual function (VF). Allowed values are `enable`, `disable` and `auto`.
+`spec.maxTxRate`:: Optional: Specify the maximum transmission rate, in Mbps, for the VF.
+`spec.minTxRate`:: Optional: Specify the minimum transmission rate, in Mbps, for the VF. This value should always be less than or equal to the maximum transmission rate.
 +
 [NOTE]
 ====
 Intel NICs do not support the `minTxRate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1772847].
 ====
-<10> Optional: Replace `<vlan_qos>` with an IEEE 802.1p priority level for the VF. The default value is `0`.
-<11> Optional: Replace `<trust_vf>` with the trust mode of the VF. The allowed values are the strings `"on"` and `"off"`.
+`spec.vlanQoS`:: Optional: Specify the IEEE 802.1p priority level for the VF. The default value is `0`.
+`spec.trust`:: Optional: Specify the trust mode of the VF. The allowed values are the strings `"on"` and `"off"`.
 +
 [IMPORTANT]
 ====
 You must enclose the value you specify in quotes or the CR is rejected by the SR-IOV Network Operator.
 ====
-<12> Optional: Replace `<capabilities>` with the capabilities to configure for this network.
+`spec.capabilities`:: Optional: Specify the capabilities to configure for this network.
 ifdef::ocp-sriov-net[]
 You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
-<13> A configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
+`spec.capabilities`:: Specify a configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition.
 endif::ocp-sriov-net[]
 
 [start=2]

--- a/modules/virt-creating-linux-bridge-nncp.adoc
+++ b/modules/virt-creating-linux-bridge-nncp.adoc
@@ -11,44 +11,43 @@
 You can create a `NodeNetworkConfigurationPolicy` (NNCP) manifest for a Linux bridge network.
 
 .Prerequisites
+
 * You have installed the Kubernetes NMState Operator.
 
 .Procedure
 
 * Create the `NodeNetworkConfigurationPolicy` manifest. This example includes sample values that you must replace with your own information.
 +
---
 [source,yaml]
 ----
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: br1-eth1-policy <1>
+  name: br1-eth1-policy
 spec:
   desiredState:
     interfaces:
-      - name: br1 <2>
-        description: Linux bridge with eth1 as a port <3>
-        type: linux-bridge <4>
-        state: up <5>
+      - name: br1
+        description: Linux bridge with eth1 as a port
+        type: linux-bridge
+        state: up
         ipv4:
-          enabled: false <6>
+          enabled: false
         bridge:
           options:
             stp:
-              enabled: false <7>
+              enabled: false
           port:
-            - name: eth1 <8>
+            - name: eth1
 ----
-<1> Name of the policy.
-<2> Name of the interface.
-<3> Optional: Human-readable description of the interface.
-<4> The type of interface. This example creates a bridge.
-<5> The requested state for the interface after creation.
-<6> Disables IPv4 in this example.
-<7> Disables STP in this example.
-<8> The node NIC to which the bridge is attached.
---
+** `metadata.name` defines the name of the node network configuration policy.
+** `spec.desiredState.interfaces.name` defines the name of the new Linux bridge.
+** `spec.desiredState.interfaces.description` is an optional field that can be used to define a human-readable description for the bridge.
+** `spec.desiredState.interfaces.type` defines the interface type. In this example, the type is a Linux bridge.
+** `spec.desiredState.interfaces.state` defines the requested state for the interface after creation.
+** `spec.desiredState.interfaces.ipv4.enabled` defines whether the ipv4 protocol is active. Setting this to `false` disables IPv4 addressing on this bridge.
+** `spec.desiredState.interfaces.bridge.options.stp.enabled` defines whether STP is active. Setting this to `false` disables STP on this bridge.
+** `spec.desiredState.interfaces.bridge.port.name` defines the node NIC to which the bridge is attached.
 +
 [NOTE]
 ====

--- a/modules/virt-creating-storage-class-csi-driver.adoc
+++ b/modules/virt-creating-storage-class-csi-driver.adoc
@@ -42,9 +42,10 @@ volumeBindingMode: WaitForFirstConsumer <2>
 parameters:
   storagePool: my-storage-pool <3>
 ----
-<1> The two possible `reclaimPolicy` values are `Delete` and `Retain`. If you do not specify a value, the default value is `Delete`.
-<2> The `volumeBindingMode` parameter determines when dynamic provisioning and volume binding occur. Specify `WaitForFirstConsumer` to delay the binding and provisioning of a persistent volume (PV) until after a pod that uses the persistent volume claim (PVC) is created. This ensures that the PV meets the pod's scheduling requirements.
-<3> Specify the name of the storage pool defined in the HPP CR.
++
+* `reclaimPolicy` specifies whether the underlying storage is deleted or retained when a user deletes a PVC. The two possible `reclaimPolicy` values are `Delete` and `Retain`. If you do not specify a value, the default value is `Delete`.
+* `volumeBindingMode` specifies the timing of PV creation. The `WaitForFirstConsumer` configuration in this example means that PV creation is delayed until a pod is scheduled to a specific node.
+* `parameters.storagePool` specifies the name of the storage pool defined in the HPP custom resource (CR).
 
 . Save the file and exit.
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
- https://issues.redhat.com/browse/CNV-74970
- https://issues.redhat.com/browse/DOCPLAN-92
- https://issues.redhat.com/browse/DOCPLAN-94

Link to docs preview:
- https://104487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-network-config.html#virt-creating-linux-bridge-nncp_virt-post-install-network-config
- https://104487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-post-install-storage-config#virt-creating-storage-class-csi-driver_virt-post-install-storage-config
- https://104487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-sriov#nw-sriov-network-attachment_virt-connecting-vm-to-sriov


QE review:
N/A, no major content changes

Additional information:
This PR will address multiple Jira issues where the scope is similar - to update the callout formatting for CNV docs ahead of migration. There will be additional follow up PRs to complete [CNV-74970](https://issues.redhat.com//browse/CNV-74970).
