### PR TITLE
TELCODOCS-2623 Update assembly cnf-tuning-low-latency-nodes-with-perf-profile with vale/style checks results from CQA

### DIFF
--- a/modules/cnf-about-irq-affinity-setting.adoc
+++ b/modules/cnf-about-irq-affinity-setting.adoc
@@ -7,6 +7,7 @@
 [id="about_irq_affinity_setting_{context}"]
 = Finding the effective IRQ affinity setting for a node
 
+[role="_abstract"]
 Some IRQ controllers lack support for IRQ affinity setting and will always expose all online CPUs as the IRQ mask. These IRQ controllers effectively run on CPU 0.
 
 The following are examples of drivers and hardware that Red Hat are aware lack support for IRQ affinity setting. The list is, by no means, exhaustive:

--- a/modules/cnf-about-the-profile-creator-tool.adoc
+++ b/modules/cnf-about-the-profile-creator-tool.adoc
@@ -6,17 +6,27 @@
 [id="cnf-about-the-profile-creator-tool_{context}"]
 = About the Performance Profile Creator
 
-The Performance Profile Creator (PPC) is a command-line tool, delivered with the Node Tuning Operator, that can help you to create a performance profile for your cluster.
+[role="_abstract"]
+The Performance Profile Creator (PPC) is a command-line tool delivered with the Node Tuning Operator that helps you tune nodes for low latency. By combining existing cluster data with user-supplied configurations, the PPC generates a performance profile tailored to your specific hardware, topology, and use case.
 
-Initially, you can use the PPC tool to process the `must-gather` data to display key performance configurations for your cluster, including the following information:
+The PPC processes must-gather data to identify key hardware configurations, which you can then use to define your profile. Key information includes:
 
 * NUMA cell partitioning with the allocated CPU IDs
 * Hyper-Threading node configuration
 
-You can use this information to help you configure the performance profile.
+Once generated and applied, the performance profile allows you to restrict CPUs for infrastructure and application containers, configure huge pages, and manage CPU partitions for latency-sensitive processes.
 
-.Running the PPC
-Specify performance configuration arguments to the PPC tool to generate a proposed performance profile that is appropriate for your hardware, topology, and use-case.
+[NOTE]
+====
+Performance profiles are only applicable to bare-metal environments where the cluster has direct access to hardware. They can be configured for both {sno} and multi-node clusters.
+====
+
+To create and apply a performance profile, follow these steps:
+
+1. Create a Machine Config Pool (MCP): Identify the nodes you want to target. For {sno} clusters, you must use the master MCP.
+2. Gather Cluster Data: Use the `must-gather` command to collect the necessary hardware and topology information.
+3. Run the PPC Tool: Use the gathered data and your specific configuration arguments to generate the profile
+4. Apply the Profile: Configure the resulting profile for your specific use case and apply it to the cluster.
 
 You can run the PPC by using one of the following methods:
 

--- a/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
+++ b/modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc
@@ -6,6 +6,7 @@
 [id="adjusting-nic-queues-with-the-performance-profile_{context}"]
 = Adjusting the NIC queues with the performance profile
 
+[role="_abstract"]
 The performance profile lets you adjust the queue count for each network device.
 
 Supported network devices:

--- a/modules/cnf-allocating-multiple-huge-page-sizes.adoc
+++ b/modules/cnf-allocating-multiple-huge-page-sizes.adoc
@@ -3,9 +3,12 @@
 // * scalability_and_performance/cnf-low-latency-tuning.adoc
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: CONCEPT
+
 [id="cnf-allocating-multiple-huge-page-sizes_{context}"]
 = Allocating multiple huge page sizes
 
+[role="_abstract"]
 You can request huge pages with different sizes under the same container. This allows you to define more complicated pods consisting of containers with different huge page size needs.
 
 For example, you can define sizes `1G` and `2M` and the Node Tuning Operator will configure both sizes on the node, as shown here:

--- a/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
+++ b/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
@@ -6,6 +6,7 @@
 [id="configuring_for_irq_dynamic_load_balancing_{context}"]
 = Configuring node interrupt affinity
 
+[role="_abstract"]
 Configure a cluster node for IRQ dynamic load balancing to control which cores can receive device interrupt requests (IRQ).
 
 .Prerequisites

--- a/modules/cnf-configuring-huge-pages.adoc
+++ b/modules/cnf-configuring-huge-pages.adoc
@@ -3,15 +3,19 @@
 // * scalability_and_performance/cnf-low-latency-tuning.adoc
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-configuring-huge-pages_{context}"]
 = Configuring huge pages
 
+[role="_abstract"]
 Nodes must pre-allocate huge pages used in an {product-title} cluster. Use the Node Tuning Operator to allocate huge pages on a specific node.
 
 {product-title} provides a method for creating and allocating huge pages. Node Tuning Operator provides an easier method for doing  this using the performance profile.
 
-For example, in the `hugepages` `pages` section of the performance profile, you can specify multiple blocks of `size`, `count`, and, optionally, `node`:
+.Procedure
 
