### PR TITLE
[enterprise-4.21] OSDOCS#16936: CQA for descheduler docs

### DIFF
--- a/modules/nodes-descheduler-about.adoc
+++ b/modules/nodes-descheduler-about.adoc
@@ -6,7 +6,8 @@
 [id="nodes-descheduler-about_{context}"]
 = About the descheduler
 
-You can use the descheduler to evict pods based on specific strategies so that the pods can be rescheduled onto more appropriate nodes.
+[role="_abstract"]
+You can use the descheduler to evict pods based on specific strategies so that the pods are rescheduled onto more appropriate nodes.
 
 You can benefit from descheduling running pods in situations such as the following:
 
@@ -25,7 +26,7 @@ When the descheduler decides to evict pods from a node, it employs the following
 
 * Pods in the `openshift-*` and `kube-system` namespaces are never evicted.
 * Critical pods with `priorityClassName` set to `system-cluster-critical` or `system-node-critical` are never evicted.
-* Static, mirrored, or stand-alone pods that are not part of a replication controller, replica set, deployment, or job are never evicted because these pods will not be recreated.
+* Static, mirrored, or standalone pods that are not part of a replication controller, replica set, deployment, stateful set, or job are never evicted because these pods are not recreated.
 * Pods associated with daemon sets are never evicted.
 * Pods with local storage are never evicted.
 * Best effort pods are evicted before burstable and guaranteed pods.

--- a/modules/nodes-descheduler-configuring-interval.adoc
+++ b/modules/nodes-descheduler-configuring-interval.adoc
@@ -6,6 +6,7 @@
 [id="nodes-descheduler-configuring-interval_{context}"]
 = Configuring the descheduler interval
 
+[role="_abstract"]
 You can configure the amount of time between descheduler runs. The default is 3600 seconds (one hour).
 
 .Prerequisites
@@ -26,7 +27,7 @@ endif::openshift-rosa,openshift-dedicated[]
 $ oc edit kubedeschedulers.operator.openshift.io cluster -n openshift-kube-descheduler-operator
 ----
 
-. Update the `deschedulingIntervalSeconds` field to the desired value:
+. Update the `deschedulingIntervalSeconds` field to the required value:
 +
 [source,yaml]
 ----
@@ -36,9 +37,10 @@ metadata:
   name: cluster
   namespace: openshift-kube-descheduler-operator
 spec:
-  deschedulingIntervalSeconds: 3600 <1>
+  deschedulingIntervalSeconds: 3600
 ...
 ----
-<1> Set the number of seconds between descheduler runs. A value of `0` in this field runs the descheduler once and exits.
++
+Set the `spec.deschedulingIntervalSeconds` field to the number of seconds you want between descheduler runs. A value of `0` in this field runs the descheduler once and exits.
 
 . Save the file to apply the changes.

--- a/modules/nodes-descheduler-configuring-profiles.adoc
+++ b/modules/nodes-descheduler-configuring-profiles.adoc
@@ -6,7 +6,8 @@
 [id="nodes-descheduler-configuring-profiles_{context}"]
 = Configuring descheduler profiles
 
-You can configure which profiles the descheduler uses to evict pods.
+[role="_abstract"]
+To manage cluster pod eviction behavior, select which descheduler profiles to enable.
 
 .Prerequisites
 
@@ -40,16 +41,16 @@ spec:
   logLevel: Normal
   managementState: Managed
   operatorLogLevel: Normal
-  mode: Predictive                                     <1>
+  mode: Predictive
   profileCustomizations:
-    namespaces:                                        <2>
+    namespaces:
       excluded:
       - my-namespace
-    podLifetime: 48h                                   <3>
-    thresholdPriorityClassName: my-priority-class-name <4>
+    podLifetime: 48h
+    thresholdPriorityClassName: my-priority-class-name
   evictionLimits:
-    total: 20                                          <5>
-  profiles:                                            <6>
+    total: 20
+  profiles:
   - AffinityAndTaints
   - TopologyAndDuplicates
   - LifecycleAndUtilization
@@ -57,15 +58,13 @@ spec:
   - EvictPodsWithPVC
 ----
 +
