### PR TITLE
OSDOCS-17447: Typo in "Prepare your Environment" for ROSA HCP and Classic

### DIFF
--- a/modules/rosa-planning-environment-application-reqs.adoc
+++ b/modules/rosa-planning-environment-application-reqs.adoc
@@ -64,7 +64,7 @@ Instance size for nodes can be modulated up or down, depending on your preferenc
 |64
 |===
 
-Some applications lend themselves well to overcommitted environments, and some do not. Most Java applications and applications that use huge pages are examples of applications that would not allow for overcommitment. That memory can not be used for other applications. In the example above, the environment would be roughly 30 percent overcommitted, a common ratio.
+Some applications lend themselves well to overcommitted environments, and some do not. Most Java applications and applications that use huge pages are examples of applications that would not allow for overcommitment. That memory cannot be used for other applications. In the example above, the environment would be roughly 30 percent overcommitted, a common ratio.
 
 The application pods can access a service either by using environment variables or DNS. If using environment variables, for each active service the variables are injected by the kubelet when a pod is run on a node. A cluster-aware DNS server watches the Kubernetes API for new services and creates a set of DNS records for each one. If DNS is enabled throughout your cluster, then all pods should automatically be able to resolve services by their DNS name. Service discovery using DNS can be used in case you must go beyond 5000 services. When using environment variables for service discovery, if the argument list exceeds the allowed length after 5000 services in a namespace, then the pods and deployments will start failing.
 


### PR DESCRIPTION
[OSDOCS-17447](https://issues.redhat.com//browse/OSDOCS-17447): Typo in "Prepare your Environment" for ROSA HCP and Classic

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17447

Link to docs preview:
HCP: https://104905--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-planning-environment.html
Classic: https://104905--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-planning-environment.html

QE review:
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
