### PR TITLE
OSDOCS-7251: Azure support mutli-FD CPMS rel notes

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -152,6 +152,11 @@ Item description::
 Detailed information.
 ////
 
+Additional control plane machine set failure domain options for {azure-short}::
+This release includes additional configuration options for control plane machine set failure domains on {azure-full}.
++
+For more information, see xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#cpmso-yaml-failure-domain-azure_cpmso-config-options-azure[Sample {azure-short} failure domain configuration].
+
 [id="ocp-release-notes-monitoring_{context}"]
 == Monitoring
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-7251](https://issues.redhat.com//browse/OSDOCS-7251) ([OSDOCS-7813](https://issues.redhat.com//browse/OSDOCS-7813))

Link to docs preview:
[Machine management](https://105267--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-machine-management_release-notes): Additional control plane machine set failure domain options for Azure

QE review:
- [ ] QE has approved this change.

Additional information: