### PR TITLE
OCPBUGS#73884: Admin-ack for Sigstore signature requirements for 4.20-4.21 updates

### DIFF
--- a/modules/nodes-sigstore-prepare-for-4.21.adoc
+++ b/modules/nodes-sigstore-prepare-for-4.21.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-sigstore-using.adoc (4.20 only)
+
+:_mod-docs-content-type: PROCEDURE
+[id="nodes-sigstore-prepare-for-4.21_{context}"]
+= Ensuring the release image Sigstore signatures are present before update
+
+[role="_abstract"]
+If you update a cluster that uses `ImageContentSourcePolicies` or `ImageDigestMirrorSets` from {product-title} 4.20 to 4.21, the update will be blocked with a _This cluster has mirrors configured. 4.21 will require Sigstore signatures..._ message. You must perform the tasks in this section to allow the update to resume. 
+
+The update is blocked because the `openshift` cluster image policy became Generally Available in 4.21. As a result, Sigstore signatures for the `quay.io/openshift-release-dev/ocp-release` images are now required for release verification.
+
+However, if you mirrored the {product-title} image repository by using the `oc adm release mirror` command, the command does not mirror the release image Sigstore signatures along with the images. You need to mirror the signature before the update can proceed.
+
+To allow the update to proceed, first perform one of the following tasks:
+
+* Remove your `ImageContentSourcePolicy` or `ImageDigestMirrorSet` object.
+
+* Mirror the `quay.io/openshift-release-dev/ocp-release` releases and the Sigstore signatures by performing one of the following tasks:
+** Use the `oc-mirror` command, as described in "Mirroring resources using the oc-mirror plugin".
+** Use the `oc image mirror` command, as described in this section.
+
+After ensuring that the Sigstore signatures are mirrored, a cluster administrator must provide a manual acknowledgment before the cluster can be updated from {product-title} 4.20 to 4.21 by running the command in _Providing the Sigstore administrator acknowledgment_ to resume the update.
+
+The following procedure explains how to use the `oc image mirror` command to mirror the Sigstore signatures for the `quay.io/openshift-release-dev/ocp-release` release images. Use this procedure to prepare for an update to {product-title} 4.21, if you have `ImageContentSourcePolicies` or `ImageDigestMirrorSets` configured, but are not using the `oc-mirror` command to mirror the release image Sigstore signatures.
+
+.Procedure
+
+* For each `quay.io/openshift-release-dev/ocp-release` release image that the cluster might need to pull from a configured mirror in the future, find the release digest, and mirror the associated Sigstore signature image by using a command similar to the following:
++
+[source,terminal]
+----
+$ oc image mirror "quay.io/openshift-release-dev/ocp-release:${RELEASE_DIGEST}.sig" "${LOCAL_REGISTRY}/${LOCAL_RELEASE_IMAGES_REPOSITORY}:${RELEASE_DIGEST}.sig"
+----
+where:
+
+`RELEASE_DIGEST`:: Specifies your digest image with the `:` character replaced by a `-` character. For example: `sha256:884e1ff5effeaa04467fab9725900e7f0ed1daa89a7734644f14783014cebdee` becomes `sha256-884e1ff5effeaa04467fab9725900e7f0ed1daa89a7734644f14783014cebdee.sig`.

--- a/modules/update-preparing-ack-sigstore.adoc
+++ b/modules/update-preparing-ack-sigstore.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-sigstore-using.adoc (4.20 only)
+
+:_mod-docs-content-type: PROCEDURE
+[id="update-preparing-ack-sigstore_{context}"]
+= Providing the Sigstore administrator acknowledgment
+
+[role="_abstract"]
+After ensuring that the Sigstore signature for each required `quay.io/openshift-release-dev/ocp-release` release image is mirrored, you can acknowledge that your cluster is ready to update from {product-title} 4.20 to 4.21.
+
+.Prerequisites
+
+* You must have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* Run the following command to acknowledge that the Sigstore signatures are mirrored and your cluster is ready update:
++
+[source,terminal]
+----
+$ oc -n openshift-config patch configmap admin-acks --patch '{"data":{"ack-4.20-sigstore-in-4.21":"true"}}' --type=merge
+----

--- a/nodes/nodes-sigstore-using.adoc
+++ b/nodes/nodes-sigstore-using.adoc
@@ -31,3 +31,12 @@ include::modules/nodes-sigstore-configure-image-policy.adoc[leveloffset=+1]
 
 * xref:../nodes/nodes-sigstore-using.adoc#nodes-sigstore-configure-parameters_nodes-sigstore-using[About cluster and image policy parameters]
 
+// Ensuring the release image Sigstore signatures are present before update. 4.20 only!!
+include::modules/nodes-sigstore-prepare-for-4.21.adoc[leveloffset=+1]
+include::modules/update-preparing-ack-sigstore.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_nodes-sigstore-using"]
+.Additional resources
+
+* xref:../disconnected/updating/mirroring-image-repository.html#mirroring-ocp-resources-ocmirror_mirroring-ocp-image-repository[Mirroring resources using the oc-mirror plugin]


### PR DESCRIPTION
Taken over from https://github.com/openshift/openshift-docs/pull/105178

We have a few places in 4.20 docs where we talk about this as a before-enabling-`TechPreviewNoUpgrade` thing.  The new module explains it again as a before-updating-to-4.21 thing.  In both cases, the release image Sigstore signature needs to be in place because the `openshift` ClusterImagePolicy will show up in the cluster (openshift/cluster-update-keys#89) and start requiring the signatures on that scope.

Doc'ed in 4.20 to give us a live place to link from the in-flight 4.20.z guard adding the admin-ack (openshift/machine-config-operator#5558).

Version(s): 4.20.z

Issue: https://issues.redhat.com/browse/OCPBUGS-73884

Link to docs preview: 
* Manage secure signatures with sigstore -> [Ensuring the release image Sigstore signatures are present before update](https://105184--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#nodes-sigstore-prepare-for-4.21_nodes-sigstore-using)
* Manage secure signatures with sigstore -> [Providing the Sigstore administrator acknowledgment](https://105184--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes-sigstore-using.html#update-preparing-ack-sigstore_nodes-sigstore-using)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
