### PR TITLE
OSDOCS-17681-RE: Added release note for SR-IOV Operator ARM arch support.

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -158,6 +158,10 @@ Applying unassisted holdover for boundary clocks and time synchronous clocks::
 +
 For more information, see xref:../networking/advanced_networking/ptp/configuring-ptp.adoc[Applying unassisted holdover for boundary clocks and time slave clocks].
 
+SR-IOV Operator supports ARM architecture::
++
+The Single Root I/O Virtualization (SR-IOV) Operator can now communicate with ARM hardware. You can now complete tasks such as configure network cards that are already plugged into an ARM server and use these cards in your applications. For instructions on how to search for ARM hardware that the SR-IOV Operator supports, see xref:../networking/hardware_networks/about-sriov.adoc[About Single Root I/O Virtualization (SR-IOV) hardware networks].
+
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-17681](https://issues.redhat.com/browse/OSDOCS-17681)

Link to docs preview:
* [SR-IOV Operator supports ARM architecture](https://104606--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-networking_release-notes)

- [x] SME hs approved this change.
- [x] QE has approved this change.
