### PR TITLE
OSDOCS:16105_RN:adding AWS DNS RN

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -215,8 +215,8 @@ As of this update, you can manage your own firewall rules when installing a clus
 +
 For more information, see xref:../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-user-managed-firewall-rules_installing-gcp-account[Managing your own firewall rules].
 
-The `ccoctl` utility supports {aws-full} permissions boundaries:: 
-+ 
+The `ccoctl` utility supports {aws-full} permissions boundaries::
++
 The Cloud Credential Operator utility (`ccoctl`) now supports attaching an {aws-short} permissions boundary to the IAM roles that it creates. You can use this feature to meet organizational security requirements that restrict the maximum permissions of created roles.
 
 Throughput customization for {aws-full} gp3 drives::
@@ -244,6 +244,11 @@ With this update, you can install a cluster on {oda} using the {ai-full}.
 +
 For more information, see xref:../installing/installing_oda/installing-oda-assisted.adoc#installing-oda-assisted-installer[Installing a cluster on {oda} by using the {ai-full}].
 
+Installing a cluster on {aws-short} with a user-provisioned DNS (Technology Preview)::
++
+You can enable a user-provisioned domain name server (DNS) instead of the default cluster-provisioned DNS solution. For example, your organization's security policies might not allow the use of public DNS services such as {aws-first} DNS. As a result, you can manage the API and Ingress DNS records in your own system rather than adding the records to the DNS of the cloud. If you use this feature, you must provide your own DNS solution that includes records for `api.<cluster_name>.<base_domain>.` and `*.apps.<cluster_name>.<base_domain>.`. Enabling a user-provisioned DNS is available as a Technology Preview feature.
++
+For more information, see xref:../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-aws-enabling-user-managed-DNS_installing-aws-customizations[Enabling a user-managed DNS] and xref:../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-aws-provisioning-own-dns-records_installing-aws-customizations[Provisioning your own DNS records].
 
 Installing a cluster on {azure-first} using NAT Gateways::
 +


### PR DESCRIPTION
Version:
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-17856

Link to docs preview:
[Installing a cluster on AWS with a user-provisioned DNS (Technology Preview)](https://104693--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-4-21-installation-and-update-custom-aws-dns_release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is the feature PR for this release note: https://github.com/openshift/openshift-docs/pull/98724.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
