### PR TITLE
OLS-2509: Update procedure for Providing custom knowledge to the LLM

### DIFF
--- a/modules/ols-providing-custom-knowledge-to-the-llm.adoc
+++ b/modules/ols-providing-custom-knowledge-to-the-llm.adoc
@@ -5,7 +5,10 @@
 [id="providing-custom-knowledge-to-the-llm_{context}"]
 = Providing custom knowledge to the LLM
 
-Customize the information available to the large language model (LLM) by providing access to a container image that resides in a remote image registry. The examples in this procedure use `quay.io` as the remote container image registry, and the path for the custom image is `quay.io/<username>/my-byok-image:latest`.
+[role="_abstract"]
+To customize the data available to a large language model (LLM), you can provide access to a container image stored in a remote registry. This action allows the model to utilize specific content for more accurate results.
+
+The examples in this procedure use `quay.io` as the remote container image registry. The path for the custom image is `quay.io/<username>/my-byok-image:latest`.
 
 :FeatureName: The BYO Knowledge tool
 include::snippets/technology-preview.adoc[]
@@ -92,8 +95,7 @@ $ podman push quay.io/<username>/my-byok-image:latest
 
 .. Insert the `spec.ols.rag` yaml code:
 +
-.Example `OLSconfig` CR file
-[source,yaml,subs="attributes,verbatim"]
+[source,yaml]
 ----
 apiVersion: ols.openshift.io/v1alpha1
 kind: OLSConfig
@@ -102,9 +104,31 @@ metadata:
 spec:
   ols:
     rag:
-      - image: quay.io/<username>/my-byok-image:latest # <1>  
+      - image: quay.io/<username>/my-byok-image:latest 
 ----
-<1> Where `image` specifies the tag for the image that was pushed to the image registry so that the {ols-long} Operator can access the custom content. The {ols-long} Operator can work with more than one RAG database that you create.
++
+* `spec.ols.rag.image` specifies the tag for the image that was pushed to the image registry so that the {ols-long} Operator can access the custom content. The {ols-long} Operator can work with more than one RAG database that you create.
+
+. Optional: Specify pull secrets in the `OLSSpec` section of the `OLSConfig` CR file. These secrets provide authentication for remote registries. Use this optional field if your RAG BYO Knowledge images reside in a private registry that the standard cluster-wide pull secret cannot access.
++
+[source,yaml]
+----
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+  namespace: openshift-lightspeed
+spec:
+  llm:
+    providers:
+...
+  ols:
+    imagePullSecrets:
+      - name: <my_pull_secret_1>
+      - name: <my_pull_secret_2>
+----
++ 
+* `spec.ols.imagePullSecrets` defines the pull secrets that {ols-long} uses only when you specify BYO Knowledge RAG images. Instead of linking a specific secret to a specific image, the system maintains a general list of pull secrets. For every BYO Knowledge image, the system tries each pull secret in sequential order until it achieves a successful authentication.
 
 . Click *Save*.
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue: https://issues.redhat.com/browse/OLS-2509

Link to docs preview:
https://105053--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#providing-custom-knowledge-to-the-llm_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
