### PR TITLE
OSDOCS-18044 Day 2 throughput configuration

### DIFF
--- a/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc
+++ b/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc
@@ -56,6 +56,9 @@ include::modules/machine-feature-aws-dedicated-instances.adoc[leveloffset=+2]
 // Non-guaranteed Spot Instances and hourly cost limits
 include::modules/machine-feature-agnostic-nonguaranteed-instances.adoc[leveloffset=+2]
 
+// Throughput for gp3 drives
+include::modules/machine-feature-aws-throughput-capi.adoc[leveloffset=+2]
+
 // Capacity Reservation configuration options
 include::modules/machine-feature-agnostic-capacity-reservation.adoc[leveloffset=+2]
 

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -37,6 +37,9 @@ include::modules/machineset-imds-options.adoc[leveloffset=+1]
 //Creating machines that use the Amazon EC2 Instance Metadata Service
 include::modules/machineset-creating-imds-options.adoc[leveloffset=+2]
 
+//Modifying gp3 drive throughput
+include::modules/machine-feature-aws-throughput.adoc[leveloffset=+1]
+
 //Machine sets that deploy machines as Dedicated Instances
 include::modules/machineset-dedicated-instances.adoc[leveloffset=+1]
 

--- a/modules/machine-feature-aws-throughput-capi.adoc
+++ b/modules/machine-feature-aws-throughput-capi.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="machine-feature-aws-throughput-capi_{context}"]
+= Configuring storage throughput for gp3 drives
+
+[role="_abstract"]
+You can improve performance for high traffic services by increasing the throughput of gp3 storage volumes in an {aws-short} cluster. You can configure the storage throughput for the root volume, non root volumes, or both.
+
+include::snippets/apply-machine-configuration-method.adoc[tag=method-machine-template]
+
+.Prerequisites
+
+* You use gp3 storage volume(s).
+
+.Procedure
+
+* On the machine template in which you want to configure throughput, add the `throughput` parameter:
++
+[source,yaml]
+----
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+kind: AWSMachineTemplate
+# ...
+spec:
+  template:
+    spec:
+      nonRootVolumes:
+      - throughput: <throughput_value>
+      rootVolume:
+        throughput: <throughput_value>
+# ...
+----
+where:
+
+`<throughput_value>`:: Specifies a value in MiB/s between 125 and 2,000. This value can only be modified on gp3 volumes. The default value is 125. You can set the throughput value for the root volume and non root volumes separately.

--- a/modules/machine-feature-aws-throughput.adoc
+++ b/modules/machine-feature-aws-throughput.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-aws.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="machine-feature-aws-throughput_{context}"]
+= Configuring storage throughput for gp3 drives
+
+[role="_abstract"]
+You can improve performance for high traffic services by increasing the throughput of gp3 storage volumes in an {aws-short} cluster. You can configure the storage throughput in a compute machine set.
+
+.Prerequisites
+
+* You use gp3 storage volume(s).
+
+.Procedure
+
+* On the machine set that you want to configure throughput, add the `throughputMib` parameter:
++
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+# ...
+spec:
+  template:
+    spec:
+      providerSpec:
+        value:
+          blockDevices:
+            - ebs:
+                throughputMib: <throughput_value>
+
+# ...
+----
+where:
+
+`<throughput_value>`:: Specifies a value in MiB/s between 125 and 2,000. This value can only be modified on gp3 volumes. The default value is 125.


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-18044

Link to docs preview:
[Cluster API](https://105492--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.html#machine-feature-aws-throughput_cluster-api-config-options-aws)
[Machine API](https://105492--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-feature-aws-throughput_creating-machineset-aws)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
