### PR TITLE
OCPBUGS-66049: [OCP 4.20.10] stale conntrack UDP entry when deleting openshift-dns pod

### DIFF
--- a/modules/zstream-4-20-10-fixed-issues.adoc
+++ b/modules/zstream-4-20-10-fixed-issues.adoc
@@ -26,5 +26,4 @@ The following issues are fixed for this release:
 
 * Before this update, the Baremetal Operator defaulted to x86_64 architecture when no architecture information was available from hardware inspection or the `BareMetalHost` spec. This caused provisioning to fail on ARM-based bare-metal clusters. With this release, the Baremetal Operator now automatically detects and uses the architecture of the running controller, enabling successful bare-metal provisioning on both x86_64 and ARM64 architectures. (link:https://issues.redhat.com/browse/OCPBUGS-69667[OCPBUGS-69667])
 
-
-
+* With this release, when service endpoints are deleted or updated, the cleanup process correctly uses the service port to match and remove stale `conntrack` entries. This change ensures that network connectivity continues to work reliably across endpoint lifecycle events. (link:https://issues.redhat.com/browse/OCPBUGS-66049[OCPBUGS-66049])


### PR DESCRIPTION
**Fixes:** [OCPBUGS-66049](https://issues.redhat.com/browse/OCPBUGS-66049)

**For:** OCP [4.20.10](https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/releasestream/4-stable/release/4.20.10)

[**Preview**](https://--ocpdocs-pr.netlify.app)

**Approvals -** `/lgtm`:
- [x] SME
- [x] QE
- [x] Peer Review