### PR TITLE
OCPBUGS-66383-20: Moved OCPBUGS-62095 note from known issue to bug fix

### DIFF
--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -1952,7 +1952,6 @@ As a result, the controller handles errors during migration better.
 
 * Before this update, unused code in the deployment and deployment configuration menus caused unnecessary menu items to display. With this release, the unused menu item definitions are removed, improving code maintainability and reducing potential issues in future updates. (link:https://issues.redhat.com/browse/OCPBUGS-56245[OCPBUGS-56245])
 
-
 * Before this update, the `/metrics` endpoint was not correctly parsing a bearer token from the authorization header on internal Prometheus scrape requests, which caused `TokenReviews` to fail and all of these requests to be denied with a 401 response. This triggered a `TargetDown` alert for the console metrics endpoint. With this release, the metrics endpoint handler was updated to correctly parse a bearer token from the authorization header for `TokenReview`. This made the `TokenReview` step behave as expected, and resolved the `TargetDown` alert. (link:https://issues.redhat.com/browse/OCPBUGS-56148[OCPBUGS-56148])
 
 * Before this update, creating a node without a disk triggered a JavaScript `TypeError` when you accessed nodes in the console. With this release, the filter property initializes correctly. As a result, the node list displays without errors. (link:https://issues.redhat.com/browse/OCPBUGS-56050[OCPBUGS-56050])
@@ -2054,13 +2053,12 @@ With this release, the warning message no longer appears in the `metrics-server`
 
 * Before this update, if a CPU-pinned container within a Guaranteed QoS pod has cgroups quota defined, rounding and small delays in kernel CPU time accounting could cause throttling of the CPU-pinned process, even if the quota is set to allow 100% consumption for each allocated CPU. With this release, when `cpu-manager-policy=static` and the qualifications for static CPU assignment are satisfied, that is containers have Guaranteed QOS with integer CPU requests, the CFS quota is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-14051[OCPBUGS-14051])
 
-
+* Before this update, the maximum open files soft limit was reduced in {product-title} builds. As a consequence, containers had a reduced maximum open files limit, causing application failures. With this release, the CRI-O configuration has been updated to restore the maximum open files limit. As a result, the maximum open files limit in containers is restored to the previous value, improving the functionality of applications that require higher limits. (link:https://issues.redhat.com/browse/OCPBUGS-62095[OCPBUGS-62095])
 
 [id="ocp-release-note-node-tuning-operator-bug-fixes_{context}"]
 === Node Tuning Operator (NTO)
 
 * Before this update, the `iommu.passthrough=1` kernel argument caused an NVIDIA GPU validator failure on Advanced RISC Machine (ARM) CPUs in {product-title} 4.18. With this release, the kernel argument is removed from the default `Tuned` CR for ARM-based environments. (link:https://issues.redhat.com/browse/OCPBUGS-52853[OCPBUGS-52853])
-
 
 
 [id="ocp-release-note-observability-bug-fixes_{context}"]
@@ -2952,8 +2950,6 @@ You can avoid this issue by providing a user-assigned identity or by leaving the
 In both cases, the installation program generates a user-assigned identity. (link:https://issues.redhat.com/browse/OCPBUGS-56008[OCPBUGS-56008])
 
 * There is a known issue in the unified software catalog view of the console. When you select *Ecosystem* -> *Software Catalog*, you must enter an existing project name or create a new project to view the software catalog. The project selection field does not effect how catalog content is installed on the cluster. As a workaround, enter any existing project name to view the software catalog. (link:https://issues.redhat.com/browse/OCPBUGS-61870[OCPBUGS-61870])
-
-* Starting with OCP 4.20, there is a decrease in the default maximum open files soft limit for containers. As a consequence, end users may experience application failures. To work around this problem, increase the container runtimes (CRI-O) ulimit configuration. (link:https://issues.redhat.com/browse/OCPBUGS-62095[OCPBUGS-62095])
 
 * Deleting and recreating test workloads with a BlueField-3 NIC causes clock jumps due to inconsistent PTP synchronization. This disrupts time synchronization in test workloads. The time synchronization stabilizes when the workloads are stable. (link:https://issues.redhat.com/browse/RHEL-93579[RHEL-93579])
 


### PR DESCRIPTION
Moving bug from a known issue to a bug fix. Doc error. Let me know if a CM is needed; I do not think it is as the same bug was referenced so a customer would have seen that the bug was fixed in the referenced Jira for the known issue.

Version(s):
4.20

Issue:
[OCPBUGS-66383](https://issues.redhat.com/browse/OCPBUGS-66383)

Link to docs preview:

* https://105683--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#ocp-release-note-node-bug-fixes_release-notes

- [x] SME has approved this change.
- [x] QE has approved this change (Min LI).
