### PR TITLE
OSDOCS-17510:Corrected Vale errors in OSD Getting started book.

### DIFF
--- a/modules/access-cluster.adoc
+++ b/modules/access-cluster.adoc
@@ -7,6 +7,7 @@
 [id="access-cluster_{context}"]
 = Accessing your cluster
 
+[role="_abstract"]
 After you have configured your identity providers, users can access the cluster from {cluster-manager-first}.
 
 .Prerequisites

--- a/modules/config-idp.adoc
+++ b/modules/config-idp.adoc
@@ -6,6 +6,7 @@
 [id="config-idp_{context}"]
 = Configuring an identity provider
 
+[role="_abstract"]
 After you have installed {product-title}, you must configure your cluster to use an identity provider. You can then add members to your identity provider to grant them access to your cluster.
 
 You can configure different identity provider types for your {product-title} cluster. Supported types include GitHub, GitHub Enterprise, GitLab, Google, LDAP, OpenID Connect, and htpasswd identity providers.
@@ -76,7 +77,7 @@ A hostname must be entered when using a hosted instance of GitHub Enterprise.
 
 . Select *Use organizations* or *Use teams* to restrict access to a GitHub organization or a GitHub team within an organization.
 
-. Enter the name of the organization or team you would like to restrict access to. Click *Add more* to specify multiple organizations or teams.
+. Enter the name of the organization or team you want to restrict access to. Click *Add more* to specify multiple organizations or teams.
 +
 [NOTE]
 ====

--- a/modules/create-wif-cluster-cli.adoc
+++ b/modules/create-wif-cluster-cli.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * osd_gcp_clusters/osd-creating-a-cluster-on-gcp-with-workload-identity-federation.adoc
+// * osd_getting_started/osd-getting-started.adoc
 
 
 :_mod-docs-content-type: PROCEDURE
@@ -10,10 +11,10 @@
 [role="_abstract"]
 You can create an {product-title} on {GCP} cluster with Workload Identity Federation (WIF) using the OpenShift Cluster Manager CLI (`ocm`) in interactive or non-interactive mode.
 
-[NOTE]
-====
-Migrating an existing non-WIF cluster to a WIF configuration is not supported. This feature can only be enabled during new cluster creation.
-====
+.Prerequisites
+
+* You have created a WIF configuration. For more information, see "Creating a Workload Identity Federation configuration".
+* You have downloaded the latest version of the {cluster-manager} CLI (`ocm`) for your operating system from the link:https://console.redhat.com/openshift/downloads[Downloads] page on {cluster-manager}.
 
 .Procedure
 You can create a WIF cluster using the `interactive` mode or the `non-interactive` mode.
@@ -28,9 +29,12 @@ In `non-interactive` mode, you specify the values for specific parameters within
 +
 [source,terminal]
 ----
-$ ocm create cluster --interactive <1>
+$ ocm create cluster --interactive
 ----
-<1> `interactive` mode enables you to specify configuration options at the interactive prompts.
++
+where:
+
+`--interactive`:: Specifies that the cluster is created in interactive mode. This mode prompts you to enter the required configuration options during cluster creation. If you do not include this parameter, the cluster is created in `non-interactive` mode by default.
 +
 ** Create a cluster in non-interactive mode by running the following command:
 +
@@ -41,43 +45,67 @@ The following example is made up optional and required parameters and may differ
 +
 [source,terminal]
 ----
-$ ocm create cluster <cluster_name> \ <1>
---provider=gcp \ <2>
---ccs=true \ <3>
---wif-config <wif_name> \ <4>
---region <gcp_region> \ <5>
---subscription-type=marketplace-gcp \ <6>
---marketplace-gcp-terms=true \ <7>
---version <version> \ <8>
---multi-az=true  \ <9>
---enable-autoscaling=true \ <10>
---min-replicas=3 \ <11>
---max-replicas=6 \ <12>
---secure-boot-for-shielded-vms=true <13>
---channel-group <channel_group_name> <14>
+$ ocm create cluster <cluster_name> \
+--provider=gcp \
+--ccs=true \
+--wif-config <wif_name> \
+--region <gcp_region> \
+--subscription-type=marketplace-gcp \
+--marketplace-gcp-terms=true \
+--version <version> \
+--multi-az=true  \
+--enable-autoscaling=true \
+--min-replicas=3 \
+--max-replicas=6 \
+--secure-boot-for-shielded-vms=true
+--channel-group <channel_group_name>
 ----
-<1> Replace `<cluster_name>` with a name for your cluster.
-<2> Set value to `gcp`.
-<3> Set value to `true`.
-<4> Replace `<wif_name>` with the name of your WIF configuration.
-<5> Replace `<gcp_region>` with the {GCP} region where the new cluster will be deployed.
-<6> Optional: The subscription billing model for the cluster.
-<7> Optional: If you provided a value of `marketplace-gcp` for the `subscription-type` parameter, `marketplace-gcp-terms` must be equal to `true`.
-<8> Optional: The desired {product-title} version.
-<9> Optional: Deploy to multiple data centers.
-<10> Optional: Enable autoscaling of compute nodes.
-<11> Optional: Minimum number of compute nodes.
-<12> Optional: Maximum number of compute nodes.
-<13> Optional: Secure Boot enables the use of Shielded VMs in the {gcp-full}.
-<14> Optional: Replace `<channel_group_name>` with the name of the channel group you want to assign the cluster to. Channel group options include `stable` and `eus`.
++
+where:
 
+`<cluster_name>`:: Specifies the name of the cluster. Replace `<cluster_name>` with a name for your cluster.
+
+`--provider=gcp`:: Specifies the cloud provider for the cluster.
+
+`--ccs=true`:: Specifies that the cluster is a Customer Cloud Subscription (CCS) cluster.
+
+`--wif-config <wif_name>`:: Specifies the name of the WIF configuration to assign to the cluster. Replace `<wif_name>` with the name of your WIF configuration.
+
+`--region <gcp_region>`:: Specifies the {GCP} region where the new cluster will be deployed. Replace `<gcp_region>` with the desired {GCP} region.
+
+`--subscription-type=marketplace-gcp`:: Specifies the subscription billing model for the cluster. This parameter is optional.
+
+`--marketplace-gcp-terms=true`:: Confirms that you have accepted the {GCP} Marketplace terms and agreements for the OpenShift Dedicated product listing. This parameter is required if you provided a value of `marketplace-gcp` for the `subscription-type` parameter.
+
+`--version <version>`:: Specifies the desired {product-title} version. This parameter is optional. However, if an {product-title} version is specified, the version must also be supported by the assigned WIF configuration. If a version is specified that is not supported by the assigned WIF configuration, cluster creation will fail.
+If this occurs, update the assigned WIF configuration to the desired version or create a new WIF configuration with the desired version. If you do not specify a version, the cluster is created with the default version for the assigned WIF configuration.
++
+For more information about supported versions for WIF configurations, see "Creating a Workload Identity Federation configuration".
+
+`--multi-az=true`:: Specifies that the cluster is deployed to multiple data centers. This parameter is optional.
+
+`--enable-autoscaling=true`:: Enables autoscaling of compute nodes. This parameter is optional.
+
+`--min-replicas=3`:: Specifies the minimum number of compute nodes. This parameter is optional.
+
+`--max-replicas=6`:: Specifies the maximum number of compute nodes. This parameter is optional.
+
+`--secure-boot-for-shielded-vms=true`:: Enables Secure Boot, which allows the use of Shielded VMs in the {gcp-full}. This parameter is optional.
+
+`--channel-group <channel_group_name>`:: Specifies the name of the channel group you want to assign the cluster to. Channel group options include `stable` and `eus`. Replace `<channel_group_name>` with the desired channel group. This parameter is optional.
 
 [IMPORTANT]
 ====
-If an {product-title} version is specified, the version must also be supported by the assigned WIF configuration. If a version is specified that is not supported by the assigned WIF configuration, cluster creation will fail.  If this occurs, update the assigned WIF configuration to the desired version or create a new WIF configuration with the desired version in the --version <osd_version> field.
+If your cluster deployment fails during installation, certain resources created during the installation process are not automatically removed from your {GCP} account. To remove these resources from your {gcp-short} account, you must delete the failed cluster. For more information, see "Deleting an {product-title} cluster on {GCP}".
 ====
 
-[IMPORTANT]
-====
-If your cluster deployment fails during installation, certain resources created during the installation process are not automatically removed from your {GCP} account. To remove these resources from your {gcp-short} account, you must delete the failed cluster.
-====
+.Verification
+
+* To verify that the cluster was created successfully, run the following command:
++
+[source,terminal]
+----
+$ ocm get cluster <cluster_name>
+----
++
+If the cluster was created successfully, the output displays the cluster state as `ready`.

--- a/modules/deleting-cluster.adoc
+++ b/modules/deleting-cluster.adoc
@@ -1,12 +1,14 @@
 // Module included in the following assemblies:
 //
-// * osd_install_access_delete_cluster/osd-deleting-a-cluster.adoc
+// * osd_gcp_clusters/osd-deleting-a-cluster.adoc
+// * osd_aws_clusters/osd-deleting-a-cluster.adoc
 // * osd_getting_started/osd-getting-started.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="deleting-cluster_{context}"]
 = Deleting your cluster
 
+[role="_abstract"]
 You can delete your {product-title} cluster in {cluster-manager-first}.
 
 .Prerequisites
@@ -16,7 +18,7 @@ You can delete your {product-title} cluster in {cluster-manager-first}.
 
 .Procedure
 
-. From {cluster-manager-url}, click on the cluster you want to delete.
+. From {cluster-manager-url}, select the cluster you want to delete.
 
 . Select *Delete cluster* from the *Actions* drop-down menu.
 

--- a/modules/deploy-app.adoc
+++ b/modules/deploy-app.adoc
@@ -15,6 +15,7 @@ ifeval::["{context}" == "rosa-quickstart"]
 :quickstart:
 endif::[]
 
+[role="_abstract"]
 From the {product-title} web console, you can deploy a test application from the Developer Catalog and expose it with a route.
 
 ifndef::quickstart[]

--- a/modules/osd-grant-admin-privileges.adoc
+++ b/modules/osd-grant-admin-privileges.adoc
@@ -7,6 +7,7 @@
 [id="osd-grant-admin-privileges_{context}"]
 = Granting administrator privileges to a user
 
+[role="_abstract"]
 After you have configured an identity provider for your cluster and added a user to the identity provider, you can grant `dedicated-admin` cluster privileges to the user.
 
 .Prerequisites

--- a/modules/osd-revoke-admin-privileges.adoc
+++ b/modules/osd-revoke-admin-privileges.adoc
@@ -7,7 +7,8 @@
 [id="osd-revoke-admin-privileges_{context}"]
 = Revoking administrator privileges from a user
 
-Follow the steps in this section to revoke `dedicated-admin` privileges from a user.
+[role="_abstract"]
+After you have granted `dedicated-admin` privileges to a user, you can revoke those privileges when they are no longer needed.
 
 .Prerequisites
 

--- a/modules/osd-revoke-user-access.adoc
+++ b/modules/osd-revoke-user-access.adoc
@@ -7,6 +7,7 @@
 [id="osd-revoke-user-access_{context}"]
 = Revoking user access to a cluster
 
+[role="_abstract"]
 You can revoke cluster access from an identity provider user by removing them from your configured identity provider.
 
 You can configure different types of identity providers for your {product-title} cluster. The following example procedure revokes cluster access for a member of a GitHub organization or team that is configured for identity provision to the cluster.

--- a/modules/scaling-cluster.adoc
+++ b/modules/scaling-cluster.adoc
@@ -6,6 +6,7 @@
 [id="scaling-cluster_{context}"]
 = Scaling your cluster
 
+[role="_abstract"]
 You can scale the number of load balancers, the persistent storage capacity, and the node count for your {product-title} cluster from {cluster-manager}.
 
 .Prerequisites
@@ -31,4 +32,4 @@ You can scale the number of load balancers, the persistent storage capacity, and
 
 .Verification
 
-* In the *Overview* tab under the *Details* heading, you can review the load balancer configuration, persistent storage details, and actual and desired node counts.
+* In the *Overview* tab under the *Details* heading, you can review the load balancer configuration, persistent storage details, and actual and required node counts.

--- a/modules/understanding-clusters.adoc
+++ b/modules/understanding-clusters.adoc
@@ -6,22 +6,23 @@
 [id="overview-of-osd-cloud-deployment-options_{context}"]
 = Overview of the {product-title} cloud deployment options
 
+[role="_abstract"]
 {product-title} offers {OCP} clusters as a managed service on {AWS} or {GCP}.
 
 Through the Customer Cloud Subscription (CCS) model, you can deploy clusters in an existing AWS or {gcp-short} cloud account that you own.
 
