### PR TITLE
OSDOCS-16863-1: CQA for MetalLB Ingress and Route Configuration

### DIFF
--- a/modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc
+++ b/modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc
@@ -4,20 +4,22 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-metallb-advertise-an-advanced-address-pool-configuration-bgp_{context}"]
-= Example: Advertise an advanced address pool configuration with BGP
+= Advertising an advanced address pool configuration with BGP
 
-Configure MetalLB as follows so that the `IPAddressPool` is advertised with the BGP protocol.
+[role="_abstract"]
+To ensure application services are reachable from external network peers through specific routing paths, configure MetalLB to advertise an advanced address pool by using the BGP. Establishing this advertisement allows your cluster to precisely communicate routing information to the external infrastructure.
+
+The procedure demonstrates how to configure MetalLB to advertise an advanced address pool by using the BGP.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
 
 . Create an IP address pool.
-
++
 .. Create a file, such as `ipaddresspool.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -34,8 +36,9 @@ spec:
     - 203.0.113.200/30
     - fc00:f853:ccd:e799::/124
   autoAssign: false
+# ...
 ----
-
++
 .. Apply the configuration for the IP address pool:
 +
 [source,terminal]
@@ -44,7 +47,7 @@ $ oc apply -f ipaddresspool.yaml
 ----
 
 . Create a BGP advertisement.
-
++
 .. Create a file, such as `bgpadvertisement1.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -61,15 +64,16 @@ spec:
     - 65535:65282
   aggregationLength: 32
   localPref: 100
+# ...
 ----
-
++
 .. Apply the configuration:
 +
 [source,terminal]
 ----
 $ oc apply -f bgpadvertisement1.yaml
 ----
-
++
 .. Create a file, such as `bgpadvertisement2.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -86,8 +90,9 @@ spec:
     - 8000:800
   aggregationLength: 30
   aggregationLengthV6: 124
+# ...
 ----
-
++
 .. Apply the configuration:
 +
 [source,terminal]

--- a/modules/nw-metallb-advertise-address-pool-with-bgp.adoc
+++ b/modules/nw-metallb-advertise-address-pool-with-bgp.adoc
@@ -3,22 +3,23 @@
 // * networking/metallb/about-advertising-ipaddresspool.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="nw-metallb-advertise-a-basic-address-pool-configuration-bgp_{context}"]
-= Example: Advertise a basic address pool configuration with BGP
+= Advertising a basic address pool configuration with BGP
 
-Configure MetalLB as follows so that the `IPAddressPool` is advertised with the BGP protocol.
+[role="_abstract"]
+To ensure application services are reachable from external network peers, configure MetalLB to advertise an `IPAddressPool` by using the BGP advertisement. Establishing this advertisement allows the external network to correctly route traffic to the load balancer IP addresses of your cluster services.
+
+The procedure demonstrates how to configure MetalLB to advertise the `IPAddressPool` by using BGP.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
 
 . Create an IP address pool.
-
++
 .. Create a file, such as `ipaddresspool.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -32,8 +33,9 @@ spec:
   addresses:
     - 203.0.113.200/30
     - fc00:f853:ccd:e799::/124
+# ...
 ----
-
++
 .. Apply the configuration for the IP address pool:
 +
 [source,terminal]
@@ -42,7 +44,7 @@ $ oc apply -f ipaddresspool.yaml
 ----
 
 . Create a BGP advertisement.
-
++
 .. Create a file, such as `bgpadvertisement.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -55,8 +57,9 @@ metadata:
 spec:
   ipAddressPools:
   - doc-example-bgp-basic
+# ...
 ----
-
++
 .. Apply the configuration:
 +
 [source,terminal]

--- a/modules/nw-metallb-advertise-ip-pools-from-node-subset.adoc
+++ b/modules/nw-metallb-advertise-ip-pools-from-node-subset.adoc
@@ -3,20 +3,20 @@
 // * networking/metallb/about-advertising-ipaddresspool.adoc
 
 :_mod-docs-content-type: PROCEDURE
-
 [id="nw-metallb-advertise-ip-pools-to-node-subset_{context}"]
 = Advertising an IP address pool from a subset of nodes
 
-To advertise an IP address from an IP addresses pool, from a specific set of nodes only, use the `.spec.nodeSelector` specification in the BGPAdvertisement custom resource. This specification associates a pool of IP addresses with a set of nodes in the cluster. This is useful when you have nodes on different subnets in a cluster and you want to advertise an IP addresses from an address pool from a specific subnet, for example a public-facing subnet only.
+[role="_abstract"]
+To restrict IP address advertisements to a specific set of nodes, such as a public-facing subnet, configure the `nodeSelector` parameter in the `BGPAdvertisement` custom resource (CR). When you configure these selectors, {product-title} routes external traffic only through designated network interfaces for improved security and isolation.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
 
-. Create an IP address pool by using a custom resource:
+. Create an IP address pool by using a CR:
 +
 [source,yaml]
 ----
@@ -29,9 +29,10 @@ spec:
   addresses:
     - 4.4.4.100-4.4.4.200
     - 2001:100:4::200-2001:100:4::400
+# ...
 ----
 
-. Control which nodes in the cluster the IP address from `pool1` advertises from by defining the `.spec.nodeSelector` value in the BGPAdvertisement custom resource:
+. Control which cluster nodes advertise the IP address from `pool1` by setting the `.spec.nodeSelector` value in the `BGPAdvertisement` CR. The following example advertises the IP address from `pool1` only from `NodeA` and `NodeB`.
 +
 [source,yaml]
 ----
@@ -47,6 +48,6 @@ spec:
       kubernetes.io/hostname: NodeA
   - matchLabels:
       kubernetes.io/hostname: NodeB
+# ...
 ----
 
-In this example, the IP address from `pool1` advertises from `NodeA` and `NodeB` only.

--- a/modules/nw-metallb-bgpadvertisement-cr.adoc
+++ b/modules/nw-metallb-bgpadvertisement-cr.adoc
@@ -6,13 +6,16 @@
 [id="nw-metallb-bgpadvertisement-cr_{context}"]
 = About the BGPAdvertisement custom resource
 
-The fields for the `BGPAdvertisements` object are defined in the following table:
+[role="_abstract"]
+To configure how the cluster announces IP addresses to external peers, define the properties of the `BGPAdvertisement` custom resource (CR). Specifying these parameters ensures that MetalLB correctly manages routing advertisements for your application services within the network.
+
+The following table describes the parameters for the `BGPAdvertisements` CR:
 
 .BGPAdvertisements configuration
 [cols="1,1,3a", options="header"]
 |===
 
-|Field
+|Parameter
 |Type
 |Description
 
@@ -22,25 +25,19 @@ The fields for the `BGPAdvertisements` object are defined in the following table
 
 |`metadata.namespace`
 |`string`
-|Specifies the namespace for the BGP advertisement.
-Specify the same namespace that the MetalLB Operator uses.
+|Specifies the namespace for the BGP advertisement. Specify the same namespace that the MetalLB Operator uses.
 
 |`spec.aggregationLength`
 |`integer`
-|Optional: Specifies the number of bits to include in a 32-bit CIDR mask.
-To aggregate the routes that the speaker advertises to BGP peers, the mask is applied to the routes for several service IP addresses and the speaker advertises the aggregated route.
-For example, with an aggregation length of `24`, the speaker can aggregate several `10.0.1.x/32` service IP addresses and advertise a single `10.0.1.0/24` route.
+|Optional: Specifies the number of bits to include in a 32-bit CIDR mask. To aggregate the routes that the speaker advertises to BGP peers, the mask is applied to the routes for several service IP addresses and the speaker advertises the aggregated route. For example, with an aggregation length of `24`, the speaker can aggregate several `10.0.1.x/32` service IP addresses and advertise a single `10.0.1.0/24` route.
 
 |`spec.aggregationLengthV6`
 |`integer`
-|Optional: Specifies the number of bits to include in a 128-bit CIDR mask.
-For example, with an aggregation length of `124`, the speaker can aggregate several `fc00:f853:0ccd:e799::x/128` service IP addresses and advertise a single `fc00:f853:0ccd:e799::0/124` route.
+|Optional: Specifies the number of bits to include in a 128-bit CIDR mask. For example, with an aggregation length of `124`, the speaker can aggregate several `fc00:f853:0ccd:e799::x/128` service IP addresses and advertise a single `fc00:f853:0ccd:e799::0/124` route.
 
 |`spec.communities`
 |`string`
-|Optional: Specifies one or more BGP communities.
-Each community is specified as two 16-bit values separated by the colon character.
-Well-known communities must be specified as 16-bit values:
+|Optional: Specifies one or more BGP communities. Each community is specified as two 16-bit values separated by the colon character. Well-known communities must be specified as 16-bit values:
 
 * `NO_EXPORT`: `65535:65281`
 * `NO_ADVERTISE`: `65535:65282`
@@ -53,8 +50,7 @@ You can also use community objects that are created along with the strings.
 
 |`spec.localPref`
 |`integer`
-|Optional: Specifies the local preference for this advertisement.
-This BGP attribute applies to BGP sessions within the Autonomous System.
+|Optional: Specifies the local preference for this advertisement. This BGP attribute applies to BGP sessions within the Autonomous System.
 
 |`spec.ipAddressPools`
 |`string`
@@ -66,10 +62,10 @@ This BGP attribute applies to BGP sessions within the Autonomous System.
 
 |`spec.nodeSelectors`
 |`string`
-|Optional: `NodeSelectors` allows to limit the nodes to announce as next hops for the load balancer IP. When empty, all the nodes are announced as next hops.
+|Optional: By setting the `NodeSelectors` parameter, you can limit the nodes to announce as next hops for the load balancer IP. When empty, all the nodes are announced as next hops.
 
 |`spec.peers`
 |`string`
-|Optional: Use a list to specify the `metadata.name` values for each `BGPPeer` resource that receives advertisements for the MetalLB service IP address. The MetalLB service IP address is assigned from the IP address pool. By default, the MetalLB service IP address is advertised to all configured `BGPPeer` resources. Use this field to limit the advertisement to specific `BGPpeer` resources.
+|Optional: Use a list to specify the `metadata.name` values for each `BGPPeer` resource that receives advertisements for the MetalLB service IP address. The MetalLB service IP address is assigned from the IP address pool. By default, the MetalLB service IP address is advertised to all configured `BGPPeer` resources. Set this parameter to limit the advertisement to specific `BGPpeer` resources.
 
 |===

--- a/modules/nw-metallb-configure-bgp-advertisement-advanced.adoc
+++ b/modules/nw-metallb-configure-bgp-advertisement-advanced.adoc
@@ -6,18 +6,15 @@
 [id="nw-metallb-configure-BGP-advertisement-advanced-use-case_{context}"]
 = Configuring MetalLB with a BGP advertisement and an advanced use case
 
-Configure MetalLB as follows so that MetalLB assigns IP addresses to load-balancer services in the ranges between `203.0.113.200` and `203.0.113.203` and between `fc00:f853:ccd:e799::0` and `fc00:f853:ccd:e799::f`.
+[role="_abstract"]
+To assign application services specific IP addresses from designated IPv4 and IPv6 ranges, configure MetalLB for advanced address allocation. Establishing these ranges and BGP advertisements ensures that your load-balancer services remain reachable through predictable network paths.
 
-To explain the two BGP advertisements, consider an instance when MetalLB assigns the IP address of `203.0.113.200` to a service.
-With that IP address as an example, the speaker advertises two routes to BGP peers:
+Configure MetalLB so that MetalLB assigns IP addresses to load-balancer services in the ranges between `203.0.113.200` and `203.0.113.203` and between `fc00:f853:ccd:e799::0` and `fc00:f853:ccd:e799::f`.
 
-* `203.0.113.200/32`, with `localPref` set to `100` and the community set to the numeric value of the `NO_ADVERTISE` community.
-This specification indicates to the peer routers that they can use this route but they should not propagate information about this route to BGP peers.
+To explain the two BGP advertisements, consider an instance when MetalLB assigns the IP address of `203.0.113.200` to a service. With that IP address as an example, the speaker advertises the following two routes to BGP peers:
 
-* `203.0.113.200/30`, aggregates the load-balancer IP addresses assigned by MetalLB into a single route.
-MetalLB advertises the aggregated route to BGP peers with the community attribute set to `8000:800`.
-BGP peers propagate the `203.0.113.200/30` route to other BGP peers.
-When traffic is routed to a node with a speaker, the `203.0.113.200/32` route is used to forward the traffic into the cluster and to a pod that is associated with the service.
+* `203.0.113.200/32`, with `localPref` set to `100` and the community set to the numeric value of the `NO_ADVERTISE` community. This specification indicates to the peer routers that they can use this route but they should not propagate information about this route to BGP peers.
 
-As you add more services and MetalLB assigns more load-balancer IP addresses from the pool, peer routers receive one local route, `203.0.113.20x/32`, for each service, as well as the `203.0.113.200/30` aggregate route.
-Each service that you add generates the `/30` route, but MetalLB deduplicates the routes to one BGP advertisement before communicating with peer routers.
+* `203.0.113.200/30`, aggregates the load-balancer IP addresses assigned by MetalLB into a single route. MetalLB advertises the aggregated route to BGP peers with the community attribute set to `8000:800`. BGP peers propagate the `203.0.113.200/30` route to other BGP peers. When traffic is routed to a node with a speaker, the `203.0.113.200/32` route is used to forward the traffic into the cluster and to a pod that is associated with the service.
+
+As you add more services and MetalLB assigns more load-balancer IP addresses from the pool, peer routers receive one local route, `203.0.113.20x/32`, for each service, and the `203.0.113.200/30` aggregate route. Each service that you add generates the `/30` route, but MetalLB deduplicates the routes to one BGP advertisement before communicating with peer routers.

--- a/modules/nw-metallb-configure-bgp-advertisement.adoc
+++ b/modules/nw-metallb-configure-bgp-advertisement.adoc
@@ -4,7 +4,9 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nw-metallb-configure-BGP-advertisement-basic-use-case_{context}"]
-= Configuring MetalLB with a BGP advertisement and a basic use case
+= Configure MetalLB with a BGP advertisement and a basic use case
 
-Configure MetalLB as follows so that the peer BGP routers receive one `203.0.113.200/32` route and one `fc00:f853:ccd:e799::1/128` route for each load-balancer IP address that MetalLB assigns to a service.
-Because the `localPref` and `communities` fields are not specified, the routes are advertised with `localPref` set to zero and no BGP communities.
+[role="_abstract"]
+To advertise specific IPv4 and IPv6 routes to peer BGP routers for assigned load-balancer IP addresses, configure MetalLB by using default preference and community settings. Establishing these routes ensures reliable external traffic delivery and consistent network propagation for your application services.
+
+Ensure that you can configure MetalLB so that the peer BGP routers receive one `203.0.113.200/32` route and one `fc00:f853:ccd:e799::1/128` route for each load-balancer IP address that MetalLB assigns to a service. If you do not specify the `localPref` and `communities` parameters, MetalLB advertises the routes with `localPref` set to `0 and no BGP communities.

