### PR TITLE
OSDOCS-17948 MTO 1.2.2 release notes

### DIFF
--- a/modules/multi-arch-tuning-operator-release-notes-1-0-0.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-0-0.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: REFERENCE
+[id="multi-arch-tuning-operator-release-notes-1-0-0_{context}"]
+= Release notes for the Multiarch Tuning Operator 1.0.0
+
+Issued: 31 October 2024
+
+[id="multi-arch-tuning-operator-1-0-0-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* With this release, the Multiarch Tuning Operator supports custom network scenarios and cluster-wide custom registries configurations.
+* With this release, you can identify pods based on their architecture compatibility by using the pod labels that the Multiarch Tuning Operator adds to newly created pods.
+* With this release, you can monitor the behavior of the Multiarch Tuning Operator by using the metrics and alerts that are registered in the Cluster Monitoring Operator.

--- a/modules/multi-arch-tuning-operator-release-notes-1-1-0.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-1-0.adoc
@@ -1,0 +1,17 @@
+:_mod-docs-content-type: REFERENCE
+[id="multi-arch-tuning-operator-release-notes-1-1-0_{context}"]
+= Release notes for the Multiarch Tuning Operator 1.1.0
+
+Issued: 18 March 2024
+
+[id="multi-arch-tuning-operator-1-1-0-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* The Multiarch Tuning Operator is now supported on managed offerings, including ROSA with Hosted Control Planes (HCP) and other HCP environments.
+
+* With this release, you can configure architecture-aware workload scheduling by using the new `plugins` field in the `ClusterPodPlacementConfig` object. You can use the `plugins.nodeAffinityScoring` field to set architecture preferences for pod placement. If you enable the `nodeAffinityScoring` plugin, the scheduler first filters out nodes that do not meet the pod requirements. Then, the scheduler prioritizes the remaining nodes based on the architecture scores defined in the `nodeAffinityScoring.platforms` field.
+
+[id="multi-arch-tuning-operator-1-1-0-bug-fixes_{context}"]
+== Bug fixes
+
+* With this release, the Multiarch Tuning Operator does not update the `nodeAffinity` field for pods that are managed by a daemon set. (link:https://issues.redhat.com/browse/OCPBUGS-45885[*OCPBUGS-45885*])

--- a/modules/multi-arch-tuning-operator-release-notes-1-1-1.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-1-1.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: REFERENCE
+[id="multi-arch-tuning-operator-release-notes-1-1-1_{context}"]
+= Release notes for the Multiarch Tuning Operator 1.1.1
+
+Issued: 27 May 2025
+
+[id="multi-arch-tuning-operator-1-1-z-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, the pod placement operand did not support authenticating registries using wildcard entries in the hostname of their pull secret. This caused inconsistent behavior with Kubelet when pulling images, because Kubelet supported wildcard entries while the operand required exact hostname matches. As a result, image pulls could fail unexpectedly when registries used wildcard hostnames.
++
+With this release, the pod placement operand supports pull secrets that include wildcard hostnames, ensuring consistent and reliable image authentication and pulling.
+
+* Previously, when image inspection failed after all retries and the `nodeAffinityScoring` plugin was enabled, the pod placement operand applied incorrect `nodeAffinityScoring` labels.
++
+With this release, the operand sets `nodeAffinityScoring` labels correctly, even when image inspection fails. It now applies these labels independently of the required affinity process to ensure accurate and consistent scheduling.

--- a/modules/multi-arch-tuning-operator-release-notes-1-2-0.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-2-0.adoc
@@ -1,0 +1,23 @@
+:_mod-docs-content-type: REFERENCE
+[id="multi-arch-tuning-operator-release-notes-1-2-0_{context}"]
+= Release notes for the Multiarch Tuning Operator 1.2.0
+
+Issued: 22 October 2025
+
+[id="multi-arch-tuning-operator-1-2-0-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* With this release, you can enable the *exec format error monitor* plugin for the Multiarch Tuning Operator. This plugin detects `ENOEXEC` errors, which occur when a pod attempts to execute a binary incompatible with the node's architecture. You enable this plugin by setting the `plugins.execFormatErrorMonitor.enabled` parameter to `true` in the `ClusterPodPlacementConfig` object. For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multi-architecture-creating-podplacement-config_multiarch-tuning-operator[Creating the ClusterPodPlacementConfig object].
+
+[id="multi-arch-tuning-operator-1-2-0-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, the Multiarch Tuning Operator incorrectly handled the Operator bundle image inspector, restricting it to a single architecture, which could cause OLM to fail when installing Operators. With this update, MTO now sets the bundle image to support all architectures, allowing Operators to be successfully installed on single-architecture clusters when the Multiarch Tuning Operator is deployed. (link:https://issues.redhat.com/browse/MULTIARCH-5546[*MULTIARCH-5546*])
+
+* Previously, when a cluster global pull secret was changed, stale authentication information could remain in the Multiarch Tuning Operator cache. With this update, the cache is cleared whenever a cluster global pull secret is changed. (link:https://issues.redhat.com/browse/MULTIARCH-5538[*MULTIARCH-5538*])
+
+* Previously, the Multiarch Tuning Operator failed to process pods if an image reference contained both a tag and a digest. With this update, the image inspector prioritizes the digest if both are present. (link:https://issues.redhat.com/browse/MULTIARCH-5584[*MULTIARCH-5584*])
+
+* Previously, the Multiarch Tuning Operator did not respect the `.spec.registrySources.containerRuntimeSearchRegistries` field in the `config.openshift.io/Image` custom resource when a workload image did not specify a registry URL. With this update, the Operator can now handle this case, allowing workload images without an explicit registry URL to be pulled successfully. (link:https://issues.redhat.com/browse/MULTIARCH-5611[*MULTIARCH-5611*])
+
+* Previously, if the `ClusterPodPlacementConfig` object was deleted less than 1 second after its creation, some finalizers were not removed in time, causing certain resources to remain. With this update, all finalizers are properly deleted when the `ClusterPodPlacementConfig` object is deleted. (link:https://issues.redhat.com/browse/MULTIARCH-5372[*MULTIARCH-5372*])

--- a/modules/multi-arch-tuning-operator-release-notes-1-2-1.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-2-1.adoc
@@ -1,0 +1,10 @@
+:_mod-docs-content-type: REFERENCE
+[id="multi-arch-tuning-operator-release-notes-1-2-1_{context}"]
+= Release notes for the Multiarch Tuning Operator 1.2.1
+
+Issued: 15 December 2025
+
+[id="multi-arch-tuning-operator-1-2-1-bug-fixes_{context}"]
+== Bug fixes
+
+* Previously, the Multiarch Tuning Operator image inspector incorrectly processed images whose registry address included a digest, tag, and port number. The port portion of the registry was incorrectly interpreted as an image tag and was trimmed, causing the inspector to construct an invalid image reference. With this update, image references that contain a digest, tag, and registry port are now correctly parsed and handled. (link:https://issues.redhat.com/browse/MULTIARCH-5767[*MULTIARCH-5767*])

--- a/modules/multi-arch-tuning-operator-release-notes-1-2-2.adoc
+++ b/modules/multi-arch-tuning-operator-release-notes-1-2-2.adoc
@@ -1,0 +1,14 @@
+:_mod-docs-content-type: REFERENCE
+[id="multi-arch-tuning-operator-release-notes-1-2-2_{context}"]
+= Release notes for the Multiarch Tuning Operator 1.2.2
+
+Issued: 6 February 2026
+
+[id="multi-arch-tuning-operator-1-2-2-enhancements_{context}"]
+== Enhancements
+
+* With this update, MTO has been updated to use the Red{nbsp}Hat Universal Base Image (UBI) 9 minimal image. This change improves compatibility with {product-title} ecosystems.
+
+* MTO has been updated to use `go` version 1.25.3, `k8s` version 1.34.1, and Operator SDK v4 version 1.33.
+
+* The `ENoExecEvent.Status.Command` field has been removed from the `ENoExecEvent` CustomResource. This field was not in use.

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.adoc
@@ -6,87 +6,19 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The Multiarch Tuning Operator (MTO) optimizes workload management within multi-architecture clusters and in single-architecture clusters transitioning to multi-architecture environments.
-
-These release notes track the development of the Multiarch Tuning Operator.
+[role="_abstract"]
+The Multiarch Tuning Operator (MTO) optimizes workload management within multi-architecture clusters and in single-architecture clusters transitioning to multi-architecture environments. Use the release notes to track the development of the Multiarch Tuning Operator.
 
 For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multiarch-tuning-operator[Managing workloads on multi-architecture clusters by using the Multiarch Tuning Operator].
 
-[id="multi-arch-tuning-operator-release-notes-1-2-1_{context}"]
-== Release notes for the Multiarch Tuning Operator 1.2.1
+include::modules/multi-arch-tuning-operator-release-notes-1-2-2.adoc[leveloffset=+1]
 
-Issued: 15 December 2025
+include::modules/multi-arch-tuning-operator-release-notes-1-2-1.adoc[leveloffset=+1]
 
-[id="multi-arch-tuning-operator-1-2-1-bug-fixes_{context}"]
-=== Bug fixes
+include::modules/multi-arch-tuning-operator-release-notes-1-2-0.adoc[leveloffset=+1]
 
-* Previously, the Multiarch Tuning Operator image inspector incorrectly processed images whose registry address included a digest, tag, and port number. The port portion of the registry was incorrectly interpreted as an image tag and was trimmed, causing the inspector to construct an invalid image reference. With this update, image references that contain a digest, tag, and registry port are now correctly parsed and handled. (link:https://issues.redhat.com/browse/MULTIARCH-5767[*MULTIARCH-5767*])
+include::modules/multi-arch-tuning-operator-release-notes-1-1-1.adoc[leveloffset=+1]
 
-[id="multi-arch-tuning-operator-release-notes-1-2-0_{context}"]
-== Release notes for the Multiarch Tuning Operator 1.2.0
+include::modules/multi-arch-tuning-operator-release-notes-1-1-0.adoc[leveloffset=+1]
 
-Issued: 22 October 2025
-
-[id="multi-arch-tuning-operator-1-2-0-new-features-and-enhancements_{context}"]
-=== New features and enhancements
-
-* With this release, you can enable the *exec format error monitor* plugin for the Multiarch Tuning Operator. This plugin detects `ENOEXEC` errors, which occur when a pod attempts to execute a binary incompatible with the node's architecture. You enable this plugin by setting the `plugins.execFormatErrorMonitor.enabled` parameter to `true` in the `ClusterPodPlacementConfig` object. For more information, see xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/multiarch-tuning-operator.adoc#multi-architecture-creating-podplacement-config_multiarch-tuning-operator[Creating the ClusterPodPlacementConfig object].
-
-[id="multi-arch-tuning-operator-1-2-0-bug-fixes_{context}"]
-=== Bug fixes
-
-* Previously, the Multiarch Tuning Operator incorrectly handled the Operator bundle image inspector, restricting it to a single architecture, which could cause OLM to fail when installing Operators. With this update, MTO now sets the bundle image to support all architectures, allowing Operators to be successfully installed on single-architecture clusters when the Multiarch Tuning Operator is deployed. (link:https://issues.redhat.com/browse/MULTIARCH-5546[*MULTIARCH-5546*])
-
-* Previously, when a cluster global pull secret was changed, stale authentication information could remain in the Multiarch Tuning Operator cache. With this update, the cache is cleared whenever a cluster global pull secret is changed. (link:https://issues.redhat.com/browse/MULTIARCH-5538[*MULTIARCH-5538*])
-
-* Previously, the Multiarch Tuning Operator failed to process pods if an image reference contained both a tag and a digest. With this update, the image inspector prioritizes the digest if both are present. (link:https://issues.redhat.com/browse/MULTIARCH-5584[*MULTIARCH-5584*])
-
-* Previously, the Multiarch Tuning Operator did not respect the `.spec.registrySources.containerRuntimeSearchRegistries` field in the `config.openshift.io/Image` custom resource when a workload image did not specify a registry URL. With this update, the Operator can now handle this case, allowing workload images without an explicit registry URL to be pulled successfully. (link:https://issues.redhat.com/browse/MULTIARCH-5611[*MULTIARCH-5611*])
-
-* Previously, if the `ClusterPodPlacementConfig` object was deleted less than 1 second after its creation, some finalizers were not removed in time, causing certain resources to remain. With this update, all finalizers are properly deleted when the `ClusterPodPlacementConfig` object is deleted. (link:https://issues.redhat.com/browse/MULTIARCH-5372[*MULTIARCH-5372*])
-
-
-[id="multi-arch-tuning-operator-release-notes-1-1-1_{context}"]
-== Release notes for the Multiarch Tuning Operator 1.1.1
-
-Issued: 27 May 2025
-
-[id="multi-arch-tuning-operator-1-1-z-bug-fixes_{context}"]
-=== Bug fixes
-
-* Previously, the pod placement operand did not support authenticating registries using wildcard entries in the hostname of their pull secret. This caused inconsistent behavior with Kubelet when pulling images, because Kubelet supported wildcard entries while the operand required exact hostname matches. As a result, image pulls could fail unexpectedly when registries used wildcard hostnames.
-+
-With this release, the pod placement operand supports pull secrets that include wildcard hostnames, ensuring consistent and reliable image authentication and pulling.
-
-* Previously, when image inspection failed after all retries and the `nodeAffinityScoring` plugin was enabled, the pod placement operand applied incorrect `nodeAffinityScoring` labels.
-+
-With this release, the operand sets `nodeAffinityScoring` labels correctly, even when image inspection fails. It now applies these labels independently of the required affinity process to ensure accurate and consistent scheduling.
-
-[id="multi-arch-tuning-operator-release-notes-1-1-0_{context}"]
-== Release notes for the Multiarch Tuning Operator 1.1.0
-
-Issued: 18 March 2024
-
-[id="multi-arch-tuning-operator-1-1-0-new-features-and-enhancements_{context}"]
-=== New features and enhancements
-
-* The Multiarch Tuning Operator is now supported on managed offerings, including ROSA with Hosted Control Planes (HCP) and other HCP environments.
-
-* With this release, you can configure architecture-aware workload scheduling by using the new `plugins` field in the `ClusterPodPlacementConfig` object. You can use the `plugins.nodeAffinityScoring` field to set architecture preferences for pod placement. If you enable the `nodeAffinityScoring` plugin, the scheduler first filters out nodes that do not meet the pod requirements. Then, the scheduler prioritizes the remaining nodes based on the architecture scores defined in the `nodeAffinityScoring.platforms` field.
-
-[id="multi-arch-tuning-operator-1-1-0-bug-fixes_{context}"]
-==== Bug fixes
-
-* With this release, the Multiarch Tuning Operator does not update the `nodeAffinity` field for pods that are managed by a daemon set. (link:https://issues.redhat.com/browse/OCPBUGS-45885[*OCPBUGS-45885*])
-
-[id="multi-arch-tuning-operator-release-notes-1-0-0_{context}"]
-== Release notes for the Multiarch Tuning Operator 1.0.0
-
-Issued: 31 October 2024
-
-[id="multi-arch-tuning-operator-1-0-0-new-features-and-enhancements_{context}"]
-=== New features and enhancements
-
-* With this release, the Multiarch Tuning Operator supports custom network scenarios and cluster-wide custom registries configurations.
-* With this release, you can identify pods based on their architecture compatibility by using the pod labels that the Multiarch Tuning Operator adds to newly created pods.
-* With this release, you can monitor the behavior of the Multiarch Tuning Operator by using the metrics and alerts that are registered in the Cluster Monitoring Operator.
+include::modules/multi-arch-tuning-operator-release-notes-1-0-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/OSDOCS-17948

Link to docs preview:
https://105012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-arch-tuning-operator-release-notes.html#multi-arch-tuning-operator-release-notes-1-2-2_multi-arch-tuning-operator-release-notes

QE review:
- [x] QE has approved this change.
