### PR TITLE
OSDOCS-17569: Adding ROSA HCP backup and recovery info

### DIFF
--- a/modules/policy-incident.adoc
+++ b/modules/policy-incident.adoc
@@ -78,7 +78,7 @@ All {product-title} clusters are backed up using cloud provider snapshots. Notab
 |===
 
 * Red Hat does not commit to any Recovery Point Objective (RPO) or Recovery Time Objective (RTO).
-* Customers are responsible for taking regular backups of their data
+* Customers are responsible for taking regular backups of their data.
 * Customers should deploy multi-AZ clusters with workloads that follow Kubernetes best practices to ensure high availability within a region.
 * If an entire cloud region is unavailable, customers must install a new cluster in a different region and restore their apps using their backup data.
 

--- a/modules/policy-incident.adoc
+++ b/modules/policy-incident.adoc
@@ -67,7 +67,7 @@ All {product-title} clusters are backed up using cloud provider snapshots. Notab
 
 |Full object store backup
 |Hourly
-|24 hour
+|24 hours
 |This is a full backup of all Kubernetes objects like etcd. No PVs are backed up in this backup schedule.
 
 |Node root volume
@@ -78,7 +78,7 @@ All {product-title} clusters are backed up using cloud provider snapshots. Notab
 |===
 
 * Red Hat does not commit to any Recovery Point Objective (RPO) or Recovery Time Objective (RTO).
-* Customers are responsible for taking regular backups of their data
+* Customers are responsible for taking regular backups of their data.
 * Customers should deploy multi-AZ clusters with workloads that follow Kubernetes best practices to ensure high availability within a region.
 * If an entire cloud region is unavailable, customers must install a new cluster in a different region and restore their apps using their backup data.
 

--- a/modules/rosa-policy-disaster-recovery.adoc
+++ b/modules/rosa-policy-disaster-recovery.adoc
@@ -5,16 +5,21 @@
 :_mod-docs-content-type: CONCEPT
 [id="rosa-policy-disaster-recovery_{context}"]
 = Disaster recovery
+
+[role="_abstract"]
 Disaster recovery includes data and configuration backup, replicating data and configuration to the disaster recovery environment, and failover on disaster events.
 
-{product-title} (ROSA) provides disaster recovery for failures that occur at the pod, node, and availability zone levels.
+The effectiveness of disaster recovery depends on the architecture. Deploy highly available applications, storage, and clusters to achieve your required level of resilience, for example:
 
-All disaster recovery requires that the customer use best practices for deploying highly available applications, storage, and cluster architecture, such as multiple machine pools across multiple availability zones, to account for the level of desired availability.
+* *Zone outages*: on a cluster, deploy multiple machine pools distributed across multiple AZs and manage your own failover.
 
-One cluster with a single machine pool will not provide disaster avoidance or recovery in the event of an availability zone or region outage. Multiple clusters with single machine pools with customer-maintained failover can account for outages at the zone or at the regional level.
+* *Regional outages*: deploy multiple clusters in several regions with multiple machine pools in more than one AZ and manage your own failover.
 
-One cluster with multiple machine pools across multiple availability zones will not provide disaster avoidance or recovery in the event of a full region outage. Multiple clusters in several regions with multiple machine pools in more than one availability-zone with customer-maintained failover can account for outages at the regional level.
+For more information about disaster recovery practices, see the _Additional resources_.
 
+The following responsibility matrix provides details about disaster recovery practices as part of {product-title}.
+
+.Disaster recovery responsibilities
 [cols="2a,3a,3a" ,options="header"]
 |===
 |Resource
@@ -24,14 +29,15 @@ One cluster with multiple machine pools across multiple availability zones will 
 |Virtual networking management
 |**Red{nbsp}Hat**
 
-- Recreate affected virtual network components that are necessary for the platform to function.
+- Re-create affected virtual network components that are necessary for the platform to function.
 |- Configure virtual networking connections with more than one tunnel where possible for protection against outages as recommended by the public cloud provider.
 - Maintain failover DNS and load balancing if using a global load balancer with multiple clusters.
 //waiting to hear back from Will G. if RH responsibilities below should have just been conditionalized out per the migration review for hcp or Classic as well.
 |Virtual Storage management
 |**Red{nbsp}Hat**
+
 ifdef::openshift-rosa[]
-- For ROSA clusters created with IAM user credentials, back up all Kubernetes objects on the cluster through hourly, daily, and weekly volume snapshots. Hourly backups are retained for 24 hrs (1 day), daily backups are retained for 168 hrs (1 week), and weekly backups are retained for 720 hrs (30 days).
+- For {product-title} clusters created with IAM user credentials, back up all Kubernetes objects on the cluster through hourly, daily, and weekly volume snapshots. Hourly backups are retained for 24 hrs (1 day), daily backups are retained for 168 hrs (1 week), and weekly backups are retained for 720 hrs (30 days).
 endif::openshift-rosa[]
 
 |- Back up customer applications and application data.
@@ -41,50 +47,65 @@ endif::openshift-rosa[]
 ifdef::openshift-rosa[]
 - Monitor the cluster and replace failed Amazon EC2 control plane or infrastructure nodes.
 endif::openshift-rosa[]
+
 - Provide the ability for the customer to manually or automatically replace failed worker nodes.
 
-|- Replace failed Amazon EC2 worker nodes by editing the
-machine pool configuration through OpenShift Cluster Manager or the ROSA CLI.
+|- Replace failed Amazon EC2 worker nodes by editing the machine pool configuration through {cluster-manager} or the {rosa-cli-first}.
+
+ifdef::openshift-rosa-hcp[]
+|Control plane
+|**Red{nbsp}Hat**
+
+- Use snapshots, troubleshooting tools, and control planes deployed in multiple AZs to minimize downtime during disaster events.
+
+- Take a full snapshot of the control plane etcd database every 6 hours and retain the snapshot for 24 hours.
+
+- In case of disaster events, notify the customer that control plane recovery is in progress. If both the control and data planes are impacted, coordinate recovery efforts with the customer.
+
+|- Cooperate with Red{nbsp}Hat during disaster recovery events.
+
+|Data plane (worker nodes)
+|**Red{nbsp}Hat**
+
+- Red{nbsp}Hat is available to support customer efforts to restore data and applications upon submission of a support case.
+
+|- Back up data plane contents and configuration.
+endif::openshift-rosa-hcp[]
 
 |AWS software (public AWS services)
 |**AWS**
 
-**Compute:** Provide Amazon EC2 features that support data resiliency such as Amazon EBS snapshots and Amazon EC2 Auto Scaling. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/disaster-recovery-resiliency.html[Resilience in Amazon EC2] in the EC2 User Guide.
+**Compute:** Provide Amazon EC2 features that support data resiliency such as Amazon EBS snapshots and Amazon EC2 Auto Scaling. For more information, see "Resilience in Amazon EC2" in the _Additional resources_.
 
-**Storage:** Provide the ability for the ROSA service
-and customers to back up the Amazon EBS volume on the cluster through Amazon EBS volume snapshots.
+**Storage:** Provide the ability for the {product-title} service and customers to back up the Amazon EBS volume on the cluster through Amazon EBS volume snapshots.
 
-**Storage:** For information about Amazon S3 features that support data resiliency, see link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/disaster-recovery-resiliency.html[Resilience in Amazon S3].
+**Storage:** For information about Amazon S3 features that support data resiliency, see "Resilience in Amazon S3" in the _Additional resources_.
 
-**Networking:** For information about Amazon VPC features that support data resiliency, see link:https://docs.aws.amazon.com/vpc/latest/userguide/disaster-recovery-resiliency.html[Resilience in Amazon Virtual Private
-Cloud] in the Amazon VPC User Guide.
+**Networking:** For information about Amazon VPC features that support data resiliency, see "Resilience in Amazon Virtual Private Cloud" in the _Additional resources_.
 
-|- Configure ROSA clusters with multiple machine pools across multiple availability zones to improve fault tolerance and cluster availability.
+|- Configure {product-title} clusters with multiple machine pools across multiple AZs to improve fault tolerance and cluster availability.
 
-- Provision persistent
-volumes using the
-Amazon EBS CSI
-driver to enable
-volume snapshots.
+- Provision persistent volumes using the Amazon EBS CSI driver to enable volume snapshots.
 
-- Create CSI volume snapshots of Amazon
-EBS persistent volumes.
+- Create CSI volume snapshots of Amazon EBS persistent volumes.
 |Hardware/AWS global infrastructure
 |**AWS**
 
-- Provide AWS global infrastructure that allows ROSA to scale
+- Provide AWS global infrastructure that allows {product-title} to scale
 ifdef::openshift-rosa[]
 control plane, infrastructure, and worker nodes
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
 nodes
 endif::openshift-rosa-hcp[]
-across
-Availability Zones. This functionality enables ROSA to orchestrate automatic failover between zones without interruption.
+across AZs. This functionality enables orchestration of automatic failover between zones without interruption.
 
