### PR TITLE
OSDOCS-15747: Support for GCP Spot VMs

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -30,11 +30,20 @@ include::modules/machineset-gcp-pd-disk-types.adoc[leveloffset=+1]
 //Configuring Confidential VM by using machine sets
 include::modules/machineset-gcp-confidential-vm.adoc[leveloffset=+1]
 
+//Machine sets that deploy machines as Spot VMs
+include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
+
+//Creating Spot VMs by using compute machine sets
+include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+2]
+
+//Module is reused a second time for legacy option and gets new context, which is reset after this feature
+:context: legacy-preempt
 //Machine sets that deploy machines as preemptible VM instances
 include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
 
 //Creating preemptible VM instances by using compute machine sets
 include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+2]
+:context: creating-machineset-gcp
 
 //Configuring Shielded VM options by using machine sets
 include::modules/machineset-gcp-shielded-vms.adoc[leveloffset=+1]

--- a/modules/machineset-creating-non-guaranteed-instances.adoc
+++ b/modules/machineset-creating-non-guaranteed-instances.adoc
@@ -13,16 +13,27 @@ endif::[]
 ifeval::["{context}" == "creating-machineset-gcp"]
 :gcp:
 endif::[]
+ifeval::["{context}" == "legacy-preempt"]
+:gcp-legacy-preempt:
+endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="machineset-creating-non-guaranteed-instance_{context}"]
 ifdef::aws[= Creating Spot Instances by using compute machine sets]
 ifdef::azure[= Creating Spot VMs by using compute machine sets]
-ifdef::gcp[= Creating preemptible VM instances by using compute machine sets]
+ifdef::gcp[= Creating Spot VMs by using compute machine sets]
+ifdef::gcp-legacy-preempt[= Creating preemptible VM instances by using compute machine sets]
 
-ifdef::aws[You can launch a Spot Instance on AWS by adding `spotMarketOptions` to your compute machine set YAML file.]
-ifdef::azure[You can launch a Spot VM on Azure by adding `spotVMOptions` to your compute machine set YAML file.]
-ifdef::gcp[You can launch a preemptible VM instance on {gcp-short} by adding `preemptible` to your compute machine set YAML file.]
+[role="_abstract"]
+You can save on costs by creating a compute machine set that deploys machines as non-guaranteed instances.
+ifdef::aws[To launch a Spot Instance on {aws-short}, you add `spotMarketOptions` to your compute machine set YAML file.]
+ifdef::azure[To launch a Spot VM on {azure-short}, you add `spotVMOptions` to your compute machine set YAML file.]
+ifdef::gcp[To launch a Spot VM on {gcp-short}, you add `provisioningModel: "Spot"` to your compute machine set YAML file.]
+ifdef::gcp-legacy-preempt[]
+To launch a preemptible VM instance on {gcp-short}, you add `preemptible` to your compute machine set YAML file.
+
+include::snippets/google-spot-over-preemtible.adoc[]
+endif::[]
 
 .Procedure
 * Add the following line under the `providerSpec` field:
@@ -66,12 +77,31 @@ ifdef::gcp[]
 ----
 providerSpec:
   value:
+    provisioningModel: "Spot"
+----
++
+If you specify `provisioningModel: "Spot"`, the machine is labeled as an `interruptible-instance` after the instance is launched.
++
+[NOTE]
+====
+This parameter is not compatible with setting the `providerSpec.value.preemptible` value to `true`.
+====
+endif::gcp[]
+ifdef::gcp-legacy-preempt[]
+[source,yaml]
+----
+providerSpec:
+  value:
     preemptible: true
 ----
 +
 If `preemptible` is set to `true`, the machine is labeled as an `interruptible-instance` after the instance is launched.
-
-endif::gcp[]
++
+[NOTE]
+====
+This parameter is not compatible with setting the `providerSpec.value.provisioningModel` value to `"Spot"`.
+====
+endif::gcp-legacy-preempt[]
 
 ifeval::["{context}" == "creating-machineset-aws"]
 :!aws:
@@ -81,4 +111,7 @@ ifeval::["{context}" == "creating-machineset-azure"]
 endif::[]
 ifeval::["{context}" == "creating-machineset-gcp"]
 :!gcp:
+endif::[]
+ifeval::["{context}" == "legacy-preempt"]
+:!gcp-legacy-preempt:
 endif::[]

--- a/modules/machineset-non-guaranteed-instance.adoc
+++ b/modules/machineset-non-guaranteed-instance.adoc
@@ -13,21 +13,34 @@ endif::[]
 ifeval::["{context}" == "creating-machineset-gcp"]
 :gcp:
 endif::[]
+ifeval::["{context}" == "legacy-preempt"]
+:gcp-legacy-preempt:
+endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id="machineset-non-guaranteed-instance_{context}"]
 ifdef::aws[= Machine sets that deploy machines as Spot Instances]
 ifdef::azure[= Machine sets that deploy machines as Spot VMs]
-ifdef::gcp[= Machine sets that deploy machines as preemptible VM instances]
+ifdef::gcp[= Machine sets that deploy machines as Spot VMs]
+ifdef::gcp-legacy-preempt[= Machine sets that deploy machines preemptible VM instances]
+
+[role="_abstract"]
 ifdef::aws[]
-You can save on costs by creating a compute machine set running on AWS that deploys machines as non-guaranteed Spot Instances. Spot Instances utilize unused AWS EC2 capacity and are less expensive than On-Demand Instances. You can use Spot Instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
+You can save on costs by creating a compute machine set running on AWS that deploys machines as non-guaranteed Spot Instances. Spot Instances use unused AWS EC2 capacity and are less expensive than On-Demand Instances. You can use Spot Instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
 endif::aws[]
 ifdef::azure[]
