### PR TITLE
OSDOCS-15747: Support for GCP Spot VMs Rel Notes

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -256,13 +256,11 @@ You can now use a `MachineConfig` object to change the installed disk partition 
 [id="ocp-release-notes-machine-management_{context}"]
 == Machine management
 
-////
-Instructions: Add entries in the following format:
-
-Item description::
+Creating {gcp-short} Spot VMs by using compute machine sets::
+With this release, {product-title} supports deploying Machine API compute machines on Spot VMs in {gcp-short} clusters.
+{gcp-short} recommends using Spot VMs over their predecessor, preemptible VMs, because they include new features that preemptible VMs do not support.
 +
-Detailed information.
-////
+For more information, see xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-non-guaranteed-instance_creating-machineset-gcp[Machine sets that deploy machines as Spot VMs].
 
 Additional control plane machine set failure domain options for {azure-short}::
 This release includes additional configuration options for control plane machine set failure domains on {azure-full}.


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-17946](https://issues.redhat.com/browse/OSDOCS-17946) / [OSDOCS-15747](https://issues.redhat.com//browse/OSDOCS-15747)

Link to docs preview:
[Machine management](https://105014--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-machine-management_release-notes): Creating Google Cloud Spot VMs by using compute machine sets

QE review:
- [x] QE has approved this change.

Additional information:
Feature docs PR: https://github.com/openshift/openshift-docs/pull/105013