### PR TITLE
OSDOCS-17996: reduce scope of mapi controller perms for gcp

### DIFF
--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -112,6 +112,9 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
 //Task part 2: Creating the required GCP resources
 include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
 
+//Restricting service account impersonation to the compute nodes service account
+include::modules/restricting-sa-impersonation-compute-sa-gcp.adoc[leveloffset=+3]
+
 //Task part 3: Incorporating the Cloud Credential Operator utility manifests
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 

--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -105,6 +105,9 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
 //Task part 2: Creating the required GCP resources
 include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
 
+//Restricting service account impersonation to the compute nodes service account
+include::modules/restricting-sa-impersonation-compute-sa-gcp.adoc[leveloffset=+3]
+
 //Task part 3: Incorporating the Cloud Credential Operator utility manifests
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 

--- a/installing/installing_gcp/installing-gcp-shared-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-shared-vpc.adoc
@@ -89,6 +89,9 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
 //Task part 2: Creating the required GCP resources
 include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
 
+//Restricting service account impersonation to the compute nodes service account
+include::modules/restricting-sa-impersonation-compute-sa-gcp.adoc[leveloffset=+3]
+
 //Task part 3: Incorporating the Cloud Credential Operator utility manifests
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -102,6 +102,9 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
 //Task part 2: Creating the required GCP resources
 include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
 
+//Restricting service account impersonation to the compute nodes service account
+include::modules/restricting-sa-impersonation-compute-sa-gcp.adoc[leveloffset=+3]
+
 //Task part 3: Incorporating the Cloud Credential Operator utility manifests
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -110,6 +110,9 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
 //Task part 2: Creating the required GCP resources
 include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
 
+//Restricting service account impersonation to the compute nodes service account
+include::modules/restricting-sa-impersonation-compute-sa-gcp.adoc[leveloffset=+3]
+
 //Task part 3: Incorporating the Cloud Credential Operator utility manifests
 include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 

