### PR TITLE
OSDOCS-17458 [NETOBSERV] Module short descriptions for troubleshooting-network-observability.adoc

### DIFF
--- a/modules/troubleshooting-network-observability-after-installation.adoc
+++ b/modules/troubleshooting-network-observability-after-installation.adoc
@@ -6,7 +6,8 @@
 [id="configure-network-traffic-console_{context}"]
 = Configuring network traffic menu entry in the {product-title} console
 
-Manually configure the network traffic menu entry in the {product-title} console when the network traffic menu entry is not listed in *Observe* menu in the {product-title} console.
+[role="_abstract"]
+Restore a missing network traffic menu entry in the *Observe* menu of the {product-title} console by manually registering the console plugin in the `FlowCollector` resource and the console operator configuration.
 
 .Prerequisites
 

--- a/modules/troubleshooting-network-observability-controller-manager-pod-out-of-memory.adoc
+++ b/modules/troubleshooting-network-observability-controller-manager-pod-out-of-memory.adoc
@@ -6,6 +6,9 @@
 [id="controller-manager-pod-runs-out-of-memory_{context}"]
 = Network observability controller manager pod runs out of memory
 
+[role="_abstract"]
+Resolve memory issues with the Network Observability Operator by increasing the memory limits in the `Subscription` object to prevent the controller manager pod from running out of memory.
+
 You can increase memory limits for the Network Observability Operator by editing the `spec.config.resources.limits.memory` specification in the `Subscription` object.
 
 .Procedure

--- a/modules/troubleshooting-network-observability-flowlogs-pipeline-kafka.adoc
+++ b/modules/troubleshooting-network-observability-flowlogs-pipeline-kafka.adoc
@@ -6,6 +6,9 @@
 [id="configure-network-traffic-flowlogs-pipeline-kafka_{context}"]
 = Flowlogs-Pipeline does not consume network flows after installing Kafka
 
+[role="_abstract"]
+Resolve issues where the flow-pipeline fails to consume network flows from Kafka by manually restarting the flow-pipeline pods to restore the connection between the flow collector and your Kafka deployment.
+
 If you deployed the flow collector first with `deploymentModel: KAFKA` and then deployed Kafka, the flow collector might not connect correctly to Kafka. Manually restart the flow-pipeline pods where Flowlogs-pipeline does not consume network flows from Kafka.
 
 .Procedure

--- a/modules/troubleshooting-network-observability-loki-empty-ring.adoc
+++ b/modules/troubleshooting-network-observability-loki-empty-ring.adoc
@@ -2,15 +2,18 @@
 
 // * networking/network_observability/troubleshooting-network-observability.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="network-observability-troubleshooting-loki-empty-ring_{context}"]
 = Loki empty ring error
 
-The Loki "empty ring" error results in flows not being stored in Loki and not showing up in the web console. This error might happen in various situations. A single workaround to address them all does not exist. There are some actions you can take to investigate the logs in your Loki pods, and verify that the `LokiStack` is healthy and ready. 
+[role="_abstract"]
+Investigate and resolve Loki "empty ring" errors by checking pod health, clearing old persistent volume claims, or restarting pods to restore connectivity and ensure network flows are properly stored and displayed.
+
+The Loki "empty ring" error results in flows not being stored in Loki and not showing up in the web console. This error might happen in various situations. A single workaround to address them all does not exist. There are some actions you can take to investigate the logs in your Loki pods, and verify that the `LokiStack` is healthy and ready.
 
 Some of the situations where this error is observed are as follows:
 
-* After a `LokiStack` is uninstalled and reinstalled in the same namespace, old PVCs are not removed, which can cause this error. 
+* After a `LokiStack` is uninstalled and reinstalled in the same namespace, old PVCs are not removed, which can cause this error.
 ** *Action*: You can try removing the `LokiStack` again, removing the PVC, then reinstalling the `LokiStack`.
-* After a certificate rotation, this error can prevent communication with the `flowlogs-pipeline` and `console-plugin` pods. 
+* After a certificate rotation, this error can prevent communication with the `flowlogs-pipeline` and `console-plugin` pods.
 ** *Action*: You can restart the pods to restore the connectivity.

--- a/modules/troubleshooting-network-observability-loki-large-query-timeout.adoc
+++ b/modules/troubleshooting-network-observability-loki-large-query-timeout.adoc
@@ -2,6 +2,9 @@
 [id="network-observability-troubleshooting-large-query-timeout_{context}"]
 = Running a large query results in Loki errors
 
