### PR TITLE
OSDOCS-17219 BareMetalHost with self-signed CA certs for BMCs

### DIFF
--- a/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+++ b/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-After successfully deploying a bare-metal cluster, consider the following postinstallation procedures.
+[role="_abstract"]
+After successfully deploying a bare-metal cluster, you can perform post installation procedures such as configuring NTP, enabling a provisioning network, and configuring a user-managed load balancer. Customizing your cluster can help you prepare the cluster for specific workloads and deployment requirements.
 
 //About the cluster API
 include::modules/bare-metal-about-the-cluster-api.adoc[leveloffset=+1]
@@ -19,6 +20,17 @@ include::modules/bare-metal-about-the-cluster-api.adoc[leveloffset=+1]
 
 // Configuring NTP for disconnected clusters
 include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+1]
+
+include::modules/bare-metal-self-signed-cert-post-install.adoc[leveloffset=+1]
+
+include::modules/bare-metal-replace-existing-bmc-ca.adoc[leveloffset=+2]
+
+include::modules/bare-metal-install-new-bmc-ca.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bmo-editing-a-baremetalhost-resource_bare-metal-postinstallation-configuration[Editing a BareMetalHost resource]
 
 // Enabling a provisioning network after installation
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]

--- a/modules/bare-metal-install-new-bmc-ca.adoc
+++ b/modules/bare-metal-install-new-bmc-ca.adoc
@@ -1,0 +1,57 @@
+// This is included in the following assemblies:
+//
+// installing/installing_bare_metal/ipi/bare-metal-postinstallation-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="bare-metal-install-new-bmc-ca_{context}"]
+= Installing a new BMC CA certificate
+
+[role="_abstract"]
+You can install a local or self-signed BMC CA certificate on a cluster which was installed without a BMC CA certificate. Providing your own BMC CA certificate secures the communication between your cluster and BMC's.
+
+.Prerequisites
+
+* You installed a cluster on bare metal without a BMC CA certificate.
+* You have a local or self-signed CA certificate.
+
+.Procedure
+
+. Create a file called `bmc-verify-ca.yaml` using a text editor, with the following contents:
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  verify_ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    <self_signed_certificate_contents>
+    -----END CERTIFICATE-----
+kind: ConfigMap
+metadata:
+  name: bmc-verify-ca
+  namespace: openshift-machine-api
+----
++
+where:
+
+`<self_signed_certificate_contents>`:: Specifies the contents of your local or self-signed CA certificate.
+
+. Apply the ConfigMap by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f bmc-verify-ca.yaml
+----
+
+. Verify that the ConfigMap has been mounted in the Ironic container by running the following command:
++
+[source,terminal]
+----
+$ oc exec -n openshift-machine-api \
+  $(oc get pods -n openshift-machine-api -l app=metal3 -o jsonpath='{.items[0].metadata.name}') \
+  -c metal3-ironic -- ls -l /certs/ca/bmc
+----
++
+If successful, the command should display the certificate file.
+
+. For each bare metal host in your cluster that you want to secure BMC communications with, follow the procedure titled _Editing a BareMetalHost resource_ and ensure that the `disableCertificateVerification` parameter is set to `false`.

--- a/modules/bare-metal-replace-existing-bmc-ca.adoc
+++ b/modules/bare-metal-replace-existing-bmc-ca.adoc
@@ -1,0 +1,42 @@
+// This is included in the following assemblies:
+//
+// installing/installing_bare_metal/ipi/bare-metal-postinstallation-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="bare-metal-replace-existing-bmc-ca_{context}"]
+= Replacing an existing BMC CA certificate
+
+[role="_abstract"]
+You can replace the BMC CA certificate with your own local or self-signed CA certificate by editing the `bmc-verify-ca` ConfigMap in the `openshift-machine-api` namespace. Providing your own CA certificate gives you control over the secure communications between your cluster and BMC's.
+
+.Prerequisites
+
+* You have installed a cluster on bare metal.
+* You configured a CA certificate for BMC communication when you installed the cluster.
+* You have a local or self-signed CA certificate.
+
+.Procedure
+
+. Edit the `bmc-verify-ca` ConfigMap by running the following command:
++
+[source,terminal]
+----
+$ oc edit configmap bmc-verify-ca -n openshift-machine-api
+----
+
+. Replace the contents of the `verify_ca.crt` stanza with your local or self-signed CA certificate, as in the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+data:
+  verify_ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    <self_signed_certificate_contents>
+    -----END CERTIFICATE-----
+kind: ConfigMap
+----
++
+where:
+
+`<self_signed_certificate_contents>`:: Specifies the contents of your local or self-signed CA certificate.