--- a/modules/restricting-sa-impersonation-compute-sa-gcp.adoc
+++ b/modules/restricting-sa-impersonation-compute-sa-gcp.adoc
@@ -1,0 +1,193 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+// * installing/installing_gcp/installing-gcp-network-customizations.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+// * installing/installing_gcp/installing-gcp-vpc.adoc
+// * installing/installing_gcp/installing-gcp-shared-vpc.adoc
+// * installing/installing_gcp/installing-gcp-private.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="restricting-sa-impersonation-compute-sa-gcp_{context}"]
+= Restricting service account impersonation to the compute nodes service account
+
+[role="_abstract"]
+After the Cloud Credential Operator utility (`ccoctl`) creates the resources for the cluster, you can restrict the {gcp-first} `iam.serviceAccounts.actAs` permission that the `ccoctl` utility granted to the Machine API controller service account to the compute nodes service account.
+
+[NOTE]
+====
+Restricting service account impersonation to the compute nodes service account is optional.
+If your organization does not require this change, you can continue to "Incorporating the Cloud Credential Operator utility manifests".
+====
+
+When the `ccoctl` utility assigns custom and {gcp-short} predefined roles to {product-title} components service accounts, it grants the `iam.serviceAccounts.actAs` permission to the Machine API controller service account at the {gcp-first} project level.
+To reduce the scope of the `iam.serviceAccounts.actAs` permission, you identify the custom role of the Machine API controller service account and replace it with a role that has a more restricted set of permissions.
+To allow this component to work, you then grant the Machine API controller service account the Service Account User role on the service account of the compute nodes instead.
+
+.Prerequisites
+
+* You have configured an account with the cloud platform that hosts your cluster.
+* You have used the `ccoctl` utility to create the cloud provider resources for your cluster.
+* You have access to your `install-config.yaml` file.
+* You have logged in to the {gcp-full} CLI (`gcloud`) as a user with permissions to manage service accounts and roles.
+
+.Procedure
+
+. Obtain the following values from your `install-config.yaml` file:
+
+** The {gcp-short} project name.
+In the YAML file, this is the value of the `platform.gcp.projectID` parameter.
+
+** The cluster name.
+In the YAML file, this is the value of the `metadata.name` parameter.
+
+** The service account for the compute nodes.
+In the YAML file, this is the value of the `compute[0].platform.gcp.serviceAccount` parameter.
+
+. Obtain the service account for the Machine API controller that the `ccoctl` utility created by running the following command:
++
+[source,terminal]
+----
+$ gcloud iam service-accounts list \
+  --filter="displayName=<cluster_name>-openshift-machine-api-gcp" \
+  --format='value(email)'
+----
++
+where `<cluster_name>` is the value specified for the `metadata.name` parameter in your `install-config.yaml` file.
+
+. Obtain the role ID of the custom role for the Machine API controller service account by running the following command:
++
+[source,terminal]
+----
+$ gcloud projects get-iam-policy <project_name> \
+  --flatten='bindings[].members' \
+  --format='table(bindings.role)' \
+  --filter="bindings.members:<machine_api_controller_service_account>"
+----
++
+where `<machine_api_controller_service_account>` is the Machine API controller service account.
+
+. List the custom role permissions for the Machine API controller service account by running the following command:
++
+[source,terminal]
+----
+$ gcloud iam roles describe <machine_api_role> \
+  --project <project_name>
+----
++
+where `<machine_api_role>` is the role ID of the custom role for the Machine API controller service account.
++
+.Example output
+[source,text]
+----
+etag: <etag_value>
+includedPermissions:
+- compute.acceleratorTypes.get
+- compute.acceleratorTypes.list
+- compute.disks.create
+- compute.disks.createTagBinding
+...
+- compute.zones.get
+- compute.zones.list
+- iam.serviceAccounts.actAs
+- iam.serviceAccounts.get
+- iam.serviceAccounts.list
+- resourcemanager.tagValues.get
+- resourcemanager.tagValues.list
+- serviceusage.quotas.get
+- serviceusage.services.get
+- serviceusage.services.list
+name: projects/<project_name>/roles/<machine_api_role>
+stage: GA
+title: <project_name>-openshift-machine-api-gcp
+----
++
+where `<project_name>` is the {gcp-short} project name specified in the `install-config.yaml` file.
++
+[NOTE]
+====
+This truncated example output might not match the permissions list for your cluster.
+====
+
+. Create a custom role that includes all of the permissions from your output except for the `iam.serviceAccounts.actAs` permission by running a command similar to the following:
++
+[source,terminal]
+----
+$ gcloud iam roles create <machine_api_role>_without_actas \
+--project=<project_name> \
+--title=<machine_api_role>_without_actas \
+--description="Required permissions for the Machine API controller without the iam.serviceAccounts.actAs permission" \
+--permissions=compute.acceleratorTypes.get,\
+compute.acceleratorTypes.list,\
+compute.disks.create,\
+compute.disks.createTagBinding,\
+...
+compute.zones.get,\
+compute.zones.list,\
+iam.serviceAccounts.get,\
+iam.serviceAccounts.list,\
+resourcemanager.tagValues.get,\
+resourcemanager.tagValues.list,\
+serviceusage.quotas.get,\
+serviceusage.services.get,\
+serviceusage.services.list
+----
++
+In this example, the new role name is the original custom role name, `<machine_api_role>`, with a `_without_actas` string added to the end.
++
+[IMPORTANT]
+====
+This truncated example command might not match the permissions list for your cluster.
+You must use the list of permissions from the output of the `gcloud iam roles describe <machine_api_role> --project <project_name>` command on your cluster.
+====
+
+. Remove the custom role that includes the `iam.serviceAccounts.actAs` permission from the Machine API controller service account by running the following command:
++
+[source,terminal]
+----
+$ gcloud projects remove-iam-policy-binding <project_name> \
+  --member "serviceAccount:<machine_api_controller_service_account>" \
+  --role "projects/<project_name>/roles/<machine_api_role>"
+----
++
+where `<machine_api_role>` is the original custom role.
+
+. Grant the custom role that excludes the `iam.serviceAccounts.actAs` permission to the Machine API controller service account by running the following command:
++
+[source,terminal]
+----
+$ gcloud projects add-iam-policy-binding <project_name> \
+  --member "serviceAccount:<machine_api_controller_service_account>" \
+  --role "projects/<project_name>/roles/<machine_api_role>_without_actas
+----
++
+where `<machine_api_role>_without_actas` is the new custom role.
+
+. Optional: To verify that the Machine API controller service account has the correct role, check the attached role ID by running the following command:
++
+[source,terminal]
+----
+$ gcloud projects get-iam-policy <project_name> \
+  --flatten='bindings[].members' \
+  --format='table(bindings.role)' \
+  --filter="bindings.members:<machine_api_controller_service_account>"
+----
++
+.Example output
+[source,text]
+----
+ROLE
+projects/<project_name>/roles/<machine_api_role>_without_actas
+----
+
+. Grant the Machine API controller service account the Service Account User role on the service account of the compute nodes by running the following command:
++
+[source,terminal]
+----
+$ gcloud iam service-accounts add-iam-policy-binding <compute_nodes_service_account> \
+  --member="serviceAccount:<machine_api_controller_service_account>" \
+  --role=roles/iam.serviceAccountUser
+----
++
+where `<compute_nodes_service_account>` is the service account for your compute nodes.
+This value is the `compute[0].platform.gcp.serviceAccount` parameter in your `install-config.yaml` file.


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-17996](https://issues.redhat.com//browse/OSDOCS-17996)

Link to docs preview:
[Restricting service account impersonation to the compute service account](https://105412--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#restricting-sa-impersonation-compute-sa-gcp_installing-gcp-customizations)

QE review:
- [ ] QE has approved this change.

Additional information:
Close enough for merge review, will squash pending QA eng ack