### PR TITLE
[enterprise-4.14] Manual CP Removed OSSM 1x 

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4085,33 +4085,33 @@ Topics:
     File: ossm-reference-kiali
   - Name: Uninstalling Service Mesh
     File: removing-ossm
-- Name: Service Mesh 1.x
-  Dir: v1x
-  Topics:
-  - Name: Service Mesh 1.x release notes
-    File: servicemesh-release-notes
-  - Name: Service Mesh architecture
-    File: ossm-architecture
-  - Name: Service Mesh and Istio differences
-    File: ossm-vs-community
-  - Name: Preparing to install Service Mesh
-    File: preparing-ossm-installation
-  - Name: Installing Service Mesh
-    File: installing-ossm
-  - Name: Security
-    File: ossm-security
-  - Name: Traffic management
-    File: ossm-traffic-manage
-  - Name: Deploying applications on Service Mesh
-    File: prepare-to-deploy-applications-ossm
-  - Name: Data visualization and observability
-    File: ossm-observability
-  - Name: Custom resources
-    File: ossm-custom-resources
-  - Name: 3scale Istio adapter for 1.x
-    File: threescale-adapter
-  - Name: Removing Service Mesh
-    File: removing-ossm
+# - Name: Service Mesh 1.x
+#   Dir: v1x
+#   Topics:
+#   - Name: Service Mesh 1.x release notes
+#     File: servicemesh-release-notes
+#   - Name: Service Mesh architecture
+#     File: ossm-architecture
+#   - Name: Service Mesh and Istio differences
+#     File: ossm-vs-community
+#   - Name: Preparing to install Service Mesh
+#     File: preparing-ossm-installation
+#   - Name: Installing Service Mesh
+#     File: installing-ossm
+#   - Name: Security
+#     File: ossm-security
+#   - Name: Traffic management
+#     File: ossm-traffic-manage
+#   - Name: Deploying applications on Service Mesh
+#     File: prepare-to-deploy-applications-ossm
+#   - Name: Data visualization and observability
+#     File: ossm-observability
+#   - Name: Custom resources
+#     File: ossm-custom-resources
+#   - Name: 3scale Istio adapter for 1.x
+#     File: threescale-adapter
+#   - Name: Removing Service Mesh
+#     File: removing-ossm
 ---
 Name: Virtualization
 Dir: virt

--- a/modules/ossm-configuring-the-threescale-wasm-auth-module.adoc
+++ b/modules/ossm-configuring-the-threescale-wasm-auth-module.adoc
@@ -25,9 +25,9 @@ Configuring the WebAssembly extension is currently a manual process. Support for
 
 * Identify a Kubernetes workload and namespace on your {SMProductShortName} deployment that you will apply this module.
 * You must have a 3scale tenant account. See link:https://www.3scale.net/signup[SaaS] or link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.11/html-single/installing_3scale/index#install-threescale-on-openshift-guide[3scale 2.11 On-Premises] with a matching service and relevant applications and metrics defined.
-ifndef::openshift-rosa,openshift-dedicated[]
-* If you apply the module to the `<product_page>` microservice in the `bookinfo` namespace, see the xref:../../service_mesh/v1x/prepare-to-deploy-applications-ossm.adoc#ossm-tutorial-bookinfo-overview_deploying-applications-ossm-v1x[Bookinfo sample application].
-endif::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+* If you apply the module to the `<product_page>` microservice in the `bookinfo` namespace, see the xref:../../service_mesh/v2x/ossm-create-mesh.adoc#ossm-tutorial-bookinfo-overview_ossm-create-mesh[Bookinfo sample application].
+endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 ** The following example is the YAML format for the custom resource for `threescale-wasm-auth` module.
 This example refers to the upstream Maistra version of {SMProductShortName}, `WasmPlugin` API. You must declare the namespace where the `threescale-wasm-auth` module is deployed, alongside a `selector` to identify the set of applications the module will apply to:
 +


### PR DESCRIPTION
This is a manual CP of https://github.com/openshift/openshift-docs/pull/104374

Doc JIRA: https://issues.redhat.com/browse/OSSM-3158

Fix Version: 4.14

Doc Preview: https://105213--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-threescale-webassembly-module.html

commit ID: b76a5180f36648d09caad60e35d1f0003a014d75

Merge reviewer: @eromanova97 