### PR TITLE
OSDOCS-17740 created zstream RNs for 4-16-55

### DIFF
--- a/modules/zstream-4-16-55-about.adoc
+++ b/modules/zstream-4-16-55-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-16-55-about_{context}"]
+= RHSA-2026:0327 - {product-title} {product-version}.55 bug fix and security update advisory
+
+
+[role="_abstract"]
+Issued: 15 January 2026
+
+{product-title} release {product-version}.55 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:0327[RHSA-2026:0327] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:0418[RHSA-2026:0418] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.55 --pullspecs
+----

--- a/modules/zstream-4-16-55-bug-fixes.adoc
+++ b/modules/zstream-4-16-55-bug-fixes.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-55-bug-fixes_{context}"]
+= Fixed Issues
+
+[role="_abstract"]
+There are no notable fixed issues in this release.
+
+

--- a/modules/zstream-4-16-55-updating.adoc
+++ b/modules/zstream-4-16-55-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-55-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3397,6 +3397,15 @@ For any {product-title} release, always review the instructions on xref:../updat
 ====
 
 // About 4-16-54 release notes
+include::modules/zstream-4-16-55-about.adoc[leveloffset=+2]
+
+// 4-16-54 release notes bug fixes
+include::modules/zstream-4-16-55-bug-fixes.adoc[leveloffset=+2]
+
+// 4-16-54 release notes updating
+include::modules/zstream-4-16-55-updating.adoc[leveloffset=+2]
+
+// About 4-16-54 release notes
 include::modules/zstream-4-16-54-about.adoc[leveloffset=+2]
 
 // 4-16-54 release notes bug fixes


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-17740

Link to docs preview:
https://104698--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-55-about_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:
To find the **Image** and **RPM IDs**, select the following links:

For the **Image ID**: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/292/diffs#40787c5bce7794331a2aaf08ab085547880249bf

For the **RPM ID**: https://errata.devel.redhat.com/advisory/157888

**Must be on VPN** to view these links.