### PR TITLE
(OLD) [SRVLOGIC-443] Document Kubernetes service discovery

### DIFF
--- a/modules/serverless-logic-customizing-podspec-definition.adoc
+++ b/modules/serverless-logic-customizing-podspec-definition.adoc
@@ -1,0 +1,121 @@
+// Module included in the following assemblies:
+//
+// * serverless/serverless-logic/serverless-logic-configuring-workflow-services.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-custom-podspec_{context}"]
+= Custom PodSpec configuration
+
+You can use a custom PodSpec configuration in the `SonataFlow` custom resource (CR) to meet specific container and deployment requirements on Red{nbsp}Hat OpenShift.
+
+You can use this feature for advanced configurations, such as:
+
+* Setting CPU and memory requests and limits
+* Adding sidecar containers
+* Configuring volumes and mounts
+* Selecting a non-default deployment model
+
+The {ServerlessLogicOperatorName} enables these customizations through the `.spec.podTemplate` attribute within the `SonataFlow` CR.
+
+The following example shows a `SonataFlow` CR with defined resource requests and limits, along with environment variables for the workflow container:
+
+[source,yaml,subs="+quotes"]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: <name>
+spec:
+  podTemplate:
+    container:
+      resources:
+        limits:
+          cpu: "250m"
+          memory: "128Mi"
+        requests:
+          cpu: "100m"
+          memory: "64Mi"
+      env:
+        - name: EXAMPLE_VAR
+          value: "value"
+    # ...
+----
+
+The `.spec.podTemplate` attribute supports most fields defined in the standard link:https://kubernetes.io/docs/reference/generated/kubernetes-api/latest/#podspec-v1-core[Kubernetes PodSpec API], and Kubernetes API validation rules apply.
+
+== Knative deployment model
+
+By default, each `SonataFlow` instance is deployed as a Kubernetes `Deployment` object. To deploy the instance as a Knative Serving `Service` object, set the `.spec.podTemplate.deploymentModel` field to `knative`.
+
+For example:
+
+[source,yaml,subs="+quotes"]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: <name>
+spec:
+  podTemplate:
+    deploymentModel: knative
+    # ...
+----
+
+[IMPORTANT]
+====
+* Do not use the Knative deployment model in *dev* profile. If you specify this option, the Operator ignores it.
+* Knative can terminate idle pods, which can interrupt long-running workflows or slow external services.
+* Enable persistence for workflows using callback states to resume after pod termination.
+* Explicitly enable `initContainers` if your workflow requires them. Knative disables them by default.
+====
+
+== Customization exceptions
+
+You can add additional containers, `initContainers`, and volumes to the pod. However, some elements are operator-managed and cannot be overridden.
+
+Container naming::
+Do not name any container `workflow` in the containers array. To customize the primary workflow container, use the `.spec.podTemplate.container` field. This approach helps prevent accidental misconfiguration when adding additional containers.
+
+Operator-managed immutable volumes and paths::
+The Operator manages certain volumes and filesystem paths and ignores any attempts to override them.
++
+[cols="1,1,2,1", options="header"]
+|===
+| Volume | Type | Path | Profile
+
+| `workflow-properties`
+| config map
+| `/deployments/config/application.properties`
+| `preview`
+
+| `workflow-properties`
+| config map
+| `${PROJECT_ROOT}/src/main/resources/application.properties`, `${PROJECT_ROOT}/src/main/resources/application-dev.properties`
+| `dev`
+
+| `resources`
+| projected
+| `${PROJECT_ROOT}/src/main/resources/`
+| `dev`
+|===
++
+[IMPORTANT]
+====
+In the *dev* profile, the Operator mounts all workflow resources defined in the `SonataFlow` CR into the `resources` projected volume. Do not mount additional volumes or data at this path to avoid configuration conflicts or data loss.
+====
+
+== Custom images
+
+Custom image in the default container::
+Set the `.spec.podTemplate.container.image` attribute to indicate that the workflow image is already built. The Operator does not rebuild, upgrade, or reconcile the image and automatically selects the *gitops* profile.
+
+Custom image in the dev profile::
+In the *dev* profile, base custom images on the default development image at `registry.redhat.io/openshift-serverless-1/logic-swf-devmode-rhel8:<version>`.
+
+Custom image in the preview profile::
+When you specify a custom image in the *preview* profile, the Operator skips the internal build process and deploys the provided image. The `.spec.resources` attribute is ignored because the workflow content is supplied entirely by the image.
+
+[IMPORTANT]
+====
+Ensure that the workflow definition in `.spec.flow` matches the workflow packaged in the provided image. If these definitions differ, configuration, service discovery, and service binding might behave unexpectedly.
+====