--- a/modules/bare-metal-self-signed-cert-post-install.adoc
+++ b/modules/bare-metal-self-signed-cert-post-install.adoc
@@ -1,0 +1,10 @@
+// This is included in the following assemblies:
+//
+// installing/installing_bare_metal/ipi/bare-metal-postinstallation-configuration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="bare-metal-self-signed-cert-post-install_{context}"]
+= Configuring a local or self-signed Baseboard Management Controller CA certificate
+
+[role="_abstract"]
+You can configure a local or self-signed Baseboard Management Controller (BMC) CA certificate on a cluster that already has a CA certificate, or add one to a cluster that was installed without a CA certificate. Providing a local or self-signed CA certificate gives you more control over secure communication with bare metal BMC's.

--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -4,16 +4,16 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="additional-install-config-parameters_{context}"]
-= Additional `install-config` parameters
+= Additional installation configuration parameters
 
-See the following tables for the required parameters, the `hosts` parameter, and the `bmc` parameter for the `install-config.yaml` file.
+[role="_abstract"]
+Some parameters, such as the cluster domain name, are required in the `install-config.yaml` file when installing a cluster on bare metal. Others, such as the provisioning network CIDR, are optional.
 
 [cols="4,1,5"]
 [options="header"]
 .Required parameters
 |===
 |Parameters |Default |Description
-
 
 | `baseDomain`
 |
@@ -23,41 +23,40 @@ See the following tables for the required parameters, the `hosts` parameter, and
 | `UEFI`
 | The boot mode for a node. Options are `legacy`, `UEFI`, and `UEFISecureBoot`. If `bootMode` is not set, Ironic sets it while inspecting the node.
 
-a| 
+a|
 ----
 platform:
-  baremetal: 
+  baremetal:
     bootstrapExternalStaticDNS
 ----
 |
 | The static network DNS of the bootstrap node. You must set this value when deploying a cluster with static IP addresses when there is no Dynamic Host Configuration Protocol (DHCP) server on the bare-metal network. If you do not set this value, the installation program will use the value from `bootstrapExternalStaticGateway`, which causes problems when the IP address values of the gateway and DNS are different.
 
-a| 
+a|
 ----
 platform:
   baremetal:
     bootstrapExternalStaticIP
 ----
 |
-| The static IP address for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare-metal network.
+| The static IP address for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare metal network.
 
-a| 
+a|
 ----
 platform:
   baremetal:
     bootstrapExternalStaticGateway
 ----
 |
-| The static IP address of the gateway for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare-metal network.
+| The static IP address of the gateway for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare metal network.
 
 | `sshKey`
 |
-| The `sshKey` configuration setting has the key in the `~/.ssh/id_rsa.pub` file required to access the control plane nodes and compute nodes. Typically, this key is from the `provisioner` node.
+| The `sshKey` parameter sets the key in the `~/.ssh/id_rsa.pub` file required to access the control plane nodes and compute nodes. Typically, this key is from the `provisioner` node.
 
 | `pullSecret`
 |
-| The `pullSecret` configuration setting has a copy of the pull secret downloaded from the link:https://console.redhat.com/openshift/install/metal/user-provisioned[Install OpenShift on Bare Metal] page when preparing the provisioner node.
-
+| The `pullSecret` parameter sets a copy of the pull secret downloaded from the link:https://console.redhat.com/openshift/install/metal/user-provisioned[Install OpenShift on Bare Metal] page when preparing the provisioner node.
 
 a|
 ----
@@ -65,8 +64,7 @@ metadata:
     name:
 ----
 |
-|The name of the {product-title} cluster. For example, `openshift`.
-
+|The {product-title} cluster name. For example, `openshift`.
 
 a|
 ----
@@ -83,8 +81,7 @@ compute:
   - name: worker
 ----
 |
-|The {product-title} cluster requires you to provide a name for compute nodes even if there are zero nodes.
-
+|The {product-title} cluster requires a name for each compute node even if there are zero nodes.
 
 a|
 ----
