### PR TITLE
[OBSDOCS-2998] Logging Z-Stream Release Notes - 6.4.2

### DIFF
--- a/modules/logging-release-notes-6-4-2.adoc
+++ b/modules/logging-release-notes-6-4-2.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-4-2_{context}"]
+= Logging 6.4.2 release notes
+
+This release includes link:https://access.redhat.com/errata/RHBA-2026:1923[RHBA-2026:1923].
+
+
+[id="openshift-logging-release-notes-6-4-2-enhancements_{context}"]
+== New features and enhancements
+
+* With this update, administrators can provide a set of custom headers when configuring log forwarding to an Elasticsearch cluster.
+(link:https://issues.redhat.com/browse/LOG-7804[LOG-7804])
+
+* With this update, an alert is added to identify when a `ClusterLogForwarder` sink is generating an error condition. For example, the alert triggers when the collector is unable to connect to a sink because the connection is refused.
+(link:https://issues.redhat.com/browse/LOG-7896[LOG-7896])
+
+
+[id="logging-release-notes-6-4-2-bug-fixes_{context}"]
+== Bug fixes
+
+* Before this update, the collector merged large application log messages without restriction. As a consequence, large messages could overflow an output buffer, causing Vector to crash and enter a repeated `CrashLoopBackOff` state. With this update, the `MaxMessageSize` tuning parameter for application logs is introduced to limit the size of messages and discard those that exceed the threshold. As a result, the collector remains stable and avoids high-impact log loss.
+(link:https://issues.redhat.com/browse/LOG-7347[LOG-7347])
+
+* Before this update, you could leave the `logType` field empty in the Azure Monitor output specification.
+However, `logType` field is required by the Vector collector.
+Missing `logType` field causes Vector collector failure.
+With this update you cannot pass an empty `logType` field for the Azure Monitor in the `ClusterLogForwarder` custom resource (CR).
+As a result, Vector pods no longer crash due to missing `logType` definition.
+(link:https://issues.redhat.com/browse/LOG-8007[LOG-8007])
+
+* Before this update, an EventRouter message with a newline character (\n) caused malformed syslog data and split events due to broken framing.
+With this update, newline characters in log message payloads are properly escaped.
+As a result, the syslog sink emits a single, well-formed line even when an EventRouter message contains a newline character.
+(link:https://issues.redhat.com/browse/LOG-8090[LOG-8090])
+
+* Before this update, if you did not define a port for the http/https output, enabling NetworkPolicy for the {clo} blocked egress for the collector.
+With this update, the NetworkPolicy is updated to use well-known port values for http/https ports.
+As a result, egress for a collector is not blocked if you enable NetworkPolicy without specifying the port for http/https output.
+(link:https://issues.redhat.com/browse/LOG-8091[LOG-8091])
+
+* Before this update, the `RestrictIngressEgress` network policy blocked traffic to the HTTP proxy.
+As a consequence, user logs were not forwarded to the HTTP output via HTTP proxy.
+With this update, the network policy for `RestrictIngressEgress` allows traffic to the HTTP proxy.
+As a result, you can forward logs to the HTTP output via HTTP proxy with `RestrictIngressEgress` network policy in place.
+(link:https://issues.redhat.com/browse/LOG-8109[LOG-8109])
+
+* Before this update, the network policy port list lacked sorting when multiple outputs or inputs receivers were present in the `ClusterLogForwarder` custom resource (CR).
+As a consequence, the user experience was inconsistent with port order in network policies when multiple outputs or inputs were present.
+With this update, network policy port sorting is fixed for serialization consistency.
+As a result, the network policy port order remains consistent, reducing unexpected changes in the end user's ClusterLogForwarder configuration.
+(link:https://issues.redhat.com/browse/LOG-8129[LOG-8129])
+
+* Before this update, enabling the `RestrictIngressEgress` network policy rule restricted scraping of collector metrics.
+This update fixes the issue by deploying a network policy that relies upon the port number instead of the named port.
+As a result, you can now scrape collector metrics with the `RestrictIngressEgress` network policy enabled.
+(link:https://issues.redhat.com/browse/LOG-8130[LOG-8130])
+
+* Before this update, the LokiStack API specification did not specify that container fields cannot be pruned in LokiStack.
+As a result, the output contained the container fields even if users pruned them in the LokiStack CR.
+With this update, the LokiStack API specification states that container cannot be pruned.
+(link:https://issues.redhat.com/browse/LOG-8507[LOG-8507])
+
+* Before this update, a short timeout between the distributor and ingester component caused HTTP 503 errors when ingesting logs into LokiStack under high loads.
+With this update, the timeout is increased to prevent the errors.
+(link:https://issues.redhat.com/browse/LOG-8583[LOG-8583])
+
+* Before this update, the `ClusterLogForwarderOutputErrorRate` alert lacked a corresponding runbook. With this update, the missing runbook is added.
+(link:https://issues.redhat.com/browse/LOG-8593[LOG-8593])
+
+* Before this update, enabling `rateLimitPerContainer` caused error events stating `Missing fields on event: ["file"]` due to incorrect configuration generation for the throttle section. With this update, the throttle configuration is generated correctly and all expected event fields are preserved when container rate limiting is active.
+(link:https://issues.redhat.com/browse/LOG-8612[LOG-8612])

--- a/release_notes/logging-release-notes.adoc
+++ b/release_notes/logging-release-notes.adoc
@@ -7,6 +7,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/logging-release-notes-6-4-2.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-4-1.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-4-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://issues.redhat.com/browse/OBSDOCS-2998

Link to docs preview:
- [6.4.2 RNs](https://105554--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes.html#logging-release-notes-6-4-2_logging-release-notes)

QE review:
- [x] QE has approved this change.
