### PR TITLE
OBSDOCS-3026 Add 4.19 limitation to troubleshooting pages

### DIFF
--- a/ui_plugins/troubleshooting-ui-plugin.adoc
+++ b/ui_plugins/troubleshooting-ui-plugin.adoc
@@ -15,6 +15,12 @@ The panel displays an interactive node graph in the {ocp-product-title} web cons
 Nodes in the graph represent a type of resource or signal, while edges represent relationships.
 When you click on a node, you are automatically redirected to the corresponding web console page.
 
+[NOTE]
+====
+The troubleshooting feature in the {coo-full} versions 1.3+ has General Availability (GA) status for {ocp-product-title} versions 4.19+ and is not supported in earlier versions.
+====
+
+
 include::modules/coo-troubleshooting-ui-plugin-install.adoc[leveloffset=+1]
 
 include::modules/coo-troubleshooting-ui-plugin-using.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
standalone-coo-docs-main

Issue:
[OBSDOCS-3026](https://issues.redhat.com//browse/OBSDOCS-3026)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
