### PR TITLE
OSDOCS-17835 add zstream RNs for 4-20-10

### DIFF
--- a/modules/zstream-4-20-10-about.adoc
+++ b/modules/zstream-4-20-10-about.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-20-10-about_{context}"]
+= RHBA-2026:0370 - {product-title} {product-version}.10 fixed issues advisory
+
+[role="_abstract"]
+Issued: 13 January 2026
+
+{product-title} release {product-version}.10 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:0370[RHBA-2026:0370] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:0419[RHBA-2026:0419] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.10 --pullspecs
+----

--- a/modules/zstream-4-20-10-enhancements.adoc
+++ b/modules/zstream-4-20-10-enhancements.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-10-enhancements_{context}"]
+= Enhancements
+
+[role="_abstract"]
+The following enhancements are included in this z-stream release:
+
+* With this update, the Cluster Network Operator now supports `KubeVirt` as a platform for dual-stack networking in {VirtProductName}, resolving a previous issue where `KubeVirt` was not recognized as a supported platform for dual-stack. This enhancement enables successful deployment of a Hosted Control Plane on {VirtProductName} with IPv4/IPv6 dual-stack networking. This improvement reduces deployment failures and ensure a smoother experience for users deploying {VirtProductName} with `KubeVirt`. (link:https://issues.redhat.com/browse/OCPBUGS-66235[OCPBUGS-66235])

--- a/modules/zstream-4-20-10-fixed-issues.adoc
+++ b/modules/zstream-4-20-10-fixed-issues.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-10-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issues are fixed for this release:
+
+* Before this update, when a HyperShift `HostedCluster` used external Domain Name Service (DNS) domains and endpoint access with PublicAndPrivate, the `allowedCIDRBlocks` parameters were wrongly applied only to the internal `kube-apiserver`, leaving the control plane Operator in an error state. With this release, the control plane Operator functions correctly and the `LoadBalancerSourceRanges` configuration has been added to the external router `LoadBalancer` service, ensuring that external `kube-apiserver` access is now properly restricted to the specified `allowedCIDRBlocks`. (link:https://issues.redhat.com/browse/OCPBUGS-63509[OCPBUGS-63509])
+
+* Before this update, when domain name service (DNS) pods were deleted and recreated in {product-title} clusters using OVN-Kubernetes networking, stale User Datagram Protocol (UDP) `conntrack` entries could remain on worker nodes. This occurred because the `conntrack` cleanup logic incorrectly used the endpoint port (the port on which the DNS pod listens, typically 5353) instead of the service port (the port clients connect to, 53) when attempting to delete stale entries. With this release, when DNS pods are deleted or updated, the cleanup process correctly uses the service port (53) to match and removes the  stale `conntrack` entries, ensuring DNS resolution continues to work reliably across pod lifecycle events. (link:https://issues.redhat.com/browse/OCPBUGS-66049[OCPBUGS-66049])
+
+* Before this update, {product-title} 4.16 and later versions failed to respect the timeout `http-keep-alive` setting due to a known upstream HAProxy bug, preventing users from effectively managing connection persistence. This lack of control resulted in inconsistent connection behaviors, where long-lived sessions might be terminated unexpectedly or held open longer than normal. With this release, the `HTTPKeepAliveTimeout` tuning option has been integrated into the `IngressController` API, providing a formal way for customers to configure and enforce this specific timeout. As a result, cluster administrators now possess the granular control necessary to align connection persistence with specific application needs. (link:https://issues.redhat.com/browse/OCPBUGS-66135[OCPBUGS-66135])
+
+* Before this update, changes in RHCOS image layering increased space usage on the rendezvous node’s ephemeral temporary file system to approximately 9.4 GiB during cluster bootstrapping. Because the ephemeral temporary file system is capped at 50% of available RAM, installation failed on hosts with less than 19 GiB of memory due to insufficient space for container images. With this release, the additional data has been moved to a separate temporary file system. As a result, any rendezvous host meeting the minimum RAM requirement for a control plane node now has sufficient capacity to successfully bootstrap a cluster. (link:https://issues.redhat.com/browse/OCPBUGS-66231[OCPBUGS-66231])
+
+* Before this update, when a HyperShift `HostedCluster` used external Domain Name Service (DNS) domains and endpoint access with PublicAndPrivate,  the `allowedCIDRBlocks` parameters were wrongly applied only to the internal `kube-apiserve`, leaving the control plane Operator in an error state. With this release, the control plane Operator functions correctly and the `LoadBalancerSourceRanges` configuration has been added to the external router `LoadBalancer` service, ensuring that external `kube-apiserver` access is now properly restricted to the specified `allowedCIDRBlocks`. (link:https://issues.redhat.com/browse/OCPBUGS-66397[OCPBUGS-66397])
+
+* Before this update, the inventory collection and provisioning process on the Bare Metal platform included network devices using the `cdc_ncm` driver. This caused significant issues because these virtual network interface cards (NICs) often triggered errors or instability during the provisioning phase. With this release, the system has been updated to explicitly ignore any network devices using the `cdc_ncm` driver. As a result, a more stable and reliable deployment process is ensured. (link:https://issues.redhat.com/browse/OCPBUGS-66934[OCPBUGS-66934])
+
+* Before this update, the *Operand* details page would incorrectly show information using only half of the screen's display area in the OpenShift web console. With this release, the *Operand* details take up the full page width as expected. (link:https://issues.redhat.com/browse/OCPBUGS-67136[OCPBUGS-67136])
+
+* Before this update, the Baremetal Operator defaulted to x86_64 architecture when no architecture information was available from hardware inspection or the `BareMetalHost` spec. This caused provisioning to fail on ARM-based bare-metal clusters. With this release, the Baremetal Operator now automatically detects and uses the architecture of the running controller, enabling successful bare-metal provisioning on both x86_64 and ARM64 architectures. (link:https://issues.redhat.com/browse/OCPBUGS-69667[OCPBUGS-69667])
+
+
+

--- a/modules/zstream-4-20-10-updating.adoc
+++ b/modules/zstream-4-20-10-updating.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-10-updating_{context}"]
+= Updating
+
+
+[role="_abstract"]
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/modules/zstream-4-20-8-fixed-issues.adoc
+++ b/modules/zstream-4-20-8-fixed-issues.adoc
@@ -4,7 +4,7 @@
 
 
 :_mod-docs-content-type: REFERENCE
-[id="zstream-4-20-58-fixed-issues_{context}"]
+[id="zstream-4-20-8-fixed-issues_{context}"]
 = Fixed issues
 
 [role="_abstract"]

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3011,6 +3011,18 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// About 4-20-10 release notes
+include::modules/zstream-4-20-10-about.adoc[leveloffset=+2]
+
+// 4-20-10 release notes enhancements
+include::modules/zstream-4-20-10-enhancements.adoc[leveloffset=+3]
+
+// 4-20-10 release notes fixed issues
+include::modules/zstream-4-20-10-fixed-issues.adoc[leveloffset=+3]
+
+// 4-20-10 release notes updating
+include::modules/zstream-4-20-10-updating.adoc[leveloffset=+3]
+
 // About 4-20-8 release notes
 include::modules/zstream-4-20-8-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
https://issues.redhat.com/browse/OSDOCS-17835

Link to docs preview:
https://104651--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-10-about_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
To find the Image and RPM IDs, select the following links:
For the Image ID: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/301/diffs#d3797d0de6ff228d0267c238c3e8bd66ca771fe5

For the RPM ID: https://errata.devel.redhat.com/advisory/157897

Must be on VPN to view these links.