### PR TITLE
CNV-74970: Remove callouts

### DIFF
--- a/modules/virt-uploading-image-virtctl.adoc
+++ b/modules/virt-uploading-image-virtctl.adoc
@@ -24,13 +24,14 @@ certificate.
 +
 [source,terminal]
 ----
-$ virtctl image-upload dv <datavolume_name> \ <1>
-  --size=<datavolume_size> \ <2>
-  --image-path=</path/to/image> \ <3>
+$ virtctl image-upload dv <datavolume_name> \
+  --size=<datavolume_size> \
+  --image-path=</path/to/image>
 ----
-<1> The name of the data volume.
-<2> The size of the data volume. For example: `--size=500Mi`, `--size=1G`
-<3> The file path of the image.
++
+`<datavolume_name>`:: The name of the data volume.
+`<datavolume_size>`:: The size of the data volume. For example: `--size=500Mi`, `--size=1G`
+`</path/to/image>`:: The file path of the image.
 +
 [NOTE]
 ====

--- a/modules/virt-using-skip-node.adoc
+++ b/modules/virt-using-skip-node.adoc
@@ -8,20 +8,21 @@
 = Using skip-node annotation
 
 [role="_abstract"]
-If you want the `node-labeller` to skip a node, annotate that node by using the `oc` CLI.
+If you want the `node-labeller` to skip a node, annotate that node by using the {oc-first}.
 
 .Prerequisites
-* You have installed the OpenShift CLI (`oc`).
+
+* You have installed the {oc-first}.
 
 .Procedure
 
 * Annotate the node that you want to skip by running the following command:
-
 +
 [source,terminal]
 ----
-$ oc annotate node <node_name> node-labeller.kubevirt.io/skip-node=true <1>
+$ oc annotate node <node_name> node-labeller.kubevirt.io/skip-node=true
 ----
-<1> Replace `<node_name>` with the name of the relevant node to skip.
++
+Replace `<node_name>` with the name of the relevant node to skip.
 +
 Reconciliation resumes on the next cycle after the node annotation is removed or set to false.

--- a/modules/virt-verify-status-bootsource-update.adoc
+++ b/modules/virt-verify-status-bootsource-update.adoc
@@ -56,7 +56,7 @@ status:
                 storage: 30Gi
         status: {}
     status:
-      commonTemplate: true <1>
+      commonTemplate: true
 # ...
   - metadata:
       annotations:
@@ -78,11 +78,12 @@ status:
               requests:
                 storage: 30Gi
         status: {}
-    status: {} <2>
+    status: {}
 # ...
 ----
-<1> Indicates a system-defined boot source.
-<2> Indicates a custom boot source.
++
+`status.dataImportCronTemplates.status.commonTemplate`:: Indicates a system-defined boot source.
+`status.dataImportCronTemplates.status`:: Indicates a custom boot source.
 
 . Verify the status of the boot source by reviewing the `status.dataImportCronTemplates.status` field.
 * If the field contains `commonTemplate: true`, it is a system-defined boot source.

--- a/modules/virt-viewing-automatically-created-storage-profiles.adoc
+++ b/modules/virt-viewing-automatically-created-storage-profiles.adoc
@@ -14,6 +14,7 @@ The system creates storage profiles for each storage class automatically. You ca
 * You have installed the {oc-first}.
 
 .Procedure
+
 . To view the list of storage profiles, run the following command:
 +
 [source,terminal]
@@ -57,7 +58,7 @@ Metadata:
   UID:                     14aef804-6688-4f2e-986b-0297fd3aaa68
 Spec:
 Status:
-  Claim Property Sets: <1>
+  Claim Property Sets:
     accessModes:
       ReadWriteMany
     volumeMode:  Block
@@ -67,15 +68,14 @@ Status:
     accessModes:
       ReadWriteOnce
     volumeMode:                   Filesystem
-  Clone Strategy:                  csi-clone <2>
-  Data Import Cron Source Format:  snapshot <3>
+  Clone Strategy:                  csi-clone
+  Data Import Cron Source Format:  snapshot
   Provisioner:                     openshift-storage.rbd.csi.ceph.com
   Snapshot Class:                  ocs-storagecluster-rbdplugin-snapclass
   Storage Class:                   ocs-storagecluster-ceph-rbd-virtualization
 Events:                            <none>
 ----
