### PR TITLE
OSDOCS#17894: Update the z-stream RNs for 4.20.11

### DIFF
--- a/modules/zstream-4-20-11-about.adoc
+++ b/modules/zstream-4-20-11-about.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-20-11-about_{context}"]
+= RHSA-2026:0663 - {product-title} {product-version}.11 fixed issues advisory
+
+[role="_abstract"]
+Issued: 20 January 2026
+
+{product-title} release {product-version}.11 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:0663[RHSA-2026:0663] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:0661[RHBA-2026:0661] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.11 --pullspecs
+----

--- a/modules/zstream-4-20-11-enhancements.adoc
+++ b/modules/zstream-4-20-11-enhancements.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-11-enhancements_{context}"]
+= Enhancements
+
+[role="_abstract"]
+The following enhancements are included in this z-stream release:
+
+* With this update, the Cluster Network Operator supports `KubeVirt` as a platform for dual-stack networking in {VirtProductName}, resolving a previous issue where `KubeVirt` was not recognized as a supported platform for dual-stack. This enhancement enables successful deployment of {hcp} on {VirtProductName} with IPv4 and IPv6 dual-stack networking. This improvement reduces deployment failures and ensures a smoother experience for users deploying {VirtProductName} with `KubeVirt`. (link:https://issues.redhat.com/browse/OCPBUGS-66253[OCPBUGS-66253])

--- a/modules/zstream-4-20-11-fixed-issues.adoc
+++ b/modules/zstream-4-20-11-fixed-issues.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-11-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issues are fixed for this release:
+
+* Before this update, Domain Name System (DNS) pods that were deleted and then re-created in {product-title} clusters that used OVN-Kubernetes networking caused inactive User Datagram Protocol (UDP) entries to remain on worker nodes. With this release, when DNS pods are deleted or updated, the cleanup process correctly uses service port 53 to match and remove inactive entries. (link:https://issues.redhat.com/browse/OCPBUGS-66049[OCPBUGS-66049])
+
+* Before this update, function misuse with non-standard input caused unexpected behavior and led to user data loss due to buffer overflow in error logging. With this release, database connection settings are updated to resolve intermittent connection errors and ensure error logging functions. These updates result in improved system stability and smooth operation. (link:https://issues.redhat.com/browse/OCPBUGS-69732[OCPBUGS-69732])
+
+* Before this update, the same version for upgrades in multi-architecture environments was incorrectly recommended due to an unapproved pull request (PR). With this release, the correct version for upgrades in multi-architecture environments is recommended. As a result, cluster upgrade compatibility is improved in these environments. (link:https://issues.redhat.com/browse/OCPBUGS-70180[OCPBUGS-70180])
+
+* Before this update, the instance architecture in worker machines did not match the Amazon Machine Image (AMI) architecture, which caused a mismatch with the user's instance type. This resulted in failed installations. With this release, the ARM64 AMI architecture mismatch with the x86_64 instance type is resolved. As a result, the installation process does not fail due to an architecture mismatch and improves the successful provisioning of worker machines. (link:https://issues.redhat.com/browse/OCPBUGS-70322[OCPBUGS-70322])
+
+* Before this update, a {op-system-first} networking timeout occurred during agent-based {product-title} installation on Virtual Local Area Network (VLAN) interfaces. As a consequence, {op-system} nodes failed to automatically configure networking during installation on bare metal systems. With this release, the {op-system} networking auto-configuration timeout has been fixed, allowing automatic network setup. As a result, {op-system} nodes automatically configure networking during installation on bare metal systems. (link:https://issues.redhat.com/browse/OCPBUGS-71212[OCPBUGS-71212])

--- a/modules/zstream-4-20-11-updating.adoc
+++ b/modules/zstream-4-20-11-updating.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-11-updating_{context}"]
+= Updating
+
+
+[role="_abstract"]
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3011,6 +3011,18 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// About 4-20-11 release notes
+include::modules/zstream-4-20-11-about.adoc[leveloffset=+2]
+
+// 4-20-11 release notes enhancements
+include::modules/zstream-4-20-11-enhancements.adoc[leveloffset=+3]
+
+// 4-20-11 release notes fixed issues
+include::modules/zstream-4-20-11-fixed-issues.adoc[leveloffset=+3]
+
+// 4-20-11 release notes updating
+include::modules/zstream-4-20-11-updating.adoc[leveloffset=+3]
+
 // About 4-20-10 release notes
 include::modules/zstream-4-20-10-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20.11

Issue:
[OSDOCS-17894](https://issues.redhat.com//browse/OSDOCS-17894)

Link to docs preview:
[4.20.11](https://105015--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-11-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:

- Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/311#3f1088e50697c19533e0a568c698ae637b2b36fa)
- ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20)