-- For more information about disaster recovery best practices, see link:https://docs.aws.amazon.com/whitepapers/latest/disaster-recovery-workloads-on-aws/disaster-recovery-options-in-the-cloud.html[Disaster recovery options in the cloud] in the AWS
-Well-Architected Framework.
-
-|- Configure ROSA clusters with multiple machine pools across multiple availability zones to improve fault tolerance and cluster availability.
-
+|- Configure {product-title} clusters with multiple machine pools across multiple AZs to improve fault tolerance and cluster availability.
 |===
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/disaster-recovery-resiliency.html[Resilience in Amazon EC2]
+* link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/disaster-recovery-resiliency.html[Resilience in Amazon S3]
+* link:https://docs.aws.amazon.com/vpc/latest/userguide/disaster-recovery-resiliency.html[Resilience in Amazon Virtual Private Cloud]
+* link:https://docs.aws.amazon.com/whitepapers/latest/disaster-recovery-workloads-on-aws/disaster-recovery-options-in-the-cloud.html[Disaster recovery options in the cloud]

--- a/modules/rosa-policy-disaster-recovery.adoc
+++ b/modules/rosa-policy-disaster-recovery.adoc
@@ -5,17 +5,22 @@
 :_mod-docs-content-type: CONCEPT
 [id="rosa-policy-disaster-recovery_{context}"]
 = Disaster recovery
-Disaster recovery includes data and configuration backup, replicating data and configuration to the disaster recovery environment, and failover on disaster events.
 
-{product-title} (ROSA) provides disaster recovery for failures that occur at the pod, node, and availability zone levels.
+[role="_abstract"]
+Disaster recovery includes backing up data and configurations, replicating them to a disaster recovery environment, and failing over during a disaster event.
 
-All disaster recovery requires that the customer use best practices for deploying highly available applications, storage, and cluster architecture, such as multiple machine pools across multiple availability zones, to account for the level of desired availability.
+The effectiveness of disaster recovery depends on the architecture. Deploy highly available applications, storage, and clusters to achieve your required level of resilience, for example:
 
-One cluster with a single machine pool will not provide disaster avoidance or recovery in the event of an availability zone or region outage. Multiple clusters with single machine pools with customer-maintained failover can account for outages at the zone or at the regional level.
+* *Zone outages*: Deploy a cluster with multiple machine pools distributed across multiple availability zones (AZs) and manage your own failover.
 
-One cluster with multiple machine pools across multiple availability zones will not provide disaster avoidance or recovery in the event of a full region outage. Multiple clusters in several regions with multiple machine pools in more than one availability-zone with customer-maintained failover can account for outages at the regional level.
+* *Regional outages*: Deploy multiple clusters in several regions with multiple machine pools in more than one AZ and manage your own failover.
 
-[cols="2a,3a,3a" ,options="header"]
+For more information, see “Disaster recovery options in the cloud” in _Additional resources_.
+
+The following responsibility matrix provides details about disaster recovery practices as part of {product-title}.
+
+.Disaster recovery responsibilities
+[cols="2a,3a,3a",options="header"]
 |===
 |Resource
 |Service responsibilities
@@ -24,14 +29,15 @@ One cluster with multiple machine pools across multiple availability zones will 
 |Virtual networking management
 |**Red{nbsp}Hat**
 
-- Recreate affected virtual network components that are necessary for the platform to function.
+- Re-create affected virtual network components that are necessary for the platform to function.
 |- Configure virtual networking connections with more than one tunnel where possible for protection against outages as recommended by the public cloud provider.
 - Maintain failover DNS and load balancing if using a global load balancer with multiple clusters.
 //waiting to hear back from Will G. if RH responsibilities below should have just been conditionalized out per the migration review for hcp or Classic as well.
-|Virtual Storage management
+|Virtual storage management
 |**Red{nbsp}Hat**
+
 ifdef::openshift-rosa[]
-- For ROSA clusters created with IAM user credentials, back up all Kubernetes objects on the cluster through hourly, daily, and weekly volume snapshots. Hourly backups are retained for 24 hrs (1 day), daily backups are retained for 168 hrs (1 week), and weekly backups are retained for 720 hrs (30 days).
+- For {product-title} clusters created with IAM user credentials, back up all Kubernetes objects on the cluster through hourly, daily, and weekly volume snapshots. Hourly backups are retained for 24 hrs (1 day), daily backups are retained for 168 hrs (1 week), and weekly backups are retained for 720 hrs (30 days).
 endif::openshift-rosa[]
 
 |- Back up customer applications and application data.
@@ -41,50 +47,62 @@ endif::openshift-rosa[]
 ifdef::openshift-rosa[]
 - Monitor the cluster and replace failed Amazon EC2 control plane or infrastructure nodes.
 endif::openshift-rosa[]
+
 - Provide the ability for the customer to manually or automatically replace failed worker nodes.
 
-|- Replace failed Amazon EC2 worker nodes by editing the
-machine pool configuration through OpenShift Cluster Manager or the ROSA CLI.
+|- Replace failed Amazon EC2 worker nodes by editing the machine pool configuration through {cluster-manager} or the {rosa-cli-first}.
+
+ifdef::openshift-rosa-hcp[]
+|Control plane
+|**Red{nbsp}Hat**
+
+- Use snapshots, troubleshooting tools, and control planes deployed in multiple AZs to minimize downtime during service-side disaster events.
+
+- Take a full snapshot of the control plane etcd database every hour and retain the snapshot for 24 hours. This backup schedule supports the Recovery Point Objective (RPO) of one hour.
++
+Note that these backups are intended for use within service-side disaster recovery scenarios and are not available for customer-requested restorations.
+
+- Commit to a Recovery Time Objective (RTO) of up to one hour, covering complete cluster restoration and post-validation checks.
+
+- During disaster events, notify the customer that control plane recovery is in progress. If both the control and data planes are impacted, coordinate recovery efforts with the customer.
+
+|- Cooperate with Red{nbsp}Hat during disaster recovery events.
+
+|Data plane (worker nodes)
+|**Red{nbsp}Hat**
+
+- Red{nbsp}Hat is available to support customer efforts to restore data and applications upon submission of a support case.
+
+|- Back up data plane contents and configuration.
+endif::openshift-rosa-hcp[]
 
 |AWS software (public AWS services)
 |**AWS**
 
-**Compute:** Provide Amazon EC2 features that support data resiliency such as Amazon EBS snapshots and Amazon EC2 Auto Scaling. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/disaster-recovery-resiliency.html[Resilience in Amazon EC2] in the EC2 User Guide.
+**Compute:** Provide Amazon EC2 features that support data resiliency such as Amazon EBS snapshots and Amazon EC2 Auto Scaling. For more information, see "Resilience in Amazon EC2" in _Additional resources_.
 
-**Storage:** Provide the ability for the ROSA service
-and customers to back up the Amazon EBS volume on the cluster through Amazon EBS volume snapshots.
+**Storage:** Provide the ability for the {product-title} service and customers to back up the Amazon EBS volume on the cluster through Amazon EBS volume snapshots.
 
-**Storage:** For information about Amazon S3 features that support data resiliency, see link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/disaster-recovery-resiliency.html[Resilience in Amazon S3].
+**Storage:** For information about Amazon S3 features that support data resiliency, see "Resilience in Amazon S3" in _Additional resources_.
 
-**Networking:** For information about Amazon VPC features that support data resiliency, see link:https://docs.aws.amazon.com/vpc/latest/userguide/disaster-recovery-resiliency.html[Resilience in Amazon Virtual Private
-Cloud] in the Amazon VPC User Guide.
+**Networking:** For information about Amazon VPC features that support data resiliency, see "Resilience in Amazon Virtual Private Cloud" in _Additional resources_.
 
-|- Configure ROSA clusters with multiple machine pools across multiple availability zones to improve fault tolerance and cluster availability.
+|- Configure {product-title} clusters with multiple machine pools across multiple AZs to improve fault tolerance and cluster availability.
 
-- Provision persistent
-volumes using the
-Amazon EBS CSI
-driver to enable
-volume snapshots.
+- Provision persistent volumes using the Amazon EBS CSI driver to enable volume snapshots.
 
-- Create CSI volume snapshots of Amazon
-EBS persistent volumes.
+- Create CSI volume snapshots of Amazon EBS persistent volumes.
 |Hardware/AWS global infrastructure
 |**AWS**
 
-- Provide AWS global infrastructure that allows ROSA to scale
+- Provide AWS global infrastructure that allows {product-title} to scale
 ifdef::openshift-rosa[]
 control plane, infrastructure, and worker nodes
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
 nodes
 endif::openshift-rosa-hcp[]
-across
-Availability Zones. This functionality enables ROSA to orchestrate automatic failover between zones without interruption.
+across AZs. This functionality enables orchestration of automatic failover between zones without interruption.
 
-- For more information about disaster recovery best practices, see link:https://docs.aws.amazon.com/whitepapers/latest/disaster-recovery-workloads-on-aws/disaster-recovery-options-in-the-cloud.html[Disaster recovery options in the cloud] in the AWS
-Well-Architected Framework.
-
-|- Configure ROSA clusters with multiple machine pools across multiple availability zones to improve fault tolerance and cluster availability.
-
+|- Configure {product-title} clusters with multiple machine pools across multiple AZs to improve fault tolerance and cluster availability.
 |===

--- a/modules/rosa-policy-incident.adoc
+++ b/modules/rosa-policy-incident.adoc
@@ -1,4 +1,3 @@
-
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-policy-shared-responsibility.adoc
@@ -7,6 +6,7 @@
 [id="rosa-policy-incident_{context}"]
 = Incident and operations management
 