---
-<1> Optional: By default, the descheduler does not evict pods. To evict pods, set `mode` to `Automatic`.
-<2> Optional: Set a list of user-created namespaces to include or exclude from descheduler operations. Use `excluded` to set a list of namespaces to exclude or use `included` to set a list of namespaces to include. Note that protected namespaces (`openshift-*`, `kube-system`, `hypershift`) are excluded by default.
-<3> Optional: Enable a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours.
-<4> Optional: Specify a priority threshold to consider pods for eviction only if their priority is lower than the specified level. Use the `thresholdPriority` field to set a numerical priority threshold (for example, `10000`) or use the `thresholdPriorityClassName` field to specify a certain priority class name (for example, `my-priority-class-name`). If you specify a priority class name, it must already exist or the descheduler will throw an error. Do not set both `thresholdPriority` and `thresholdPriorityClassName`.
-<5> Optional: Set the maximum number of pods to evict during each descheduler run.
-<6> Add one or more profiles to enable. Available profiles: `AffinityAndTaints`, `TopologyAndDuplicates`, `LifecycleAndUtilization`, `SoftTopologyAndDuplicates`, `EvictPodsWithLocalStorage`, `EvictPodsWithPVC`, `CompactAndScale`, and `LongLifecycle`. Ensure that you do not enable profiles that conflict with each other.
+where:
 
-You can enable multiple profiles; the order that the profiles are specified in is not important.
---
-+
+`spec.mode`:: Specifies the eviction mode. By default, the descheduler does not evict pods. To evict pods, set `mode` to `Automatic`.
+`spec.profileCustomizations.namespaces`:: Specifies a list of user-created namespaces to include or exclude from descheduler operations. Use `excluded` to set a list of namespaces to exclude or use `included` to set a list of namespaces to include. Note that protected namespaces (`openshift-*`, `kube-system`, `hypershift`) are excluded by default. This value is optional.
+`spec.profileCustomizations.podLifetime`:: Specifies a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours. This value is optional.
+`spec.profileCustomizations.thresholdPriorityClassName`:: Specifies a priority threshold to consider pods for eviction only if their priority is lower than the specified level. Use the `thresholdPriority` field to set a numerical priority threshold (for example, `10000`) or use the `thresholdPriorityClassName` field to specify a certain priority class name (for example, `my-priority-class-name`). If you specify a priority class name, it must already exist or the descheduler will throw an error. Do not set both `thresholdPriority` and `thresholdPriorityClassName`. This value is optional.
+`spec.evictionLimits.total`:: Specifies the maximum number of pods to evict during each descheduler run. This value is optional.
+`spec.profiles`:: Specifies one or more profiles to enable. Available profiles: `AffinityAndTaints`, `TopologyAndDuplicates`, `LifecycleAndUtilization`, `SoftTopologyAndDuplicates`, `EvictPodsWithLocalStorage`, `EvictPodsWithPVC`, `CompactAndScale`, and `LongLifecycle`. You can enable multiple profiles, but ensure that you do not enable profiles that conflict with each other. The order of the list of profiles is not important.
+
 . Save the file to apply the changes.

--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -2,7 +2,7 @@
 //
 // * nodes/scheduling/descheduler/nodes-descheduler-configuring.adoc
 
-ifeval::["{context}" == "nodes-descheduler-about"]
+ifeval::["{context}" == "nodes-descheduler-configuring"]
 :nodes:
 endif::[]
 
@@ -14,6 +14,7 @@ endif::[]
 [id="nodes-descheduler-installing_{context}"]
 = Installing the descheduler
 
+[role="_abstract"]
 The descheduler is not available by default. To enable the descheduler, you must install the {descheduler-operator} from the software catalog and enable one or more descheduler profiles.
 
 By default, the descheduler runs in predictive mode, which means that it only simulates pod evictions. You must change the mode to automatic for the descheduler to perform the pod evictions.
@@ -64,7 +65,7 @@ ifdef::virt[]
 ====
 The only profile currently available for {VirtProductName} is `LongLifecycle`.
 ====
-
++
 You can also configure the profiles and settings for the descheduler later using the OpenShift CLI (`oc`).
 endif::virt[]
 ifdef::nodes[]
@@ -102,10 +103,11 @@ This setting is experimental and should not be used in a production environment.
 ... Optional: Use the *Descheduling Interval Seconds* field to change the number of seconds between descheduler runs. The default is `3600` seconds.
 .. Click *Create*.
 
++
 You can also configure the profiles and settings for the descheduler later using the OpenShift CLI (`oc`). If you did not adjust the profiles when creating the descheduler instance from the web console, the `AffinityAndTaints` profile is enabled by default.
 endif::nodes[]
 
-ifeval::["{context}" == "nodes-descheduler-about"]
+ifeval::["{context}" == "nodes-descheduler-configuring"]
 :!nodes:
 endif::[]
 

--- a/modules/nodes-descheduler-profiles.adoc
+++ b/modules/nodes-descheduler-profiles.adoc
@@ -14,6 +14,9 @@ endif::[]
 [id="nodes-descheduler-profiles_{context}"]
 = Descheduler profiles
 
+[role="_abstract"]
+Use descheduler profiles to enable specific eviction strategies that rebalance your cluster based on criteria such as pod lifecycle or node utilization.
+
 ifdef::nodes[]
 The following descheduler profiles are available:
 
@@ -100,20 +103,23 @@ You cannot have both `KubeVirtRelieveAndMigrate` and `LongLifeCycle` enabled at 
 endif::virt[]
 
 `KubeVirtRelieveAndMigrate`:: This profile is an enhanced version of the `LongLifeCycle` profile.
-
++
 The `KubeVirtRelieveAndMigrate` profile evicts pods from high-cost nodes to reduce overall resource expenses and enable workload migration. It also periodically rebalances workloads to help maintain similar spare capacity across nodes, which supports better handling of sudden workload spikes. Nodes can experience the following costs:
-
++
 --
 * **Resource utilization**: Increased resource pressure raises the overhead for running applications.
 * **Node maintenance**: A higher number of containers on a node increases resource consumption and maintenance costs.
-
+--
++
 The profile enables the `LowNodeUtilization` strategy with the `EvictionsInBackground` alpha feature. The profile also exposes the following customization fields:
-
++
+--
 * `devActualUtilizationProfile`: Enables load-aware descheduling.
 * `devLowNodeUtilizationThresholds`: Sets experimental thresholds for the `LowNodeUtilization` strategy. Do not use this field with `devDeviationThresholds`.
 * `devDeviationThresholds`: Treats nodes with below-average resource usage as underutilized to help redistribute workloads from overutilized nodes. Do not use this field with `devLowNodeUtilizationThresholds`. Supported values are: `Low` (10%:10%), `Medium` (20%:20%), `High` (30%:30%), `AsymmetricLow` (0%:10%), `AsymmetricMedium` (0%:20%), `AsymmetricHigh` (0%:30%).
 * `devEnableSoftTainter`: Enables the soft-tainting component to dynamically apply or remove soft taints as scheduling hints.
-
+--
++
 .Example configuration
 [source,yaml]
 ----
@@ -133,9 +139,9 @@ spec:
     devDeviationThresholds: AsymmetricLow
     devActualUtilizationProfile: PrometheusCPUCombined
 ----
-
++
 The `KubeVirtRelieveAndMigrate` profile requires PSI metrics to be enabled on all worker nodes. You can enable this by applying the following `MachineConfig` custom resource (CR):
-
++
 .Example `MachineConfig` CR
 [source,yaml]
 ----
@@ -149,12 +155,12 @@ spec:
   kernelArguments:
     - psi=1
 ----
-
++
 [NOTE]
 ====
 The name of the `MachineConfig` object is significant because machine configs are processed in lexicographical order. By default, a config that starts with `98-` disables PSI. To ensure that PSI is enabled, name your config with a higher prefix, such as `99-openshift-machineconfig-worker-psi-karg`.
 ====
-
++
 You can use this profile with the `SoftTopologyAndDuplicates` profile to also rebalance pods based on soft topology constraints, which can be useful in hosted control plane environments.
 
 // Show LongLifecycle profile both for virt and nodes
@@ -166,7 +172,7 @@ You can use this profile with the `SoftTopologyAndDuplicates` profile to also re
 ** A node is considered underutilized if its usage is below 20% for all thresholds (CPU, memory, and number of pods).
 ** A node is considered overutilized if its usage is above 50% for any of the thresholds (CPU, memory, and number of pods).
 --
---
++
 ifdef::nodes[]
 [WARNING]
 ====

