### PR TITLE
OSDOCS 17854 Upstream KEDA 2.18.1 changes

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-creating-workload.adoc
+++ b/modules/nodes-cma-autoscaling-custom-creating-workload.adoc
@@ -150,7 +150,7 @@ spec:
 <11> Optional: Specifies the maximum number of replicas when scaling up. The default is `100`.
 <12> Optional: Specifies the minimum number of replicas when scaling down.
 <13> Optional: Specifies the parameters for audit logs. as described in the "Configuring audit logging" section.
-<14> Optional: Specifies the number of replicas to fall back to if a scaler fails to get metrics from the source for the number of times defined by the `failureThreshold` parameter. For more information on fallback behavior, see the link:https://keda.sh/docs/latest/reference/scaledobject-spec/#fallback[KEDA documentation].
+<14> Optional: Specifies the number of replicas to fall back to if a scaler fails to get metrics from the source for the number of times defined by the `failureThreshold` parameter. Not supported for CPU or memory triggers. For more information on fallback behavior, see the link:https://keda.sh/docs/latest/reference/scaledobject-spec/#fallback[KEDA documentation].
 <15> Optional: Specifies the replica count to be used if a fallback occurs. Enter one of the following options or omit the parameter:
 * Enter `static` to use the number of replicas specified by the `fallback.replicas` parameter. This is the default.
 * Enter `currentReplicas` to maintain the current number of replicas.

--- a/modules/nodes-cma-autoscaling-custom-creating-workload.adoc
+++ b/modules/nodes-cma-autoscaling-custom-creating-workload.adoc
@@ -76,19 +76,22 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   annotations:
-    autoscaling.keda.sh/paused-replicas: "0" <1>
-  name: scaledobject <2>
+    autoscaling.keda.sh/paused <1> 
+    autoscaling.keda.sh/paused-replicas: "0" <2>
+    autoscaling.keda.sh/paused-scale-in: "true" <3>
+    autoscaling.keda.sh/paused-scale-out: "true" <4>
+  name: scaledobject <5>
   namespace: my-namespace
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1 <3>
-    name: example-deployment <4>
-    kind: Deployment <5>
-    envSourceContainerName: .spec.template.spec.containers[0] <6>
-  cooldownPeriod:  200 <7>
-  maxReplicaCount: 100 <8>
-  minReplicaCount: 0 <9>
-  metricsServer: <10>
+    apiVersion: apps/v1 <6>
+    name: example-deployment <7>
+    kind: Deployment <8>
+    envSourceContainerName: .spec.template.spec.containers[0] <9>
+  cooldownPeriod:  200 <10>
+  maxReplicaCount: 100 <11>
+  minReplicaCount: 0 <12>
+  metricsServer: <13>
     auditConfig:
       logFormat: "json"
       logOutputVolumeClaim: "persistentVolumeClaimName"
@@ -101,16 +104,16 @@ spec:
         maxAge: "2"
         maxBackup: "1"
         maxSize: "50"
-  fallback: <11>
+  fallback: <14>
     failureThreshold: 3
     replicas: 6
-    behavior: static <12>
-  pollingInterval: 30 <13>
+    behavior: static <15>
+  pollingInterval: 30 <16>
   advanced:
-    restoreToOriginalReplicaCount: false <14>
+    restoreToOriginalReplicaCount: false <17>
     horizontalPodAutoscalerConfig:
-      name: keda-hpa-scale-down <15>
-      behavior: <16>
+      name: keda-hpa-scale-down <18>
+      behavior: <19>
         scaleDown:
           stabilizationWindowSeconds: 300
           policies:
@@ -118,7 +121,7 @@ spec:
             value: 100
             periodSeconds: 15
   triggers:
-  - type: prometheus <17>
+  - type: prometheus <20>
     metadata:
       serverAddress: https://thanos-querier.openshift-monitoring.svc.cluster.local:9092
       namespace: kedatest
@@ -126,32 +129,39 @@ spec:
       threshold: '5'
       query: sum(rate(http_requests_total{job="test-app"}[1m]))
       authModes: basic
-    authenticationRef: <18>
+    authenticationRef: <21>
       name: prom-triggerauthentication
       kind: TriggerAuthentication
 ----
