### PR TITLE
OSDOCS 17998 CMA 2.18.1 release notes

### DIFF
--- a/modules/nodes-pods-autoscaling-custom-rn-2181.adoc
+++ b/modules/nodes-pods-autoscaling-custom-rn-2181.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-user-namespaces.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nodes-pods-autoscaling-custom-rn-2181_{context}"]
+= Custom Metrics Autoscaler Operator 2.18.1-1 release notes
+
+Issued: 15 January 2026
+
+This release of the Custom Metrics Autoscaler Operator 2.18.1-1 provides new features and enhancements, deprecated features, and bug fixes for running the Operator in an {product-title} cluster. The following advisory is available for the Custom Metrics Autoscaler Operator:
+
+* link:https://access.redhat.com/errata/RHBA-2026:0730[RHBA-2026:0730]
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
+====
+
+[id="nodes-pods-autoscaling-custom-rn-2181-new_{context}"]
+== New features and enhancements
+
+[id="nodes-pods-autoscaling-custom-rn-2181-new-activation_{context}"]
+=== Forced activation
+
+You can now temporarily force the activation of a scale target by adding the `autoscaling.keda.sh/force-activation: "true"` annotation to the `ScaledObject` custom resource (CR). (link:https://github.com/kedacore/keda/issues/6903[KEDA issue 6903])
+
+[id="nodes-pods-autoscaling-custom-rn-2181-new-labels_{context}"]
+=== Excluding labels from being propagated to the HPA
+
+You can now exclude specific labels from being propagated to a Horizontal Pod Autoscaler (HPA) by using the `scaledobject.keda.sh/hpa-excluded-labels` annotation to the `ScaledObject` or `ScaledJob` CR. (link:https://github.com/kedacore/keda/issues/6849[KEDA issue 6849])
+
+[id="nodes-pods-autoscaling-custom-rn-2181-new-pause-scaling-down_{context}"]
+=== Pause in scaling down
+
+You can now pause the scaling down of an object without preventing the object from scaling up. (link:https://github.com/kedacore/keda/issues/6902[KEDA issue 6902])
+
+[id="nodes-pods-autoscaling-custom-rn-2181-new-pause-scaling-up_{context}"]
+=== Pause in scaling up
+
+You can now pause the scaling up for an object without preventing the object from scaling down. (link:https://github.com/kedacore/keda/issues/7022[KEDA issue 7022])
+
+[id="nodes-pods-autoscaling-custom-rn-2181-new-pause-s390x_{context}"]
+=== Support for the s390x architecture
+
+The Operator can now run on `s390x` architecture. Previously it ran on `amd64`, `ppc64le`, or `arm64`. (link:https://github.com/kedacore/keda/issues/6543[KEDA issue 6543])
+
+[id="nodes-pods-autoscaling-custom-rn-2181-new-pause-fallback_{context}"]
+=== Fallback for triggers of `Value` metric type
+
+Fallback is now supported for triggers that use the `Value` metric type. Previously, fallback was supported for only the `AverageValue` metric type. (link:https://github.com/kedacore/keda/pull/6655[KEDA issue 6655])
+
+[id="nodes-pods-autoscaling-custom-rn-2181-new-pause-partitions_{context}"]
+=== Support for even distribution of Kafka partitions
+
+You can now configure a Kafka scaler to scale Kafka consumers by partition count on the topic. This ensures that the partitions are evenly spread across all consumers. (link:https://github.com/kedacore/keda/issues/2581[KEDA issue 2581])
+
+
+[id="nodes-pods-autoscaling-custom-rn-2181-new-log-zap_{context}"]
+=== The Zap logger has replaced the Kubernetes logger 
+
+The Operator now use	s the Zap logging library to emit logs. (link:https://github.com/kedacore/keda/issues/5732[KEDA issue 5732])
+
+[id="nodes-pods-autoscaling-custom-rn-2181-deprecated_{context}"]
+== Deprecated and removed features
+
+* For the CPU and Memory triggers, the `type` setting, deprecated in an earlier version, is removed. You must use `metricType` instead. (link:https://github.com/kedacore/keda/pull/6698[KEDA bug 6698])
+
+[id="nodes-pods-autoscaling-custom-rn-2181-bugs_{context}"]
+== Bug fixes
+
+* Before this update, a bug in the pending-pod-condition detection logic caused duplicate jobs to be created for scaled jobs that have slow-starting containers. This fix changes the logic to properly evaluate each pod individually and correctly identify when a job is no longer pending. (link:https://github.com/kedacore/keda/pull/6698[KEDA bug 6698])
+
+* Before this update, if a deployment object contained an `envFrom` parameter that included a prefix setting, the prefix was ignored and the environment variable keys were added to the scaler configuration without the prefix. With this fix, the prefix is now added to the environment variable key. (link:https://github.com/kedacore/keda/issues/6728[KEDA bug 6728])
+
+* Before this update, a scale client was not initialized when creating a new scale handler. This was due to a segmentation fault that occurred when accessing an uninitialized scale client in the scale handler during non-static fallback modes for specific scale target types. This fix corrects this issue. (link:https://github.com/kedacore/keda/pull/6992[KEDA bug 6992])
+
+* Before this update, if a user created a scaled object, the object had the `Paused` status condition of `Unknown`. This fix properly sets the `Paused` condition to `false`. (link:https://github.com/kedacore/keda/pull/7011[KEDA bug 7011])
+
+* Before this update, after removing the `autoscaling.keda.sh/paused-replicas` from a scaled object CR, the object could still have the `Paused` status condition of `true`. This issue has been resolved and the object reports the pause status correctly. (link:https://github.com/kedacore/keda/pull/6982[KEDA bug 6982])
+
+* Before this update, when creating a scaled object with the `scaledobject.keda.sh/transfer-hpa-ownership` annotation, the object status might not list the name of the HPA that is taking ownership of the object. With this fix, the HPA name is reported correctly. (link:https://github.com/kedacore/keda/pull/6336[KEDA bug 6336])
+
+* Before this update, a cron trigger incorrectly prevented scaling the replicas to 0 even if the cron schedule was inactive and the `minReplicaCount` value is `0`. This happened because the trigger always reported a metric value of `1` during its inactive periods. With this fix, the cron trigger is now able to return a metric of `0`, allowing  an object to scale to 0.  (link:https://github.com/kedacore/keda/pull/6886[KEDA bug 6886])
+
+* Before this update, in a Kafka trigger, specifying `sasl:none` resulted in an error, despite `none` being the default value for `sasl`. With this fix, you can now configure `sasl:none` in a Kafka trigger. (link:https://github.com/kedacore/keda/pull/7061[KEDA bug 7061])
+
+* Before this update, when scaling to 0, the Operator might not check if all scalers are not active. As a result, the Operator could scale an object to 0 even though there were active scalers. This fix corrects this issue. (link:https://github.com/kedacore/keda/issues/6986[KEDA issue 6986])
+
+ 

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -6,9 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following release notes are for previous versions of the Custom Metrics Autoscaler Operator.
+[role="_abstract"]
+You can review the following release notes to learn about changes in previous versions of the Custom Metrics Autoscaler Operator.
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
+
+include::modules/nodes-pods-autoscaling-custom-rn-2172-2.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-autoscaling-custom-rn-2172.adoc[leveloffset=+1]
 

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -6,7 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The release notes for the Custom Metrics Autoscaler Operator for Red Hat OpenShift describe new features and enhancements, deprecated features, and known issues.
+
+[role="_abstract"]
+You can review the following release notes to learn about changes in the Custom Metrics Autoscaler Operator version 2.18.1-1. The release notes for the Custom Metrics Autoscaler Operator for Red Hat OpenShift describe new features and enhancements, deprecated features, and known issues.
 
 The Custom Metrics Autoscaler Operator uses the Kubernetes-based Event Driven Autoscaler (KEDA) and is built on top of the {product-title} horizontal pod autoscaler (HPA).
 
@@ -26,47 +28,46 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |{product-title} version
 |General availability
 
-|2.17.2-2
+|2.18.1-1
 |4.20
 |General availability
 
-|2.17.2-2
+|2.18.1-1
+|4.21
+|General availability
+
+|2.18.1-1
 |4.19
 |General availability
 
-|2.17.2-2
+|2.18.1-1
 |4.18
 |General availability
 
 
-|2.17.2-2
+|2.18.1-1
 |4.17
 |General availability
 
-|2.17.2-2
+|2.18.1-1
 |4.16
 |General availability
 
-|2.17.2-2
+|2.18.1-1
 |4.15
 |General availability
 
-|2.17.2-2
+|2.18.1-1
 |4.14
 |General availability
 
-|2.17.2-2
+|2.18.1-1
 |4.13
 |General availability
 
-|2.17.2-2
+|2.18.1-1
 |4.12
 |General availability
 |===
 
-include::modules/nodes-pods-autoscaling-custom-rn-2172-2.adoc[leveloffset=+1]
-
-[IMPORTANT]
-====
-Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
-====
+include::modules/nodes-pods-autoscaling-custom-rn-2181.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17998

Link to docs preview:
[Custom Metrics Autoscaler Operator release notes](https://104920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.html) -- Added abstract; updated versions, include new module for 2.18.1 release notes.
[Release notes for past releases of the Custom Metrics Autoscaler Operator](https://104920--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past) -- Added abstract, moved module for 2.17.2 release notes in. 