### PR TITLE
OCPBUGS#74079: Add confidential VM support for NCCads_H100_v5

### DIFF
--- a/modules/installation-azure-confidential-vms.adoc
+++ b/modules/installation-azure-confidential-vms.adoc
@@ -28,6 +28,7 @@ You can use confidential VMs with the following VM sizes:
 * DCedsv5-series
 * ECesv5-series
 * ECedsv5-series
+* NCCads_H100_v5
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
[OCPBUGS-74079]: Add confidential VM support for NCCads_H100_v5

Version(s):

- 4.20 and 4.19
- 4.21+, see https://github.com/openshift/openshift-docs/pull/105314

Issue:
https://issues.redhat.com/browse/OCPBUGS-74079

Link to docs preview:
[Enabling confidential VMs]()

QE review:

- [x] QE has approved this change.