### PR TITLE
[enterprise-4.18] OSDOCS 16929 CQA2.0 of NODES-1: Core Node Cluster Resource Configuration fix Vale

### DIFF
--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -11,8 +11,6 @@ As an administrator, you can use feature gates to enable features that are not p
 
 include::modules/nodes-cluster-enabling-features-about.adoc[leveloffset=+1]
 
-For more information about the features activated by the `TechPreviewNoUpgrade` feature gate, see the _Additional Resources_ section.
-
 include::modules/nodes-cluster-enabling-features-install.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-enabling-features-console.adoc[leveloffset=+1]
@@ -23,20 +21,20 @@ include::modules/nodes-cluster-enabling-features-cli.adoc[leveloffset=+1]
 [id="additional-resources_nodes-cluster-enabling"]
 == Additional resources
 
-** xref:../../cicd/builds/running-entitled-builds.adoc#builds-running-entitled-builds-with-sharedsecret-objects_running-entitled-builds[Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds]
+* xref:../../cicd/builds/running-entitled-builds.adoc#builds-running-entitled-builds-with-sharedsecret-objects_running-entitled-builds[Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds]
 
-** xref:../../storage/container_storage_interface/ephemeral-storage-csi-inline.adoc#ephemeral-storage-csi-inline[CSI inline ephemeral volumes]
+* xref:../../storage/container_storage_interface/ephemeral-storage-csi-inline.adoc#ephemeral-storage-csi-inline[CSI inline ephemeral volumes]
 
-** xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-managing[Swap memory on nodes]
+* xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-managing[Swap memory on nodes]
 
-** xref:../../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[Managing machines with the Cluster API]
+* xref:../../machine_management/cluster_api_machine_management/cluster-api-about.adoc#cluster-api-about[Managing machines with the Cluster API]
 
-** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#disabling-insights-operator-gather_using-insights-operator[Disabling the Insights Operator gather operations]
+* xref:../../support/remote_health_monitoring/using-insights-operator.adoc#disabling-insights-operator-gather_using-insights-operator[Disabling the Insights Operator gather operations]
 
-** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#enabling-insights-operator-gather_using-insights-operator[Enabling the Insights Operator gather operations]
+* xref:../../support/remote_health_monitoring/using-insights-operator.adoc#enabling-insights-operator-gather_using-insights-operator[Enabling the Insights Operator gather operations]
 
-** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#running-insights-operator-gather_using-insights-operator[Running an Insights Operator gather operation]
+* xref:../../support/remote_health_monitoring/using-insights-operator.adoc#running-insights-operator-gather_using-insights-operator[Running an Insights Operator gather operation]
 
-** xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]
 
-** xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement].
+* xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement]


### PR DESCRIPTION
Fixing [Vale errors introduced in the cherrypick](https://github.com/openshift/openshift-docs/pull/104574#discussion_r2677491162), but missed. 