### PR TITLE
OSDOCS-17681-feature: Added SR-IOV ARM support note to feature docs

### DIFF
--- a/networking/hardware_networks/about-sriov.adoc
+++ b/networking/hardware_networks/about-sriov.adoc
@@ -6,7 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The Single Root I/O Virtualization (SR-IOV) specification is a standard for a type of PCI device assignment that can share a single device with multiple pods.
+[role="_abstract"]
+To share a single physical device with multiple pods, implement the Single Root I/O Virtualization (SR-IOV) specification. This standard enables flexible PCI device assignment, allowing a device to show as multiple separate physical devices for efficient resource allocation.
+
+[NOTE]
+====
+As of {product-title} 4.21, the SR-IOV Operator can support ARM hardware.
+====
 
 You can configure a Single Root I/O Virtualization (SR-IOV) device in your cluster by using the xref:../../networking/networking_operators/sr-iov-operator/installing-sriov-operator.adoc#installing-sriov-operator[SR-IOV Operator].
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-17681](https://issues.redhat.com/browse/OSDOCS-17681)

Link to docs preview:
* [About Single Root I/O Virtualization (SR-IOV) hardware networks](https://104638--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html)

- [x] SME hs approved this change.
- [x] QE has approved this change.
