### PR TITLE
OSDOCS#17801: IPE enablement release note

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -31,7 +31,7 @@ Applying VPA recommendations without pod re-creation::
 +
 You can now configure a Vertical Pod Autoscaler Operator (VPA) in the `InPlaceOrRecreate` mode. In this mode, the VPA attempts to apply the recommended updates without re-creating pods. If the VPA is unable to update the pods in place, the VPA falls back to re-creating the pods. For more information, see xref:../nodes/pods/nodes-pods-vertical-autoscaler.adoc#nodes-pods-vertical-autoscaler-modes_nodes-pods-vertical-autoscaler[About the Vertical Pod Autoscaler Operator modes].
 
-Cluster Autoscaler Operator can now cordon nodes before removing the node:: 
+Cluster Autoscaler Operator can now cordon nodes before removing the node::
 +
 By default, when the Cluster Autoscaler Operator removes a node, it does not cordon the node when draining the pods from the node. You can configure the Operator to cordon the node before draining and moving the pods. For more information, see xref:../machine_management/applying-autoscaling.adoc#cluster-autoscaler-about_applying-autoscaling[About the cluster autoscaler].
 
@@ -162,7 +162,7 @@ The following additional VCF and VVF components are outside the scope of Red Hat
 [id="ocp-release-notes-machine-config-operator_{context}"]
 == Machine Config Operator
 
-Boot image management for {azure-short} and {vmw-short} clusters promoted to GA:: 
+Boot image management for {azure-short} and {vmw-short} clusters promoted to GA::
 +
 Updating boot images has been promoted to GA for {azure-full} and {vmw-full} clusters. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Boot image management].
 
@@ -295,6 +295,14 @@ Item description::
 +
 Detailed information.
 ////
+
+Enabling hardware metrics monitoring on bare-metal clusters (Technology Preview)::
++
+With this update, you can enable your cluster to collect hardware metrics from the Redfish-compatible baseboard management controllers of your bare-metal nodes.
+Metrics include temperature, power consumption, fan status, and drive health.
+You enable this Technology Preview feature by enabling the Ironic Prometheus Exporter in your cluster as a postinstallation task.
++
+For more information, see xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bm-about-ipe_bare-metal-postinstallation-configuration[Hardware metrics in the Monitoring stack].
 
 [id="ocp-release-notes-rhcos_{context}"]
 == Red Hat Enterprise Linux CoreOS (RHCOS)


### PR DESCRIPTION
[OSDOCS-17801](https://issues.redhat.com/browse/OSDOCS-17801)

Version(s): 4.21

This PR adds a release note for enabling hardware metrics monitoring for bare metal nodes.

QE review:
- [x] QE has approved this change.

Preview: [Postinstallation configuration](https://105005--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-post-install-configuration_release-notes)