### PR TITLE
OSDOCS-18051: custom DNS install known issue

### DIFF
--- a/modules/rn-ocp-release-notes-known-issues.adoc
+++ b/modules/rn-ocp-release-notes-known-issues.adoc
@@ -46,3 +46,7 @@ A native abort capability for servicing operations might be planned for a future
 * There is a known issue with the ability to configure the maximum throughput of gp3 storage volumes in an {aws-short} cluster.
 This feature does not work with control plane machine sets.
 There is no workaround for this issue, but it is planned to be fixed in a later release. (link:https://issues.redhat.com/browse/OCPBUGS-74478[OCPBUGS-74478])
+
+* When installing a private cluster on {gcp-first} behind a proxy with user-provisioned DNS, you might encounter installation errors indicating the bootstrap failed to complete or the cluster initialization failed.
+In both cases, the installation can succeed, resulting in a healthy cluster.
+As a workaround, install the private cluster on a bastion host that is within the same virtual private cloud (VPC) as the cluster to be deployed. (link:https://issues.redhat.com/browse/OCPBUGS-54901[OCPBUGS-54901])


### PR DESCRIPTION
[OSDOCS-18051](https://issues.redhat.com/browse/OSDOCS-18051)

Version(s): 4.21

This PR adds a known issue to the release notes relating to custom DNS installs.

QE review:
I'm getting retroactive QE approval next week, see [this comment](https://github.com/openshift/openshift-docs/pull/105489#issuecomment-3824136836) for details

Preview: [Known issues](https://105489--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-notes-known-issues_release-notes)