### PR TITLE
TELCODOCS-2500-RN Adding RN for GNSS-to-NTP failover

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -338,6 +338,16 @@ Support for {SMProductName} version 3.2::
 +
 {product-title} {product-version} updates {SMProductShortName} to version 3.2. This version update incorporates essential CVE fixes and ensures that your {product-title} instances receive the latest fixes, features, and enhancements. See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.2/html/release_notes/ossm-release-notes[{SMProductShortName} 3.2 release notes] for more information.
 
+PTP Operator introduces GNSS-to-NTP failover for high-precision timing::
++
+With this release, the PTP Operator introduces an active GNSS-to-NTP failover configuration to ensure time synchronization continuity in environments requiring extremely high time accuracy.
++
+When the primary Global Navigation Satellite System (GNSS) signal is lost or compromised, for example because of satellite jamming, the system automatically fails over to Network Time Protocol (NTP) to maintain time accuracy. When the GNSS signal is restored, the system automatically recovers back to using GNSS as the primary time source.
++
+This feature is particularly important in telco environments that require high precision time synchronization with built-in redundancy. To enable GNSS to NTP failover, you configure the `PtpConfig` resource with the `ntpfailover` plugin enabled and configure both `chronyd` and `ts2phc` settings.
++
+For more information, see xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#cnf-configuring-gnss-ntp-failover_configuring-ptp[Configuring GNSS failover to NTP for time synchronization continuity].
+
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 


### PR DESCRIPTION
[Telcodocs 2500]: GNSS (GPS) as the Primary System Clock Time Source with NTP Fallback
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.21
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2500
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://104970--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-networking_release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
