### PR TITLE
Updating the version number for raw GH file to fetch 4.21 

### DIFF
--- a/modules/installation-azure-confidential-vms.adoc
+++ b/modules/installation-azure-confidential-vms.adoc
@@ -28,6 +28,7 @@ You can use confidential VMs with the following VM sizes:
 * DCedsv5-series
 * ECesv5-series
 * ECedsv5-series
+* NCCads_H100_v5
 
 [IMPORTANT]
 ====

--- a/modules/installation-azure-tested-machine-types.adoc
+++ b/modules/installation-azure-tested-machine-types.adoc
@@ -17,5 +17,5 @@ The following Microsoft Azure instance types have been tested with {product-titl
 .Machine types based on 64-bit x86 architecture
 [%collapsible]
 ====
-include::https://raw.githubusercontent.com/openshift/installer/release-4.20/docs/user/azure/tested_instance_types_x86_64.md[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.21/docs/user/azure/tested_instance_types_x86_64.md[]
 ====


### PR DESCRIPTION
[OSDOCS-13992](https://issues.redhat.com//browse/OSDOCS-13992): Updating the version number for raw GH file to fetch 4.21 to include support for NVIDIA H100 and H200 enabled machine series

Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/OSDOCS-13992
https://issues.redhat.com/browse/OCPBUGS-74079

Link to docs preview:

- [ Tested instance types for Azure - Machine types based on 64-bit x86 architecture](https://105314--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-customizations.html#installation-azure-tested-machine-types_installing-azure-customizations)
- [Enabling confidential VMs](https://105314--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_azure/ipi/installing-azure-customizations.html#installation-azure-confidential-vms_installing-azure-customizations)

QE review:
- [ ] QE has approved this change.

Additional information:
**Merge only when https://github.com/openshift/installer/pull/10234 is merged**
