### PR TITLE
[enterprise-4.16/4.17] OSDOCS#16936: CQA for secondary scheduler docs

### DIFF
--- a/modules/nodes-secondary-scheduler-about.adoc
+++ b/modules/nodes-secondary-scheduler-about.adoc
@@ -6,6 +6,7 @@
 [id="nodes-secondary-scheduler-about_{context}"]
 = About the {secondary-scheduler-operator}
 
+[role="_abstract"]
 The {secondary-scheduler-operator-full} provides a way to deploy a custom secondary scheduler in {product-title}. The secondary scheduler runs alongside the default scheduler to schedule pods. Pod configurations can specify which scheduler to use.
 
 The custom scheduler must have the `/bin/kube-scheduler` binary and be based on the link:https://kubernetes.io/docs/concepts/scheduling-eviction/scheduling-framework/[Kubernetes scheduling framework].

--- a/modules/nodes-secondary-scheduler-configuring-console.adoc
+++ b/modules/nodes-secondary-scheduler-configuring-console.adoc
@@ -6,9 +6,10 @@
 [id="nodes-secondary-scheduler-configuring-console_{context}"]
 = Deploying a secondary scheduler
 
-After you have installed the {secondary-scheduler-operator}, you can deploy a secondary scheduler.
+[role="_abstract"]
+After you have installed the {secondary-scheduler-operator}, you can deploy a secondary scheduler to apply custom placement logic for specific pods.
 
-.Prerequisities
+.Prerequisites
 
 ifndef::openshift-rosa,openshift-dedicated[]
 * You are logged in to {product-title} as a user with the `cluster-admin` role.
@@ -32,27 +33,30 @@ endif::openshift-rosa,openshift-dedicated[]
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "secondary-scheduler-config"                  <1>
-  namespace: "openshift-secondary-scheduler-operator" <2>
+  name: "secondary-scheduler-config"
+  namespace: "openshift-secondary-scheduler-operator"
 data:
   "config.yaml": |
     apiVersion: kubescheduler.config.k8s.io/v1
-    kind: KubeSchedulerConfiguration                  <3>
+    kind: KubeSchedulerConfiguration
     leaderElection:
       leaderElect: false
     profiles:
-      - schedulerName: secondary-scheduler            <4>
-        plugins:                                      <5>
+      - schedulerName: secondary-scheduler
+        plugins:
           score:
             disabled:
               - name: NodeResourcesBalancedAllocation
               - name: NodeResourcesLeastAllocated
 ----
-<1> The name of the config map. This is used in the *Scheduler Config* field when creating the `SecondaryScheduler` CR.
-<2> The config map must be created in the `openshift-secondary-scheduler-operator` namespace.
-<3> The `KubeSchedulerConfiguration` resource for the secondary scheduler. For more information, see link:https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-KubeSchedulerConfiguration[`KubeSchedulerConfiguration`] in the Kubernetes API documentation.
-<4> The name of the secondary scheduler. Pods that set their `spec.schedulerName` field to this value are scheduled with this secondary scheduler.
-<5> The plugins to enable or disable for the secondary scheduler. For a list default scheduling plugins, see link:https://kubernetes.io/docs/reference/scheduling/config/#scheduling-plugins[Scheduling plugins] in the Kubernetes documentation.
++
+where:
+
+`metadata.name`:: Specifies the name of the config map. This is used in the *Scheduler Config* field when creating the `SecondaryScheduler` CR.
+`metadata.namespace`:: Specifies the namespace to create the config map in. The namespace must be `openshift-secondary-scheduler-operator`.
+`data."config.yaml".kind`:: Specifies the `KubeSchedulerConfiguration` resource for the secondary scheduler. For more information, see link:https://kubernetes.io/docs/reference/config-api/kube-scheduler-config.v1/#kubescheduler-config-k8s-io-v1-KubeSchedulerConfiguration[`KubeSchedulerConfiguration`] in the Kubernetes API documentation.
+`data."config.yaml".profiles.schedulerName`:: Specifies the name of the secondary scheduler. Pods that set their `spec.schedulerName` field to this value are scheduled with this secondary scheduler.
+`data."config.yaml".profiles.plugins`:: Specifies the plugins to enable or disable for the secondary scheduler. For a list default scheduling plugins, see link:https://kubernetes.io/docs/reference/scheduling/config/#scheduling-plugins[Scheduling plugins] in the Kubernetes documentation.
 
 .. Click *Create*.
 