@@ -94,7 +91,6 @@ compute:
 |
 |Replicas sets the number of compute nodes in the {product-title} cluster.
 
-
 a|
 ----
 controlPlane:
@@ -102,7 +98,6 @@ controlPlane:
 ----
 |
 |The {product-title} cluster requires a name for control plane nodes.
-
 
 a|
 ----
@@ -112,25 +107,7 @@ controlPlane:
 |
 |Replicas sets the number of control plane nodes included as part of the {product-title} cluster.
 
-a|
-----
-arbiter:
-    name: arbiter
-----
-|
-|The {product-title} cluster requires a name for arbiter nodes.
-
-
-a|
-----
-arbiter:
-    replicas: 1
-----
-|
-|The `replicas` parameter sets the number of arbiter nodes for the {product-title} cluster.
-
-a| `provisioningNetworkInterface` |  | The name of the network interface on nodes connected to the provisioning network. For {product-title} 4.9 and later releases, use the `bootMACAddress` configuration setting to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` configuration setting to identify the name of the NIC.
-
+a| `provisioningNetworkInterface` |  | The name of the network interface on nodes connected to the provisioning network. For {product-title} 4.9 and later releases, use the `bootMACAddress` parameter to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` parameter to identify the name of the NIC.
 
 | `defaultMachinePlatform` | | The default configuration used for machine pools without a platform configuration.
 
@@ -140,11 +117,10 @@ You must either provide this setting in the `install-config.yaml` file as a rese
 
 [NOTE]
 ====
-Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or an IPv6 address for the `apiVIP` configuration setting. From {product-title} 4.12 or later, the `apiVIP` configuration setting is deprecated. Instead, use a list format for the `apiVIPs` configuration setting to specify an IPv4 address, an IPv6 address or both IP address formats.
+Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or an IPv6 address for the `apiVIP` parameter. From {product-title} 4.12 or later, the `apiVIP` parameter is deprecated. Instead, use a list format for the `apiVIPs` parameter to specify an IPv4 address, an IPv6 address or both IP address formats.
 ====
 
-
-| `disableCertificateVerification` | `False` | `redfish` and `redfish-virtualmedia` need this parameter to manage BMC addresses. The value should be `True` when using a self-signed certificate for BMC addresses.
+| `bmcCACert` | | `redfish` and `redfish-virtualmedia` need this parameter to manage BMC addresses when using self-signed certificates with `disableCertificateVerification` set to `False`.
 
 | `ingressVIPs` | a| (Optional) The virtual IP address for ingress traffic.
 
@@ -152,7 +128,7 @@ You must either provide this setting in the `install-config.yaml` file as a rese
 
 [NOTE]
 ====
-Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or an IPv6 address for the `ingressVIP` configuration setting. In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a list format for the `ingressVIPs` configuration setting to specify an IPv4 addresses, an IPv6 addresses or both IP address formats.
+Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or an IPv6 address for the `ingressVIP` parameter. In {product-title} 4.12 and later, the `ingressVIP` parameter is deprecated. Instead, use a list format for the `ingressVIPs` parameter to specify an IPv4 addresses, an IPv6 addresses or both IP address formats.
 ====
 
 |===
@@ -181,7 +157,7 @@ platform:
 
 a|`provisioningNetworkCIDR`
 |`172.22.0.0/24`
-|The CIDR for the network to use for provisioning. The installation program requires this option when not using the default address range on the provisioning network.
+|The CIDR for the network to use for provisioning. When not using the default address range on the provisioning network, you must set this configuration parameter.
 
 |`clusterProvisioningIP`
 |The third IP address of the `provisioningNetworkCIDR`.
@@ -189,11 +165,11 @@ a|`provisioningNetworkCIDR`
 
 |`bootstrapProvisioningIP`
 |The second IP address of the `provisioningNetworkCIDR`.
-|The IP address on the bootstrap VM where the provisioning services run while the installation program is deploying the control plane (master) nodes. Defaults to the second IP address of the provisioning subnet. For example, `172.22.0.2` or `2620:52:0:1307::2`.
+|The IP address on the bootstrap VM where the provisioning services run while the installation program is deploying the control plane nodes. Defaults to the second IP address of the provisioning subnet. For example, `172.22.0.2` or `2620:52:0:1307::2`.
 
 | `externalBridge`
 | `baremetal`
