### PR TITLE
OSDOCS-17968:Update the z-stream RNs for 4.18.32

### DIFF
--- a/modules/zstream-4-18-32-about.adoc
+++ b/modules/zstream-4-18-32-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-32-about_{context}"]
+= RHSA-2026:1062 - {product-title} {product-version}.32 fixed issues and security update
+
+[role="_abstract"]
+Issued: 03 February 2026
+
+{product-title} release {product-version}.32 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:1062[RHSA-2026:1062] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:0979[RHBA-2026:0979] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.18.32 --pullspecs
+----

--- a/modules/zstream-4-18-32-fixed-issues.adoc
+++ b/modules/zstream-4-18-32-fixed-issues.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-32-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+You can ensure your environment remains stable by reviewing these fixed issues to verify resolved bugs.
+
+The following issues are fixed for this release:
+
+* Before this update, when service endpoints were deleted and recreated in {product-title} clusters using OVN-Kubernetes networking and the service port differed from the endpoint port, stale User Datagram Protocol (UDP) connection tracking (conntrack) entries could remain on compute nodes. This occurred because the `conntrack` cleanup logic incorrectly used the endpoint port, which is the target port on the pod, instead of the externally-facing service port that clients connect to when attempting to delete stale entries. With this release, the cleanup process uses the service port when deleting or updating service endpoints. This change ensures that stale `conntrack` entries are correctly matched and removed. Network connectivity now remains reliable during service endpoint lifecycle changes. (link:https://issues.redhat.com/browse/OCPBUGS-70346[OCPBUGS-70346])
+
+* Before this update, a runtime error prevented an egress IP address from being created in an {product-title} cluster on {azure-first}. With this release, a code fix resolves the runtime error. As a result, an egress IP address can be created in an {product-title}t cluster on {azure-short}. (link:https://issues.redhat.com/browse/OCPBUGS-73750[OCPBUGS-73750])
+
+* Before this update, `iptables-alerter` pods experienced high CPU usage in some clusters due to an issue in the 4.18.20 upgrade. As a consequence, high CPU usage impacted `iptables-alerter` pods, causing performance degradation. With this release, iptables-alerter CPU usage has been reduced by optimizing code in version 4.18.21. As a result, high CPU usage for `iptables-alerter` pods has been resolved, improving cluster performance. (link:https://issues.redhat.com/browse/OCPBUGS-73767[OCPBUGS-73767])
+
+* Before this update, {aws-first} APIs returned inconsistent results regarding the existence of a `Machine`. The safeguards designed to handle this inconsistency checked the stored instance ID in the incorrect location. As a consequence, during {aws-short} API instability, virtual machines (VMs) leaked and attempted to join the cluster indefinitely. With this release, the system uses the correct provider ID for consistency checks. If an instance does not appear within 20 seconds, the machine status changes to `Failed` to prevent instance leaks. (link:https://issues.redhat.com/browse/OCPBUGS-73789[OCPBUGS-73789])
+
+* Before this update, if etcd shared a volume with OLM, disk contention might occur. With this release, the default catalog polling interval is increased from ten minutes to four hours. As a result, some instances of catalog pod startup probe failures are fixed. Red{nbsp}Hat strongly recommends that etcd use a dedicated volume. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/scalability_and_performance/recommended-performance-and-scalability-practices-2#recommended-etcd-practices_recommended-etcd-practices[Recommended performance and scalability practices]. (link:https://issues.redhat.com/browse/OCPBUGS-73833[OCPBUGS-73833]) 

--- a/modules/zstream-4-18-32-updating.adoc
+++ b/modules/zstream-4-18-32-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-18-32-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.18 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-18-release-notes.adoc
+++ b/release_notes/ocp-4-18-release-notes.adoc
@@ -3077,6 +3077,15 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+// 4.18.32 about
+include::modules/zstream-4-18-32-about.adoc[leveloffset=+2]
+
+// 4.18.32 fixed issues
+include::modules/zstream-4-18-32-fixed-issues.adoc[leveloffset=+2]
+
+// 4.18.32 updating
+include::modules/zstream-4-18-32-updating.adoc[leveloffset=+2]
+
 // 4.18.31 about
 include::modules/zstream-4-18-31-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.18

Issue:
https://issues.redhat.com/browse/OSDOCS-17968

Link to docs preview:
https://105340--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-18-release-notes.html#rhsa-20261062-openshift-container-platform-branch-build-32-fixed-issues-and-security-update

Additional information:
4.18.32 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/326
4.18.32 ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18