--- a/modules/nodes-secondary-scheduler-install-console.adoc
+++ b/modules/nodes-secondary-scheduler-install-console.adoc
@@ -6,7 +6,8 @@
 [id="nodes-secondary-scheduler-install-console_{context}"]
 = Installing the {secondary-scheduler-operator}
 
-You can use the web console to install the {secondary-scheduler-operator-full}.
+[role="_abstract"]
+You can install the {secondary-scheduler-operator-full} through the {product-title} web console to configure a secondary scheduler.
 
 .Prerequisites
 

--- a/modules/nodes-secondary-scheduler-pod-console.adoc
+++ b/modules/nodes-secondary-scheduler-pod-console.adoc
@@ -6,9 +6,10 @@
 [id="nodes-secondary-scheduler-pod-console_{context}"]
 = Scheduling a pod using the secondary scheduler
 
-To schedule a pod using the secondary scheduler, set the `schedulerName` field in the pod definition.
+[role="_abstract"]
+To schedule a pod by using the secondary scheduler, set the `schedulerName` field in the pod definition.
 
-.Prerequisities
+.Prerequisites
 
 ifndef::openshift-rosa,openshift-dedicated[]
 * You are logged in to {product-title} as a user with the `cluster-admin` role.
@@ -48,9 +49,10 @@ spec:
         allowPrivilegeEscalation: false
         capabilities:
           drop: [ALL]
-  schedulerName: secondary-scheduler <1>
+  schedulerName: secondary-scheduler
 ----
-<1> The `schedulerName` field must match the name that is defined in the config map when you configured the secondary scheduler.
++
+The `spec.schedulerName` field must match the name that is defined in the config map when you configured the secondary scheduler.
 
 . Click *Create*.
 

--- a/modules/nodes-secondary-scheduler-remove-resources-console.adoc
+++ b/modules/nodes-secondary-scheduler-remove-resources-console.adoc
@@ -6,7 +6,8 @@
 [id="nodes-secondary-scheduler-remove-resources-console_{context}"]
 = Removing {secondary-scheduler-operator} resources
 
-Optionally, after uninstalling the {secondary-scheduler-operator-full}, you can remove its related resources from your cluster.
+[role="_abstract"]
+Optionally, remove the custom resource definition (CRD) and associated namespace after the {secondary-scheduler-operator-full} is uninstalled. This cleans up all remaining secondary scheduler artifacts.
 
 .Prerequisites
 
@@ -22,7 +23,7 @@ endif::openshift-rosa,openshift-dedicated[]
 
 . Log in to the {product-title} web console.
 
-. Remove CRDs that were installed by the {secondary-scheduler-operator}:
+. Remove the CRD that was installed by the {secondary-scheduler-operator}:
 .. Navigate to *Administration* -> *CustomResourceDefinitions*.
 .. Enter `SecondaryScheduler` in the *Name* field to filter the CRDs.
 .. Click the Options menu {kebab} next to the *SecondaryScheduler* CRD and select *Delete Custom Resource Definition*:

--- a/modules/nodes-secondary-scheduler-rn-1.3.0.adoc
+++ b/modules/nodes-secondary-scheduler-rn-1.3.0.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+
+// This release notes module is allowed to contain xrefs. It must only ever be included from one assembly.
+
+:_mod-docs-content-type: REFERENCE
+[id="secondary-scheduler-operator-release-notes-1.3.0_{context}"]
+= Release notes for {secondary-scheduler-operator-full} 1.3.0
+
+[role="_abstract"]
+Review the release notes for {secondary-scheduler-operator} 1.3.0 to learn what is new and updated with this release.
+
+Issued: 1 July 2024
+
+The following advisory is available for the {secondary-scheduler-operator-full} 1.3.0:
+
+* link:https://access.redhat.com/errata/RHSA-2024:3637[RHSA-2024:3637]
+
+[id="secondary-scheduler-operator-1.3.0-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* You can now install and use the {secondary-scheduler-operator} in an {product-title} cluster running in FIPS mode.
++
+--
+include::snippets/fips-snippet.adoc[]
+--
+
+[id="secondary-scheduler-1.3.0-bug-fixes_{context}"]
+== Bug fixes
+
+* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+[id="secondary-scheduler-operator-1.3.0-known-issues_{context}"]
+== Known issues
+
+* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[WRKLDS-645])