-| The name of the bare-metal bridge of the hypervisor attached to the bare-metal network.
+| The name of the bare metal bridge of the hypervisor attached to the bare metal network.
 
 | `provisioningBridge`
 | `provisioning`
@@ -214,9 +190,9 @@ a|`provisioningNetworkCIDR`
 
 | `provisioningNetwork`
 |
-| The `provisioningNetwork` configuration setting determines whether the cluster uses the provisioning network. If it does, the configuration setting also determines if the cluster manages the network.
+| The `provisioningNetwork` parameter determines whether the cluster uses the provisioning network. If it does, the parameter also determines if the cluster manages the network.
 
-`Disabled`: Set this parameter to `Disabled` to disable the requirement for a provisioning network. When set to `Disabled`, you must only use virtual media based provisioning, or start the cluster by using the {ai-full}. If set to `Disabled` and using power management, BMCs must be accessible from the bare-metal network. If set to `Disabled`, you must provide two IP addresses on the bare-metal network that the installation program uses for the provisioning services.
+`Disabled`: Set this parameter to `Disabled` to disable the requirement for a provisioning network. When set to `Disabled`, you must only use virtual media based provisioning, or install the cluster by using the Assisted Installer. If `Disabled` and using power management, BMCs must be accessible from the bare metal network. If `Disabled`, you must provide two IP addresses on the bare metal network for the provisioning services to use.
 
 `Managed`: Set this parameter to `Managed`, which is the default, to fully manage the provisioning network, including DHCP, TFTP, and so on.
 
@@ -241,7 +217,7 @@ a|`provisioningNetworkCIDR`
 
 The `hosts` parameter is a list of separate bare metal assets used to build the cluster.
 
-[width="100%", cols="3,2,5",  options="header"]
+[width="100%", cols="4,1,4",  options="header"]
 .Hosts
 |===
 |Name |Default |Description
@@ -249,10 +225,9 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 |
 | The name of the `BareMetalHost` resource to associate with the details. For example, `openshift-master-0`.
 
-
 | `role`
 |
-| The role of the bare-metal node. Either `master` (control plane node) or `worker` (compute node).
+| The role of the bare metal node. Either `master` (control plane node) or `worker` (compute node).
 
 
 | `bmc`
@@ -260,9 +235,52 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 | Connection details for the baseboard management controller. See the BMC addressing section for additional details.
 
 
+a|
+----
+bmc:
+    address:
+----
+|
+| The protocol and address of the BMC as a URL.
+
+a|
+----
+bmc:
+    username:
+----
+|
+| The username of the BMC.
+
+a|
+----
+bmc:
+    password:
+----
+|
+| The password of the BMC.
+
+
+a|
+----
+bmc:
+    disableCertificateVerification:
+----
+| `False`
+| `redfish` and `redfish-virtualmedia` need this parameter to manage BMC addresses. For {product-title} 4.16 and earlier, the value should be `True` when using a self-signed certificate. {product-title} supports self-signed certificates with certificate verification when used with the `bmcVerifyCA` parameter.
+
+a|
+----
+platform:
+  baremetal:
+    bmcVerifyCA:
+----
+|
+| A local or self-signed CA certificate that the installation program will use to secure communication with the BMC. If you specify your own CA certificate, ensure that `disableCertificateVerification` is set to `False` so that the user-provided CA certificate is validated.
+
+
 | `bootMACAddress`
 |
-a| The MAC address of the NIC that the host uses for the provisioning network. Ironic retrieves the IP address using the `bootMACAddress` configuration setting. Then, it binds to the host.
+a| The MAC address of the NIC that the host uses for the provisioning network. Ironic retrieves the IP address by using the `bootMACAddress` parameter. Then, it binds to the host.
 
 [NOTE]
 ====

--- a/modules/ipi-install-bmc-addressing-for-cisco-cimc.adoc
+++ b/modules/ipi-install-bmc-addressing-for-cisco-cimc.adoc
@@ -4,27 +4,13 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="bmc-addressing-for-cisco-cimc_{context}"]
-= BMC addressing for Cisco CIMC
+= BMC addressing for Cisco Integrated Management Controller
 
