### PR TITLE
OSDOCS-17902: Resolves ADV errors in MNW

### DIFF
--- a/modules/nw-multus-advanced-annotations.adoc
+++ b/modules/nw-multus-advanced-annotations.adoc
@@ -172,7 +172,6 @@ $ oc edit pod <name>
 ----
 +
 .macvlan CNI plugin JSON configuration object using static IP and MAC address
-+
 [source,yaml]
 ----
 apiVersion: v1

--- a/modules/nw-networkpolicy-allow-external-clients.adoc
+++ b/modules/nw-networkpolicy-allow-external-clients.adoc
@@ -92,7 +92,7 @@ $ oc apply -f web-allow-external.yaml
 +
 ifndef::microshift[]
 This policy allows traffic from all resources, including external traffic as illustrated in the following diagram:
-
++
 image::292_OpenShift_Configuring_multi-network_policy_1122.png[Allow traffic from external clients]
 endif::microshift[]
 

--- a/modules/nw-networkpolicy-delete-cli.adoc
+++ b/modules/nw-networkpolicy-delete-cli.adoc
@@ -19,12 +19,19 @@ endif::[]
 [role="_abstract"]
 You can delete a {name} policy in a namespace.
 
-ifndef::multi,microshift[]
+ifndef::multi[]
 [NOTE]
 ====
-If you log in with a user with the `cluster-admin` role, then you can delete any network policy in the cluster.
+If you log in with `cluster-admin` privileges, you can delete network policies in any namespace in the cluster.
 ====
-endif::multi,microshift[]
+endif::multi[]
+
+ifndef::microshift[]
+[NOTE]
+====
+If you log in with `cluster-admin` privileges, you can delete network policies in any namespace in the cluster. In the web console, you can delete policies directly in YAML or by using the *Actions* menu.
+====
+endif::microshift[]
 
 .Prerequisites
 ifndef::microshift[]
@@ -55,10 +62,3 @@ ifdef::multi[]
 endif::multi[]
 :!name:
 :!role:
-
-ifndef::microshift[]
-[NOTE]
-====
-If you log in to the web console with `cluster-admin` privileges, you have a choice of deleting a network policy in any namespace in the cluster directly in YAML or from the policy in the web console through the *Actions* menu.
-====
-endif::microshift[]

--- a/modules/nw-networkpolicy-edit.adoc
+++ b/modules/nw-networkpolicy-edit.adoc
@@ -16,14 +16,21 @@ endif::[]
 = Editing a {name} policy
 
 [role="_abstract"]
-You can edit a {name} policy in a namespace.
+To modify existing policy configurations, you can edit a {name} policy in a namespace. Edit policies by modifying the policy file and applying it with `oc apply`, or by using the `oc edit` command directly.
 
-ifndef::multi,microshift[]
+ifndef::multi[]
 [NOTE]
 ====
-If you log in with a user with the `cluster-admin` role, then you can edit a network policy in any namespace in the cluster.
+If you log in with `cluster-admin` privileges, you can edit network policies in any namespace in the cluster.
 ====
-endif::multi,microshift[]
+endif::multi[]
+
+ifndef::microshift[]
+[NOTE]
+====
+If you log in with `cluster-admin` privileges, you can edit network policies in any namespace in the cluster. In the web console, you can edit policies directly in YAML or by using the *Actions* menu.
+====
+endif::microshift[]
 
 .Prerequisites
 ifndef::microshift[]
@@ -91,10 +98,3 @@ ifdef::multi[]
 endif::multi[]
 :!name:
 :!role:
-
-ifndef::microshift[]
-[NOTE]
-====
-If you log in to the web console with `cluster-admin` privileges, you have a choice of editing a network policy in any namespace in the cluster directly in YAML or from the policy in the web console through the *Actions* menu.
-====
-endif::microshift[]

--- a/modules/nw-networkpolicy-view-cli.adoc
+++ b/modules/nw-networkpolicy-view-cli.adoc
@@ -19,12 +19,19 @@ endif::[]
 [role="_abstract"]
 You can examine the {name} policies in a namespace.
 
-ifndef::multi,microshift[]
+ifndef::multi[]
 [NOTE]
 ====
-If you log in with a user with the `cluster-admin` role, then you can view any network policy in the cluster.
+If you log in with `cluster-admin` privileges, you can edit network policies in any namespace in the cluster.
 ====
-endif::multi,microshift[]
+endif::multi[]
+
+ifndef::microshift[]
+[NOTE]
+====
+If you log in with `cluster-admin` privileges, you can edit network policies in any namespace in the cluster. In the web console, you can edit policies directly in YAML or by using the *Actions* menu.
+====
+endif::microshift[]
 
 .Prerequisites
 
@@ -87,10 +94,3 @@ ifdef::multi[]
 endif::multi[]
 :!name:
 :!role:
-
-ifndef::microshift[]
-[NOTE]
-====
-If you log in to the web console with `cluster-admin` privileges, you have a choice of viewing a network policy in any namespace in the cluster directly in YAML or from a form in the web console.
-====
-endif::microshift[]

--- a/modules/working-with-multi-network-policy.adoc
+++ b/modules/working-with-multi-network-policy.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-multi-network-policy.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="working-with-multi-network-policy_{context}"]
+= Working with multi-network policy
+
+[role="_abstract"]
+To manage network traffic isolation and security for pods on secondary networks, you can create, edit, view, and delete multi-network policies. Before you work with multi-network policies, you must enable multi-network policy support for your cluster.

--- a/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc
+++ b/networking/multiple_networks/secondary_networks/configuring-multi-network-policy.adoc
@@ -30,10 +30,7 @@ include::modules/nw-multi-network-policy-enable.adoc[leveloffset=+1]
 
 include::modules/nw-multi-network-policy-ipv6-suppport.adoc[leveloffset=+1]
 
-[id="{context}_working-with-multi-network-policy"]
-== Working with multi-network policy
-
-As a cluster administrator, you can create, edit, view, and delete multi-network policies. Before you do any of these tasks, you must have enabled multi-network policy support for your cluster.
+include::modules/working-with-multi-network-policy.adoc[leveloffset=+1]
 
 include::modules/nw-networkpolicy-create-cli.adoc[leveloffset=+2]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://104863--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/attaching-pod

https://104863--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/secondary_networks/configuring-multi-network-policy

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
