### PR TITLE
TRACING-5947: document that non-multitenant Tempo instances are not supported

### DIFF
--- a/modules/distr-tracing-tempo-install-tempomonolithic-cli.adoc
+++ b/modules/distr-tracing-tempo-install-tempomonolithic-cli.adoc
@@ -28,6 +28,11 @@ $ oc login --username=<your_username>
 ====
 
 * You have defined one or more tenants and configured the read and write permissions. For more information, see "Configuring the read permissions for tenants" and "Configuring the write permissions for tenants".
++
+[IMPORTANT]
+====
+TempoMonolithic instances without configured tenants provide no authentication or authorization on the ingest or query paths, and are *not supported on OpenShift*.
+====
 
 .Procedure
 

--- a/modules/distr-tracing-tempo-install-tempomonolithic-web-console.adoc
+++ b/modules/distr-tracing-tempo-install-tempomonolithic-web-console.adoc
@@ -18,6 +18,11 @@ You can install a `TempoMonolithic` instance from the *Administrator* view of th
 * For {product-dedicated}, you must be logged in using an account with the `dedicated-admin` role.
 
 * You have defined one or more tenants and configured the read and write permissions. For more information, see "Configuring the read permissions for tenants" and "Configuring the write permissions for tenants".
++
+[IMPORTANT]
+====
+TempoMonolithic instances without configured tenants provide no authentication or authorization on the ingest or query paths, and are *not supported on OpenShift*.
+====
 
 .Procedure
 

--- a/modules/distr-tracing-tempo-install-tempostack-cli.adoc
+++ b/modules/distr-tracing-tempo-install-tempostack-cli.adoc
@@ -32,6 +32,11 @@ Object storage is required and not included with the {TempoShortName}. You must 
 ====
 
 * You have defined one or more tenants and configured the read and write permissions. For more information, see "Configuring the read permissions for tenants" and "Configuring the write permissions for tenants".
++
+[IMPORTANT]
+====
+TempoStack instances without configured tenants provide no authentication or authorization on the ingest or query paths, and are *not supported on OpenShift*.
+====
 
 .Procedure
 

--- a/modules/distr-tracing-tempo-install-tempostack-web-console.adoc
+++ b/modules/distr-tracing-tempo-install-tempostack-web-console.adoc
@@ -22,6 +22,11 @@ Object storage is required and not included with the {TempoShortName}. You must 
 ====
 
 * You have defined one or more tenants and configured the read and write permissions. For more information, see "Configuring the read permissions for tenants" and "Configuring the write permissions for tenants".
++
+[IMPORTANT]
+====
+TempoStack instances without configured tenants provide no authentication or authorization on the ingest or query paths, and are *not supported on OpenShift*.
+====
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
all supported OCP versions

Issue:
https://issues.redhat.com/browse/TRACING-5947

Link to docs preview:
https://105448--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/distr_tracing/distr-tracing-tempo-installing.html#distr-tracing-tempo-install-tempostack-web-console_distr-tracing-tempo-installing

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