-The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
-
-[source,yaml]
-----
-platform:
-  baremetal:
-    hosts:
-      - name: <hostname>
-        role: <master | worker>
-        bmc:
-          address: <address> <1>
-          username: <user>
-          password: <password>
-----
-<1> The `address` configuration setting specifies the protocol.
+[role="_abstract"]
+You can connect to a Cisco Integrated Management Controller (CIMC) system using the Redfish virtual media protocol. The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
 
 For Cisco UCS C-Series and X-Series servers, Red Hat supports Cisco Integrated Management Controller (CIMC).
 
-.BMC address format for Cisco CIMC
 [width="100%", cols="1,3", options="header"]
 |====
 |Protocol|Address Format

--- a/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
+++ b/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
@@ -3,28 +3,13 @@
 // installing/installing_bare_metal/ipi/ipi-install-configuration-files.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id='bmc-addressing-for-dell-idrac_{context}']
+[id="bmc-addressing-for-dell-idrac_{context}"]
 = BMC addressing for Dell iDRAC
 
+[role="_abstract"]
+You can configure the `bmc` parameter to use the iDRAC virtual media protocol, the Redfish network boot protocol, or the IPMI protocol to connect to a Dell iDRAC system.
+
 The `address` configuration setting for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network. The `username` configuration for each `bmc` entry must specify a user with `Administrator` privileges.
-
-[source,yaml]
-----
-platform:
-  baremetal:
-    hosts:
-      - name: <hostname>
-        role: <master | worker>
-        bmc:
-          address: <address> <1>
-          username: <user> <2>
-          password: <password>
-----
-<1> The `address` configuration setting specifies the protocol.
-<2> The `username` configuration setting must specify a user with `Administrator` privileges.
-
-For Dell hardware, Red Hat supports integrated Dell Remote Access Controller (iDRAC) virtual media, Redfish network boot, and IPMI.
-
 
 == BMC address formats for Dell iDRAC
 [width="100%", cols="1,3", options="header"]
@@ -67,14 +52,14 @@ platform:
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates.
+It is recommended to have a certificate of authority for the out-of-band management addresses. For {product-title} 4.16 and earlier, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. For {product-title} 4.17 and later, you can include `disableCertificateVerification: False` when used in conjunction with the `bmcCACert` configuration setting.
 
 [NOTE]
 ====
 Ensure the {product-title} cluster nodes have *AutoAttach* enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach*.
 ====
 
-The following example demonstrates a Redfish configuration that uses the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -90,6 +75,37 @@ platform:
           disableCertificateVerification: True
 ----
 
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: False` configuration parameter along with the `bmcCACert` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    bmcCACert:
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: idrac-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/System.Embedded.1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: False
+----
 
 == Redfish network boot for iDRAC
 
@@ -108,7 +124,9 @@ platform:
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if you use self-signed certificates. The following example demonstrates a Redfish configuration that uses the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+It is recommended to have a certificate of authority for the out-of-band management addresses. For {product-title} 4.16 and earlier, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. For {product-title} 4.17 and later, you can include `disableCertificateVerification: False` when used in conjunction with the `bmcCACert` configuration setting.
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -123,6 +141,39 @@ platform:
           password: <password>
           disableCertificateVerification: True
 ----
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: False` configuration parameter along with the `bmcCACert` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    bmcCACert:
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/System.Embedded.1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: False
+----
+
 
 [NOTE]
 ====

--- a/modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc
+++ b/modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc
@@ -3,36 +3,18 @@
 // installing/installing_bare_metal/ipi/ipi-install-configuration-files.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id='bmc-addressing-for-fujitsu-irmc_{context}']
+[id="bmc-addressing-for-fujitsu-irmc_{context}"]
 = BMC addressing for Fujitsu iRMC
 
-The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
+[role="_abstract"]
+You can connect to a Fujitsu iRMC system using the iRMC protocol or the IPMI protocol. The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
 
-[source,yaml]
-----
-platform:
-  baremetal:
-    hosts:
-      - name: <hostname>
-        role: <master | worker>
-        bmc:
-          address: <address> <1>
-          username: <user>
-          password: <password>
-----
-<1> The `address` configuration setting specifies the protocol.
-
-For Fujitsu hardware, Red Hat supports integrated Remote Management Controller (iRMC) and IPMI.
-
-.BMC address formats for Fujitsu iRMC
 [options="header"]
 |====
 |Protocol|Address Format
 |iRMC| `irmc://<out-of-band-ip>`
 |IPMI| `ipmi://<out-of-band-ip>`
 |====
