### PR TITLE
OCPBUGS 61202 MCO CA certificate not rotated after upgrade from OCP 418.9 to 4.19.2 – machine-config-server-ca Secret/ConfigMap missing

### DIFF
--- a/security/certificate_types_descriptions/machine-config-operator-certificates.adoc
+++ b/security/certificate_types_descriptions/machine-config-operator-certificates.adoc
@@ -64,6 +64,11 @@ The MCS CA and MCS cert are valid for 10 years and are automatically rotated by 
 
 The issued serving certificates are valid for 10 years.
 
+[NOTE]
+====
+This automatic certificate rotation applies only to clusters that use machine sets. For clusters that do not use machine sets, such as vSphere user-provisioned infrastructure clusters, you are required to manually rotate these certificates. For more information on manual certificate rotation, see the Red{nbsp}Hat Knowledgebase article link:https://access.redhat.com/articles/regenerating_cluster_certificates#regenerating-ca-certificates-for-the-machine-config-server-5[Regenerating CA certificates for the Machine Config Server]. 
+====
+
 [id="cert-types-machine-config-operator-certificates-custom"]
 == Customization
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-61202

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->