### PR TITLE
OCPBUGS#62719: Added a release note for the fixed issue

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -111,6 +111,11 @@ Instructions: Add entries in the following format under the appropriate heading:
 
 To maintain compatibility with Kubernetes 1.34, CoreDNS has been updated to version 1.13.1. This update resolves intermittent DNS resolution issues reported in previous versions and includes upstream performance fixes and security patches.
 
+[id="clock-state-metrics_{context}"]
+=== Clock state metrics degrade correctly after upstream clock loss
+
+Previously, when the upstream clock connection was lost and the clock entered the `unlocked` state, the `ptp4l` and `ts2phc` clock state metrics did not degrade as expected. This behavior caused inconsistent time synchronization state reporting. This issue has been fixed. When the upstream clock connection is lost, the `ptp4l` and `ts2phc` clock state metrics now degrade correctly, providing consistent time synchronization state reporting.
+
 [id="rn-ocp-release-note-node-fixed-issues_{context}"]
 == Node
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OCPBUGS-62719](https://issues.redhat.com/browse/OCPBUGS-62719)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
Clock state metrics degrade correctly after upstream clock loss
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->