### PR TITLE
[TRACING-5867]: Document Tempo Operator configuration via OLM Subscription environment

### DIFF
--- a/modules/distr-tracing-tempo-config-operator.adoc
+++ b/modules/distr-tracing-tempo-config-operator.adoc
@@ -1,0 +1,192 @@
+// Module included in the following assemblies:
+//
+// * observability/distr_tracing/distr-tracing-tempo-configuring.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="distr-tracing-tempo-config-operator_{context}"]
+= Configuring the {TempoOperator}
+
+The {TempoOperator} can be configured via the OLM Subscription custom resource (CR) to override default settings. This configuration method uses environment variables that take precedence over any ConfigMap-based configuration.
+
+.Example Subscription CR with operator configuration
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: tempo-product
+  namespace: openshift-tempo-operator
+spec:
+  channel: stable
+  name: tempo-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  config:
+    env:
+    - name: FEATURE_GATES # <1>
+      value: "openshift.route,openshift.servingCertsService"
+    - name: TLS_PROFILE # <2>
+      value: "Modern"
+----
+<1> Comma-separated list of feature gates to enable or disable. Prefix a gate with `-` to disable it.
+<2> TLS security profile for the operator.
+
+You can also configure these values from the {product-title} web console by editing the Subscription object under *Operators* -> *Installed Operators* -> *{TempoOperator}* -> *Subscription*.
+
+[id="tempo-operator-env-vars_{context}"]
+== {TempoOperator} environment variables
+
+The following tables list the environment variables that can be used to configure the {TempoOperator}.
+
+.Feature gates
+[options="header"]
+[cols="a, a"]
+|===
+|Feature gate |Description
+
+|`openshift.route`
+|Enables OpenShift Route creation for Tempo components.
+
+|`openshift.servingCertsService`
+|Enables OpenShift service serving certificates.
+
+|`openshift.oauthProxy`
+|Enables OpenShift OAuth proxy integration.
+
+|`httpEncryption`
+|Enables HTTP encryption for Tempo components.
+
+|`grpcEncryption`
+|Enables gRPC encryption for Tempo components.
+
+|`prometheusOperator`
+|Enables Prometheus Operator integration for metrics.
+
+|`grafanaOperator`
+|Enables Grafana Operator integration.
+
+|`builtInCertManagement`
+|Enables built-in certificate management.
+
+|`observability.metrics.createServiceMonitors`
+|Enables creation of ServiceMonitor resources for Prometheus.
+
+|`observability.metrics.createPrometheusRules`
+|Enables creation of PrometheusRule resources for alerts.
+
+|`networkPolicies`
+|Enables creation of NetworkPolicy resources.
+
+|===
+
+.General configuration environment variables
+[options="header"]
+[cols="a, a, a"]
+|===
+|Environment variable |Description |Example value
+
+|`FEATURE_GATES`
+|Comma-separated list of feature gates to enable or disable. Prefix a gate with `-` to disable it.
+|`openshift.route,openshift.servingCertsService,-networkPolicies`
+
+|`DISTRIBUTION`
+|Sets the distribution type.
+|`openshift`
+
+|`TLS_PROFILE`
+|TLS security profile type.
+|`Old`, `Intermediate`, or `Modern`
+
+|`OPENSHIFT_BASE_DOMAIN`
+|Sets the OpenShift base domain for route generation.
+|`apps.example.com`
+
+|`DEFAULT_POD_SECURITY_CONTEXT`
+|Default PodSecurityContext as JSON.
+|`{"runAsNonRoot": true}`
+
+|===
+
+.Built-in certificate management environment variables
+[options="header"]
+[cols="a, a, a"]
+|===
+|Environment variable |Description |Example value
+
+|`BUILT_IN_CERT_MANAGEMENT_CA_VALIDITY`
+|CA certificate validity duration.
+|`8760h`
+
+|`BUILT_IN_CERT_MANAGEMENT_CA_REFRESH`
+|CA certificate refresh interval.
+|`7008h`
+
+|`BUILT_IN_CERT_MANAGEMENT_CERT_VALIDITY`
+|Certificate validity duration.
+|`2160h`
+
+|`BUILT_IN_CERT_MANAGEMENT_CERT_REFRESH`
+|Certificate refresh interval.
+|`1728h`
+
+|===
+
+.Controller manager environment variables
+[options="header"]
+[cols="a, a, a"]
+|===
+|Environment variable |Description |Example value
+
+|`METRICS_BIND_ADDRESS`
+|Metrics server bind address.
+|`:8080`
+
+|`METRICS_SECURE`
+|Enables secure metrics serving.
+|`true`
+
+|`HEALTH_PROBE_BIND_ADDRESS`
+|Health probe bind address.
+|`:8081`
+
+|`WEBHOOK_PORT`
+|Webhook server port.
+|`9443`
+
+|===
+
+.Leader election environment variables
+[options="header"]
+[cols="a, a, a"]
+|===
+|Environment variable |Description |Example value
+
+|`LEADER_ELECTION_ENABLED`
+|Enables or disables leader election.
+|`true`
+
+|`LEADER_ELECTION_RESOURCE_LOCK`
+|Resource lock type.
+|`leases`
+
+|`LEADER_ELECTION_RESOURCE_NAMESPACE`
+|Namespace for leader election resources.
+|`openshift-tempo-operator`
+
+|`LEADER_ELECTION_RESOURCE_NAME`
+|Name of the leader election resource.
+|`tempo-operator-lock`
+
+|`LEADER_ELECTION_LEASE_DURATION`
+|Leader election lease duration.
+|`15s`
+
+|`LEADER_ELECTION_RENEW_DEADLINE`
+|Leader election renew deadline.
+|`10s`
+
+|`LEADER_ELECTION_RETRY_PERIOD`
+|Leader election retry period.
+|`2s`
+
+|===

--- a/observability/distr_tracing/distr-tracing-tempo-configuring.adoc
+++ b/observability/distr_tracing/distr-tracing-tempo-configuring.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 The {TempoOperator} uses a custom resource definition (CRD) file that defines the architecture and configuration settings for creating and deploying the {TempoShortName} resources. You can install the default configuration or modify the file.
 
+include::modules/distr-tracing-tempo-config-operator.adoc[leveloffset=+1]
+
 ifdef::openshift-enterprise,openshift-dedicated[]
 [id="configuring-storages_{context}"]
 == Configuring back-end storage


### PR DESCRIPTION
  Additional information:
  This PR documents how to configure the Tempo Operator via environment variables in the OLM
  Subscription CR.

  The Tempo Operator migrated from ConfigMap-based configuration to environment variables,
  allowing users to override operator settings directly through the Subscription resource
  without modifying ConfigMaps.

  Changes:
  - Added new module: modules/distr-tracing-tempo-config-operator.adoc
  - Updated assembly: observability/distr_tracing/distr-tracing-tempo-configuring.adoc

  The documentation covers:
  - Example Subscription CR with environment variable configuration
  - Feature gates (openshift.route, openshift.servingCertsService, prometheusOperator, etc.)
  - General configuration variables (FEATURE_GATES, TLS_PROFILE, DISTRIBUTION, etc.)
  - Built-in certificate management settings
  - Controller manager settings (metrics, health probes, webhooks)
  - Leader election settings