### PR TITLE
OBSDOCS-3026 update ui plugins overview as well to highlight troubleshooting for 4.19+

### DIFF
--- a/ui_plugins/observability-ui-plugins-overview.adoc
+++ b/ui_plugins/observability-ui-plugins-overview.adoc
@@ -31,9 +31,9 @@ For more information, see the xref:../ui_plugins/logging-ui-plugin.adoc#logging-
 [id="troubleshooting_{context}"]
 == Troubleshooting
 
-The troubleshooting panel UI plugin for {ocp-product-title} version 4.16+ provides observability signal correlation, powered by the open source Korrel8r project.
+The troubleshooting panel UI plugin for {ocp-product-title} version 4.19+ provides observability signal correlation, powered by the open source Korrel8r project.
 You can use the troubleshooting panel available from the *Observe* -> *Alerting* page to easily correlate metrics, logs, alerts, netflows, and additional observability signals and resources, across different data stores.
-Users of {ocp-product-title} version 4.17+ can also access the troubleshooting UI panel from the Application Launcher {launch}.
+You can also access the troubleshooting UI panel from the Application Launcher {launch}.
 
 The output of Korrel8r is displayed as an interactive node graph. When you click on a node, you are automatically redirected to the corresponding web console page with the specific information for that node, for example, metric, log, or pod.
 


### PR DESCRIPTION

Version(s):
standalone-coo-docs-1-latest

Issue:
[OBSDOCS-3026](https://issues.redhat.com//browse/OBSDOCS-3026) 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