-<1> `Claim Property Sets` is an ordered list of `AccessMode`/`VolumeMode` pairs, which describe the PVC modes that are used to provision VM disks.
-<2> The `Clone Strategy` line indicates the clone strategy to be used.
-<3> `Data Import Cron Source Format` indicates whether golden images on this storage are stored as PVCs or volume snapshots.
-
-
++
+`status.claimPropertySets`:: `Claim Property Sets` is an ordered list of `AccessMode`/`VolumeMode` pairs, which describe the PVC modes that are used to provision VM disks.
+`status.cloneStrategy`:: The `Clone Strategy` line indicates the clone strategy to be used.
+`status.dataImportCronSourceFormat`:: `Data Import Cron Source Format` indicates whether golden images on this storage are stored as PVCs or volume snapshots.

--- a/modules/virt-viewing-network-state-of-node.adoc
+++ b/modules/virt-viewing-network-state-of-node.adoc
@@ -36,9 +36,9 @@ Example output:
 apiVersion: nmstate.io/v1
 kind: NodeNetworkState
 metadata:
-  name: node01 <1>
+  name: node01
 status:
-  currentState: <2>
+  currentState:
     dns-resolver:
 # ...
     interfaces:
@@ -47,8 +47,9 @@ status:
 # ...
     routes:
 # ...
-  lastSuccessfulUpdateTime: "2020-01-31T12:14:00Z" <3>
+  lastSuccessfulUpdateTime: "2020-01-31T12:14:00Z"
 ----
-<1> The name of the `NodeNetworkState` object is taken from the node.
-<2> The `currentState` contains the complete network configuration for the node, including DNS, interfaces, and routes.
-<3> Timestamp of the last successful update. This is updated periodically as long as the node is reachable and can be used to evalute the freshness of the report.
++
+`metadata.name`:: The name of the `NodeNetworkState` object is taken from the node.
+`status.currentState`:: The `currentState` contains the complete network configuration for the node, including DNS, interfaces, and routes.
+`status.lastSuccessfulUpdateTime`:: Timestamp of the last successful update. This is updated periodically if the node is reachable and can be used to evaluate the freshness of the report.

--- a/modules/virt-vm-custom-scheduler.adoc
+++ b/modules/virt-vm-custom-scheduler.adoc
@@ -10,6 +10,7 @@
 You can use a custom scheduler to schedule a virtual machine (VM) on a node.
 
 .Prerequisites
+
 * A secondary scheduler is configured for your cluster.
 * You have installed the {oc-first}.
 
@@ -27,7 +28,7 @@ spec:
   runStrategy: Always
   template:
     spec:
-      schedulerName: my-scheduler <1>
+      schedulerName: my-scheduler
       domain:
         devices:
           disks:
@@ -36,8 +37,8 @@ spec:
                 bus: virtio
 # ...
 ----
-<1> The name of the custom scheduler. If the `schedulerName` value does not match an existing scheduler, the `virt-launcher` pod stays in a `Pending` state until the specified scheduler is found.
-
++
+`schedulerName`:: The name of the custom scheduler. If the `schedulerName` value does not match an existing scheduler, the `virt-launcher` pod stays in a `Pending` state until the specified scheduler is found.
 
 .Verification
 
@@ -78,4 +79,3 @@ Events:
   Normal  Scheduled  21m   my-scheduler  Successfully assigned default/virt-launcher-vm-fedora-dpc87 to node01
 [...]
 ----
-


### PR DESCRIPTION
Version(s):
4.14+
(4.12 differs too much to CP)

Issue:
https://issues.redhat.com/browse/CNV-74970

Link to docs preview:
- https://105394--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vms_advanced/creating_vms_advanced_web/virt-creating-vms-uploading-images#virt-uploading-image-virtctl_virt-creating-vms-uploading-images
- https://105394--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/nodes/virt-preventing-node-reconciliation#virt-using-skip-node_virt-preventing-node-reconciliation
- https://105394--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-automatic-bootsource-updates#virt-verify-status-bootsource-update_virt-automatic-bootsource-updates
- https://105394--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-storage-profile#virt-viewing-automatically-created-storage-profiles_virt-configuring-storage-profile
- https://105394--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config#virt-viewing-network-state-of-node_k8s-nmstate-updating-node-network-config
- https://105394--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-schedule-vms#virt-vm-custom-scheduler_virt-schedule-vms

QE review:
n/a - formatting changes only

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
