### PR TITLE
OSDOCS-17507:Corrected Vale errors in OSD Planning book.

### DIFF
--- a/modules/aws-limits.adoc
+++ b/modules/aws-limits.adoc
@@ -6,7 +6,7 @@
 [id="aws-limits_{context}"]
 = AWS account limits
 
-
+[role="_abstract"]
 The {product-title} cluster uses a number of Amazon Web Services (AWS) components, and the default link:https://docs.aws.amazon.com/general/latest/gr/aws_service_limits.html[service limits] affect your ability to install {product-title} clusters. If you use certain cluster configurations, deploy your cluster in certain AWS regions, or run multiple clusters from your account, you might need to request additional resources for your AWS account.
 
 The following table summarizes the AWS components whose limits can impact your ability to install and run {product-title} clusters.

--- a/modules/ccs-aws-customer-procedure.adoc
+++ b/modules/ccs-aws-customer-procedure.adoc
@@ -5,8 +5,9 @@
 :_mod-docs-content-type: PROCEDURE
 [id="ccs-aws-customer-procedure_{context}"]
 = Required customer procedure
-// TODO: Better procedure heading that tells you what this is doing
 
+// TODO: Better procedure heading that tells you what this is doing
+[role="_abstract"]
 The Customer Cloud Subscription (CCS) model allows Red Hat to deploy and manage {product-title} into a customer’s Amazon Web Services (AWS) account. Red Hat requires several prerequisites in order to provide these services.
 
 .Procedure

--- a/modules/ccs-aws-customer-requirements.adoc
+++ b/modules/ccs-aws-customer-requirements.adoc
@@ -6,7 +6,7 @@
 [id="ccs-aws-customer-requirements_{context}"]
 = Customer requirements
 
-
+[role="_abstract"]
 {product-title} clusters using a Customer Cloud Subscription (CCS) model on Amazon Web Services (AWS) must meet several prerequisites before they can be deployed.
 
 [id="ccs-requirements-account_{context}"]

--- a/modules/ccs-aws-iam.adoc
+++ b/modules/ccs-aws-iam.adoc
@@ -6,6 +6,7 @@
 [id="ccs-aws-iam_{context}"]
 = Red Hat managed IAM references for AWS
 
+[role="_abstract"]
 Red Hat is responsible for creating and managing the following Amazon Web Services (AWS) resources: IAM policies, IAM users, and IAM roles.
 
 [id="aws-policy-iam-policies_{context}"]

--- a/modules/ccs-aws-provisioned.adoc
+++ b/modules/ccs-aws-provisioned.adoc
@@ -6,7 +6,7 @@
 [id="ccs-aws-provisioned_{context}"]
 = Provisioned AWS Infrastructure
 
-
+[role="_abstract"]
 This is an overview of the provisioned Amazon Web Services (AWS) components on a deployed {product-title} cluster. For a more detailed listing of all provisioned AWS components, see the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[{OCP} documentation].
 
 [id="aws-policy-ec2_{context}"]
@@ -79,7 +79,7 @@ A *public subnet* connects directly to the internet through an internet gateway.
 
 * *NAT gateways*: One NAT Gateway per public subnet.
 
-=== Sample VPC Architecture
+== Sample VPC Architecture
 
 image::VPC-Diagram.png[VPC Reference Architecture]
 
@@ -89,7 +89,7 @@ image::VPC-Diagram.png[VPC Reference Architecture]
 AWS security groups provide security at the protocol and port-access level; they are associated with EC2 instances and Elastic Load Balancing. Each security group contains a set of rules that filter traffic coming in and out of an EC2 instance. You must ensure the ports required for the link:https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-user-infra.html#installation-aws-user-infra-other-infrastructure_installing-aws-user-infra[{OCP} installation] are open on your network and configured to allow access between hosts.
 
 [id="osd-security-groups-custom_{context}"]
-=== Additional custom security groups
+== Additional custom security groups
 When you create a cluster by using a non-managed VPC, you can add custom security groups during cluster creation. Custom security groups are subject to the following limitations:
 
 * You must create the custom security groups in AWS before you create the cluster. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html[Amazon EC2 security groups for Linux instances].

--- a/modules/ccs-aws-scp.adoc
+++ b/modules/ccs-aws-scp.adoc
@@ -6,7 +6,7 @@
 [id="ccs-aws-scp_{context}"]
 = Minimum required service control policy (SCP)
 
-
+[role="_abstract"]
 Service control policy (SCP) management is the responsibility of the customer. These policies are maintained in the AWS Organization and control what services are available within the attached AWS accounts.
 
 [cols="2a,2a,2a,2a",options="header"]

--- a/modules/ccs-aws-understand.adoc
+++ b/modules/ccs-aws-understand.adoc
@@ -6,7 +6,7 @@
 [id="ccs-aws-understand_{context}"]
 = Understanding Customer Cloud Subscriptions on AWS
 
-
+[role="_abstract"]
 To deploy {product-title} into your existing Amazon Web Services (AWS) account using the Customer Cloud Subscription (CCS) model, Red Hat requires several prerequisites be met.
 
 Red Hat recommends the usage of an AWS Organization to manage multiple AWS accounts. The AWS Organization, managed by the customer, hosts multiple AWS accounts. There is a root account in the organization that all accounts will refer to in the account hierarchy.

--- a/modules/ccs-gcp-customer-procedure-serviceaccount.adoc
+++ b/modules/ccs-gcp-customer-procedure-serviceaccount.adoc
@@ -7,6 +7,7 @@
 = Service account authentication type procedure
 // TODO: Same as other module - Better procedure heading that tells you what this is doing
 
+[role="_abstract"]
 Besides the required customer procedures listed in _Required customer procedure_, there are other specific actions that you must take when creating an {product-title} cluster on {GCP} using a service account as the authentication type.
 
 .Procedure

--- a/modules/ccs-gcp-customer-procedure-wif.adoc
+++ b/modules/ccs-gcp-customer-procedure-wif.adoc
@@ -123,8 +123,7 @@ resourcemanager.projects.updatePolicyBinding
 
 [IMPORTANT]
 ====
-[subs="attributes+"]
-OpenShift Cluster Manager API command-line interface (`ocm`) is a Developer Preview feature only.
+The {cluster-manager} API command-line interface (`ocm`) is a Developer Preview feature only.
 For more information about the support scope of Red Hat Developer Preview features, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
 ====
 +
@@ -136,7 +135,6 @@ For more information about the support scope of Red Hat Developer Preview featur
 
 .. If your system supports a web-based browser, run the Red{nbsp}Hat single sign-on (SSO) authorization code command for secure authentication:
 +
-.Syntax
 [source,terminal]
 ----
 $ ocm login --use-auth-code

--- a/modules/ccs-gcp-customer-requirements.adoc
+++ b/modules/ccs-gcp-customer-requirements.adoc
@@ -6,7 +6,7 @@
 [id="ccs-gcp-customer-requirements_{context}"]
 = Customer requirements
 
-
+[role="_abstract"]
 {product-title} clusters using a Customer Cloud Subscription (CCS) model on {gcp-first} must meet several prerequisites before they can be deployed.
 
 [id="ccs-gcp-requirements-account_{context}"]

--- a/modules/ccs-gcp-iam.adoc
+++ b/modules/ccs-gcp-iam.adoc
@@ -6,7 +6,7 @@
 
 = Red Hat managed {gcp-full} resources
 
-
+[role="_abstract"]
 Red Hat is responsible for creating and managing the following IAM {gcp-first} resources.
 
 [IMPORTANT]

--- a/modules/ccs-gcp-provisioned.adoc
+++ b/modules/ccs-gcp-provisioned.adoc
@@ -6,6 +6,7 @@
 [id="ccs-gcp-provisioned_{context}"]
 = Provisioned {gcp-short} Infrastructure
 
