### PR TITLE
OSDOCS Adds oc describe instructions to viewing pods page

### DIFF
--- a/modules/troubleshooting-general-describe-pod.adoc
+++ b/modules/troubleshooting-general-describe-pod.adoc
@@ -1,24 +1,24 @@
 // Module included in the following assemblies:
 //
+// * nodes/pods/nodes-pods-viewing.adoc
 // * edge_computing/day_2_core_cnf_clusters/troubleshooting/troubleshooting-general-troubleshooting.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="troubleshooting-general-describe-pod_{context}"]
 = Describing a pod
 
-Describing a pod gives you information about that pod to help with troubleshooting.
-The `Events` section provides detailed information about the pod and the containers inside of it.
+[role="_abstract"]
+To troubleshoot pod issues and view detailed information about a pod in {product-title}, you can describe a pod using the `oc describe pod` command. The *Events* section in the output provides detailed information about the pod and the containers inside of it.
 
 .Procedure
 
 * Describe a pod by running the following command:
 +
---
 [source,terminal]
 ----
 $ oc describe pod -n <namespace> busybox-1
 ----
-
++
 .Example output
 [source,terminal]
 ----
@@ -39,6 +39,3 @@ Events:
   Normal  Created  41m (x170 over 7d1h)  kubelet  Created container busybox
   Normal  Started  41m (x170 over 7d1h)  kubelet  Started container busybox
 ----
---
-
-For more information, see "oc describe".

--- a/nodes/pods/nodes-pods-viewing.adoc
+++ b/nodes/pods/nodes-pods-viewing.adoc
@@ -10,6 +10,13 @@ As an administrator, you can view cluster pods, check their health, and evaluate
 
 include::modules/nodes-pods-viewing-project.adoc[leveloffset=+1]
 
+include::modules/troubleshooting-general-describe-pod.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../cli_reference/openshift_cli/developer-cli-commands.adoc#oc-describe[oc describe]
+
 include::modules/nodes-pods-viewing-usage.adoc[leveloffset=+1]
 
 include::modules/viewing-resource-logs-cli-console.adoc[leveloffset=+1]


### PR DESCRIPTION
I just want to go ahead and get the merge review out of the way so that I can merge it later. QE ack'd this in Slack but I think I'll ask her to look at the PR, too:

XiuJuan Wang
  [9:52 PM](https://redhat-internal.slack.com/archives/D04A83AQS4S/p1768791142443009)
hmm, yes, this looks good for me, oc describe is a good tool for debuging

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://104958--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/pods/nodes-pods-viewing.html

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
