### PR TITLE
OSDOCS-17767: aws gp3 throughput parameter

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -958,6 +958,15 @@ Optional AWS configuration parameters are described in the following table:
   platform:
     aws:
       rootVolume:
+        throughput:
+|The maximum throughput of the root volume. This throughput can be customized only for the gp3 volume type. The minimum value is 125 MiB/s and the maximum value is 2000 MiB/s.
+
+*Value:* Integer, for example `1000`.
+
+|compute:
+  platform:
+    aws:
+      rootVolume:
         kmsKeyARN:
 |The Amazon Resource Name (key ARN) of a KMS key. This is required to encrypt operating system volumes of worker nodes with a specific KMS key.
 
@@ -1029,6 +1038,15 @@ Optional AWS configuration parameters are described in the following table:
 |The type of the root volume for control plane machines.
 
 *Value:* Valid link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html[AWS EBS volume type], such as `io1`.
+
+|controlPlane:
+  platform:
+    aws:
+      rootVolume:
+        throughput:
+|The maximum throughput of the root volume. This throughput can be customized only for the gp3 volume type. The minimum value is 125 MiB/s and the maximum value is 2000 MiB/s.
+
+*Value:* Integer, for example `1000`.
 
 |controlPlane:
   platform:


### PR DESCRIPTION
[OSDOCS-17767](https://issues.redhat.com/browse/OSDOCS-17767)

Version(s): 4.21+

This PR adds a new parameter for AWS root volumes for customizing the throughput of gp3 volumes.

QE review:
- [x] QE has approved this change.

Preview: [Optional AWS configuration parameters](https://104662--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-optional-aws_installation-config-parameters-aws)