### PR TITLE
 [OCPSTRAT-1698]: Added a new module for removing device and deviceClass from LVM in 4.21

### DIFF
--- a/modules/lvms-about-removing-devices-from-a-vg.adoc
+++ b/modules/lvms-about-removing-devices-from-a-vg.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-removing-devices-from-a-vg_{context}"]
+= About removing devices and device classes from a volume group
+
+The `deviceSelector` field in the `LVMCluster` CR contains the configuration to specify the paths to the devices that you can remove from the Logical Volume Manager (LVM) volume group.
+
+You can remove the device paths in the `deviceSelector.paths` field.
+
+[WARNING]
+====
+Ensure that the device you want to remove is empty. You can use the `pvdisplay` command to see attributes of physical volumes (PVs) used in LVM 
+
+There is at least one more device specified in the `deviceSelector.paths` field.
+
+====
+
+You can also remove the deviceClass from the `LVMCluster`. For device class deletion, there is no need to delete `deviceSelector.paths`.
+
+[WARNING]
+====
+Ensure that the deviceClass you want to remove is not the default deviceClass. That is, the `deviceClasses.default` is `false`.
+
+The disks specified in the `deviceSelector.paths` field are empty.
+
+There is at least one more deviceClass specified in the `storage` field.
+
+====

--- a/storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -157,6 +157,8 @@ include::modules/lvms-scaling-storage-of-clusters-using-cli.adoc[leveloffset=+2]
 
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-adding-devices-to-a-vg_logical-volume-manager-storage[About adding devices to a volume group]
 
+* xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#about-removing-devices-from-a-vg_logical-volume-manager-storage[About removing devices and device classes from a volume group]
+
 include::modules/lvms-scaling-storage-of-clusters-using-web-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-17598
https://issues.redhat.com/browse/OCPSTRAT-1698

Link to docs preview:
https://104937--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage_local/persistent-storage-using-lvms.html

QE review:
- [ ] QE has approved this change.

