### PR TITLE
OSDOCS#17846: Remove manual etcd cluster restoration steps

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
@@ -25,19 +25,4 @@ include::modules/dr-restoring-cluster-state.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
 
-// Restoring a cluster from etcd backup manually
-include::modules/manually-restoring-cluster-etcd-backup.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-[id="additional-resources_dr-restoring-cluster-state"]
-== Additional resources
-
-* xref:../../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[Backing up etcd data]
-
-* xref:../../../installing/installing_bare_metal/upi/installing-bare-metal.adoc#installing-bare-metal[Installing a user-provisioned cluster on bare metal]
-
-* xref:../../../networking/networking_overview/accessing-hosts.adoc#accessing-hosts[Creating a bastion host to access {product-title} instances and the control plane nodes with SSH]
-
-* xref:../../../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#replacing-a-bare-metal-control-plane-node_bare-metal-expanding[Replacing a bare-metal control plane node]
-
 include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+1]

--- a/etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
+++ b/etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
@@ -62,16 +62,6 @@ include::modules/dr-restoring-cluster-state.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc#cpmso-ts-etcd-degraded_cpmso-troubleshooting[Recovering a degraded etcd Operator]
 
-// Restoring a cluster from etcd backup manually
-include::modules/manually-restoring-cluster-etcd-backup.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd-data_backup-etcd[Backing up etcd data]
-* xref:../../installing/installing_bare_metal/upi/installing-bare-metal.adoc#installing-bare-metal[Installing a user-provisioned cluster on bare metal]
-* xref:../../networking/networking_overview/accessing-hosts.adoc#accessing-hosts-on-aws_accessing-hosts[Accessing hosts on Amazon Web Services in an installer-provisioned infrastructure cluster]
-* xref:../../installing/installing_bare_metal/bare-metal-expanding-the-cluster.adoc#replacing-a-bare-metal-control-plane-node_bare-metal-expanding[Replacing a bare-metal control plane node]
-
 include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+2]
 
 // Recovering from expired control plane certificates

--- a/modules/manually-restoring-cluster-etcd-backup.adoc
+++ b/modules/manually-restoring-cluster-etcd-backup.adoc
@@ -1,8 +1,6 @@
 // Module included in the following assemblies:
 //
-// * disaster_recovery/scenario-2-manually-restoring-cluster-etcd-backup.adoc
 // * post_installation_configuration/cluster-tasks.adoc
-// * etcd/etcd-backup-restore/etcd-disaster-recovery.adoc
 
 
 :_mod-docs-content-type: PROCEDURE


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-17846](https://issues.redhat.com/browse/OSDOCS-17846)

Link to docs preview:
[Restoring to a previous cluster state](https://105624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html)
[Disaster recovery](https://105624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/etcd/etcd-backup-restore/etcd-disaster-recovery.html)

QE review:
- [x] QE has approved this change.

Additional information:
N/A