### PR TITLE
OSDOCS-7251: Azure support mutli-FD CPMS

### DIFF
--- a/modules/cpmso-yaml-failure-domain-azure.adoc
+++ b/modules/cpmso-yaml-failure-domain-azure.adoc
@@ -4,13 +4,21 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="cpmso-yaml-failure-domain-azure_{context}"]
-= Sample Azure failure domain configuration
+= Sample {azure-short} failure domain configuration
 
-The control plane machine set concept of a failure domain is analogous to existing Azure concept of an link:https://learn.microsoft.com/en-us/azure/azure-web-pubsub/concept-availability-zones[_Azure availability zone_]. The `ControlPlaneMachineSet` CR spreads control plane machines across multiple failure domains when possible.
+[role="_abstract"]
+You can configure your {azure-first} control plane machine set to spread control plane machines across more than one failure domain when possible.
 
-When configuring Azure failure domains in the control plane machine set, you must specify the availability zone name. An Azure cluster uses a single subnet that spans multiple zones.
+The control plane machine set concept of a failure domain is analogous to existing {azure-short} concept of an link:https://learn.microsoft.com/en-us/azure/azure-web-pubsub/concept-availability-zones[_Azure availability zone_].
 
-.Sample Azure failure domain values
+When configuring {azure-short} failure domains in the control plane machine set, you must specify the availability zone name.
+An {azure-short} cluster can use the following configurations:
+
+* One subnet for each availability zone.
+* One subnet that spans more than one availability zone.
+* More than one subnet in more than one availability zone.
+
+.Sample {azure-short} failure domain values
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1
@@ -25,16 +33,33 @@ spec:
     machines_v1beta1_machine_openshift_io:
       failureDomains:
         azure:
-        - zone: "1" # <1>
+        - internalLoadBalancer: <internal_lb_name>
+        - subnet: <subnet_name>
+        - zone: "1"
         - zone: "2"
         - zone: "3"
-        platform: Azure # <2>
+        platform: Azure
 # ...
 ----
-<1> Each instance of `zone` specifies an Azure availability zone for a failure domain.
+where:
+
+`spec.template.machines_v1beta1_machine_openshift_io.failureDomains.azure.internalLoadBalancer`::
+Specifies the name of the internal load balancer for the virtual machine.
+When omitted, the control plane machine set uses `internalLoadBalancer` value from the machine `providerSpec` template.
+Do not change this value.
+
+`spec.template.machines_v1beta1_machine_openshift_io.failureDomains.azure.subnet`::
+Specifies the network subnet in which to create the control plane VM.
+When omitted, the control plane machine set uses the `subnet` value from the machine `providerSpec` template.
+
+`spec.template.machines_v1beta1_machine_openshift_io.failureDomains.azure.zone`::
+Each instance of `zone` specifies an {azure-short} availability zone for a failure domain.
 +
 [NOTE]
 ====
-If the cluster is configured to use a single zone for all failure domains, the `zone` parameter is configured in the provider specification instead of in the failure domain configuration.
+If the cluster uses a single zone for all failure domains, the `zone` parameter is in the provider specification instead of in the failure domain configuration.
 ====
-<2> Specifies the cloud provider platform name. Do not change this value.
+
+`spec.template.machines_v1beta1_machine_openshift_io.failureDomains.platform`::
+Specifies the cloud provider platform name.
+Do not change this value.


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-7251](https://issues.redhat.com//browse/OSDOCS-7251)

Link to docs preview:
[Sample Azure failure domain configuration](https://105098--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.html#cpmso-yaml-failure-domain-azure_cpmso-config-options-azure)

QE review:
- [x] QE has approved this change.

Additional information:
* Includes some edits for DITA compliance