### PR TITLE
CNV-27898: Install OCP Virt on IBM Cloud

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4745,6 +4745,9 @@ Topics:
   - Name: Uninstalling OKD Virtualization
     File: uninstalling-virt
     Distros: openshift-origin
+  - Name: Installing OpenShift Virtualization on IBM Cloud bare-metal nodes
+    File: virt-install-ibm-cloud-bm-nodes
+    Distros: openshift-enterprise
 - Name: Postinstallation configuration
   Dir: post_installation_configuration
   Topics:

--- a/modules/virt-install-ibm-cloud-cluster-network-access.adoc
+++ b/modules/virt-install-ibm-cloud-cluster-network-access.adoc
@@ -1,0 +1,89 @@
+// Module included in the following assemblies:
+//
+// * virt/install/virt-install-ibm-cloud-bm-nodes.adoc
+
+:_mod-docs-content-type: PROCEDURE 
+[id="virt-install-ibm-cloud-cluster-network-access_{context}"]
+= Configuring cluster networking and access
+
+[role="_abstract"]
+Configure networking and access to allow for remote management of the cluster.
+
+.Procedure
+. Edit `/etc/samba/smb.conf` to use the following configuration:
++
+[source,text]
+----
+[global]
+      log level = 3
+          workgroup = SAMBA
+          security = user
+
+          passdb backend = tdbsam
+
+          printing = cups
+          printcap name = cups
+          load printers = yes
+          cups options = raw
+
+      server min protocol = NT1
+      ntlm auth = yes
+
+[share]
+      comment = ISO Files
+      path = /root/share
+      browseable = yes
+      public = no
+      read only = no
+      directory mode = 0555
+      valid users = root
+----
++
+[NOTE]
+====
+For a more detailed example of the `smb.conf` file, see the `smb.conf.example` file in the same directory.
+====
+
+. Save the file.
+
+. Verify the new Samba configuration:
++
+[source,terminal]
+----
+$ testparm
+----
+
+. Restart the Samba service:
++
+[source,terminal]
+----
+$ systemctl restart smb
+----
+
+. Verify that the Samba service is running and active:
++
+[source,terminal]
+----
+$ systemctl status smb
+----
+
+. Configure SSL VPN access to {ibm-cloud-title}:
+.. Perform the procedure at link:https://cloud.ibm.com/docs/iaas-vpn?topic=iaas-vpn-getting-started[Getting started with {ibm-cloud-title} Virtual Private Networking] in the {ibm-cloud-title} documentation.
+.. Download and install the MotionPro SSL VPN client.
+.. Connect to the appropriate {ibm-cloud-title} endpoint:
++
+[source,terminal]
+----
+$ sudo MotionPro --host $<vpn_endpoint> --user $<vpn_username> --passwd $<vpn_password>
+----
++
+where:
+
+<vpn_endpoint>:: The appropriate SSL VPN endpoint.
+<vpn_username>:: The SSL VPN user name you configured.
+<vpn_password>:: The SSL VPN password you configured.
++
+[NOTE]
+====
+Connecting to the {ibm-cloud-title} SSL VPN will disconnect you from any open VPN connections.
+====

