### PR TITLE
[enterprise-4.18] CNV#40857: VMs mount same PVC in read-write 4.18

### DIFF
--- a/modules/virt-storage-pv-csi-overview.adoc
+++ b/modules/virt-storage-pv-csi-overview.adoc
@@ -2,10 +2,18 @@
 //
 // * virt/storage/virt-storage-with-csi-paradigm.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="virt-storage-vp-csi-overview_{context}"]
 = Virtual machine CSI storage overview
 
-{VirtProductName} integrates with the Container Storage Interface (CSI) to manage VM storage. Storage classes define storage capabilities such as performance tiers and types. PersistentVolumeClaims (PVCs) request storage resources, which bind to PersistentVolumes (PVs). CSI drivers connect Kubernetes to vendor storage backends, including iSCSI, NFS, and Fibre Channel.
+[role="_abstract"]
+{VirtProductName} integrates with the Container Storage Interface (CSI) to manage virtual machine (VM) storage.
+
+Storage classes define storage capabilities such as performance tiers and types. PersistentVolumeClaims (PVCs) request storage resources, which bind to PersistentVolumes (PVs). CSI drivers connect Kubernetes to vendor storage backends, including iSCSI, NFS, and Fibre Channel.
+
+[IMPORTANT]
+====
+A VM can start even if its PVC is already mounted by another pod. This behavior follows Kubernetes PVC access semantics and can lead to data corruption if multiple writers access the same volume.
+====
 
 image:virt-storage-csi-paradigm.png[title="Virtual machine disks and the CSI paradigm"]


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/CNV-40857

Link to docs preview:
https://105090--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-storage-with-csi-paradigm.html

Additional information:
4.18 cherry-pick 45c9ec30103d5dfc8553cd5ad405592ae100a189 (xref: #104980)

