### PR TITLE
PR for SRVLOGIC-715: Add a section for upgrading the OpenShift Serverless Logic Operator from 1.36.0 to 1.37.0

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -418,6 +418,8 @@ Topics:
     File: serverless-logic-upgrading-operator-from-1-34-to-1-35
   - Name: Upgrading Serverless Logic Operator from 1.35.0 to 1.36.0
     File: serverless-logic-upgrading-operator-from-1-35-to-1-36
+  - Name: Upgrading Serverless Logic Operator from 1.36.0 to 1.37.0
+    File: serverless-logic-upgrading-operator-from-1-36-to-1-37
 
 ---
 # Knative kn CLI

--- a/modules/serverless-logic-upgrade-1-37-backing-up-data-index-database.adoc
+++ b/modules/serverless-logic-upgrade-1-37-backing-up-data-index-database.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-backing-up-data-index-database_{context}"]
+= Backing up the Data Index database
+
+[role="_abstract"]
+You must back up the Data Index database before upgrading to prevent data loss.
+
+.Procedure
+* Take a full backup of the Data Index database, ensuring:
+** The backup includes all database objects and not just table data.
+** The backup is stored in a secure location.

--- a/modules/serverless-logic-upgrade-1-37-backing-up-job-service-database.adoc
+++ b/modules/serverless-logic-upgrade-1-37-backing-up-job-service-database.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-backing-up-job-service-database_{context}"]
+= Backing up the Jobs Service database
+
+[role="_abstract"]
+You must back up the Jobs Service database before upgrading to maintain the job scheduling data.
+
+.Procedure
+* Take a full backup of the Jobs Service database, ensuring:
+** The backup includes all database objects and not just table data.
+** The backup is stored in a secure location.

