### PR TITLE
TELCODOCS-2277-RN Document IPAddressPool Status, ServiceBGPStatuses, BGPsessionsStates RN

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -256,6 +256,16 @@ The monitoring stack documentation is now available as a separate documentation 
 [id="ocp-release-notes-networking_{context}"]
 == Networking
 
+MetalLB Operator status reporting::
++
+You can now use enhanced MetalLB Operator reporting features to view real-time operational data for IP address allocation and Border Gateway Protocol (BGP) connectivity. Previously, viewing this information required manual log inspection across multiple controllers. With this release, you can monitor your network health and resolve connectivity issues directly through the following custom resources:
++
+* `IPAddressPool`: Monitor cluster-wide IP address allocation through the `status` field to track usage and prevent address exhaustion.
+* `ServiceBGPStatus`: Verify which service IP addresses are announced to specific BGP peers to ensure correct route advertisements.
+* `BGPSessionStatus`: Check the real-time state of BGP and Bidirectional Forwarding Detection sessions to quickly identify connectivity drops.
++
+For more information, see xref:../networking/ingress_load_balancing/metallb/monitoring-metallb-status.adoc[Monitoring MetalLB configuration status].
+
 Applying unassisted holdover for boundary clocks and time synchronous clocks::
 +
 {product-title} 4.20 introduced unassisted holdover for boundary clocks and time synchronous clocks as a Technology Preview feature. This feature is now Generally Available (GA).


### PR DESCRIPTION
[TELCODOCS-2277]: Document IPAddressPool Status, ServiceBGPStatuses, BGPsessionsStates
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.21 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2277
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://104979--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
