### PR TITLE
Moving BMO read only filesystem RN to technical changes

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -31,7 +31,7 @@ Applying VPA recommendations without pod re-creation::
 +
 You can now configure a Vertical Pod Autoscaler Operator (VPA) in the `InPlaceOrRecreate` mode. In this mode, the VPA attempts to apply the recommended updates without re-creating pods. If the VPA is unable to update the pods in place, the VPA falls back to re-creating the pods. For more information, see xref:../nodes/pods/nodes-pods-vertical-autoscaler.adoc#nodes-pods-vertical-autoscaler-modes_nodes-pods-vertical-autoscaler[About the Vertical Pod Autoscaler Operator modes].
 
-Cluster Autoscaler Operator can now cordon nodes before removing the node:: 
+Cluster Autoscaler Operator can now cordon nodes before removing the node::
 +
 By default, when the Cluster Autoscaler Operator removes a node, it does not cordon the node when draining the pods from the node. You can configure the Operator to cordon the node before draining and moving the pods. For more information, see xref:../machine_management/applying-autoscaling.adoc#cluster-autoscaler-about_applying-autoscaling[About the cluster autoscaler].
 
@@ -192,7 +192,7 @@ The following additional VCF and VVF components are outside the scope of Red Hat
 [id="ocp-release-notes-machine-config-operator_{context}"]
 == Machine Config Operator
 
-Boot image management for {azure-short} and {vmw-short} clusters promoted to GA:: 
+Boot image management for {azure-short} and {vmw-short} clusters promoted to GA::
 +
 Updating boot images has been promoted to GA for {azure-full} and {vmw-full} clusters. For more information, see xref:../machine_configuration/mco-update-boot-images.adoc#mco-update-boot-images[Boot image management].
 
@@ -299,10 +299,6 @@ Item description::
 +
 Detailed information.
 ////
-
-Bare Metal Operator has read-only root filesystem by default::
-+
-As of this update, the Bare Metal Operator has the `readOnlyRootFilesystem` security context setting enabled to meet common hardening recommendations.
 
 [id="ocp-release-notes-operator-lifecycle_{context}"]
 == Operator lifecycle

--- a/modules/rn-ocp-release-notes-notable-changes.adoc
+++ b/modules/rn-ocp-release-notes-notable-changes.adoc
@@ -15,3 +15,7 @@ Detailed information.
 {vmw-full} 7 and VMware Cloud Foundation 4 end of general support::
 +
 Broadcom has ended general support for {vmw-full} 7 and VMware Cloud Foundation (VCF) 4. If your existing {product-title} cluster is running on either of these platforms, you must plan to migrate or upgrade your VMware infrastructure to a supported version. {product-title} supports installation on {vmw-short} 8 Update 1 or later, or VCF 5 or later.
+
+Bare Metal Operator has read-only root filesystem by default::
++
+As of this update, the Bare Metal Operator has the `readOnlyRootFilesystem` security context setting enabled to meet common hardening recommendations.


### PR DESCRIPTION
Version(s):
4.21

Preview:
https://105318--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-notes-notable-changes_release-notes

"Operator development" RN section is not appropriate for this RN.