### PR TITLE
OLS-2560: Use OpenShift instead of {product-title} inside of code blocks

### DIFF
--- a/modules/quick-start-content-guidelines.adoc
+++ b/modules/quick-start-content-guidelines.adoc
@@ -29,12 +29,12 @@ After clicking a quick start card, a side panel slides in that introduces the qu
 ** *Correct example*:
 +
 ----
-In this quick start, you will deploy a sample application to {product-title}.
+In this quick start, you will deploy a sample application to Red Hat OpenShift Container Platform.
 ----
 ** *Incorrect example*:
 +
 ----
-This quick start shows you how to deploy a sample application to {product-title}.
+This quick start shows you how to deploy a sample application to Red Hat OpenShift Container Platform.
 ----
 * The introduction should be a maximum of four to five sentences, depending on the complexity of the feature. A long introduction can overwhelm the user.
 * List the quick start tasks after the introduction content, and start each task with a verb. Do not specify the number of tasks because the copy would need to be updated every time a task is added or removed.

--- a/modules/update-selecting-the-target-release.adoc
+++ b/modules/update-selecting-the-target-release.adoc
@@ -129,7 +129,7 @@ Cluster version is 4.15.33
 Upgradeable=False
 
   Reason: AdminAckRequired
-  Message: Kubernetes 1.28 and therefore {product-title} 4.16 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
+  Message: Kubernetes 1.28 and therefore OpenShift 4.16 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
 
 Upstream is unset, so the cluster will use an appropriate default.
 Channel: fast-4.16 (available channels: candidate-4.15, candidate-4.16, eus-4.15, eus-4.16, fast-4.15, fast-4.16, stable-4.15, stable-4.16)
@@ -193,7 +193,7 @@ Cluster version is 4.14.34
 Upgradeable=False
 
   Reason: AdminAckRequired
-  Message: Kubernetes 1.27 and therefore {product-title} 4.15 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
+  Message: Kubernetes 1.27 and therefore OpenShift 4.15 remove several APIs which require admin consideration. Please see the knowledge article https://access.redhat.com/articles/6958394 for details and instructions.
 
 Upstream is unset, so the cluster will use an appropriate default.
 Channel: stable-4.15 (available channels: candidate-4.14, candidate-4.15, eus-4.14, eus-4.15, fast-4.14, fast-4.15, stable-4.14, stable-4.15)


### PR DESCRIPTION
AsciiDocs variable substitution doesn't work inside of code blocks.

Version(s):
4.16-4.22

Issue:
https://issues.redhat.com/browse/OLS-2560

Link to docs preview:

QE review:
- [ ] QE has approved this change.


Additional information:
 See {product-title} in
https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/web_console/creating-quick-start-tutorials
https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/edge_computing/day-2-operations-for-openshift-container-platform-clusters#update-changing-channel-early-eus-to-eus_update-api
https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/edge_computing/day-2-operations-for-openshift-container-platform-clusters#update-updating-y-stream_update-api
for examples.