-<1> Optional: Specifies that the Custom Metrics Autoscaler Operator is to scale the replicas to the specified value and stop autoscaling, as described in the "Pausing the custom metrics autoscaler for a workload" section.
-<2> Specifies a name for this custom metrics autoscaler.
-<3> Optional: Specifies the API version of the target resource. The default is `apps/v1`.
-<4> Specifies the name of the object that you want to scale.
-<5> Specifies the `kind` as `Deployment`, `StatefulSet` or `CustomResource`.
-<6> Optional: Specifies the name of the container in the target resource, from which the custom metrics autoscaler gets environment variables holding secrets and so forth. The default is `.spec.template.spec.containers[0]`.
-<7> Optional. Specifies the period in seconds to wait after the last trigger is reported before scaling the deployment back to `0` if the `minReplicaCount` is set to `0`. The default is `300`.
-<8> Optional: Specifies the maximum number of replicas when scaling up. The default is `100`.
-<9> Optional: Specifies the minimum number of replicas when scaling down.
-<10> Optional: Specifies the parameters for audit logs. as described in the "Configuring audit logging" section.
-<11> Optional: Specifies the number of replicas to fall back to if a scaler fails to get metrics from the source for the number of times defined by the `failureThreshold` parameter. For more information on fallback behavior, see the link:https://keda.sh/docs/latest/reference/scaledobject-spec/#fallback[KEDA documentation].
-<12> Optional: Specifies the replica count to be used if a fallback occurs. Enter one of the following options or omit the parameter:
+<1> Optional: Specifies that the Custom Metrics Autoscaler Operator should pause scaling immediately and maintain the current instance count. 
+<2> Optional: Specifies that the Custom Metrics Autoscaler Operator is to scale the replicas to the specified value and stop autoscaling, as described in the "Pausing the custom metrics autoscaler for a workload" section.
+<3> Optional: Specifies whether the Custom Metrics Autoscaler Operator pauses scale down for the object, while allowing the object to scale up.
+     * If `true`, scaling down is disabled, even if the current number of pods is above the `minReplicaCount`. 
+     * If `false`, scaling down is enabled, and scaling is restored to the original configuration. 
+<4> Optional: Specifies whether the Custom Metrics Autoscaler Operator pauses scale up for the object, while allowing the object to scale down.
+     * If `true`, scaling up is disabled, even if the current number of pods is above the `minReplicaCount`. 
+     * If `false`, scaling down is enabled, and scaling is restored to the original configuration. 
+<5> Specifies a name for this custom metrics autoscaler.
+<6> Optional: Specifies the API version of the target resource. The default is `apps/v1`.
+<7> Specifies the name of the object that you want to scale.
+<8> Specifies the `kind` as `Deployment`, `StatefulSet` or `CustomResource`.
+<9> Optional: Specifies the name of the container in the target resource, from which the custom metrics autoscaler gets environment variables holding secrets and so forth. The default is `.spec.template.spec.containers[0]`.
+<10> Optional. Specifies the period in seconds to wait after the last trigger is reported before scaling the deployment back to `0` if the `minReplicaCount` is set to `0`. The default is `300`.
+<11> Optional: Specifies the maximum number of replicas when scaling up. The default is `100`.
+<12> Optional: Specifies the minimum number of replicas when scaling down.
+<13> Optional: Specifies the parameters for audit logs. as described in the "Configuring audit logging" section.
+<14> Optional: Specifies the number of replicas to fall back to if a scaler fails to get metrics from the source for the number of times defined by the `failureThreshold` parameter. For more information on fallback behavior, see the link:https://keda.sh/docs/latest/reference/scaledobject-spec/#fallback[KEDA documentation].
+<15> Optional: Specifies the replica count to be used if a fallback occurs. Enter one of the following options or omit the parameter:
 * Enter `static` to use the number of replicas specified by the `fallback.replicas` parameter. This is the default.
 * Enter `currentReplicas` to maintain the current number of replicas.
 * Enter `currentReplicasIfHigher` to maintain the current number of replicas, if that number is higher than the `fallback.replicas` parameter. If the current number of replicas is lower than the `fallback.replicas` parameter, use the `fallback.replicas` value.
 * Enter `currentReplicasIfLower` to maintain the current number of replicas, if that number is lower than the `fallback.replicas` parameter. If the current number of replicas is higher than the `fallback.replicas` parameter, use the `fallback.replicas` value.
-<13> Optional: Specifies the interval in seconds to check each trigger on. The default is `30`.
-<14> Optional: Specifies whether to scale back the target resource to the original replica count after the scaled object is deleted. The default is `false`, which keeps the replica count as it is when the scaled object is deleted.
-<15> Optional: Specifies a name for the horizontal pod autoscaler. The default is `keda-hpa-{scaled-object-name}`.
-<16> Optional: Specifies a scaling policy to use to control the rate to scale pods up or down, as described in the "Scaling policies" section.
-<17> Specifies the trigger to use as the basis for scaling, as described in the "Understanding the custom metrics autoscaler triggers" section. This example uses {product-title} monitoring.
-<18> Optional: Specifies a trigger authentication or a cluster trigger authentication. For more information, see _Understanding the custom metrics autoscaler trigger authentication_ in the _Additional resources_ section.
+<16> Optional: Specifies the interval in seconds to check each trigger on. The default is `30`.
+<17> Optional: Specifies whether to scale back the target resource to the original replica count after the scaled object is deleted. The default is `false`, which keeps the replica count as it is when the scaled object is deleted.
+<18> Optional: Specifies a name for the horizontal pod autoscaler. The default is `keda-hpa-{scaled-object-name}`.
+<18> Optional: Specifies a scaling policy to use to control the rate to scale pods up or down, as described in the "Scaling policies" section.
+<20> Specifies the trigger to use as the basis for scaling, as described in the "Understanding the custom metrics autoscaler triggers" section. This example uses {product-title} monitoring.
+<21> Optional: Specifies a trigger authentication or a cluster trigger authentication. For more information, see _Understanding the custom metrics autoscaler trigger authentication_ in the _Additional resources_ section.
 * Enter `TriggerAuthentication` to use a trigger authentication. This is the default.
 * Enter `ClusterTriggerAuthentication` to use a cluster trigger authentication.
 

