### PR TITLE
OSDOCS-18046: Network policy update for 4.21

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -346,6 +346,10 @@ This feature is particularly important in telco environments that require high p
 +
 For more information, see xref:../networking/advanced_networking/ptp/configuring-ptp.adoc#cnf-configuring-gnss-ntp-failover_configuring-ptp[Configuring GNSS failover to NTP for time synchronization continuity].
 
+Network policies for additional namespaces::
+With this release, OpenShift Container Platform continues to deploy Kubernetes network policies to additional system namespaces to control ingress and egress traffic. It is anticipated that future releases might include network policies for additional system namespaces and Red Hat Operators.
+
+
 [id="ocp-release-notes-nodes_{context}"]
 == Nodes
 


### PR DESCRIPTION
[OSDOCS-18046]: Release note for network policies for 4.21

Version(s): enterprise-4.21 only

Issue:
https://issues.redhat.com/browse/OSDOCS-18046

Link to docs preview:
https://105480--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-networking_release-notes:~:text=Network%20policies%20for%20additional%20namespaces

QE review:
N/A