### PR TITLE
OSDOCS 17899 Document Kernel PSI Enablement in OpenShift 4.21

### DIFF
--- a/modules/nodes-nodes-psi-enable.adoc
+++ b/modules/nodes-nodes-psi-enable.adoc
@@ -1,0 +1,120 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/nodes-nodes-managing.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-nodes-psi-enable_{context}"]
+= Enabling Pressure Stall Information (PSI) monitoring
+
+[role="_abstract"]
+You can enable Linux Pressure Stall Information (PSI) monitoring by using a `MachineConfig` object. Enabling PSI monitoring makes PSI metrics for CPU, memory, and I/O available for your cluster. You can use the metrics to help identify disruptions caused by CPU, memory, and I/O resource issues for better scheduling and eviction decisions.
+
+[IMPORTANT]
+====
+The performance impact of enabling PSI is negligible. However, for latency-sensitive environments, you can enable PSI in a test environment to determine its impact before enabling it on production clusters. Or, you can enable the PSI on one worker node and monitor for the performance impact. Then, gradually enable the feature on more worker nodes. Enabling PSI introduces new container metrics that can increase the RSS memory usage of `prometheus-k8s` pods. On a cluster with a large number of containers, monitor the memory usage of the `prometheus-k8s` pods and adjust resource as needed.
+====
+
+.Prerequisites
+
+* You have obtained the label associated with the static `MachineConfigPool` CR for the type of node you want to configure.
+
+.Procedure
+
+. Create a YAML file similar to the following that contains the machine configuration:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: <label>
+  name: 99-openshift-machineconfig-<label>-kargs
+spec:
+  kernelArguments:
+    - psi=1
+----
+where:
++
+`metadata.labels.machineconfiguration.openshift.io/role:<label>`:: Specifies the role of the nodes where you want to enable PSI.
+`spec.kernelArguments.psi.1`:: Specifies that Pressure Stall Information (PSI) monitoring is to be enabled.
+
+. Create the `MachineConfig` object by running a command similar to the following:
++
+[source,terminal]
+----
+$ oc create -f <file-name>.yaml
+----
++
+The nodes with the specified role reboot while the changes are applied. 
+
+.Verification
+
+. After the nodes return to the `Ready` state, start a debug session for a node by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+. Set `/host` as the root directory within the debug shell by running the following command:
++
+[source,terminal]
+----
+sh-5.1# chroot /host
+----
+
+. Use any or all of the following methods to verify that PSI is enabled on the node:
+
+* Check that PSI is enabled by running the following command:
++
+[source,terminal]
+----
+sh-5.1# cat /proc/cmdline | grep psi=1
+----
++
+.Example output
+[source,terminal]
+----
+BOOT_IMAGE=(hd0,gpt3)/boot/ostree/rhcos-462f0c234e81f17224d7dbd4dc22d3f7046f70179e259c41a0a807e8b2f99428/vmlinuz-5.14.0-570.80.1.el9_6.x86_64 rw ostree=/ostree/boot.0/rhcos/462f0c234e81f17224d7dbd4dc22d3f7046f70179e259c41a0a807e8b2f99428/0 ignition.platform.id=gcp console=tty0 console=ttyS0,115200n8 root=UUID=d8254ef4-668e-49c5-b430-a45eefb834d7 rw rootflags=prjquota boot=UUID=22972ae8-ed08-43ff-931d-49e6d737c542 systemd.unified_cgroup_hierarchy=1 cgroup_no_v1=all psi=1
+----
+where:
+
+`psi=1`:: Specifies that PSI is enabled on the node.
+
+* Check that the PSI files are present by running the following command:
++
+[source,terminal]
+----
+sh-5.1# ls /proc/pressure/
+----
++
+[source,terminal]
+.Example output
+----
+cpu  io  irq  memory
+----
+where:
+
+ `cpu`, `io`, `irq`, and `memory`:: Specifies the pressure files, indicating the PSI is enabled.
+
+* Check the PSI metrics to show the percentage of time processes were stalled waiting for CPU resources by running the following command:
++
+[source,terminal]
+----
+# cat /proc/pressure/cpu
+----
++
+[source,terminal]
+.Example output
+----
+some avg10=0.91 avg60=1.05 avg300=1.28 total=61523749                                                                                                                                                                                                      full avg10=0.00 avg60=0.00 avg300=0.00 total=0
+----
+where:
++
+--
+`some`:: Specifies the share of time in which at least some tasks are stalled while waiting for CPU.
+`full`:: Specifies the share of time in which all non-idle tasks are stalled while waiting for CPU.
+--
++
+For more information on using PSI metrics, see "PSI - Pressure Stall Information" in the Linux Kernel documentation.

--- a/nodes/nodes/nodes-nodes-managing.adoc
+++ b/nodes/nodes/nodes-nodes-managing.adoc
@@ -34,8 +34,11 @@ include::modules/nodes-nodes-parallel-container-pulls-configure.adoc[leveloffset
 
 include::modules/nodes-control-plane-osp-migrating.adoc[leveloffset=+1]
 
+include::modules/nodes-nodes-psi-enable.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 == Additional resources
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-managing-machines[Managing control plane machines with control plane machine sets]
-
+* link:https://docs.kernel.org/accounting/psi.html[PSI - Pressure Stall Information (Linux Kernel documentation)]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17899

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
