### PR TITLE
OSDOCS-17874#changing TP to GA

### DIFF
--- a/modules/bmo-performing-a-live-update-to-the-hostfirmwarecomponents-resource.adoc
+++ b/modules/bmo-performing-a-live-update-to-the-hostfirmwarecomponents-resource.adoc
@@ -6,15 +6,18 @@
 [id="bmo-performing-a-live-update-to-the-hostfirmwarecomponents-resource_{context}"]
 = Performing a live update to the HostFirmwareComponents resource
 
+[role="_abstract"]
 You can perform a live update to the `HostFirmwareComponents` resource on an already provisioned host. Live updates do not trigger deprovisioning and reprovisioning the host.
 
-:FeatureName: Live updating a host
-include::snippets/technology-preview.adoc[]
-:!FeatureName:
-
-[IMPORTANT]
+[WARNING]
 ====
-Do not perform live updates on production hosts. You can perform live updates to the BIOS for testing purposes. We do not recommend that you perform live updates to the BMC on {product-title} {product-version} for test purposes, especially on earlier generation hardware.
+Performing a live update to the `HostFirmwareComponents` resource can be a destructive and destabilizing action. Perform these updates only after careful consideration.
+
+Before you apply a live update in a production cluster, validate the update in a development or test cluster. Ensure that these updates comply with your organization's test policies before you apply them to a production cluster.
+
+If a cluster has fewer than three compute nodes, use caution. Firmware updates in such clusters can result in the cluster entering a degraded state.
+
+Do not interrupt firmware updates. If the update stops responding, engage the support of your hardware vendor.
 ====
 
 .Prerequisites
@@ -27,13 +30,17 @@ Do not perform live updates on production hosts. You can perform live updates to
 +
 [source,terminal]
 ----
-$ oc patch hostfirmwarecomponents <hostname> --type merge -p \// <1>
-    '{"spec": {"updates": [{"component": "<type>", \// <2>
-                        "url": "<url>"}]}}' <3>
+$ oc patch hostfirmwarecomponents <hostname> --type merge -p \
+    '{"spec": {"updates": [{"component": "<type>", \
+                        "url": "<url>"}]}}'
 ----
-<1> Replace `<hostname>` with the name of the host.
-<2> Replace `<type>` with the type of component. Specify `bios` or `bmc`.
-<3> Replace `<url>` with the URL for the component.
++
+where:
+
+`<hostname>`:: Specifies the name of the host.
+`<type>`:: Specifies the type of component, either `bios` or `bmc`.
+`<url>`:: Specifies the URL for the component.
+
 +
 [NOTE]
 ====
