### PR TITLE
OSDOCS-17822 [NETOBSERV] Network Observability Operator 1.11 release notes

### DIFF
--- a/modules/network-observability-operator-release-notes-1-11-advisory.adoc
+++ b/modules/network-observability-operator-release-notes-1-11-advisory.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes_{context}"]
+= Network Observability Operator 1.11 advisory
+
+[role="_abstract"]
+You can review the advisory for Network Observability Operator 1.11 release.
+
+//add when available, likely just before or immediately after release day.
+//* link: [RHEA- Network Observability Operator 1.11]

--- a/modules/network-observability-operator-release-notes-1-11-fixed-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-11-fixed-issues.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-11-fixed-issues_{context}"]
+= Network Observability Operator 1.11 fixed issues
+
+[role="_abstract"]
+The Network Observability Operator 1.11 release contains several fixed issues that improve performance and the user experience.
+
+Missing dates in charts::
+Before this update, the chart tooltip date was not displayed as intended, due to a breaking change in a dependency. As a consequence, users experienced missing date information in the {product-title} web console plugin's *Overview* tab chart, affecting data context.
++
+With this release, the chart tooltip date display is restored.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2518[NETOBSERV-2518]
+
+Warning message for Direct mode not refreshed after upscaling::
+Before this update, cluster information was not refreshed after scaling, causing a warning message to persist in large clusters, not updating with changes.
++
+With this release, cluster information is now refreshed when it changes, resulting in the warning message for large clusters in `Direct` mode updating with changes in cluster size, improving user visibility.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2494[NETOBSERV-2494]
+
+Unenriched OVN IPs::
+Before this update, some IPs declared by OVN-Kubernetes were not enriched, causing unenriched IPs like `100.64.0.x` to not appear in `Machines` network. As a consequence, IPs not enriched caused the wrong network visibility for users.
++
+With this release, missing IPs in OVN-Kubernetes are now enriched, appearing in `Machines` network. As a result, IPs declared by OVN-Kubernetes are correctly enriched, improving the visibility of network traffic sources in `Machines` network.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2484[NETOBSERV-2484]
+
+Improved operator API discovery reliability::
+Before this update, a race condition during Network Observability Operator startup could cause API discovery to fail silently. As a consequence, the operator could fail to recognize the {product-title} cluster, leading to missing mandatory `ClusterRoleBinding` resources and preventing components from functioning correctly.
++
+With this release, the Network Observability Operator continues to check for API availability over time and reconciliation is blocked if discovery fails. As a result, the operator correctly identifies the environment and ensures all required roles are created.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2574[NETOBSERV-2574]
+
+Added missing translation fields to IPFIX exports::
+Before this update, some network flow fields were missing translations during the IPFIX export process. As a result, exported IPFIX data was incomplete or difficult to interpret in external collectors.
++
+With this release, the missing translation fields (xlat) have been added to the `flowlogs-pipeline` IPFIX exporter. IPFIX exports now provide a complete set of translated fields for consistent network observability.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2553[NETOBSERV-2553]
+
+Fixed FlowMetric form creation link and defaults::
+Before this update, the link to create a `FlowMetric` custom resource incorrectly directed users to a YAML editor instead of the intended form view. Additionally, the editor was pre-filled with incorrect default values.
++
+With this release, the link correctly leads to the `FlowMetric` resource creation form with the expected default settings. As a result, users can now easily create `FlowMetric` resources through the user interface.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2520[NETOBSERV-2520]
+
+Virtual machine resource type icon in Topology view::
+Before this update, virtual machine (VM) owner types incorrectly displayed a generic question mark (?) icon in the *Topology* view.
++
+With this release, the user interface now includes a specific icon for VM resources. As a result, users can more easily identify and distinguish VM traffic within the network topology.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2487[NETOBSERV-2487]
+
+DNS optimization, update DNS Alerts::
+Before this update, many DNS "NXDOMAIN" code were returned due to ambiguous URL being used in network observability.
++
+With this release, these URLs have been disambiguated, resulting in a more optimal use of DNS.
+
+link:https://issues.redhat.com/browse/NETOBSERV-2485[NETOBSERV-2485]
+
+
+
+
+////
+Follow this format:
+
+MetricName and Remap fields are validated::
++
+Before this update, users could create a `FlowMetric` custom resource (CR) with an invalid metric name. Although the `FlowMetric` CR was successfully created, the underlying metric would fail silently without providing any error feedback to the user.
++
+With this release, the `FlowMetric`, `metricName`, and `remap` fields are now validated before creation, so users are immediately notified if they enter an invalid name.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2348[NETOBSERV-2348]
+////

