### PR TITLE
OSDOCS-17818 [NETOBSERV] New Feature: Service Deployment Model

### DIFF
--- a/modules/network-observability-architecture.adoc
+++ b/modules/network-observability-architecture.adoc
@@ -17,6 +17,20 @@ If you do not use Loki, you can generate metrics with Prometheus. Those metrics 
 
 image::network-observability-architecture.png[Network Observability eBPF export architecture]
 
-If you are using the Kafka option, the eBPF agent sends the network flow data to Kafka, and the `flowlogs-pipeline` reads from the Kafka topic before sending to Loki, as shown in the following diagram.
+There are three deployment model options for the Network Observability Operator.
 
+[NOTE]
+====
+The Network Observability Operator does not manage Loki or other data stores. You must install Loki separately by using the {loki-op}. If you use Kafka, you must install it separately by using the Kafka Operator.
+====
+
+Service deployment model::
+When the `spec.deploymentModel` field in the `FlowCollector` resource is set to `Service`, agents are deployed per node as daemon sets. The `flowlogs-pipeline` is a standard deployment with a service. You can scale the `flowlogs-pipeline` component by using the `spec.processor.consumerReplicas` field.
+
+Direct deployment model::
+When the `spec.deploymentModel` field is set to `Direct`, agents and the `flowlogs-pipeline` are both deployed per node as daemon sets. This model is suitable for technology assessments and small clusters. However, it is less memory-efficient in large clusters because each instance of `flowlogs-pipeline` caches the same cluster information.
+
+Kafka deployment model (optional)::
+If you use the Kafka option, the `eBPF agent` sends the network flow data to Kafka. You can scale the `flowlogs-pipeline` component by using the `spec.processor.consumerReplicas` field. The `flowlogs-pipeline` component reads from the Kafka topic before sending data to Loki, as shown in the following diagram.
++
 image::network-observability-arch-kafka-FLP.png[Network Observability using Kafka]


### PR DESCRIPTION
[OSDOCS-17818](https://issues.redhat.com//browse/OSDOCS-17818) [NETOBSERV] New Feature: Service Deployment Model

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the `no-1.11` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the no-1.11 content just before its GA.

Issue:
https://issues.redhat.com/browse/OSDOCS-17818

Link to docs preview:
* Network Observability Operator architecture: https://104657--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/understanding-network-observability-operator.html#network-observability-architecture_nw-network-observability-operator 


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Some content restructuring was done to accommodate the addition of the Service deployment model content.
* Content for each deployment model was updated to match https://github.com/netobserv/network-observability-operator/blob/main/docs/Architecture.md#service-deployment-model 
* Diagram updates are being handled separately.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
