### PR TITLE
OSDOCS-17767: AWS gp3 throughput RN

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -124,6 +124,12 @@ As of this update, you can manage your own firewall rules when installing a clus
 +
 For more information, see xref:../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-user-managed-firewall-rules_installing-gcp-account[Managing your own firewall rules].
 
+Throughput customization for {aws-full} gp3 drives::
++
+With this update, you can now customize the maximum throughput for gp3 `rootVolume` drives when installing a cluster on {aws-full}. This customization is set by modifying the `compute.platform.aws.rootVolume.throughput` or `controlPlane.platform.aws.rootVolume.throughput` parameters in the `install-config.yaml` file.
++
+For more information, see xref:../installing/installing_aws/installation-config-parameters-aws.adoc#installation-configuration-parameters-optional-aws_installation-config-parameters-aws[Optional AWS configuration parameters].
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 == Machine Config Operator
 


### PR DESCRIPTION
[OSDOCS-17767](https://issues.redhat.com/browse/OSDOCS-17767)

Version(s): 4.21

RN for the new throughput parameter for AWS gp3 volume types

QE review:
- [x] QE has approved this change.

Preview: [Installation and update](https://104760--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-install-update_release-notes)