+[role="_abstract"]
+Understand how you can mitigate Loki timeout and request errors when running large queries by using indexed filters, leveraging Prometheus for long time ranges, creating custom metrics, or adjusting Loki and FlowCollector performance settings.
+
 When running large queries for a long time, Loki errors can occur, such as a `timeout` or `too many outstanding requests`. There is no complete corrective for this issue, but there are several ways to mitigate it:
 
 Adapt your query to add an indexed filter::

--- a/modules/troubleshooting-network-observability-loki-resource-exhausted.adoc
+++ b/modules/troubleshooting-network-observability-loki-resource-exhausted.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-troubleshooting-loki-resource-exhausted_{context}"]
 = Troubleshooting Loki ResourceExhausted error
 
+[role="_abstract"]
+Resolve Loki `ResourceExhausted` errors by adjusting the `batchSize` in the `FlowCollector` resource or the maximum message size settings in your Loki configuration to ensure flow data stays within memory limits.
+
 Loki may return a `ResourceExhausted` error when network flow data sent by network observability exceeds the configured maximum message size. If you are using the Red{nbsp}Hat {loki-op}, this maximum message size is configured to 100 MiB.
 
 .Procedure

--- a/modules/troubleshooting-network-observability-loki-tenant-rate-limit.adoc
+++ b/modules/troubleshooting-network-observability-loki-tenant-rate-limit.adoc
@@ -6,6 +6,9 @@
 [id="network-observability-troubleshooting-loki-tenant-rate-limit_{context}"]
 = LokiStack rate limit errors
 
+[role="_abstract"]
+Resolve Loki rate limit errors and prevent data loss by updating the `LokiStack` resource to increase the ingestion rate and burst limits for your network observability data streams.
+
 A rate-limit placed on the Loki tenant can result in potential temporary loss of data and a 429 error: `Per stream rate limit exceeded (limit:xMB/sec) while attempting to ingest for stream`. You might consider having an alert set to notify you of this error. For more information, see "Creating Loki rate limit alerts for the NetObserv dashboard" in the Additional resources of this section.
 
 You can update the LokiStack CRD with the `perStreamRateLimit` and `perStreamRateLimitBurst` specifications, as shown in the following procedure.

--- a/modules/troubleshooting-network-observability-must-gather.adoc
+++ b/modules/troubleshooting-network-observability-must-gather.adoc
@@ -6,7 +6,8 @@
 [id="network-observability-must-gather_{context}"]
 = Using the must-gather tool
 
-You can use the must-gather tool to collect information about the Network Observability Operator resources and cluster-wide resources, such as pod logs, `FlowCollector`, and `webhook` configurations.
+[role="_abstract"]
+Use the must-gather tool to collect diagnostic information about Network Observability Operator resources, including pod logs and configuration details, to assist in troubleshooting cluster issues.
 
 .Procedure
 . Navigate to the directory where you want to store the must-gather data.

--- a/modules/troubleshooting-network-observability-network-flow.adoc
+++ b/modules/troubleshooting-network-observability-network-flow.adoc
@@ -4,9 +4,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="configure-network-traffic-interfaces_{context}"]
-= Failing to see network flows from both `br-int` and `br-ex` interfaces
+= Failing to see network flows from both br-int and br-ex interfaces
 
