### PR TITLE
OCPBUGS-66049: [OCP 4.21] stale conntrack UDP entry when deleting openshift-dns pod

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -110,6 +110,12 @@ Instructions: Add entries in the following format under the appropriate heading:
 [id="rn-ocp-release-note-networking-fixed-issues_{context}"]
 == Networking
 
+Failed DNS queries in OpenShift clusters using OVN-Kubernetes networking::
+In this update, the issue of DNS query failures due to stale UDP connection tracking (conntrack) entries in OpenShift clusters using OVN-Kubernetes networking has been resolved.
+
+Before this update, DNS pods that were deleted and recreated in OpenShift clusters using OVN-Kubernetes networking caused stale UDP conntrack entries to remain on worker nodes. This occurred, due to conntrack cleanup logic incorrectly using endpoint port 5353 instead of service port 53 when attempting to delete stale entries.
+
+After this fix, when DNS pods are deleted or updated, the cleanup process correctly uses service port 53 to match and remove stale conntrack entries. link:https://issues.redhat.com/browse/OCPBUGS-66049[OCPBUGS-66049].
 
 [id="rn-ocp-release-note-node-fixed-issues_{context}"]
 == Node
@@ -149,4 +155,3 @@ Instructions: Add entries in the following format under the appropriate heading:
 
 [id="rn-ocp-release-note-storage-fixed-issues_{context}"]
 == Storage
-


### PR DESCRIPTION
**Fixes:** [OCPBUGS-66049](https://issues.redhat.com/browse/OCPBUGS-66049)

**NOTE:** OCPBUGS-66049 is part of [TELCODOCS-2524: 4.21 Document Fixed Issues](https://issues.redhat.com/browse/TELCODOCS-2524)

**For:** OCP 4.21
See the following PRs for OCP [4.20.z](https://github.com/openshift/openshift-docs/pull/104902), 4.19.z and 4.18.z

[**Preview**](https://104781--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-note-networking-fixed-issues_release-notes)

**Approvals -** `/lgtm`:
- [x] SME
- [x] QE
- [ ] Peer Review