### PR TITLE
Remove kube-reserved 'Understanding how to allocate resources for nodes' 

### DIFF
--- a/modules/nodes-nodes-resources-configuring-about.adoc
+++ b/modules/nodes-nodes-resources-configuring-about.adoc
@@ -7,26 +7,14 @@
 = Understanding how to allocate resources for nodes
 
 [role="_abstract"]
-CPU and memory resources reserved for node components in {product-title} are based on two node settings: `kube-reserved` and `system-reserved`. These settings are automatically configured upon node start up, or you can manually set these values as needed. 
+CPU and memory resources for the node and system components on your nodes are automatically configured and assigned upon node start up or you can manually set these values as needed. Ensuring proper resources for these services can help ensure that your cluster is operating efficiently.
 
-[options="header",cols="1,2"]
-|===
-|Setting |Description
-
-|`kube-reserved`
-| This setting is not used with {product-title}. Add the CPU and memory resources that you planned to reserve to the `system-reserved` setting.
-
-|`system-reserved`
-| This setting identifies the resources to reserve for the node components and system components, such as CRI-O and Kubelet. The default settings depend on the {product-title} and Machine Config Operator versions. Confirm the default `systemReserved` parameter on the `machine-config-operator` repository.
-|===
-
-If a flag is not set, the defaults are used. If none of the flags are set, the
-allocated resource is set to the node's capacity as it was before the
-introduction of allocatable resources.
+Specific CPU and memory resources for the node components and system components in the systemd `system.slice` cgroup, such as CRI-O and Kubelet, are based on the `system-reserved` setting in the kubelet. The default `system-reserved` setting differ, based on the {product-title} and Machine Config Operator versions in your cluster. You can confirm the default `systemReserved` parameter on the `machine-config-operator` repository.
 
 [NOTE]
 ====
-Any CPUs specifically reserved using the `reservedSystemCPUs` parameter are not available for allocation using `kube-reserved` or `system-reserved`.
+* Any CPUs specifically reserved using the `reservedSystemCPUs` parameter in a `KubeletConfig` object are not available for allocation using `system-reserved`.
+* Kubernetes `kubeReserved` is not supported in {product-title}.
 ====
 
 By default, {product-title} uses a script on each worker node to automatically determine the optimal `system-reserved` CPU and memory resources for nodes. The script runs on node start up and uses the following calculations by default. 

--- a/modules/nodes-nodes-resources-configuring-about.adoc
+++ b/modules/nodes-nodes-resources-configuring-about.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nodes-nodes-resources-configuring-about_{context}"]
-= Understanding how to allocate resources for nodes
+= Understanding how resources are allocated to nodes
 
 [role="_abstract"]
 {product-title} uses a script to determine optimal CPU and memory resources for the node and system components on your nodes. Or, you can manually set these values as needed. Ensuring proper resources for these services can help ensure that your cluster is operating efficiently.
 
-These CPU and resource calculations are based on the installed CPU and memory capacity on each node and assigned upon node start up. These resources are reserved for the node and system components in the systemd `system.slice` cgroup, such as CRI-O and kubelet. By default, before the scripts runs, {product-title} reserves 500m for CPU and 1 Gi of memory for the node and system components.    
+These resource calculations are based on the installed CPU and memory capacity on each node and assigned upon node start up. These resources are reserved for the node and system components in the systemd `system.slice` cgroup, such as CRI-O and kubelet. By default, before the scripts runs, {product-title} reserves 500m for CPU and 1 Gi of memory for the node and system components.    
 
 [NOTE]
 ====
@@ -48,6 +48,8 @@ For example, on a 4-core node, 0.5 vCPU is reserved for node and system componen
 ====
 Any CPUs specifically reserved using the `reservedSystemCPUs` parameter in a `KubeletConfig` object are not available for allocation using `system-reserved`.
 ====
+
+You can manually manage CPU and memory reservations for the node and system components by configuring the `system-reserved` parameter in a `MachineConfig` object, as described in "Manually allocating resources for nodes".
 
 [id="computing-allocated-resources_{context}"]
 == How {product-title} computes allocated resources

