### PR TITLE
OSDOCS#17182: OCP 4.21 OLMv1 GA support for webhooks in bundles

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2136,6 +2136,8 @@ Topics:
 - Name: Cluster extensions
   Dir: ce
   Topics:
+  - Name: Supported extensions
+    File: olmv1-supported-extensions
   - Name: Managing extensions
     File: managing-ce
   - Name: Extension configuration

--- a/extensions/arch/operator-controller.adoc
+++ b/extensions/arch/operator-controller.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Operator Controller is the central component of {olmv1-first} and consumes the other {olmv1} component, catalogd. It extends Kubernetes with an API through which users can install Operators and extensions.
 
 include::modules/olmv1-clusterextension-api.adoc[leveloffset=+1]
@@ -14,6 +15,7 @@ include::modules/olmv1-clusterextension-api.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../../operators/understanding/olm/olm-colocation.adoc#olm-colocation[Operator Lifecycle Manager (OLM) -> Multitenancy and Operator colocation]
+* xref:../../extensions/ce/olmv1-supported-extensions.adoc#olmv1-supported-extensions[Supported extensions]
 
 include::modules/olmv1-about-target-versions.adoc[leveloffset=+2]
 

--- a/extensions/ce/managing-ce.adoc
+++ b/extensions/ce/managing-ce.adoc
@@ -6,18 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-After a catalog has been added to your cluster, you have access to the versions, patches, and over-the-air updates of the extensions and Operators that are published to the catalog.
-
-You can use custom resources (CRs) to manage extensions declaratively from the CLI.
+[role="_abstract"]
+You use catalogs to access the versions, patches, and over-the-air updates for extensions and Operators. You use custom resources (CRs) to manage extensions declaratively from the CLI.
 
 include::snippets/olmv1-cli-only.adoc[]
-
-include::modules/olmv1-supported-extensions.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../operators/understanding/olm/olm-operatorconditions.adoc#olm-operatorconditions[Operator conditions]
 
 include::modules/olmv1-finding-operators-to-install.adoc[leveloffset=+1]
 
@@ -46,7 +38,7 @@ include::modules/olmv1-installing-an-operator-in-a-specific-namespace.adoc[level
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../extensions/ce/managing-ce.adoc#olmv1-supported-extensions_managing-ce[Supported extensions]
+* xref:../../extensions/ce/olmv1-supported-extensions.adoc#olmv1-supported-extensions[Supported extensions]
 
 * xref:../../authentication/using-rbac.adoc#rbac-projects-namespaces_using-rbac[Projects and namespaces]
 

--- a/extensions/ce/olmv1-supported-extensions.adoc
+++ b/extensions/ce/olmv1-supported-extensions.adoc
@@ -1,0 +1,34 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="olmv1-supported-extensions"]
+= Supported extensions
+include::_attributes/common-attributes.adoc[]
+:context: olmv1-supported-extensions
+
+toc::[]
+
+[role="_abstract"]
+To install an Operator as a cluster extension, it must meet bundle format, install mode, and dependency requirements. {olmv1-first} supports extensions that use webhooks for validation, mutation, or conversion.
+
+{olmv1-first} supports extensions that use the `AllNamespaces` install mode. With this mode, the Operator watches and manages resources across all namespaces in the cluster.
+
+As a Technology Preview feature, you can configure an extension to watch a specific namespace. This limits watching to one namespace instead of the entire cluster.
+
+include::modules/olmv1-about-supported-bundle-formats.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Bundle format]
+* xref:../../operators/understanding/olm/olm-operatorconditions.adoc#olm-operatorconditions[Operator conditions]
+
+include::modules/olmv1-webhook-support.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../architecture/admission-plug-ins.adoc#admission-webhook-types_admission-plug-ins[Types of webhook admission plugins]
+* xref:../../security/certificate_types_descriptions/service-ca-certificates.adoc#add-service-certificate_service-ca-certificates[Service CA certificates]
+* xref:../../operators/operator-reference.adoc#openshift-service-ca-operator_operator-reference[OpenShift Service CA Operator]
+* link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook[Validating admission webhooks (Kubernetes documentation)]
+* link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook[Mutating admission webhooks (Kubernetes documentation)]
+* link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#webhook-conversion[Conversion webhooks (Kubernetes documentation)]

--- a/modules/olmv1-about-supported-bundle-formats.adoc
+++ b/modules/olmv1-about-supported-bundle-formats.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * extensions/ce/olmv1-supported-extensions.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olmv1-about-supported-bundle-formats_{context}"]
+= Supported bundle formats and dependencies
+
+[role="_abstract"]
+To install an Operator as a cluster extension, the Operator must be packaged using the `registry+v1` bundle format. {olmv1} does not support Operators that declare dependencies by using file-based catalog properties.
+
+To install an Operator as a cluster extension, it must meet the following criteria:
+
+* The Operator is packaged using the `registry+v1` bundle format.
+* The Operator does not declare dependencies by using the following file-based catalog properties:
+** `olm.gvk.required`
+** `olm.package.required`
+** `olm.constraint`
+
+{olmv1} verifies that an Operator meets these requirements during installation. If an Operator does not meet these criteria, {olmv1} reports the issue in the cluster extension status conditions.
+
+include::snippets/olmv1-operator-conditions-support.adoc[]

--- a/modules/olmv1-webhook-support.adoc
+++ b/modules/olmv1-webhook-support.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * extensions/ce/olmv1-supported-extensions.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="olmv1-webhook-support_{context}"]
+= Webhook support
+
+[role="_abstract"]
+{olmv1-first} supports Operators that use webhooks for validation, mutation, or conversion. Operators use webhooks to enforce security policies or inject configurations into resources.
+
+The OpenShift Service CA Operator automatically manages webhook certificates. When you install an Operator that includes webhooks, the OpenShift Service CA Operator completes the following actions:
+
+* Applies Service CA annotations to webhook configurations and services.
+* Generates TLS certificates in the namespace where you install the cluster extension.
+* Mounts certificate secrets to the Operator deployment.
+* Configures webhook services with proper TLS settings.

--- a/snippets/olmv1-tp-extension-support.adoc
+++ b/snippets/olmv1-tp-extension-support.adoc
@@ -11,11 +11,9 @@ Currently, {olmv1-first} supports installing cluster extensions that meet all of
 * The extension must use the `registry+v1` bundle format introduced in {olmv0}.
 * The extension must support installation via the `AllNamespaces` install mode.
 ** You can use the `SingleNamespace` and `OwnNamespace` install modes as a Technology Preview feature in {product-title} {product-version} .
-* The extension must not use webhooks.
-** You can install extensions that use webhooks as a Technology Preview feature in {product-title} {product-version}.
 * The extension must not declare dependencies by using any of the following file-based catalog properties:
 ** `olm.gvk.required`
 ** `olm.package.required`
 ** `olm.constraint`
 
-{olmv1} checks that the extension you want to install meets these constraints. If the extension that you want to install does not meet these constraints, an error message is printed in the cluster extension's conditions.
+{olmv1} checks that the extension meets these constraints. If the extension does not meet these constraints, {olmv1} reports an error message in the cluster extension conditions.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.21
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-17182](https://issues.redhat.com//browse/OSDOCS-17182)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- Main edits: https://104922--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/arch/operator-controller.html

xrefs and abstracts
- https://104922--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/managing-ce.html
- https://104922--ocpdocs-pr.netlify.app/openshift-enterprise/latest/extensions/ce/olmv1-supported-extensions.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