+. In the `hugepages` `pages` section of the performance profile, specify blocks of `size`, `count`, and, optionally, `node`:
++
 [source,yaml]
 ----
 hugepages:
@@ -19,18 +23,18 @@ hugepages:
    pages:
    - size:  "1G"
      count:  4
-     node:  0 <1>
+     node:  0
 ----
-
-<1> `node` is the NUMA node in which the huge pages are allocated. If you omit `node`, the pages are evenly spread across all NUMA nodes.
++
+where:
++
+`node`
+: Specifies the NUMA node in which the huge pages are allocated. If you omit this field, the pages are evenly spread across all NUMA nodes.
 
 [NOTE]
 ====
 Wait for the relevant machine config pool status that indicates the update is finished.
 ====
-
-These are the only configuration steps you need to do to allocate huge pages.
-
 
 .Verification
 

--- a/modules/cnf-configuring-hyperthreading-for-a-cluster.adoc
+++ b/modules/cnf-configuring-hyperthreading-for-a-cluster.adoc
@@ -6,6 +6,7 @@
 [id="cnf-configuring-hyperthreading-for-a-cluster_{context}"]
 = Configuring Hyper-Threading for a cluster
 
+[role="_abstract"]
 To configure Hyper-Threading for an {product-title} cluster, set the CPU threads in the performance profile to the same cores that are configured for the reserved or isolated CPU pools.
 
 [NOTE]
@@ -34,8 +35,6 @@ You can view which threads are running on the host CPUs by logging in to the clu
 $ lscpu --all --extended
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE MAXMHZ    MINMHZ
@@ -58,8 +57,6 @@ Alternatively, to view the threads that are set for a particular physical CPU co
 $ cat /sys/devices/system/cpu/cpu0/topology/thread_siblings_list
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 0-4
@@ -80,7 +77,7 @@ $ cat /sys/devices/system/cpu/cpu0/topology/thread_siblings_list
 ====
 The reserved and isolated CPU pools must not overlap and together must span all available cores in the worker node.
 ====
-
++
 [IMPORTANT]
 ====
 Hyper-Threading is enabled by default on most Intel processors. If you enable Hyper-Threading, all threads processed by a particular core must be isolated or processed on the same core.
@@ -89,13 +86,7 @@ When Hyper-Threading is enabled, all guaranteed pods must use multiples of the s
 See link:https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-options[Static policy options] for more information.
 ====
 
-[id="disabling_hyperthreading_for_low_latency_applications_{context}"]
-== Disabling Hyper-Threading for low latency applications
-
-When configuring clusters for low latency processing, consider whether you want to disable Hyper-Threading before you deploy the cluster. To disable Hyper-Threading, perform the following steps:
-
-. Create a performance profile that is appropriate for your hardware and topology.
-. Set `nosmt` as an additional kernel argument. The following example performance profile illustrates this setting:
+. Optional: To disable Hyper-Threading for low latency applications, set `nosmt` as an additional kernel argument in the performance profile. The following example performance profile illustrates this setting:
 +
 [source,yaml]
 ----

--- a/modules/cnf-configuring-power-saving-for-nodes.adoc
+++ b/modules/cnf-configuring-power-saving-for-nodes.adoc
@@ -6,6 +6,7 @@
 [id="cnf-configuring-power-saving-for-nodes_{context}"]
 = Configuring power saving for nodes that run colocated high and low priority workloads
 
+[role="_abstract"]
 You can enable power savings for a node that has low priority workloads that are colocated with high priority workloads without impacting the latency or throughput of the high priority workloads. Power saving is possible without modifications to the workloads themselves.
 
 [IMPORTANT]
@@ -27,10 +28,11 @@ $ podman run --entrypoint performance-profile-creator -v \
 /must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} \
 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true \
 --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node \
---must-gather-dir-path /must-gather --power-consumption-mode=low-latency \ <1>
+--must-gather-dir-path /must-gather --power-consumption-mode=low-latency \
 --per-pod-power-management=true > my-performance-profile.yaml
 ----
-<1> The `power-consumption-mode` argument must be `default` or `low-latency` when the `per-pod-power-management` argument is set to `true`.
++
+The `power-consumption-mode` argument must be `default` or `low-latency` when the `per-pod-power-management` argument is set to `true`.
 
 +
 .Example `PerformanceProfile` with `perPodPowerManagement`
@@ -60,9 +62,10 @@ metadata:
 spec:
     ...
     additionalKernelArgs:
-    - cpufreq.default_governor=schedutil <1>
+    - cpufreq.default_governor=schedutil
 ----
-<1> Using the `schedutil` governor is recommended, however, you can use other governors such as the `ondemand` or `powersave` governors.
++
+Using the `schedutil` governor is recommended, but you can use other governors such as the `ondemand` or `powersave` governors.
 
 . Set the maximum CPU frequency in the `TunedPerformancePatch` CR:
 +
@@ -72,6 +75,7 @@ spec:
   profile:
   - data: |
       [sysfs]
-      /sys/devices/system/cpu/intel_pstate/max_perf_pct = <x> <1>
+      /sys/devices/system/cpu/intel_pstate/max_perf_pct = <x>
 ----