+[role="_abstract"]
 Red{nbsp}Hat is responsible for overseeing the service components required for default platform networking.
 AWS is responsible for protecting the hardware infrastructure that runs all of the services offered in the AWS Cloud. The customer is responsible for incident and operations management of customer application data and any custom networking the customer has configured for the cluster network or virtual network.
 
@@ -20,8 +20,7 @@ AWS is responsible for protecting the hardware infrastructure that runs all of t
 |Application networking
 |**Red{nbsp}Hat**
 
-- Monitor native OpenShift router
-service, and respond to alerts.
+- Monitor native OpenShift router service, and respond to alerts.
 |- Monitor health of application routes, and the endpoints behind them.
 - Report outages to Red{nbsp}Hat and AWS.
 
@@ -29,36 +28,30 @@ service, and respond to alerts.
 |**Red{nbsp}Hat**
 
 - Monitor, alert, and address incidents related to cluster DNS, network plugin connectivity between cluster components, and the default Ingress Controller.
-|- Monitor and address incidents related to optional Ingress Controllers, additional Operators installed through the software catalog, and network plugins replacing the default OpenShift CNI plugins.
+|- Monitor and address incidents related to optional Ingress Controllers, additional Operators installed through the software catalog, and network plugins replacing the default OpenShift Container Network Interface (CNI) plugins.
 
 |Virtual networking management
 |**Red{nbsp}Hat**
 
-- Monitor AWS load balancers, Amazon VPC subnets, and AWS service components necessary for default
-platform networking. Respond to alerts.
+- Monitor AWS load balancers, Amazon Virtual Private Cloud (VPC) subnets, and AWS service components necessary for default platform networking. Respond to alerts.
 |- Monitor health of AWS load balancer endpoints.
-- Monitor network traffic that is optionally configured through Amazon VPC-to-VPC connection, AWS VPN connection, or AWS
-Direct Connect for potential issues or
-security threats.
+- Monitor network traffic that is optionally configured through Amazon VPC-to-VPC connection, AWS VPN connection, or AWS Direct Connect for potential issues or security threats.
 
 |Virtual storage management
 |**Red{nbsp}Hat**
 
-- Monitor Amazon EBS volumes attached to cluster nodes and Amazon S3 buckets used for the ROSA service’s built-in container image
-registry. Respond to alerts.
+- Monitor Amazon Elastic Block Store (EBS) volumes attached to cluster nodes and Amazon S3 buckets used for the {product-title} service's built-in container image registry. Respond to alerts.
 |- Monitor health of application data.
-- If customer managed AWS KMS keys are
-used, create and control the key lifecycle and
-key policies for Amazon EBS encryption.
+- If customer managed AWS Key Management Service (KMS) keys are used, create and control the key lifecycle and key policies for Amazon EBS encryption.
 
 |Platform monitoring
 |**Red{nbsp}Hat**
 
-- Maintain a centralized monitoring and alerting system for all ROSA cluster components, site reliability engineer (SRE) services, and underlying AWS accounts.
+- Maintain a centralized monitoring and alerting system for all {product-title} cluster components, site reliability engineer (SRE) services, and underlying AWS accounts.
 |
 ifdef::openshift-rosa-hcp[]
 - Monitor capacity of worker nodes.
-- Configure cluster monitoring stack components for monitoring and alerts. 
+- Configure cluster monitoring stack components for monitoring and alerts.
 endif::openshift-rosa-hcp[]
 
 |Incident management
@@ -71,7 +64,7 @@ endif::openshift-rosa-hcp[]
 |Infrastructure and data resiliency
 |**Red{nbsp}Hat**
 
-- There is no Red{nbsp}Hat-provided backup method available for ROSA clusters with STS.
+- There is no Red{nbsp}Hat-provided backup method available for {product-title} clusters with the Security Token Service (STS).
 - Red{nbsp}Hat does not commit to any Recovery Point Objective (RPO) or Recovery Time Objective (RTO).
 |- Take regular backups of data and deploy multi-AZ clusters with workloads that follow Kubernetes best practices to ensure high availability within a region.
 - If an entire cloud region is unavailable, install a new cluster in a different region and restore apps using backup data.
@@ -86,17 +79,14 @@ endif::openshift-rosa-hcp[]
 |AWS software (public AWS services)
 |**AWS**
 
-- For information regarding AWS incident and operations management, see link:https://docs.aws.amazon.com/whitepapers/latest/aws-operational-resilience/how-aws-maintains-operational-resilience-and-continuity-of-service.html#incident-management[How AWS maintains operational resilience and continuity of service] in the AWS whitepaper.
-|- Monitor health of AWS resources in the
-customer account.
-- Use IAM tools to apply the appropriate
-permissions to AWS resources in the customer account.
+- For information regarding AWS incident and operations management, see "How AWS maintains operational resilience and continuity of service" in the AWS whitepaper linked in the _Additional resources_.
+|- Monitor health of AWS resources in the customer account.
+- Use IAM tools to apply the appropriate permissions to AWS resources in the customer account.
 
 |Hardware/AWS global infrastructure
 |**AWS**
 
