### PR TITLE
[OCPBUGS#70310]: Incorrect_Json_format

### DIFF
--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -65,12 +65,14 @@ $ oc create secret tls <secret> \//<1>
 ----
 $ oc patch apiserver cluster \
      --type=merge -p \
-     '{"spec":{"servingCerts": {"namedCertificates": \
-     [{"names": ["<FQDN>"], \//<1>
-     "servingCertificate": {"name": "<secret>"}}]}}}' <2>
+     '{"spec":{"servingCerts": {"namedCertificates":
+     [{"names": ["<FQDN>"],
+     "servingCertificate": {"name": "<secret>"}}]}}}'
 ----
-<1> Replace `<FQDN>` with the FQDN that the API server should provide the certificate for. Do not include the port number.
-<2> Replace `<secret>` with the name used for the secret in the previous step.
+where:
+
+<FQDN>:: Replace `<FQDN>` with the FQDN that the API server should provide the certificate for. Do not include the port number.
+<secret>:: Replace `<secret>` with the name used for the secret in the previous step.
 
 . Examine the `apiserver/cluster` object and confirm the secret is now
 referenced.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12 +

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-70310

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://105650--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/certificates/api-server.html#customize-certificates-api-add-named_api-server-certificates

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
