### PR TITLE
Updates core cluster network settings docs

### DIFF
--- a/modules/nw-cfg-config-all-multi-cni.adoc
+++ b/modules/nw-cfg-config-all-multi-cni.adoc
@@ -5,9 +5,8 @@
 [id="nw-enabling-all-multi-cni_{context}"]
 = Enabling all-multicast mode by using the tuning CNI
 
-You can enable all-multicast mode by using the tuning Container Network Interface (CNI) meta plugin.
-
-The following procedure describes how to configure the tuning CNI to enable the all-multicast mode.
+[role="_abstract"]
+To enable all-multicast mode on network interfaces in {product-title}, you can use the tuning Container Network Interface (CNI) meta plugin in a network attachment definition. When enabled, the interface receives all multicast packets on the network.
 
 .Procedure
 
@@ -18,33 +17,39 @@ The following procedure describes how to configure the tuning CNI to enable the 
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: <name> <1>
-  namespace: default <2>
+  name: <name>
+  namespace: default
 spec:
   config: '{
-    "cniVersion": "0.4.0", <3>
-    "name": "<name>", <4>
+    "cniVersion": "0.4.0",
+    "name": "<name>",
     "plugins": [{
-       "type": "<main_CNI_plugin>" <5>
+       "type": "<main_CNI_plugin>"
       },
       {
-       "type": "tuning", <6>
-       "allmulti": true <7>
+       "type": "tuning",
+       "allmulti": true
         }
       }
      ]
 }
 ----
-<1> Specifies the name for the additional network attachment to create. The name must be unique within the specified namespace.
-<2> Specifies the namespace that the object is associated with.
-<3> Specifies the CNI specification version.
-<4> Specifies the name for the configuration. Match the configuration name to the name value of the network attachment definition.
-<5> Specifies the name of the main CNI plugin to configure.
-<6> Specifies the name of the CNI meta plugin.
-<7> Changes the all-multicast mode of interface. If enabled, all multicast packets on the network will be received by the interface.
 +
-An example YAML file is shown here:
+where:
 +
+--
+
+`name`:: Specifies the name for the additional network attachment to create. The name must be unique within the specified namespace.
+`namespace`:: Specifies the namespace that the object is associated with.
+`cniVersion`:: Specifies the CNI specification version.
+`name`:: Specifies the name for the configuration. Match the configuration name to the name value of the network attachment definition.
+`main_CNI_plugin`:: Specifies the name of the main CNI plugin to configure.
+`tuning`:: Specifies the name of the CNI meta plugin.
+`allmulti`:: Specifies the all-multicast mode of interface. If enabled, all multicast packets on the network will be received by the interface.
+
+--
++
+.Example network attachment definition
 [source,yaml]
 ----
 apiVersion: "k8s.cni.cncf.io/v1"
@@ -91,30 +96,37 @@ metadata:
   name: allmultipod
   namespace: default
   annotations:
-    k8s.v1.cni.cncf.io/networks: setallmulti <1>
+    k8s.v1.cni.cncf.io/networks: setallmulti
 spec:
   containers:
   - name: podexample
     image: centos
     command: ["/bin/bash", "-c", "sleep INF"]
     securityContext:
-      runAsUser: 2000 <2>
-      runAsGroup: 3000 <3>
-      allowPrivilegeEscalation: false <4>
-      capabilities: <5>
+      runAsUser: 2000
+      runAsGroup: 3000
+      allowPrivilegeEscalation: false
+      capabilities:
         drop: ["ALL"]
   securityContext:
-    runAsNonRoot: true <6>
-    seccompProfile: <7>
+    runAsNonRoot: true
+    seccompProfile:
       type: RuntimeDefault
 ----
-<1> Specifies the name of the configured `NetworkAttachmentDefinition`.
-<2> Specifies the user ID the container is run with.
-<3> Specifies which primary group ID the containers is run with.
-<4> Specifies if a pod can request privilege escalation. If unspecified, it defaults to `true`. This boolean directly controls whether the `no_new_privs` flag gets set on the container process.
-<5> Specifies the container capabilities. The `drop: ["ALL"]` statement indicates that all Linux capabilities are dropped from the pod, providing a more restrictive security profile.
-<6> Specifies that the container will run with a user with any UID other than 0.
-<7> Specifies the container's seccomp profile. In this case, the type is set to `RuntimeDefault`. Seccomp is a Linux kernel feature that restricts the system calls available to a process, enhancing security by minimizing the attack surface.
++
+where:
++
+--
+
+`k8s.v1.cni.cncf.io/networks`:: Specifies the name of the configured `NetworkAttachmentDefinition`.
+`runAsUser`:: Specifies which user ID the container is run with.
+`runAsGroup`:: Specifies which primary group ID the containers is run with.
+`allowPrivilegeEscalation`:: Specifies if a pod can request to allow privilege escalation. If unspecified, it defaults to true. This boolean directly controls whether the `no_new_privs` flag gets set on the container process.
+`capabilities`:: Specifies privileged actions without giving full root access. This policy ensures all capabilities are dropped from the pod.
+`runAsNonRoot: true`:: Specifies that the container will run with a user with any UID other than 0.
+`seccompProfile`:: Specifies the default seccomp profile for a pod or container workload.
+
+--
 
 . Apply the settings specified in the YAML file by running the following command:
 +
