### PR TITLE
OSDOCS-16843: CQA for the NOP-2 External DNS Operator (EDO)

### DIFF
--- a/modules/configuring-egress-proxy-edns-operator.adoc
+++ b/modules/configuring-egress-proxy-edns-operator.adoc
@@ -6,7 +6,8 @@
 [id="nw-configuring-cluster-wide-proxy_{context}"]
 = Trusting the certificate authority of the cluster-wide proxy
 
-You can configure the External DNS Operator to trust the certificate authority of the cluster-wide proxy.
+[role="_abstract"]
+To enable the External DNS Operator to authenticate with the cluster-wide proxy, configure the Operator to trust the certificate authority (CA) of the proxy. This ensures secure communication when routing DNS traffic through the proxy.
 
 .Procedure
 
@@ -33,7 +34,7 @@ $ oc -n external-dns-operator patch subscription external-dns-operator --type='j
 
 .Verification
 
-* After the deployment of the External DNS Operator is completed, verify that the trusted CA environment variable is added, outputted as `trusted-ca`, to the `external-dns-operator` deployment by running the following command:
+* After deploying the External DNS Operator, verify that the trusted CA environment variable is added by running the following command. The output must show `trusted-ca` for the `external-dns-operator` deployment.
 +
 [source,terminal]
 ----

--- a/modules/nw-control-dns-records-public-aws-with-VPC.adoc
+++ b/modules/nw-control-dns-records-public-aws-with-VPC.adoc
@@ -4,11 +4,13 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-control-dns-records-public-aws-with-VPC_{context}"]
-= Creating DNS records in a different AWS Account using a shared VPC
+= Creating DNS records in a different AWS account by using a shared VPC
 
-You can use the ExternalDNS Operator to create DNS records in a different AWS account using a shared Virtual Private Cloud (VPC). By using a shared VPC, an organization can connect resources from multiple projects to a common VPC network. Organizations can then use VPC sharing to use a single Route 53 instance across multiple AWS accounts.
+[role="_abstract"]
+To create DNS records in a different AWS account, configure the ExternalDNS Operator to use a shared Virtual Private Cloud (VPC). Your organization can then use a single Route 53 instance for name resolution across multiple accounts and projects.
 
 .Prerequisites
+
 * You have created two Amazon AWS accounts: one with a VPC and a Route 53 private hosted zone configured (Account A), and another for installing a cluster (Account B).
 * You have created an IAM Policy and IAM Role with the appropriate permissions in Account A for Account B to create DNS records in the Route 53 hosted zone of Account A.
 * You have installed a cluster in Account B into the existing VPC for Account A.
@@ -24,7 +26,6 @@ $ aws --profile account-a iam get-role --role-name user-rol1 | head -1
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 ROLE	arn:aws:iam::1234567890123:role/user-rol1	2023-09-14T17:21:54+00:00	3600	/	AROA3SGB2ZRKRT5NISNJN	user-rol1
@@ -38,7 +39,6 @@ $ aws --profile account-a route53 list-hosted-zones | grep testextdnsoperator.ap
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 HOSTEDZONES	terraform	/hostedzone/Z02355203TNN1XXXX1J6O	testextdnsoperator.apacshift.support. 5
@@ -62,16 +62,19 @@ spec:
     type: AWS
     aws: 
       assumeRole: 
-        arn: arn:aws:iam::12345678901234:role/user-rol1 <1>
+        arn: arn:aws:iam::12345678901234:role/user-rol1
   source:  
     type: OpenShiftRoute 
     openshiftRouteOptions:
       routerName: default 
 EOF
 ----
-<1> Specify the Role ARN  to have DNS records created in Account A.
++
+where:
++
+`arn`:: Specifies the Role ARN to have DNS records created in Account A.
 
-. Check the records created for OpenShift Container Platform (OCP) routes by using the following command:
+. Check the records created for {product-title} routes by entering the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-control-dns-records-public-hosted-zone-aws.adoc
+++ b/modules/nw-control-dns-records-public-hosted-zone-aws.adoc
@@ -4,20 +4,21 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nw-control-dns-records-public-hosted-zone-aws_{context}"]
-= Creating DNS records on an public hosted zone for AWS by using Red Hat External DNS Operator
+= Creating DNS records on a public hosted zone for AWS by using Red Hat External DNS Operator
 
+[role="_abstract"]
 You can create DNS records on a public hosted zone for AWS by using the Red Hat External DNS Operator. You can use the same instructions to create DNS records on a hosted zone for AWS GovCloud.
 
 .Procedure
 
