### PR TITLE
[OBSDOCS-2542] Add link to loki obj storage in Loki install

### DIFF
--- a/modules/installing-loki-operator-cli.adoc
+++ b/modules/installing-loki-operator-cli.adoc
@@ -125,7 +125,7 @@ stringData: # <2>
   region: eu-central-1
 ----
 <1> Use the name `logging-loki-s3` to match the name used in LokiStack.
-<2> For the contents of the secret see the Loki object storage section.
+<2> For the contents of the secret see the link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage_configuring-the-log-store[Loki object storage section].
 +
 --
 include::snippets/logging-retention-period-snip.adoc[leveloffset=+1]

--- a/modules/installing-loki-operator-web-console.adoc
+++ b/modules/installing-loki-operator-web-console.adoc
@@ -42,7 +42,7 @@ An Operator might display a `Failed` status before the installation completes. I
 
 . While the Operator installs, create the namespace to which the log store will be deployed.
 
-.. Click *+* in the top right of the screen to access the *Import YAML* page. 
+.. Click *+* in the top right of the screen to access the *Import YAML* page.
 
 .. Add the YAML definition for the `openshift-logging` namespace:
 +
@@ -63,7 +63,7 @@ metadata:
 
 . Create a secret with the credentials to access the object storage.
 
-.. Click *+* in the top right of the screen to access the *Import YAML* page. 
+.. Click *+* in the top right of the screen to access the *Import YAML* page.
 
 .. Add the YAML definition for the secret. For example, create a secret to access Amazon Web Services (AWS) s3:
 +
@@ -84,7 +84,7 @@ stringData: <3>
 ----
 <1> Note down the name used for the secret `logging-loki-s3` to use it later when creating the `LokiStack` resource.
 <2> Set the namespace to `openshift-logging` as that will be the namespace used to deploy `LokiStack`.
-<3> For the contents of the secret see the Loki object storage section.
+<3> For the contents of the secret see the link:https://docs.redhat.com/en/documentation/red_hat_openshift_logging/{logging-major-version}/html/configuring_logging/configuring-lokistack-storage#logging-loki-storage_configuring-the-log-store[Loki object storage section].
 +
 --
 include::snippets/logging-retention-period-snip.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- standalone-logging-docs-6.0
- standalone-logging-docs-6.1
- standalone-logging-docs-6.2
- standalone-logging-docs-6.3
- standalone-logging-docs-6.4
- standalone-logging-docs-6.5

Issue:
- https://issues.redhat.com/browse/OBSDOCS-2542

Link to docs preview:
- in https://github.com/openshift/openshift-docs/pull/107248

QE review:
- [x] QE approval not needed.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