-Alternatively, you can install {product-title} in a cloud account that is owned by Red Hat.
+Alternatively, you can install {product-title} in a cloud account that is owned by Red{nbsp}Hat.
 
 [id="osd-deployment-option-ccs_{context}"]
 == Deploying clusters using the Customer Cloud Subscription (CCS) model
 
-The Customer Cloud Subscription (CCS) model enables you to deploy Red Hat managed {product-title} clusters in an existing {AWS} or {GCP} account that you own. Red Hat requires several prerequisites be met in order to provide this service, and this service is supported by Red Hat Site Reliability Engineers (SRE).
+The Customer Cloud Subscription (CCS) model enables you to deploy Red{nbsp}Hat managed {product-title} clusters in an existing {AWS} or {GCP} account that you own. Red{nbsp}Hat requires several prerequisites be met to provide this service, and this service is supported by Red{nbsp}Hat Site Reliability Engineers (SRE).
 
-In the CCS model, the customer pays the cloud infrastructure provider directly for cloud costs, and the cloud infrastructure account is part of an organization owned by the customer, with specific access granted to Red Hat. In this model, the customer pays Red Hat for the CCS subscription and pays the cloud provider for the cloud costs.
+In the CCS model, the customer pays the cloud infrastructure provider directly for cloud costs, and the cloud infrastructure account is part of an organization owned by the customer, with specific access granted to Red{nbsp}Hat. In this model, the customer pays Red{nbsp}Hat for the CCS subscription and pays the cloud provider for the cloud costs.
 
-By using the CCS model, you can use the services that are provided by your cloud provider, in addition to the services provided by Red Hat.
+By using the CCS model, you can use the services that are provided by your cloud provider, in addition to the services provided by Red{nbsp}Hat.
 
 [id="osd-deployment-option-red-hat-cloud-account_{context}"]
-== Deploying clusters in Red Hat cloud accounts
+== Deploying clusters in Red{nbsp}Hat cloud accounts
 
-As an alternative to the CCS model, you can deploy {product-title} clusters in AWS or {gcp-short} cloud accounts that are owned by Red Hat. With this model, Red Hat is responsible for the cloud account and the cloud infrastructure costs are paid directly by Red Hat. The customer only pays the Red Hat subscription costs.
+As an alternative to the CCS model, you can deploy {product-title} clusters in AWS or {gcp-short} cloud accounts that are owned by Red{nbsp}Hat. With this model, Red{nbsp}Hat is responsible for the cloud account and the cloud infrastructure costs are paid directly by Red{nbsp}Hat. The customer only pays the Red{nbsp}Hat subscription costs.

--- a/osd_getting_started/osd-getting-started.adoc
+++ b/osd_getting_started/osd-getting-started.adoc
@@ -2,12 +2,17 @@
 [id="osd-getting-started"]
 = Getting started with {product-title}
 include::_attributes/attributes-openshift-dedicated.adoc[]
+
 :context: osd-getting-started
 
 toc::[]
 
 [role="_abstract"]
-Follow this getting started document to quickly create a {product-title} cluster, grant user access, deploy your first application, and learn how to scale and delete your cluster.
+Follow this getting started document to create a {product-title} cluster, grant user access, deploy your first application, and learn how to scale and delete your cluster.
+
+For {product-title} clusters deployed on {gcp-short}, Red Hat recommends using {gcp-short} Workload Identity Federation (WIF) as the authentication type for installing and interacting with the {product-title} cluster deployed on {gcp-short} because it provides enhanced security.
+
+Red Hat also recommends creating an {product-title} cluster deployed on {gcp-short} in Private cluster mode with Private Service Connect (PSC) to manage and monitor a cluster to avoid all public ingress network traffic. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.adoc#creating-a-gcp-psc-enabled-private-cluster[Private Service Connect overview].
 
 [id="osd-getting-started-prerequisites"]
 == Prerequisites
@@ -15,63 +20,14 @@ Follow this getting started document to quickly create a {product-title} cluster
 * You reviewed the xref:../osd_architecture/osd-understanding.adoc#osd-understanding[introduction to {product-title}] and the documentation on xref:../architecture/index.adoc#architecture-overview[architecture concepts].
 * You reviewed the xref:../osd_getting_started/osd-understanding-your-cloud-deployment-options.adoc#osd-understanding-your-cloud-deployment-options[{product-title} cloud deployment options].
 
