### PR TITLE
[OSDOCS#17598]: Added new module for removing device and device classes for 4.21

### DIFF
--- a/modules/lvms-about-adding-devices-to-a-vg.adoc
+++ b/modules/lvms-about-adding-devices-to-a-vg.adoc
@@ -10,7 +10,7 @@ The `deviceSelector` field in the `LVMCluster` CR contains the configuration to 
 
 You can specify the device paths in the `deviceSelector.paths` field, the `deviceSelector.optionalPaths` field, or both. If you do not specify the device paths in both the `deviceSelector.paths` field and the `deviceSelector.optionalPaths` field, {lvms} adds the supported unused devices to the volume group (VG). 
 
-[WARNING]
+[IMPORTANT]
 ====
 It is recommended to avoid referencing disks using symbolic naming, such as `/dev/sdX`, as these names may change across reboots within RHCOS. Instead, you must use stable naming schemes, such as `/dev/disk/by-path/` or `/dev/disk/by-id/`, to ensure consistent disk identification.
 

--- a/modules/lvms-about-removing-devices-deviceclasses-from-a-vg.adoc
+++ b/modules/lvms-about-removing-devices-deviceclasses-from-a-vg.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="about-removing-devices-deviceclasses-from-a-vg_{context}"]
+= About removing devices and device classes from a volume group
+
+[role="_abstract"]
+The `deviceSelector` field in the `LVMCluster` CR contains the configuration to specify the paths to the devices that you can remove from the Logical Volume Manager (LVM) volume group.
+
+== Removing the device paths in the deviceSelector.paths field
+
+You can remove the device paths in the `deviceSelector.paths` field.
+
+[IMPORTANT]
+====
+Ensure that the following criteria are met before removing device paths: 
+
+* The device that you want to remove is empty. You can use the `pvdisplay` command to see attributes of physical volumes (PVs) used in LVM. 
+
+* At least one additional device is specified in the `deviceSelector.paths` field.
+
+====
+
+== Removing the deviceClass from the LVMCluster
+
+You can also remove the `deviceClass` object from the `LVMCluster` resource. For device class deletion, there is no need to delete `deviceSelector.paths` object.
+
+[IMPORTANT]
+====
+Ensure that the following criteria are met before removing a device class: 
+
+* The `deviceClasses.default` field is set to `false`.
+
+* The disks specified in the `deviceSelector.paths` field are empty.
+
+* At least one additional device class is specified in the `storage` field.
+
+====

--- a/modules/lvms-about-removing-devices-deviceclasses-from-a-vg.adoc
+++ b/modules/lvms-about-removing-devices-deviceclasses-from-a-vg.adoc
@@ -9,6 +9,7 @@
 [role="_abstract"]
 The `deviceSelector` field in the `LVMCluster` CR contains the configuration to specify the paths to the devices that you can remove from the Logical Volume Manager (LVM) volume group.
 
+[id="removing-device-paths-in-deviceselectorpaths-field_{context}"]
 == Removing the device paths in the deviceSelector.paths field
 
 You can remove the device paths in the `deviceSelector.paths` field.
@@ -20,9 +21,9 @@ Ensure that the following criteria are met before removing device paths:
 * The device that you want to remove is empty. You can use the `pvdisplay` command to see attributes of physical volumes (PVs) used in LVM. 
 
 * At least one additional device is specified in the `deviceSelector.paths` field.
-
 ====
 
+[id="removing-device-classes-from-lvmcluster_{context}"]
 == Removing the deviceClass from the LVMCluster
 
 You can also remove the `deviceClass` object from the `LVMCluster` resource. For device class deletion, there is no need to delete `deviceSelector.paths` object.
@@ -36,5 +37,4 @@ Ensure that the following criteria are met before removing a device class:
 * The disks specified in the `deviceSelector.paths` field are empty.
 
 * At least one additional device class is specified in the `storage` field.
-
 ====

--- a/storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -85,6 +85,9 @@ include::modules/lvms-about-adding-devices-to-a-vg.adoc[leveloffset=+2]
 
 * xref:../../storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-unsupported-devices_logical-volume-manager-storage[Devices not supported by {lvms}]
 
+// About removing devices and device classes from a volume group
+include::modules/lvms-about-removing-devices-deviceclasses-from-a-vg.adoc[leveloffset=+2]
+
 // Devices not supported by LVMS
 include::modules/lvms-unsupported-devices.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
  https://issues.redhat.com/browse/OSDOCS-17598
  https://issues.redhat.com/browse/OCPSTRAT-1698

Link to docs preview:
https://105230--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage_local/persistent-storage-using-lvms.html#about-removing-devices-deviceclasses-from-a-vg_logical-volume-manager-storage

QE review:
- [x] QE has approved this change.


Additional information:

