### PR TITLE
OSDOCS-17372:Corrected Vale errors in OSD clusters on AWS book.

### DIFF
--- a/modules/deleting-cluster-aws.adoc
+++ b/modules/deleting-cluster-aws.adoc
@@ -7,6 +7,7 @@
 [id="deleting-cluster_aws_{context}"]
 = Deleting your cluster
 
+[role="_abstract"]
 You can delete your {product-title} cluster in {cluster-manager-first}.
 
 .Prerequisites
@@ -18,6 +19,6 @@ You can delete your {product-title} cluster in {cluster-manager-first}.
 
 . From {cluster-manager-url}, click on the cluster you want to delete.
 
-. Select *Delete cluster* from the *Actions* drop-down menu.
+. Select *Delete cluster* from the *Actions* list.
 
 . Type the name of the cluster highlighted in bold, then click *Delete*. Cluster deletion occurs automatically.

--- a/modules/osd-create-cluster-ccs-aws.adoc
+++ b/modules/osd-create-cluster-ccs-aws.adoc
@@ -7,10 +7,11 @@
 [id="osd-create-aws-cluster-ccs_{context}"]
 = Creating a cluster on AWS
 
+[role="_abstract"]
 By using the Customer Cloud Subscription (CCS) billing model, you can create an {product-title} cluster in an existing
 {AWS} account that you own.
 
-You can also select the Red Hat cloud account infrastructure type to deploy {product-title} in a cloud provider account that is owned by Red Hat.
+You can also select the Red{nbsp}Hat cloud account infrastructure type to deploy {product-title} in a cloud provider account that is owned by Red{nbsp}Hat.
 
 Complete the following prerequisites to use the CCS model to deploy and manage {product-title} into your AWS account.
 
@@ -73,12 +74,6 @@ To customize the subdomain, select the *Create customize domain prefix* checkbox
 ... Accept the default setting *Use default KMS Keys* to use your default AWS KMS key, or select *Use Custom KMS keys* to use a custom KMS key.
 .... With *Use Custom KMS keys* selected, enter the AWS Key Management Service (KMS) custom key Amazon Resource Name (ARN) ARN in the *Key ARN* field.
 The key is used for encrypting all control plane, infrastructure, worker node root volumes, and persistent volumes in your cluster.
-//Commented out due to changes in the UI
-//[IMPORTANT]
-//====
-//Only persistent volumes (PVs) created from the default storage class are encrypted with this specific key.
-//PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
-//====
 +
 ... Optional: Select *Enable FIPS cryptography* if you require your cluster to be FIPS validated.
 +

--- a/osd_aws_clusters/creating-an-aws-cluster.adoc
+++ b/osd_aws_clusters/creating-an-aws-cluster.adoc
@@ -2,12 +2,13 @@
 [id="osd-creating-a-cluster-on-aws"]
 = Creating a cluster on AWS
 include::_attributes/attributes-openshift-dedicated.adoc[]
+
 :context: osd-creating-a-cluster-on-aws
 
 toc::[]
 
 [role="_abstract"]
-You can deploy {product-title} on {AWS} by using your own AWS account through the Customer Cloud Subscription (CCS) model or by using an AWS infrastructure account that is owned by Red Hat.
+You can deploy {product-title} on {AWS} by using your own AWS account through the Customer Cloud Subscription (CCS) model or by using an AWS infrastructure account that is owned by Red{nbsp}Hat.
 
 [id="osd-creating-a-cluster-on-aws-prerequisites_{context}"]
 == Prerequisites
@@ -20,12 +21,12 @@ include::modules/osd-create-cluster-ccs-aws.adoc[leveloffset=+1]
 [id="additional-resources_{context}"]
 == Additional resources
 
-* For information about configuring a proxy with {product-title}, see xref:../networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.adoc#configuring-a-cluster-wide-proxy[Configuring a cluster-wide proxy].
-* For details about the AWS service control policies required for CCS deployments, see xref:../osd_planning/aws-ccs.adoc#ccs-aws-scp_aws-ccs[Minimum required service control policy (SCP)].
-* For information about persistent storage for {product-title}, see the xref:../osd_architecture/osd_policy/osd-service-definition.adoc#sdpolicy-storage_osd-service-definition[Storage] section in the {product-title} service definition.
-* For information about load balancers for {product-title}, see the xref:../osd_architecture/osd_policy/osd-service-definition.adoc#load-balancers_osd-service-definition[Load balancers] section in the {product-title} service definition.
-* For more information about etcd encryption, see the xref:../osd_architecture/osd_policy/osd-service-definition.adoc#etcd-encryption_osd-service-definition[etcd encryption service definition].
-* For information about the end-of-life dates for {product-title} versions, see the xref:../osd_architecture/osd_policy/osd-life-cycle.adoc#osd-life-cycle[{product-title} update life cycle].
-* For information about the requirements for custom additional security groups, see xref:../osd_planning/aws-ccs.adoc#osd-security-groups-custom_aws-ccs[Additional custom security groups].
-* For information about configuring identity providers, see xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[Configuring identity providers].
-* For information about revoking cluster privileges, see xref:../authentication/osd-revoking-cluster-privileges.adoc#osd-revoking-cluster-privileges[Revoking privileges and access to an {product-title} cluster].
+* xref:../networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.adoc#configuring-a-cluster-wide-proxy[Configuring a cluster-wide proxy]
+* xref:../osd_planning/aws-ccs.adoc#ccs-aws-scp_aws-ccs[Minimum required service control policy (SCP)]
+* xref:../osd_architecture/osd_policy/osd-service-definition.adoc#sdpolicy-storage_osd-service-definition[Storage]
+* xref:../osd_architecture/osd_policy/osd-service-definition.adoc#load-balancers_osd-service-definition[Load balancers]
+* xref:../osd_architecture/osd_policy/osd-service-definition.adoc#etcd-encryption_osd-service-definition[etcd encryption]
+* xref:../osd_architecture/osd_policy/osd-life-cycle.adoc#osd-life-cycle[{product-title} update life cycle]
+* xref:../osd_planning/aws-ccs.adoc#osd-security-groups-custom_aws-ccs[Additional custom security groups]
+* xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[Configuring identity providers]
+* xref:../authentication/osd-revoking-cluster-privileges.adoc#osd-revoking-cluster-privileges[Revoking privileges and access to an {product-title} cluster]

--- a/osd_aws_clusters/osd-deleting-a-cluster-aws.adoc
+++ b/osd_aws_clusters/osd-deleting-a-cluster-aws.adoc
@@ -2,6 +2,7 @@
 [id="osd-deleting-a-cluster"]
 = Deleting an {product-title} cluster on AWS
 include::_attributes/attributes-openshift-dedicated.adoc[]
+
 :context: osd-deleting-a-cluster-aws
 
 toc::[]


### PR DESCRIPTION
Version(s):
4.20+

Issue:
[OSDOCS-17372](https://issues.redhat.com//browse/OSDOCS-17372)

Link to docs preview:

- https://105437--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_aws_clusters/creating-an-aws-cluster.html

- https://105437--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_aws_clusters/osd-deleting-a-cluster-aws.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