--- a/modules/nw-metallb-configure-l2-advertisement-interface.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement-interface.adoc
@@ -6,21 +6,21 @@
 [id="nw-metallb-configure-with-L2-advertisement-interface_{context}"]
 = Configuring MetalLB with an L2 advertisement for selected interfaces
 
-By default, the IP addresses from IP address pool that has been assigned to the service, is advertised from all the network interfaces. The `interfaces` field in the `L2Advertisement` custom resource definition is used to restrict those network interfaces that advertise the IP address pool.
+[role="_abstract"]
+To restrict which network interfaces advertise assigned service IP addresses, configure the interfaces parameter in the MetalLB `L2Advertisement` custom resource (CR). Defining specific interfaces ensures that cluster services are reachable only through designated network paths for improved traffic management and isolation.
 
-This example shows how to configure MetalLB so that the IP address pool is advertised only from the network interfaces listed in the `interfaces` field of all nodes.
+The example in the procedure shows how to configure MetalLB so that the IP address pool is advertised only from the network interfaces listed in the `interfaces` parameter of all nodes.
 
 .Prerequisites
 
-* You have installed the OpenShift CLI (`oc`).
-
+* You have installed the {oc-first}.
 * You are logged in as a user with `cluster-admin` privileges.
 
 .Procedure
 
 . Create an IP address pool.
