### PR TITLE
CNV#75702: [DOC] SWAP is disabled after node reboot

### DIFF
--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -62,7 +62,7 @@ $ oc wait mcp worker --for condition=Updated=True --timeout=-1s
 
 . Provision swap by creating a `MachineConfig` object:
 
-.. Create a `MachineConfig` file with the paramaters shown in the following example:
+.. Create a `MachineConfig` file with the parameters shown in the following example:
 +
 [source,yaml]
 ----
@@ -76,8 +76,29 @@ spec:
   config:
     ignition:
       version: 3.5.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,YXBpVmVyc2lvbjoga3ViZWxldC5jb25maWcuazhzLmlvL3YxYmV0YTEKa2luZDogS3ViZWxldENvbmZpZ3VyYXRpb24KZmFpbFN3YXBPbjogZmFsc2UK
+        mode: 420
+        overwrite: true
+        path: /etc/openshift/kubelet.conf.d/90-swap.conf
     systemd:
       units:
+        - contents: |
+            [Unit]
+            Description=Enable swap
+            ConditionFirstBoot=no
+            ConditionPathExists=/var/tmp/swapfile
+
+            [Service]
+            Type=oneshot
+            ExecStart=/bin/sh -c "sudo swapon /var/tmp/swapfile"
+
+            [Install]
+            RequiredBy=kubelet-dependencies.target
+          enabled: true
+          name: swap-enable.service
         - contents: |
             [Unit]
             Description=Provision and enable swap
@@ -87,7 +108,7 @@ spec:
             [Service]
             Type=oneshot
             Environment=SWAP_SIZE_MB=5000
-            ExecStart=/bin/sh -c "sudo dd if=/dev/zero of=/var/tmp/swapfile count=${SWAP_SIZE_MB} bs=1M && \
+            ExecStart=/bin/sh -c "sudo fallocate -l ${SWAP_SIZE_MB}M /var/tmp/swapfile && \
             sudo chmod 600 /var/tmp/swapfile && \
             sudo mkswap /var/tmp/swapfile && \
             sudo swapon /var/tmp/swapfile && \


### PR DESCRIPTION
Version(s): 4.17+

Issue: [CNV-75702](https://issues.redhat.com/browse/CNV-75702)

Link to docs preview: [Using wasp-agent to increase VM workload density](https://104771--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-configuring-higher-vm-workload-density.html#virt-using-wasp-agent-to-configure-higher-vm-workload-density_virt-configuring-higher-vm-workload-density)

QE review:
- [x] QE has approved this change.