--- a/modules/network-observability-operator-release-notes-1-11-known-issues.adoc
+++ b/modules/network-observability-operator-release-notes-1-11-known-issues.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-11-known-issues_{context}"]
+= Network Observability Operator 1.11 known issues
+
+[role="_abstract"]
+The following known issues affect the Network Observability Operator 1.11 release.
+
+Health rules do not trigger when the sampling rate increases because of `lowVolumeThreshold`::
+Network observability alerts might not trigger when an elevated sampling rate causes the volume to fall below the `lowVolumeThreshold` filter. This results in fewer alerts being evaluated or displayed.
++
+To work around this problem, adjust the `lowVolumeThreshold` value to align with the sampling rate to ensure consistent alert evaluation.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2613[NETOBSERV-2613]
+
+
+DNS metrics unavailable when Loki is disabled::
+When the `DNSTracking` feature is enabled in a "Loki-less" installation, the required metrics for DNS graphs are unavailable. As a consequence, you cannot view DNS latency and response codes in the dashboard.
++
+To work around this problem, you must either disable the `DNSTracking` option or enable Loki in the `FlowCollector` resource by setting `spec.loki.enable` to true.
++
+link:https://issues.redhat.com/browse/NETOBSERV-2621[NETOBSERV-2621]

--- a/modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+// * network_observability/network-observability-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="network-observability-operator-release-notes-1-11-new-features-enhancements_{context}"]
+= Network Observability Operator 1.11 new features and enhancements
+
+[role="_abstract"]
+Learn about the new features and enhancements in the Network Observability Operator 1.11 release, including hierarchical governance with the `FlowCollectorSlice` resource, a new Service deployment model, and the general availability of health rules.
+
+Per-tenant hierarchical governance with the FlowCollectorSlice resource::
+This release introduces the `FlowCollectorSlice` API to support hierarchical governance, allowing project administrators to independently manage sampling and subnet labeling for their specific namespaces.
++
+This feature was implemented to reduce global processing overhead and provide tenant autonomy in large-scale environments where individual teams require self-service visibility without cluster-wide configuration changes. As a result, organizations can selectively collect traffic and delegate data enrichment tasks to the project level while maintaining centralized cluster control.
+
+New Service deployment model for the `FlowCollector` resource::
+This release introduces a new `Service` deployment model in the `FlowCollector` custom resource. This model provides an intermediate option between the `Direct` and `Kafka` models. In the `Service` model, the eBPF agent is deployed as a `daemon` set, and the `flowlogs-pipeline` component is deployed as a scalable service.
++
+This model offers improved performance in large clusters by reducing cache duplication across component instances.
+
+Health rules are generally available::
+The health alerts feature, introduced in previous versions as a Technology Preview feature, is fully supported as health rules in the Network Observability Operator 1.11 release.
++
+[IMPORTANT]
+====
+Network Observability health rules are available on {product-title} 4.16 and later.
+====
++
+This eBPF-based system correlates network metrics with infrastructure metadata to provide proactive notifications and automated insights into cluster health, such as traffic surges or latency trends. As a result, you can use the *Network Health* dashboard in the {product-title} web console to manage categorized alerts, customize thresholds, and create recording rules for improved visualization performance.
+
+Enhanced network traffic visualization and filtering::
+This release introduces enhanced visualization and filtering tools in the {product-title} web console.
+
+* Inline filter editing: You can now edit filter chips directly within the filter input field. This enhancement provides a more efficient method for modifying long filter values that were previously truncated, eliminating the need to manually copy and paste values. This update adopts an inline editing convention consistent with the Saved filters feature.
+* External traffic quick filters: New quick filters allow you to monitor external ingress and egress traffic actively. This enhancement streamlines network management, enabling you to identify and address issues related to external network communication quickly.
+* Intuitive resource iconography: The {product-title} console now uses specific icons for Kubernetes kinds, groups, and filters. These icons provide a more intuitive and visually consistent experience, making it easier to navigate the network topology and identify applied filters at a glance.
+
+DNS resolution analysis::
+This release includes eBPF-based DNS tracking to enrich network flow records with domain names.
++
+This feature was implemented to reduce the mean time to identify (MTTI) by allowing administrators to immediately distinguish between network routing failures and service discovery issues, such as `NXDOMAIN` errors.
+
+Integration with Gateway API::
+This release introduces automatic integration between the Network Observability Operator and the Gateway API when a `GatewayClass` resource is created. This feature provides high-level traffic attribution for cluster ingress and egress traffic without requiring manual configuration of the `FlowCollector` resource.
++
+[IMPORTANT]
+====
+Integration with Gateway API is available on {product-title} 4.19 and later.
+====
++
+You can verify the automated mapping of network flows to Gateway API resources in the *Observe* → *Network Traffic* view of the {product-title} web console. The *Owner* column displays the Gateway name, providing a direct link to the associated Gateway resource page.
+
+Improved data resilience in the Overview and Topology views::
+With this release, functional data remains visible in the *Overview* and *Topology* views even if some background queries fail. This enhancement ensures that the scope and group dropdown menus in the Topology view remain accessible during partial service disruptions.
++
+Additionally, the *Overview* page now displays active error messages to assist with troubleshooting, providing better visibility into system health without interrupting the monitoring workflow.
+
+Improved categorization of unknown network flows::
+With this release, network flows from unknown sources are categorized into four distinct groups: external, unknown service, unknown node, and unknown pod.
++
+This enhancement uses subnet labels to separate unknown IP subnets, providing a clearer network topology. This improved visibility helps to identify potential security threats and allows for a more targeted analysis of unknown elements within the cluster.
+
+Improved performance for new Network Observability installations::
+The default performance of the Network Observability Operator is improved for new installations. The default value for `cacheActiveTimeout` is increased from 5 to 15 seconds, and the `cacheMaxFlows` value is increased from 100,000 to 120,000 to accommodate higher flow volumes.
++
+[IMPORTANT]
+====
+These new default values apply only to new installations; existing installations retain their current configurations.
+====
++
+These changes reduce CPU load by up to 40%.
+
+Improved LokiStack status monitoring and reporting::
+With this release, the Network Observability Operator monitors the status of the `LokiStack` resource and reports errors or configuration issues. The Network Observability Operator verifies `LokiStack` conditions, including pending or failed pods and specific warning conditions.
++
+This enhancement provides more actionable information in the `FlowCollector` status, allowing for more effective troubleshooting of the `LokiStack` component within network observability.
+
+Visual indicators for Loki indexed fields in the filter menu::
+With this release, the network observability console plugin highlights Loki indexed fields in the filter dropdown menu.
++
+This enhancement improves query performance by indicating which fields are indexed for faster data retrieval. Using indexed fields when filtering data reduces the time required to browse and analyze network flows within the console.
+

