### PR TITLE
[enterprise-4.20] wasp-agent: fix MachineConfig section

### DIFF
--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -76,8 +76,29 @@ spec:
   config:
     ignition:
       version: 3.5.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,YXBpVmVyc2lvbjoga3ViZWxldC5jb25maWcuazhzLmlvL3YxYmV0YTEKa2luZDogS3ViZWxldENvbmZpZ3VyYXRpb24KZmFpbFN3YXBPbjogZmFsc2UK
+        mode: 420
+        overwrite: true
+        path: /etc/openshift/kubelet.conf.d/90-swap.conf
     systemd:
       units:
+        - contents: |
+            [Unit]
+            Description=Enable swap
+            ConditionFirstBoot=no
+            ConditionPathExists=/var/tmp/swapfile
+
+            [Service]
+            Type=oneshot
+            ExecStart=/bin/sh -c "sudo swapon /var/tmp/swapfile"
+
+            [Install]
+            RequiredBy=kubelet-dependencies.target
+          enabled: true
+          name: swap-enable.service
         - contents: |
             [Unit]
             Description=Provision and enable swap
@@ -87,7 +108,7 @@ spec:
             [Service]
             Type=oneshot
             Environment=SWAP_SIZE_MB=5000
-            ExecStart=/bin/sh -c "sudo dd if=/dev/zero of=/var/tmp/swapfile count=${SWAP_SIZE_MB} bs=1M && \
+            ExecStart=/bin/sh -c "sudo fallocate -l ${SWAP_SIZE_MB}M /var/tmp/swapfile && \
             sudo chmod 600 /var/tmp/swapfile && \
             sudo mkswap /var/tmp/swapfile && \
             sudo swapon /var/tmp/swapfile && \


### PR DESCRIPTION
Signed-off-by: Igor Bezukh ibezukh@redhat.com

the deployment process was updated with a new MC
that is fixing the issue with swap device being
disabled after node reboot and also with being
forward compatible with OCP 4.22 breaking changes
regarding swap configuration and kubeletConfig


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20.x
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: 
https://issues.redhat.com/browse/CNV-75702
https://issues.redhat.com/browse/CNV-75837


<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
