### PR TITLE
PR for SRVCOM-4061: Replaced all the occurences of rhel8 with rhel9 and also updated the kn cli installation ZIP links

### DIFF
--- a/modules/serverless-installing-cli-linux-rpm-package-manager.adoc
+++ b/modules/serverless-installing-cli-linux-rpm-package-manager.adoc
@@ -43,21 +43,21 @@ For {op-system-base-full}, you can install the Knative (`kn`) CLI as an RPM by u
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="openshift-serverless-1-for-rhel-8-x86_64-rpms"
+# subscription-manager repos --enable="openshift-serverless-1-for-rhel-9-x86_64-rpms"
 ----
 +
 * Linux on {ibmzProductName} and {linuxoneProductName} (s390x)
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="openshift-serverless-1-for-rhel-8-s390x-rpms"
+# subscription-manager repos --enable="openshift-serverless-1-for-rhel-9-s390x-rpms"
 ----
 +
 * Linux on {ibmpowerProductName} (ppc64le)
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="openshift-serverless-1-for-rhel-8-ppc64le-rpms"
+# subscription-manager repos --enable="openshift-serverless-1-for-rhel-9-ppc64le-rpms"
 ----
 
 . Install the Knative (`kn`) CLI as an RPM by using a package manager:

--- a/modules/serverless-installing-cli-linux.adoc
+++ b/modules/serverless-installing-cli-linux.adoc
@@ -2,7 +2,7 @@
 //
 // * serverless/cli_tools/installing-kn.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="installing-cli-linux_{context}"]
 = Installing the Knative CLI for Linux
 
@@ -27,11 +27,13 @@ $ kn: No such file or directory
 . Download the relevant Knative (`kn`) CLI `tar.gz` archive:
 +
 --
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
+* link:https://mirror.openshift.com/pub/cgw/serverless/latest/kn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
+* link:https://mirror.openshift.com/pub/cgw/serverless/latest/kn-linux-arm64.tar.gz[Linux (aarch64, ARM64)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
+* link:https://mirror.openshift.com/pub/cgw/serverless/latest/kn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
+
+* link:https://mirror.openshift.com/pub/cgw/serverless/latest/kn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
 --
 +
 You can also download any version of `kn` by navigating to that version's corresponding directory in the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/[Serverless client download mirror].

--- a/modules/serverless-installing-cli-macos.adoc
+++ b/modules/serverless-installing-cli-macos.adoc
@@ -2,19 +2,21 @@
 //
 // * serverless/cli_tools/installing-kn.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="serverless-installing-cli-macos_{context}"]
 = Installing the Knative CLI for macOS
 
 If you are using macOS, you can install the Knative (`kn`) CLI as a binary file. To do this, you must download and unpack a `tar.gz` archive and add the binary to a directory on your `PATH`.
 
-// no prereqs?
-
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-macos-amd64.tar.gz[Knative (`kn`) CLI `tar.gz` archive].
+. Download the relevant Knative (`kn`) CLI `tar.gz` archive:
 +
-You can also download any version of `kn` by navigating to that version's corresponding directory in the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/[Serverless client download mirror].
+--
+* link:https://mirror.openshift.com/pub/cgw/serverless/latest/kn-darwin-amd64.tar.gz[macOS (x86_64)]
+
+* link:https://mirror.openshift.com/pub/cgw/serverless/latest/kn-darwin-arm64.tar.gz[macOS (ARM64)]
+--
 
 . Unpack and extract the archive.
 

--- a/modules/serverless-installing-cli-windows.adoc
+++ b/modules/serverless-installing-cli-windows.adoc
@@ -12,7 +12,7 @@ If you are using Windows, you can install the Knative (`kn`) CLI as a binary fil
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-windows-amd64.zip[Knative (`kn`) CLI ZIP archive].
+. Download the link:https://mirror.openshift.com/pub/cgw/serverless/latest/kn-windows-amd64.zip[Knative (`kn`) CLI ZIP archive].
 +
 You can also download any version of `kn` by navigating to that version's corresponding directory in the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/[Serverless client download mirror].
 


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.37`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-4061

**Doc preview:**

- [Installing the Knative CLI for Linux by using an RPM package manager](https://104603--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/installing-kn.html#serverless-installing-cli-linux-rpm-package-manager_installing-kn)
- [Installing the Knative CLI for Linux](https://104603--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/installing-kn.html#installing-cli-linux_installing-kn)
- [Installing the Knative CLI for macOS](https://104603--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/installing-kn.html#serverless-installing-cli-macos_installing-kn)
- [Installing the Knative CLI for Windows](https://104603--ocpdocs-pr.netlify.app/openshift-serverless/latest/install/installing-kn.html#installing-cli-windows_installing-kn)

**Reviews:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
- [x] Peer has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->