### PR TITLE
OSDOCS-17769: m7 instance type RN

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -253,6 +253,11 @@ For more information, see xref:../installing/installing_bare_metal/bare-metal-po
 xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bmo-performing-a-live-update-to-the-hostfirmwarecomponents-resource_bare-metal-postinstallation-configuration[Performing a live update to the HostFirmwareComponents resource], and
 xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bmo-setting-the-hostupdatepolicy-resource_bare-metal-postinstallation-configuration[Setting the HostUpdatePolicy resource].
 
+Testing for {aws-full} m7 instance type::
++
+As of {product-title} 4.21, m7 instance types have been tested for installations on {aws-full}.
+For more information about tested instance types, see xref:../installing/installing_aws/ipi/installing-aws-customizations.adoc#installation-aws-tested-machine-types_installing-aws-customizations[Tested instance types for {aws-short}].
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 == Machine Config Operator
 


### PR DESCRIPTION
[OSDOCS-17769](https://issues.redhat.com/browse/OSDOCS-17769)

Version(s): 4.21+ 

RN for the new m7 AWS instance type

QE review:
- [x] QE has approved this change.

Preview: [Installation and update](https://104759--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-install-update_release-notes)