### PR TITLE
OSDOCS-17797 adding unsupported snippet to RODOO

### DIFF
--- a/nodes/pods/run_once_duration_override/index.adoc
+++ b/nodes/pods/run_once_duration_override/index.adoc
@@ -6,7 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can use the {run-once-operator} to specify a maximum time limit that run-once pods can be active for.
+
+:operator-name: The {run-once-operator}
+include::snippets/operator-not-available.adoc[]
 
 // About the {run-once-operator}
 include::modules/rodoo-about.adoc[leveloffset=+1]

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-install.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-install.adoc
@@ -6,7 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can use the {run-once-operator} to specify a maximum time limit that run-once pods can be active for. By enabling the run-once duration override on a namespace, all future run-once pods created or updated in that namespace have their `activeDeadlineSeconds` field set to the value specified by the {run-once-operator}.
+
+:operator-name: The {run-once-operator}
+include::snippets/operator-not-available.adoc[]
 
 [NOTE]
 ====

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Cluster administrators can use the {run-once-operator} to force a limit on the time that run-once pods can be active. After the time limit expires, the cluster tries to terminate the run-once pods. The main reason to have such a limit is to prevent tasks such as builds to run for an excessive amount of time.
 
 To apply the run-once duration override from the {run-once-operator} to run-once pods, you must enable it on each applicable namespace.
@@ -14,14 +15,5 @@ These release notes track the development of the {run-once-operator} for {produc
 
 For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
 
-[id="run-once-duration-override-operator-release-notes-1-2-0"]
-== {run-once-operator} 1.2.0
-
-Issued: 16 October 2024
-
-The following advisory is available for the {run-once-operator} 1.2.0: (link:https://access.redhat.com/errata/RHSA-2024:7548[RHSA-2024:7548])
-
-[id="run-once-duration-override-operator-1-2-0-bug-fixes"]
-=== Bug fixes
-
-* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+:operator-name: The {run-once-operator}
+include::snippets/operator-not-available.adoc[]

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-uninstall.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 You can remove the {run-once-operator} from {product-title} by uninstalling the Operator and removing its related resources.
 
+:operator-name: The {run-once-operator}
+include::snippets/operator-not-available.adoc[]
+
 // Uninstalling the {run-once-operator}
 include::modules/rodoo-uninstall-operator.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.21
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-17797](https://issues.redhat.com/browse/OSDOCS-17797)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://105512--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/index.html
https://105512--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-install.html
https://105512--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Adding the unsupported snippet as there will be a short gap in support for RODOO between OCP 4.21 GA and RODOO 1.4.0 GA. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