-- For information regarding AWS incident and operations management, see link:https://docs.aws.amazon.com/whitepapers/latest/aws-operational-resilience/how-aws-maintains-operational-resilience-and-continuity-of-service.html#incident-management[How AWS maintains operational
-resilience and continuity of service] in the AWS white paper.
+- For information regarding AWS incident and operations management, see "How AWS maintains operational resilience and continuity of service" in the AWS whitepaper linked in the _Additional resources_.
 
 |- Configure, manage, and monitor customer applications and data to ensure application and data security controls are properly enforced.
 
@@ -114,7 +104,7 @@ An incident is an event that results in a degradation or outage of one or more R
 
 An incident can be raised by a customer or a Customer Experience and Engagement (CEE) member through a support case, directly by the centralized monitoring and alerting system, or directly by a member of the SRE team.
 
-Depending on the impact on the service and customer, the incident is categorized in terms of link:https://access.redhat.com/support/offerings/production/sla[severity].
+Depending on the impact on the service and customer, the incident is categorized in terms of severity. To learn more, see "Production Support Terms of Service" in the _Additional resources_.
 
 When managing a new incident, Red{nbsp}Hat uses the following general workflow:
 
@@ -177,3 +167,8 @@ Red{nbsp}Hat can assist with activities including but not limited to:
 The impact of a cluster upgrade on capacity is evaluated as part of the upgrade testing process to ensure that capacity is not negatively impacted by new additions to the cluster. During a cluster upgrade, additional worker nodes are added to make sure that total cluster capacity is maintained during the upgrade process.
 
 Capacity evaluations by the Red{nbsp}Hat SRE staff also happen in response to alerts from the cluster, after usage thresholds are exceeded for a certain period of time. Such alerts can also result in a notification to the customer.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.aws.amazon.com/whitepapers/latest/aws-operational-resilience/how-aws-maintains-operational-resilience-and-continuity-of-service.html#incident-management[How AWS maintains operational resilience and continuity of service]
+* link:https://access.redhat.com/support/offerings/production/sla[Production Support Terms of Service]

--- a/modules/rosa-policy-incident.adoc
+++ b/modules/rosa-policy-incident.adoc
@@ -1,4 +1,3 @@
-
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa_policy_service_definition/rosa-policy-shared-responsibility.adoc
@@ -7,6 +6,7 @@
 [id="rosa-policy-incident_{context}"]
 = Incident and operations management
 
+[role="_abstract"]
 Red{nbsp}Hat is responsible for overseeing the service components required for default platform networking.
 AWS is responsible for protecting the hardware infrastructure that runs all of the services offered in the AWS Cloud. The customer is responsible for incident and operations management of customer application data and any custom networking the customer has configured for the cluster network or virtual network.
 
@@ -20,8 +20,7 @@ AWS is responsible for protecting the hardware infrastructure that runs all of t
 |Application networking
 |**Red{nbsp}Hat**
 
-- Monitor native OpenShift router
-service, and respond to alerts.
+- Monitor native OpenShift router service, and respond to alerts.
 |- Monitor health of application routes, and the endpoints behind them.
 - Report outages to Red{nbsp}Hat and AWS.
 
@@ -29,36 +28,30 @@ service, and respond to alerts.
 |**Red{nbsp}Hat**
 
 - Monitor, alert, and address incidents related to cluster DNS, network plugin connectivity between cluster components, and the default Ingress Controller.
-|- Monitor and address incidents related to optional Ingress Controllers, additional Operators installed through the software catalog, and network plugins replacing the default OpenShift CNI plugins.
+|- Monitor and address incidents related to optional Ingress Controllers, additional Operators installed through the software catalog, and network plugins replacing the default OpenShift Container Network Interface (CNI) plugins.
 
 |Virtual networking management
 |**Red{nbsp}Hat**
 
-- Monitor AWS load balancers, Amazon VPC subnets, and AWS service components necessary for default
-platform networking. Respond to alerts.
+- Monitor AWS load balancers, Amazon Virtual Private Cloud (VPC) subnets, and AWS service components necessary for default platform networking. Respond to alerts.
 |- Monitor health of AWS load balancer endpoints.
-- Monitor network traffic that is optionally configured through Amazon VPC-to-VPC connection, AWS VPN connection, or AWS
-Direct Connect for potential issues or
-security threats.
+- Monitor network traffic that is optionally configured through Amazon VPC-to-VPC connection, AWS VPN connection, or AWS Direct Connect for potential issues or security threats.
 
 |Virtual storage management
 |**Red{nbsp}Hat**
 