--- a/modules/nodes-nodes-resources-configuring-about.adoc
+++ b/modules/nodes-nodes-resources-configuring-about.adoc
@@ -7,17 +7,16 @@
 = Understanding how to allocate resources for nodes
 
 [role="_abstract"]
-CPU and memory resources for the node and system components on your nodes are automatically configured and assigned upon node start up or you can manually set these values as needed. Ensuring proper resources for these services can help ensure that your cluster is operating efficiently.
+{product-title} uses a script to determine optimal CPU and memory resources for the node and system components on your nodes. Or, you can manually set these values as needed. Ensuring proper resources for these services can help ensure that your cluster is operating efficiently.
 
-Specific CPU and memory resources for the node components and system components in the systemd `system.slice` cgroup, such as CRI-O and Kubelet, are based on the `system-reserved` setting in the kubelet. The default `system-reserved` setting differ, based on the {product-title} and Machine Config Operator versions in your cluster. You can confirm the default `systemReserved` parameter on the `machine-config-operator` repository.
+These CPU and resource calculations are based on the installed CPU and memory capacity on each node and assigned upon node start up. These resources are reserved for the node and system components in the systemd `system.slice` cgroup, such as CRI-O and kubelet. By default, before the scripts runs, {product-title} reserves 500m for CPU and 1 Gi of memory for the node and system components.    
 
 [NOTE]
 ====
-* Any CPUs specifically reserved using the `reservedSystemCPUs` parameter in a `KubeletConfig` object are not available for allocation using `system-reserved`.
-* Kubernetes `kubeReserved` is not supported in {product-title}.
+The Kubernetes `kubeReserved` parameter is not supported in {product-title}.
 ====
 
-By default, {product-title} uses a script on each worker node to automatically determine the optimal `system-reserved` CPU and memory resources for nodes. The script runs on node start up and uses the following calculations by default. 
+The script uses the following calculations by default. 
 
 Memory reservation::
 The memory reservation is weighted. For smaller nodes, {product-title} reserves a higher percentage of memory. For larger nodes, {product-title} reserves a smaller percentage of the remaining capacity. 
@@ -45,9 +44,9 @@ CPU reservation::
 +
 For example, on a 4-core node, 0.5 vCPU is reserved for node and system components, leaving 3.5 vCPUs for workloads. Note that 1000 millicores is equal to 1CPU/vCPU.
 +
-[IMPORTANT]
+[NOTE]
 ====
-If you updated your cluster from a version earlier than 4.21, automatic allocation of system resources is disabled by default. To enable the feature, delete the `50-worker-auto-sizing-disabled` machine config. 
+Any CPUs specifically reserved using the `reservedSystemCPUs` parameter in a `KubeletConfig` object are not available for allocation using `system-reserved`.
 ====
 
 [id="computing-allocated-resources_{context}"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17949

Implent the first three bullets in [this comment](https://github.com/openshift/openshift-docs/pull/103868#issuecomment-3758110344):

* kube-reserved clarification: I took a closer look at the kube-reserved row in the table. As you noted, it is best to remove this row entirely from the table to avoid confusion. Instead, we should add a standalone note stating that kube-reserved is not utilized in OpenShift.
* system-reserved definition: For the system-reserved description, please specify that this setting applies to all processes that use the system.slice cgroup
* Remove unused flag references: We should remove the lines starting with "If a flag is not set...". This page does not discuss specific command-line flags, so this phrasing might be confusing to the reader.

Note that references to a script that [automatically determines system-reserved](https://github.com/openshift/openshift-docs/pull/103868/files#diff-70824a24a8c1e07b7ff61f27bb5d0ff6a0513848cac8f48f35d9f9d8104cc97aR10) applies to 4.21+ only. Thus previous versions need to be manually CPd or separate PR.

Link to docs preview:
Allocating resources for nodes in an OpenShift Container Platform cluster -> [Understanding how resources are allocated to nodes](https://105623--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring) -- Updated title and text throughout. Removed table and kube-reserved. Explicitly stated that kube-reserved is not supported. Removed reference to setting flag.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
