### PR TITLE
OBSDOCS-2151: Security config fix for FileLog Receiver

### DIFF
--- a/modules/otel-receivers-filelog-receiver.adoc
+++ b/modules/otel-receivers-filelog-receiver.adoc
@@ -12,7 +12,7 @@ The Filelog Receiver tails and parses logs from files.
 :FeatureName: The Filelog Receiver
 include::snippets/technology-preview.adoc[]
 
-.OpenTelemetry Collector custom resource with the enabled Filelog Receiver that tails a text file
+.OpenTelemetry Collector custom resource with an enabled Filelog Receiver that tails a text file
 [source,yaml]
 ----
 # ...
@@ -31,7 +31,93 @@ include::snippets/technology-preview.adoc[]
 # ...
 ----
 <1> A list of file glob patterns that match the file paths to be read.
-<2> An array of operators. Each operator performs a simple task such as parsing a timestamp or JSON. To process logs into a desired format, chain the operators together.
+<2> An array of Operators. Each Operator performs a simple task such as parsing a timestamp or JSON. To process logs into a needed format, chain the Operators together.
+
+The next example shows how to make the Filelog Receiver work within security context constraints.
+
+.OpenTelemetry Collector custom resource with an enabled Filelog Receiver that parses cluster logs
+[source,yaml]
+----
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: otel-clusterlogs-collector-scc <1>
+allowPrivilegedContainer: false
+requiredDropCapabilities:
+- ALL
+allowHostDirVolumePlugin: true
+volumes:
+- configMap
+- emptyDir
+- hostPath
+- projected
+- secret
+defaultAllowPrivilegeEscalation: false
+allowPrivilegeEscalation: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+readOnlyRootFilesystem: true
+forbiddenSysctls:
+- '*'
+seccompProfiles:
+- runtime/default
+users:
+- system:serviceaccount:observability:clusterlogs-collector <2>
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: clusterlogs
+  namespace: observability
+spec:
+  mode: daemonset
+  config:
+    receivers:
+      filelog:
+        include:
+        - "/var/log/pods/*/*/*.log"
+        exclude:
+        - "/var/log/pods/*/otc-container/*.log" <3>
+        - "/var/log/pods/*/*/*.gz"
+        - "/var/log/pods/*/*/*.log.*"
+        - "/var/log/pods/*/*/*.tmp"
+        include_file_path: true
+        include_file_name: false
+        operators:
+        - type: container
+    exporters:
+      debug:
+        verbosity: detailed
+    service:
+      pipelines:
+        logs:
+          receivers: [filelog]
+          exporters: [debug]
+  securityContext:
+    runAsUser: 0
+    seLinuxOptions:
+      type: spc_t
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+      - ALL
+  volumeMounts:
+  - name: varlogpods
+    mountPath: /var/log/pods
+    readOnly: true
+  volumes:
+  - name: varlogpods
+    hostPath:
+      path: /var/log/pods
+----
+<1> Configure a security context constraint (SCC) to allow access to files on the host.
+<2> The OpenTelemetry Operator created this service account for the Collector. Assign the SCC to this service account.
+<3> Exclude logs from the Collector container.
 
 You can use this receiver to collect logs from pod filesystems in one of two ways:
 
@@ -39,7 +125,7 @@ You can use this receiver to collect logs from pod filesystems in one of two way
 
 * Deploying the receiver as a DaemonSet on the host machine with appropriate permissions to access Kubernetes logs.
 
-To collect logs from application containers, you can use this receiver with sidecar injection. The {OTELOperator} allows injecting an OpenTelemetry Collector as a sidecar container into an application pod. This approach is useful when your application writes logs to files within the container filesystem. This receiver can then tail log files and apply operators to parse the logs.
+To collect logs from application containers, you can use this receiver with sidecar injection. The {OTELOperator} allows injecting an OpenTelemetry Collector as a sidecar container into an application pod. This approach is useful when your application writes logs to files within the container filesystem. This receiver can then tail log files and apply Operators to parse the logs.
 
 To use this receiver in sidecar mode to collect logs from application containers, you must configure volume mounts in the `OpenTelemetryCollector` custom resource. Both the application container and the sidecar Collector must mount the same shared volume, such as `emptyDir`. Define the volume in the application's `Pod` specification. See the following example:
 


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/openshift-docs/pull/104837

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 3.8
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-2151
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://104860--ocpdocs-pr.netlify.app/openshift-otel/latest/otel-collector/otel-collector-receivers.html#otel-receivers-filelog-receiver_otel-collector-receivers
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change (in nhttps://github.com/openshift/openshift-docs/pull/95995).
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
