### PR TITLE
OLS-2493: Update URL in the doc

### DIFF
--- a/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-cli.adoc
@@ -6,6 +6,7 @@
 [id="ols-creating-lightspeed-custom-resource-file-using-cli_{context}"]
 = Creating the Lightspeed custom resource file using the CLI
 
+[role="_abstract"]
 The Custom Resource (CR) file contains information that the Operator uses to deploy {ols-long}. The specific content of the CR file is unique for each large language model (LLM) provider. To create the CR file, choose the configuration file for the LLM provider that you are using.
 
 .Prerequisites
@@ -69,7 +70,7 @@ spec:
       name: openshift-service-ca.crt
 ----
 <1> By default, the {rhelai} API key requires a token as part of the request. If your {rhelai} configuration does not require a token, you must set the token value to any valid string for the request to authenticate.
-<2> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`.
+<2> The URL endpoint must end with `v1` to be valid. For example, `\https://3.23.103.8:8000/v1`.
 <3> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 +
 .{rhoai} CR file

--- a/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
+++ b/modules/ols-creating-lightspeed-custom-resource-file-using-web-console.adoc
@@ -6,6 +6,7 @@
 [id="ols-creating-lightspeed-custom-resource-file-using-web-console_{context}"]
 = Creating the Lightspeed custom resource file by using the web console
 
+[role="_abstract"]
 The Custom Resource (CR) file contains information that the Operator uses to deploy {ols-long}. The specific content of the CR file is unique for each large language model (LLM) provider. To create the CR file, choose the configuration file for the LLM provider that you are using.
 
 .Prerequisites
@@ -69,7 +70,7 @@ spec:
     defaultModel: models/<model_name>
 ----
 <1> By default, the {rhelai} API key requires a token as part of the request. If your {rhelai} configuration does not require a token, you must set the token value to any valid string for the request to authenticate.
-<2> The URL endpoint must end with `v1` to be valid. For example, `\https://http://3.23.103.8:8000/v1`. 
+<2> The URL endpoint must end with `v1` to be valid. For example, `\https://3.23.103.8:8000/v1`. 
 <3> Specify whether to hide the {ols-long} icon in the {ocp-product-title} web console. The default setting is `false`, which does not hide the icon. Setting the `hideIcon` field to `true` hides the icon. For example, you can hide the icon from cluster users that do not have access to the {ols-long} API.
 +
 .{rhoai} CR file


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue: https://issues.redhat.com/browse/OLS-2493

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