--- a/modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-gitops-profile.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-gitops-profile_{context}"]
+= Deleting workflows with the gitops profile
+
+[role="_abstract"]
+Before upgrading the Operator, you must delete workflows running with the `gitops` profile. When the upgrade is complete, you must rebuild the corresponding workflow image using the new {ServerlessLogicProductName} 1.37.0 serverless workflow builder image and you must redeploy the workflow using the new image.
+
+.Procedure
+. If you are using persistence, back up the workflow database and ensure the backup includes both database objects and table data.
+
+. Ensure you have a backup of all necessary Kubernetes resources, including `SonataFlow` custom resources (CRs), `ConfigMap` resources, or any other related custom configurations.
+
+. Delete the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc delete -f <workflow.yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-preview-profile.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-preview-profile_{context}"]
+= Deleting workflows with the preview profile
+
+[role="_abstract"]
+Before upgrading the Operator, you must delete workflows running with the `preview` profile. When the upgrade is complete, you must redeploy the workflows.
+
+.Procedure
+. If you are using persistence, back up the workflow database and ensure the backup includes both database objects and table data.
+
+. Ensure you have a backup of all necessary Kubernetes resources, including `SonataFlow` custom resources (CRs), `ConfigMap` resources, or any other related custom configurations.
+
+. Delete the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc delete -f <workflow.yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-deleting-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-deleting-workflows-with-dev-profile.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-deleting-workflows-with-dev-profile_{context}"]
+= Deleting workflows with the dev profile
+
+[role="_abstract"]
+Before upgrading the Operator, you must delete workflows running with the `dev` profile. When the upgrade is complete, you must redeploy the workflows.
+
+.Procedure
+. Ensure you have a backup of all necessary Kubernetes resources, including `SonataFlow` custom resources (CRs), `ConfigMap` resources, or any other related custom configurations.
+
+. Delete the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc delete -f <workflow.yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-finalizing-data-index.adoc
+++ b/modules/serverless-logic-upgrade-1-37-finalizing-data-index.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-finalizing-data-index_{context}"]
+= Finalizing the Data Index upgrade
+
+[role="_abstract"]
+After the {ServerlessLogicOperatorName} is upgraded to version 1.37.0, the Data Index service is automatically updated. You can optionally finalize the upgrade by identifying and removing ReplicaSets that belong to the earlier 1.36.0 version.
+
+.Procedure
+. Optional: Verify that a new ReplicaSet for the Data Index 1.37.0 version is created by running the following command:
++
+[source,terminal]
+----
+$ oc get replicasets -o custom-columns=Name:metadata.name,Image:spec.template.spec.containers[*].image -n <target_namespace>
+----
++
+You will get an output similar to the following example:
++
+[source,terminal,subs="verbatim,quotes"]
+----
+Name                                                Image
+sonataflow-platform-data-index-service-1111111111   registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel8:1.36.0
+
+sonataflow-platform-data-index-service-2222222222   registry.redhat.io/openshift-serverless-1/logic-data-index-postgresql-rhel9:1.37.0
+----
+
+. Optional: Delete your old `ReplicaSet` resource by running the following command:
++
+[source,terminal]
+----
+$ oc delete replicaset sonataflow-platform-data-index-service-1111111111 -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-finalizing-job-service.adoc
+++ b/modules/serverless-logic-upgrade-1-37-finalizing-job-service.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-finalizing-job-service_{context}"]
+= Finalizing the Job Service upgrade
+
+[role="_abstract"]
+After the {ServerlessLogicOperatorName} is upgraded to version 1.37.0, the Job Service is automatically updated. You can optionally finalize the upgrade by identifying and removing ReplicaSets that belong to the earlier 1.36.0 version.
+
+.Procedure
+. Optional: Verify that a new ReplicaSet for the Job Service 1.37.0 version is created by running the following command:
++
+[source,terminal]
+----
+$ oc get replicasets -o custom-columns=Name:metadata.name,Image:spec.template.spec.containers[*].image -n <target_namespace>
+----
++
+You will get an output similar to the following example:
++
+[source,terminal,subs="verbatim,quotes"]
+----
+sonataflow-platform-jobs-service-1111111111    registry.redhat.io/openshift-serverless-1/logic-jobs-service-postgresql-rhel8:1.36.0
+
+sonataflow-platform-jobs-service-2222222222     registry.redhat.io/openshift-serverless-1/logic-jobs-service-postgresql-rhel9:1.37.0
+----
+
+. Optional: Delete your old `ReplicaSet` running the Job Service 1.36.0 version by running the following command:
++
+[source,terminal]
+----
+$ oc delete replicaset sonataflow-platform-jobs-service-1111111111 -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-redeploying-workflows-with-dev-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-redeploying-workflows-with-dev-profile.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-redeploying-workflows-with-dev-profile_{context}"]
+= Redeploying workflows with the dev profile
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.37.0, you must redeploy workflows that use the `dev` profile to complete the upgrade process.
+
+.Procedure
+. Ensure that all required Kubernetes resources are restored before redeploying the workflow. The resources also include the `ConfigMap` resource with the `application.properties` field.
+
+. Redeploy the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f <workflow_yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-redeploying-workflows-with-gitops-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-redeploying-workflows-with-gitops-profile.adoc
@@ -1,0 +1,97 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-redeploying-workflows-with-gitops-profile_{context}"]
+= Redeploying workflows with the gitops profile
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.37.0, you must rebuild and redeploy workflows that use the `gitops` profile to complete the upgrade process.
+
+.Procedure
+. Rebuild the workflow image using the {ServerlessLogicProductName} 1.37.0 serverless workflow builder image:
++
+[source,terminal]
+----
+registry.redhat.io/openshift-serverless-1/logic-swf-builder-rhel9:1.37.0
+----
++
+[NOTE]
+====
+When rebuilding the image, the {ServerlessLogicOperatorName} generates a workflow deployment with `imagePullPolicy: IfNotPresent` by default. This means that if an already deployed workflow `<workflow_name>` is redeployed with the same image name, even when that image was rebuilt, the previously downloaded image is reused.
+====
+
+. Ensure that the new image is picked up by using one of the following alternatives:
+
+.. Use a new image tag and configure the workflow to use it.
++
+Use the current image tag by running the following command:
++
+[source,terminal]
+----
+quay.io/my-images/my-workflow:1.0
+----
++
+Use the new image tag by running the following command:
++
+[source,terminal]
+----
+quay.io/my-images/my-workflow:1.0-1
+----
++
+Update the `workflow` custom resource (CR) similar to the following example:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: my-workflow
+  annotations:
+    sonataflow.org/description: My Workflow
+    sonataflow.org/version: '1.0'
+    sonataflow.org/profile: gitops
+spec:
+  podTemplate:
+    container:
+      # only change the image name/tag
+      image: quay.io/my-images/my-workflow:1.0-1
+  flow:
+    # the workflow definition (don't change)
+----
+
+.. Preserve the image name and configure the workflow with `imagePullPolicy: Always` as follows:
++
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: my-workflow
+  annotations:
+    sonataflow.org/description: My Workflow
+    sonataflow.org/version: '1.0'
+    sonataflow.org/profile: gitops
+spec:
+  podTemplate:
+    container:
+      image: quay.io/my-images/my-workflow:1.0
+      # only change the imagePullStrategy
+      imagePullPolicy: Always
+  flow:
+    # the workflow definition (don't change).
+----
++
+[NOTE]
+====
+When rebuilding the image and redeploying the workflow, do not change the workflow definition or any workflow-related assets. This includes the workflow name, version, and description.
+====
+
+. Ensure that all Kubernetes resources required by the workflow are created. This includes any user-provided resources, such as a `ConfigMap` containing the `application.properties` file.
+
+. Redeploy the workflow by running the following command:
++ 
+[source,terminal]
+----
+$ oc apply -f <workflow_yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrade-1-37-redeploying-workflows-with-preview-profile.adoc
+++ b/modules/serverless-logic-upgrade-1-37-redeploying-workflows-with-preview-profile.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrade-1-37-redeploying-workflows-with-preview-profile_{context}"]
+= Redeploying workflows with the preview profile
+
+[role="_abstract"]
+After upgrading the {ServerlessLogicOperatorName} to version 1.37.0, you must redeploy workflows that use the `preview` profile to complete the upgrade process.
+
+.Procedure
+. Ensure that all required Kubernetes resources, including the `ConfigMap` with the `application.properties` field, are created before redeploying the workflow.
+
+. Redeploy the workflow by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f <workflow_yaml> -n <target_namespace>
+----