--- a/modules/nodes-cma-autoscaling-custom-creating-workload.adoc
+++ b/modules/nodes-cma-autoscaling-custom-creating-workload.adoc
@@ -159,7 +159,7 @@ spec:
 <16> Optional: Specifies the interval in seconds to check each trigger on. The default is `30`.
 <17> Optional: Specifies whether to scale back the target resource to the original replica count after the scaled object is deleted. The default is `false`, which keeps the replica count as it is when the scaled object is deleted.
 <18> Optional: Specifies a name for the horizontal pod autoscaler. The default is `keda-hpa-{scaled-object-name}`.
-<18> Optional: Specifies a scaling policy to use to control the rate to scale pods up or down, as described in the "Scaling policies" section.
+<19> Optional: Specifies a scaling policy to use to control the rate to scale pods up or down, as described in the "Scaling policies" section.
 <20> Specifies the trigger to use as the basis for scaling, as described in the "Understanding the custom metrics autoscaler triggers" section. This example uses {product-title} monitoring.
 <21> Optional: Specifies a trigger authentication or a cluster trigger authentication. For more information, see _Understanding the custom metrics autoscaler trigger authentication_ in the _Additional resources_ section.
 * Enter `TriggerAuthentication` to use a trigger authentication. This is the default.

--- a/modules/nodes-cma-autoscaling-custom-trigger-kafka.adoc
+++ b/modules/nodes-cma-autoscaling-custom-trigger-kafka.adoc
@@ -41,9 +41,11 @@ spec:
       allowIdleConsumers: true <8>
       scaleToZeroOnInvalidOffset: false <9>
       excludePersistentLag: false <10>
-      version: '1.0.0' <11>
-      partitionLimitation: '1,2,10-20,31' <12>
-      tls: enable <13>
+      ensureEvenDistributionOfPartitions: 'false' <11>
+      limitToPartitionsWithLag <12>
+      version: '1.0.0' <13>
+      partitionLimitation: '1,2,10-20,31' <14>
+      tls: enable <15>
 ----
 <1> Specifies Kafka as the trigger type.
 <2> Specifies the name of the Kafka topic on which Kafka is processing the offset lag.
@@ -61,6 +63,12 @@ spec:
 <10> Optional: Specifies whether the trigger includes or excludes partition lag for partitions whose current offset is the same as the current offset of the previous polling cycle.
       * If `true`, the scaler excludes partition lag in these partitions.
       * If `false`, the trigger includes all consumer lag in all partitions. This is the default.
-<11> Optional: Specifies the version of your Kafka brokers. Must be specified as a quoted string value. The default is `1.0.0`.
-<12> Optional: Specifies a comma-separated list of partition IDs to scope the scaling on. If set, only the listed IDs are considered when calculating lag. Must be specified as a quoted string value. The default is to consider all partitions.
-<13> Optional: Specifies whether to use TSL client authentication for Kafka. The default is `disable`. For information on configuring TLS, see "Understanding custom metrics autoscaler trigger authentications".
+<11> Optional: Specifies whether the trigger ensures that replicas are spread evenly across the topic partitions.
+      * If `true`, the replicas are scaled evenly across the partitions.
+      * If `false`, the replicas are scaled based on the calculated lag and the lag threshold, and are not distributed evenly across partitions. This is the default.
+<12> Optional: Specifies whether the number of replicas can exceed the number of partitions that are experiencing lag.
+      * If `true`, the number of replicas cannot exceed the number of partitions having lag. The `topic` parameter must be specified and the `allowIdleConsumers` must be `false`.
+      * If `false`, the number of replicas can exceed the number of partitions having lag. This is the default.
+<13> Optional: Specifies the version of your Kafka brokers. Must be specified as a quoted string value. The default is `1.0.0`.
+<14> Optional: Specifies a comma-separated list of partition IDs to scope the scaling on. If set, only the listed IDs are considered when calculating lag. Must be specified as a quoted string value. The default is to consider all partitions.
+<15> Optional: Specifies whether to use TSL client authentication for Kafka. The default is `disable`. For information on configuring TLS, see "Understanding custom metrics autoscaler trigger authentications".


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17854

[Forced activation](https://github.com/kedacore/keda/issues/6903)
[Excluding labels from being propagated to the HPA](https://github.com/kedacore/keda/issues/6849)
[Pause in scaling down](https://github.com/kedacore/keda/issues/6902)
[Pause in scaling up](https://github.com/kedacore/keda/issues/7022)
[Support for the s390x architecture](https://github.com/kedacore/keda/issues/6543)
[Fallback for triggers of `Value` metric type](https://github.com/kedacore/keda/pull/6655)
[Support for even distribution of Kafka partitions](https://github.com/kedacore/keda/issues/2581)
[The Zap logger has replaced the Kubernetes logger](https://github.com/kedacore/keda/issues/5732)
[`type` setting, deprecated in an earlier version, is removed](https://github.com/kedacore/keda/pull/6698)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