-. Check the user profile, such as `system:admin`, by running the following command. The user profile must have access to the `kube-system` namespace. If you do not have the credentials, you can fetch the credentials from the `kube-system` namespace to use the cloud provider client by running the following command:
+. Check the user profile by running the following command. The profile, such as `system:admin`, must have access to the `kube-system` namespace. If you do not have the credentials, you can fetch the credentials from the `kube-system` namespace to use the cloud provider client by running the following command:
 +
 [source,terminal]
 ----
 $ oc whoami
 ----
 
-. Fetch the values from aws-creds secret present in `kube-system` namespace.
+. Fetch the values from the `aws-creds` secret that exists in the `kube-system` namespace.
 +
 [source,terminal]
 ----
@@ -56,7 +57,7 @@ $ aws route53 list-hosted-zones | grep testextdnsoperator.apacshift.support
 HOSTEDZONES	terraform	/hostedzone/Z02355203TNN1XXXX1J6O	testextdnsoperator.apacshift.support.	5
 ----
 
-. Create `ExternalDNS` resource for `route` source:
+. Create the `ExternalDNS` CR for the `route` source:
 +
 [source,yaml]
 ----
@@ -64,30 +65,33 @@ $ cat <<EOF | oc create -f -
 apiVersion: externaldns.olm.openshift.io/v1beta1
 kind: ExternalDNS
 metadata:
-  name: sample-aws <1>
+  name: sample-aws
 spec:
   domains:
-  - filterType: Include   <2>
-    matchType: Exact   <3>
-    name: testextdnsoperator.apacshift.support <4>
+  - filterType: Include
+    matchType: Exact
+    name: testextdnsoperator.apacshift.support
   provider:
-    type: AWS <5>
-  source:  <6>
-    type: OpenShiftRoute <7>
+    type: AWS
+  source:
+    type: OpenShiftRoute
     openshiftRouteOptions:
-      routerName: default <8>
+      routerName: default
 EOF
 ----
-<1> Defines the name of external DNS resource.
-<2> By default all hosted zones are selected as potential targets. You can include a hosted zone that you need.
-<3> The matching of the target zone's domain has to be exact (as opposed to regular expression match).
-<4> Specify the exact domain of the zone you want to update. The hostname of the routes must be subdomains of the specified domain.
-<5> Defines the `AWS Route53` DNS provider.
-<6> Defines options for the source of DNS records.
-<7> Defines OpenShift `route` resource as the source for the DNS records which gets created in the previously specified DNS provider.
-<8> If the source is `OpenShiftRoute`, then you can pass the OpenShift Ingress Controller name. External DNS Operator selects the canonical hostname of that router as the target while creating CNAME record.
++
+where:
++
+`metadata.name`:: Specifies the name of the external DNS resource.
+`spec.domains`:: By default all hosted zones are selected as potential targets. You can include a hosted zone that you need.
+`domains.matchType`:: Specifies that the matching of the domain from the target zone has to be exact. Exact as opposed to regular expression match.
+`domains.name`:: Specifies the exact domain of the zone you want to update. The hostname of the routes must be subdomains of the specified domain.
+`provider.type`:: Specifies the `AWS Route53` DNS provider.
+`source`:: Specifies the options for the source of DNS records.
+`source.type`:: Specifies the `OpenShiftRoute` resource as the source for the DNS records which gets created in the previously specified DNS provider.
+`openshiftRouteOptions.routerName`:: If the source is `OpenShiftRoute`, then you can pass the OpenShift Ingress Controller name. External DNS Operator selects the canonical hostname of that router as the target while creating the CNAME record.
 
-. Check the records created for OCP routes using the following command:
+. Check the records created for {product-title} routes by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-control-dns-records-public-hosted-zone-azure.adoc
+++ b/modules/nw-control-dns-records-public-hosted-zone-azure.adoc
@@ -6,7 +6,8 @@
 [id="nw-control-dns-records-public-hosted-zone-azure_{context}"]
 = Creating DNS records on an Azure DNS zone
 
-You can create Domain Name Server (DNS) records on a public or private DNS zone for Azure by using the External DNS Operator.
+[role="_abstract"]
+To create DNS records on a public or private DNS zone for Azure, use the External DNS Operator. The Operator manages external name resolution for your cluster.
 
 .Prerequisites
 
@@ -57,7 +58,6 @@ $ oc get routes --all-namespaces | grep console
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 openshift-console          console             console-openshift-console.apps.test.azure.example.com                       console             https   reencrypt/Redirect     None
@@ -66,14 +66,14 @@ openshift-console          downloads           downloads-openshift-console.apps.
 
 . Get a list of DNS zones.
 +