--- a/modules/serverless-logic-upgrading-1-37-osl-operator.adoc
+++ b/modules/serverless-logic-upgrading-1-37-osl-operator.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+// * serverless-logic/serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+:_mod-docs-content-type: PROCEDURE
+[id="serverless-logic-upgrading-1-37-osl-operator_{context}"]
+= Upgrading the {ServerlessLogicOperatorName} to 1.37.0
+
+[role="_abstract"]
+You can upgrade the {ServerlessLogicOperatorName} from version 1.36.0 to 1.37.0 by performing the following steps.
+
+.Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have installed the OpenShift CLI (`oc`).
+* You have version 1.36.0 of {ServerlessLogicOperatorName} installed.
+
+.Procedure
+. Uninstall the current {ServerlessLogicOperatorName} 1.36.0.
++
+.. Delete the existing Operator subscription by running the following command:
++
+[source,terminal]
+----
+$ oc delete subscriptions.operators.coreos.com logic-operator-rhel8 -n openshift-serverless-logic
+----
++
+[NOTE]
+====
+You must use the fully qualified resource name `subscriptions.operators.coreos.com` to avoid short-name collisions with Knative Eventing resources.
+====
++
+.. Delete the existing `ClusterServiceVersion` (CSV) by running the following command:
++
+[source,terminal]
+----
+$ oc delete csv logic-operator-rhel8.v1.36.0 -n openshift-serverless-logic
+----
+
+. In every namespace where a `SonataFlowPlatform` resource is installed and configured with `dbMigrationStrategy: job` for either Data Index or Job Service, remove the associated database migration job by running the following command:
++
+[source,terminal]
+----
+$ oc delete job sonataflow-db-migrator-job -n <target-namespace>
+----
+
+. Install the {ServerlessLogicOperatorName} 1.37.0:
++
+.. Create the following `Subscription` resource similar to the following example:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/logic-operator.openshift-serverless-logic: ''
+  name: logic-operator
+  namespace: openshift-serverless-logic
+spec:
+  channel: stable
+  installPlanApproval: Manual
+  name: logic-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: logic-operator.v1.37.0
+----
++
+[NOTE]
+====
+You must use `Manual` install plan approval.
+====
+
+.. Query the pending install plan by running the following command:
++
+[source,terminal]
+----
+$ oc get installplan -n openshift-serverless-logic
+----
++
+You must get an output similar to the following:
++
+[source,terminal]
+----
+NAME            CSV                            APPROVAL   APPROVED
+install-XXXX    logic-operator.v1.37.0         Manual     false
+----
++
+.. Approve the install plan by running the following command:
++
+[source,terminal]
+----
+$ oc patch installplan install-XXXX -n openshift-serverless-logic --type merge -p '{"spec":{"approved":true}}'
+----
+
+.Verification
+
+After completing the upgrade, verify that the {ServerlessLogicOperatorName} is running correctly and that the upgrade to version 1.37.0 was successful before restoring or redeploying workflows and services.
+
+* Verify that the {ServerlessLogicOperatorName} 1.37.0 is running correctly and the output shows the Operator in the `Succeeded` phase, by running the following command:
++
+[source,terminal]
+----
+$ oc get clusterserviceversion logic-operator.v1.37.0
+----
++
+You will get an output similar to the following example:
++
+[source,terminal]
+----
+NAME                          DISPLAY                               VERSION   REPLACES                      PHASE
+logic-operator.v1.37.0        OpenShift Serverless Logic Operator   1.37.0                                  Succeeded
+----

