### PR TITLE
OSDOCS-16676 -wgabor-openshft-apiserver:RN Bug Batch

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -130,6 +130,8 @@ To maintain compatibility with Kubernetes 1.34, CoreDNS has been updated to vers
 [id="rn-ocp-release-note-ocp-api-server-fixed-issues_{context}"]
 == OpenShift API Server
 
+* Before this update, there was an incorrect error field path for `hostUsers` when validating a security context constraint. It was shown as `.spec.securityContext.hostUsers`, but `hostUsers` is not in the security context. With this release, the error field path is now `.spec.hostUsers`. (link:https://issues.redhat.com/browse/OCPBUGS-65727[OCPBUGS-65727])
+
 
 [id="rn-ocp-release-note-ocp-cli-fixed-issues_{context}"]
 == OpenShift CLI (oc)


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-16676

Link to docs preview:
https://105605--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-note-ocp-api-server-fixed-issues_release-notes


QE review:
- [ ] QE has approved this change.


Additional information:

