### PR TITLE
TRACING-5934: Improve SCC example for filelogreceiver

### DIFF
--- a/modules/otel-receivers-filelog-receiver.adoc
+++ b/modules/otel-receivers-filelog-receiver.adoc
@@ -60,8 +60,34 @@ forbiddenSysctls:
 - '*'
 seccompProfiles:
 - runtime/default
-users:
-- system:serviceaccount:observability:clusterlogs-collector <2>
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: otel-clusterlogs-collector-scc
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - otel-clusterlogs-collector-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: otel-clusterlogs-collector-scc
+  namespace: observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: otel-clusterlogs-collector-scc
+subjects:
+- kind: ServiceAccount
+  name: clusterlogs-collector <2>
+  namespace: observability
 ---
 apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
@@ -70,13 +96,19 @@ metadata:
   namespace: observability
 spec:
   mode: daemonset
+  podAnnotations:
+    openshift.io/required-scc: otel-clusterlogs-collector-scc
+  tolerations:
+  - key: node-role.kubernetes.io/control-plane <3>
+    operator: Exists
+    effect: NoSchedule
   config:
     receivers:
       filelog:
         include:
         - "/var/log/pods/*/*/*.log"
         exclude:
-        - "/var/log/pods/*/otc-container/*.log" <3>
+        - "/var/log/pods/*/otc-container/*.log" <4>
         - "/var/log/pods/*/*/*.gz"
         - "/var/log/pods/*/*/*.log.*"
         - "/var/log/pods/*/*/*.tmp"
@@ -114,7 +146,8 @@ spec:
 ----
 <1> Configure a security context constraint (SCC) to allow access to files on the host.
 <2> The OpenTelemetry Operator created this service account for the Collector. Assign the SCC to this service account.
-<3> Exclude logs from the Collector container.
+<3> Schedule the Collector on control plane nodes.
+<4> Exclude logs from the Collector container.
 
 You can use this receiver to collect logs from pod filesystems in one of two ways:
 


### PR DESCRIPTION
Added the following improvements
* use ClusterRole and RoleBinding
* add `openshift.io/required-scc` annotation
* schedule collector on control plane nodes

Thanks to @michaelalang for the feedback and for suggesting these edits!

Version(s):
all supported OCP versions

Issue:
https://issues.redhat.com/browse/TRACING-5934

Link to docs preview:
https://105308--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/otel/otel-collector/otel-collector-receivers.html#otel-receivers-filelog-receiver_otel-collector-receivers

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
cc @IshwarKanse  @max-cx 