### PR TITLE
OSDOCS-17979 created zstream RNs for 4-14-61

### DIFF
--- a/modules/zstream-4-14-61-about.adoc
+++ b/modules/zstream-4-14-61-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-61-about_{context}"]
+= RHBA-2026:1003 - {product-title} 4.14.61 bug fix advisory
+
+[role="_abstract"]
+Issued: 29 January 2026
+
+{product-title} release 4.14.61, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:1003[RHBA-2026:1003] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:0995[RHSA-2026:0995] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.14.61 --pullspecs
+----

--- a/modules/zstream-4-14-61-bug-fixes.adoc
+++ b/modules/zstream-4-14-61-bug-fixes.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-61-bug-fixes_{context}"]
+= Bug fixes
+
+[role="_abstract"]
+There are no notable fixed issues in this release.

--- a/modules/zstream-4-14-61-updating.adoc
+++ b/modules/zstream-4-14-61-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-14-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-14-61-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} {product-version} cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -3427,6 +3427,15 @@ For any {product-title} release, always review the instructions on xref:../updat
 ====
 
 //4.14.60 about
+include::modules/zstream-4-14-61-about.adoc[leveloffset=+2]
+
+//4.14.60 bug fixes
+include::modules/zstream-4-14-61-bug-fixes.adoc[leveloffset=+3]
+
+//4.14.60 updating
+include::modules/zstream-4-14-61-updating.adoc[leveloffset=+3]
+
+//4.14.60 about
 include::modules/zstream-4-14-60-about.adoc[leveloffset=+2]
 
 //4.14.60 bug fixes


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-17979

Link to docs preview:
https://105487--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#zstream-4-14-61-about_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:

