### PR TITLE
[OSDOCS#17849]: Update for zstream release notes 4.18.31.

### DIFF
--- a/modules/zstream-4-18-31-about.adoc
+++ b/modules/zstream-4-18-31-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+= RHSA-2026:0338 - {product-title} {product-version}.31 fixed issues and security update
+
+[role="_abstract"]
+Issued: 14 January 2026
+
+{product-title} release {product-version}.28 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:0338[RHSA-2026:0338] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:0331[RHSA-2026:0331] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.31 --pullspecs
+----
+

--- a/modules/zstream-4-18-31-fixed-issues.adoc
+++ b/modules/zstream-4-18-31-fixed-issues.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+= Fixed issues
+[role="_abstract"]
+You can ensure your environment remains stable by reviewing these fixed issues to verify resolved bugs.
+
+The following issues are fixed for this release:
+
+* Before this update, the installation program created images that did not support instance types requiring NVMe or SCSI. This caused installations to fail when using those specific instance types. With this release, the installation program now supports NVMe and SCSI instance types. You can now use these instances for your OpenShift deployments. (link:https://issues.redhat.com/browse/OCPBUGS-52659[OCPBUGS-52659])
+
+* Before this update, a null pointer dereference occurred in the `waitFor` method due to failed {gcp-first} (GCP) API calls or uninitialized clients. As a consequence, users experienced a panic error during cluster destruction on GCP. With this release, the null pointer dereference in the Cluster Uninstaller utility is fixed, preventing panic errors during {product-title} cluster destruction on GCP. As a result, cluster destruction on GCP no longer triggers a panic error with the updated {product-title} 4.18 release. (link:https://issues.redhat.com/browse/OCPBUGS-63494[OCPBUGS-63494])
+
+* Before this update, the `EgressFirewall` resource retained managed fields after a machine was deleted. As a consequence, large clusters experienced etcd storage buildup, which increased the risk of API server instability or failure. With this release, the installation program does not retain information for deleted machines, which prevents unnecessary etcd growth. As a result, you can manage large clusters in {product-title} 4.18.0 without risking API server breakdowns due to stale `EgressFirewall` data. (link:https://issues.redhat.com/browse/OCPBUGS-66140[OCPBUGS-66140])
+
+* Before this update, a validation error occurred during the creation of user accounts with special characters in the email address. As a consequence, user account creation failed. With this release, the validation error is resolved. As a result, user account creation with special characters in the email address is successful. (link:https://issues.redhat.com/browse/OCPBUGS-66381[OCPBUGS-66381])
+
+* Before this update, the Ironic API advertised an unreachable IP address even when a routable path existed. As a consequence, users could not access the Ironic API because the advertised IP address was non-routable. With this release, the installation program verifies the routability of the advertised IP address for the Ironic API. As a result, the Ironic API is consistently reachable, ensuring a reliable user experience in {product-title} 4.18.0. (link:https://issues.redhat.com/browse/OCPBUGS-68360[OCPBUGS-68360])
+
+* Before this update, `HAProxy` pods frequently exceeded the `maxConn` limit because idle connections remained open when using the `idle-close-on-response` setting. As a consequence, `HAProxy` pods entered a `CrashLoop` state, resulting in performance degradation and persistent reconciliation failures. With this release, the `IdleConnectionTerminationPolicy` is activated to ensure idle connections are closed correctly. As a result, `HAProxy` pods in {product-title} 4.18.0 no longer exceed the `maxConn` limit or experience crashes related to connection buildup. (link:https://issues.redhat.com/browse/OCPBUGS-70315[OCPBUGS-70315])
+
+
+

--- a/modules/zstream-4-18-31-updating.adoc
+++ b/modules/zstream-4-18-31-updating.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-31-updating_{context}"]
+= Updating
+
+
+[role="_abstract"]
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3072,6 +3072,14 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+// 4.18.31 about
+include::modules/zstream-4-18-31-about.adoc[leveloffset=+2]
+
+// 4.18.31 fixed issues
+include::modules/zstream-4-18-31-fixed-issues.adoc[leveloffset=+2]
+
+// 4.18.31 updating
+include::modules/zstream-4-18-31-updating.adoc[leveloffset=+2]
 
 // 4.18.30 about
 include::modules/zstream-4-18-30-about.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-17849

Link to docs preview:
[4.18.31](https://104655--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#rhsa-2026338-openshift-container-platform-branch-build-31-fixed-issues-and-security-update)

QE review:
N/A for zstream release notes


Additional information:
https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/293

https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18
