### PR TITLE
OSDOCS#15568: Add the RNs for the MicroShift CoreDNS plugin feature

### DIFF
--- a/modules/microshift-4-21-new-features-enhancements.adoc
+++ b/modules/microshift-4-21-new-features-enhancements.adoc
@@ -24,6 +24,13 @@ You can now use the SR-IOV Network Operator to configure and access high-perform
 
 //* xref:../microshift_networking/microshift-sriov.adoc#microshift-sriov[Using the SR-IOV Operator]
 
+
+[id="microshift-4-21-CoreDNS_{context}"]
+== {microshift-short} hosts file for DNS support
+
+You can use a hosts file mechanism to resolve custom, fixed hostnames for applications running within {microshift-short} pods. Previously, workloads in pods could not resolve hostnames that were not accessible through standard DNS resolution. Now, you can configure {microshift-short} to use a functionality similar to the `/etc/hosts` file, ensuring that applications can successfully resolve hostnames for local machines or external services.
+
+
 //TODO add new features and enhancements as needed
 //[id="microshift-4-21-placeholder-feature2_{context}"]
 //== placeholder feature 2


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-15568](https://issues.redhat.com//browse/OSDOCS-15568)

Link to docs preview:
[MicroShift hosts file for DNS support](https://105503--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-21-release-notes.html#microshift-4-21-CoreDNS_release-notes)

QE review:
- [x] QE has approved this change. (Kasturi)
