### PR TITLE
CNV#76050: [docs] wasp-agent: remove "Pod eviction conditions" paragraph

### DIFF
--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -7,7 +7,7 @@
 = Using wasp-agent to increase VM workload density
 
 [role="_abstract"]
-The `wasp-agent` component facilitates memory overcommitment by assigning swap resources to worker nodes. It also manages pod evictions when nodes are at risk due to high swap I/O traffic or high utilization.
+The `wasp-agent` component facilitates memory overcommitment by assigning swap resources to worker nodes.
 
 The `wasp-agent` component is deployed automatically if `memoryOvercommitPercentage` is set to more than `100` when you first create the `HyperConverged` custom resource (CR).
 

--- a/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc
+++ b/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.adoc
@@ -20,5 +20,3 @@ Memory overcommitment can lower workload performance on a highly utilized system
 include::modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc[leveloffset=+1]
 
 include::modules/virt-removing-wasp-agent.adoc[leveloffset=+1]
-
-include::modules/virt-wasp-agent-pod-eviction.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.17+

Issue: [CNV-76050](https://issues.redhat.com/browse/CNV-76050)

Link to docs preview: [Configuring higher VM workload density](https://104654--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.html#virt-using-wasp-agent-to-configure-higher-vm-workload-density_virt-configuring-higher-vm-workload-density) (with `Pod eviction conditions used by wasp-agent` topic removed)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

