### PR TITLE
OSDOCS-16070:Removal of tech preview refs in GDP documentation

### DIFF
--- a/microshift_configuring/microshift-gdp.adoc
+++ b/microshift_configuring/microshift-gdp.adoc
@@ -4,10 +4,6 @@
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-generic-device-plugin
 
-:FeatureName: The Generic Device Plugin for {microshift-short}
-
-include::snippets/technology-preview.adoc[]
-
 toc::[]
 
 The Generic Device Plugin (GDP) for {microshift-short} enables your containerized applications to securely access physical host devices, such as serial ports, video cameras, or sound cards directly from within Kubernetes pods. By using GDP, you can extend capabilities of {microshift-short} to support applications that require direct hardware interaction, such as Internet of Things (IoT) applications.

--- a/modules/microshift-proc-configuring-generic-device-plugin.adoc
+++ b/modules/microshift-proc-configuring-generic-device-plugin.adoc
@@ -6,10 +6,6 @@
 [id="microshift-configuring-generic-device-plugin_{context}"]
 = Configuring the Generic Device Plugin
 
-:FeatureName: The Generic Device Plugin for {microshift-short}
-
-include::snippets/technology-preview.adoc[]
-
 The Generic Device Plugin (GDP) is disabled by default in {microshift-short}. To use the GDP, you must enable it and specify which host devices your Kubernetes applications can access. To enable the GDP, you must modify the {microshift-short} `config.yaml` file or create a configuration snippet file. For example, `/etc/microshift/config.d/10-gdp.yaml`.
 
 .Prerequisites


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-16070

Link to docs preview:
https://105575--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift-gdp.html

QE review:
- [x] QE has approved this change.