### PR TITLE
OSDOCS-15819 day 2 firewall management note

### DIFF
--- a/modules/installation-gcp-user-managed-firewall-rules.adoc
+++ b/modules/installation-gcp-user-managed-firewall-rules.adoc
@@ -9,6 +9,11 @@
 [role="_abstract"]
 You can manage your own firewall rules when installing a cluster on {gcp-short} into an existing VPC by enabling the `firewallRulesManagement` parameter in the `install-config.yaml` file. You can limit the permissions that you grant to the installation program by managing your own firewall rules.
 
+[IMPORTANT]
+====
+If you manage your own firewall rules, you must continue to manage them through the lifetime of the cluster. If you create a new service, create a new firewall rule that permits traffic on the service port, from the desired source addresses to the compute nodes. An example rule is described in the table below.
+====
+
 If you want to manage your own firewall rules, you must create the following rules before installation:
 
 [cols="1,1,1,1"]
@@ -59,6 +64,11 @@ If you want to manage your own firewall rules, you must create the following rul
 |`tcp:30000-32767`
 |`35.191.0.0/16`, `130.211.0.0/22`, `209.85.152.0/22`, `209.85.204.0/22`
 |`<control_plane_node_tags>`, `<compute_node_tags>`
+
+|`<sample_rule_name>`
+|`<service_port>`
+|`<allowed_external_cidr>`
+|`<compute_node_tags>`
 |====
 where:
 
@@ -66,6 +76,8 @@ where:
 `<control_plane_node_tags>`:: Specifies the network tags that apply to the control plane machines in your cluster. These tags must be specified in the `install-config.yaml` file you use to deploy the cluster.
 `<compute_node_tags>`:: Specifies the network tags that apply to the compute machines in your cluster. These tags must be specified in the `install-config.yaml` file you use to deploy the cluster.
 `<internal_network_cidr>`:: Specifies the network CIDR of the machine network that contains all the machines in your cluster.
+`<sample_rule_name>`:: Specifies the name of a custom rule added after installation, for example if you create a new service in your cluster. You can add multiple custom rules as needed.
+`<service_port>`:: Specifies the port or port range of the service you created, and the network protocol, such as TCP or UDP. If you create a service using `oc expose`, you can find the service port and protocol by running the command `oc get service <service_name> -o jsonpath='{.spec.ports[0].port}'`, where `<service_name>` is the name of the service you created.
 
 After installation, you can reduce the port range of the `ingress-k8s-http-hc` and `internal-cluster` rules from `tcp:30000-32767` to the individual port that the ingress load balancer service uses, which is not known before installation. You can determine the service port by running the following command after installation:
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-15819

Link to docs preview:
https://105093--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-user-managed-firewall-rules_installing-gcp-account

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
Day 1 PR: https://github.com/openshift/openshift-docs/pull/104757
