### PR TITLE
OCPBUGS Document runc to crun migration for 4.18+

### DIFF
--- a/machine_configuration/machine-configs-custom.adoc
+++ b/machine_configuration/machine-configs-custom.adoc
@@ -13,8 +13,14 @@ include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leve
 
 include::modules/create-a-containerruntimeconfig-crd.adoc[leveloffset=+1]
 
+include::modules/config-container-runtime.adoc[leveloffset=+1]
+
 include::modules/set-the-default-max-container-root-partition-size-for-overlay-with-crio.adoc[leveloffset=+1]
 
 include::modules/create-crio-default-capabilities.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
+* xref:../nodes/containers/nodes-containers-using.adoc#nodes-containers-runtimes[About the container engine and container runtime]

--- a/modules/config-container-runtime.adoc
+++ b/modules/config-container-runtime.adoc
@@ -1,0 +1,97 @@
+// Module included in the following assemblies:
+//
+// * machine_configuration/machine-configs-custom.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="config-container-runtime_{context}"]
+= Configuring the container runtime
+
+[role="_abstract"]
+You can configure the container runtime used with new workloads on your nodes, based on which runtime you or your organization prefers. You can use either crun, which is considered a faster and more lightweight runtime, or runc, which is more widely used than crun. 
+
+For information on crun and runc, see "About the container engine and container runtime".
+
+Starting in {product-title} 4.18, crun is the default container runtime for new installations. You can change between the runtimes by using a `ContainerRuntimeConfig` object, as described in the following procedure. Changing the container runtime affects new workloads only. Existing workloads continue to use their existing container runtime. 
+
+If you updated your cluster from {product-title} 4.17, the runc container runtime remains unchanged as the default. During the upgrade, two `MachineConfig` objects, one for the control plane nodes and one for the worker nodes, were created to override the new default runtime. You can migrate the container runtime to crun, on a schedule of your choosing, by removing either or both of the `MachineConfig` objects.
+
+.Procedure
+
+* If your cluster is updated from {product-title} 4.17, you can use the crun container runtime by deleting the following `MachineConfig` objects:
+
+** Migrate your worker nodes to crun by running the following command:
++
+[source,terminal]
+----
+$ oc delete machineconfig 00-override-worker-generated-crio-default-container-runtime
+----
+
+** Migrate your control plane nodes to crun by running the following command:
++
+[source,terminal]
+----
+$ oc delete machineconfig 00-override-master-generated-crio-default-container-runtime
+----
+
+* For any {product-title} 4.18 or greater cluster, you can configure crun or runc as the container runtime for specific nodes by creating a container runtime configuration:
+
+. Create a YAML file for the `ContainerRuntimeConfig` CR:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+ name: configure-runc
+spec:
+ machineConfigPoolSelector:
+   matchLabels:
+     pools.operator.machineconfiguration.openshift.io/worker: ''
+ containerRuntimeConfig:
+   defaultRuntime: "runc"
+----
+where:
++
+--
+* `spec.machineConfigPoolSelector.matchLabels`:: Specifies a label for the machine config pool that you want you want to modify.
+* `spec.containerRuntimeConfig.defaultRuntime`:: Specifies the container runtime to use with new workloads on the nodes in the specified machine config pool, either `crun` or `runc`.
+--
+
+. Create the `ContainerRuntimeConfig` CR:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
+
+.Verification
+
+. After the nodes return to a ready state, open an `oc debug` session to a node by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
++
+. Set `/host` as the root directory within the debug shell by running the following command:
++
+[source,terminal]
+----
+sh-5.1# chroot /host
+----
+
+. Check the container runtime by using the following command:
++
+[source,terminal]
+----
+sh-5.1# crio status config | grep default_runtime
+----
++
+.Example output
+[source,terminal]
+----
+INFO[2026-01-27 23:09:18.413462914Z] Starting CRI-O, version: 1.30.14-6.rhaos4.17.gitfa27f6f.el9, git: unknown(clean) 
+    default_runtime = "runc"
+----
++
+The `default_runtime` parameter specifies the container runtime that {product-title} uses for new workloads on this node, either `crun` or `runc`, depending on what you have configured.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-66362

Version(s):
4.18+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
Machine configuration -> Configuring MCO-related custom resources -> [Configuring the container runtime](https://105525--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/machine-configs-custom.html#config-container-runtime_machine-configs-custom)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
