### PR TITLE
OSDOCS:13784 _2: adding GCP endpoints access

### DIFF
--- a/installing/installing_gcp/installing-gcp-default.adoc
+++ b/installing/installing_gcp/installing-gcp-default.adoc
@@ -6,8 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on
-{gcp-first} that uses the default configuration options.
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a cluster on {gcp-first} that uses the default configuration options.
 
 == Prerequisites
 
@@ -15,6 +15,7 @@ In {product-title} version {product-version}, you can install a cluster on
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If you are installing using a link:https://cloud.google.com/vpc/docs/private-service-connect[Private Service Connect (PSC) endpoint], you must configure the endpoint in the same Virtual Private Cloud (VPC) where you install the cluster, specified in the `install-config.yaml` file, as described in xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[Installing a cluster on {gcp-short} into an existing VPC].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {product-title} {product-version}, you can install a cluster on {gcp-first} in a restricted network by creating an internal mirror of the installation release content on an existing Google Virtual Private Cloud (VPC).
 
 [IMPORTANT]
@@ -29,6 +30,7 @@ Because the installation media is on the mirror host, you can use that computer 
 ** Contains the mirror registry
 ** Has firewall rules or a peering connection to access the mirror registry hosted elsewhere
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
+* If you are installing using a link:https://cloud.google.com/vpc/docs/private-service-connect[Private Service Connect (PSC) endpoint], you must configure the endpoint in the same Virtual Private Cloud (VPC) where you install the cluster, specified in the `install-config.yaml` file, as described in xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[Installing a cluster on {gcp-short} into an existing VPC].
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {product-title} version {product-version}, you can install a cluster on {gcp-first} that uses infrastructure that you provide and an internal mirror of the installation release content.
 
 [IMPORTANT]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -712,7 +712,6 @@ endif::agent[]
     name: arbiter
 |The {product-title} cluster requires a name for arbiter nodes. For example, `arbiter`.
 
-
 |arbiter:
     replicas: 1
 |The `replicas` parameter sets the number of arbiter nodes for the {product-title} cluster. You cannot set this field to a value that is greater than 1.
@@ -739,6 +738,21 @@ If you are using Azure File storage, you cannot enable FIPS mode.
 ====
 
 *Value:* `false` or `true`
+
+|endpoint:
+  name: <endpoint_name>
+  clusterUseOnly: `true` or `false`
+|The `name` parameter contains the name of the Private Service Connect (PSC) endpoints.
+
+[IMPORTANT]
+====
+When `clusterUseOnly` is `false`, its default setting, you must run the installation program from a bastion host that is within the same VPC where you want to deploy the cluster.
+====
+
+When you want the installation program to use the public API endpoints and cluster operators to use the API endpoint overrides, set `clusterUseOnly` to `true`. When you want both the installation program and the cluster operators to use the API endpoint overrides, for example if you are running the installation program from a bastion host that is within the same VPC where you want to deploy the cluster, set `clusterUseOnly` to `false` . The parameter is optional and defaults to `false`.
+
+*Value:* String or boolean
+
 endif::openshift-origin,ibm-power-vs[]
 |imageContentSources:
 |Sources and repositories for the release-image content.


### PR DESCRIPTION
Versions:
4.21+

Issue:
https://issues.redhat.com/browse/OSDOCS-13784

Link to docs preview:
- [Optional configuration parameters](https://104643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-optional_installation-config-parameters-gcp)

**Installing a cluster quickly on Google Cloud**
- [Prerequisites](https://104643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-default#prerequisites)

**Installing a cluster on Google Cloud in a disconnected environment**

- [Prerequisites](https://104643--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned#prerequisites_installing-restricted-networks-gcp-installer-provisioned) 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