--- a/modules/nodes-secondary-scheduler-rn-1.3.1.adoc
+++ b/modules/nodes-secondary-scheduler-rn-1.3.1.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+
+// This release notes module is allowed to contain xrefs. It must only ever be included from one assembly.
+
+:_mod-docs-content-type: REFERENCE
+[id="secondary-scheduler-operator-release-notes-1.3.1_{context}"]
+= Release notes for {secondary-scheduler-operator-full} 1.3.1
+
+[role="_abstract"]
+Review the release notes for {secondary-scheduler-operator} 1.3.1 to learn what is new and updated with this release.
+
+Issued: 3 October 2024
+
+The following advisory is available for the {secondary-scheduler-operator-full} 1.3.1:
+
+* link:https://access.redhat.com/errata/RHEA-2024:7073[RHEA-2024:7073]
+
+[id="secondary-scheduler-operator-1.3.1-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* This release of the {secondary-scheduler-operator} adds support for {ibm-z-name} and {ibm-power-name}.
+
+[id="secondary-scheduler-1.3.1-bug-fixes_{context}"]
+== Bug fixes
+
+* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+[id="secondary-scheduler-operator-1.3.1-known-issues_{context}"]
+== Known issues
+
+* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[WRKLDS-645])

--- a/modules/nodes-secondary-scheduler-rn-1.3.2.adoc
+++ b/modules/nodes-secondary-scheduler-rn-1.3.2.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+
+// This release notes module is allowed to contain xrefs. It must only ever be included from one assembly.
+
+:_mod-docs-content-type: REFERENCE
+[id="secondary-scheduler-operator-release-notes-1.3.2_{context}"]
+= Release notes for {secondary-scheduler-operator-full} 1.3.2
+
+[role="_abstract"]
+Review the release notes for {secondary-scheduler-operator} 1.3.2 to learn what is new and updated with this release.
+
+Issued: 19 November 2025
+
+The following advisory is available for the {secondary-scheduler-operator-full} 1.3.2:
+
+* link:https://access.redhat.com/errata/RHBA-2025:21745[RHBA-2025:21745]
+
+[id="secondary-scheduler-operator-1.3.2-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* This release rebuilds the base image for the {secondary-scheduler-operator} to improve its image grade.
+
+[id="secondary-scheduler-operator-1.3.2-known-issues_{context}"]
+== Known issues
+
+* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[WRKLDS-645])

--- a/modules/nodes-secondary-scheduler-uninstall-console.adoc
+++ b/modules/nodes-secondary-scheduler-uninstall-console.adoc
@@ -6,7 +6,8 @@
 [id="nodes-secondary-scheduler-uninstall-console_{context}"]
 = Uninstalling the {secondary-scheduler-operator}
 
-You can uninstall the {secondary-scheduler-operator-full} by using the web console.
+[role="_abstract"]
+You can use the web console to uninstall the {secondary-scheduler-operator-full} if you no longer need the Operator in your cluster.
 
 .Prerequisites
 

--- a/nodes/scheduling/secondary_scheduler/index.adoc
+++ b/nodes/scheduling/secondary_scheduler/index.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can install the {secondary-scheduler-operator} to run a custom secondary scheduler alongside the default scheduler to schedule pods.
 
 // About the {secondary-scheduler-operator}

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can run a custom secondary scheduler in {product-title} by installing the {secondary-scheduler-operator}, deploying the secondary scheduler, and setting the secondary scheduler in the pod definition.
 
 // Installing the {secondary-scheduler-operator}

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -6,79 +6,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The {secondary-scheduler-operator-full} allows you to deploy a custom secondary scheduler in your {product-title} cluster.
+[role="_abstract"]
+Review the {secondary-scheduler-operator-full} release notes to track its development and learn what is new and changed with each release.
 