--- a/modules/serverless-logic-service-discovery.adoc
+++ b/modules/serverless-logic-service-discovery.adoc
@@ -1,0 +1,108 @@
+// Module included in the following assemblies:
+//
+// * serverless/serverless-logic/serverless-logic-configuring-workflow-services.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="serverless-logic-kubernetes-service-discovery_{context}"]
+= Kubernetes service discovery
+
+You can use Kubernetes service discovery to reference Kubernetes resources using a custom URI for HTTP requests. The OpenShift Serverless Logic Operator resolves this URI into a network endpoint (URL) during workflow deployment.
+
+[NOTE]
+====
+Service discovery triggers a scan of workflow configuration parameters. If application startup time is critical, consider using a static URL instead.
+====
+
+== URI pattern for service discovery
+
+Service discovery URIs follow a structure based on the Group, Version, and Kind (GVK) of the resource:
+
+[source,terminal]
+----
+kubernetes:<kind>.<version>.<group>/<namespace>/<resource_name>?<attribute_name>=<attribute_value>
+----
+where:
+
+`<kind>.<version>.<group>`:: Specifies the GVK of the resource.
+`<namespace>`:: Specifies the namespace of the resource. Defaults to current namespace if omitted.
+`<resource_name>`:: Specifies the name of the target resource.
+`<attribute_name>=<attribute_value>`:: Specifies additional resource attributes, such as labels or ports.
+
+Supported schemes and resources::
+
+The service discovery URI supports the following schemes:
+
+* `kubernetes`
+* `openshift`
+* `knative`
++
+For Knative Services, you can use a simplified `knative:<namespace>/<service_name>` pattern.
+
++
+--
+The following table lists the supported Kubernetes resources for GVK identifiers:
+
+[cols="1,1", options="header"]
+|===
+| Resource | GVK identifier
+
+| Kubernetes Service
+| `services.v1`
+
+| Knative Service
+| `services.v1.serving.knative.dev`
+
+| Pod
+| `pods.v1`
+
+| Deployment
+| `deployments.v1.apps`
+
+| DeploymentConfig
+| `deploymentconfigs.v1.apps.openshift.io`
+
+| StatefulSet
+| `statefulsets.v1.apps`
+
+| Route
+| `routes.v1.route.openshift.io`
+
+| Ingress
+| `ingresses.v1.networking.k8s.io`
+|===
+--
+
+Query parameters::
+Query parameters allow the Operator to filter or select specific resources when multiple matches exist.
++
+--
+The following table lists the supported query parameters:
+
+[cols="1,2,1", options="header"]
+|===
+|Parameter|Purpose|Example
+
+|label
+|Filter resources when multiple resources match. Supports multiple labels joined with `&`.
+|`label=app=myapp&env=prod`
+
+|port
+|Select a specific port if multiple ports are exposed.
+|`port-name=http`
+|===
+--
+
+== Service discovery resolution
+
+The Operator performs Kubernetes service discovery during the deployment of a managed workflow. It scans the associated workflow config map for URIs that match the discovery pattern, parses each URI, queries the Kubernetes API, and writes the resolved endpoints to an operator-managed config map.
+
+The Operator resolves resources differently based on their type:
+
+* *Direct URL resolution*: For `Service`, `KnativeService`, `Ingress`, or `Route` resources, the Operator returns the service URL or host IP. The Operator automatically uses `https` if TLS is detected.
+* *Indirect service resolution*: For `Pod`, `Deployment`, `DeploymentConfig`, or `StatefulSet` resources, the Operator checks for an associated service. If found, the Operator returns the service URL.
+* *Error handling*: If URI parsing fails or the resource does not exist, the Operator logs an exception. If a resource exists but has no associated service, the Operator issues a warning.
+
+[IMPORTANT]
+====
+The operator-managed config map is fully controlled by the Operator. Any manual edits are overwritten during the next reconciliation cycle.
+====

--- a/serverless-logic/serverless-logic-configuring-workflow-services.adoc
+++ b/serverless-logic/serverless-logic-configuring-workflow-services.adoc
@@ -13,3 +13,7 @@ include::modules/serverless-logic-modifying-workflow-configuration.adoc[leveloff
 include::modules/serverless-logic-modifying-managed-properties-workflow-services.adoc[leveloffset=+1]
 
 include::modules/serverless-logic-defining-global-managed-properties.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-service-discovery.adoc[leveloffset=+1]
+
+include::modules/serverless-logic-customizing-podspec-definition.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- `serverless-docs-1.36`
- `serverless-docs-1.37`
- `serverless-docs-1.38`

Issue:
- https://issues.redhat.com/browse/SRVLOGIC-443

Link to docs preview:
- [Kubernetes service discovery](https://105667--ocpdocs-pr.netlify.app/openshift-serverless/latest/serverless-logic/serverless-logic-configuring-workflow-services.html#serverless-logic-kubernetes-service-discovery_serverless-logic-configuring-workflow-services)

QE review:
- [x] QE has approved this change.