-
-.. Create a file, such as `ipaddresspool.yaml`, and enter the configuration details like the following example:
++
+.. Create a file, such as `ipaddresspool.yaml`, and enter the configuration details as shown in the following example:
 +
 [source,yaml]
 ----
@@ -33,18 +33,19 @@ spec:
   addresses:
     - 4.4.4.0/24
   autoAssign: false
+# ...
 ----
-
-.. Apply the configuration for the IP address pool like the following example:
++
+.. Apply the configuration for the IP address pool as shown in the following example:
 +
 [source,terminal]
 ----
 $ oc apply -f ipaddresspool.yaml
 ----
 
-. Create a L2 advertisement advertising the IP with `interfaces` selector.
-
-.. Create a YAML file, such as `l2advertisement.yaml`, and enter the configuration details like the following example:
+. Create an L2 advertisement with the `interfaces` selector to advertise the IP address.
++
+.. Create a YAML file, such as `l2advertisement.yaml`, and enter the configuration details as shown the following example:
 +
 [source,yaml]
 ----
@@ -59,15 +60,16 @@ spec:
    interfaces:
    - interfaceA
    - interfaceB
+# ...
 ----
-
-.. Apply the configuration for the advertisement like the following example:
++
+.. Apply the configuration for the advertisement as shown in the following example:
 +
 [source,terminal]
 ----
 $ oc apply -f l2advertisement.yaml
 ----
