### PR TITLE
[enterprise-4.16] CNV#40857: VMs mount same PVC in read-write 4.16

### DIFF
--- a/modules/virt-about-libguestfs-tools-virtctl-guestfs.adoc
+++ b/modules/virt-about-libguestfs-tools-virtctl-guestfs.adoc
@@ -6,6 +6,7 @@
 [id="virt-about-libguestfs-tools-virtctl-guestfs_{context}"]
 = Libguestfs and virtctl guestfs commands
 
+[role="_abstract"]
 `Libguestfs` tools help you access and modify virtual machine (VM) disk images. You can use `libguestfs` tools to view and edit files in a guest, clone and build virtual machines, and format and resize disks.
 
 You can also use the `virtctl guestfs` command and its sub-commands to modify, inspect, and debug VM disks on a PVC. To see a complete list of possible sub-commands, enter `virt-` on the command line and press the Tab key. For example:
@@ -70,6 +71,11 @@ You can also overwrite the image's pull policy by setting the `pull-policy` opti
 |===
 
 The command also checks if a PVC is in use by another pod, in which case an error message appears. However, once the `libguestfs-tools` process starts, the setup cannot avoid a new pod using the same PVC. You must verify that there are no active `virtctl guestfs` pods before starting the VM that accesses the same PVC.
+
+[IMPORTANT]
+====
+A VM can start even if its PVC is already mounted by another pod. This behavior follows Kubernetes PVC access semantics and can lead to data corruption if multiple writers access the same volume.
+====
 
 [NOTE]
 =====


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/CNV-40857

Link to docs preview:
https://105094--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-using-the-cli-tools.html#virt-about-libguestfs-tools-virtctl-guestfs_virt-using-the-cli-tools

Additional information:
this was not cherry-picked as the documentation did not exist in 4.16. i've added the note to the most appropriate place in 4.16 (xref: #104980)

