### PR TITLE
[enterprise-4.17] wasp-agent: fix MachineConfig section

### DIFF
--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -76,6 +76,20 @@ spec:
       units:
         - contents: |
             [Unit]
+            Description=Enable swap
+            ConditionFirstBoot=no
+            ConditionPathExists=/var/tmp/swapfile
+            
+            [Service]
+            Type=oneshot
+            ExecStart=/bin/sh -c "sudo swapon /var/tmp/swapfile"
+            
+            [Install]
+            RequiredBy=kubelet-dependencies.target
+          enabled: true
+          name: swap-enable.service
+        - contents: |
+            [Unit]
             Description=Provision and enable swap
             ConditionFirstBoot=no
             ConditionPathExists=!/var/tmp/swapfile


### PR DESCRIPTION
Signed-off-by: Igor Bezukh <ibezukh@redhat.com>

the deployment process was updated with a new MC
that is fixing the issue with swap device being
disabled after node reboot


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.17.x
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/CNV-75702
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
