### PR TITLE
DOCS Update - Typo - nw-bgp-routing-disable.adoc

### DIFF
--- a/modules/nw-bgp-routing-disable.adoc
+++ b/modules/nw-bgp-routing-disable.adoc
@@ -9,7 +9,7 @@
 As a cluster administrator, you can disable Border Gateway Protocol (BGP) routing support for your cluster on bare-metal infrastructure.
 
 [id="enabling-bgp-routing-support_{context}"]
-== Enabling BGP routing support
+== Disabling BGP routing support
 
 As a cluster administrator, you can disable BGP routing support for your cluster.
 


### PR DESCRIPTION
Typo fix in the doc [Disabling Border Gateway Protocol (BGP) routing](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/advanced_networking/bgp-routing#nw-bgp-routing-config_disable-bgp-routing)

Link: 
https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/advanced_networking/bgp-routing#enabling-bgp-routing-support_disable-bgp-routing

Version(s):
4.19+
