### PR TITLE
OCPBUGS#70297: oc adm release mirror command deprecation note

### DIFF
--- a/disconnected/installing-mirroring-installation-images.adoc
+++ b/disconnected/installing-mirroring-installation-images.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 You can ensure your clusters only use container images that satisfy your organizational controls on external content. Before you install a cluster on infrastructure that you provision in a restricted network, you must mirror the required container images into that environment. By using the `oc adm` command, you can mirror release and catalog images in OpenShift. To mirror container images, you must have a registry for mirroring.
 
+[NOTE]
+====
+The `oc adm release mirror` command is planned for deprecation in a future release. Additionally, when using this command, release image signatures are not automatically mirrored to the disconnected registry. Missing release signatures prevent cluster upgrades, as `ClusterImagePolicy` requires all release images to be verified. To ensure image signatures are correctly mirrored, it is recommended to use the oc-mirror v2 plugin.
+====
+
 // TODO: Is this procedure going to be marked deprecated for 4.10 so that it could be removed in the future?
 // TODO: Add a link to the TP procedure?
 // TODO: Consider updating the title of this one to indicate the difference? Or wait to make any changes like that til GA, til we know if it'll stick around or be completely replaced by the oc-mirror one?


### PR DESCRIPTION
Version(s): 4.21+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-70297
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
The note mentioned in https://105307--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/installing-mirroring-installation-images.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