-
-.iRMC
 
 Fujitsu nodes can use `irmc://<out-of-band-ip>` and defaults to port `443`. The following example demonstrates an iRMC configuration within the `install-config.yaml` file.
 

--- a/modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc
+++ b/modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc
@@ -3,37 +3,21 @@
 // installing/installing_bare_metal/ipi/ipi-install-configuration-files.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id='bmc-addressing-for-hpe-ilo_{context}']
+[id="bmc-addressing-for-hpe-ilo_{context}"]
 = BMC addressing for HPE iLO
+
+[role="_abstract"]
+You can connect to an HPE iLO system using the Redfish virtual media protocol, the Redfish network boot protocol, or the IPMI protocol.
 
 The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
 
-[source,yaml]
-----
-platform:
-  baremetal:
-    hosts:
-      - name: <hostname>
-        role: <master | worker>
-        bmc:
-          address: <address> <1>
-          username: <user>
-          password: <password>
-----
-<1> The `address` configuration setting specifies the protocol.
-
-For HPE integrated Lights Out (iLO), Red Hat supports Redfish virtual media, Redfish network boot, and IPMI.
-
-.BMC address formats for HPE iLO
 [width="100%", cols="1,3", options="header"]
 |====
 |Protocol|Address Format
-|Redfish virtual media| `redfish-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/1`
-|Redfish network boot| `redfish://<out-of-band-ip>/redfish/v1/Systems/1`
-|IPMI| `ipmi://<out-of-band-ip>`
+|Redfish virtual media| `redfish-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/1`
+|Redfish network boot| `redfish://<out_of_band_ip>/redfish/v1/Systems/1`
+|IPMI| `ipmi://<out_of_band_ip>`
 |====
-
-See the following sections for additional details.
 
 
 == Redfish virtual media for HPE iLO
@@ -48,12 +32,14 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+It is recommended to have a certificate of authority for the out-of-band management addresses. For {product-title} 4.16 and earlier, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. For {product-title} 4.17 and later, you can include `disableCertificateVerification: False` when used in conjunction with the `bmcCACert` parameter.
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -63,11 +49,44 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
           disableCertificateVerification: True
 ----
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: False` configuration parameter along with the `bmcCACert` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    bmcCACert:
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish-virtualmedia://<out_of_band_ip>/redfish/v1/Systems/1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: False
+----
+
 
 [NOTE]
 ====
@@ -78,7 +97,7 @@ Redfish virtual media is not supported on 9th generation systems running iLO4, b
 
 == Redfish network boot for HPE iLO
 
-To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installer requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
+To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installation program requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -88,12 +107,14 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+It is recommended to have a certificate of authority for the out-of-band management addresses. For {product-title} 4.16 and earlier, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. For {product-title} 4.17 and later, you can include `disableCertificateVerification: False` when used in conjunction with the `bmcCACert` parameter.
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -103,7 +124,39 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: True
+----
+
+The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: False` configuration parameter along with the `bmcCACert` configuration parameter within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    bmcCACert:
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
           disableCertificateVerification: True

--- a/modules/ipi-install-bmc-addressing.adoc
+++ b/modules/ipi-install-bmc-addressing.adoc
@@ -6,14 +6,18 @@
 [id='bmc-addressing_{context}']
 = BMC addressing
 
-Most vendors support Baseboard Management Controller (BMC) addressing with the Intelligent Platform Management Interface (IPMI). IPMI does not encrypt communications. It is suitable for use within a data center over a secured or dedicated management network. Check with your vendor to see if they support Redfish network boot. Redfish delivers simple and secure management for converged, hybrid IT and the Software Defined Data Center (SDDC). Redfish is human readable and machine capable, and leverages common internet and web services standards to expose information directly to the modern tool chain. If your hardware does not support Redfish network boot, use IPMI.
+[role="_abstract"]
+The Intelligent Platform Management Interface (IPMI) and the Redfish network boot protocol are two common methods of addressing a Baseboard Management Controller (BMC).
 