-<1> The `max_perf_pct` controls the maximum frequency that the `cpufreq` driver is allowed to set as a percentage of the maximum supported cpu frequency. This value applies to all CPUs. You can check the maximum supported frequency in `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq`. As a starting point, you can use a percentage that caps all CPUs at the `All Cores Turbo` frequency. The `All Cores Turbo` frequency is the frequency that all cores will run at when the cores are all fully occupied.
++
+The `max_perf_pct` controls the maximum frequency that the `cpufreq` driver is allowed to set as a percentage of the maximum supported cpu frequency. This value applies to all CPUs. You can check the maximum supported frequency in `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq`. As a starting point, you can use a percentage that caps all CPUs at the `All Cores Turbo` frequency. The `All Cores Turbo` frequency is the frequency that all cores will run at when the cores are all fully occupied.

--- a/modules/cnf-configuring-workload-hints.adoc
+++ b/modules/cnf-configuring-workload-hints.adoc
@@ -7,9 +7,8 @@
 [id="configuring-workload-hints_{context}"]
 = Configuring node power consumption and realtime processing with workload hints
 
-.Procedure
-
-* Create a `PerformanceProfile` appropriate for the environment's hardware and topology by using the Performance Profile Creator (PPC) tool. The following table describes the possible values set for the `power-consumption-mode` flag associated with the PPC tool and the workload hint that is applied. 
+[role="_abstract"]
+Create a `PerformanceProfile` appropriate for the environment's hardware and topology by using the Performance Profile Creator (PPC) tool. The following table describes the possible values set for the `power-consumption-mode` flag associated with the PPC tool and the workload hint that is applied.
 
 .Impact of combinations of power consumption and real-time settings on latency
 [cols="1,1,1,1",options="header"]
@@ -17,6 +16,7 @@
 |Performance Profile creator setting |Hint |Environment |Description
 
 |Default
+[role="_abstract"]
 a|[source,terminal]
 ----
 workloadHints:
@@ -58,9 +58,9 @@ perPodPowerManagement: true
 |Allows for power management per pod.
 |===
 
-.Example
+== Example
 
-The following configuration is commonly used in a telco RAN DU deployment. 
+The following configuration is commonly used in a telco RAN DU deployment.
 
 [source,yaml]
 ----
@@ -73,9 +73,10 @@ The following configuration is commonly used in a telco RAN DU deployment.
       workloadHints:
         realTime: true
         highPowerConsumption: false
-        perPodPowerManagement: false <1>
+        perPodPowerManagement: false
 ----
-<1> Disables some debugging and monitoring features that can affect system latency.
+
+Disables some debugging and monitoring features that can affect system latency.
 
 [NOTE]
 ====

--- a/modules/cnf-cpu-infra-container.adoc
+++ b/modules/cnf-cpu-infra-container.adoc
@@ -7,6 +7,7 @@
 [id="cnf-cpu-infra-container_{context}"]
 = Restricting CPUs for infra and application containers
 
+[role="_abstract"]
 Generic housekeeping and workload tasks use CPUs in a way that may impact latency-sensitive processes. By default, the container runtime uses all online CPUs to run all containers together, which can result in context switches and spikes in latency. Partitioning the CPUs prevents noisy processes from interfering with latency-sensitive processes by separating them from each other. The following table describes how processes run on a CPU after you have tuned the node using the Node Tuning Operator:
 
 .Process' CPU assignments
@@ -36,11 +37,9 @@ Generic housekeeping and workload tasks use CPUs in a way that may impact latenc
 
 The allocatable capacity of cores on a node for pods of all QoS process types, `Burstable`,  `BestEffort`, or `Guaranteed`, is equal to the capacity of the isolated pool. The capacity of the reserved pool is removed from the node's total core capacity for use by the cluster and operating system housekeeping duties.
 
-.Example 1
-A node features a capacity of 100 cores. Using a performance profile, the cluster administrator allocates 50 cores to the isolated pool and 50 cores to the reserved pool. The cluster administrator assigns 25 cores to QoS `Guaranteed` pods and 25 cores for `BestEffort` or `Burstable` pods. This matches the capacity of the isolated pool.
+For example, a node features a capacity of 100 cores. Using a performance profile, the cluster administrator allocates 50 cores to the isolated pool and 50 cores to the reserved pool. The cluster administrator assigns 25 cores to QoS `Guaranteed` pods and 25 cores for `BestEffort` or `Burstable` pods. This matches the capacity of the isolated pool.
 
-.Example 2
-A node features a capacity of 100 cores. Using a performance profile, the cluster administrator allocates 50 cores to the isolated pool and 50 cores to the reserved pool. The cluster administrator assigns 50 cores to QoS `Guaranteed` pods and one core for `BestEffort` or `Burstable` pods. This exceeds the capacity of the isolated pool by one core. Pod scheduling fails because of insufficient CPU capacity.
+However, if the cluster administrator assigns 50 cores to QoS `Guaranteed` pods and one core for `BestEffort` or `Burstable` pods, this exceeds the capacity of the isolated pool by one core. Pod scheduling fails because of insufficient CPU capacity.
 
 
 The exact partitioning pattern to use depends on many factors like hardware, workload characteristics and the expected system load. Some sample use cases are as follows:
@@ -76,11 +75,12 @@ metadata:
   name: infra-cpus
 spec:
   cpu:
-    reserved: "0-4,9" <1>
-    isolated: "5-8" <2>
-  nodeSelector: <3>
+    reserved: "0-4,9"
+    isolated: "5-8"
+  nodeSelector:
     node-role.kubernetes.io/worker: ""
 ----
-<1> Specify which CPUs are for infra containers to perform cluster and operating system housekeeping duties.
-<2> Specify which CPUs are for application containers to run workloads.
-<3> Optional: Specify a node selector to apply the performance profile to specific nodes.
+
+* `spec.cpu.reserved` - Specifies which CPUs are for infra containers to perform cluster and operating system housekeeping duties.
+* `spec.cpu.isolated` - Specifies which CPUs are for application containers to run workloads.
+* `spec.nodeSelector` - Optional. Specifies a node selector to apply the performance profile to specific nodes.

--- a/modules/cnf-creating-mcp-for-ppc.adoc
+++ b/modules/cnf-creating-mcp-for-ppc.adoc
@@ -6,6 +6,7 @@
 [id="creating-mcp-for-ppc_{context}"]
 = Creating a machine config pool to target nodes for performance tuning
 
+[role="_abstract"]
 For multi-node clusters, you can define a machine config pool (MCP) to identify the target nodes that you want to configure with a performance profile. 
 
 In {sno} clusters, you must use the `master` MCP because there is only one node in the cluster. You do not need to create a separate MCP for {sno} clusters.
@@ -21,9 +22,10 @@ In {sno} clusters, you must use the `master` MCP because there is only one node 
 +
 [source,terminal]
 ----
-$ oc label node <node_name> node-role.kubernetes.io/worker-cnf="" <1>
+$ oc label node <node_name> node-role.kubernetes.io/worker-cnf=""
 ----
-<1> Replace `<node_name>` with the name of your node. This example applies the `worker-cnf` label.
++
+Replace `<node_name>` with the name of your node. This example applies the `worker-cnf` label.
 
 . Create a `MachineConfigPool` resource containing the target nodes:
 
@@ -35,9 +37,9 @@ $ oc label node <node_name> node-role.kubernetes.io/worker-cnf="" <1>
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfigPool
 metadata:
-  name: worker-cnf <1>
+  name: worker-cnf
   labels:
-    machineconfiguration.openshift.io/role: worker-cnf <2>
+    machineconfiguration.openshift.io/role: worker-cnf
 spec:
   machineConfigSelector:
     matchExpressions:
@@ -49,11 +51,12 @@ spec:
   paused: false
   nodeSelector:
     matchLabels:
-      node-role.kubernetes.io/worker-cnf: "" <3>
+      node-role.kubernetes.io/worker-cnf: ""
 ----
-<1> Specify a name for the `MachineConfigPool` resource.
-<2> Specify a unique label for the machine config pool.
-<3> Specify the nodes with the target label that you defined.
+
+* `metadata.name` - Specifies a name for the `MachineConfigPool` resource.
+* `metadata.labels.machineconfiguration.openshift.io/role` - Specifies a unique label for the machine config pool.
+* `spec.nodeSelector.matchLabels` - Specifies the nodes with the target label that you defined.
 
 .. Apply the `MachineConfigPool` resource by running the following command:
 +

--- a/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
@@ -6,6 +6,7 @@
 [id="gathering-data-about-your-cluster-using-must-gather_{context}"]
 = Gathering data about your cluster for the PPC
 
+[role="_abstract"]
 The Performance Profile Creator (PPC) tool requires `must-gather` data. As a cluster administrator, run the `must-gather` command to capture information about your cluster.
 
 .Prerequisites
@@ -31,9 +32,10 @@ The command creates a folder with the `must-gather` data in your local directory
 +
 [source,terminal]
 ----
-$ tar cvaf must-gather.tar.gz <must_gather_folder> <1>
+$ tar cvaf must-gather.tar.gz <must_gather_folder>
 ----
-<1> Replace with the name of the `must-gather` data folder.
++
+Replace `<must_gather_folder>` with the name of the `must-gather` data folder.
 +
 [NOTE]
 ====

--- a/modules/cnf-logging-associated-with-adjusting-nic-queues.adoc
+++ b/modules/cnf-logging-associated-with-adjusting-nic-queues.adoc
@@ -2,9 +2,12 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: REFERENCE
+
 [id="logging-associated-with-adjusting-nic-queues_{context}"]
 = Logging associated with adjusting NIC queues
 
+[role="_abstract"]
 Log messages detailing the assigned devices are recorded in the respective Tuned daemon logs. The following messages might be recorded to the `/var/log/tuned/tuned.log` file:
 
 * An `INFO` message is recorded detailing the successfully assigned devices:

--- a/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
+++ b/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
@@ -2,9 +2,12 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: CONCEPT
+
 [id="managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus_{context}"]
 = Managing device interrupt processing for guaranteed pod isolated CPUs
 