-You can save on costs by creating a compute machine set running on Azure that deploys machines as non-guaranteed Spot VMs. Spot VMs utilize unused Azure capacity and are less expensive than standard VMs. You can use Spot VMs for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
+You can save on costs by creating a compute machine set running on Azure that deploys machines as non-guaranteed Spot VMs. Spot VMs use unused Azure capacity and are less expensive than standard VMs. You can use Spot VMs for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
 endif::azure[]
 ifdef::gcp[]
-You can save on costs by creating a compute machine set running on {gcp-short} that deploys machines as non-guaranteed preemptible VM instances. Preemptible VM instances utilize excess Compute Engine capacity and are less expensive than normal instances. You can use preemptible VM instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
+You can save on costs by creating a compute machine set running on {gcp-short} that deploys machines as non-guaranteed Spot VMs.
+Spot VMs use excess Compute Engine capacity and are less expensive than normal instances.
+You can use Spot VMs for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
 endif::gcp[]
+ifdef::gcp-legacy-preempt[]
+You can save on costs by creating a compute machine set running on {gcp-short} that deploys machines as non-guaranteed preemptible VM instances.
+Preemptible VM instances use excess Compute Engine capacity and are less expensive than normal instances.
+You can use preemptible VM instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
+endif::gcp-legacy-preempt[]
 
 ifdef::aws[]
 AWS EC2 can terminate a Spot Instance at any time. AWS gives a two-minute warning to the user when an interruption occurs. {product-title} begins to remove the workloads from the affected instances when AWS issues the termination warning.
@@ -53,7 +66,26 @@ Interruptions can occur when using Spot VMs for the following reasons:
 When Azure terminates an instance, a termination handler running on the Spot VM node deletes the machine resource. To satisfy the compute machine set `replicas` quantity, the compute machine set creates a machine that requests a Spot VM.
 endif::azure[]
 ifdef::gcp[]
-{gcp-short} Compute Engine can terminate a preemptible VM instance at any time. Compute Engine sends a preemption notice to the user indicating that an interruption will occur in 30 seconds. {product-title} begins to remove the workloads from the affected instances when Compute Engine issues the preemption notice. An ACPI G3 Mechanical Off signal is sent to the operating system after 30 seconds if the instance is not stopped. The preemptible VM instance is then transitioned to a `TERMINATED` state by Compute Engine.
+include::snippets/google-spot-over-preemtible.adoc[]
+
+{gcp-short} Compute Engine can terminate a Spot VM at any time.
+Compute Engine sends a best-effort preemption notice to the user indicating that an interruption will occur after 30 seconds.
+{product-title} begins to remove the workloads from the affected instances when Compute Engine issues the preemption notice.
+An ACPI G3 Mechanical Off signal is sent to the operating system after 30 seconds if the instance is not stopped.
+The Spot VM is then transitioned to a `TERMINATED` state by Compute Engine.
+
+Interruptions can occur when using Spot VMs for the following reasons:
+
+* There is a system or maintenance event
+* The supply of Spot VMs decreases
+
+When {gcp-short} terminates an instance, a termination handler running on the Spot VM node deletes the machine resource.
+To satisfy the compute machine set `replicas` quantity, the compute machine set creates a machine that requests a Spot VM.
+endif::gcp[]
+ifdef::gcp-legacy-preempt[]
+include::snippets/google-spot-over-preemtible.adoc[]
+
+{gcp-short} Compute Engine can terminate a preemptible VM instance at any time. Compute Engine sends a preemption notice to the user indicating that an interruption will occur after 30 seconds. {product-title} begins to remove the workloads from the affected instances when Compute Engine issues the preemption notice. An ACPI G3 Mechanical Off signal is sent to the operating system after 30 seconds if the instance is not stopped. The preemptible VM instance is then transitioned to a `TERMINATED` state by Compute Engine.
 
 Interruptions can occur when using preemptible VM instances for the following reasons:
 
@@ -62,7 +94,7 @@ Interruptions can occur when using preemptible VM instances for the following re
 * The instance reaches the end of the allotted 24-hour period for preemptible VM instances
 
 When {gcp-short} terminates an instance, a termination handler running on the preemptible VM instance node deletes the machine resource. To satisfy the compute machine set `replicas` quantity, the compute machine set creates a machine that requests a preemptible VM instance.
-endif::gcp[]
+endif::gcp-legacy-preempt[]
 
 ifeval::["{context}" == "creating-machineset-aws"]
 :!aws:
@@ -72,4 +104,7 @@ ifeval::["{context}" == "creating-machineset-azure"]
 endif::[]
 ifeval::["{context}" == "creating-machineset-gcp"]
 :!gcp:
+endif::[]
+ifeval::["{context}" == "legacy-preempt"]
+:!gcp-legacy-preempt:
 endif::[]

--- a/snippets/google-spot-over-preemtible.adoc
+++ b/snippets/google-spot-over-preemtible.adoc
@@ -1,0 +1,11 @@
+// Text snippet included in the following modules:
+//
+// * modules/machineset-creating-non-guaranteed-instances.adoc
+// * modules/machineset-non-guaranteed-instance.adoc
+
+:_mod-docs-content-type: SNIPPET
+
+[NOTE]
+====
+{gcp-short} recommends using Spot VMs over preemptible VMs because Spot VMs include new features that preemptible VMs do not support.
+====


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-17764](https://issues.redhat.com/browse/OSDOCS-17764) / [OSDOCS-15747](https://issues.redhat.com//browse/OSDOCS-15747)

Link to docs preview:
[Creating Spot VMs by using compute machine sets](https://105013--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-non-guaranteed-instance_creating-machineset-gcp)

QE review:
- [x] QE has approved this change.

Additional information: