### PR TITLE
OSDOCS-15819 User managed firewall rules for GCP at install time

### DIFF
--- a/installing/installing_gcp/installing-gcp-account.adoc
+++ b/installing/installing_gcp/installing-gcp-account.adoc
@@ -6,8 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Before you can install {product-title}, you must configure a
-{gcp-first} project to host it.
+[role="_abstract"]
+Before you can install {product-title}, you must configure a {gcp-first} project to host it. You can configure custom roles and permissions, DNS configuration, and manage your own {gcp-short} firewall rules.
 
 include::modules/installation-gcp-project.adoc[leveloffset=+1]
 
@@ -26,6 +26,8 @@ include::modules/minimum-required-permissions-ipi-gcp.adoc[leveloffset=+2]
 include::modules/minimum-required-permissions-ipi-gcp-xpn.adoc[leveloffset=+2]
 
 include::modules/minimum-required-permissions-ipi-gcp-provided-sas.adoc[leveloffset=+2]
+
+include::modules/installation-gcp-user-managed-firewall-rules.adoc[leveloffset=+1]
 
 include::modules/installation-gcp-regions.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-shared-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-shared-vpc.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {product-title} version {product-version}, you can install a cluster into a shared Virtual Private Cloud (VPC) on {gcp-first}. In this installation method, the cluster is configured to use a VPC from a different {gcp-short} project. A shared VPC enables an organization to connect resources from multiple projects to a common VPC network. You can communicate within the organization securely and efficiently by using internal IP addresses from that network. For more information about shared VPC, see link:https://cloud.google.com/vpc/docs/shared-vpc[Shared VPC overview in the {gcp-short} documentation].
 
 The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
@@ -21,6 +22,7 @@ The installation program provisions the rest of the required infrastructure, whi
 * You have a {gcp-short} host project that contains a shared VPC network and that has a configured Cloud Router and Cloud NAT gateway, to ensure that internet access from the VPC is available. For more information, see link:https://cloud.google.com/network-connectivity/docs/router/concepts/overview[Cloud Router overview] and  link:https://cloud.google.com/nat/docs/overview[Cloud NAT overview] (Google documentation).
 * You have a {gcp-short} service account that has the xref:../../installing/installing_gcp/installing-gcp-account.adoc#minimum-required-permissions-ipi-gcp-xpn_installing-gcp-account[required {gcp-short} permissions] in both the host and service projects.
 * If you want to provide your own private hosted zone, you must have created one in the service project with the DNS pattern `cluster-name.baseDomain.`, for example `testCluster.example.com.`. The private hosted zone must be bound to the VPC in the host project. For more information about cross-project binding, see link:https://cloud.google.com/dns/docs/zones/cross-project-binding[Create a zone with cross-project binding] (Google documentation). If you do not provide a private hosted zone, the installation program will provision one automatically.
+* If you manage your {gcp-short} firewall rules, you xref:../../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-user-managed-firewall-rules_installing-gcp-account[configured the required firewall rules].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -6,8 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster into an existing Virtual Private Cloud (VPC) on {gcp-first}. The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify
-parameters in the `install-config.yaml` file before you install the cluster.
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a cluster into an existing Virtual Private Cloud (VPC) on {gcp-first}. The installation program provisions the rest of the required infrastructure, which you can further customize. To customize the installation, you modify parameters in the `install-config.yaml` file before you install the cluster.
 
 == Prerequisites
 
@@ -15,6 +15,7 @@ parameters in the `install-config.yaml` file before you install the cluster.
 * You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a {gcp-short} project] to host the cluster.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If you manage your {gcp-short} firewall rules, you xref:../../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-user-managed-firewall-rules_installing-gcp-account[configured the required firewall rules].
 
 include::modules/installation-custom-gcp-vpc.adoc[leveloffset=+1]
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2717,6 +2717,13 @@ Additional {gcp-short} configuration parameters are described in the following t
 
 |platform:
   gcp:
+    firewallRulesManagement:
+|Specifies the firewall management policy for the cluster. `Managed` indicates that the firewall rules will be created and destroyed by the cluster. `Unmanaged` indicates that the user should create and destroy the firewall rules. For shared VPC installation, if the credential you provided the installation program doesn't have firewall rules management permissions, the `firewallRulesManagement` parameter can be absent or set to `Unmanaged`. For non-shared VPC installation, if the credential you provided the installation program doesn't have firewall rules management permissions, the `firewallRulesManagement` parameter must be set to `Unmanaged`. If you manage your own firewall rules, you must pre-configure the VPC network and the firewall rules before the installation.
+
+*Value:* String. `Managed` or `Unmanaged`. The default value is `Managed`.
+
+|platform:
+  gcp:
     network:
 |The name of the existing Virtual Private Cloud (VPC) where you want to deploy your cluster. If you want to deploy your cluster into a shared VPC, you must set `platform.gcp.networkProjectID` with the name of the {gcp-short} project that contains the shared VPC.
 