--- a/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-36-to-1-37.adoc
+++ b/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-36-to-1-37.adoc
@@ -1,0 +1,69 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="serverless-logic-upgrading-operator-from-1-36-to-1-37"]
+= Upgrading OpenShift Serverless Logic Operator from version 1.36.0 to 1.37.0
+include::_attributes/common-attributes.adoc[]
+:context: serverless-logic-upgrading-operator-from-1-36-to-1-37
+
+toc::[]
+
+[role="_abstract"]
+You can upgrade the {ServerlessLogicOperatorName} from version 1.36.0 to 1.37.0. The upgrade process involves preparing the existing workflows and services, updating the Operator, and restoring the workflows after the upgrade.
+
+[IMPORTANT]
+====
+Different workflow profiles require different upgrade steps. Follow the instructions for each profile carefully.
+====
+
+[id="serverless-logic-1-37-preparing-for-the-upgrade_{context}"]
+== Preparing for the upgrade
+
+Before starting the upgrade process, you need to prepare your {ServerlessLogicProductName} environment to upgrade from version 1.36.0 to 1.37.0. 
+
+The preparation process is as follows:
+
+* Deleting workflows based on their profiles.
+* Backing up all necessary databases and resources.
+* Ensuring you have a record of all custom configurations.
+
+.Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have backups for all workflow, Data Index, and Job Service databases where persistence is enabled.
+* You have access to all namespaces where SonataFlow, Data Index, and Job Service are deployed.
+* You have installed the OpenShift CLI (`oc`).
+
+include::modules/serverless-logic-upgrade-1-37-deleting-workflows-with-dev-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-preview-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-deleting-migrating-workflows-with-gitops-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-backing-up-data-index-database.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-backing-up-job-service-database.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrading-1-37-osl-operator.adoc[leveloffset=+1]
+
+[id="serverless-logic-1-37-finalizing-the-upgrade_{context}"]
+== Finalizing the upgrade
+
+After upgrading the {ServerlessLogicOperatorName} to version 1.37.0, you must finalize the upgrade process by restoring or scaling workflows and cleaning up old services. This ensures that your system runs cleanly on the new version and that all dependent components are configured correctly.
+
+Follow the appropriate steps below based on the profile of your workflows and services.
+
+.Prerequisites
+* You have access to the cluster with `cluster-admin` privileges.
+* You have {ServerlessLogicOperatorName} installed on your cluster.
+* You have access to a {ServerlessLogicProductName} project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
+* You have installed the OpenShift CLI (`oc`).
+
+include::modules/serverless-logic-upgrade-1-37-finalizing-data-index.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-finalizing-job-service.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-redeploying-workflows-with-dev-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-redeploying-workflows-with-preview-profile.adoc[leveloffset=+2]
+
+include::modules/serverless-logic-upgrade-1-37-redeploying-workflows-with-gitops-profile.adoc[leveloffset=+2]


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.37`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-715

**Doc preview:**

- [Upgrading OpenShift Serverless Logic Operator from version 1.36.0 to 1.37.0](https://104497--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-managing-upgrades/serverless-logic-upgrading-operator-from-1-36-to-1-37.html#serverless-logic-1-37-preparing-for-the-upgrade_serverless-logic-upgrading-operator-from-1-36-to-1-37)

**Reviews:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] Peer has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->