--- a/modules/nodes-descheduler-rn-5.2.0.adoc
+++ b/modules/nodes-descheduler-rn-5.2.0.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+
+// This release notes module is allowed to contain xrefs. It must only ever be included from one assembly.
+
+:_mod-docs-content-type: REFERENCE
+[id="descheduler-operator-release-notes-5.2.0_{context}"]
+= Release notes for {descheduler-operator} 5.2.0
+
+[role="_abstract"]
+Review the release notes for {descheduler-operator} 5.2.0 to learn what is new and updated with this release.
+
+Issued: 9 July 2025
+
+The following advisory is available for the {descheduler-operator} 5.2.0:
+
+* link:https://access.redhat.com/errata/RHBA-2025:10724[RHBA-2025:10724]
+
+[id="descheduler-operator-5.2.0-new-features_{context}"]
+== New features and enhancements
+
+* This release of the {descheduler-operator} updates the Kubernetes version to 1.32.
+
+[id="descheduler-operator-5.2.0-bug-fixes_{context}"]
+== Bug fixes
+
+* This release of the {descheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+// No known issues to list
+// [id="descheduler-operator-5.2.0-known-issues_{context}"]
+// === Known issues
+//
+// * TODO

--- a/modules/nodes-descheduler-rn-5.3.0.adoc
+++ b/modules/nodes-descheduler-rn-5.3.0.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+
+// This release notes module is allowed to contain xrefs. It must only ever be included from one assembly.
+
+:_mod-docs-content-type: REFERENCE
+[id="descheduler-operator-release-notes-5.3.0_{context}"]
+= Release notes for {descheduler-operator} 5.3.0
+
+[role="_abstract"]
+Review the release notes for {descheduler-operator} 5.3.0 to learn what is new and updated with this release.
+
+Issued: 29 October 2025
+
+The following advisory is available for the {descheduler-operator} 5.3.0:
+
+* link:https://access.redhat.com/errata/RHBA-2025:19249[RHBA-2025:19249]
+
+[id="descheduler-operator-5.3.0-new-features_{context}"]
+== New features and enhancements
+
+* The descheduler profile `DevKubeVirtRelieveAndMigrate` has been renamed to `KubeVirtRelieveAndMigrate` and is now generally available. The updated profile improves VM eviction stability during live migrations by enabling background evictions and reducing oscillatory behavior. This profile is only available for use with {VirtProductName}.
++
+For more information, see xref:../../../virt/managing_vms/advanced_vm_management/virt-enabling-descheduler-evictions.adoc#virt-configuring-descheduler-evictions_virt-enabling-descheduler-evictions[Configuring descheduler evictions for virtual machines].
+
+* This release of the {descheduler-operator} updates the Kubernetes version to 1.33.
+
+// No bug fixes or CVEs to list
+// [id="descheduler-operator-5.3.0-bug-fixes_{context}"]
+// === Bug fixes
+//
+// * This release of the {descheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+// No known issues to list
+// [id="descheduler-operator-5.3.0-known-issues_{context}"]
+// === Known issues
+//
+// * TODO

--- a/modules/nodes-descheduler-rn-5.3.1.adoc
+++ b/modules/nodes-descheduler-rn-5.3.1.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+
+// This release notes module is allowed to contain xrefs. It must only ever be included from one assembly.
+
+:_mod-docs-content-type: REFERENCE
+[id="descheduler-operator-release-notes-5.3.1_{context}"]
+= Release notes for {descheduler-operator} 5.3.1
+
+[role="_abstract"]
+Review the release notes for {descheduler-operator} 5.3.1 to learn what is new and updated with this release.
+
+Issued: 4 December 2025
+
+The following advisory is available for the {descheduler-operator} 5.3.1:
+
+* link:https://access.redhat.com/errata/RHBA-2025:22737[RHBA-2025:22737]
+
+[id="descheduler-operator-5.3.1-new-features_{context}"]
+== New features and enhancements
+
+* This release rebuilds the {descheduler-operator} to improve its image grade.

--- a/modules/nodes-descheduler-uninstalling.adoc
+++ b/modules/nodes-descheduler-uninstalling.adoc
@@ -6,7 +6,8 @@
 [id="nodes-descheduler-uninstalling_{context}"]
 = Uninstalling the descheduler
 
-You can remove the descheduler from your cluster by removing the descheduler instance and uninstalling the {descheduler-operator}. This procedure also cleans up the `KubeDescheduler` CRD and `openshift-kube-descheduler-operator` namespace.
+[role="_abstract"]
+If you no longer need the descheduler in your cluster, you can remove it by deleting the descheduler instance and uninstalling the {descheduler-operator}. You can also delete the `KubeDescheduler` CRD and `openshift-kube-descheduler-operator` namespace.
 
 .Prerequisites
 

--- a/nodes/scheduling/descheduler/index.adoc
+++ b/nodes/scheduling/descheduler/index.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 While the xref:../../../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[scheduler] is used to determine the most suitable node to host a new pod, the descheduler can be used to evict a running pod so that the pod can be rescheduled onto a more suitable node.
 
 // About the descheduler

--- a/nodes/scheduling/descheduler/nodes-descheduler-configuring.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-configuring.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can run the descheduler in {product-title} by installing the {descheduler-operator} and setting the desired profiles and other customizations.
+[role="_abstract"]
+You can run the descheduler in {product-title} by installing the {descheduler-operator} and setting the required profiles and other customizations.
 
 // Installing the descheduler
 include::modules/nodes-descheduler-installing.adoc[leveloffset=+1]

--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -6,77 +6,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The {descheduler-operator} allows you to evict pods so that they can be rescheduled on more appropriate nodes.
+[role="_abstract"]
+Review the {descheduler-operator} release notes to track its development and learn what is new and changed with each release.
 
-These release notes track the development of the {descheduler-operator}.
+The {descheduler-operator} allows you to evict pods so that they can be rescheduled on more appropriate nodes.
 
 For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#nodes-descheduler-about_nodes-descheduler-about[About the descheduler].
 
-[id="descheduler-operator-release-notes-5.3.1"]
-== Release notes for {descheduler-operator} 5.3.1
+// Release notes for Kube Descheduler Operator 5.3.1
+include::modules/nodes-descheduler-rn-5.3.1.adoc[leveloffset=+1]
 
-Issued: 4 December 2025
+// Release notes for Kube Descheduler Operator 5.3.0
+include::modules/nodes-descheduler-rn-5.3.0.adoc[leveloffset=+1]
 
-The following advisory is available for the {descheduler-operator} 5.3.1:
-
-* link:https://access.redhat.com/errata/RHBA-2025:22737[RHBA-2025:22737]
-
-[id="descheduler-operator-5.3.1-new-features"]
-=== New features and enhancements
-
-* This release rebuilds the {descheduler-operator} to improve its image grade.
-
-[id="descheduler-operator-release-notes-5.3.0"]
-== Release notes for {descheduler-operator} 5.3.0
-
-Issued: 29 October 2025
-
-The following advisory is available for the {descheduler-operator} 5.3.0:
-
-* link:https://access.redhat.com/errata/RHBA-2025:19249[RHBA-2025:19249]
-
-[id="descheduler-operator-5.3.0-new-features"]
-=== New features and enhancements
-
-* The descheduler profile `DevKubeVirtRelieveAndMigrate` has been renamed to `KubeVirtRelieveAndMigrate` and is now generally available. The updated profile improves VM eviction stability during live migrations by enabling background evictions and reducing oscillatory behavior. This profile is only available for use with {VirtProductName}.
-+
-For more information, see xref:../../../virt/managing_vms/advanced_vm_management/virt-enabling-descheduler-evictions.adoc#virt-configuring-descheduler-evictions_virt-enabling-descheduler-evictions[Configuring descheduler evictions for virtual machines].
-
-* This release of the {descheduler-operator} updates the Kubernetes version to 1.33.
-
-// No bug fixes or CVEs to list
-// [id="descheduler-operator-5.3.0-bug-fixes"]
-// === Bug fixes
-//
-// * This release of the {descheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-// No known issues to list
-// [id="descheduler-operator-5.3.0-known-issues"]
-// === Known issues
-//
-// * TODO
-
-[id="descheduler-operator-release-notes-5.2.0"]
-== Release notes for {descheduler-operator} 5.2.0
-
-Issued: 9 July 2025
-
-The following advisory is available for the {descheduler-operator} 5.2.0:
-
-* link:https://access.redhat.com/errata/RHBA-2025:10724[RHBA-2025:10724]
-
-[id="descheduler-operator-5.2.0-new-features"]
-=== New features and enhancements
-
-* This release of the {descheduler-operator} updates the Kubernetes version to 1.32.
-
-[id="descheduler-operator-5.2.0-bug-fixes"]
-=== Bug fixes
-
-* This release of the {descheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-// No known issues to list
-// [id="descheduler-operator-5.2.0-known-issues"]
-// === Known issues
-//
-// * TODO
+// Release notes for Kube Descheduler Operator 5.2.0
+include::modules/nodes-descheduler-rn-5.2.0.adoc[leveloffset=+1]

--- a/nodes/scheduling/descheduler/nodes-descheduler-uninstalling.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-uninstalling.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can remove the {descheduler-operator} from {product-title} by uninstalling the Operator and removing its related resources.
+[role="_abstract"]
+If you no longer need the {descheduler-operator} in your cluster, you can uninstall the Operator and remove its related resources.
 
 // Uninstalling the descheduler
 include::modules/nodes-descheduler-uninstalling.adoc[leveloffset=+1]


### PR DESCRIPTION
Manual CP of #104529. This is necessary because there was a previous PR (#75589) that wasn't CP'd properly to the latest enterprise version. This series of PRs pulls in the changes added by that PR though.