### PR TITLE
OSDOCS-17505:Corrected Vale errors in OSD architecture sections of Architecture book.

### DIFF
--- a/architecture/osd-architecture-models-gcp.adoc
+++ b/architecture/osd-architecture-models-gcp.adoc
@@ -6,6 +6,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 With {product-title} on {GCP}, you can create clusters that are accessible over public or private networks.
 
 include::modules/osd-gcp-architecture.adoc[leveloffset=+1]

--- a/modules/osd-gcp-architecture.adoc
+++ b/modules/osd-gcp-architecture.adoc
@@ -6,6 +6,7 @@
 [id="osd-gcp-architecture_{context}"]
 = Private {product-title} on {GCP} architecture on public and private networks
 
+[role="_abstract"]
 You can customize the access patterns for your API server endpoint and Red Hat SRE management by choosing one of the following network configuration types:
 
 * Private cluster with Private Service Connect (PSC).

--- a/modules/osd-private-architecture-model-gcp.adoc
+++ b/modules/osd-private-architecture-model-gcp.adoc
@@ -6,6 +6,7 @@
 [id="osd-private-architecture-model_{context}"]
 = Private {product-title} on {GCP} without Private Service Connect (PSC) architecture model
 
+[role="_abstract"]
 With a private network configuration, your cluster API server endpoint and application routes are private. Private {product-title} on {gcp-short} clusters use some public subnets, but no control plane or worker nodes are deployed in public subnets.
 
 [IMPORTANT]

--- a/modules/osd-private-psc-architecture-model-gcp.adoc
+++ b/modules/osd-private-psc-architecture-model-gcp.adoc
@@ -6,6 +6,7 @@
 [id="osd-private-psc-architecture-model-gcp_{context}"]
 = Private {product-title} on {GCP} with Private Service Connect architecture model
 
+[role="_abstract"]
 With a private {gcp-short} Private Service Connect (PSC) network configuration, your cluster API server endpoint and application routes are private. Public subnets or NAT gateways are not required in your VPC for egress.
 Red Hat SRE management access the cluster over the {gcp-short} PSC-enabled private connectivity. The default ingress controller are private. Additional ingress controllers can be public or private. The following diagram shows network connectivity of a private cluster with PSC.
 

--- a/modules/osd-public-architecture-model-gcp.adoc
+++ b/modules/osd-public-architecture-model-gcp.adoc
@@ -6,6 +6,7 @@
 [id="osd-public-architecture-model-gcp_{context}"]
 = Public {product-title} on {GCP} architecture model
 
+[role="_abstract"]
 With a public network configuration, your cluster API server endpoint and application routes are internet-facing. The default ingress controller can be public or private. The following image shows the network connectivity of a public cluster.
 
 .{product-title} on {GCP} deployed on a public network

--- a/modules/osd-understanding-private-service-connect.adoc
+++ b/modules/osd-understanding-private-service-connect.adoc
@@ -7,6 +7,7 @@
 [id="osd-understanding-private-service-connect_{context}"]
 = Understanding Private Service Connect
 
+[role="_abstract"]
 Private Service Connect (PSC), a capability of {gcp-full} networking, enables private communication between services across different projects or organizations within {gcp-short}. Users that implement PSC as part of their network connectivity can deploy {product-title} clusters in a private and secured environment within {GCP} without any public facing cloud resources.
 
 For more information about PSC, see link:https://cloud.google.com/vpc/docs/private-service-connect[Private Service Connect].

--- a/modules/private-service-connect-psc-architecture.adoc
+++ b/modules/private-service-connect-psc-architecture.adoc
@@ -7,6 +7,7 @@
 [id="psc-architecture_{context}"]
 = Private Service Connect architecture
 
+[role="_abstract"]
 The PSC architecture includes producer services and consumer services. Using PSC, the consumers can access producer services privately from inside their VPC network. Similarly, it allows producers to host services in their own separate VPC networks and offer a private connect to their consumers.
 
 The following image depicts how Red HAT SREs and other internal resources access and support clusters created using PSC.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17505](https://issues.redhat.com//browse/OSDOCS-17505)

Link to docs preview:

- [OpenShift Dedicated on Google Cloud architecture models](https://105203--ocpdocs-pr.netlify.app/openshift-dedicated/latest/architecture/osd-architecture-models-gcp.html)
- [Private Service Connect overview](https://105203--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.html)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- QE approval is not required to merge this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