-
++
 [IMPORTANT]
 ====
 The interface selector does not affect how MetalLB chooses the node to announce a given IP by using L2. The chosen node does not announce the service if the node does not have the selected interface.

--- a/modules/nw-metallb-configure-l2-advertisement-label.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement-label.adoc
@@ -4,22 +4,22 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-metallb-configure-with-L2-advertisement-label_{context}"]
-= Configuring MetalLB with a L2 advertisement and label
+= Configuring MetalLB with an L2 advertisement and labels
 
-The `ipAddressPoolSelectors` field in the `BGPAdvertisement` and `L2Advertisement` custom resource definitions is used to associate the `IPAddressPool` to the advertisement based on the label assigned to the `IPAddressPool` instead of the name itself.
+[role="_abstract"]
+To dynamically associate IP address pools with advertisements by using labels instead of specific names, configure the `ipAddressPoolSelectors` parameter in the MetalLB custom resource (CR). By using selectors, you can manage network routing more efficiently by automatically grouping address pools as your cluster scales.
 
-This example shows how to configure MetalLB so that the `IPAddressPool` is advertised with the L2 protocol by configuring the `ipAddressPoolSelectors` field.
+The example in the procedure shows how to configure MetalLB so that the `IPAddressPool` is advertised with the L2 protocol by configuring the `ipAddressPoolSelectors` field.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
 
 . Create an IP address pool.
-
++
 .. Create a file, such as `ipaddresspool.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -34,8 +34,9 @@ metadata:
 spec:
   addresses:
     - 172.31.249.87/32
+# ...
 ----
-
++
 .. Apply the configuration for the IP address pool:
 +
 [source,terminal]
@@ -43,8 +44,8 @@ spec:
 $ oc apply -f ipaddresspool.yaml
 ----
 
-. Create a L2 advertisement advertising the IP using `ipAddressPoolSelectors`.
-
+. Create an L2 advertisement that advertises the IP address by using `ipAddressPoolSelectors`.
++
 .. Create a file, such as `l2advertisement.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -61,8 +62,9 @@ spec:
           operator: In
           values:
             - east
+# ...
 ----
-
++
 .. Apply the configuration:
 +
 [source,terminal]

--- a/modules/nw-metallb-configure-l2-advertisement.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement.adoc
@@ -6,18 +6,18 @@
 [id="nw-metallb-configure-with-L2-advertisement_{context}"]
 = Configuring MetalLB with an L2 advertisement
 
-Configure MetalLB as follows so that the `IPAddressPool` is advertised with the L2 protocol.
+[role="_abstract"]
+To provide fault-tolerant external IP addresses for cluster services, configure MetalLB to advertise an `IPAddressPool` by using the Layer 2 protocol. Establishing this advertisement ensures that application workloads remain reachable within the local network through standard address discovery protocols.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-
+* Install the {oc-first}. 
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
 
 . Create an IP address pool.
