### PR TITLE
OLS-2541: Create short descriptions for modules in operation assembly

### DIFF
--- a/modules/ols-about-lightspeed-conversations.adoc
+++ b/modules/ols-about-lightspeed-conversations.adoc
@@ -2,7 +2,8 @@
 [id="ols-about-lightspeed-conversations_{context}"]
 = About Lightspeed conversations
 
-{ols-long} is designed to answer questions about {ocp-short-name}, {k8s}, and additional {ocp-short-name} components, such as {ocp-virt}, {ocp-pipe}, and {ossm}. 
+[role="_abstract"]
+Get technical assistance for {ocp-short-name}, {k8s}, and specialized {ocp-short-name} components, such as {ocp-virt} and {ossm}, using {ols-long}.
 
 {ols-long} will not answer questions that are unrelated to the targeted topics. In some cases, you may need to rephrase an ambiguously worded question because {ols-long} could not correctly interpret what you asked. Conversation history helps provide context that {ols-long} references when generating answers. Using specific language helps increase the success of responses. For example, instead of asking "How do I start a virtual machine?" try asking "How do I start a virtual machine in {ocp-virt}?"
 

--- a/modules/ols-asking-general-information.adoc
+++ b/modules/ols-asking-general-information.adoc
@@ -5,7 +5,8 @@
 [id="ols-asking-general-information_{context}"]
 = Asking a general question
 
-This procedure shows how to ask {ols-long} a general question about the {ocp-product-title}.
+[role="_abstract"]
+Ask general questions about {ocp-product-title} using {ols-long} to quickly find documentation, best practices, and product information.
 
 .Procedure
 

--- a/modules/ols-asking-related-questions.adoc
+++ b/modules/ols-asking-related-questions.adoc
@@ -2,7 +2,8 @@
 [id="ols-asking-related-questions_{context}"]
 = Asking related questions
 
-This procedure shows how to ask {ols-long} a series of related questions in order to obtain more highly refined information. {ols-long} uses the conversation history to help create context. 
+[role="_abstract"]
+Ask a series of follow-up questions in {ols-long} to refine your results. {ols-long} maintains conversation history to provide context-aware responses and more accurate information.
 
 .Procedure
 

--- a/modules/ols-attaching-a-resource-object-to-your-query.adoc
+++ b/modules/ols-attaching-a-resource-object-to-your-query.adoc
@@ -5,7 +5,8 @@
 [id="ols-attaching-a-resource-object-to-your-query_{context}"]
 = Attaching a resource object to your question
 
-This procedure explains how to attach a resource object to provide additional context for your question. 
+[role="_abstract"]
+Attach a cluster resource object to your {ols-long} query to provide specific context and receive more relevant, data-driven troubleshooting advice.
 
 .Procedure
 

--- a/modules/ols-initiating-chat-using-chat-window.adoc
+++ b/modules/ols-initiating-chat-using-chat-window.adoc
@@ -5,7 +5,8 @@
 [id="ols-initiating-chat-using-chat-window_{context}"]
 = Using the chat window to ask a question 
 
-This procedure explains how to use the {ols-official} icon to ask a question using natural language.
+[role="_abstract"]
+Ask questions using natural language by interacting with the {ols-official} icon to receive immediate support and information.
 
 .Procedure
  

--- a/modules/ols-providing-feedback-for-conversation.adoc
+++ b/modules/ols-providing-feedback-for-conversation.adoc
@@ -5,7 +5,8 @@
 [id="ols-providing-feedback-for-conversation_{context}"]
 = Providing feedback for a conversation 
 
-{ols-long} includes an integrated feedback system. This procedure explains how to provide feedback to {red-hat} for a specific {ols-long} question and response.
+[role="_abstract"]
+Provide feedback to {red-hat} on specific {ols-long} interactions to improve the quality and accuracy of future responses.
 
 .Prerequisites
 

--- a/modules/ols-sample-dialogs-overview.adoc
+++ b/modules/ols-sample-dialogs-overview.adoc
@@ -2,6 +2,8 @@
 [id="ols-sample-dialogs-overview_{context}"]
 = Sample conversation overview
 
-The following examples are intended to serve as samples you can use to start a conversation with {ols-long}. In some cases, the conversation includes an initial question and then one or more follow-up questions. Rephrasing questions or asking a more precise follow-up question can help increase the success of the reply.
+[role="_abstract"]
 
-Some of the examples suggest specific workflows to follow in the user interface. Be sure to ask the follow-up questions without starting a new dialog. {ols-long} uses the entire conversation as context, so follow-up questions should help refine answers.
+Use these sample prompts and follow-up strategies to initiate effective conversations with {ols-long} and improve response accuracy. 
+
+Some of the examples suggest specific workflows to follow in the user interface. Be sure to ask the follow-up questions without starting a new dialog. {ols-long} uses the entire conversation as context, so follow-up questions should help refine answers. Rephrasing questions or asking a more precise follow-up question can help increase the success of the reply.

--- a/modules/ols-starting-a-new-chat.adoc
+++ b/modules/ols-starting-a-new-chat.adoc
@@ -5,9 +5,10 @@
 [id="ols-starting-a-new-chat_{context}"]
 = Starting a new chat conversation
 
-When you ask follow-up questions, {ols-long} references the conversation history to provide additional context that influences the replies it generates. Whenever you initiate a new conversation with {ols-long} you should clear the chat history.
+[role="_abstract"]
+Reset your {ols-long} session by clearing the chat history to start a new conversation without influence from previous context.
 
-This procedure explains how to clear the chat history and start a new conversation. 
+When you ask follow-up questions, {ols-long} references the conversation history to provide additional context that influences the replies it generates. Whenever you initiate a new conversation with {ols-long} you should clear the chat history.
 
 .Procedure
 

--- a/modules/ols-using-lightspeed-to-troubleshoot-alerts.adoc
+++ b/modules/ols-using-lightspeed-to-troubleshoot-alerts.adoc
@@ -5,7 +5,8 @@
 [id="ols-using-lightspeed-to-troubleshoot-alerts_{context}"]
 = Using {ols-long} to troubleshoot alerts
 
-This procedure shows how to use {ols-long} to troubleshoot alerts. 
+[role="_abstract"]
+Analyze and resolve cluster alerts by querying {ols-long} for root cause explanations, documentation links, and recommended remediation steps.
 
 .Procedure
 

--- a/operate/ols-using-openshift-lightspeed.adoc
+++ b/operate/ols-using-openshift-lightspeed.adoc
@@ -6,14 +6,23 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following topics provide information about submitting a question to {ols-long}, attaching resources to your question, and troubleshooting alerts.
+[role="_abstract"]
+Submit questions to {ols-long}, manage resource attachments, and resolve system alerts to optimize your troubleshooting experience.
 
 include::modules/ols-initiating-chat-using-chat-window.adoc[leveloffset=+1]
+
 include::modules/ols-about-lightspeed-conversations.adoc[leveloffset=+1]
+
 include::modules/ols-providing-feedback-for-conversation.adoc[leveloffset=+1]
+
 include::modules/ols-sample-dialogs-overview.adoc[leveloffset=+1]
+
 include::modules/ols-asking-general-information.adoc[leveloffset=+2]
+
 include::modules/ols-asking-related-questions.adoc[leveloffset=+2]
+
 include::modules/ols-attaching-a-resource-object-to-your-query.adoc[leveloffset=+2]
+
 include::modules/ols-using-lightspeed-to-troubleshoot-alerts.adoc[leveloffset=+2]
+
 include::modules/ols-starting-a-new-chat.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2541

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
