### PR TITLE
OSDOCS#17767: RN for day 2 throughput config

### DIFF
--- a/modules/rn-ocp-release-notes-known-issues.adoc
+++ b/modules/rn-ocp-release-notes-known-issues.adoc
@@ -42,3 +42,7 @@ For information on the oc-mirror v2 plugin, see _Mirroring images for a disconne
 --
 +
 A native abort capability for servicing operations might be planned for a future release.
+
+* There is a known issue with the ability to configure the maximum throughput of gp3 storage volumes in an {aws-short} cluster.
+This feature does not work with control plane machine sets.
+There is no workaround for this issue, but it is planned to be fixed in a later release. (link:https://issues.redhat.com/browse/OCPBUGS-74478[OCPBUGS-74478])

--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -320,6 +320,12 @@ This release includes additional configuration options for control plane machine
 +
 For more information, see xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#cpmso-yaml-failure-domain-azure_cpmso-config-options-azure[Sample {azure-short} failure domain configuration].
 
+Configuration of throughput for {aws-full} gp3 volumes on EBS devices::
++
+This release includes support for configuring the maximum throughput for gp3 drives on EBS devices for clusters installed on {aws-first}.
++
+For more information, see xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machine-feature-aws-throughput_creating-machineset-aws[Configuring storage throughput for gp3 drives (Machine API)] and xref:../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#machine-feature-aws-throughput-capi_cluster-api-config-options-aws[Configuring storage throughput for gp3 drives (Cluster API)].
+
 [id="ocp-release-notes-monitoring_{context}"]
 == Monitoring
 
@@ -479,7 +485,7 @@ You can apply a Volume Attributes Classes to a persistent volume claim (PVC). If
 +
 Volume Attributes Classes have parameters that describe volumes belonging to them. If a parameter is omitted, the default is used at volume provisioning. If a user applies the PVC with a different Volume Attributes Class with omitted parameters, the default value of the parameters might be used depending on the CSI driver implementation. For more information, see the related CSI driver documentation.
 +
-For more information, see xref:../storage/understanding-persistent-storage.adoc#storage-persistent-storage-pvc-volumeattributesclass_understanding-persistent-storage[Volume Attributes Classes]. 
+For more information, see xref:../storage/understanding-persistent-storage.adoc#storage-persistent-storage-pvc-volumeattributesclass_understanding-persistent-storage[Volume Attributes Classes].
 
 Azure File CSI supporting snapshots feature is generally available::
 +


### PR DESCRIPTION
Version(s): 4.21 only

This PR adds an RN for the day 2 configuration of maximum throughput of gp3 drives on AWS.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

Preview: 

- [Machine Management](https://105391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-machine-management_release-notes)
- [Known issues](https://105391--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-notes-known-issues_release-notes)