### PR TITLE
[OSDOCS#17969]: Update z-stream release notes for 4.17.47

### DIFF
--- a/modules/zstream-4-17-44-fixed-issues.adoc
+++ b/modules/zstream-4-17-44-fixed-issues.adoc
@@ -3,8 +3,8 @@
 // * release_notes/ocp-4-17-release-notes.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="zstream-4-17-44-bug-fixes_{context}"]
-= Bug fixes
+[id="zstream-4-17-44-fixed-issues_{context}"]
+= Fixed issues
 
 [role="_abstract"]
 

--- a/modules/zstream-4-17-45-fixed-issues.adoc
+++ b/modules/zstream-4-17-45-fixed-issues.adoc
@@ -3,8 +3,8 @@
 // * release_notes/ocp-4-17-release-notes.adoc
 
 :_mod-docs-content-type: REFERENCE
-[id="zstream-4-17-45-bug-fixes_{context}"]
-= Bug fixes
+[id="zstream-4-17-45-fixed-issues_{context}"]
+= Fixed issues
 
 [role="_abstract"]
 The following bugs are fixed for this release:

--- a/modules/zstream-4-17-47-about.adoc
+++ b/modules/zstream-4-17-47-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-17-47-about_{context}"]
+= RHSA-2026:0715 - {product-title} {product-version}.47 bug fix advisory
+
+[role="_abstract"]
+Issued: 21 January 2026
+
+{product-title} release {product-version}.47 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:0715[RHSA-2026:0715] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:0701[RHBA-2025:0701] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.17.47--pullspecs
+----

--- a/modules/zstream-4-17-47-enhancements.adoc
+++ b/modules/zstream-4-17-47-enhancements.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-47-enhancements_{context}"]
+= Enhancements
+
+[role="_abstract"]
+
+The following new features are available in this release:
+
+* You can now collect logs that contain command-line information from `virt-launcher` pods. These logs serve as a centralized record of the JSON-encoded command-line options used to start virtual machines. You can use this data to troubleshoot and analyze virtual machine startup issues. This feature is backported to specific {product-title} versions. (link:https://issues.redhat.com/browse/OCPBUGS-61775[OCPBUGS-61775])
+
+

--- a/modules/zstream-4-17-47-fixed-issues.adoc
+++ b/modules/zstream-4-17-47-fixed-issues.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-47-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issues are fixed with this release:
+
+* Before this release, pods on the same node could not reach a pod's secondary `Localnet` interface on a `br-ex` bridge, so the pod defaulted to the primary network. With this release, communication between a `Localnet` pod and a pod running on the same node is possible, if the `Localnet` network's IP addresses are on the same subnet as the host network. (link:https://issues.redhat.com/browse/OCPBUGS-59381[OCPBUGS-59381])
+
+* Before this update, bonded network configurations with `mode=active-backup` and `fail_over_mac=follow` failed due to a race condition, causing interfaces to be activated multiple times and leading to unpredictable states and identical MAC addresses. As a consequence, these configurations flapped, causing high availability issues. With this release, the bonded network configuration issue is fixed by modifying `configure-ovs.sh` to check for both `activating` and `active` states. As a result, bonded network configurations with `active-backup` mode and `fail_over_mac=follow` does not flap, ensuring high availability.
+ (link:https://issues.redhat.com/browse/OCPBUGS-60890[OCPBUGS-60890])
+
+* Before this update, Prometheus `Remote-Write` caused alerts due to dropped samples in relabeling configuration. As a consequence, the Prometheus `Remote-Write Behind` alert was active. With this release, the `Remote-Write` issue is resolved, and dropped samples do not trigger the alert. As a result, the Prometheus `Remote-Write Behind` alert does not become active when samples are dropped due to relabeling configuration. (link:https://issues.redhat.com/browse/OCPBUGS-61766[OCPBUGS-61766])
+
+* Before this update, `NMState` service failed due to a dependency issue with `NetworkManager-wait-online` in bare metal deployments. As a consequence, the `NMState` service failed in {product-title} deployments, causing `br-ex` configuration issues and deployment failures. With this release, the `NetworkManager-wait-online` dependency issue is resolved, and ensures that the `NMState` service does not fail in {product-title} deployments, and network configuration is applied correctly. (link:https://issues.redhat.com/browse/OCPBUGS-61859[OCPBUGS-61859])
+

--- a/modules/zstream-4-17-47-updating.adoc
+++ b/modules/zstream-4-17-47-updating.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-17-47-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+
+To update an {product-title} 4.17 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+

--- a/release_notes/ocp-4-17-release-notes.adoc
+++ b/release_notes/ocp-4-17-release-notes.adoc
@@ -2942,35 +2942,49 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
-//  4.17.46 about
+//  4.17.47 about
+include::modules/zstream-4-17-47-about.adoc[leveloffset=+2]
+
+//4.17.47 bug fixes
+include::modules/zstream-4-17-47-fixed-issues.adoc[leveloffset=+2]
+
+//4.17.47 enhancements
+include::modules/zstream-4-17-47-enhancements.adoc[leveloffset=+2]
+
+//4.17.47 updating
+include::modules/zstream-4-17-47-updating.adoc[leveloffset=+2]
+
+
+// 4.17.46 about
 include::modules/zstream-4-17-46-about.adoc[leveloffset=+2]
 
 //4.17.46 bug fixes
 include::modules/zstream-4-17-46-fixed-issues.adoc[leveloffset=+2]
 
-//4.17.46 bug fixes
+//4.17.46 updating
 include::modules/zstream-4-17-46-updating.adoc[leveloffset=+2]
 
-//  4.17.45 about
+
+// 4.17.45 about
 include::modules/zstream-4-17-45-about.adoc[leveloffset=+2]
 
 //4.17.45 bug fixes
-include::modules/zstream-4-17-45-bug-fixes.adoc[leveloffset=+2]
+include::modules/zstream-4-17-45-fixed-issues.adoc[leveloffset=+2]
 
-//4.17.45 bug fixes
+//4.17.45 updating
 include::modules/zstream-4-17-45-updating.adoc[leveloffset=+2]
 
 
-//  4.17.44 about
+// 4.17.44 about
 include::modules/zstream-4-17-44-about.adoc[leveloffset=+2]
 
 //4.17.44 bug fixes
-include::modules/zstream-4-17-44-bug-fixes.adoc[leveloffset=+2]
+include::modules/zstream-4-17-44-fixed-issues.adoc[leveloffset=+2]
 
-//4.17.44 bug fixes
+//4.17.44 updating
 include::modules/zstream-4-17-44-updating.adoc[leveloffset=+2]
 
-// 4.17.42
+// 4.17.43
 [id="ocp-4-17-43_{context}"]
 === RHBA-2025:19314 - {product-title} {product-version}.43 bug fix update and security
 


### PR DESCRIPTION
Version(s):
4.17

Issue:
https://issues.redhat.com/browse/OSDOCS-17969

Link to docs preview:
[4.17.47](https://105085--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-17-release-notes.html#zstream-4-17-47-about_release-notes)

QE review:
- [ ] QE has approved this change.


Additional information:


