### PR TITLE
OCPBUGS#73884: modules/nodes-sigstore-prepare-for-4.21: Explain Signature mirroring

### DIFF
--- a/modules/nodes-sigstore-prepare-for-4.21.adoc
+++ b/modules/nodes-sigstore-prepare-for-4.21.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-sigstore-using.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-sigstore-admin-ack_{context}"]
+= Preparing for 4.21
+
+[NOTE]
+====
+If you are updating a cluster that uses ImageContentSourcePolicies or ImageDigestMirrorSets from {product-title} 4.20 to 4.21, the update will blocked with a _This cluster has mirrors configured. 4.21 will require Sigstore signatures..._ message. The update is blocked intentionally in order to alert you that the `openshift` ClusterImagePolicy becomes generally available in 4.21, and Sigstore signatures for quay.io/openshift-release-dev/ocp-release will be required for release verification.
+
+To allow the update, either:
+
+* Remove your ImageContentSourcePolicies and ImageDigestMirrorSets, or
+* Ensure that any mirrored quay.io/openshift-release-dev/ocp-release releases also have mirrored Sigstore signatures, either by:
+** Using `oc-mirror`, see _Mirroring resources using the oc-mirror plugin_.
+** Using `oc image mirror`, as described in this section.
+
+After ensuring that those Sigstore signatures are mirrored, inform the cluster of your preparation with:
+
+[source,terminal]
+----
+$ oc -n openshift-config patch configmap admin-acks --patch '{"data":{"ack-4.20-sigstore-in-4.21":"true"}}' --type=merge
+----
+====
+
+This procedure explains how to use `oc image mirror` to mirror Sigstore signatures for quay.io/openshift-release-dev/ocp-release images, to prepare for an update to 4.21, if you have ImageContentSourcePolicies or ImageDigestMirrorSets configured but are not using `oc-mirror`.
+
+.Procedure
+
+For each quay.io/openshift-release-dev/ocp-release release image that the cluster might need to pull from a configured mirror in the future, find the release digest, and mirror the associated Sigstore signature image with:
+
+[source,terminal]
+----
+$ oc image mirror "quay.io/openshift-release-dev/ocp-release:${RELEASE_DIGEST}.sig" "${LOCAL_REGISTRY}/${LOCAL_RELEASE_IMAGES_REPOSITORY}:${RELEASE_DIGEST}.sig"
+----
+where:
+
+`RELEASE_DIGEST`:: Specifies your digest image with the `:` character replaced by a `-` character. For example: `sha256:884e1ff5effeaa04467fab9725900e7f0ed1daa89a7734644f14783014cebdee` becomes `sha256-884e1ff5effeaa04467fab9725900e7f0ed1daa89a7734644f14783014cebdee.sig`.

--- a/nodes/nodes-sigstore-using.adoc
+++ b/nodes/nodes-sigstore-using.adoc
@@ -20,6 +20,8 @@ include::modules/nodes-sigstore-configure.adoc[leveloffset=+1]
 
 include::modules/nodes-sigstore-configure-cluster-policy.adoc[leveloffset=+1]
 
+include::modules/nodes-sigstore-prepare-for-4.21.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-configure-parameters_nodes-sigstore-using[About cluster and image policy parameters]


### PR DESCRIPTION
We have a few places in 4.20 docs where we talk about this as a before-enabling-`TechPreviewNoUpgrade` thing.  The new module explains it again as a before-updating-to-4.21 thing.  In both cases, the release image Sigstore signature needs to be in place because the `openshift` ClusterImagePolicy will show up in the cluster (openshift/cluster-update-keys#89) and start requiring the signatures on that scope.

Doc'ed in 4.20 to give us a live place to link from the in-flight 4.20.z guard adding the admin-ack (openshift/machine-config-operator#5558).

Version(s): 4.20.z

Issue: https://issues.redhat.com/browse/OCPBUGS-73884

Link to docs preview: https://105178--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
