### PR TITLE
OSDOCS-15089 Updating the 4.21 TechPreviewNoUpgrade featureset list

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -7,7 +7,7 @@
 = Understanding feature gates
 
 [role="_abstract"]
-You can use the `FeatureGate` custom resource (CR) to enable specific feature sets so that you can use specific non-default features in your cluster. 
+You can use the `FeatureGate` custom resource (CR) to enable specific feature sets so that you can use specific non-default features in your cluster.
 
 A feature set is a collection of {product-title} features that are not enabled by default.
 
@@ -28,39 +28,48 @@ The following Technology Preview features are enabled by this feature set:
 ** `AlibabaPlatform`
 ** `AutomatedEtcdBackup`
 ** `AWSClusterHostedDNS`
-//** `AWSClusterHostedDNSInstall` TP in 4.20.z, QE says to remove for 4.20.0. https://github.com/openshift/openshift-docs/pull/99971/files#r2418324446
-//** `AWSDedicatedHosts` Planned TP in 4.21 https://github.com/openshift/openshift-docs/pull/99971/files#r2418426941
+** `AWSClusterHostedDNSInstall`
+** `AWSDedicatedHosts`
+** `AWSDualStackInstall`
 ** `AWSServiceLBNetworkSecurityGroup`
-//** `AzureClusterHostedDNSInstall` Planned 4.21 https://github.com/openshift/openshift-docs/pull/99971/files#r2418323357
-//** `AzureDedicatedHosts` Target version 4.21 https://github.com/openshift/openshift-docs/pull/99971/files#r2418333707
+** `AzureClusterHostedDNSInstall`
+** `AzureDedicatedHosts`
+** `AzureDualStackInstall`
 ** `AzureMultiDisk`
 ** `AzureWorkloadIdentity`
 ** `BootcNodeManagement`
+** `BootImageSkewEnforcement`
 ** `BuildCSIVolumes`
+** `CBORServingAndStorage`
+** `ClientsPreferCBOR`
+** `ClusterAPIInstallIBMCloud`
+** `ClusterAPIMachineManagement`
 ** `ClusterMonitoringConfig`
 ** `ClusterVersionOperatorConfiguration`
 ** `ConsolePluginContentSecurityPolicy`
 ** `CPMSMachineNamePrefix`
+** `CRDCompatibilityRequirementOperator`
 ** `DNSNameResolver`
-** `DynamicResourceAllocation`
+** `DualReplica`
 ** `DyanmicServiceEndpointIBMCloud`
 ** `EtcdBackendQuota`
+** `EventTTL`
 ** `Example`
 ** `ExternalOIDC`
 ** `ExternalOIDCWithUIDAndExtraClaimMappings`
 ** `GatewayAPI`
 ** `GatewayAPIController`
+** `GCPClusterHostedDNS`
 ** `GCPClusterHostedDNSInstall`
 ** `GCPCustomAPIEndpoints`
-//** `GCPCustomAPIEndpointsInstall` Moved to 4.21 https://github.com/openshift/openshift-docs/pull/99971/files#r2418310866
+** `GCPCustomAPIEndpointsInstall`
+** `GCPDualStackInstall`
 ** `HighlyAvailableArbiter`
+** `HyperShiftOnlyDynamicResourceAllocation`
 ** `ImageModeStatusReporting`
 ** `ImageStreamImportMode`
 ** `ImageVolume`
-** `IngressControllerDynamicConfigurationManager`
-** `IngressControllerLBSubnetsAWS`
 ** `InsightsConfig`
-** `InsightsConfigAPI`
 ** `InsightsOnDemandDataGather`
 ** `IrreconcilableMachineConfig`
 ** `KMSEncryptionProvider`
@@ -70,12 +79,14 @@ The following Technology Preview features are enabled by this feature set:
 ** `ManagedBootImages`
 ** `ManagedBootImagesAWS`
 ** `ManagedBootImagesAzure`
+** `ManagedBootImagesCPMS`
 ** `ManagedBootImagesvSphere`
 ** `MaxUnavailableStatefulSet`
 ** `MetricsCollectionProfiles`
 ** `MinimumKubeletVersion`
 ** `MixedCPUsAllocation`
 ** `MultiDiskSetup`
+** `MutableCSINodeAllocatableCount`
 ** `MutatingAdmissionPolicy`
 ** `NetworkDiagnosticsConfig`
 ** `NetworkLiveMigration`
@@ -85,9 +96,11 @@ The following Technology Preview features are enabled by this feature set:
 ** `NewOLMOwnSingleNamespace`
 ** `NewOLMPreflightPermissionChecks`
 ** `NewOLMWebhookProviderOpenshiftServiceCA`
-** `NoRegistryClusterOperations`
+** `NoRegistryClusterInstall`
 ** `NutanixMultiSubnets`
+** `OnPremDNSRecords`
 ** `OpenShiftPodSecurityAdmission`
+** `OSStreams`
 ** `OVNObservability`
 ** `PinnedImages`
 ** `PreconfiguredUDNAddresses`
@@ -96,11 +109,12 @@ The following Technology Preview features are enabled by this feature set:
 ** `RouteExternalCertificate`
 ** `SELinuxMount`
 ** `ServiceAccountTokenNodeBinding`
-** `SetEIPForNLBIngressController`
 ** `SignatureStores`
 ** `SigstoreImageVerification`
 ** `SigstoreImageVerificationPKI`
+** `StoragePerformantSecurityPolicy`
 ** `TranslateStreamCloseWebsocketRequests`
+** `UpgradeStatus`
 ** `UserNamespacesPodSecurityStandards`
 ** `UserNamespacesSupport`
 ** `VolumeAttributesClass`
@@ -110,11 +124,9 @@ The following Technology Preview features are enabled by this feature set:
 ** `VSphereMixedNodeEnv`
 ** `VSphereMultiDisk`
 ** `VSphereMultiNetworks`
-** `VSphereMultiVCenters`
-** `TwoNodeOpenShiftClusterWithFencing`
 --
 
-See the _Additional resources_ sections for information on some of these features. 
+See the _Additional resources_ sections for information on some of these features.
 
 ////
 Do not document per Derek Carr: https://github.com/openshift/api/pull/370#issuecomment-510632939


### PR DESCRIPTION
Version(s): 4.21
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-15089](https://issues.redhat.com/browse/OSDOCS-15089)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://105393--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Making the docs TechPreviewNoUpgrade list match [this 4.21 list](https://github.com/openshift/api/blob/release-4.21/features.md).
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
