### PR TITLE
OSDOCS-15167: Documented the Example: Network interface with a predic…

### DIFF
--- a/modules/virt-example-predictable-route-table-id.adoc
+++ b/modules/virt-example-predictable-route-table-id.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="virt-example-predictable-route-table-id_{context}"]
+= Example: Network interface with a predictable route table ID
+
+[role="_abstract"]
+To simplify network administration and reduce configuration errors in {product-title}, configure routes by using names instead of Virtual Routing and Forwarding (VRF) routing table ID numbers. 
+
+Using human-readable names ensures that network routes are easier to identify and maintain without tracking abstract numerical identifiers.
+
+The following `NodeNetworkConfigurationPolicy` (NNCP) YAML file shows an example of creating a VRF instance and applying a route to the VRF instance. The VRF instance uses the stable method of referencing the VRF by name rather than a potentially shifting ID.
+
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: vrf-predictable-policy
+spec:
+  nodeSelector:
+    vrf: "true"
+  maxUnavailable: 3
+  desiredState:
+    interfaces:
+      - name: vrf0
+        type: vrf
+        state: up
+        vrf:
+          route-table-id: 100
+          port:
+            - eth1
+            - eth2
+    routes:
+      config:
+        - destination: 198.51.200.0/24
+          route-type: blackhole
+          vrf-name: vrf0
+# ...
+----
+
+where:
+--
+`spec.nodeSelector.vrf`:: Specifies the application of the policy only to nodes that have the `vrf: true` label. This configuration prevents accidental network changes on nodes that do not require VRF support.
+`spec.desiredState.interfaces.type`:: Specifies the creation of a VRF-type interface.
+`spec.desiredState.interfaces.vrf.route-table-id`:: Specifies the `route-table-id` that the `vrf` name maps to in the routing table.
+`spec.desiredState.routes.config.route-type`:: Specifies the route type. NetworkManager supports the `unicast`, `local`, `blackhole`, `unreachable`, `prohibit`, and `throw` route types. The default is unicast. The example sets a `blackhole` route that drops any packets within the IP address range of this route. The range for the `blackhole` route is the destination CIDR, such as `198.51.200.0/24`.
+`spec.desiredState.routes.config.vrf-name`:: Specifies a stable link in that if a policy changes the `route-table-id` parameter to a different value, the route automatically follows the `vrf0` name to the new ID. You do not need to manually update the route configuration.
+--

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -115,6 +115,10 @@ include::modules/virt-example-vf-host-services.adoc[leveloffset=+2]
 // Example: Network interface with a VRF instance node network configuration policy
 include::modules/virt-example-host-vrf.adoc[leveloffset=+2]
 
+// Example: Network interface with a predictable route table ID
+include::modules/virt-example-predictable-route-table-id.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
 .Additional resources
 
 * xref:../../networking/multiple_networks/about-virtual-routing-and-forwarding.adoc#cnf-about-virtual-routing-and-forwarding_about-virtual-routing-and-forwarding[About virtual routing and forwarding]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-15167](https://issues.redhat.com/browse/OSDOCS-15167)

Link to docs preview:
 [Example: Network interface with a predictable route table ID](https://104549--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-predictable-route-table-id_k8s-nmstate-updating-node-network-config)

- [x] SME has approved this change.
- [x] QE has approved this change.

https://github.com/nmstate/nmstate/pull/3016
https://github.com/nmstate/kubernetes-nmstate/pull/1399