-You can modify the BMC address during installation while the node is in the `Registering` state. If you need to modify the BMC address after the node leaves the `Registering` state, you must disconnect the node from Ironic, edit the `BareMetalHost` resource, and reconnect the node to Ironic. See the _Editing a BareMetalHost resource_ section for details.
+Most vendors support Baseboard Management Controller (BMC) addressing with the Intelligent Platform Management Interface (IPMI). IPMI does not encrypt communications. It is suitable for use within a data center over a secured or dedicated management network. Check with your vendor to see if they support Redfish network boot.
 
+Redfish delivers simple and secure management for converged, hybrid IT and the Software Defined Data Center (SDDC). Redfish is human readable and machine capable, and leverages common internet and web services standards to expose information directly to the modern tool chain. If your hardware does not support Redfish network boot, use IPMI.
+
+You can change the BMC address during installation while the node is in the `Registering` state. If you need to change the BMC address after the node leaves the `Registering` state, you must disconnect the node from Ironic, edit the `BareMetalHost` resource, and reconnect the node to Ironic. See the _Editing a BareMetalHost resource_ section for details.
 
 == IPMI
 
-Hosts using IPMI use the `ipmi://<out-of-band-ip>:<port>` address format, which defaults to port `623` if not specified. The following example demonstrates an IPMI configuration within the `install-config.yaml` file.
+IPMI uses the `ipmi://<out_of_band_ip>:<port>` address format, which defaults to port `623` if not specified. The following example demonstrates an IPMI configuration within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -23,20 +27,20 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: ipmi://<out-of-band-ip>
+          address: ipmi://<out_of_band_ip>
           username: <user>
           password: <password>
 ----
 
 [IMPORTANT]
 ====
-The `provisioning` network is required when PXE booting using IPMI for BMC addressing. It is not possible to PXE boot hosts without a `provisioning` network. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`. See "Redfish virtual media for HPE iLO" in the "BMC addressing for HPE iLO" section or "Redfish virtual media for Dell iDRAC" in the "BMC addressing for Dell iDRAC" section for additional details.
+When PXE booting using IPMI for BMC addressing, you must use a provisioning network. It is not possible to PXE boot hosts without a provisioning network. If you deploy without a provisioning network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`. See "Redfish virtual media for HPE iLO" in the "BMC addressing for HPE iLO" section or "Redfish virtual media for Dell iDRAC" in the "BMC addressing for Dell iDRAC" section for additional details.
 ====
 
 
 == Redfish network boot
 
-To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installer requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
+To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installation program requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -46,12 +50,12 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
 ----
 
-While it is recommended to have a certificate of authority for the out-of-band management addresses, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
+It is recommended to have a certificate of authority for the out-of-band management addresses. On {product-title} 4.16 and earlier, you must include `disableCertificateVerification: True` in the `bmc` configuration if using self-signed certificates. The following example demonstrates a Redfish configuration by using the `disableCertificateVerification: True` configuration parameter within the `install-config.yaml` file.
 
 [source,yaml]
 ----
@@ -61,9 +65,40 @@ platform:
       - name: openshift-master-0
         role: master
         bmc:
-          address: redfish://<out-of-band-ip>/redfish/v1/Systems/1
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
           username: <user>
           password: <password>
           disableCertificateVerification: True
 ----
 
+On {product-title} 4.17 and later, you can include `disableCertificateVerification: False` in the `bmc` configuration to verify self-signed certificates when used in conjunction with the `bmcCACert` parameter. The following example demonstrates the configuration of a BMC CA certificate.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    bmcCACert:
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+      ......
+      ......
+      ......
+      -----END CERTIFICATE-----
+     hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish://<out_of_band_ip>/redfish/v1/Systems/1
+          username: <user>
+          password: <password>
+          disableCertificateVerification: False
+----


### PR DESCRIPTION
Picking up John Wilkins previous PR https://github.com/openshift/openshift-docs/pull/81521

Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-17219

Link to docs preview:
[Day 2 procedures](https://104571--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#bare-metal-self-signed-cert-post-install_bare-metal-postinstallation-configuration)
[BMC addressing (and subsequent addressing modules)](https://104571--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow#bmc-addressing_ipi-install-installation-workflow)
[Install config parameter](https://104571--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow#hosts)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
