### PR TITLE
OSDOCS-15819 Release note for GCP BYO firewall rules

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -118,6 +118,12 @@ Installing a cluster on {azure-full} uses Marketplace images by default::
 +
 As of this update, the {product-title} installation program uses Marketplace images by default when installing a cluster on {azure-short}. This speeds up the installation by removing the need to upload a virtual hard disk to {azure-short} and create an image during installation. This feature is not supported on Azure Stack Hub, or for {azure-short} installations that use Confidential VMs.
 
+Managing your own firewall rules when installing a cluster on {gcp-short} into an existing VPC::
++
+As of this update, you can manage your own firewall rules when installing a cluster on {gcp-short} into an existing VPC by enabling the `firewallRulesManagement` parameter in the `install-config.yaml` file. You can limit the permissions that you grant to the installation program by managing your own firewall rules.
++
+For more information, see xref:../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-user-managed-firewall-rules_installing-gcp-account[Managing your own firewall rules].
+
 [id="ocp-release-notes-machine-config-operator_{context}"]
 == Machine Config Operator
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-15819

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

xref will fail until https://github.com/openshift/openshift-docs/pull/104757 merges