-
++
 .. Create a file, such as `ipaddresspool.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -31,8 +31,9 @@ spec:
   addresses:
     - 4.4.4.0/24
   autoAssign: false
+# ...
 ----
-
++
 .. Apply the configuration for the IP address pool:
 +
 [source,terminal]
@@ -40,8 +41,8 @@ spec:
 $ oc apply -f ipaddresspool.yaml
 ----
 
-. Create a L2 advertisement.
-
+. Create an L2 advertisement.
++
 .. Create a file, such as `l2advertisement.yaml`, with content like the following example:
 +
 [source,yaml]
@@ -54,8 +55,9 @@ metadata:
 spec:
   ipAddressPools:
    - doc-example-l2
+  # ...
 ----
-
++
 .. Apply the configuration:
 +
 [source,terminal]

--- a/modules/nw-metallb-configure-secondary-interface.adoc
+++ b/modules/nw-metallb-configure-secondary-interface.adoc
@@ -2,35 +2,37 @@
 [id="nw-metallb-configure-secondary-interface_{context}"]
 = Configuring MetalLB with secondary networks
 
-From {product-title} 4.14 the default network behavior is to not allow forwarding of IP packets between network interfaces. Therefore, when MetalLB is configured on a secondary interface, you need to add a machine configuration to enable IP forwarding for only the required interfaces. 
+[role="_abstract"]
+To enable traffic forwarding for MetalLB on a secondary network interface, add a machine configuration that allows IP packet forwarding between interfaces. Implementing this configuration ensures that application services remain reachable when they use nondefault network paths.
+
 [NOTE]
 ====
-{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during upgrade to enable global IP forwarding. 
+From {product-title} 4.14 the default network behavior does not allow forwarding of IP packets between network interfaces.
+
+{product-title} clusters upgraded from 4.13 are not affected because a global parameter is set during an upgrade to enable global IP forwarding. 
 ====
 
 To enable IP forwarding for the secondary interface, you have two options:
 
 * Enable IP forwarding for a specific interface.
 * Enable IP forwarding for all interfaces.
-+
+
 [NOTE]
 ====
 Enabling IP forwarding for a specific interface provides more granular control, while enabling it for all interfaces applies a global setting.
 ====
 
-[id="nw-enabling-ip-forwarding-specific-interface_{context}"]
-== Enabling IP forwarding for a specific interface
 .Procedure
 
-. Patch the Cluster Network Operator, setting the parameter `routingViaHost` to `true`, by running the following command: 
+. Patch the Cluster Network Operator, setting the parameter `routingViaHost` to `true` by running the following command: 
 +
 [source,terminal]
 ----
 $ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig": {"routingViaHost": true} }}}}' --type=merge
 ----
 
-. Enable forwarding for a specific secondary interface, such as `bridge-net` by creating and applying a `MachineConfig` CR:
-
+. Enable forwarding for a specific secondary interface, such as `bridge-net`, by creating and applying a `MachineConfig` CR:
++
 ..  Base64-encode the string that is used to configure network kernel parameters by running the following command on your local machine:
 +
 [source,terminal]
@@ -39,14 +41,13 @@ $ echo -e "net.ipv4.conf.bridge-net.forwarding = 1" | base64 -w0
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 bmV0LmlwdjQuY29uZi5icmlkZ2UtbmV0LmZvcndhcmRpbmcgPSAxCg==
 ----
-
++
 .. Create the `MachineConfig` CR to enable IP forwarding for the specified secondary interface named `bridge-net`.
-
++
 .. Save the following YAML in the `enable-ip-forward.yaml` file:
 +
 [source,yaml]
@@ -55,7 +56,7 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: <node_role> <1> 
+    machineconfiguration.openshift.io/role: <node_role>
   name: 81-enable-global-forwarding
 spec:
   config:
@@ -64,17 +65,20 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,bmV0LmlwdjQuY29uZi5icmlkZ2UtbmV0LmZvcndhcmRpbmcgPSAxCg== <2>
+          source: data:text/plain;charset=utf-8;base64,bmV0LmlwdjQuY29uZi5icmlkZ2UtbmV0LmZvcndhcmRpbmcgPSAxCg==
           verification: {}
         filesystem: root
         mode: 420
         path: /etc/sysctl.d/enable-global-forwarding.conf
   osImageURL: ""
+# ...
 ----
 +
-<1> Node role where you want to enable IP forwarding, for example, `worker`
-<2> Populate with the generated base64 string 
-
+where:
++
+`<node_role>`:: Node role where you want to enable IP forwarding, for example, `worker`.
+`contents.source`:: Populate with the generated Base64 string.
++
 .. Apply the configuration by running the following command:
 +
 [source,terminal]
@@ -82,26 +86,31 @@ spec:
 $ oc apply -f enable-ip-forward.yaml
 ----
 
+. Optional: Enable IP forwarding globally by running the following command:
++
+[source,terminal]
+----
+$ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding": "Global"}}}}}' --type=merge
+----
+
 .Verification
 
-.  After you apply the machine config, verify the changes by following this procedure: 
-
-.. Enter into a debug session on the target node by running the following command: 
+.  After you apply the machine config, verify the changes by completing the following steps: 
++
+.. Enter into a debug session on the target node by running the following command. This command instantiates a debug pod called `<node-name>-debug`.
 +
 [source,terminal]
 ----
 $ oc debug node/<node-name>
 ----
-This step instantiates a debug pod called `<node-name>-debug`.
-
-.. Set `/host` as the root directory within the debug shell by running the following command:
++
+.. Set `/host` as the root directory within the debug shell by running the following command. The debug pod mounts root file system of the host in `/host` within the pod. By changing the root directory to `/host`, you can run binaries contained in the executable paths of the host.
 +
 [source,terminal]
 ----
 $ chroot /host
 ----
-The debug pod mounts the host’s root file system in `/host` within the pod. By changing the root directory to `/host`, you can run binaries contained in the host’s executable paths.
-
++
 .. Verify that IP forwarding is enabled by running the following command: 
 +
 [source,terminal]
@@ -109,21 +118,10 @@ The debug pod mounts the host’s root file system in `/host` within the pod. By
 $ cat /etc/sysctl.d/enable-global-forwarding.conf
 ----
 +
-.Expected output
-
+.Example output
 [source,terminal]
 ----
 net.ipv4.conf.bridge-net.forwarding = 1 
 ----
 +
 The output indicates that IPv4 forwarding is enabled on the `bridge-net` interface.
-
-[id="nw-enabling-ip-forwarding-globally_{context}"]
-== Enabling IP forwarding globally 
-
-* Enable IP forwarding globally by running the following command:
-+
-[source,terminal]
-----
-$ oc patch network.operator cluster -p '{"spec":{"defaultNetwork":{"ovnKubernetesConfig":{"gatewayConfig":{"ipForwarding": "Global"}}}}}' --type=merge
-----

--- a/modules/nw-metallb-l2padvertisement-cr.adoc
+++ b/modules/nw-metallb-l2padvertisement-cr.adoc
@@ -6,13 +6,16 @@
 [id="nw-metallb-l2padvertisement-cr_{context}"]
 = About the L2Advertisement custom resource
 
-The fields for the `l2Advertisements` object are defined in the following table:
+[role="_abstract"]
+To configure how application services are announced over a Layer 2 network, define the properties in the `L2Advertisement` custom resource (CR). Establishing these parameters ensures that MetalLB correctly manages routing for your load-balancer IP addresses within the local network infrastructure
+
+The following table details parameters for the `l2Advertisements` CR:
 
 .L2 advertisements configuration
 [cols="1,1,3a", options="header"]
 |===
 
-|Field
+|Parameter
 |Type
 |Description
 
@@ -22,8 +25,7 @@ The fields for the `l2Advertisements` object are defined in the following table:
 
 |`metadata.namespace`
 |`string`
-|Specifies the namespace for the L2 advertisement.
-Specify the same namespace that the MetalLB Operator uses.
+|Specifies the namespace for the L2 advertisement. Specify the same namespace that the MetalLB Operator uses.
 
 |`spec.ipAddressPools`
 |`string`
@@ -31,17 +33,17 @@ Specify the same namespace that the MetalLB Operator uses.
 
 |`spec.ipAddressPoolSelectors`
 |`string`
-|Optional: A selector for the `IPAddressPools` that gets advertised with this advertisement. This is for associating the `IPAddressPool` to the advertisement based on the label assigned to the `IPAddressPool` instead of the name itself. If no `IPAddressPool` is selected by this or by the list, the advertisement is applied to all the `IPAddressPools`.
+|Optional: A selector for the `IPAddressPools` to advertise with this advertisement. This is for associating the `IPAddressPool` to the advertisement based on the label assigned to the `IPAddressPool` instead of the name itself. If no `IPAddressPool` is selected by this or by the list, the advertisement is applied to all the `IPAddressPools`.
 
 |`spec.nodeSelectors`
 |`string`
-|Optional: `NodeSelectors` limits the nodes to announce as next hops for the load balancer IP. When empty, all the nodes are announced as next hops.
+|Optional: `NodeSelectors` limits the nodes to announce as next hops for the load balancer IP. If empty, MetalLB announces all nodes as next hops.
 
 :FeatureName: Limiting the nodes to announce as next hops
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
 |`spec.interfaces`
 |`string`
-|Optional: The list of `interfaces` that are used to announce the load balancer IP.
+|Optional: The list of `interfaces` to announce the load balancer IP address.
 
 |===

--- a/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.adoc
+++ b/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.adoc
@@ -6,12 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can configure MetalLB so that the IP address is advertised with layer 2 protocols, the BGP protocol, or both.
-With layer 2, MetalLB provides a fault-tolerant external IP address. With BGP, MetalLB provides fault-tolerance for the external IP address and load balancing.
+[role="_abstract"]
+To provide fault-tolerant external IP addresses and load balancing for cluster services, configure MetalLB to advertise addresses by using Layer 2 protocols, the Border Gateway Protocol (BGP), or both. Selecting the appropriate protocol ensures reliable traffic routing and high availability for your application workloads.
 
-MetalLB supports advertising using L2 and BGP for the same set of IP addresses.
+MetalLB supports advertising by using Layer 2 and BGP for the same set of IP addresses.
 
-MetalLB provides the flexibility to assign address pools to specific BGP peers effectively to a subset of nodes on the network. This allows for more complex configurations, for example facilitating the isolation of nodes or the segmentation of the network.
+MetalLB provides the flexibility to assign address pools to specific BGP peers, effectively limiting advertising to a subset of nodes on the network. This allows for more complex configurations, such as facilitating the isolation of nodes or the segmentation of the network.
 
 // BGP advertisement custom resource
 include::modules/nw-metallb-bgpadvertisement-cr.adoc[leveloffset=+1]
@@ -25,22 +25,22 @@ include::modules/nw-metallb-advertise-address-pool-with-bgp.adoc[leveloffset=+2]
 // Configure MetalLB with a BGP advertisement
 include::modules/nw-metallb-configure-bgp-advertisement-advanced.adoc[leveloffset=+1]
 
-// Advertise MetalLB with a BGP advertisement
+// Advertising MetalLB with a BGP advertisement
 include::modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc[leveloffset=+2]
 
-// Advertise IP address pools from a subset of nodes
+// Advertising IP address pools from a subset of nodes
 include::modules/nw-metallb-advertise-ip-pools-from-node-subset.adoc[leveloffset=+1]
 
 // L2 advertisement custom resource
 include::modules/nw-metallb-l2padvertisement-cr.adoc[leveloffset=+1]
 
-// Configure MetalLB with a L2 advertisement
+// Configure MetalLB with an L2 advertisement
 include::modules/nw-metallb-configure-l2-advertisement.adoc[leveloffset=+1]
 
-// Configure MetalLB with a L2 advertisement using label
+// Configuring MetalLB with an L2 advertisement and labels
 include::modules/nw-metallb-configure-l2-advertisement-label.adoc[leveloffset=+1]
 
-// Configure MetalLB with a L2 advertisement using interface
+// Configure MetalLB with an L2 advertisement using interface
 include::modules/nw-metallb-configure-l2-advertisement-interface.adoc[leveloffset=+1]
 
 // Configure MetalLB with a secondary interface
@@ -50,4 +50,4 @@ include::modules/nw-metallb-configure-secondary-interface.adoc[leveloffset=+1]
 [id="additional-resources_about-advertiseipaddress"]
 == Additional resources
 
-* xref:../../../networking/ingress_load_balancing/metallb/metallb-configure-community-alias.adoc#metallb-configure-community-alias[Configuring a community alias].
+* xref:../../../networking/ingress_load_balancing/metallb/metallb-configure-community-alias.adoc#metallb-configure-community-alias[Configuring a community alias]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-16863](https://issues.redhat.com/browse/OSDOCS-16863)

Link to docs preview:
* [About advertising for the IP address pools](https://104829--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/about-advertising-ipaddresspool.html)

- [ ] SME has approved this change.
- [ ] QE has approved this change.