-[id="osd-getting-started-create-cluster"]
-== Creating an {product-title} cluster
-
-You can install {product-title} in your own cloud provider account through the Customer Cloud Subscription (CCS) model or in a cloud account that is owned by Red Hat. For more information about the deployment options for {product-title}, see xref:../osd_getting_started/osd-understanding-your-cloud-deployment-options.adoc#osd-understanding-your-cloud-deployment-options[Understanding your cloud deployment options].
-
-Choose from one of the following methods to deploy your cluster.
-
-[id="osd-getting-started-create-cluster-gcp-ccs"]
-=== Creating a cluster on {gcp-short} using the CCS model
-
-You can install {product-title} in your own {GCP} account by using the CCS model. Complete the steps in one of the following sections to deploy {product-title} in your own {gcp-short} account.
-
-* Red Hat recommends using {gcp-short} Workload Identity Federation (WIF) as the authentication type for installing and interacting with the {product-title} cluster deployed on {gcp-short} because it provides enhanced security. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on {gcp-short} with Workload Identity Federation authentication].
-
-* Red Hat also recommends creating an {product-title} cluster deployed on {gcp-short} in Private cluster mode with Private Service Connect (PSC) to manage and monitor a cluster to avoid all public ingress network traffic. For more information, see xref:../osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.adoc#creating-a-gcp-psc-enabled-private-cluster[Private Service Connect overview].
-
-* For installing and interacting with the {product-title} cluster deployed on {gcp-short} by using the Service Account authentication type, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc#osd-create-gcp-cluster-ccs_osd-creating-a-cluster-on-gcp-sa[Creating a cluster on {gcp-short} with Service Account authentication].
-
-[id="osd-getting-started-create-cluster-aws-ccs"]
-=== Creating a cluster on AWS using the CCS model
-
-You can install {product-title} in your own {AWS} account by using the CCS model.
-
-* xref:../osd_aws_clusters/creating-an-aws-cluster.adoc#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws[Creating a cluster on AWS]
-
-[id="osd-getting-started-create-cluster-red-hat-cloud-account"]
-=== Creating a cluster using a Red Hat cloud account
-
-Complete the steps in one of the following sections to deploy {product-title} in a cloud account that is owned by Red Hat:
-
-* xref:../osd_gcp_clusters/creating-a-gcp-cluster-redhat-account.adoc#creating-a-gcp-cluster-rh-account[Creating a cluster on {gcp-short} with a Red Hat cloud account]: You can install {product-title} in an {gcp-short} account that is owned by Red Hat.
-
-* xref:../osd_aws_clusters/creating-an-aws-cluster.adoc#osd-create-aws-cluster-red-hat-account_osd-creating-a-cluster-on-aws[Creating a cluster on AWS]: You can install {product-title} in an AWS account that is owned by Red Hat.
-// Update link when OSDOCS-12950 goes live.
-
+include::modules/create-wif-cluster-cli.adoc[leveloffset=+1]
+include::modules/osd-create-cluster-ccs-aws.adoc[leveloffset=+1]
+include::modules/osd-create-cluster-red-hat-account.adoc[leveloffset=+1]
 include::modules/config-idp.adoc[leveloffset=+1]
-
-.Additional resources
-
-* For detailed steps to configure each of the supported identity provider types, see xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[Configuring identity providers].
-
 include::modules/osd-grant-admin-privileges.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../osd_architecture/osd_policy/osd-service-definition.adoc#cluster-admin-user_osd-service-definition[Customer administrator user]
-
 include::modules/access-cluster.adoc[leveloffset=+1]
 include::modules/deploy-app.adoc[leveloffset=+1]
 include::modules/scaling-cluster.adoc[leveloffset=+1]
-
-.Additional resources
-
-* For information about machine pools, see xref:../osd_cluster_admin/osd_nodes/osd-nodes-machinepools-about.adoc#osd-machine-pools-about[About machine pools].
-* For detailed steps to enable autoscaling for compute nodes in your cluster, see xref:../osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes.adoc#nodes-about-autoscaling-nodes[About autoscaling nodes on a cluster].
-
 include::modules/osd-revoke-admin-privileges.adoc[leveloffset=+1]
 include::modules/osd-revoke-user-access.adoc[leveloffset=+1]
 include::modules/deleting-cluster.adoc[leveloffset=+1]
@@ -87,11 +43,11 @@ include::modules/deleting-cluster.adoc[leveloffset=+1]
 [id="additional-resources_{context}"]
 == Additional resources
 
