### PR TITLE
DOCPLAN-75: Remove callout

### DIFF
--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -22,7 +22,7 @@ Using `spec.domain.resources.requests.memory` in the VM manifest disables the me
 
 .Prerequisites
 
-* You have installed the OpenShift CLI (`oc`).
+* You have installed the {oc-first}.
 * You are logged into the cluster with the `cluster-admin` role.
 * A memory overcommit ratio is defined.
 * The node belongs to a worker pool.
@@ -195,9 +195,10 @@ $ oc get nodes -l node-role.kubernetes.io/worker
 +
 [source,terminal]
 ----
-$ oc debug node/<selected_node> -- free -m <1>
+$ oc debug node/<selected_node> -- free -m
 ----
-<1> Replace `<selected_node>` with the node name.
++
+Replace `<selected_node>` with the node name.
 +
 If swap is provisioned, an amount greater than zero is displayed in the `Swap:` row.
 +


### PR DESCRIPTION
Version(s):
4.16+
File doesn't seem to exist in older versions

Issue:
https://issues.redhat.com/browse/DOCPLAN-75

Link to docs preview:
https://104644--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.html#virt-using-wasp-agent-to-configure-higher-vm-workload-density_virt-configuring-higher-vm-workload-density

QE review:
n/a

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