@@ -44,9 +51,11 @@ You can also use the `oc edit <hostname> hostfirmwarecomponents -n openshift-mac
 +
 [source,terminal]
 ----
-$ oc drain <node_name> --force <1> 
+$ oc drain <node_name> --force
 ----
-<1> Replace `<node_name>` with the name of the node.
++
+
+Replace `<node_name>` with the name of the node.
 
 . Power off the host for a period of 5 minutes by running the following command:
 +

--- a/modules/bmo-performing-a-live-update-to-the-hostfirmwaresettings-resource.adoc
+++ b/modules/bmo-performing-a-live-update-to-the-hostfirmwaresettings-resource.adoc
@@ -6,11 +6,19 @@
 [id="bmo-performing-a-live-update-to-the-hostfirmwaresettings-resource_{context}"]
 = Performing a live update to the HostFirmwareSettings resource
 
+[role="_abstract"]
 You can perform a live update to the `HostFirmareSettings` resource after it has begun running workloads. Live updates do not trigger deprovisioning and reprovisioning the host.
 
-:FeatureName: Live updating a host
-include::snippets/technology-preview.adoc[]
-:!FeatureName:
+[WARNING]
+====
+Performing a live update to the `HostFirmareSettings` resource can be a destructive and destabilizing action. Perform these updates only after careful consideration.
+
+Before you apply a live update in a production cluster, validate the update in a development or test cluster. Ensure that these updates comply with your organization's test policies before you apply them to a production cluster.
+
+If a cluster has fewer than three compute nodes, use caution. Firmware updates in such clusters can result in the cluster entering a degraded state.
+
+Do not interrupt firmware updates. If the update stops responding, engage the support of your hardware vendor.
+====
 
 .Prerequisites
 
@@ -22,11 +30,16 @@ include::snippets/technology-preview.adoc[]
 +
 [source,terminal]
 ----
-$ oc patch hostfirmwaresettings <hostname> --type merge -p \// <1>
-    '{"spec": {"settings": {"<name>": "<value>"}}}' <2>
+$ oc patch hostfirmwaresettings <hostname> --type merge -p \
+    '{"spec": {"settings": {"<name>": "<value>"}}}'
 ----
-<1> Replace `<hostname>` with the name of the host.
-<2> Replace `<name>` with the name of the setting. Replace `<value>` with the value of the setting. You can set multiple name-value pairs.
++
+where:
+
+`<hostname>`:: Specifies the name of the host.
+`<name>`:: Specifies the name of the setting.
+`<value>`:: Specifies the value of the setting. You can set multiple name-value pairs.
+
 +
 [NOTE]
 ====
@@ -37,9 +50,10 @@ Get the `FirmwareSchema` resource to determine which settings the hardware suppo
 +
 [source,terminal]
 ----
-$ oc drain <node_name> --force <1>
+$ oc drain <node_name> --force
 ----
-<1> Replace `<node_name>` with the name of the node.
++
+For `<node_name>`, specify the name of the node.
 
 . Power off the host for a period of 5 minutes by running the following command:
 +

--- a/modules/bmo-setting-the-hostupdatepolicy-resource.adoc
+++ b/modules/bmo-setting-the-hostupdatepolicy-resource.adoc
@@ -6,11 +6,19 @@
 [id="bmo-setting-the-hostupdatepolicy-resource_{context}"]
 = Setting the HostUpdatePolicy resource
 
-By default, the `HostUpdatePolicy` disables live updates. To enable live updates, use the following procedure.
+[role="_abstract"]
+By default, the `HostUpdatePolicy` disables live updates. To enable live updates, create the `HostUpdatePolicy` resource.
 
-:FeatureName: Setting the `HostUpdatePolicy` resource
-include::snippets/technology-preview.adoc[]
-:!FeatureName:
+[WARNING]
+====
+Performing a live update to the `HostUpdatePolicy` resource can be a destructive and destabilizing action. Perform these updates only after careful consideration.
+
+Before you apply a live update in a production cluster, validate the update in a development or test cluster. Ensure that these updates comply with your organization's test policies before you apply them to a production cluster.
+
+If a cluster has fewer than three compute nodes, use caution. Firmware updates in such clusters can result in the cluster entering a degraded state.
+
+Do not interrupt firmware updates. If the update stops responding, engage the support of your hardware vendor.
+====
 
 .Procedure
 
@@ -29,13 +37,15 @@ You can use any text editor you prefer.
 apiVersion: metal3.io/v1alpha1
 kind: HostUpdatePolicy
 metadata:
-  name: <hostname> <1>
+  name: <hostname>
   namespace: openshift-machine-api
 spec:
   firmwareSettings: onReboot
   firmwareUpdates: onReboot
 ----
-<1> Replace `<hostname>` with the name of the host.
++
+
+Replace `<hostname>` with the name of the host.
 
 . Save the changes to the `hup.yaml` file.
 


### PR DESCRIPTION
Versions:
4.21+

Issue:
https://issues.redhat.com/browse/OSDOCS-17874

Link to docs preview:
[Performing a live update to the HostFirmwareSettings resource](https://104780--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#bmo-performing-a-live-update-to-the-hostfirmwaresettings-resource_bare-metal-postinstallation-configuration)
[Performing a live update to the HostFirmwareComponents resource](https://104780--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#bmo-performing-a-live-update-to-the-hostfirmwarecomponents-resource_bare-metal-postinstallation-configuration)
[Setting the HostUpdatePolicy resource](https://104780--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#bmo-setting-the-hostupdatepolicy-resource_bare-metal-postinstallation-configuration)

QE review:
- [x] QE has approved this change.


Additional information:
I added some formatting changes to the modules (e.g., [role="_abstract"], replacing callout text with bulleted lists). These do not change the content. These additions are required for the migration of the OS documentation to DITA, planned for later this year.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
