### PR TITLE
OSDOCS-17727:Update instructions for Install into an existing VPC.

### DIFF
--- a/modules/ccs-gcp-provisioned.adoc
+++ b/modules/ccs-gcp-provisioned.adoc
@@ -35,14 +35,20 @@ This is an overview of the provisioned {gcp-first} components on a deployed {pro
 ** 350 GB SSD persistent disk  (deleted on instance deletion)
 
 [id="gcp-policy-vpc_{context}"]
-== VPC
+== Installing a new cluster into an existing VPC
 
-include::snippets/snip_install-cluster-in-vpc.adoc[]
+You must have at least one VPC network within the {GCP} project where the {product-title} cluster is being installed. The VPC network must include the following subnets within the same region as the cluster:
 
-* **Subnets:** One master subnet for the control plane workloads and one worker subnet for all others. An additional subnet is required for Google Private Service Connect (PSC) when a private cluster is deployed using PSC.
-* **Router tables:** One global route table per VPC.
-* **Internet gateways:** One internet gateway per cluster.
-* **NAT gateways:**  One master NAT gateway and one worker NAT gateway per cluster.
+* A control plane subnet for the OpenShift control plane.
+* A compute subnet for user workloads.
+* A Private Service Connect (PSC) subnet when a private cluster is deployed using PSC.
+
+[NOTE]
+====
+Installing a new {product-title} cluster into a VPC that was automatically created by the installer for a different cluster is not supported.
+
+IPv6 and dual-stack (IPv4 and IPv6) address ranges are not supported within the {product-title} cluster.
+====
 
 [id="gcp-policy-services_{context}"]
 == Services

--- a/modules/create-wif-cluster-ocm.adoc
+++ b/modules/create-wif-cluster-ocm.adoc
@@ -127,11 +127,6 @@ Private Service Connect is supported only with *Install into an existing VPC*.
 +
 .. If you are installing into an existing VPC and you want to enable an HTTP or HTTPS proxy for your cluster, select *Configure a cluster-wide proxy*.
 +
-[IMPORTANT]
-====
-In order to configure a cluster-wide proxy for your cluster, you must first create the Cloud network address translation (NAT) and a Cloud router. See the _Additional resources_ section for more information.
-====
-+
 . Accept the default application ingress settings, or to create your own custom settings, select *Custom Settings*.
 
 .. Optional: Provide route selector.
@@ -163,16 +158,14 @@ For more information, see link:https://cloud.google.com/vpc/docs/provisioning-sh
 
 .. Select *Install into {gcp-short} Shared VPC*.
 .. Specify the *Host project ID*. If the specified host project ID is incorrect, cluster creation fails.
-
+--
 +
-.. If you opted to install the cluster in an existing {gcp-short} VPC, provide your *Virtual Private Cloud (VPC) subnet settings* and select *Next*.
-You must have created the Cloud network address translation (NAT) and a Cloud router. See _Additional resources_ for information about Cloud NATs and Google VPCs.
+. If you opted to install the cluster in an existing {GCP} VPC, provide your VPC subnet settings and select *Next*. You must ensure that your VPC is configured to allow outbound internet access to the domains required for the {product-title} service. This outbound access is required for the {product-title} service to communicate with Red{nbsp}Hat's management plane and SRE tooling via secure and encrypted endpoints over the public internet.
 +
 [NOTE]
 ====
 If you are installing a cluster into a Shared VPC, the VPC name and subnets are shared from the host project.
 ====
---
 . Click *Next*.
 . If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
 +

--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -208,15 +208,7 @@ For information about Shared VPC permissions, see link:https://cloud.google.com/
 ====
 
 +
-. If you opted to install the cluster in an existing {gcp-short} VPC, provide your *Virtual Private Cloud (VPC) subnet settings* and select *Next*.
-You must have created the Cloud network address translation (NAT) and a Cloud router. See the "Additional resources" section for information about Cloud NATs and Google VPCs.
-
-+
-[NOTE]
-====
-If you are installing a cluster into a Shared VPC, the VPC name and subnets are shared from the host project.
-====
-
+. If you opted to install the cluster in an existing {gcp-short} VPC, provide your *Virtual Private Cloud (VPC) subnet settings* and select *Next*. You must ensure that your VPC is configured to allow outbound internet access to the domains required for the {product-title} service. This outbound access is required for the {product-title} service to communicate with Red{nbsp}Hat's management plane and SRE tooling via secure and encrypted endpoints over the public internet.
 . If you opted to configure a cluster-wide proxy, provide your proxy configuration details on the *Cluster-wide proxy* page:
 +
 .. Enter a value in at least one of the following fields:


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17727](https://issues.redhat.com//browse/OSDOCS-17727)

Link to docs preview:

- [Creating a Workload Identity Federation cluster using OpenShift Cluster Manager](https://104955--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.html#create-wif-cluster-ocm_osd-creating-a-cluster-on-gcp-with-workload-identity-federation)
- [Creating a cluster with Service Account authentication using OpenShift Cluster Manager](https://104955--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-cluster-sa.html)
- [Provisioned Google Cloud Infrastructure](https://104955--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs#ccs-gcp-provisioned_gcp-ccs)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
