### PR TITLE
OSDOCS-17768: AWS southeast 6 region

### DIFF
--- a/modules/installation-aws-regions.adoc
+++ b/modules/installation-aws-regions.adoc
@@ -32,6 +32,7 @@ The following {aws-short} public regions are supported:
 * `ap-southeast-3` (Jakarta)
 * `ap-southeast-4` (Melbourne)
 * `ap-southeast-5` (Malaysia)
+* `ap-southeast-6` (New Zealand)
 * `ap-southeast-7` (Thailand)
 * `ca-central-1` (Central Canada)
 * `ca-west-1` (Calgary)


### PR DESCRIPTION
[OSDOCS-16274](https://issues.redhat.com/browse/OSDOCS-16274)

Version(s): 4.21+

This PR adds New Zealand to the list of supported AWS regions

QE review:
- [x] QE has approved this change.

Preview: [AWS public regions](https://104659--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-public_installing-aws-account)