### PR TITLE
OSDOCS#15568: Add MicroShift DNS hosts configuration feature

### DIFF
--- a/microshift_configuring/microshift-using-config-yaml.adoc
+++ b/microshift_configuring/microshift-using-config-yaml.adoc
@@ -21,6 +21,8 @@ include::modules/microshift-nw-advertise-address.adoc[leveloffset=+2]
 
 include::modules/microshift-config-nodeport-limits.adoc[leveloffset=+2]
 
+include::modules/microshift-config-resolve-custom-hostnames.adoc[leveloffset=+2]
+
 [id="additional-resources_microshift-using-config-yaml"]
 [role="_additional-resources"]
 == Additional resources

--- a/modules/microshift-config-parameters-table.adoc
+++ b/modules/microshift-config-parameters-table.adoc
@@ -74,6 +74,14 @@ The following table explains {microshift-short} configuration YAML parameters an
 |`valid domain`
 |Base domain of the node. All managed DNS records are subdomains of this base.
 
+|`dns.hosts.status`
+|`Enabled`, `Disabled`
+|Default set to `Disabled` when not configured.
+
+|`dns.hosts.file`
+|`String`
+|Filepath by default set to `/etc/hosts`.
+
 |`etcd.memoryLimitMB`
 |`number`
 |By default, `etcd` uses as much memory as needed to handle the load on the system. However, in memory constrained systems, it might be preferred or necessary to limit the amount of memory `etcd` can to use at a given time.

--- a/modules/microshift-config-resolve-custom-hostnames.adoc
+++ b/modules/microshift-config-resolve-custom-hostnames.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * microshift_configuring/microshift-using-config-yaml.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="microshift-resolve-custom-hostnames_{context}"]
+= Configuring custom hostnames
+
+[role="_abstract"]
+You can use the `hosts` file to resolve custom hostnames for pod workloads. This enables applications to resolve fixed hostnames, such as the local machine or external services, by applying `/etc/hosts` functionality to DNS queries within the node. The functionality is applied by adding specific configuration to the {microshift-short} configuration YAML file, and completing a service restart.
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+* You have root access to the node.
+
+.Procedure
+. Edit the {microshift-short} configuration in the `/etc/microshift/config.yaml` file.
+. Add the following `hosts` configuration at the end of the file:
++
+[source,yaml]
+----
+dns:
+ hosts:
+   status: <Enabled|Disabled>
+   file: <filepath>
+----
+
+. Save your configuration YAML file.
+. Restart the {microshift-short} service to activate the configuration changes:
++ 
+[source,terminal]
+----
+$ sudo systemctl restart microshift
+----
++
+After this initial restart, if `dns.hosts.status` is set to `Enabled`, {microshift-short} automatically monitors the `dns.hosts.file` file for updates. You do not have to restart the {microshift-short} service until the {microshift-short} configuration YAML file is changed again.
++
+[NOTE]
+====
+After you save the `/etc/hosts` file, it takes up to 90 seconds for the change to be active in the pods. During this period, the pods might not properly resolve hostnames.
+====


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-15568](https://issues.redhat.com//browse/OSDOCS-15568)

Link to docs preview:
[Configuring custom hostnames](https://104923--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-resolve-custom-hostnames_microshift-using-config-yaml)
[Parameters and values for the MicroShift config.yaml file](https://104923--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-yaml.html#microshift-config-parameters-table_microshift-using-config-yaml)

QE review:
- [x ] QE has approved this change. (Kasturi)
