### PR TITLE
OSDOCS#17359: Fujitsu iRMC driver deprecation

### DIFF
--- a/modules/rn-ocp-release-notes-deprecated-features.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-features.adoc
@@ -9,3 +9,11 @@ Item description::
 +
 Detailed information.
 ////
+
+Deprecation of Fujitsu Integrated Remote Management Controller (iRMC) driver for bare-metal machines::
++
+As of {product-title} 4.21, support for the Fujitsu iRMC baseboard management controller (BMC) driver has been deprecated and will be removed in a future release.
+If a `BareMetalHost` resource contains a BMC address with `irmc://` as its URI scheme, the resource must be updated to use another BMC scheme, such as `redfish://` or `ipmi://`.
+Once support for this driver is removed, hosts that use `irmc://` URI schemes will become unmanageable.
++
+For information about updating the `BareMetalHost` resource, see xref:../installing/installing_bare_metal/bare-metal-postinstallation-configuration.adoc#bmo-editing-a-baremetalhost-resource_bare-metal-postinstallation-configuration[Editing a BareMetalHost resource].

--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -70,6 +70,10 @@
 |Deprecated
 |Removed
 
+|Installing a cluster using Fujitsu iRMC drivers on bare-metal machines
+|General Availability
+|General Availability
+|Deprecated
 |====
 
 [id="ocp-release-note-machine-manage-dep-rem_{context}"]
@@ -84,6 +88,11 @@
 |General Availability
 |Deprecated
 |
+
+|Managing bare-metal machines using Fujitsu iRMC drivers
+|General Availability
+|General Availability
+|Deprecated
 |====
 
 [id="ocp-release-note-networking-dep-rem_{context}"]


### PR DESCRIPTION
[OSDOCS-17359](https://issues.redhat.com/browse/OSDOCS-17359)

Version(s): 4.21

This PR adds a deprecation notice for Fujitsu iRMC drivers

QE review:
- [x] QE has approved this change.

Preview: [Deprecated features](https://105499--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-notes-deprecated-features_release-notes)