### PR TITLE
OSDOCS-16676-networking-tavery:RN Bug Batch

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -106,10 +106,9 @@ Instructions: Add entries in the following format under the appropriate heading:
 [id="rn-ocp-release-note-networking-fixed-issues_{context}"]
 == Networking
 
-[id="Update-CoreDNS-to-1.13.1_{context}"]
-=== Update CoreDNS to version 1.13.1 for Kubernetes 1.34 compatibility
+* Before this update, an incorrect private key containing certificate data caused HAProxy reload failure in OpenShift 4.14. As a consequence, incorrect certificate configuration caused HAProxy router pods to fail reloads, which led to a partial outage. With this release, `haproxy` now validates certificates. As a result, router reload failures with invalid certificates are prevented. (link:https://issues.redhat.com/browse/OCPBUGS-49769[OCPBUGS-49769])
 
-To maintain compatibility with Kubernetes 1.34, CoreDNS has been updated to version 1.13.1. This update resolves intermittent DNS resolution issues reported in previous versions and includes upstream performance fixes and security patches.
+* To maintain compatibility with Kubernetes 1.34, CoreDNS has been updated to version 1.13.1. This update resolves intermittent DNS resolution issues reported in previous versions and includes upstream performance fixes and security patches.
 
 [id="rn-ocp-release-note-node-fixed-issues_{context}"]
 == Node


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-16676

Link to docs preview:
https://105482--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-note-networking-fixed-issues_release-notes

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->