### PR TITLE
OSDOCS-7251: Azure support mutli-FD CPMS docs patch

### DIFF
--- a/modules/cpmso-yaml-failure-domain-azure.adoc
+++ b/modules/cpmso-yaml-failure-domain-azure.adoc
@@ -33,24 +33,16 @@ spec:
     machines_v1beta1_machine_openshift_io:
       failureDomains:
         azure:
-        - internalLoadBalancer: <internal_lb_name>
-        - subnet: <subnet_name>
         - zone: "1"
+          subnet: <subnet_zone_1>
         - zone: "2"
+          subnet: <subnet_zone_2>
         - zone: "3"
+          subnet: <subnet_zone_3>
         platform: Azure
 # ...
 ----
 where:
-
-`spec.template.machines_v1beta1_machine_openshift_io.failureDomains.azure.internalLoadBalancer`::
-Specifies the name of the internal load balancer for the virtual machine.
-When omitted, the control plane machine set uses `internalLoadBalancer` value from the machine `providerSpec` template.
-Do not change this value.
-
-`spec.template.machines_v1beta1_machine_openshift_io.failureDomains.azure.subnet`::
-Specifies the network subnet in which to create the control plane VM.
-When omitted, the control plane machine set uses the `subnet` value from the machine `providerSpec` template.
 
 `spec.template.machines_v1beta1_machine_openshift_io.failureDomains.azure.zone`::
 Each instance of `zone` specifies an {azure-short} availability zone for a failure domain.
@@ -59,6 +51,10 @@ Each instance of `zone` specifies an {azure-short} availability zone for a failu
 ====
 If the cluster uses a single zone for all failure domains, the `zone` parameter is in the provider specification instead of in the failure domain configuration.
 ====
+
+`spec.template.machines_v1beta1_machine_openshift_io.failureDomains.azure.subnet`::
+Optional: Specifies the network subnet in which to create the control plane VM.
+When omitted, the control plane machine set uses the `subnet` value from the machine `providerSpec` template.
 
 `spec.template.machines_v1beta1_machine_openshift_io.failureDomains.platform`::
 Specifies the cloud provider platform name.


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-7251](https://issues.redhat.com//browse/OSDOCS-7251)

Link to docs preview:
[Sample Azure failure domain configuration](https://105337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.html#cpmso-yaml-failure-domain-azure_cpmso-config-options-azure)

QE review:
- [x] QE has approved this change.

Additional information:
* Updates for #105098 issues