-* For information about the end-of-life dates for {product-title} versions, see the xref:../osd_architecture/osd_policy/osd-life-cycle.adoc#osd-life-cycle[{product-title} update life cycle].
-
-* For more information about deploying {product-title} clusters on AWS, see xref:../osd_aws_clusters/creating-an-aws-cluster.adoc#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws[Creating a cluster on AWS].
-
-* For more information about deploying {product-title} clusters on {gcp-short}, see  xref:../osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc#osd-creating-a-cluster-on-gcp-sa[Creating a cluster on {gcp-short} with Service Account authentication] and xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on {gcp-short} with Workload Identity Federation authentication].
-
-* For documentation on upgrading your cluster, see xref:../upgrading/osd-upgrades.adoc#osd-upgrades[{product-title} cluster upgrades].
+* xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#create-wif-configuration[Creating a Workload Identity Federation configuration]
+* xref:../osd_cluster_admin/osd_nodes/osd-nodes-machinepools-about.adoc#osd-machine-pools-about[About machine pools]
+* xref:../osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes.adoc#nodes-about-autoscaling-nodes[About autoscaling nodes on a cluster]
+* xref:../osd_architecture/osd_policy/osd-service-definition.adoc#cluster-admin-user_osd-service-definition[Customer administrator user]
+* xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[Configuring identity providers]
+* xref:../osd_architecture/osd_policy/osd-life-cycle.adoc#osd-life-cycle[{product-title} update life cycle]
+* xref:../upgrading/osd-upgrades.adoc#osd-upgrades[{product-title} cluster upgrades]
 

--- a/osd_getting_started/osd-understanding-your-cloud-deployment-options.adoc
+++ b/osd_getting_started/osd-understanding-your-cloud-deployment-options.adoc
@@ -2,6 +2,7 @@
 [id="osd-understanding-your-cloud-deployment-options"]
 = Understanding your cloud deployment options
 include::_attributes/attributes-openshift-dedicated.adoc[]
+
 :context: osd-understanding-your-cloud-deployment-options
 
 toc::[]
@@ -11,15 +12,10 @@ You can install {product-title} on {AWS} or {GCP} using a cloud account that you
 
 include::modules/understanding-clusters.adoc[leveloffset=+1]
 
-[id="next-steps_{context}"]
-== Next steps
-
-* xref:../osd_getting_started/osd-getting-started.adoc#osd-getting-started-create-cluster[Creating an {product-title} cluster]
-
 [id="additional-resources-cloud-deploy_{context}"]
 == Additional resources
 
-* For more information about using Customer Cloud Subscriptions on {gcp-short}, see xref:../osd_planning/gcp-ccs.adoc#ccs-gcp-understand[Understanding Customer Cloud Subscriptions on {gcp-short}].
+* xref:../osd_planning/gcp-ccs.adoc#ccs-gcp-understand[Understanding Customer Cloud Subscriptions on {gcp-short}]
 
-* For more information about using Customer Cloud Subscriptions on AWS, see xref:../osd_planning/aws-ccs.adoc#ccs-aws-understand[Understanding Customer Cloud Subscriptions on AWS].
+* xref:../osd_planning/aws-ccs.adoc#ccs-aws-understand[Understanding Customer Cloud Subscriptions on AWS]
 


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-17510](https://issues.redhat.com//browse/OSDOCS-17510)

Link to docs preview:

**OSD**
- [Getting started with OpenShift Dedicated](https://105654--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_getting_started/osd-getting-started)

**ROSA**
- [Configuring identity providers](https://105654--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/sd-configuring-identity-providers.html)
- [Red Hat OpenShift Service on AWS quick start guide](https://105654--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-quickstart-guide.html)

**ROSA Classic**
- [Configuring identity providers](https://105654--ocpdocs-pr.netlify.app/openshift-rosa/latest/authentication/sd-configuring-identity-providers.html)
- [Red Hat OpenShift Service on AWS (classic architecture) quick start guide](https://105654--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart-guide-ui.html)
- [Comprehensive guide to getting started with Red Hat OpenShift Service on AWS (classic architecture)](https://105654--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-getting-started.html)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- QE approval is not required to merge this PR

Additional information:
This PR addresses Vale errors in the Getting started book in the OSD documentation. It also restructures the guide as it was previously made up of mainly links.
