### PR TITLE
[OSDOCS#18025]: Added files for 4.16.56 z stream release notes.

### DIFF
--- a/modules/zstream-4-16-56-about.adoc
+++ b/modules/zstream-4-16-56-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-16-56-about_{context}"]
+= RHBA-2026:0992 - {product-title} {product-version}.56 bug fix advisory
+
+
+[role="_abstract"]
+Issued: 29 January 2026
+
+{product-title} release {product-version}.56 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:0992[RHBA-2026:0992] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:0984[RHBA-2026:0984] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.56 --pullspecs
+----

--- a/modules/zstream-4-16-56-fixed-issues.adoc
+++ b/modules/zstream-4-16-56-fixed-issues.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-56-fixed-issues_{context}"]
+= Fixed Issues
+
+[role="_abstract"]
+
+* Before this update, HAProxy pods frequently exceeded the `maxConn` limit because idle connections remained open when using the `idle-close-on-response` setting. As a consequence, HAProxy pods entered a CrashLoop state, resulting in performance degradation and persistent reconciliation failures. With this release, the IdleConnectionTerminationPolicy is activated to ensure idle connections are closed correctly. As a result, HAProxy pods in {product-title} 4.18.0 no longer exceed the maxConn limit or experience crashes related to connection buildup.(link:https://issues.redhat.com/browse/OCPBUGS-71202[OCPBUGS-71202])
+
+* Before this update, a validation error occurred during the creation of user accounts with special characters in the email address. As a consequence, user account creation failed. With this release, the validation error is resolved. As a result, user account creation with special characters in the email address is successful. (link:https://issues.redhat.com/browse/OCPBUGS-72541[OCPBUGS-72541])
+
+* Before this update, {product-title} release 4.16.55 and earlier releases remained on the stable-4.16 channel instead of switching to the eus-4.16 channel. This caused 'VersionNotFound' errors when attempting to retrieve update information, because of which, the recommended updates were not available. With this release, the installation program directs 4.16.56 and later releases to the Extended Update Support (EUS) channel ensuring the releases receive recommended update notices and the `VersonNotFound` error no longer displays. (link:https://issues.redhat.com/browse/OCPBUGS-73879[OCPBUGS-73879])
+
+* Before this update, AWS APIs returned inconsistent results regarding the existence of a Machine. The safeguards designed to handle this inconsistency checked the stored instance ID in the incorrect location. Consequently, during AWS API instability, virtual machines (VMs) leaked and attempted to join the cluster indefinitely. With this release, the system uses the correct provider ID for consistency checks. If an instance does not appear within 20 seconds, the machine status changes to Failed to prevent instance leaks. (link:https://issues.redhat.com/browse/OCPBUGS-73903[OCPBUGS-73903])

--- a/modules/zstream-4-16-56-updating.adoc
+++ b/modules/zstream-4-16-56-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-56-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3396,13 +3396,22 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
-// About 4-16-54 release notes
+// About 4-16-56 release notes
+include::modules/zstream-4-16-56-about.adoc[leveloffset=+2]
+
+// 4-16-56 release notes bug fixes
+include::modules/zstream-4-16-56-fixed-issues.adoc[leveloffset=+2]
+
+// 4-16-56 release notes updating
+include::modules/zstream-4-16-56-updating.adoc[leveloffset=+2]
+
+// About 4-16-55 release notes
 include::modules/zstream-4-16-55-about.adoc[leveloffset=+2]
 
-// 4-16-54 release notes bug fixes
+// 4-16-55 release notes bug fixes
 include::modules/zstream-4-16-55-bug-fixes.adoc[leveloffset=+2]
 
-// 4-16-54 release notes updating
+// 4-16-55 release notes updating
 include::modules/zstream-4-16-55-updating.adoc[leveloffset=+2]
 
 // About 4-16-54 release notes


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-18025

Link to docs preview:
https://105392--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#ocp-4-16-asynchronous-errata-updates_release-notes

QE review:
- [ ] QE has approved this change.


Additional information:

