### PR TITLE
DOCPLAN-32: Remove callouts

### DIFF
--- a/modules/virt-node-placement-rule-examples.adoc
+++ b/modules/virt-node-placement-rule-examples.adoc
@@ -23,7 +23,7 @@ To specify the nodes where OLM deploys the {VirtProductName} Operators, edit the
 
 Currently, you cannot configure node placement rules for the `Subscription` object by using the web console.
 
-The `Subscription` object does not support the `affinity` node pplacement rule.
+The `Subscription` object does not support the `affinity` node placement rule.
 
 Example `Subscription` object with `nodeSelector` rule:
 
@@ -42,9 +42,10 @@ spec:
   channel: "stable"
   config:
     nodeSelector:
-      example.io/example-infra-key: example-infra-value <1>
+      example.io/example-infra-key: example-infra-value
 ----
-<1> OLM deploys the {VirtProductName} Operators on nodes labeled `example.io/example-infra-key = example-infra-value`.
+
+OLM deploys the {VirtProductName} Operators on nodes labeled `example.io/example-infra-key = example-infra-value`.
 
 Example `Subscription` object with `tolerations` rule:
 
@@ -68,13 +69,14 @@ spec:
       value: "virtualization" <1>
       effect: "NoSchedule"
 ----
-<1> OLM deploys {VirtProductName} Operators on nodes labeled `key = virtualization:NoSchedule` taint. Only pods with the matching tolerations are scheduled on these nodes.
+
+OLM deploys {VirtProductName} Operators on nodes labeled `key = virtualization:NoSchedule` taint. Only pods with the matching tolerations are scheduled on these nodes.
 endif::openshift-rosa,openshift-dedicated[]
 
 [id="hyperconverged-object-node-placement-rules_{context}"]
 == HyperConverged object node placement rule example
 
-To specify the nodes where {VirtProductName} deploys its components, you can edit the `nodePlacement` object in the HyperConverged custom resource (CR) file that you create during {VirtProductName} installation.
+To specify the nodes where {VirtProductName} deploys its components, you can edit the `nodePlacement` object in the `HyperConverged` custom resource (CR) file that you create during {VirtProductName} installation.
 
 Example `HyperConverged` object with `nodeSelector` rule:
 
@@ -95,8 +97,9 @@ spec:
       nodeSelector:
         example.io/example-workloads-key: example-workloads-value <2>
 ----
-<1> Infrastructure resources are placed on nodes labeled `example.io/example-infra-key = example-infra-value`.
-<2> workloads are placed on nodes labeled `example.io/example-workloads-key = example-workloads-value`.
+
+* Infrastructure resources are placed on nodes labeled `example.io/example-infra-key = example-infra-value`.
+* Workloads are placed on nodes labeled `example.io/example-workloads-key = example-workloads-value`.
 
 Example `HyperConverged` object with `affinity` rule:
 
@@ -139,9 +142,10 @@ spec:
                 values:
                 - 8 <3>
 ----
-<1> Infrastructure resources are placed on nodes labeled `example.io/example-infra-key = example-value`.
-<2> workloads are placed on nodes labeled `example.io/example-workloads-key = example-workloads-value`.
-<3> Nodes that have more than eight CPUs are preferred for workloads, but if they are not available, pods are still scheduled.
+
+* Infrastructure resources are placed on nodes labeled `example.io/example-infra-key = example-value`.
+* Workloads are placed on nodes labeled `example.io/example-workloads-key = example-workloads-value`.
+* Nodes that have more than eight CPUs are preferred for workloads, but if they are not available, pods are still scheduled.
 
 Example `HyperConverged` object with `tolerations` rule:
 
@@ -161,7 +165,8 @@ spec:
         value: "virtualization"
         effect: "NoSchedule"
 ----
-<1> Nodes reserved for {VirtProductName} components are labeled with the `key = virtualization:NoSchedule` taint. Only pods with matching tolerations are scheduled on reserved nodes.
+
+Nodes reserved for {VirtProductName} components are labeled with the `key = virtualization:NoSchedule` taint. Only pods with matching tolerations are scheduled on reserved nodes.
 
 [id="hostpathprovisioner-object-node-placement-rules_{context}"]
 == HostPathProvisioner object node placement rule example
@@ -170,10 +175,10 @@ You can edit the `HostPathProvisioner` object directly or by using the web conso
 
 [WARNING]
 ====
-You must schedule the hostpath provisioner and the {VirtProductName} components on the same nodes. Otherwise, virtualization pods that use the hostpath provisioner cannot run. You cannot run virtual machines.
+You must schedule the hostpath provisioner (HPP) and the {VirtProductName} components on the same nodes. Otherwise, virtualization pods that use the hostpath provisioner cannot run. You cannot run virtual machines.
 ====
 
-After you deploy a virtual machine (VM) with the hostpath provisioner (HPP) storage class, you can remove the hostpath provisioner pod from the same node by using the node selector. However, you must first revert that change, at least for that specific node, and wait for the pod to run before trying to delete the VM.
+After you deploy a virtual machine (VM) with the HPP storage class, you can remove the hostpath provisioner pod from the same node by using the node selector. However, you must first revert that change, at least for that specific node, and wait for the pod to run before trying to delete the VM.
 
 You can configure node placement rules by specifying `nodeSelector`, `affinity`, or `tolerations` for the `spec.workload` field of the `HostPathProvisioner` object that you create when you install the hostpath provisioner.
 
@@ -194,4 +199,5 @@ spec:
     nodeSelector:
       example.io/example-workloads-key: example-workloads-value <1>
 ----
-<1> Workloads are placed on nodes labeled `example.io/example-workloads-key = example-workloads-value`.
+
+Workloads are placed on nodes labeled `example.io/example-workloads-key = example-workloads-value`.


### PR DESCRIPTION
Version(s):
4.14+
(file doesn't appear to have been present in earlier versions)

Issue:
https://issues.redhat.com/browse/DOCPLAN-32

Link to docs preview:
https://104566--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-node-placement-virt-components.html

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
