### PR TITLE
OLS-2539: Create short descriptions for modules in installation assembly

### DIFF
--- a/install/ols-installing-openshift-lightspeed.adoc
+++ b/install/ols-installing-openshift-lightspeed.adoc
@@ -8,10 +8,12 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The installation process for {ols-official} consists of two main tasks: installing the {ols-long} Operator and configuring the {ols-long} Service to interact with the large language model (LLM) provider.
+To install {ols-official}, you must install the {ols-long} Operator and configure the service to interact with a large language model (LLM) provider.
 
 include::modules/ols-large-language-model-overview.adoc[leveloffset=+1]
+
 include::modules/ols-about-subscription-requirements.adoc[leveloffset=+1]
+
 include::modules/ols-about-adding-operators-to-a-cluster.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -22,4 +24,5 @@ include::modules/ols-about-adding-operators-to-a-cluster.adoc[leveloffset=+1]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/administrator-tasks#olm-installing-operators-from-software-catalog_olm-adding-operators-to-a-cluster[About Operator installation with software catalog]
 
 include::modules/ols-installing-operator-from-operatorhub.adoc[leveloffset=+2]
+
 include::modules/ols-installing-operator-from-software-catalog.adoc[leveloffset=+2]

--- a/modules/ols-about-adding-operators-to-a-cluster.adoc
+++ b/modules/ols-about-adding-operators-to-a-cluster.adoc
@@ -6,6 +6,5 @@
 
 = About adding Operators to a cluster
 
-Using Operator Lifecycle Manager (OLM), cluster administrators can install OLM-based Operators to an {ocp-product-title} cluster.
-
-As a cluster administrator, you can install an Operator by using the OperatorHub or the software catalog, depending on which {ocp-product-title} version is installed.
+[role="_abstract"]
+Install Operators on your {ocp-product-title} cluster by using Operator Lifecycle Manager (OLM) through the OperatorHub or software catalog.

--- a/modules/ols-about-subscription-requirements.adoc
+++ b/modules/ols-about-subscription-requirements.adoc
@@ -6,7 +6,9 @@
 = About subscription requirements
 
 [role="_abstract"]
-{ols-official} requires a valid and active subscription to one of the listed OpenShift products.
+Review the supported {ocp-product-title} product subscriptions and account requirements necessary to activate and use the {ols-long} Service in your environment.
+
+{ols-official} requires a valid and active subscription to one of the listed products.
 
 * {oke-first}
 * {ove-first}

--- a/modules/ols-large-language-model-overview.adoc
+++ b/modules/ols-large-language-model-overview.adoc
@@ -7,7 +7,7 @@
 = Large Language Model (LLM) overview
 
 [role="_abstract"]
-A large language model (LLM) is a type of artificial intelligence program trained on vast quantities of data. The {ols-long} Service interacts with the LLM to generate answers to questions. 
+Learn how the {ols-long} Service uses large language models (LLMs) to provide intelligent, context-aware answers to your questions about {ocp-product-title}.
 
 You can configure {rhelai} or {rhoai} as the LLM provider for the {ols-long} Service. Either LLM provider can use a server or inference service that processes inference queries. 
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2539

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
