### PR TITLE
OSDOCS Final ADV edits for Configuring Network Settings

### DIFF
--- a/modules/nw-nodeport-service-range-edit.adoc
+++ b/modules/nw-nodeport-service-range-edit.adoc
@@ -6,7 +6,8 @@
 [id="nw-nodeport-service-range-edit_{context}"]
 = Expanding the node port range
 
-You can expand the node port range for your cluster. After you install your {product-title} cluster, you cannot shrink the node port range on either side of the currently configured range.
+[role="_abstract"]
+To expand the node port range for your {product-title} cluster after installation, you can use the `oc patch` command to update the `serviceNodePortRange` parameter. You can expand the range on either side, but you cannot shrink it after installation.
 
 [IMPORTANT]
 ====
@@ -35,7 +36,7 @@ $ oc patch network.config.openshift.io cluster --type=merge -p \
 --
 where:
 
-`<port_range>`:: specifies your expanded range, such as `30000-32900`.
+`<port_range>`:: Specifies the expanded range, such as `30000-32900`.
 --
 +
 [TIP]

--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -7,7 +7,10 @@
 [id="nw-proxy-configure-object_{context}"]
 = Enabling the cluster-wide proxy
 
-The `Proxy` object is used to manage the cluster-wide egress proxy. When a cluster is installed or upgraded without the proxy configured, a `Proxy` object is still generated but it has a nil `spec`. For example:
+[role="_abstract"]
+To enable the cluster-wide egress proxy for your {product-title} cluster, you can modify the `Proxy` object to configure HTTP and HTTPS proxy settings and specify domains that bypass the proxy.
+
+When a cluster is installed or upgraded without the proxy configured, a `Proxy` object is still generated but it has a nil `spec`. For example:
 
 [source,yaml]
 ----
@@ -60,12 +63,16 @@ metadata:
   name: user-ca-bundle <3>
   namespace: openshift-config <4>
 ----
-<1> This data key must be named `ca-bundle.crt`.
-<2> One or more PEM-encoded X.509 certificates used to sign the proxy's
-identity certificate.
-<3> The config map name that is referenced from the `Proxy` object.
-<4> The config map must exist in the `openshift-config` namespace.
 +
+where:
++
+--
+`data.ca-bundle.crt`:: Specifies the data key that must be named `ca-bundle.crt`.
+`<MY_PEM_ENCODED_CERTS>`:: Specifies one or more PEM-encoded X.509 certificates used to sign the proxy's identity certificate.
+`user-ca-bundle`:: Specifies the config map name that is referenced from the `Proxy` object.
+`openshift-config`:: Specifies the namespace that the config map must exist in.
+--
+
 .. Create the config map from the `user-ca-bundle.yaml` file by entering the following command:
 +
 [source,terminal]
@@ -99,15 +106,14 @@ spec:
     name: user-ca-bundle <5>
 ----
 +
---
-<1> A proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be `http`.
-<2> A proxy URL to use for creating HTTPS connections outside the cluster. The URL scheme must be either `http` or `https`. Specify a URL for the proxy that supports the URL scheme. For example, most proxies report an error if they are configured to use `https` but they only support `http`. This failure message may not propagate to the logs and can appear to be a network connection failure instead. If using a proxy that listens for `https` connections from the cluster, you might need to configure the cluster to accept the CAs and certificates that the proxy uses.
-<3> A comma-separated list of destination domain names, domains, IP addresses (or other network CIDRs), and port numbers to exclude proxying.
+where:
 +
-[NOTE]
-====
-Port numbers are only supported when configuring IPv6 addresses. Port numbers are not supported when configuring IPv4 addresses.
-====
+--
+`httpProxy`:: Specifies the proxy URL to use for creating HTTP connections outside the cluster. The URL scheme must be `http`.
+
+`httpsProxy`:: Specifies the proxy URL to use for creating HTTPS connections outside the cluster. The URL scheme must be either `http` or `https`. Specify a URL for the proxy that supports the URL scheme. For example, most proxies report an error if they are configured to use `https` but they only support `http`. This failure message may not propagate to the logs and can appear to be a network connection failure instead. If using a proxy that listens for `https` connections from the cluster, you might need to configure the cluster to accept the CAs and certificates that the proxy uses.
+
+`noProxy`:: Specifies a comma-separated list of destination domain names, domains, IP addresses (or other network CIDRs), and port numbers to exclude proxying. Note that Port numbers are only supported when configuring IPv6 addresses. Port numbers are not supported when configuring IPv4 addresses.
 +
 Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
 +