@@ -157,9 +169,12 @@ sh-4.4# ip link
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 2: eth0@if22: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8901 qdisc noqueue state UP mode DEFAULT group default
-    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0 <1>
+    link/ether 0a:58:0a:83:00:10 brd ff:ff:ff:ff:ff:ff link-netnsid 0
 3: net1@if24: <BROADCAST,MULTICAST,ALLMULTI,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default
-    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0 <2>
+    link/ether ee:9b:66:a4:ec:1d brd ff:ff:ff:ff:ff:ff link-netnsid 0
 ----
-<1> `eth0@if22` is the primary interface
-<2> `net1@if24` is the secondary interface configured with the network-attachment-definition that supports the all-multicast mode (ALLMULTI flag)
++
+where:
+
+`eth0@if22`:: Specifies the primary interface.
+`net1@if24`:: Specifies the secondary interface configured with the network-attachment-definition that supports the all-multicast mode (ALLMULTI flag).

--- a/modules/nw-cfg-tuning-interface-cni.adoc
+++ b/modules/nw-cfg-tuning-interface-cni.adoc
@@ -5,7 +5,8 @@
 [id="nw-configuring-tuning-cni_{context}"]
 = Configuring system controls by using the tuning CNI
 
-The following procedure configures the tuning CNI to change the interface-level network `net.ipv4.conf.IFNAME.accept_redirects` sysctl. This example enables accepting and sending ICMP-redirected packets. In the tuning CNI meta plugin configuration, the interface name is represented by the `IFNAME` token and is replaced with the actual name of the interface at runtime.
+[role="_abstract"]
+To configure interface-level network sysctls in {product-title}, you can use the tuning CNI meta plugin in a network attachment definition. Configure the `net.ipv4.conf.IFNAME.accept_redirects` sysctl to enable accepting and sending ICMP-redirected packets.
 
 .Procedure
 
@@ -16,34 +17,40 @@ The following procedure configures the tuning CNI to change the interface-level 
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: <name> <1>
-  namespace: default <2>
+  name: <name>
+  namespace: default
 spec:
   config: '{
-    "cniVersion": "0.4.0", <3>
-    "name": "<name>", <4>
+    "cniVersion": "0.4.0",
+    "name": "<name>",
     "plugins": [{
-       "type": "<main_CNI_plugin>" <5>
+       "type": "<main_CNI_plugin>"
       },
       {
-       "type": "tuning", <6>
+       "type": "tuning",
        "sysctl": {
-            "net.ipv4.conf.IFNAME.accept_redirects": "1" <7>
+            "net.ipv4.conf.IFNAME.accept_redirects": "1"
         }
       }
      ]
 }
 ----
-<1> Specifies the name for the additional network attachment to create. The name must be unique within the specified namespace.
-<2> Specifies the namespace that the object is associated with.
-<3> Specifies the CNI specification version.
-<4> Specifies the name for the configuration. It is recommended to match the configuration name to the name value of the network attachment definition.
-<5> Specifies the name of the main CNI plugin to configure.
-<6> Specifies the name of the CNI meta plugin.
-<7> Specifies the sysctl to set. The interface name is represented by the `IFNAME` token and is replaced with the actual name of the interface at runtime.
 +
-An example YAML file is shown here:
+where:
 +
+--
+
+`name`:: Specifies the name for the additional network attachment to create. The name must be unique within the specified namespace.
+`namespace`:: Specifies the namespace that the object is associated with.
+`cniVersion`:: Specifies the CNI specification version.
+`name`:: Specifies the name for the configuration. It is recommended to match the configuration name to the name value of the network attachment definition.
+`main_CNI_plugin`:: Specifies the name of the main CNI plugin to configure.
+`tuning`:: Specifies the name of the CNI meta plugin.
+`sysctl`:: Specifies the sysctl to set. The interface name is represented by the `IFNAME` token and is replaced with the actual name of the interface at runtime.
+
+--
++
+.Example network attachment definition
 [source,yaml]
 ----
 apiVersion: "k8s.cni.cncf.io/v1"
