### PR TITLE
OSDOCS-16161-re: Removed the nodes-nodes-audit-policy-custom.adoc note

### DIFF
--- a/modules/nodes-nodes-audit-policy-custom.adoc
+++ b/modules/nodes-nodes-audit-policy-custom.adoc
@@ -6,14 +6,10 @@
 [id="configuring-audit-policy-custom_{context}"]
 = Configuring the audit log policy with custom rules
 
-You can configure an audit log policy that defines custom rules. You can specify multiple groups and define which profile to use for that group.
+[role="_abstract"]
+To apply custom rules without inheriting settings from a pre-defined profile, configure an audit log policy. This configuration ensures that only your specific rules are enforced, providing precise control over audit logging.
 
-These custom rules take precedence over the top-level profile field. The custom rules are evaluated from top to bottom, and the first that matches is applied.
-
-[IMPORTANT]
-====
-If you set the top-level profile field to `None`, an API server, such as the Kubernetes API server, ignores custom rules and disables audit logging.
-====
+You can set a profile to `Default`, `WriteRequestBodies`, `AllRequestBodies`, or `None`.
 
 .Prerequisites
 
@@ -28,7 +24,7 @@ If you set the top-level profile field to `None`, an API server, such as the Kub
 $ oc edit apiserver cluster
 ----
 
-. Add the `spec.audit.customRules` field:
+. Add the `spec.audit.customRules` parameter:
 +
 [source,yaml]
 ----
@@ -38,21 +34,24 @@ metadata:
 ...
 spec:
   audit:
-    customRules:                        <1>
+    customRules:
     - group: system:authenticated:oauth
       profile: WriteRequestBodies
     - group: system:authenticated
       profile: AllRequestBodies
-    profile: Default                    <2>
+    profile: Default
 ----
-<1> Add one or more groups and specify the profile to use for that group. These custom rules take precedence over the top-level profile field. The custom rules are evaluated from top to bottom, and the first that matches is applied.
-<2> Set to `Default`, `WriteRequestBodies`, or `AllRequestBodies`. If you do not set this top-level profile field, it defaults to the `Default` profile.
++
+where:
++
+`audit.customRules`:: Specifies the profile to use for that group. You can add one or more groups.
+`audit.profile`:: Specifies one of the following settings: `Default`, `WriteRequestBodies`, `AllRequestBodies`, or `None`. If you do not set a value for the parameter, the value defaults to the `Default` profile.
 
 . Save the file to apply the changes.
 
 .Verification
 
-* Verify that a new revision of the Kubernetes API server pods is rolled out. It can take several minutes for all nodes to update to the new revision.
+* Verify that a new revision of the Kubernetes API server pods is rolled out. The rollout operation can take several minutes for all nodes to update to the new revision.
 +
 [source,terminal]
 ----
@@ -64,11 +63,14 @@ Review the `NodeInstallerProgressing` status condition for the Kubernetes API se
 [source,terminal]
 ----
 AllNodesAtLatestRevision
-3 nodes are at revision 12 <1>
+3 nodes are at revision 12
 ----
-<1> In this example, the latest revision number is `12`.
++
+where:
++
+`revision`: Specifies the latest revision number. The example shows `12` as the revision number.
 +
 If the output shows a message similar to one of the following messages, the update is still in progress. Wait a few minutes and try again.
-
++
 ** `3 nodes are at revision 11; 0 nodes have achieved new revision 12`
 ** `2 nodes are at revision 11; 1 nodes are at revision 12`


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-16161](https://issues.redhat.com/browse/OSDOCS-16161)

Link to docs preview:
* [Configuring the audit log policy with custom rules](https://105064--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/audit-log-policy-config.html#configuring-audit-policy-custom_audit-log-policy-config)

- [ ] SME has approved this change (SAYED AMRIN HANIF/Damien Grisonnet).
- [ ] QE has approved this change (Rahul Gangwar).

[Google doc](https://docs.google.com/document/d/1XZcByIQjHK_hWSvhGEiGz8MzaG3foigcGySedSIi824/edit?tab=t.0)

Contacted Dean West and Kevin Rizza
