### PR TITLE
OCPBUGS-74309: Updatd the br-ex docs for clarify default ovs

### DIFF
--- a/modules/creating-manifest-file-customized-br-ex-bridge.adoc
+++ b/modules/creating-manifest-file-customized-br-ex-bridge.adoc
@@ -16,39 +16,43 @@ endif::[]
 
 [role="_abstract"]
 ifndef::postinstall-bare-metal[]
-As an alternative to using the `configure-ovs.sh` shell script to set a `br-ex` bridge on a bare-metal platform, you can create a `MachineConfig` object that includes an NMState configuration file. The host `nmstate-configuration.service` and `nmstate.service` apply the NMState configuration file to each node that runs in your cluster.
+By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge. For advanced networking requirements, on a bare-metal platform you can override the default behavior by creating a `MachineConfig` object that includes an NMState configuration file. 
+
+Consider using the customized `br-ex` bridge configuration for any of the following tasks:
+
+* You need to modify the `br-ex` bridge after you installed the cluster.
+* You need to modify the maximum transmission unit (MTU) for your cluster.
+* You need to update DNS values.
+* You need to modify attributes for a different bond interface, such as MIImon (Media Independent Interface Monitor), bonding mode, or Quality of Service (QoS).
+* You need to enable Link Layer Discovery Protocol (LLDP) to discover and troubleshoot switch connectivity.
 endif::postinstall-bare-metal[]
 
+Consider using the default OVS br-ex bridge configuration if you require a standard environment with a single network interface controller (NIC) and standard OVS settings.
+
 ifdef::postinstall-bare-metal[]
-As an alternative to using the `configure-ovs.sh` shell script to set a `br-ex` bridge on a bare-metal platform, you can create a `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) that includes an NMState configuration file. 
+By default, {product-title} automatically configures the Open vSwitch (OVS) `br-ex` bridge on bare-metal nodes. For advanced networking requirements, you can override the default behavior by creating a `NodeNetworkConfigurationPolicy` (NNCP) custom resource (CR) that includes an NMState configuration file. 
 
 The Kubernetes NMState Operator uses the NMState configuration file to create a customized `br-ex` bridge network configuration on each node in your cluster.
 
 [IMPORTANT]
 ====
-After creating the `NodeNetworkConfigurationPolicy` CR, copy content from the NMState configuration file that was created during cluster installation into the NNCP CR. An incomplete NNCP CR file means that the network policy described in the file cannot get applied to nodes in the cluster. 
+After creating the `NodeNetworkConfigurationPolicy` CR, copy content from the NMState configuration file that was created during cluster installation into the NNCP CR. An incomplete NNCP CR can result in loss of network connectivity, because the NNCP overrides all existing policies.
 ====
 
-This feature supports the following tasks:
+Consider using the customized `br-ex` bridge configuration for any of the following tasks:
 
-* Modifying the maximum transmission unit (MTU) for your cluster.
-* Modifying attributes of a different bond interface, such as MIImon (Media Independent Interface Monitor), bonding mode, or Quality of Service (QoS).
-* Updating DNS values.
-endif::postinstall-bare-metal[]
-
-Consider the following use cases for creating a manifest object that includes a customized `br-ex` bridge:
-
-* You want to make postinstallation changes to the bridge, such as changing the Open vSwitch (OVS) or OVN-Kubernetes `br-ex` bridge network. The `configure-ovs.sh` shell script does not support making postinstallation changes to the bridge.
+* You want to make postinstallation changes to the bridge, such as changing the Open vSwitch (OVS) or OVN-Kubernetes `br-ex` bridge network. The default OVS `br-ex` bridge mechanism does not support making postinstallation changes to the bridge.
 * You want to deploy the bridge on a different interface than the interface available on a host or server IP address.
-* You want to make advanced configurations to the bridge that are not possible with the `configure-ovs.sh` shell script. Using the script for these configurations might result in the bridge failing to connect multiple network interfaces and facilitating data forwarding between the interfaces.
+* You want to make advanced configurations to the bridge that are not possible with the default OVS `br-ex` bridge mechanism. Using the default mechanism for these configurations might result in the bridge failing to connect multiple network interfaces and facilitating data forwarding between the interfaces.
+endif::postinstall-bare-metal[]
 
 ifndef::postinstall-bare-metal[]
 [NOTE]
 ====
-If you require an environment with a single network interface controller (NIC) and default network settings, use the `configure-ovs.sh` shell script.
+If you require an environment with a single network interface controller (NIC) and default network settings, use the default OVS `br-ex` bridge mechanism.
 ====
 
-After you install {op-system-first} and the system reboots, the Machine Config Operator injects Ignition configuration files into each node in your cluster, so that each node received the `br-ex` bridge network configuration. To prevent configuration conflicts, the `configure-ovs.sh` shell script receives a signal to not configure the `br-ex` bridge.
+After you install {op-system-first} and the system reboots, the Machine Config Operator injects Ignition configuration files into each node in your cluster, so that each node receives the `br-ex` bridge network configuration. To prevent configuration conflicts, the default OVS `br-ex` bridge mechanism is disabled.
 endif::postinstall-bare-metal[]
 
 [WARNING]
@@ -73,12 +77,12 @@ The following list of interface names are reserved and you cannot use the names 
 
 .Prerequisites
 ifndef::postinstall-bare-metal[]
-* Optional: You have installed the link:https://nmstate.io/[`nmstate`] API so that you can validate the NMState configuration.
+* Optional: You have installed the link:https://nmstate.io/user/quick_guide.html[`nmstatectl`] CLI tool to validate your NMState configuration.
 endif::postinstall-bare-metal[]
 
 ifdef::postinstall-bare-metal[]
-* You set a customized `br-ex` by using the alternative method to `configure-ovs`.
-* You installed the Kubernetes NMState Operator.
+* You have installed the Kubernetes NMState Operator.
+* You have identified the specific nodes where you want to apply the policy.
 endif::postinstall-bare-metal[]
 
 .Procedure


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OCPBUGS-74309](https://issues.redhat.com/browse/OCPBUGS-74309)

Link to docs preview:

* https://105243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/bare-metal-postinstallation-configuration.html
* https://105243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/ipi/ipi-install-installation-workflow.html
* https://105243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal.html
* https://105243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.html
* https://105243--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.html

- [x] SME has approved this change.
- [x] QE has approved this change.