--- a/modules/virt-install-ibm-cloud-complete-cluster-config.adoc
+++ b/modules/virt-install-ibm-cloud-complete-cluster-config.adoc
@@ -1,0 +1,257 @@
+// Module included in the following assemblies:
+//
+// * virt/install/virt-install-ibm-cloud-bm-nodes.adoc
+
+:_mod-docs-content-type: PROCEDURE 
+[id="virt-install-ibm-cloud-complete-cluster-config_{context}"]
+= Completing the cluster configuration
+
+[role="_abstract"]
+Complete the cluster configuration by installing software on the control plane and compute nodes and configuring DNS for external access.
+
+.Procedure
+. For each bare-metal server, perform the following tasks:
+.. Access the server using the IPMI console.
++
+[NOTE]
+====
+The IP address and credentials for IPMI console access is available in the *Remote management* section for each server.
+====
+
+.. Mount the Assisted Installer ISO file with the following attributes:
++
+* *Virtual Media*: CD-ROM Image
+* *Share host*: The private IP address of the Bastion server.
+* *Path to image*: The location of the Assisted Installer ISO file.
+* *User*: root
+* *Password*: The root user password you configured.
+
+.. Click *Save and Mount*.
+.. Verify the ISO mounted successfully.
+.. Restart the server by selecting *Remote Control* -> *Power Control* -> *Reset Server* -> *Perform Action*.
+
+. Return to the *Assisted Installer* service.
+
+. Select the *Install {VirtProductName}* and *Install {rh-storage}* checkboxes in the *Assisted Installer* options.
+
+. Select a role for each host. 
++
+[NOTE]
+====
+The cluster consists of 3 control plane and 3 compute nodes.
+====
+
+. Wait for the *Assisted Installer* interface to indicate each node is ready.
+
+. Click *Next*.
+
+. Select *Cluster Managed Network*.
+
+. Select the *API VIP* and *Ingress VIP* checkboxes to obtain them from DHCP or leave them unchecked to enter static values.
+
+. Click *Install*.
+
+. For each bare-metal server, perform the following tasks:
+.. Access the server using the IPMI console.
++
+[NOTE]
+====
+The IP address and credentials for IPMI console access is available in the *Remote management* section for each server.
+====
+
+.. Select *Virtual Media* -> *CD-Rom Image*.
+.. Click *Unmount*.
+.. Select *Remote Control* -> *Power Control* -> *Reset Server* -> *Perform Action* to restart the server.
+
+. Locate the *Cluster Credentials* section of the installation summary.
+
+. Perform the following tasks in the *Cluster Credentials* section:
+.. Download the `kubeconfig` file.
+.. Save the `kubeadmin` password.
+
+. Install `haproxy` on the Bastion virtual server instance. 
+
+. Configure `haproxy` for your environment. The following is an example configuration:
++
+[source,text]
+----
+#---------------------------------------------------------------------
+# Example configuration for a possible web application.  See the
+# full configuration options online.
+#
+#   https://www.haproxy.org/download/1.8/doc/configuration.txt
+#
+#---------------------------------------------------------------------
+
+#---------------------------------------------------------------------
+# Global settings
+#---------------------------------------------------------------------
+global
+  # to have these messages end up in /var/log/haproxy.log you will
+  # need to:
+  #
+  # 1) configure syslog to accept network log events.  This is done
+  # by adding the '-r' option to the SYSLOGD_OPTIONS in
+  # /etc/sysconfig/syslog
+  #
+  # 2) configure local2 events to go to the /var/log/haproxy.log
+  #   file. A line like the following can be added to
+  #   /etc/sysconfig/syslog
+  #
+  # local2.*                    /var/log/haproxy.log
+  #
+  log       127.0.0.1 local2
+
+  chroot    /var/lib/haproxy
+  pidfile   /var/run/haproxy.pid
+  maxconn   4000
+  user      haproxy
+  group     haproxy
+  daemon
+
+  # turn on stats unix socket
+  stats socket /var/lib/haproxy/stats
+
+  # utilize system-wide crypto-policies
+  #ssl-default-bind-ciphers PROFILE=SYSTEM
+  #ssl-default-server-ciphers PROFILE=SYSTEM
+
+#---------------------------------------------------------------------
+# common defaults that all the 'listen' and 'backend' sections will
+# use if not designated in their block
+#---------------------------------------------------------------------
+defaults
+  mode                  tcp
+  log                   global
+  option                httplog
+  option                dontlognull
+  option http-server-close
+  option forwardfor     except 127.0.0.0/8
+  option                redispatch
+  retries               3
+  timeout http-request  10s
+  timeout queue         1m
+  timeout connect       10s
+  timeout client        1m
+  timeout server        1m
+  timeout http-keep-alive 10s
+  timeout check         10s
+  maxconn               3000
+#---------------------------------------------------------------------
+# main frontend which proxys to the backends
+#---------------------------------------------------------------------
+
+frontend api
+  bind <api_ip_address>:<api_port>
+  default_backend controlplaneapi
+
+frontend apiinternal
+  bind <apiinternal_ip_address>:<apiinternal_port>
+  default_backend controlplaneapiinternal
+
+frontend secure
+  bind <frontend_secure_ip_address>:<frontend_secure_port>
+  default_backend secure
+
+frontend insecure
+  bind <frontend_insecure_ip_address>:<frontend_insecure_port>
+  default_backend insecure
+
+#---------------------------------------------------------------------
+# static backend
+#---------------------------------------------------------------------
+
+backend controlplaneapi
+  balance source
+  server api <controlplaneapi_ip_address>:<controlplaneapi_port> check
+
+backend controlplaneapiinternal
+  balance source
+  server api <controlplaneapiinternal_ip_address>:<controlplaneapiinternal_port> check
+
+backend secure
+  balance source
+  server ingress <backend_secure_ip_address>:<backend_secure_port> check
+
+backend insecure
+  balance source
+  server ingress <backend_insecure_ip_address>:<backend_insecure_port> check
+----
++
+where:
+
+<api_ip_address>:<api_port>:: The front end IP address and port used by the Kubernetes API server.
+<apiinternal_ip_address>:<apiinternal_port>:: The front end IP address and port used for internal cluster management.
+<frontend_secure_ip_address>:<frontend_secure_port>:: The front end IP address and port used for HTTPS traffic for hosted applications.
+<frontend_insecure_ip_address>:<frontend_insecure_port>:: The front end IP address and port used for HTTP traffic for hosted applications.
+<controlplaneapi_ip_address>:<controlplaneapi_port>:: The back end IP address and port used by the Kubernetes API server.
+<controlplaneapiinternal_ip_address>:<controlplaneapiinternal_port>:: The back end IP address and port used for internal cluster management.
+<backend_secure_ip_address>:<backend_secure_port>:: The back end IP address and port used for HTTPS traffic for hosted applications.
+<backend_insecure_ip_address>:<backend_insecure_port>:: The back end IP address and port used for HTTP traffic for hosted applications.
++
+[NOTE]
+====
+Replace the example values with values applicable to your network configuration.
+====
+
+. Save the `haproxy` configuration.
+
+. Configure two DNS Address records (A records) for the subdomain that are externally available over the Internet:
++
+[source,text]
+----
+<bastion_public_ip_address> api.<cluster_name>.<cluster_domain>
+<bastion_public_ip_address> *.apps..<cluster_name>.<cluster_domain>
+----
++
+where:
+
+<bastion_public_ip_address>:: The externally available IP address of the Bastion virtual server instance.
+<cluster_name>:: The name assigned to the cluster.
+<cluster_domain>:: The domain assigned to the cluster.
+
+.Verification
+
+. Perform the following tasks to verify cluster access using command line access:
+.. Set your environment with the `kubeconfig` file:
++
+[source,terminal]
+----
+$ export KUBECONFIG=<kubeconfig_file_path>
+----
++
+where:
+
+<kubeconfig_file_path>:: The path to the downloaded `kubeconfig` file.
+.. Check cluster node status:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+[NOTE]
+====
+The command output should show all nodes as `Ready` in the `STATUS` column and the `ROLES` column should show that control plane and compute nodes are present.
+====
+.. Check the cluster version:
++
+[source, terminal]
+----
+$ oc get clusterversion
+----
++
+[NOTE]
+====
+The command output should say `Condition: Available`.
+====
+
+. Perform the following tasks to verify cluster access using the web console:
+.. Paste the access URL provided by Assisted Installer into your web browser.
++
+[NOTE]
+====
+By default, clusters use self-signed certificates. This may cause your browser to display a message that says *Connection not private* or a similar warning. You can close this warning and continue.
+====
+.. Navigate to the URL.
+.. Log in to the cluster with the username `kubeadmin` and the `kubeadmin` password provided in the *Cluster Credentials* section.

--- a/modules/virt-install-ibm-cloud-config-new-cluster.adoc
+++ b/modules/virt-install-ibm-cloud-config-new-cluster.adoc
@@ -1,0 +1,141 @@
+// Module included in the following assemblies:
+//
+// * virt/install/virt-install-ibm-cloud-bm-nodes.adoc
+
+:_mod-docs-content-type: PROCEDURE 
+[id="virt-install-ibm-cloud-config-new-cluster_{context}"]
+= Configuring {ibm-cloud-title} for the new cluster
+
+[role="_abstract"]
+Configure and provision the {ibm-cloud-title} environment to establish the operational framework and nodes for your {VirtProductName} cluster.
+
+.Procedure
+. Create a new virtual server instance in {ibm-cloud-title} at link:https://cloud.ibm.com/gen1/infrastructure/provision/vs[Virtual Server for Classic] to be the Bastion server. This instance is used to run the installation and provide environment services. 
+
+. Change the default properties of the new virtual server instance to the following values. Use the provided defaults for all other values.
++
+* *Type of virtual server:* Public
+* *Operating system:* CentOS
+* Your public SSH RSA key
+
+. Note the private VLAN and subnet the virtual server instance is assigned to at link:https://cloud.ibm.com/classic/network/vlans[VLANs].
+
+. Provision 6 bare-metal nodes in {ibm-cloud-title} at link:https://cloud.ibm.com/gen1/infrastructure/provision/bm[Bare metal server provision]. Use the following values when provisioning the nodes:
+
+* *Domain*: A subdomain you can add records to.
+* *Quantity*: 6
+* *Location*: The same location as the virtual server instance.
+* *Storage disks*: RAID 1
+* *Network Interface*: Private
+* *Private VLAN*: The same as noted for the virtual server instance.
+
+. Confirm all nodes are provisioned and ready at link:https://cloud.ibm.com/gen1/infrastructure/devices[Device list].
+
+. Rename the control plane nodes to `control0-<domain-name>`, `control1-<domain-name>`, and `control2-<domain-name>`. Replace `<domain-name>` with the domain used when provisioning the nodes.
+
+. Rename the compute nodes to `compute0-<domain-name>`, `compute1-<domain-name>`, and `compute2-<domain-name>`. Replace `<domain-name>` with the domain used when provisioning the nodes.
+
+. Configure the Bastion virtual server instance as a default network gateway.
+
+. Configure DHCP by editing `/etc/dhcp/dhcpd.conf` on the Bastion virtual server instance. For example:
++
+[source,text]
+----
+# Set DNS name and DNS server's IP address or hostname
+option domain-name  <dns_domain_name>;
+option domain-name-servers  <dns_ip_addresses>;
+
+# Declare DHCP Server
+authoritative;
+
+# The default DHCP lease time
+default-lease-time <default_lease_value>;
+
+# Set the maximum lease time
+max-lease-time <max_lease_value>;
+
+# Set Network address, subnet mask and gateway
+
+subnet <subnet_ip_address> netmask <subnet_mask> {
+  # Range of IP addresses to allocate
+  range dynamic-bootp <dynamic_boot_lower_address> <dynamic_boot_upper_address>;
+  # Provide broadcast address
+  option broadcast-address <broadcast_ip_address>;
+  # Set default gateway
+  option routers <default_gateway_ip_address>;
+----
++
+where:
+
+<dns_domain_name>:: The default domain name for DNS clients.
+<dns_ip_addresses>:: A comma-seperated list of DNS server IP addresses.
+<default_lease_value>:: The default number of seconds a client keeps an assigned address.
+<max_lease_value>:: The maximum number of seconds a client keeps an assigned address.
+<subnet_ip_address>:: The start of the subnet IP address range.
+<subnet_mask>:: The subnet mask of the subnet IP address range.
+<broad_ip_address>:: The broadcast IP address to use when to use sending a message to every device on the subnet.
+<default_gateway_ip_address>:: The default gateway of the subnet.
+
+. Restart DHCP on the Bastion virtual server instance:
++
+[source,terminal]
+----
+$ systemctl restart dhcpd
+----
+
+. Enable IP forwarding on the Bastion virtual server instance:
++
+[source,terminal]
+----
+$ sysctl -w net.ipv4.ip_forward=1
+----
+
+. Verify IP forwarding is enabled on the Bastion virtual server instance:
++
+[source,terminal]
+----
+$ sysctl -p /etc/sysctl.conf
+----
+
+. Restart the network service on the Bastion virtual server instance:
++
+[source,terminal]
+----
+$ service network restart
+----
+
+. Verify if `firewalld` is enabled on the Bastion virtual server instance:
++
+[source,terminal]
+----
+$ firewall-cmd --state
+----
+
+. If the `firewalld` service is not enabled on the Bastion virtual server instance, enable the service:
++
+[source,terminal]
+----
+$ systemctl enable firewalld
+----
+
+. Start the `firewalld` service:
++
+[source,terminal]
+----
+$ systemctl start firewalld
+----
+
+
+. Add network address translation (NAT) rules to the `firewalld` service:
++
+[source,terminal]
+----
+$ firewall-cmd --add-masquerade --permanent
+----
+
+. Restart the `firewalld` service:
++
+[source,terminal]
+----
+$ firewall-cmd --reload
+----

--- a/modules/virt-install-ibm-cloud-initialize-new-cluster.adoc
+++ b/modules/virt-install-ibm-cloud-initialize-new-cluster.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * virt/install/virt-install-ibm-cloud-bm-nodes.adoc
+
+:_mod-docs-content-type: PROCEDURE 
+[id="virt-install-ibm-cloud-initialize-new-cluster_{context}"]
+= Initializing the new cluster configuration
+
+[role="_abstract"]
+Initialize the new cluster configuration using the {VirtProductName} Assisted Installer service and Samba on the Bastion virtual server instance.
+
+.Procedure
+. Log in to the *Assisted Installer* service.
+
+. Create a new cluster. The new cluster has the following properties:
+
+* *Cluster name*: The name used to identify the cluster under the base domain.
+* *Base domain*: The domain used to provision the bare-metal nodes.
+
+. Click *Next*.
+
+. Click *Generate Discovery ISO*.
+
+. Provide your public SSH RSA key when prompted. 
+
+. Copy and save the generated `wget` command for the ISO file. This will be used later to connect to the cluster nodes.
+
+. Install Samba server on the Bastion virtual server instance:
++
+[source,terminal]
+----
+$ dnf install samba
+----
+
+. Enable Samba server on the Bastion virtual server instance:
++
+[source,terminal]
+----
+$ systemctl enable smb --now
+----
+
+. Configure NAT rules for the Samba server:
++
+[source,terminal]
+----
+$ firewall-cmd --permanent --zone=FedoraWorkstation --add-service=samba
+$ firewall-cmd --reload
+----
+
+. Configure a root user password:
++
+[source,terminal]
+----
+$ sudo smbpasswd -a root
+----
+
+. Create a share directory:
++
+[source,terminal]
+----
+$ mkdir <share_directory>
+----
++
+Replace `<share_directory>` with the share directory name.
+
+. Navigate to the share directory and download the Assisted Installer ISO file using the generated `wget` command.

--- a/virt/install/virt-install-ibm-cloud-bm-nodes.adoc
+++ b/virt/install/virt-install-ibm-cloud-bm-nodes.adoc
@@ -1,0 +1,28 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="virt-install-ibm-cloud-bm-nodes"]
+
+= Installing {VirtProductName} on {ibm-cloud-title} bare-metal nodes
+
+:context: virt-install-ibm-cloud-bm-nodes 
+
+toc::[]
+
+[role="_abstract"]
+Install {VirtProductName} on {ibm-cloud-title} bare-metal nodes using Assisted Installer. The cluster has 6 bare-metal nodes (3 control and 3 compute). An additional virtual machine is required for bootstrapping and to act as a Samba server, DHCP server, network gateway, and load balancer.
+
+== Prerequisites
+
+* An account in {ibm-cloud-title} with permissions to order and operate bare-metal nodes.
+* An {ibm-cloud-title} SSL VPN user, to access the SuperMicro IPMI interface of a node.
+* Install the OpenShift CLI (`oc`).
+
+
+include::modules/virt-install-ibm-cloud-config-new-cluster.adoc[leveloffset=+1]
+
+include::modules/virt-install-ibm-cloud-initialize-new-cluster.adoc[leveloffset=+1]
+
+include::modules/virt-install-ibm-cloud-cluster-network-access.adoc[leveloffset=+1]
+
+include::modules/virt-install-ibm-cloud-complete-cluster-config.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Add content for installing CNV on IBM Cloud bare metal nodes.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21

Issue:
[CNV-27898](https://issues.redhat.com/browse/CNV-27898)

Link to docs preview:
[Installing OpenShift Virtualization on IBM Cloud bare-metal nodes](https://104533--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/virt-install-ibm-cloud-bm-nodes.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