-These release notes track the development of the {secondary-scheduler-operator-full}.
+The {secondary-scheduler-operator} allows you to deploy a custom secondary scheduler in your {product-title} cluster.
 
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
 
-[id="secondary-scheduler-operator-release-notes-1.3.2_{context}"]
-== Release notes for {secondary-scheduler-operator-full} 1.3.2
+// Release notes for Secondary Scheduler Operator for Red Hat OpenShift 1.3.2
+include::modules/nodes-secondary-scheduler-rn-1.3.2.adoc[leveloffset=+1]
 
-Issued: 19 November 2025
+// Release notes for Secondary Scheduler Operator for Red Hat OpenShift 1.3.1
+include::modules/nodes-secondary-scheduler-rn-1.3.1.adoc[leveloffset=+1]
 
-The following advisory is available for the {secondary-scheduler-operator-full} 1.3.2:
-
-* link:https://access.redhat.com/errata/RHBA-2025:21745[RHBA-2025:21745]
-
-[id="secondary-scheduler-operator-1.3.2-new-features-and-enhancements_{context}"]
-=== New features and enhancements
-
-* This release rebuilds the base image for the {secondary-scheduler-operator} to improve its image grade.
-
-[id="secondary-scheduler-operator-1.3.2-known-issues_{context}"]
-=== Known issues
-
-* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])
-
-[id="secondary-scheduler-operator-release-notes-1.3.1_{context}"]
-== Release notes for {secondary-scheduler-operator-full} 1.3.1
-
-Issued: 3 October 2024
-
-The following advisory is available for the {secondary-scheduler-operator-full} 1.3.1:
-
-* link:https://access.redhat.com/errata/RHEA-2024:7073[RHEA-2024:7073]
-
-[id="secondary-scheduler-operator-1.3.1-new-features-and-enhancements_{context}"]
-=== New features and enhancements
-
-* This release of the {secondary-scheduler-operator} adds support for {ibm-z-name} and {ibm-power-name}.
-
-[id="secondary-scheduler-1.3.1-bug-fixes_{context}"]
-=== Bug fixes
-
-* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-[id="secondary-scheduler-operator-1.3.1-known-issues_{context}"]
-=== Known issues
-
-* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])
-
-[id="secondary-scheduler-operator-release-notes-1.3.0_{context}"]
-== Release notes for {secondary-scheduler-operator-full} 1.3.0
-
-Issued: 1 July 2024
-
-The following advisory is available for the {secondary-scheduler-operator-full} 1.3.0:
-
-* link:https://access.redhat.com/errata/RHSA-2024:3637[RHSA-2024:3637]
-
-[id="secondary-scheduler-operator-1.3.0-new-features-and-enhancements_{context}"]
-=== New features and enhancements
-
-* You can now install and use the {secondary-scheduler-operator} in an {product-title} cluster running in FIPS mode.
-+
---
-include::snippets/fips-snippet.adoc[]
---
-
-[id="secondary-scheduler-1.3.0-bug-fixes_{context}"]
-=== Bug fixes
-
-* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-[id="secondary-scheduler-operator-1.3.0-known-issues_{context}"]
-=== Known issues
-
-* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])
+// Release notes for Secondary Scheduler Operator for Red Hat OpenShift 1.3.0
+include::modules/nodes-secondary-scheduler-rn-1.3.0.adoc[leveloffset=+1]

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can remove the {secondary-scheduler-operator-full} from {product-title} by uninstalling the Operator and removing its related resources.
+[role="_abstract"]
+If you no longer need the {secondary-scheduler-operator-full} in your cluster, you can uninstall the Operator and remove its related resources.
 
 // Uninstalling the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-uninstall-console.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16 and 4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-16936

Link to docs preview:

- https://104491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/index.html
- https://104491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html
- https://104491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html
- https://104491--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.html

QE review:
 N/A CQA changes only

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Related PR for newest version: #104488