### PR TITLE
OCPBUGS-66383-21: Moved OCPBUGS-62095 note from known issue to bug fix

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -125,7 +125,6 @@ Instructions: Add entries in the following format under the appropriate heading:
 // [id="rn-ocp-release-note-node-fixed-issues_{context}"]
 // == Node
 
-
 [id="rn-ocp-release-note-node-tuning-operator-fixed-issues_{context}"]
 == Node Tuning Operator
 

--- a/modules/rn-ocp-release-notes-known-issues.adoc
+++ b/modules/rn-ocp-release-notes-known-issues.adoc
@@ -26,7 +26,7 @@ where:
 +
 For information on the oc-mirror v2 plugin, see _Mirroring images for a disconnected installation by using the oc-mirror plugin v2_.
 
-* Starting with {product-title} 4.21, there is a decrease in the default maximum open files soft limit for containers. As a consequence, end users might experience application failures. To work around this problem, increase the container runtimes (CRI-O) ulimit configuration using a method of your choice, such as the `ulimit` command. (link:https://issues.redhat.com/browse/OCPBUGS-62095[OCPBUGS-62095])
+* Starting with {product-title} {product-version}, a decrease exists in the default maximum open files soft limit for containers. As a consequence, end users might experience application failures. To work around this issue, increase the container runtimes (CRI-O) ulimit configuration by using a method of your choice, such as the `ulimit` command. Note that if you upgrade your cluster from {product-title} 4.20 to {product-version}, the existing maximum open files limit is retained. (link:https://issues.redhat.com/browse/OCPBUGS-62095[OCPBUGS-62095])
 
 * Currently, on clusters with SR-IOV network virtual functions configured, a race condition might occur between system services responsible for network device renaming and the TuneD service managed by the Node Tuning Operator. As a consequence, the TuneD profile might become degraded after the node restarts, leading to performance degradation. As a workaround, restart the TuneD pod to restore the profile state. (link:https://issues.redhat.com/browse/OCPBUGS-41934[OCPBUGS-41934])
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OCPBUGS-66383](https://issues.redhat.com/browse/OCPBUGS-66383)

Link to docs preview:

* https://105678--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-note-node-fixed-issues_release-notes


- [x] SME has approved this change.
- [x] QE has approved this change (Min LI).
