### PR TITLE
OSDOCS-17786 Openshift Bare metal: Configure containers to set readOnlyRootFilesystem to true

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -191,6 +191,9 @@ Item description::
 Detailed information.
 ////
 
+Bare Metal Operator has read-only root filesystem by default::
++
+As of this update, the Bare Metal Operator has the `readOnlyRootFilesystem` security context setting enabled to meet common hardening recommendations.
 
 [id="ocp-release-notes-operator-lifecycle_{context}"]
 == Operator lifecycle


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-17786

Link to docs preview:
https://104570--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-operator-development_release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

