### PR TITLE
OBSDOCS-3017: Fix bug KUBE_NODE_NAME not set configuring k8sattributes processor

### DIFF
--- a/modules/otel-processors-kubernetes-attributes-processor.adoc
+++ b/modules/otel-processors-kubernetes-attributes-processor.adoc
@@ -7,7 +7,7 @@
 = Kubernetes Attributes Processor
 
 [role="_abstract"]
-The Kubernetes Attributes Processor enables automatic configuration of spans, metrics, and log resource attributes by using the Kubernetes metadata.
+The Kubernetes Attributes Processor enables automatic attachment of Kubernetes metadata as resource attributes to spans, metrics, and logs.
 This processor supports traces, metrics, and logs.
 This processor automatically identifies the Kubernetes resources, extracts the metadata from them, and incorporates this extracted metadata as resource attributes into relevant spans, metrics, and logs. It utilizes the Kubernetes API to discover all pods operating within a cluster, maintaining records of their IP addresses, pod UIDs, and other relevant metadata.
 
@@ -15,6 +15,7 @@ This processor automatically identifies the Kubernetes resources, extracts the m
 [source,yaml]
 ----
 kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: otel-collector
 rules:
@@ -24,17 +25,25 @@ rules:
   - apiGroups: ['apps']
     resources: ['replicasets']
     verbs: ['get', 'watch', 'list']
-# ...
 ----
 
 .OpenTelemetry Collector using the Kubernetes Attributes Processor
 [source,yaml]
 ----
 # ...
+spec:
+  env:
+    - name: KUBE_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
   config:
     processors:
          k8sattributes:
-             filter:
+             filter: # <1>
+                 namespace:
                  node_from_env_var: KUBE_NODE_NAME
+
 # ...
 ----
+<1> Optional: Filters resource objects cached for metadata extraction, reducing API requests and memory usage.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): main, 3.8, 3.9
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-3017
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://105171--ocpdocs-pr.netlify.app/openshift-otel/latest/otel-collector/otel-collector-processors.html#otel-processors-kubernetes-attributes-processor_otel-collector-processors
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Based on https://github.com/openshift/openshift-docs/pull/105162/
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