+[role="_abstract"]
 The Node Tuning Operator can manage host CPUs by dividing them into reserved CPUs for cluster and operating system housekeeping duties, including pod infra containers, and isolated CPUs for application containers to run the workloads. This allows you to set CPUs for low latency workloads as isolated.
 
 Device interrupts are load balanced between all isolated and reserved CPUs to avoid CPUs being overloaded, with the exception of CPUs where there is a guaranteed pod running. Guaranteed pod CPUs are prevented from processing device interrupts when the relevant annotations are set for the pod.

--- a/modules/cnf-managing-ha-nrop-scheduler.adoc
+++ b/modules/cnf-managing-ha-nrop-scheduler.adoc
@@ -22,8 +22,9 @@ metadata:
   name: example-auto-ha
 spec:
   imageSpec: 'registry.redhat.io/openshift4/noderesourcetopology-scheduler-rhel9:v{product-version}'
-  # The 'replicas' field is not included, enabling auto-detection.
 ----
+
+The `replicas` field is not included, enabling auto-detection.
 
 You can control scheduler behavior by using one of the following options:
 

--- a/modules/cnf-memory-optimization.adoc
+++ b/modules/cnf-memory-optimization.adoc
@@ -6,4 +6,5 @@
 [id="cnf-configuring-kernal-page-size_{context}"]
 = Configuring memory page sizes
 
+[role="_abstract"]
 By configuring memory page sizes, system administrators can implement more efficient memory management on a specific node to suit workload requirements. The Node Tuning Operator provides a method for configuring huge pages and kernel page sizes by using a performance profile.

--- a/modules/cnf-performance-profile-creator-arguments.adoc
+++ b/modules/cnf-performance-profile-creator-arguments.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
-
+:_mod-docs-content-type: REFERENCE
 [id="performance-profile-creator-arguments_{context}"]
 = Performance Profile Creator arguments
 
@@ -17,6 +17,7 @@
 | `must-gather-dir-path`
 | The path of the must gather directory.
 
+[role="_abstract"]
 This argument is only required if you run the PPC tool by using Podman. If you use the PPC with the wrapper script, do not use this argument. Instead, specify the directory path to the `must-gather` tarball by using the `-t` option for the wrapper script.
 
 | `reserved-cpu-count`

--- a/modules/cnf-running-the-performance-creator-profile-offline.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-offline.adoc
@@ -6,6 +6,7 @@
 [id="running-the-performance-profile-creator-wrapper-script_{context}"]
 = Running the Performance Profile Creator wrapper script
 
+[role="_abstract"]
 The wrapper script simplifies the process of creating a performance profile with the Performance Profile Creator (PPC) tool. The script handles tasks such as pulling and running the required container image, mounting directories into the container, and providing parameters directly to the container through Podman.
 
 For more information about the Performance Profile Creator arguments, see the section _"Performance Profile Creator arguments"_.
@@ -147,8 +148,6 @@ Password: <password>
 $ ./run-perf-profile-creator.sh -h
 ----
 +
-.Example output
-+
 [source,terminal]
 ----
 Wrapper usage:
@@ -195,7 +194,6 @@ $ ./run-perf-profile-creator.sh -t /<path_to_must_gather_dir>/must-gather.tar.gz
 +
 * `-t /<path_to_must_gather_dir>/must-gather.tar.gz` specifies the path to directory containing the must-gather tarball. This is a required argument for the wrapper script.
 +
-.Example output
 [source,terminal]
 ----
 level=info msg="Cluster info:"
@@ -244,7 +242,6 @@ The `mcp-name` argument in this example is set to `worker-cnf` based on the outp
 ----
 $ cat my-performance-profile.yaml
 ----
-.Example output
 +
 [source,yaml]
 ----

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -6,6 +6,7 @@
 [id="running-the-performance-profile-profile-cluster-using-podman_{context}"]
 = Running the Performance Profile Creator using Podman
 
+[role="_abstract"]
 As a cluster administrator, you can use Podman with the Performance Profile Creator (PPC) to create a performance profile.
 
 For more information about the PPC arguments, see the section _"Performance Profile Creator arguments"_.
@@ -33,7 +34,6 @@ The PPC uses the `must-gather` data from your cluster to create the performance 
 $ oc get mcp
 ----
 +
-.Example output
 [source,terminal]
 ----
 NAME         CONFIG                                                 UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE
@@ -61,8 +61,6 @@ Password: <password>
 ----
 $ podman run --rm --entrypoint performance-profile-creator registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} -h
 ----
-+
-.Example output
 +
 [source,terminal]
 ----
@@ -108,7 +106,6 @@ $ podman run --entrypoint performance-profile-creator -v <path_to_must_gather>:/
 ** The directory containing the `must-gather` data.
 ** An existing directory containing the `must-gather` decompressed .tar file.
 +
-.Example output
 [source,terminal]
 ----
 level=info msg="Nodes names targeted by master pool are: "
@@ -154,7 +151,6 @@ $ podman run --entrypoint performance-profile-creator -v <path_to_must_gather>:/
 The `mcp-name` argument in this example is set to `worker-cnf` based on the output of the command `oc get mcp`. For {sno} use `--mcp-name=master`.
 ====
 +
-.Example output
 [source,terminal]
 ----
 level=info msg="Nodes targeted by worker-cnf MCP are: [worker-2]"
@@ -173,7 +169,6 @@ level=info msg="Additional Kernel Args based on configuration: []"
 ----
 $ cat my-performance-profile.yaml
 ----
-.Example output
 +
 [source,yaml]
 ----

--- a/modules/cnf-telco-core-reference-design-performance-profile-template.adoc
+++ b/modules/cnf-telco-core-reference-design-performance-profile-template.adoc
@@ -6,6 +6,7 @@
 [id="cnf-telco-core-reference-design-performance-profile-template_{context}"]
 = Telco core reference design performance profile
 
+[role="_abstract"]
 The following performance profile configures node-level performance settings for {product-title} clusters on commodity hardware to host telco core workloads.
 
 .Telco core reference design performance profile

--- a/modules/cnf-telco-ran-reference-design-performance-profile-template.adoc
+++ b/modules/cnf-telco-ran-reference-design-performance-profile-template.adoc
@@ -6,6 +6,7 @@
 [id="cnf-telco-ran-reference-design-performance-profile-template_{context}"]
 = Telco RAN DU reference design performance profile
 
+[role="_abstract"]
 The following performance profile configures node-level performance settings for {product-title} clusters on commodity hardware to host telco RAN DU workloads.
 
 .Telco RAN DU reference design performance profile

--- a/modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc
+++ b/modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc
@@ -3,12 +3,14 @@
 // * scalability_and_performance/low_latency_tuning/cnf-provisioning-low-latency-workloads.adoc
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: CONCEPT
+
 [id="nto_supported_api_versions_{context}"]
 = Supported performance profile API versions
 
+[role="_abstract"]
 The Node Tuning Operator supports `v2`, `v1`, and `v1alpha1` for the performance profile `apiVersion` field. The v1 and v1alpha1 APIs are identical. The v2 API includes an optional boolean field `globallyDisableIrqLoadBalancing` with a default value of `false`.
 
-[discrete]
 [id="use-device-interrupt-processing-for-isolated-cpus_{context}"]
 == Upgrading the performance profile to use device interrupt processing
 
@@ -19,14 +21,12 @@ When you upgrade the Node Tuning Operator performance profile custom resource de
 `globallyDisableIrqLoadBalancing` toggles whether IRQ load balancing will be disabled for the Isolated CPU set. When the option is set to `true` it disables IRQ load balancing for the Isolated CPU set. Setting the option to `false` allows the IRQs to be balanced across all CPUs.
 ====
 
-[discrete]
 [id="upgrading_nto_api_from_v1alpha1_to_v1_{context}"]
-=== Upgrading Node Tuning Operator API from v1alpha1 to v1
+== Upgrading Node Tuning Operator API from v1alpha1 to v1
 
 When upgrading Node Tuning Operator API version from v1alpha1 to v1, the v1alpha1 performance profiles are converted on-the-fly using a "None" Conversion strategy and served to the Node Tuning Operator with API version v1.
 
-[discrete]
 [id="upgrading_nto_api_from_v1alpha1_to_v1_or_v2_{context}"]
-=== Upgrading Node Tuning Operator API from v1alpha1 or v1 to v2
+== Upgrading Node Tuning Operator API from v1alpha1 or v1 to v2
 
 When upgrading from an older Node Tuning Operator API version, the existing v1 and v1alpha1 performance profiles are converted using a conversion webhook that injects the `globallyDisableIrqLoadBalancing` field with a value of `true`.

--- a/modules/cnf-verifying-queue-status.adoc
+++ b/modules/cnf-verifying-queue-status.adoc
@@ -2,12 +2,15 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
 
+:_mod-docs-content-type: CONCEPT
+
 [id="verifying-queue-status_{context}"]
 = Verifying the queue status
 
-In this section, a number of examples illustrate different performance profiles and how to verify the changes are applied.
+[role="_abstract"]
+Verify that NIC queue configurations are correctly applied by checking queue status with `ethtool` after deploying performance profiles with different device targeting strategies.
 
-.Example 1
+== Example 1
 
 In this example, the net queue count is set to the reserved CPU count (2) for _all_ supported devices.
 
@@ -84,12 +87,12 @@ Current hardware settings:
 RX:         0
 TX:         0
 Other:      0
-Combined:   2 <1>
+Combined:   2
 ----
++
+The combined channel shows that the total count of reserved CPUs for _all_ supported devices is 2. This matches what is configured in the performance profile.
 
-<1> The combined channel shows that the total count of reserved CPUs for _all_ supported devices is 2. This matches what is configured in the performance profile.
-
-.Example 2
+== Example 2
 
 In this example, the net queue count is set to the reserved CPU count (2) for _all_ supported network devices with a specific `vendorID`.
 
@@ -145,13 +148,13 @@ Current hardware settings:
 RX:         0
 TX:         0
 Other:      0
-Combined:   2 <1>
+Combined:   2
 ----
