### PR TITLE
[OSDOCS#17442]Updated product names as per CQA template in Prepare your environment section.

### DIFF
--- a/modules/rosa-prereq-roles-overview.adoc
+++ b/modules/rosa-prereq-roles-overview.adoc
@@ -70,7 +70,7 @@ ifdef::openshift-rosa-hcp[]
 +
 For {product-title} clusters, you must create the following Operator roles and attach the indicated AWS Managed policies:
 +
-.Required Operator roles and AWS Managed policies for {hcp-title}
+.Required Operator roles and AWS Managed policies for {product-title}
 [options="header"]
 |===
 | Role name | AWS-managed policy name

--- a/modules/rosa-sts-operator-roles.adoc
+++ b/modules/rosa-sts-operator-roles.adoc
@@ -15,7 +15,7 @@ ifdef::openshift-rosa[]
 The Operator policies are tagged with the Operator and version they are compatible with. The correct policy for an Operator role is determined by using the tags.
 endif::openshift-rosa[]
 ifdef::openshift-rosa-hcp[]
-AWS managed Operator policies are versioned in AWS IAM. The latest version of an AWS managed policy is always used, so you do not need to manage or schedule upgrades for AWS managed policies used by {rosa-short}.
+AWS managed Operator policies are versioned in AWS IAM. The latest version of an AWS managed policy is always used, so you do not need to manage or schedule upgrades for AWS managed policies used by {product-title}.
 endif::openshift-rosa-hcp[]
 
 [NOTE]
@@ -31,7 +31,7 @@ ifdef::openshift-rosa[]
 |Resource|Description
 
 |`<cluster_name>-<hash>-openshift-cluster-csi-drivers-ebs-cloud-credentials`
-|An IAM role required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+|An IAM role required by {product-title} to manage back-end storage through the Container Storage Interface (CSI).
 
 |`<cluster_name>-<hash>-openshift-machine-api-aws-cloud-credentials`
 |An IAM role required by the ROSA Machine Config Operator to perform core cluster functionality.
@@ -56,7 +56,7 @@ ifdef::openshift-rosa[]
 endif::openshift-rosa[]
 
 ifdef::openshift-rosa-hcp[]
-.Required Operator roles and AWS Managed policies for {rosa-short}
+.Required Operator roles and AWS Managed policies for {product-title}
 [options="header"]
 |===
 | Role name | AWS Managed policy name | Role description
@@ -67,11 +67,11 @@ ifdef::openshift-rosa-hcp[]
 
 | `openshift-image-registry-installer-cloud-credentials`
 | `ROSAImageRegistryOperatorPolicy`
-| An IAM role required by the ROSA Image Registry Operator to manage the {product-registry} storage in AWS S3 for a cluster.
+| An IAM role required by the {product-title} Image Registry Operator to manage the {product-registry} storage in AWS S3 for a cluster.
 
 | `kube-system-kube-controller-manager`
 | `ROSAKubeControllerPolicy`
-| An IAM role required for OpenShift management on HCP clusters.
+| An IAM role required for OpenShift management on hosted control planes (HCP) clusters.
 
 | `kube-system-capa-controller-manager`
 | `ROSANodePoolManagementPolicy`
@@ -79,7 +79,7 @@ ifdef::openshift-rosa-hcp[]
 
 | `kube-system-control-plane-operator`
 | `ROSAControlPlaneOperatorPolicy`
-| An IAM role required control plane management on HCP clusters.
+| An IAM role required for control plane management on HCP clusters.
 
 | `kube-system-kms-provider`
 | `ROSAKMSProviderPolicy`
@@ -87,11 +87,11 @@ ifdef::openshift-rosa-hcp[]
 
 | `openshift-ingress-operator-cloud-credentials`
 | `ROSAIngressOperatorPolicy`
-|An IAM role required by the ROSA Ingress Operator to manage external access to a cluster.
+|An IAM role required by the {product-title} Ingress Operator to manage external access to a cluster.
 
 | `openshift-cluster-csi-drivers-ebs-cloud-credentials`
 | `ROSAAmazonEBSCSIDriverOperatorPolicy`
-| An IAM role required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+| An IAM role required by {product-title} to manage back-end storage through the Container Storage Interface (CSI).
 
 |===
 endif::openshift-rosa-hcp[]

--- a/modules/sd-planning-cluster-maximums.adoc
+++ b/modules/sd-planning-cluster-maximums.adoc
@@ -8,16 +8,19 @@
 = Cluster maximums
 
 [role="_abstract"]
-Consider the following tested object maximums when you plan a {product-title}
+Consider the following tested object maximums when you plan
 ifdef::openshift-rosa[]
-(ROSA)
-endif::[]
-cluster installation. The table specifies the maximum limits for each tested type in a
-ifdef::openshift-rosa[]
-(ROSA)
+a {product-title}
 endif::[]
 ifdef::openshift-dedicated[]
-{product-title}
+an {product-title}
+endif::[]
+cluster installation. The table specifies the maximum limits for each tested type in
+ifdef::openshift-rosa[]
+a {product-title}
+endif::[]
+ifdef::openshift-dedicated[]
+an {product-title}
 endif::[]
 cluster.
 

--- a/modules/sd-planning-considerations.adoc
+++ b/modules/sd-planning-considerations.adoc
@@ -8,9 +8,12 @@
 = Control plane and infrastructure node sizing and scaling
 
 [role="_abstract"]
-When you install a {product-title}
+When you install
 ifdef::openshift-rosa[]
-(ROSA)
+a {product-title}
+endif::[]
+ifdef::openshift-dedicated[]
+an {product-title}
 endif::[]
 cluster, the sizing of the control plane and infrastructure nodes are automatically determined by the compute node count.
 
@@ -98,7 +101,7 @@ endif::[]
 ====
 The maximum number of compute nodes on
 ifdef::openshift-rosa[]
-ROSA
+{product-title}
 endif::[]
 ifdef::openshift-dedicated[]
 {product-title}
@@ -123,7 +126,7 @@ The resizing alert is triggered for the control plane nodes in a cluster when th
 ====
 The maximum number of compute nodes on
 ifdef::openshift-rosa[]
-ROSA
+{product-title}
 endif::[]
 ifdef::openshift-dedicated[]
 {product-title}
@@ -142,7 +145,7 @@ Resizing alerts are triggered for the infrastructure nodes in a cluster when it 
 ====
 The maximum number of compute nodes on
 ifdef::openshift-rosa[]
-ROSA
+{rosa-title}
 endif::[]
 ifdef::openshift-dedicated[]
 {product-title}


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17442

Link to docs preview:
[Cluster-specific operator IAM role reference](https://105604--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-hcp-prepare-iam-roles-resources.html#rosa-sts-operator-roles_prepare-role-resources)
[Limits and scalability (OSD)](https://105604--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/osd-limits-scalability.html)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- QE approval is not required for this PR as no procedural changes involved.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
