### PR TITLE
TELCODOCS#2534: Removed TP note for the PolicyGenerator with ZTP feature

### DIFF
--- a/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
+++ b/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.adoc
@@ -11,13 +11,7 @@ toc::[]
 You can use the {cgu-operator-first} to manage the software lifecycle of managed clusters that you have deployed using {ztp-first} and {cgu-operator-first}.
 {cgu-operator} uses {rh-rhacm-first} {policy-gen-cr} policies to manage and control changes applied to target clusters.
 
-:Featurename: Using PolicyGenerator resources with {ztp}
-include::snippets/technology-preview.adoc[]
-
-[role="_additional-resources"]
-.Additional resources
-
-* For more information about the {cgu-operator-full}, see xref:../../edge_computing/cnf-talm-for-cluster-upgrades.adoc#cnf-about-topology-aware-lifecycle-manager-config_cnf-topology-aware-lifecycle-manager[About the {cgu-operator-full}].
+For more information about the {cgu-operator-full}, see xref:../../edge_computing/cnf-talm-for-cluster-upgrades.adoc#cnf-about-topology-aware-lifecycle-manager-config_cnf-topology-aware-lifecycle-manager[About the {cgu-operator-full}].
 
 include::modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[TELCODOCS-2534](https://issues.redhat.com/browse/TELCODOCS-2534)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Updating managed clusters in a disconnected environment with PolicyGenerator resources and TALM](https://104544--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/policygenerator_for_ztp/ztp-talm-updating-managed-policies-pg.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->