-.. For public DNS zones by running the following command:
+.. For public DNS zones, enter the following command:
 +
 [source,terminal]
 ----
 $ az network dns zone list --resource-group "${RESOURCE_GROUP}"
 ----
 +
-.. For private DNS zones by running the following command:
+.. For private DNS zones, enter the following command:
 +
 [source,terminal]
 ----
@@ -83,42 +83,45 @@ $ az network private-dns zone list -g "${RESOURCE_GROUP}"
 . Create a YAML file, for example, `external-dns-sample-azure.yaml`, that defines the `ExternalDNS` object:
 +
 .Example `external-dns-sample-azure.yaml` file
-+
 [source,yaml]
 ----
 apiVersion: externaldns.olm.openshift.io/v1beta1
 kind: ExternalDNS
 metadata:
-  name: sample-azure <1>
+  name: sample-azure
 spec:
   zones:
-  - "/subscriptions/1234567890/resourceGroups/test-azure-xxxxx-rg/providers/Microsoft.Network/dnszones/test.azure.example.com" <2>
+  - "/subscriptions/1234567890/resourceGroups/test-azure-xxxxx-rg/providers/Microsoft.Network/dnszones/test.azure.example.com"
   provider:
-    type: Azure <3>
+    type: Azure
   source:
-    openshiftRouteOptions: <4>
-      routerName: default <5>
-    type: OpenShiftRoute <6>
+    openshiftRouteOptions:
+      routerName: default
+    type: OpenShiftRoute
+# ...
 ----
-<1> Specifies the External DNS name.
-<2> Defines the zone ID. For a private DNS zone, change `dnszones` to `privateDnsZones`.
-<3> Defines the provider type.
-<4> You can define options for the source of DNS records.
-<5> If the source type is `OpenShiftRoute`, you can pass the OpenShift Ingress Controller name. External DNS selects the canonical hostname of that router as the target while creating CNAME record.
-<6> Defines the `route` resource as the source for the Azure DNS records.
++
+where:
++
+`metadata.name`:: Specifies the External DNS name.
+`spec.zones`:: Specifies the zone ID. For a private DNS zone, change `dnszones` to `privateDnsZones`.
+`provider.type`:: Specifies the provider type.
+`source.openshiftRouteOptions`:: Specifies the options for the source of DNS records.
+`routerName`:: If the source type is `OpenShiftRoute`, you can pass the OpenShift Ingress Controller name. The External DNS Operator selects the canonical hostname of that router as the target while creating the CNAME record.
+`source.type`:: Specifies the `route` resource as the source for the Azure DNS records.
 
 .Troubleshooting
 
 . Check the records created for the routes.
 +
-.. For public DNS zones by running the following command:
+.. For public DNS zones, enter the following command:
 +
 [source,terminal]
 ----
 $ az network dns record-set list -g "${RESOURCE_GROUP}" -z "${ZONE_NAME}" | grep console
 ----
 +
-.. For private DNS zones by running the following command:
+.. For private DNS zones, enter the following command:
 +
 [source,terminal]
 ----

--- a/modules/nw-external-dns-operator-configuration-parameters.adoc
+++ b/modules/nw-external-dns-operator-configuration-parameters.adoc
@@ -2,11 +2,12 @@
 //
 // * networking/external_dns_operator/nw-configuration-parameters.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: REFERENCE
 [id="nw-external-dns-operator-configuration-parameters_{context}"]
 = External DNS Operator configuration parameters
 
-The External DNS Operator includes the following configuration parameters:
+[role="_abstract"]
+To customize the behavior of the External DNS Operator, configure the available parameters in the `ExternalDNS` custom resource (CR). By configuring parameters, you can control how the Operator synchronizes services and routes with your external DNS provider.
 
 [cols="3a,8a",options="header"]
 |===
@@ -19,13 +20,13 @@ The External DNS Operator includes the following configuration parameters:
 ----
 spec:
   provider:
-    type: AWS <1>
+    type: AWS
     aws:
       credentials:
-        name: aws-access-key <2>
+        name: aws-access-key
 ----
-<1> Defines available options such as AWS, {gcp-short}, Azure, and Infoblox.
-<2> Defines a secret name for your cloud provider.
+* `provider.type`: Specifies available options such as AWS, {gcp-short}, Azure, and Infoblox.
+* `provider.aws.credentials.name`: Specifies a secret name for your cloud provider.
 
 |`zones`
 |Enables you to specify DNS zones by their domains. If you do not specify zones, the `ExternalDNS` resource discovers all of the zones present in your cloud provider account.
@@ -33,10 +34,9 @@ spec:
 [source,yaml]
 ----
 zones:
-- "myzoneid" <1>
+- "<zone_id>"
 ----
-
-<1> Specifies the name of DNS zones.
+* `<zone_id>`: Specifies the name of DNS zones.
 
 |`domains`
 |Enables you to specify AWS zones by their domains. If you do not specify domains, the `ExternalDNS` resource discovers all of the zones present in your cloud provider account.
@@ -44,61 +44,55 @@ zones:
 [source,yaml]
 ----
 domains:
-- filterType: Include <1>
-  matchType: Exact <2>
-  name: "myzonedomain1.com" <3>
 - filterType: Include
-  matchType: Pattern <4>
-  pattern: ".*\\.otherzonedomain\\.com" <5>
+  matchType: Exact
+  name: "myzonedomain1.com"
+- filterType: Include
+  matchType: Pattern
+  pattern: ".*\\.otherzonedomain\\.com"
 ----
-<1> Ensures that the `ExternalDNS` resource includes the domain name.
-<2> Instructs `ExternalDNS` that the domain matching has to be exact as opposed to regular expression match.
-<3> Defines the name of the domain.
-<4> Sets the `regex-domain-filter` flag in the `ExternalDNS` resource. You can limit possible domains by using a Regex filter.
-<5> Defines the regex pattern to be used by the `ExternalDNS` resource to filter the domains of the target zones.
+* `domains.filterType`: Specifies that the `ExternalDNS` resource includes the domain name.
+* `domains.matchType`: Specifies that the domain matching has to be exact as opposed to regular expression match.
+* `domains.name`: Specifies the name of the domain.
+* `filterType.matchType`: Specifies the `regex-domain-filter` flag in the `ExternalDNS` resource. You can limit possible domains by using a Regex filter.
+* `filterType.pattern`: Specifies the regex pattern to be used by the `ExternalDNS` resource to filter the domains of the target zones.
 
 |`source`
 |Enables you to specify the source for the DNS records, `Service` or `Route`.
 
 [source,yaml]
 ----
-source: <1>
-  type: Service <2>
+source:
+  type: Service
   service:
-    serviceType:<3>
+    serviceType:
       - LoadBalancer
       - ClusterIP
-  labelFilter: <4>
+  labelFilter:
     matchLabels:
       external-dns.mydomain.org/publish: "yes"
-  hostnameAnnotation: "Allow" <5>
+  hostnameAnnotation: "Allow"
   fqdnTemplate:
-  - "{{.Name}}.myzonedomain.com" <6>
+  - "{{.Name}}.myzonedomain.com"
 ----
-<1> Defines the settings for the source of DNS records.
-<2> The `ExternalDNS` resource uses the `Service` type as the source for creating DNS records.
-<3> Sets the `service-type-filter` flag in the `ExternalDNS` resource. The `serviceType` contains the following fields:
-* `default`: `LoadBalancer`
-* `expected`: `ClusterIP`
-* `NodePort`
-* `LoadBalancer`
-* `ExternalName`
-<4> Ensures that the controller considers only those resources which matches with label filter.
-<5> The default value for `hostnameAnnotation` is `Ignore` which instructs `ExternalDNS` to generate DNS records using the templates specified in the field `fqdnTemplates`. When the value is `Allow` the DNS records get generated based on the value specified in the `external-dns.alpha.kubernetes.io/hostname` annotation.
-<6> The External DNS Operator uses a string to generate DNS names from sources that do not define a hostname, or to add a hostname suffix when paired with the fake source.
+* `source`: Specifies the settings for the source of DNS records.
+* `source.type`: Specifies that the `ExternalDNS` CR uses the `Service` type as the source for creating DNS records.
+* `service.serviceType`: Specifies the `service-type-filter` flag in the `ExternalDNS` resource. The `serviceType` contains the following fields: `default`: `LoadBalancer`; `expected`: `ClusterIP`; `NodePort`; `LoadBalancer`; `ExternalName`.
+* `service.labelFilter`: Specifies that the controller considers only those resources that match with label filter.
+* `hostnameAnnotation`: Specifies that the default value for `hostnameAnnotation` is `Ignore` which instructs `ExternalDNS` to generate DNS records by using the templates specified in the field `fqdnTemplates`. When the value is `Allow` the DNS records get generated based on the value specified in the `external-dns.alpha.kubernetes.io/hostname` annotation.
+* `fqdnTemplate`: Specifies that the External DNS Operator uses a string to generate DNS names from sources that do not define a hostname, or to add a hostname suffix when paired with the fake source.
 
 [source,yaml]
 ----
 source:
-  type: OpenShiftRoute <1>
+  type: OpenShiftRoute
   openshiftRouteOptions:
-    routerName: default <2>
+    routerName: default
     labelFilter:
       matchLabels:
         external-dns.mydomain.org/publish: "yes"
 ----
-
-<1> Creates DNS records.
-<2> If the source type is `OpenShiftRoute`, then you can pass the Ingress Controller name. The `ExternalDNS` resource uses the canonical name of the Ingress Controller as the target for CNAME records.
+* `source.type`: Specifies the creation of DNS records.
+* `openshiftRouteOptions.routerName`: Specifies if the source type is `OpenShiftRoute`. If so, you can pass the Ingress Controller name. The `ExternalDNS` resource uses the canonical name of the Ingress Controller as the target for CNAME records.
 
 |===

--- a/networking/networking_operators/external_dns_operator/external-dns-operator-release-notes.adoc
+++ b/networking/networking_operators/external_dns_operator/external-dns-operator-release-notes.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-The External DNS Operator deploys and manages `ExternalDNS` to provide name resolution for services and routes from the external DNS provider to {product-title}. 
+The External DNS Operator deploys and manages `ExternalDNS` to provide name resolution for services and routes. This enables your external DNS provider to resolve hostnames directly to {product-title} resources.
 
 [IMPORTANT]
 ====

--- a/networking/networking_operators/external_dns_operator/nw-configuration-parameters.adoc
+++ b/networking/networking_operators/external_dns_operator/nw-configuration-parameters.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The External DNS Operator includes the following configuration parameters.
+[role="_abstract"]
+To customize the behavior of the External DNS Operator, configure the available parameters in the `ExternalDNS` custom resource (CR). By configuraing parameters, you can control how the Operator synchronizes services and routes with your external DNS provider.
 
 include::modules/nw-external-dns-operator-configuration-parameters.adoc[leveloffset=+1]

--- a/networking/networking_operators/external_dns_operator/nw-configuring-cluster-wide-egress-proxy.adoc
+++ b/networking/networking_operators/external_dns_operator/nw-configuring-cluster-wide-egress-proxy.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-After configuring the cluster-wide proxy, the Operator Lifecycle Manager (OLM) triggers automatic updates to all of the deployed Operators with the new contents of the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
+[role="_abstract"]
+To propagate proxy settings to your deployed Operators, configure the cluster-wide proxy. The Operator Lifecycle Manager (OLM) automatically updates these Operators with the new `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables.
 
 include::modules/configuring-egress-proxy-edns-operator.adoc[leveloffset=+1]

--- a/networking/networking_operators/external_dns_operator/nw-creating-dns-records-on-aws.adoc
+++ b/networking/networking_operators/external_dns_operator/nw-creating-dns-records-on-aws.adoc
@@ -6,10 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can create DNS records on AWS and AWS GovCloud by using the External DNS Operator.
+[role="_abstract"]
+To create DNS records on AWS and AWS GovCloud, use the External DNS Operator. The Operator manages external name resolution for your cluster services directly through the Operator.
 
-// Creating DNS records on an public hosted zone for AWS by using Red Hat External DNS Operator
+// Creating DNS records on a public hosted zone for AWS by using Red Hat External DNS Operator
 include::modules/nw-control-dns-records-public-hosted-zone-aws.adoc[leveloffset=+1]
 
-// Creating DNS records in a different AWS Account using a shared VPC
+// Creating DNS records in a different AWS account by using a shared VPC
 include::modules/nw-control-dns-records-public-aws-with-VPC.adoc[leveloffset=+1]

--- a/networking/networking_operators/external_dns_operator/nw-creating-dns-records-on-azure.adoc
+++ b/networking/networking_operators/external_dns_operator/nw-creating-dns-records-on-azure.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can create DNS records on Azure by using the External DNS Operator.
+[role="_abstract"]
+To create DNS records on {azure-first}, use the External DNS Operator. By using this Operator, you can manage external name resolution for your cluster services.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Please ignore the networking/networking_operators/external_dns_operator/external-dns-operator-release-notes.adoc file as I need to determine its modularity status in a follow-up PR.

Version(s):
4.16+

Issue:
[OSDOCS-16843](https://issues.redhat.com/browse/OSDOCS-16843)

Link to docs preview:

* https://105476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/external-dns-operator-release-notes.html
* https://105476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/nw-configuration-parameters.html
* https://105476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/nw-configuring-cluster-wide-egress-proxy.html
* https://105476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/nw-creating-dns-records-on-aws.html
* https://105476--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_operators/external_dns_operator/nw-creating-dns-records-on-azure.html
