### PR TITLE
OSDOCS#17996: reduce scope of mapi controller perms for gcp RNs

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -189,6 +189,12 @@ Detailed information.
 [id="ocp-release-notes-install-update_{context}"]
 == Installation and update
 
+Restricting service account impersonation to the compute nodes service account::
++
+When you install a {gcp-first} and configure it to use {gcp-short} Workload Identity, you can now restrict the {gcp-short} `iam.serviceAccounts.actAs` permission that the Cloud Credential Operator utility grants the Machine API controller service account at the project level to only the compute nodes service account.
++
+For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#restricting-sa-impersonation-compute-sa-gcp_installing-gcp-customizations[Restricting service account impersonation to the compute nodes service account].
+
 Configuring {image-mode-os-lower} during installation is now supported::
 +
 You can now apply a custom layered image to your nodes during {product-title} installation. For more information, see xref:../machine_configuration/mco-coreos-layering.adoc#coreos-layering-install-time_mco-coreos-layering[Applying a custom layered image during OpenShift Container Platform installation].


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-17996](https://issues.redhat.com//browse/OSDOCS-17996)

Link to docs preview:
[Restricting service account impersonation to the compute nodes service account](https://105690--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-install-update_release-notes)

QE review:
- [ ] QE has approved this change.

Additional information:
Rel notes to accompany #105412