+[role="_abstract"]
 This is an overview of the provisioned {gcp-first} components on a deployed {product-title} cluster. For a more detailed listing of all provisioned {gcp-short} components, see the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[{OCP} documentation].
 
 [id="gcp-policy-instances_{context}"]

--- a/modules/ccs-gcp-understand.adoc
+++ b/modules/ccs-gcp-understand.adoc
@@ -6,7 +6,7 @@
 [id="ccs-gcp-understand_{context}"]
 = Understanding Customer Cloud Subscriptions on {gcp-short}
 
-
+[role="_abstract"]
 Red{nbsp}Hat {product-title} provides a Customer Cloud Subscription (CCS) model that allows Red{nbsp}Hat to deploy and manage {product-title} into a customer's existing {GCP} account. Red{nbsp}Hat requires several prerequisites be met in order to provide this service.
 
 Red{nbsp}Hat recommends the usage of a {gcp-short} project, managed by the customer, to organize all of your {gcp-short} resources. A project consists of a set of users and APIs, as well as billing, authentication, and monitoring settings for those APIs.

--- a/modules/sd-planning-cluster-maximums-environment.adoc
+++ b/modules/sd-planning-cluster-maximums-environment.adoc
@@ -7,6 +7,7 @@
 [id="planning-cluster-maximums-environment-sd_{context}"]
 = OpenShift Container Platform testing environment and configuration
 
+[role="_abstract"]
 The following table lists the OpenShift Container Platform environment and configuration on which the cluster maximums are tested for the AWS cloud platform.
 
 [options="header",cols="8*"]

--- a/modules/sd-planning-cluster-maximums.adoc
+++ b/modules/sd-planning-cluster-maximums.adoc
@@ -7,6 +7,7 @@
 [id="tested-cluster-maximums-sd_{context}"]
 = Cluster maximums
 
+[role="_abstract"]
 Consider the following tested object maximums when you plan a {product-title}
 ifdef::openshift-rosa[]
 (ROSA)

--- a/modules/sd-planning-considerations.adoc
+++ b/modules/sd-planning-considerations.adoc
@@ -7,6 +7,7 @@
 [id="control-plane-and-infra-node-sizing-and-scaling-sd_{context}"]
 = Control plane and infrastructure node sizing and scaling
 
+[role="_abstract"]
 When you install a {product-title}
 ifdef::openshift-rosa[]
 (ROSA)

--- a/osd_planning/gcp-ccs.adoc
+++ b/osd_planning/gcp-ccs.adoc
@@ -23,8 +23,8 @@ include::modules/osd-gcp-psc-firewall-prerequisites.adoc[leveloffset=+1]
 [id="additional-resources_{context}"]
 == Additional resources
 
-*  xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 
-* For more information about creating an {product-title} cluster with the Workload Identity Federation (WIF) authentication type, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on {gcp-short} with Workload Identity Federation authentication].
+* xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on {gcp-short} with Workload Identity Federation authentication]
 
 * For more information about the specific roles and permissions that are specific to clusters created when using the Workload Identity Federation (WIF) authentication type, see link:https://github.com/openshift/managed-cluster-config/blob/master/resources/wif/4.19/vanilla.yaml[managed-cluster-config].

--- a/osd_planning/osd-limits-scalability.adoc
+++ b/osd_planning/osd-limits-scalability.adoc
@@ -7,6 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 This document details the tested cluster maximums for {product-title} clusters, along with information about the test environment and configuration used to test the maximums. Information about control plane and infrastructure node sizing and scaling is also provided.
 
 include::modules/sd-planning-cluster-maximums.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17507](https://issues.redhat.com//browse/OSDOCS-17507)

Link to docs preview:

- https://105115--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs.html
- https://105115--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html
- https://105115--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/osd-limits-scalability.html

Peer review:
- [x] Peer reviewer has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