--- a/modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc
@@ -48,7 +48,7 @@ This release introduces automatic integration between the Network Observability 
 Integration with Gateway API is available on {product-title} 4.19 and later.
 ====
 +
-You can verify the automated mapping of network flows to Gateway API resources in the *Observe* → *Network Traffic* view of the {product-title} web console. The *Owner* column displays the Gateway name, providing a direct link to the associated Gateway resource page.
+You can verify the automated mapping of network flows to Gateway API resources in the *Observe* -> *Network Traffic* view of the {product-title} web console. The *Owner* column displays the Gateway name, providing a direct link to the associated Gateway resource page.
 
 Improved data resilience in the Overview and Topology views::
 With this release, functional data remains visible in the *Overview* and *Topology* views even if some background queries fail. This enhancement ensures that the scope and group dropdown menus in the Topology view remain accessible during partial service disruptions.

--- a/observability/network_observability/network-observability-operator-release-notes.adoc
+++ b/observability/network_observability/network-observability-operator-release-notes.adoc
@@ -13,20 +13,12 @@ These release notes track the development of the Network Observability Operator 
 
 For an overview of the Network Observability Operator, see xref:../../observability/network_observability/network-observability-overview.adoc#network-observability-overview[About network observability].
 
-include::modules/network-observability-operator-release-notes-1-10-1.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-11-advisory.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-10-1-cves.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-11-new-features-enhancements.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-10-1-fixed-issues.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-11-known-issues.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-10-advisory.adoc[leveloffset=+1]
+include::modules/network-observability-operator-release-notes-1-11-fixed-issues.adoc[leveloffset=+1]
 
-include::modules/network-observability-operator-release-notes-1-10-new-features-enhancements.adoc[leveloffset=+1]
-
-include::modules/network-observability-operator-release-notes-1-10-technology-preview-features.adoc[leveloffset=+1]
-
-include::modules/network-observability-operator-release-notes-1-10-removed-features.adoc[leveloffset=+1]
-
-include::modules/network-observability-operator-release-notes-1-10-known-issues.adoc[leveloffset=+1]
-
-include::modules/network-observability-operator-release-notes-1-10-fixed-issues.adoc[leveloffset=+1]
+//Purposely missing [role="_abstract"] as it used to ensure Vale is running correctly.

--- a/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
+++ b/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.adoc
@@ -13,6 +13,24 @@ These release notes track past developments of the Network Observability Operato
 
 The Network Observability Operator enables administrators to observe and analyze network traffic flows for {product-title} clusters.
 
+include::modules/network-observability-operator-release-notes-1-10-1.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-1-cves.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-1-fixed-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-advisory.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-new-features-enhancements.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-technology-preview-features.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-removed-features.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-known-issues.adoc[leveloffset=+1]
+
+include::modules/network-observability-operator-release-notes-1-10-fixed-issues.adoc[leveloffset=+1]
+
 include::modules/network-observability-operator-release-notes-1-9-3-advisory.adoc[leveloffset=+1]
 
 include::modules/network-observability-operator-release-notes-1-9-2-advisory.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-17822](https://issues.redhat.com//browse/OSDOCS-17822) [NETOBSERV] Network Observability Operator 1.11 release notes

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the no-1.11 branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the <no-.11> content just before its GA.

Issue:
https://issues.redhat.com/browse/OSDOCS-17822

Link to docs preview:
* Network Observability Operator 1.11 release notes: https://104645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html
* 1.11 advisory: https://104645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-release-notes-1-11_network-observability-operator-release-notes
* New feature and enhancements: https://104645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-release-notes-1-11-new-features-enhancements_network-observability-operator-release-notes
* Known issues: https://104645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-release-notes-1-11-known-issues_network-observability-operator-release-notes
* Fixed issues: https://104645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-operator-release-notes.html#network-observability-operator-release-notes-1-11-fixed-issues_network-observability-operator-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* There is a lot of rel notes content for this release so submitting to Doc Merge Review before Advisory is available so there is enough time for reviews and any changes.
* Advisory is added last as it usually available just before release. If it is available before this PR goes through Doc merge review, it will be added. Otherwise, a new PR will be created to update the Advisory with the appropriate Advisory link.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
