### PR TITLE
OSDOCS-17810: clarify VAC support for dynamic PVC performance updates

### DIFF
--- a/modules/storage-persistent-storage-pvc-volumeattributesclass.adoc
+++ b/modules/storage-persistent-storage-pvc-volumeattributesclass.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Volume Attributes Classes provide a way for administrators to describe "classes" of storage they offer. These different classes can correspond to different quality-of-service levels. You can then apply Volume Attributes Classes to a persistent volume claim (PVC). If needed, you can apply new Volume Attributes Classes that become available in the cluster to the PVC.
 
+In {product-title} 4.21, you can assign a VolumeAttributesClass to a persistent volume claim to modify storage performance characteristics such as IOPS or throughput. This update does not require volume reprovisioning or application downtime and allows on-demand performance tuning for supported storage providers.
+
 == Limitations
 Volume Attributes Classes have the following limitations:
 


### PR DESCRIPTION
This PR clarifies that starting in OpenShift Container Platform 4.21, a VolumeAttributesClass can be assigned to an existing persistent volume claim to adjust storage performance characteristics such as IOPS or throughput without reprovisioning.

Applies to OpenShift Container Platform 4.21 only.

Version(s): OpenShift Container Platform 4.21

Issue: https://issues.redhat.com/browse/OSDOCS-17810

