### PR TITLE
OSDOCS#17801: enable hardware metrics for BM nodes

### DIFF
--- a/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+++ b/installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
@@ -52,6 +52,17 @@ include::modules/nw-osp-services-external-load-balancer.adoc[leveloffset=+1]
 // Configuring a user-managed load balancer
 include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+2]
 
+// Hardware metrics in the Monitoring stack
+include::modules/bm-about-ipe.adoc[leveloffset=+1]
+
+// Adding hardware metrics to Prometheus observability stack
+include::modules/bm-configuring-ipe.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features[Enabling features using feature gates]
+
 // Using the Bare Metal Operator
 include::modules/bmo-config-using-bare-metal-operator.adoc[leveloffset=+1]
 

--- a/modules/bm-about-ipe.adoc
+++ b/modules/bm-about-ipe.adoc
@@ -1,0 +1,23 @@
+// This is included in the following assemblies:
+//
+// * installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="bm-about-ipe_{context}"]
+= Hardware metrics in the Monitoring stack
+
+[role="_abstract"]
+Hardware metrics can be exported to the cluster by enabling the Ironic Prometheus Exporter (IPE).
+
+IPE is a tool that exposes the hardware sensor data of cluster nodes in the Prometheus format.
+When you enable IPE in your cluster, the tool collects data from the baseboard management controller (BMC) of each node and exports the data to the cluster's monitoring stack.
+
+[NOTE]
+====
+This method of collecting hardware metrics works only on Redfish-compatible BMCs.
+====
+
+You can then view these hardware metrics alongside other metrics in the **Observe** tab of the web console.
+
+:FeatureName: Monitoring bare metal hardware metrics
+include::snippets/technology-preview.adoc[]

--- a/modules/bm-configuring-ipe.adoc
+++ b/modules/bm-configuring-ipe.adoc
@@ -1,0 +1,84 @@
+// This is included in the following assemblies:
+//
+// * installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="bm-configuring-ipe_{context}"]
+= Adding node hardware metrics to the Monitoring stack
+
+[role="_abstract"]
+To access hardware metrics for your bare-metal nodes in the web console, enable the Ironic Prometheus Exporter in your cluster.
+
+.Prerequisites
+
+* You have enabled the `TechPreviewNoUpgrade` feature set in your cluster's `FeatureGate` custom resource (CR).
+For more information, see "Enabling features using feature gates".
+
+* You bare-metal nodes use Redfish-compatible baseboard management controllers (BMCs).
+
+.Procedure
+
+. Enable the Ironic Prometheus Exporter by running the following command:
++
+[source,terminal]
+----
+$ oc patch provisioning provisioning-configuration \
+    --type=merge \
+    -p '{"spec":{"prometheusExporter":{"enabled":true}}}'
+----
+
+. Optional: Configure the data collection interval by running the following command:
++
+[source,terminal]
+----
+$ oc patch provisioning provisioning-configuration \
+    --type=merge \
+    -p '{"spec":{"prometheusExporter":{"sensorCollectionInterval":<interval>}}}'
+----
++
+Replace `<interval>` with the interval in seconds for collecting sensor data from BMCs.
+The minimum value is `60`.
+
+. Optional: Disable default alerting rules for hardware metrics by running the following command:
++
+[source,terminal]
+----
+$ oc patch provisioning provisioning-configuration \
+    --type=merge \
+    -p '{"spec":{"prometheusExporter":{"disableDefaultPrometheusRules":true}}}'
+----
++
+When `disableDefaultPrometheusRules` is set to `true`, the configuration prevents deployment of default alerting rules for hardware metrics.
+
+. Optional: Disable the Ironic Prometheus Exporter by running the following command:
++
+[source,terminal]
+----
+$ oc patch provisioning provisioning-configuration \
+    --type=merge \
+    -p '{"spec":{"prometheusExporter":{"enabled":false}}}'
+----
+
+.Verification
+
+. From the web console, click *Observe* -> *Metrics* and enter "baremetal" into the **Expression** field.
+Several autocomplete suggestions should appear, such as the following examples:
++
+`baremetal_power_status`
++
+`baremetal_temperature_status`
++
+`baremetal_drive_status`
++
+`baremetal_fan_status`
+
+. Select one of the autocomplete suggestions and click **Run Queries**.
+
+. Verify that the queried hardware metrics appear in the UI.
+
+. If you did not disable default alerting rules, view them by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-machine-api get promrule metal3-defaults -oyaml
+----


### PR DESCRIPTION
[OSDOCS-17801](https://issues.redhat.com/browse/OSDOCS-17801)

Version(s): 4.21+

This PR adds docs for enabling hardware metrics monitoring for bare metal nodes.

QE review:
- [x] QE has approved this change.

Preview:
[Hardware metrics in the Monitoring stack](https://105001--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#bm-about-ipe_bare-metal-postinstallation-configuration)
[Adding node hardware metrics to the Monitoring stack](https://105001--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html#bm-configuring-ipe_bare-metal-postinstallation-configuration)