@@ -117,8 +123,10 @@ For example, if you have a CIDR block value, such as `10.0.0.0/24`, for the `nop
 If you scale up compute nodes that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
 +
 This field is ignored if neither the `httpProxy` or `httpsProxy` fields are set.
-<4> One or more URLs external to the cluster to use to perform a readiness check before writing the `httpProxy` and `httpsProxy` values to status.
-<5> A reference to the config map in the `openshift-config` namespace that contains additional CA certificates required for proxying HTTPS connections. Note that the config map must already exist before referencing it here. This field is required unless the proxy's identity certificate is signed by an authority from the {op-system} trust bundle.
+
+`readinessEndpoints`:: Specifies one or more URLs external to the cluster to use to perform a readiness check before writing the `httpProxy` and `httpsProxy` values to status.
+
+`trustedCA`:: Specifies a reference to the config map in the `openshift-config` namespace that contains additional CA certificates required for proxying HTTPS connections. Note that the config map must already exist before referencing it here. This field is required unless the proxy's identity certificate is signed by an authority from the {op-system} trust bundle.
 --
 
 . Save the file to apply the changes.

--- a/modules/nw-proxy-remove.adoc
+++ b/modules/nw-proxy-remove.adoc
@@ -6,7 +6,8 @@
 [id="nw-proxy-remove_{context}"]
 = Removing the cluster-wide proxy
 
-The `cluster` Proxy object cannot be deleted. To remove the proxy from a cluster, remove all `spec` fields from the Proxy object.
+[role="_abstract"]
+The `cluster` Proxy object cannot be deleted. To remove the cluster-wide proxy configuration from your {product-title} cluster, you can remove all spec fields from the `Proxy` object by using the `oc edit` command.
 
 .Prerequisites
 

--- a/modules/nw-verify-proxy-configuration.adoc
+++ b/modules/nw-verify-proxy-configuration.adoc
@@ -7,7 +7,8 @@
 [id="nw-verify-proxy-configuration_{context}"]
 = Verifying the cluster-wide proxy configuration
 
-After the cluster-wide proxy configuration is deployed, you can verify that it is working as expected. Follow these steps to check the logs and validate the implementation.
+[role="_abstract"]
+To verify that your cluster-wide proxy configuration is working correctly in {product-title}, you can check the `Proxy` object status, review Machine Config Operator logs, and confirm that system components are routing external requests through the proxy.
 
 .Prerequisites
 

--- a/networking/configuring_network_settings/configuring-node-port-service-range.adoc
+++ b/networking/configuring_network_settings/configuring-node-port-service-range.adoc
@@ -6,9 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-During cluster installation, you can configure the node port range to meet the requirements of your cluster. After cluster installation, only a cluster administrator can expand the range as a postinstallation task. If your cluster uses a large number of node ports, consider increasing the available port range according to the requirements of your cluster.
-
-If you do not set a node port range during cluster installation, the default range of `30000-32768` applies to your cluster. In this situation, you can expand the range on either side, but you must preserve `30000-32768` within your new port range.
+[role="_abstract"]
+To meet your cluster node port requirements in {product-title}, you can configure the node port service range during installation or expand it after installation. You can expand the default range of `30000-32768` on either side while preserving this default range within your new configuration.
 
 [IMPORTANT]
 ====

--- a/networking/configuring_network_settings/enable-cluster-wide-proxy.adoc
+++ b/networking/configuring_network_settings/enable-cluster-wide-proxy.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Production environments can deny direct access to the internet and instead have an HTTP or HTTPS proxy available. You can configure {product-title} to use a proxy by xref:../../networking/configuring_network_settings/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[modifying the Proxy object for existing clusters] or by configuring the proxy settings in the `install-config.yaml` file for new clusters.
+[role="_abstract"]
+To enable your {product-title} cluster to use an HTTP or HTTPS proxy when direct internet access is denied, you can configure cluster-wide proxy settings by modifying the `Proxy` object for existing clusters or by configuring proxy settings in the `install-config.yaml` file for new clusters.
 
 After you enable a cluster-wide egress proxy for your cluster on a supported platform, {op-system-first} populates the `status.noProxy` parameter with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your `install-config.yaml` file that exists on the supported platform.
 
@@ -26,13 +27,13 @@ metadata:
   name: cluster
 # ...
 networking:
-  clusterNetwork: <1>
+  clusterNetwork:
   - cidr: <ip_address_from_cidr>
     hostPrefix: 23
   network type: OVNKubernetes
-  machineNetwork: <2>
+  machineNetwork:
   - cidr: <ip_address_from_cidr>
-  serviceNetwork: <3>
+  serviceNetwork:
   - 172.30.0.0/16
 # ...
 status:
@@ -41,13 +42,18 @@ status:
   - .cluster.local
   - .svc
   - 127.0.0.1
-  - <api_server_internal_url> <4>
+  - <api_server_internal_url>
 # ...
 ----
-<1> Specify IP address blocks from which pod IP addresses are allocated. The default value is `10.128.0.0/14` with a host prefix of `/23`.
-<2> Specify the IP address blocks for machines. The default value is `10.0.0.0/16`.
-<3> Specify IP address block for services. The default value is `172.30.0.0/16`.
-<4> You can find the URL of the internal API server by running the `oc get infrastructures.config.openshift.io cluster -o jsonpath='{.status.etcdDiscoveryDomain}'` command.
+
+where:
+
+--
+`<ip_address_from_cidr>`:: Specifies IP address blocks from which pod IP addresses are allocated. The default value is `10.128.0.0/14` with a host prefix of `/23`.
+`<ip_address_from_cidr>`:: Specifies IP address blocks for machines. The default value is `10.0.0.0/16`.
+`<ip_address_from_cidr>`:: Specifies IP address block for services. The default value is `172.30.0.0/16`.
+`<api_server_internal_url>`:: You can find the URL of the internal API server by running the `oc get infrastructures.config.openshift.io cluster -o jsonpath='{.status.etcdDiscoveryDomain}'` command.
+--
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
PR 4/4 https://issues.redhat.com/browse/OSDOCS-16861

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-16861

Link to docs preview:
https://105585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_network_settings/enable-cluster-wide-proxy.html

https://105585--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_network_settings/configuring-node-port-service-range.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
