### PR TITLE
OSSM-11909 2.6.12 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -212,7 +212,7 @@ endif::[]
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.11
+:SMProductVersion: 2.6.12
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-6-11.adoc
+++ b/modules/ossm-release-2-6-11.adoc
@@ -10,8 +10,6 @@ This release of {SMProductName} updates the {SMProductName} Operator version to 
 
 This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
 
-include::snippets/ossm-current-version-support-snippet.adoc[]
-
 You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 
 [id="ossm-release-2-6-11-components_{context}"]

--- a/modules/ossm-release-2-6-12.adoc
+++ b/modules/ossm-release-2-6-12.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/servicemesh-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-6-12_{context}"]
+= {SMProductName} version 2.6.12
+
+[role="_abstract"]
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.12, and includes the `ServiceMeshControlPlane` resource version updates for 2.6.12.
+
+This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
+You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
+
+[id="ossm-release-2-6-12-components_{context}"]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.8
+
+|Kiali Server
+|1.73
+|===
+
+[id="ossm-fixed-issues-2-6-12_{context}"]
+== Fixed issues
+
+* Before this update, when you used the Kiali operator 2.17 or later with {SMProductName} 2.6 and enabled the Kiali add-on in the Service Mesh control plane (SMCP) configuration, the Kiali config map always set the `cluster_wide_access` value to `true`. As a consequence, Kiali maintained cluster-wide permissions even if you selected a restricted mode in the SMCP. With this release, the operator correctly sets the `cluster_wide_access` value based on the mode specified in the SMCP. As a result, Kiali permissions now correctly match your service mesh configuration.
++
+https://issues.redhat.com/browse/OSSM-11635[OSSM-11635]

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 // The following include statements pull in the module files that comprise 2.x release notes.
 
+include::modules/ossm-release-2-6-12.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-11.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-6-10.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.12 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

Doc JIRA: https://issues.redhat.com/browse/OSSM-11909

Fix Version: 4.14+

Doc Previews: https://104684--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-release-2-6-12_ossm-release-notes

QE Review: @mkralik3 
Peer Review: @kaldesai 