--- a/modules/installation-gcp-user-managed-firewall-rules.adoc
+++ b/modules/installation-gcp-user-managed-firewall-rules.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assembly:
+//
+// * installing/installing_gcp/installing-gcp-account.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="installation-gcp-user-managed-firewall-rules_{context}"]
+= Managing your own firewall rules
+
+[role="_abstract"]
+You can manage your own firewall rules when installing a cluster on {gcp-short} into an existing VPC by enabling the `firewallRulesManagement` parameter in the `install-config.yaml` file. You can limit the permissions that you grant to the installation program by managing your own firewall rules.
+
+If you want to manage your own firewall rules, you must create the following rules before installation:
+
+[cols="1,1,1,1"]
+|====
+|Rule Name |Protocol:Port |Source |Destination
+
+|bootstrap-in-ssh
+|`tcp:22`
+|`<allowed_external_cidr>`
+|`<control_plane_node_tags>`
+
+|api
+|`tcp:6443`
+|`<allowed_external_cidr>`
+|`<control_plane_node_tags>`
+
+|health-checks
+|`tcp:6080,6443,22624`
+|`35.191.0.0/16`, `130.211.0.0/22`, `209.85.152.0/22`, `209.85.204.0/22`
+|`<control_plane_node_tags>`
+
+|etcd
+|`tcp:2379,2380`
+|`<control_plane_node_tags>`
+|`<control_plane_node_tags>`
+
+|control-plane
+|`tcp:10257,10259,22623`
+|`<control_plane_node_tags>`, `<compute_node_tags>`
+|`<control_plane_node_tags>`
+
+|internal-network
+|icmp,`tcp:22`
+|`<internal_network_cidr>`
+|`<control_plane_node_tags>`, `<compute_node_tags>`
+
+|internal-cluster
+|`udp:500,4500,4789,6081`, `udp:9000-9999,30000-32767`, `esp`, `tcp:9000-9999,10250`, `tcp:30000-32767`
+|`<control_plane_node_tags>`, `<compute_node_tags>`
+|`<control_plane_node_tags>`, `<compute_node_tags>`
+
+|ingress-k8s-fw
+|`tcp:80,443`
+|`<allowed_external_cidr>`
+|`<control_plane_node_tags>`, `<compute_node_tags>`
+
+|ingress-k8s-http-hc
+|`tcp:30000-32767`
+|`35.191.0.0/16`, `130.211.0.0/22`, `209.85.152.0/22`, `209.85.204.0/22`
+|`<control_plane_node_tags>`, `<compute_node_tags>`
+|====
+where:
+
+`<allowed_external_cidr>`:: Specifies a network CIDR of the machines that you want to grant access to your cluster. For a public cluster, this would typically be `0.0.0.0/0`. For a private cluster, access might be restricted to the cluster machine network.
+`<control_plane_node_tags>`:: Specifies the network tags that apply to the control plane machines in your cluster. These tags must be specified in the `install-config.yaml` file you use to deploy the cluster.
+`<compute_node_tags>`:: Specifies the network tags that apply to the compute machines in your cluster. These tags must be specified in the `install-config.yaml` file you use to deploy the cluster.
+`<internal_network_cidr>`:: Specifies the network CIDR of the machine network that contains all the machines in your cluster.
+
+After installation, you can reduce the port range of the `ingress-k8s-http-hc` and `internal-cluster` rules from `tcp:30000-32767` to the individual port that the ingress load balancer service uses, which is not known before installation. You can determine the service port by running the following command after installation:
+
+[source,terminal]
+----
+$ oc get svc router-default -n openshift-ingress -o jsonpath='{.spec.ports[*].nodePort}'
+----

--- a/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
@@ -2,10 +2,11 @@
 //
 // * installing/installing_gcp/installing-gcp-account.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="minimum-required-permissions-ipi-gcp-xpn_{context}"]
 = Required {gcp-short} permissions for shared VPC installations
 
+[role="_abstract"]
 When you are installing a cluster to a link:https://cloud.google.com/vpc/docs/shared-vpc[shared VPC], you must configure the service account for both the host project and the service project.
 
 [IMPORTANT]
