### PR TITLE
OLS-2542: Create short descriptions for modules in tshooting assembly

### DIFF
--- a/modules/ols-operator-missing-from-operatorhub-list.adoc
+++ b/modules/ols-operator-missing-from-operatorhub-list.adoc
@@ -6,6 +6,6 @@
 = Operator Missing from the Operator Hub list
 
 [role="_abstract"] 
-If you are not running your {ocp-product-title} cluster on an x86 architecture, for example OpenShift Local on M1 Mac, you will not see the {ols-long} Operator in Operator Hub due to the way the Operator Hub filters architectures. 
+The {ols-long} Operator is visible in the Operator Hub only for supported architectures, as filtering prevents it from appearing on non-x86 platforms.
 
 {ols-long} is only supported on x86 architecture.

--- a/modules/ols-thinking-model-generates-delineator-prompt.adoc
+++ b/modules/ols-thinking-model-generates-delineator-prompt.adoc
@@ -6,7 +6,7 @@
 = Thinking model generates delineator prompt
 
 [role="_abstract"]
-In some cases, thinking or reasoning models produce output that has delineators, such as `THOUGHT` or `reasoning`, to separate the thinking process from the model output that the {ols-long} Service uses to answer your question. 
+Reasoning models use delineators, such as `THOUGHT` or `reasoning`, to distinguish internal thought processes from the final response provided by the {ols-long} Service.
 
 The {ols-long} Service does not configure the delineator behavior or produce the delineators in the output. The delineator feature is a model configuration setting. Typically, you can disable the feature using one of the following methods:
 

--- a/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
+++ b/troubleshoot/ols-troubleshooting-openshift-lightspeed.adoc
@@ -8,8 +8,10 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Find solutions and workarounds for common issues encountered when using and configuring the {ols-long} Operator and Service.
+Review solutions and workarounds for common installation, configuration, and operational issues encountered with the {ols-long}.
 
 include::modules/ols-502-bad-gateway-errors.adoc[leveloffset=+1]
+
 include::modules/ols-operator-missing-from-operatorhub-list.adoc[leveloffset=+1]
+
 include::modules/ols-thinking-model-generates-delineator-prompt.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2542

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