-
-<1> The total count of reserved CPUs for all supported devices with `vendorID=0x1af4` is 2.
++
+The total count of reserved CPUs for all supported devices with `vendorID=0x1af4` is 2.
 For example, if there is another network device `ens2` with `vendorID=0x1af4` it will also have total net queues of 2. This matches what is configured in the performance profile.
 
-.Example 3
+== Example 3
 
 In this example, the net queue count is set to the reserved CPU count (2) for _all_ supported network devices that match any of the defined device identifiers.
 
@@ -177,7 +180,7 @@ E: INTERFACE=eth0
 ...
 ----
 
-* Set the net queues to 2 for a device with `interfaceName` equal to `eth0` and any devices that have a `vendorID=0x1af4` with the following performance profile:
+* Set the net queues to 2 for a device with `interfaceName` equal to `eth0` and for any devices that have a `vendorID=0x1af4` with the following performance profile:
 +
 [source,yaml]
 ----
@@ -218,8 +221,8 @@ Current hardware settings:
 RX:         0
 TX:         0
 Other:      0
-Combined:   2 <1>
+Combined:   2
 ----
 +
-<1> The total count of reserved CPUs for all supported devices with `vendorID=0x1af4` is set to 2.
+The total count of reserved CPUs for all supported devices with `vendorID=0x1af4` is set to 2.
 For example, if there is another network device `ens2` with `vendorID=0x1af4`, it will also have the total net queues set to 2. Similarly, a device with `interfaceName` equal to `eth0` will have total net queues set to 2.

--- a/modules/configuring-kernal-page-size.adoc
+++ b/modules/configuring-kernal-page-size.adoc
@@ -6,12 +6,13 @@
 [id="cnf-page-size-optimization_{context}"]
 = Configuring kernel page sizes
 
-Use the `kernelPageSize` specification in a performance profile to configure the kernel page size on a specific node. Specify larger kernel page sizes for memory-intensive, high-performance workloads. 
+[role="_abstract"]
+Use the `kernelPageSize` specification in a performance profile to configure the kernel page size on a specific node. Specify larger kernel page sizes for memory-intensive, high-performance workloads.
 
 [NOTE]
 ====
-For nodes with an x86_64 or AMD64 architecture, you can only specify `4k` for the `kernelPageSize` specification. 
-For nodes with an AArch64 architecture, you can specify `4k` or `64k` for the `kernelPageSize` specification. You must disable the realtime kernel before you can use the `64k` option. 
+For nodes with an x86_64 or AMD64 architecture, you can only specify `4k` for the `kernelPageSize` specification.
+For nodes with an AArch64 architecture, you can specify `4k` or `64k` for the `kernelPageSize` specification. You must disable the realtime kernel before you can use the `64k` option.
 The default value is `4k`.
 ====
 
@@ -32,17 +33,17 @@ apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile
 metadata:
     name: example-performance-profile
-#...
 spec:
-    kernelPageSize: "64k" <1>
+    kernelPageSize: "64k"
     realTimeKernel:
-        enabled: false <2>
+        enabled: false
     nodeSelector:
-        node-role.kubernetes.io/worker: "" <3>
+        node-role.kubernetes.io/worker: ""
 ----
-<1> This example specifies a kernel page size of `64k`. You can only specify `64k` for nodes with an AArch64 architecture. The default value is `4k`.
-<2> You must disable the realtime kernel to use the `64k` kernel page size option.
-<3> This example targets nodes with the `worker` role.
+
+* `spec.kernelPageSize` - Specifies a kernel page size of `64k`. You can only specify `64k` for nodes with an AArch64 architecture. The default value is `4k`.
+* `spec.realTimeKernel.enabled` - Must be set to `false` to use the `64k` kernel page size option.
+* `spec.nodeSelector` - Targets nodes with the `worker` role.
 
 . Apply the performance profile to the cluster:
 +
@@ -52,6 +53,7 @@ $ oc create -f pp-kernel-pages.yaml
 ----
 +
 .Example output
+[source,terminal]
 ----
 performanceprofile.performance.openshift.io/example-performance-profile created
 ----
@@ -62,9 +64,9 @@ performanceprofile.performance.openshift.io/example-performance-profile created
 +
 [source,bash]
 ----
-$ oc debug node/<node_name> <1>
+$ oc debug node/<node_name>
 ----
-<1> Replace `<node_name>` with the name of the node with the performance profile applied.
+Replace `<node_name>` with the name of the node with the performance profile applied
 
 . Verify that the kernel page size is set to the value you specified in the performance profile by running the following command:
 +
@@ -74,6 +76,7 @@ $ getconf PAGESIZE
 ----
 +
 .Example output
+[source,terminal]
 ----
 65536
 ----

--- a/modules/installation-openstack-ovs-dpdk-performance-profile.adoc
+++ b/modules/installation-openstack-ovs-dpdk-performance-profile.adoc
@@ -6,6 +6,7 @@
 [id="installation-openstack-ovs-dpdk-performance-profile_{context}"]
 = Performance profile template for clusters that use OVS-DPDK on OpenStack
 
+[role="_abstract"]
 To maximize machine performance in a cluster that uses Open vSwitch with the Data Plane Development Kit (OVS-DPDK) on {rh-openstack-first}, you can use a performance profile.
 
 You can use the following performance profile template to create a profile for your deployment.

--- a/scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc
+++ b/scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc
@@ -20,7 +20,7 @@ When writing your applications, follow the general recommendations described in 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles[Creating a performance profile]
+* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-about-the-profile-creator-tool_cnf-low-latency-perf-profile[About the Performance Profile Creator]
 
 include::modules/cnf-scheduling-workload-onto-worker-with-real-time-capabilities.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
+++ b/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc
@@ -6,36 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Tune nodes for low latency by using the cluster performance profile.
-You can restrict CPUs for infra and application containers, configure huge pages, Hyper-Threading, and configure CPU partitions for latency-sensitive processes.
+Tune nodes for low latency by using the cluster performance profile. You can restrict CPUs for infra and application containers, and configure huge pages, Hyper-Threading, and CPU partitions for latency-sensitive processes.
 
-[id="cnf-create-performance-profiles"]
-== Creating a performance profile
-
-You can create a cluster performance profile by using the Performance Profile Creator (PPC) tool. The PPC is a function of the Node Tuning Operator. 
-
-The PPC combines information about your cluster with user-supplied configurations to generate a performance profile that is appropriate to your hardware, topology and use-case.
-
-[NOTE]
-====
-Performance profiles are applicable only to bare-metal environments where the cluster has direct access to the underlying hardware resources. You can configure performances profiles for both {sno} and multi-node clusters.
-====
-
-The following is a high-level workflow for creating and applying a performance profile in your cluster:
-
-* Create a machine config pool (MCP) for nodes that you want to target with performance configurations. In {sno} clusters, you must use the `master` MCP because there is only one node in the cluster.
-
-* Gather information about your cluster using the `must-gather` command.
-
-* Use the PPC tool to create a performance profile by using either of the following methods:
-
-** Run the PPC tool by using Podman. 
-
-** Run the PPC tool by using a wrapper script.
-
-* Configure the performance profile for your use case and apply the performance profile to your cluster.
-
-include::modules/cnf-about-the-profile-creator-tool.adoc[leveloffset=+2]
+include::modules/cnf-about-the-profile-creator-tool.adoc[leveloffset=+1]
 
 include::modules/cnf-creating-mcp-for-ppc.adoc[leveloffset=+2]
 
@@ -54,16 +27,11 @@ include::modules/cnf-running-the-performance-creator-profile-offline.adoc[levelo
 
 include::modules/cnf-performance-profile-creator-arguments.adoc[leveloffset=+2]
 
-[id="cnf-create-performance-profiles-reference"]
-=== Reference performance profiles
+include::modules/installation-openstack-ovs-dpdk-performance-profile.adoc[leveloffset=+2]
 
-Use the following reference performance profiles as the basis to develop your own custom profiles.
+include::modules/cnf-telco-ran-reference-design-performance-profile-template.adoc[leveloffset=+2]
 
-include::modules/installation-openstack-ovs-dpdk-performance-profile.adoc[leveloffset=+3]
-
-include::modules/cnf-telco-ran-reference-design-performance-profile-template.adoc[leveloffset=+3]
-
-include::modules/cnf-telco-core-reference-design-performance-profile-template.adoc[leveloffset=+3]
+include::modules/cnf-telco-core-reference-design-performance-profile-template.adoc[leveloffset=+2]
 
 include::modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc[leveloffset=+1]
 
@@ -98,18 +66,12 @@ include::modules/cnf-configuring-huge-pages.adoc[leveloffset=+2]
 
 include::modules/cnf-allocating-multiple-huge-page-sizes.adoc[leveloffset=+2]
 
-[id="cnf-reducing-nic-queues-with-nto"]
-== Reducing NIC queues using the Node Tuning Operator
-
-The Node Tuning Operator facilitates reducing NIC queues for enhanced performance.
-Adjustments are made using the performance profile, allowing customization of queues for different network devices.
-
 include::modules/cnf-adjusting-nic-queues-with-the-performance-profile.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles[Creating a performance profile].
+* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-about-the-profile-creator-tool_cnf-low-latency-perf-profile[About the Performance Profile Creator]
 
 include::modules/cnf-verifying-queue-status.adoc[leveloffset=+2]
 

--- a/scalability_and_performance/telco-core-rds.adoc
+++ b/scalability_and_performance/telco-core-rds.adoc
@@ -52,7 +52,7 @@ include::modules/telco-core-workloads-on-schedulable-control-planes.adoc[levelof
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-create-performance-profiles[Creating a performance profile]
+* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-about-the-profile-creator-tool_cnf-low-latency-perf-profile[About the Performance Profile Creator]
 
 * xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-du-configuring-host-firmware-requirements_sno-configure-for-vdu[Configuring host firmware for low latency and high performance]
 


### PR DESCRIPTION
[TELCODOCS-2623]: Updating cnf-tuning-low-latency-nodes-with-perf-profile with vale/style corrections

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 > 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2563
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://104892--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.html


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