@@ -22,43 +23,38 @@ If you are not installing to a shared Virtual Private Cloud (VPC), you can skip 
 When installing a cluster on shared Virtual Private Cloud (VPC) infrastructure and you want to manually create credentials, grant the `compute.subnetworks.use` permission on the host project to the credentials that the Machine API Operator uses.
 ====
 
-Ensure that the host project applies one of the following configurations to the service account:
+Ensure that the host project applies one of the following configurations to the service account, noting that the permissions for creating and deleting firewalls are not required if you manage your own firewall rules:
 
 .Required permissions for creating firewalls in the host project
-[source,text]
-----
+====
 * `projects/<host-project>/roles/dns.networks.bindPrivateDNSZone`
 * `roles/compute.networkAdmin`
 * `roles/compute.securityAdmin`
-----
+====
 
 .Required permissions for deleting firewalls in the host project
-[source,text]
-----
+====
 * `compute.firewalls.delete`
 * `compute.networks.updatePolicy`
-----
+====
 
 .Required minimal permissions
-[source,text]
-----
+====
 * `projects/<host-project>/roles/dns.networks.bindPrivateDNSZone`
 * `roles/compute.networkUser`
-----
+====
 
 If you do not supply a service account for control plane nodes in the `install-config.yaml` file, grant the following permissions to the service account in the host project. If you do not supply a service account for compute nodes in the `install-config.yaml` file, grant the following permissions to the service account in the host project for cluster destruction. If you do supply service accounts for control plane and compute nodes, you do not need to grant the following permissions.
 
-[source,text]
-----
+====
 * `resourcemanager.projects.getIamPolicy`
 * `resourcemanager.projects.setIamPolicy`
-----
+====
 
 The following permissions are required when you select a separate project for the location of the DNS zone or zones. These permissions are also required when the DNS zone or zones are located in a third project.
 
 .Required minimal permissions for provisioning DNS resources in a separate project
-[source,text]
-----
+====
 * `dns.changes.create`
 * `dns.changes.get`
 * `dns.managedZones.create`
@@ -69,4 +65,4 @@ The following permissions are required when you select a separate project for th
 * `dns.resourceRecordSets.create`
 * `dns.resourceRecordSets.delete`
 * `dns.resourceRecordSets.list`
-----
+====

--- a/modules/minimum-required-permissions-ipi-gcp.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp.adoc
@@ -6,9 +6,10 @@
 [id="minimum-required-permissions-ipi-gcp_{context}"]
 = Required {gcp-short} permissions for installer-provisioned infrastructure
 
-When you attach the `Owner` role to the service account that you create, you grant that service account all permissions, including those that are required to install {product-title}.
+[role="_abstract"]
+When you attach the `Owner` role to the service account that you create, you grant that service account all permissions, including those that are required to install {product-title}. If your organization's security policies require a more restrictive set of permissions, you can create link:https://cloud.google.com/iam/docs/creating-custom-roles[custom roles] with the necessary permissions.
 
-If your organization's security policies require a more restrictive set of permissions, you can create link:https://cloud.google.com/iam/docs/creating-custom-roles[custom roles] with the necessary permissions. The following permissions are required for the installer-provisioned infrastructure for creating and deleting the {product-title} cluster.
+The following permissions are required for the installer-provisioned infrastructure for creating and deleting the {product-title} cluster.
 
 .Required permissions for creating network resources
 [%collapsible]
@@ -21,7 +22,9 @@ If your organization's security policies require a more restrictive set of permi
 * `compute.addresses.use`
 * `compute.addresses.useInternal`
 * `compute.firewalls.create`
+** This permission is not required if you install into an existing VPC and manage your own firewall rules. See the _Managing your own firewall rules_ section.
 * `compute.firewalls.delete`
+** This permission is not required if you install into an existing VPC and manage your own firewall rules. See the _Managing your own firewall rules_ section.
 * `compute.firewalls.get`
 * `compute.firewalls.list`
 * `compute.forwardingRules.create`


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-15819

Link to docs preview:
[Managing your own firewall rules](https://104757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account#installation-gcp-user-managed-firewall-rules_installing-gcp-account)
[non-XPN permissions](https://104757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account#minimum-required-permissions-ipi-gcp_installing-gcp-account)
[XPN permissions](https://104757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account#minimum-required-permissions-ipi-gcp-xpn_installing-gcp-account)
[Existing VPC prerequisites](https://104757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-vpc#prerequisites)
[Shared VPC prerequisites](https://104757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-shared-vpc#installation-gcp-shared-vpc-prerequisites_installing-gcp-shared-vpc)
[Installation configuration parameters](https://104757--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Potential Day 2 procedures will be taken up in a [separate PR](https://github.com/openshift/openshift-docs/pull/105093).