@@ -91,30 +98,37 @@ metadata:
   name: tunepod
   namespace: default
   annotations:
-    k8s.v1.cni.cncf.io/networks: tuningnad <1>
+    k8s.v1.cni.cncf.io/networks: tuningnad
 spec:
   containers:
   - name: podexample
     image: centos
     command: ["/bin/bash", "-c", "sleep INF"]
     securityContext:
-      runAsUser: 2000 <2>
-      runAsGroup: 3000 <3>
-      allowPrivilegeEscalation: false <4>
-      capabilities: <5>
+      runAsUser: 2000
+      runAsGroup: 3000
+      allowPrivilegeEscalation: false
+      capabilities:
         drop: ["ALL"]
   securityContext:
-    runAsNonRoot: true <6>
-    seccompProfile: <7>
+    runAsNonRoot: true
+    seccompProfile:
       type: RuntimeDefault
 ----
-<1> Specify the name of the configured `NetworkAttachmentDefinition`.
-<2> `runAsUser` controls which user ID the container is run with.
-<3> `runAsGroup` controls which primary group ID the containers is run with.
-<4> `allowPrivilegeEscalation` determines if a pod can request to allow privilege escalation. If unspecified, it defaults to true. This boolean directly controls whether the `no_new_privs` flag gets set on the container process.
-<5> `capabilities` permit privileged actions without giving full root access. This policy ensures all capabilities are dropped from the pod.
-<6> `runAsNonRoot: true` requires that the container will run with a user with any UID other than 0.
-<7> `RuntimeDefault` enables the default seccomp profile for a pod or container workload.
++
+where:
++
+--
+
+`k8s.v1.cni.cncf.io/networks`:: Specifies the name of the configured `NetworkAttachmentDefinition`.
+`runAsUser`:: Specifies which user ID the container is run with.
+`runAsGroup`:: Specifies which primary group ID the containers is run with.
+`allowPrivilegeEscalation`:: Specifies if a pod can request to allow privilege escalation. If unspecified, it defaults to true. This boolean directly controls whether the `no_new_privs` flag gets set on the container process.
+`capabilities`:: Specifies privileged actions without giving full root access. This policy ensures all capabilities are dropped from the pod.
+`runAsNonRoot: true`:: Specifies that the container will run with a user with any UID other than 0.
+`seccompProfile`:: Specifies the default seccomp profile for a pod or container workload.
+
+--
 
 . Apply the yaml by running the following command:
 +

--- a/networking/configuring_network_settings/configure-syscontrols-interface-tuning-cni.adoc
+++ b/networking/configuring_network_settings/configure-syscontrols-interface-tuning-cni.adoc
@@ -6,18 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In Linux, sysctl allows an administrator to modify kernel parameters at runtime. You can modify interface-level network sysctls using the tuning Container Network Interface (CNI) meta plugin. The tuning CNI meta plugin operates in a chain with a main CNI plugin as illustrated.
+[role="_abstract"]
+To modify kernel parameters and interface attributes at runtime in {product-title}, you can use the tuning Container Network Interface (CNI) meta plugin. The plugin operates in a chain with a main CNI plugin and allows you to change sysctls and interface attributes such as promiscuous mode, all-multicast mode, MTU, and MAC address.
 
 image::264_OpenShift_CNI_plugin_chain_0722.png[CNI plugin]
-
-The main CNI plugin assigns the interface and passes this interface to the tuning CNI meta plugin at runtime. You can change some sysctls and several interface attributes such as promiscuous mode, all-multicast mode, MTU, and MAC address in the network namespace by using the tuning CNI meta plugin.
 
 include::modules/nw-cfg-tuning-interface-cni.adoc[leveloffset=+1]
 
 include::modules/nw-cfg-config-all-multi-cni.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_nodes-setting-interface-level-network-sysctls"]
+[id="additional-resources_nodes-setting-interface-level-network-sysctls_{context}"]
 == Additional resources
 
 * xref:../../nodes/containers/nodes-containers-sysctls.adoc#nodes-containers-sysctls[Using sysctls in containers]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-16861

Link to docs preview:
https://105097--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_network_settings/configure-syscontrols-interface-tuning-cni.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