-- Monitor Amazon EBS volumes attached to cluster nodes and Amazon S3 buckets used for the ROSA service’s built-in container image
-registry. Respond to alerts.
+- Monitor Amazon Elastic Block Store (EBS) volumes attached to cluster nodes and Amazon S3 buckets used for the {product-title} service's built-in container image registry. Respond to alerts.
 |- Monitor health of application data.
-- If customer managed AWS KMS keys are
-used, create and control the key lifecycle and
-key policies for Amazon EBS encryption.
+- If customer managed AWS Key Management Service (KMS) keys are used, create and control the key lifecycle and key policies for Amazon EBS encryption.
 
 |Platform monitoring
 |**Red{nbsp}Hat**
 
-- Maintain a centralized monitoring and alerting system for all ROSA cluster components, site reliability engineer (SRE) services, and underlying AWS accounts.
+- Maintain a centralized monitoring and alerting system for all {product-title} cluster components, site reliability engineer (SRE) services, and underlying AWS accounts.
 |
 ifdef::openshift-rosa-hcp[]
 - Monitor capacity of worker nodes.
-- Configure cluster monitoring stack components for monitoring and alerts. 
+- Configure cluster monitoring stack components for monitoring and alerts.
 endif::openshift-rosa-hcp[]
 
 |Incident management
@@ -71,8 +64,7 @@ endif::openshift-rosa-hcp[]
 |Infrastructure and data resiliency
 |**Red{nbsp}Hat**
 
-- There is no Red{nbsp}Hat-provided backup method available for ROSA clusters with STS.
-- Red{nbsp}Hat does not commit to any Recovery Point Objective (RPO) or Recovery Time Objective (RTO).
+- There is no Red{nbsp}Hat-provided backup method available for {product-title} clusters with the Security Token Service (STS).
 |- Take regular backups of data and deploy multi-AZ clusters with workloads that follow Kubernetes best practices to ensure high availability within a region.
 - If an entire cloud region is unavailable, install a new cluster in a different region and restore apps using backup data.
 
@@ -86,17 +78,14 @@ endif::openshift-rosa-hcp[]
 |AWS software (public AWS services)
 |**AWS**
 
-- For information regarding AWS incident and operations management, see link:https://docs.aws.amazon.com/whitepapers/latest/aws-operational-resilience/how-aws-maintains-operational-resilience-and-continuity-of-service.html#incident-management[How AWS maintains operational resilience and continuity of service] in the AWS whitepaper.
-|- Monitor health of AWS resources in the
-customer account.
-- Use IAM tools to apply the appropriate
-permissions to AWS resources in the customer account.
+- For information regarding AWS incident and operations management, see "How AWS maintains operational resilience and continuity of service" in the AWS whitepaper linked in _Additional resources_.
+|- Monitor health of AWS resources in the customer account.
+- Use IAM tools to apply the appropriate permissions to AWS resources in the customer account.
 
 |Hardware/AWS global infrastructure
 |**AWS**
 
-- For information regarding AWS incident and operations management, see link:https://docs.aws.amazon.com/whitepapers/latest/aws-operational-resilience/how-aws-maintains-operational-resilience-and-continuity-of-service.html#incident-management[How AWS maintains operational
-resilience and continuity of service] in the AWS white paper.
+- For information regarding AWS incident and operations management, see "How AWS maintains operational resilience and continuity of service" in the AWS whitepaper linked in _Additional resources_.
 
 |- Configure, manage, and monitor customer applications and data to ensure application and data security controls are properly enforced.
 
@@ -114,7 +103,7 @@ An incident is an event that results in a degradation or outage of one or more R
 
 An incident can be raised by a customer or a Customer Experience and Engagement (CEE) member through a support case, directly by the centralized monitoring and alerting system, or directly by a member of the SRE team.
 
-Depending on the impact on the service and customer, the incident is categorized in terms of link:https://access.redhat.com/support/offerings/production/sla[severity].
+Depending on the impact on the service and customer, the incident is categorized in terms of severity. To learn more, see "Production Support Terms of Service" in _Additional resources_.
 
 When managing a new incident, Red{nbsp}Hat uses the following general workflow:
 
@@ -177,3 +166,8 @@ Red{nbsp}Hat can assist with activities including but not limited to:
 The impact of a cluster upgrade on capacity is evaluated as part of the upgrade testing process to ensure that capacity is not negatively impacted by new additions to the cluster. During a cluster upgrade, additional worker nodes are added to make sure that total cluster capacity is maintained during the upgrade process.
 
 Capacity evaluations by the Red{nbsp}Hat SRE staff also happen in response to alerts from the cluster, after usage thresholds are exceeded for a certain period of time. Such alerts can also result in a notification to the customer.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.aws.amazon.com/whitepapers/latest/aws-operational-resilience/how-aws-maintains-operational-resilience-and-continuity-of-service.html#incident-management[How AWS maintains operational resilience and continuity of service]
+* link:https://access.redhat.com/support/offerings/production/sla[Production Support Terms of Service]

--- a/modules/rosa-release-notes-Q2-2026.adoc
+++ b/modules/rosa-release-notes-Q2-2026.adoc
@@ -9,6 +9,10 @@
 The following items were added during the second quarter of 2026.
 
 ifdef::openshift-rosa-hcp[]
+Disaster recovery policies have been updated::
++
+A new backup and recovery strategy for the {product-title} cluster control planes has been implemented. For more information, see https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-policy-disaster-recovery_rosa-policy-responsibility-matrix[Disaster recovery].
+
 Users can create FIPS-encrypted Red Hat OpenShift Service on AWS clusters::
 +
 With this update, you can create Red Hat OpenShift Service on AWS clusters with Federal Information Processing Standards (FIPS) encryption that adhere to the highest data security levels. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/install_clusters/index#rosa-hcp-creating-cluster-with-fips-encryption[Deploying {product-title} clusters using FIPS encryption].

--- a/modules/rosa-release-notes-Q2-2026.adoc
+++ b/modules/rosa-release-notes-Q2-2026.adoc
@@ -10,7 +10,7 @@ The following items were added during the second quarter of 2026.
 
 New worker node instance types are available::
 +
-With this update, {product-title} offers 8th generation worker instances such as G7e, P6-B300, and more. For more information and details on instance type differences, see 
+With this update, {product-title} offers 8th generation worker instances such as G7e, P6-B300, and more. For more information and details on instance type differences, see
 ifndef::openshift-rosa-hcp[]
 link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws_classic_architecture/4/html/introduction_to_rosa/policies-and-service-definition#rosa-instance-types[{product-title} instance types.]
 endif::openshift-rosa-hcp[]

--- a/modules/rosa-release-notes-Q3-2026.adoc
+++ b/modules/rosa-release-notes-Q3-2026.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+// * rosa-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rosa-q3-2026_{context}"]
+= Q3 2026
+
+[role="_abstract"]
+The following items were added during the third quarter of 2026.
+
+//This RN is HCP-only. If you're adding this Q3 module to Classic, please, remember to conditionalize this RN for HCP.
+Disaster recovery policies are updated::
++
+A new backup and recovery strategy for the {product-title} cluster control planes is implemented, minimizing cluster risk from disaster events. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html-single/introduction_to_rosa/index#rosa-policy-disaster-recovery_rosa-policy-responsibility-matrix[Disaster recovery].

--- a/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc
@@ -62,5 +62,9 @@ endif::openshift-rosa-hcp[]
 .Additional resources
 
 * xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc#rosa-nodes-machinepools-about[About machine pools]
+* link:https://docs.aws.amazon.com/whitepapers/latest/disaster-recovery-workloads-on-aws/disaster-recovery-options-in-the-cloud.html[Disaster recovery options in the cloud]
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/disaster-recovery-resiliency.html[Resilience in Amazon EC2]
+* link:https://docs.aws.amazon.com/AmazonS3/latest/userguide/disaster-recovery-resiliency.html[Resilience in Amazon S3]
+* link:https://docs.aws.amazon.com/vpc/latest/userguide/disaster-recovery-resiliency.html[Resilience in Amazon Virtual Private Cloud]
 
 include::modules/rosa-policy-customer-responsibility.adoc[leveloffset=+1]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -11,6 +11,10 @@ toc::[]
 [role="_abstract"]
 Find new additions, recent changes, and relevant updates for {product-title} listed below in quarterly increments.
 
+ifdef::openshift-rosa-hcp[]
+include::modules/rosa-release-notes-Q3-2026.adoc[leveloffset=+1]
+endif::openshift-rosa-hcp[]
+
 include::modules/rosa-release-notes-Q2-2026.adoc[leveloffset=+1]
 
 include::modules/rosa-release-notes-Q1-2026.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-17569](https://issues.redhat.com/browse/OSDOCS-17569) Adding ROSA HCP backup and recovery information

Version(s):
4.22+
5.0+

Issue:
https://issues.redhat.com/browse/OSDOCS-17569

**Link to docs preview:**

- [ROSA HCP: Disaster recovery](https://104588--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-disaster-recovery_rosa-policy-responsibility-matrix) - 2 new rows in the table (Control plane and Data plane)
- [ROSA HCP release notes](https://104588--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html)
- ROSA Classic got no new content, as expected: [Disaster recovery](https://104588--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-disaster-recovery_rosa-policy-responsibility-matrix) and [Release notes](https://104588--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html)

QE review:

Additional information:

- PR also addresses several Vale errors.