### PR TITLE
OSDOCS-16461:adds 4.21.0 async relnote MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-21-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-21-release-notes.adoc
@@ -15,7 +15,7 @@ include::modules/microshift-4-21-new-features-enhancements.adoc[leveloffset=+1]
 
 include::modules/microshift-4-21-tech-preview.adoc[leveloffset=+1]
 
-include::modules/microshift-4-21-bug-fixes.adoc[leveloffset=+1]
+//include::modules/microshift-4-21-bug-fixes.adoc[leveloffset=+1]
 
 include::modules/microshift-4-21-known-issues.adoc[leveloffset=+1]
 

--- a/modules/microshift-4-21-0-async.adoc
+++ b/modules/microshift-4-21-0-async.adoc
@@ -4,14 +4,19 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="microshift-4-21-0-async_{context}"]
-= RHEA-2026:XXXXX - {microshift-short} 4.21.0 bug fix and enhancement update
+= RHEA-2025:23728 - {microshift-short} 4.21.0 bug fix and enhancement update
 
 [role="_abstract"]
-Issued: DD Month 2026
+Issued: 01 February 2026
 
-{product-title} release 4.21.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2026:XXXX[RHEA-2026:XXXXX] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHXX-2026:XXXX[RHXX-2026:XXXX] advisory.
+{product-title} release 4.21.0 is now available. Bug fixes and enhancements are listed in the link:https://access.redhat.com/errata/RHEA-2025:23728[RHEA-2025:23728] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHBA-2026:1481[RHBA-2026:1481] advisory.
 
 See the latest images included with {microshift-short} by using the following instructions:
 
 * xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
 * xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-21-0-enhancement_{context}"]
+== Enhancement
+
+* Before this update, the readiness detection mechanism in MicroShift had inefficient polling intervals and redundant client creation that delayed startup confirmation and resource readiness detection. With this release, the mechanism has been enhanced to reduce polling intervals and eliminate redundant client creation. As a result, deployment readiness is confirmed faster, which reduces startup delays and improves resource readiness detection. (link:https://issues.redhat.com/browse/OCPBUGS-65846[OCPBUGS-65846])

--- a/modules/microshift-4-21-new-features-enhancements.adoc
+++ b/modules/microshift-4-21-new-features-enhancements.adoc
@@ -37,9 +37,9 @@ You can now use the SR-IOV Network Operator to configure and access high-perform
 [id="microshift-4-21-doc-enhancements_{context}"]
 == Documentation enhancements
 
-With this release, instructions for managing storage in {microshift-short} are updated.
-//For more information, see 
-//xref:../storage-overview-microshift/index.adoc#index[Storage overview].
+With this release, instructions for managing storage in {microshift-short} are updated. For more information, see the following link:
+
+* xref:../microshift_storage/index.adoc#index[Storage]
 
 //[id="microshift-4-21-doc-enhancements_{context}"]
 //== Documentation enhancements


### PR DESCRIPTION
**This PR is for the MicroShift 4.21 errata Release Note that is scheduled for February 1, 2026. Do not merge until that date."

Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-16461

Link to docs preview:
https://105061--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html#microshift-4-21-0-enhancement_release-notes

QE review:
- [ ] QE has approved this change.