### PR TITLE
OSDOCS-17929 Adding release note for architecture aware autoscaling

### DIFF
--- a/modules/rn-ocp-release-notes-notable-changes.adoc
+++ b/modules/rn-ocp-release-notes-notable-changes.adoc
@@ -19,3 +19,7 @@ Broadcom has ended general support for {vmw-full} 7 and VMware Cloud Foundation 
 Bare Metal Operator has read-only root filesystem by default::
 +
 As of this update, the Bare Metal Operator has the `readOnlyRootFilesystem` security context setting enabled to meet common hardening recommendations.
+
+MachineSets advertise node architecture for autoscaling::
++
+With this update, MachineSets advertise the architecture of their nodes, which allows the autoscaler to intelligently scale MachineSets in multi-architecture environments.


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-17929

Link to docs preview:
https://104898--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-notes-notable-changes_release-notes

QE review:
Approved in main PR

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
