### PR TITLE
CNV#75837: [docs] wasp-agent documentation should support upgrade to OCP 4.21

### DIFF
--- a/modules/virt-removing-wasp-agent.adoc
+++ b/modules/virt-removing-wasp-agent.adoc
@@ -32,21 +32,6 @@ $ oc -n openshift-cnv patch HyperConverged/kubevirt-hyperconverged \
 $ oc delete machineconfig 90-worker-swap
 ----
 
-. Delete the associated `KubeletConfig` custom resource (CR) by running the following command:
-+
-[source,terminal]
-----
-$ oc delete kubeletconfig custom-config
-----
-
-. Wait for the worker nodes to reconcile, by running the following command and observing the output:
-+
-[source,terminal]
-----
-$ oc wait mcp worker --for condition=Updated=True --timeout=-1s
-----
-
-
 .Verification
 
 * Confirm that swap is no longer enabled on a node, by running the following command and observing the output:

--- a/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
+++ b/modules/virt-using-wasp-agent-to-configure-higher-vm-workload-density.adoc
@@ -34,33 +34,7 @@ The `wasp-agent` component deploys an Open Container Initiative (OCI) hook to en
 
 .Procedure
 
-. Configure the `kubelet` service to permit swap usage:
-.. Create or edit a `KubeletConfig` file with the parameters shown in the following example:
-+
-[source,yaml]
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: KubeletConfig
-metadata:
-  name: custom-config
-spec:
-  machineConfigPoolSelector:
-    matchLabels:
-      pools.operator.machineconfiguration.openshift.io/worker: ''  # MCP
-      #machine.openshift.io/cluster-api-machine-role: worker # machine
-      #node-role.kubernetes.io/worker: '' # node
-  kubeletConfig:
-    failSwapOn: false
-----
-
-.. Wait for the worker nodes to sync with the new configuration by running the following command:
-+
-[source,yaml]
-----
-$ oc wait mcp worker --for condition=Updated=True --timeout=-1s
-----
-
-. Provision swap by creating a `MachineConfig` object:
+* Provision swap by creating a `MachineConfig` object:
 
 .. Create a `MachineConfig` file with the parameters shown in the following example:
 +


### PR DESCRIPTION
Version(s): 4.21

Issue: [CNV-75837](https://issues.redhat.com/browse/CNV-75837)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.