### PR TITLE
OCPBUGS-74535 Adds warning to creating netpol docs

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -10,7 +10,6 @@ By default, all pods in a project are accessible from other pods and network end
 
 If a pod is matched by selectors in one or more `NetworkPolicy` objects, then the pod will accept only connections that are allowed by at least one of those `NetworkPolicy` objects. A pod that is not selected by any `NetworkPolicy` objects is fully accessible.
 
-
 A network policy applies to only the Transmission Control Protocol (TCP), User Datagram Protocol (UDP), Internet Control Message Protocol (ICMP), and Stream Control Transmission Protocol (SCTP) protocols. Other protocols are not affected.
 
 [WARNING]
@@ -20,6 +19,10 @@ A network policy applies to only the Transmission Control Protocol (TCP), User D
 * Using the `namespaceSelector` field without the `podSelector` field set to `{}` will not include `hostNetwork` pods. You must use the `podSelector` set to `{}` with the `namespaceSelector` field in order to target `hostNetwork` pods when creating network policies.
 
 * Network policies cannot block traffic from localhost or from their resident nodes.
+
+* When creating a network policy, do not apply the `network.openshift.io/policy-group: ingress` label to custom namespace or projects. This label is Operator-managed and reserved for {product-title} networking functions. It should not be altered on system-created namespaces.
++
+Using this label can result in intermittent network connectivity drops, unintended application of system `NetworkPolicies` resource, or configuration drift as the operator attempts to reconcile the state. For custom traffic grouping, always use unique, user-defined labels as shown in the following procedure.
 ====
 
 // TODO OSDOCS-11830 These examples should be broken out into subsections that developers can easily navigate to. The following content makes this module far more reference than concept.

--- a/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
+++ b/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
@@ -39,6 +39,13 @@ ifndef::microshift[]
 endif::microshift[]
 * You are working in the namespace that the {name} policy applies to.
 
+[WARNING]
+====
+Do not apply the `network.openshift.io/policy-group: ingress` label to custom namespace or projects. This label is Operator-managed and reserved for {product-title} networking functions. It should not be altered on system-created namespaces.
+
+Using this label can result in intermittent network connectivity drops, unintended application of system `NetworkPolicies` resource, or configuration drift as the operator attempts to reconcile the state. For custom traffic grouping, always use unique, user-defined labels as shown in the following procedure.
+====
+
 .Procedure
 
 . Create a policy that allows traffic from all pods in a particular namespaces with a label `purpose=production`. Save the YAML in the `web-allow-prod.yaml` file:


### PR DESCRIPTION
Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OCPBUGS-74535

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
