### PR TITLE
OSDOCS#18026: Update the z-stream RNs for 4.20.12

### DIFF
--- a/modules/zstream-4-20-12-about.adoc
+++ b/modules/zstream-4-20-12-about.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-20-12-about_{context}"]
+= RHSA-2026:1000 - {product-title} {product-version}.12 fixed issues advisory
+
+[role="_abstract"]
+Issued: 27 January 2026
+
+{product-title} release {product-version}.12 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:1000[RHSA-2026:1000] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:0977[RHBA-2026:0977] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.12 --pullspecs
+----

--- a/modules/zstream-4-20-12-fixed-issues.adoc
+++ b/modules/zstream-4-20-12-fixed-issues.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-12-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issues are fixed for this release:
+
+* Before this update, the `maxUnhealthy` field in the `MachineHealthCheck` custom resource definition (CRD), did not document the default value. With this release, the CRD documents the default value. (link:https://issues.redhat.com/browse/OCPBUGS-61314[OCPBUGS-61314])
+
+* Before this update, the `systemd` entrypoint in containers prevented config map mounts from working correctly, resulting in broken file permissions. With this release, the `systemd` entrypoint issue is resolved, allowing config map mounts with correct file permissions. As a result, the `systemd` entrypoint issue is resolved, and ensures correct file permissions for config map mounts. (link:https://issues.redhat.com/browse/OCPBUGS-69670[OCPBUGS-66970])
+
+* Before this update, increased release payload size was caused by unnecessary Advanced RISC Machines (ARM) ISO inclusion. As a consequence, all users experienced a 1.2 GiB increase in release payload size. With this release, the ARM ISO is removed from a single-arch payload, requiring the use of a multiarch payload. As a result, the release payload size is reduced, and the download speed for users is improved. (link:https://issues.redhat.com/browse/OCPBUGS-71203[OCPBUGS-71203])
+
+* Before this update, the storage Operator failed to create RoleBinding for the Prometheus ServiceAccount in the `openshift-cluster-csi-drivers` namespace. As a consequence, monitoring of the storage Operator namespace failed, preventing Prometheus from scraping metrics. With this release, RoleBinding for Prometheus is added to the storage Operator. As a result, Prometheus can access the storage Operator namespace, which improves monitoring and reduces API traffic. (link:https://issues.redhat.com/browse/OCPBUGS-72563[OCPBUGS-72563])
+
+* Before this update, {aws-first} inconsistency caused an `instance ID` leak due to logic that was not updated during machine creation. As a consequence, machine creation leaked instances due to inconsistent {aws-short} responses and outdated code. With this release, the inconsistent `instance ID` storage is fixed during machine creation, and prevents virtual machine leakage. As a result, {aws-short} instance leaks are resolved, and consistent machine creation is ensured. (link:https://issues.redhat.com/browse/OCPBUGS-72570[OCPBUGS-72570])
+
+* Before this update, control plane machines were created in incorrect availability zones due to improper machine specification configuration. With this release, control plane machines created in incorrect zones are fixed and cluster stability is improved. (link:https://issues.redhat.com/browse/OCPBUGS-73785[OCPBUGS-73785])
+

--- a/modules/zstream-4-20-12-known-issues.adoc
+++ b/modules/zstream-4-20-12-known-issues.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-12-known-issues_{context}"]
+= Known issues
+
+[role="_abstract"]
+This release contains the following known issues:
+
+
+* If a `must-gather` archive features a custom namespace directory ending with the suffix `nodes`, the Performance Profile Creator tool fails to analyze the archive. This occurs because of the tool's search logic, which incorrectly reports a `multiple matches` error. To work around this problem, rename the custom namespace directory so that it does not end with the `nodes` suffix, and run the tool again. (link:https://issues.redhat.com/browse/OCPBUGS-63751[OCPBUGS-63751])
+
+* Upgrading to {product-title} 4.20 sets incorrect `ulimit` values and caused serverless Operator issues. To resolve this issue, upgrade to a nightly build later than {product-title} `4.20.0-0.nightly-2026-01-16-181948`. (link:https://issues.redhat.com/browse/OCPBUGS-70201[OCPBUGS-70201])
+
+

--- a/modules/zstream-4-20-12-updating.adoc
+++ b/modules/zstream-4-20-12-updating.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-12-updating_{context}"]
+= Updating
+
+
+[role="_abstract"]
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3040,6 +3040,18 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+// About 4-20-12 release notes
+include::modules/zstream-4-20-12-about.adoc[leveloffset=+2]
+
+// 4-20-12 release notes enhancements
+include::modules/zstream-4-20-12-known-issues.adoc[leveloffset=+3]
+
+// 4-20-12 release notes fixed issues
+include::modules/zstream-4-20-12-fixed-issues.adoc[leveloffset=+3]
+
+// 4-20-12 release notes updating
+include::modules/zstream-4-20-12-updating.adoc[leveloffset=+3]
+
 // About 4-20-11 release notes
 include::modules/zstream-4-20-11-about.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-18026](https://issues.redhat.com//browse/OSDOCS-18026)

Link to docs preview:
[4.20.12](https://105414--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
- Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/323/diffs#50e74ab42a6e968b3be3bcec3c7696efe78071c9)
- ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20)