### PR TITLE
OSDOCS-17654: Adding customer global pull secret in HCP for ROSA

### DIFF
--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -15,7 +15,28 @@ endif::[]
 = Updating the global cluster pull secret
 
 [role="_abstract"]
-To add new registries or change authentication for your {product-title} cluster, you can update the global pull secret by replacing it or appending new credentials. Use the `oc set data secret/pull-secret` command to apply the updated pull secret to all nodes in your cluster.
+To add new registries or update authentication for your {product-title} cluster, you can update the global pull secret by appending new credentials to the _additional-pull-secret_. To do this, you can use the `oc set data secret/additional-pull-secret -n kube-system` command. Hypershift manages the new credential propagation among the HostedCluster nodes.
+
+ifdef::openshift-rosa-hcp[]
+This feature provides a dedicated mechanism to separate your private credentials from the pull secret managed by the service, ensuring cluster functionality while restricting external visibility of your sensitive data. This separation allows you to independently rotate secrets and maintain exclusive ownership for compliance without impacting core managed service operations.
+
+{product-title} already has some immutable entries in the file, and you will not be able to modify those. If you are in this situation, you can follow this approach to use the same registry with different credentials.
+This is a sample of authentication that is already in place:
+
+[source,terminal]
+----
+"auths":
+  "<quay.io: xxxxYYYzzzz>"
+----
+In the following case you can add a more specific entry such as:
+
+[source,terminal]
+----
+"auths":
+  "<quay.io/sampleNamespace": 111445656>"
+----
+This adds a new layer to the pull secret without affecting the original registry entry.
+endif::openshift-rosa-hcp[]
 
 ifndef::image-pull-secrets[]
 Use this procedure when you need a separate registry to store images than the registry used during installation.
@@ -24,9 +45,16 @@ endif::image-pull-secrets[]
 ifdef::image-pull-secrets[]
 [IMPORTANT]
 ====
+ifdef::openshift-enterprise[]
+The global pull secret is a HostedControlPlane feature only and is not an OCP standalone feature.
+endif::openshift-enterprise[]
+ifdef::openshift-rosa-hcp[]
+The global pull secret is a HostedControlPlane feature only and is not an OCP standalone feature and is also only available on {product-title} version 4.20.6 and later.
+endif::openshift-rosa-hcp[]
+
 To transfer your cluster to another owner, you must initiate the transfer in {cluster-manager-url} and then update the pull secret on the cluster. Updating a cluster's pull secret without initiating the transfer in {cluster-manager} causes the cluster to stop reporting Telemetry metrics in {cluster-manager}.
 
-For more information, see "Transferring cluster ownership" in the {cluster-manager-first} documentation.
+For more information, see _Transferring cluster ownership_ under _Additional resources_ in the {cluster-manager-first} documentation.
 ====
 endif::image-pull-secrets[]
 
@@ -69,7 +97,6 @@ where:
 
 `<pull_secret_location>`:: Specifies the path to the pull secret file.
 --
-
 . Update the global pull secret for your cluster by entering the following command. Note that this update rolls out to all nodes, which can take some time depending on the size of your cluster.
 +
 [source,terminal]
@@ -83,6 +110,45 @@ where:
 
 `<pull_secret_location>`:: Specifies the path to the new pull secret file.
 --
++
+This merges your additional pull secret with the original HostedCluster pull secret, making it available to all nodes in the cluster.
+
+. Optional: Modify the additional pull secret added by entering the following command:
++
+[source,terminal]
+----
+$ oc edit secret additional-pull-secret -n kube-system
+----
++
+The secret must contain a valid DockerConfigJSON format.
++
+.Example pull secret
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: additional-pull-secret
+  namespace: kube-system
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: <base64-encoded-docker-config-json>
+----
++
+This results in the following states of the each pull secret:
+
+* *Original*: immutable
+* *Additional*: mutable
+* *Global*: final state of both the original and additional pull secrets
+
+. Optional: Delete the additional pull secret added by entering the following command:
++
+[source,terminal]
+----
+$ oc delete secret additional-pull-secret -n kube-system
+----
++
+This triggers the automatic cleanup process across your nodes.
 
 ifeval::["{context}" == "using-image-pull-secrets"]
 :!image-pull-secrets:

--- a/modules/rosa-release-notes-Q1-2026.adoc
+++ b/modules/rosa-release-notes-Q1-2026.adoc
@@ -10,8 +10,6 @@ The following items were added during the first quarter of 2026.
 
 ifdef::openshift-rosa-hcp[]
 * **AWS Windows License Included now available for {product-title}.** You can now add a Windows License Included enabled machine pool to a {product-title} cluster. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-machine-pools#creating_a_machine_pools_cli_win_li_rosa-managing-worker-nodes[Creating a machine pool with AWS Windows License Included enabled using the {rosa-cli}].
+
+* **Updating the global pull secret now available for {product-title} clusters.** You can now modify the global pull secret to include additional pull secrets for accessing container images from private registries. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/images/managing-images#images_update_global_pull_secret_using_image_pull_secret[Updating the global cluster pull secret].
 endif::openshift-rosa-hcp[]
-
-
-
-

--- a/openshift_images/managing_images/using-image-pull-secrets.adoc
+++ b/openshift_images/managing_images/using-image-pull-secrets.adoc
@@ -26,13 +26,12 @@ include::modules/using-pull-secret.adoc[leveloffset=+2]
 
 include::modules/images-pulling-from-private-registries.adoc[leveloffset=+2]
 
-// cannot get resource "secrets" in API group "" in the namespace "openshift-config" 
-ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+// cannot get resource "secrets" in API group "" in the namespace "openshift-config"
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/images-update-global-pull-secret.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * link:https://docs.redhat.com/en/documentation/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#transferring-cluster-ownership_downloading-and-updating-pull-secrets[Transferring cluster ownership]
-
-endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
+endif::openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17654

Link to docs preview:
[HCP](https://105229--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