-br-ex` and `br-int` are virtual bridge devices operated at OSI layer 2. The eBPF agent works at the IP and TCP levels, layers 3 and 4 respectively. You can expect that the eBPF agent captures the network traffic passing through `br-ex` and `br-int`, when the network traffic is processed by other interfaces such as physical host or virtual pod interfaces. If you restrict the eBPF agent network interfaces to attach only to `br-ex` and `br-int`, you do not see any network flow.
+[role="_abstract"]
+Resolve issues with missing network flows by removing interface restrictions on virtual bridge devices like `br-int` and `br-ex`, ensuring the eBPF agent can attach to the appropriate Layer 3 interfaces.
+
+`br-ex` and `br-int` are virtual bridge devices operated at OSI layer 2. The eBPF agent works at the IP and TCP levels, layers 3 and 4 respectively. You can expect that the eBPF agent captures the network traffic passing through `br-ex` and `br-int`, when the network traffic is processed by other interfaces such as physical host or virtual pod interfaces. If you restrict the eBPF agent network interfaces to attach only to `br-ex` and `br-int`, you do not see any network flow.
 
 Manually remove the part in the `interfaces` or `excludeInterfaces` that restricts the network interfaces to `br-int` and `br-ex`.
 

--- a/modules/troubleshooting-network-observability-query-loki-manually.adoc
+++ b/modules/troubleshooting-network-observability-query-loki-manually.adoc
@@ -6,7 +6,10 @@
 [id="troubleshooting-query-loki-manually_{context}"]
 = Running custom queries to Loki
 
-For troubleshooting, can run custom queries to Loki. There are two examples of ways to do this, which you can adapt according to your needs by replacing the <api_token> with your own.
+[role="_abstract"]
+Troubleshoot network flow data by running custom Loki queries to retrieve available labels or filter logs by specific criteria, such as source namespaces, using the command-line interface.
+
+There are two examples of ways to do this, which you can adapt according to your needs by replacing the <api_token> with your own.
 
 [NOTE]
 ====
@@ -14,20 +17,20 @@ These examples use the `netobserv` namespace for the Network Observability Opera
 ====
 
 .Prerequisites
-* Installed Loki Operator for use with Network Observability Operator
+* Installed {loki-op} for use with Network Observability Operator.
 
 .Procedure
 
-* To get all available labels, run the following: 
+. To get all available labels, run the following command:
 +
 [source,terminal]
 ----
 $ oc exec deployment/netobserv-plugin -n netobserv -- curl -G -s -H 'X-Scope-OrgID:network' -H 'Authorization: Bearer <api_token>' -k https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network/loki/api/v1/labels | jq
 ----
 
-* To get all flows from the source namespace, `my-namespace`, run the following: 
+. To get all flows from the source namespace, `my-namespace`, run the following command:
 +
 [source,terminal]
 ----
-$ oc exec deployment/netobserv-plugin -n netobserv -- curl -G -s -H 'X-Scope-OrgID:network' -H 'Authorization: Bearer <api_token>' -k https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network/loki/api/v1/query --data-urlencode 'query={SrcK8S_Namespace="my-namespace"}' | jq 
+$ oc exec deployment/netobserv-plugin -n netobserv -- curl -G -s -H 'X-Scope-OrgID:network' -H 'Authorization: Bearer <api_token>' -k https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network/loki/api/v1/query --data-urlencode 'query={SrcK8S_Namespace="my-namespace"}' | jq
 ----


### PR DESCRIPTION
[OSDOCS-17458](https://issues.redhat.com//browse/OSDOCS-17458) [NETOBSERV] Module short descriptions for troubleshooting-network-observability.adoc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+ since migration related

Issue:
https://issues.redhat.com/browse/OSDOCS-17458

Link to docs preview:
* Using the must-gather tool: https://104530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html#network-observability-must-gather_network-observability-troubleshooting
* Configuring network traffic menu entry in the OpenShift Container Platform console: https://104530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html#configure-network-traffic-console_network-observability-troubleshooting
* Flowlogs-Pipeline does not consume network flows after installing Kafka: https://104530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html#configure-network-traffic-flowlogs-pipeline-kafka_network-observability-troubleshooting
* Failing to see network flows from both br-int and br-ex interfaces: https://104530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html#configure-network-traffic-interfaces_network-observability-troubleshooting
* Network observability controller manager pod runs out of memory: https://104530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html#controller-manager-pod-runs-out-of-memory_network-observability-troubleshooting
* Running custom queries to Loki: https://104530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html#troubleshooting-query-loki-manually_network-observability-troubleshooting
* Troubleshooting Loki ResourceExhausted error: https://104530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html#network-observability-troubleshooting-loki-resource-exhausted_network-observability-troubleshooting
* Loki empty ring error: https://104530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html#network-observability-troubleshooting-loki-empty-ring_network-observability-troubleshooting

Resource Troubleshooting:
* LokiStack rate limit errors: https://104530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html#network-observability-troubleshooting-loki-tenant-rate-limit_network-observability-troubleshooting
* Running a large query results in Loki errors: https://104530--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/troubleshooting-network-observability.html#network-observability-troubleshooting-large-query-timeout_network-observability-troubleshooting


QE review:
QE review is not required for this PR.

Additional information:
* This PR only adds `[role="_abstract"]`
* All other pre-migration related issues are being addressed by separate Jiras and their corresponding PRs in this Epic https://issues.redhat.com/browse/OSDOCS-14479
* In some instances, small file changes were made, or `mod_doc_type:` was adjusted to accurately reflect the content.
* There might be cherry-pick failures as not all modules apply to all OCP branches. If there are cherry-pick failures, I will create manual cherry-picks for appropriate branches.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
