### PR TITLE
OSDOCS-17183-vlan: Created a procedure Defining additional VLANs in t…

### DIFF
--- a/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
+++ b/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
@@ -11,6 +11,7 @@ toc::[]
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You have read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You have read the documentation for supported and unsupported OVN-Kubernetes network plugin use cases on xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#nw-ovn-kubernetes-purpose_about-ovn-kubernetes[OVN-Kubernetes purpose].
 
 include::modules/virt-planning-bare-metal-cluster-for-ocp-virt.adoc[leveloffset=+1]
 

--- a/modules/nw-multus-edit-network-additional-vlans.adoc
+++ b/modules/nw-multus-edit-network-additional-vlans.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/edit-additional-network.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-multus-edit-network-additional-vlans_{context}"]
+= Using an OVN-Kubernetes localnet topology to map VLANs to a secondary interface
+
+[role="_abstract"]
+You can use OVN-Kubernetes localnet topology in a `NetworkAttachmentDefinition` (NAD) to map a specific VLAN ID from the physical network to the secondary interface of a pod.
+
+To provide multiple VLANs for cluster workloads in {product-title}, define additional VLANs in the `NetworkAttachmentDefinition` custom resource (CR). Configuring trunk ports ensures that the physical network associates correctly with your virtual infrastructure for reliable traffic management.
+
+The example in the procedure demonstrates the following configurations:
+
+* Physical switch ports connect to {product-title} nodes by using VLAN trunking. The trunk carries tagged traffic for the VLANs you define in NADs.
+* The `br-ex` acts as the OVS bridge that connects virtual workloads to the physical workloads.
+* Multiple NADs with specific VLAN tags get created by using the `localnet` topology. This configuration defines specific VLAN IDs for traffic isolation.
+* Pods or virtual machines (VMs) attach to the NAD CRs for the purposes of improved network connectivity.
+
+.Prerequisites
+
+* You installed the {oc-first}.
+* You logged in as a user with `cluster-admin` privileges.
+* You installed the NMState Operator.
+* You configured the `br-ex` bridge interface during cluster installation.
+
+.Procedure
+
+. Create an `NetworkAttachmentDefinition` CR for each VLAN, such as `nad-cvlan100.yaml`. OVN-Kubernetes uses the NAD files to tag and untag Ethernet frames for pods or VMs.
++
+.Example configuration
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vlan-100
+  namespace: default
+spec:
+  config: |-
+    {
+      "cniVersion": "0.4.0",
+      "name": "localnet-vlan-100",
+      "type": "ovn-k8s-cni-overlay",
+      "physicalNetworkName": "physnet",
+      "topology": "localnet",
+      "vlanID": 100,
+      "mtu": 1500,
+      "netAttachDefName": "default/vlan-100"
+    }
+# ...
+----
+
+. Attach pods or VMs to the VLANs by referencing the NAD in the configuration for the pod or VM:
++
+.Example pod configuration
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/networks: vlan-100
+# ...
+----
++
+.Example VM configuration
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+    template:
+        spec:
+        networks:
+        - multus:
+            networkName: vlan-100
+            name: secondary-vlan
+# ...
+----

--- a/modules/nw-ovn-kubernetes-features.adoc
+++ b/modules/nw-ovn-kubernetes-features.adoc
@@ -33,5 +33,8 @@ Red{nbsp}Hat does not support the following postinstallation configurations that
 Red{nbsp}Hat does support the following postinstallation configurations that use the OVN-Kubernetes network plugin:
 
 * Creating additional VLANs from the base physical interface, such as `eth0.100`, where you configured the primary network interface as a VLAN for a node during cluster installation. This works because the Open vSwitch (OVS) bridge attaches to the initial VLAN sub-interface, such as `eth0.100`, leaving the base physical interface available for new configurations.
+
 * Creating an additional OVN secondary network with a `localnet` topology network requires that you define the secondary network in a `NodeNetworkConfigurationPolicy` (NNCP) object. After you create the network, pods or virtual machines (VMs) can then attach to the network. These secondary networks give a dedicated connection to the physical network, which might or might not use VLAN tagging. You cannot access these networks from the host network of a node where the host does not have the required setup, such as the required network settings.
+
+* Defining additional VLANs in the `vlanID` parameter of the `NetworkAttachmentDefinition` (NAD) custom resource (CR). By mapping the `br-ex` bridge to a physical interface, the interface acts as a trunk port that can carry multiple VLANs. OVN-Kubernetes can then manage tagging and untagging of network packets, also known as _Ethernet frames_. To ensure strong connectivity, configure the physical switch ports as trunks.
 

--- a/modules/virt-what-you-can-do-with-virt.adoc
+++ b/modules/virt-what-you-can-do-with-virt.adoc
@@ -35,6 +35,11 @@ endif::[]
 
 You can manage your cluster and virtualization resources by using the *Virtualization* perspective of the {product-title} web console, and by using the {oc-first}.
 
+[IMPORTANT]
+====
+For supported and unsupported OVN-Kubernetes network plugin use cases, see "OVN-Kubernetes purpose". 
+====
+
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 {VirtProductName} is designed and tested to work well with {rh-storage-first} features.
 

--- a/networking/multiple_networks/secondary_networks/editing-additional-network.adoc
+++ b/networking/multiple_networks/secondary_networks/editing-additional-network.adoc
@@ -10,3 +10,5 @@ toc::[]
 To update network settings or change network parameters for a secondary network in {product-title}, you can modify the configuration for an existing secondary network. Edit the `NetworkAttachmentDefinition` custom resource to apply your changes.
 
 include::modules/nw-multus-edit-network.adoc[leveloffset=+1]
+
+include::modules/nw-multus-edit-network-additional-vlans.adoc[leveloffset=+1]

--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -49,6 +49,7 @@ endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../virt/about_virt/virt-supported-limits.adoc#virt-supported-limits[{VirtProductName} supported limits]
+* xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#nw-ovn-kubernetes-purpose_about-ovn-kubernetes[OVN-Kubernetes purpose]
 endif::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 * xref:../../storage/index.adoc#openshift-storage-common-terms_storage-overview[Glossary of common terms for {product-title} storage]
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-17183](https://issues.redhat.com/browse/OSDOCS-17183)

Link to docs preview:

* [Mapping VLANs to the secondary interface of a pod](https://104770--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/editing-additional-network.html#nw-multus-edit-network-additional-vlans_edit-additional-network)

- [x] SME has approved this change (Ramesh Sahoo).
- [x] QE has approved this change (Ross Brattain).


https://access.redhat.com/solutions/7041230
https://mail.google.com/mail/u/0/?ik=a97decb9e4&view=om&permmsgid=msg-f:1854742979205537769