### PR TITLE
OLS-2538: Create short descriptions for modules in about assembly

### DIFF
--- a/about/ols-about-openshift-lightspeed.adoc
+++ b/about/ols-about-openshift-lightspeed.adoc
@@ -6,11 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The following topics provide an overview of {ols-official} and discuss functional requirements.
+[role="_abstract"]
+{ols-official} is a generative AI service that helps developers and administrators solve problems by providing context-aware recommendations for {ocp-product-title}.
 
 include::modules/ols-openshift-lightspeed-overview.adoc[leveloffset=+1]
+
 include::modules/ols-about-product-coverage.adoc[leveloffset=+2]
+
 include::modules/ols-openshift-requirements.adoc[leveloffset=+1]
+
 include::modules/ols-minimum-cluster-resource-requirements.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
@@ -19,10 +23,14 @@ include::modules/ols-minimum-cluster-resource-requirements.adoc[leveloffset=+2]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/support/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring[About remote health monitoring]
 
 include::modules/ols-large-language-model-requirements.adoc[leveloffset=+1]
+
 //Xavier wanted to remove vLLM until further testing is performed.
 //include::modules/ols-about-openshift-ai-vllm.adoc[leveloffset=+2]
+
 include::modules/ols-openshift-lightspeed-fips-support.adoc[leveloffset=+1]
+
 include::modules/ols-supported-platforms.adoc[leveloffset=+1]
+
 include::modules/ols-about-running-openshift-lightspeed-in-disconnected-mode.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -38,22 +46,29 @@ include::modules/ols-about-data-use.adoc[leveloffset=+1]
 * xref:../configure/ols-configuring-openshift-lightspeed.adoc#ols-filtering-and-redacting-information_ols-configuring-openshift-lightspeed[Filtering and redacting information]
 
 include::modules/ols-about-data-telemetry-transcript-and-feedback-collection.adoc[leveloffset=+1]
+
 include::modules/ols-remote-health-monitoring-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 // OpenShift Lightspeed is a layered product that publishes using the standalone doc approach. Links to core OCP have to use links instead of xref. 
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/support/remote-health-monitoring-with-connected-clusters#about-remote-health-monitoring[About remote health monitoring]
+
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/support/remote-health-monitoring-with-connected-clusters#opting-out-remote-health-reporting[Opting out of remote health reporting]
 
 include::modules/ols-transcript-collection-overview.adoc[leveloffset=+2]
+
 include::modules/ols-feedback-collection-overview.adoc[leveloffset=+2]
+
 include::modules/ols-disabling-data-collection-operator.adoc[leveloffset=+2]
 
 //The following resources are for the assembly, and link withing the standalone doc set
 [id="additional-resources_{context}"]
 == Additional resources
 * xref:../configure/ols-configuring-openshift-lightspeed.adoc#ols-creating-the-credentials-secret-using-web-console_ols-configuring-openshift-lightspeed[Creating the credential secret using the web console]
+
 * xref:../configure/ols-configuring-openshift-lightspeed.adoc#ols-creating-the-credentials-secret-using-cli_ols-configuring-openshift-lightspeed[Creating the credential secret using the CLI]
+
 * xref:../configure/ols-configuring-openshift-lightspeed.adoc#ols-creating-lightspeed-custom-resource-file-using-web-console_ols-configuring-openshift-lightspeed[Creating the Lightspeed custom resource file using the web console]
+
 * xref:../configure/ols-configuring-openshift-lightspeed.adoc#ols-creating-lightspeed-custom-resource-file-using-cli_ols-configuring-openshift-lightspeed[Creating the Lightspeed custom resource file using the CLI]

--- a/modules/ols-about-data-telemetry-transcript-and-feedback-collection.adoc
+++ b/modules/ols-about-data-telemetry-transcript-and-feedback-collection.adoc
@@ -5,7 +5,9 @@
 [id="ols-about-data-telemetry-transcript-and-feedback-collection_{context}"]
 = About data, telemetry, transcript, and feedback collection
 
-{ols-long} is a virtual assistant that you interact with using natural language. Communicating with {ols-long} involves sending chat messages, which may include information about your cluster, your cluster resources, or other aspects of your environment. These messages are sent to {ols-long}, potentially with some content filtered or redacted, and then sent to the LLM provider that you have configured.
+[role="_abstract"]
+
+{ols-long} processes natural-language messages and cluster metadata through a redaction layer before transmitting the data to your configured LLM provider.
 
 Do not enter any information into the {ols-long} user interface that you do not want sent to the LLM provider.
 

--- a/modules/ols-about-data-use.adoc
+++ b/modules/ols-about-data-use.adoc
@@ -1,11 +1,15 @@
+// Module included in the following assemblies:
+// * about/ols-about-openshift-lightspeed
+
 :_mod-docs-content-type: CONCEPT
-[id="ols-about-data-use"]
+[id="ols-about-data-use_{context}"]
 = About data use
-:context: ols-about-data-use
 
-{ols-official} is a virtual assistant you interact with using natural language. Using the {ols-long} interface, you send chat messages that {ols-long} transforms and sends to the Large Language Model (LLM) provider you have configured for your environment. These messages can contain information about your cluster, cluster resources, or other aspects of your environment.
+[role="_abstract"]
 
-The {ols-long} service has limited capabilities to filter or redact the information you provide to the LLM. Do not enter information into the {ols-long} interface that you do not want to send to the LLM provider.
+{ols-long} enriches user chat messages with cluster and environment context before sending them to the configured large language model (LLM) provider for response generation.
+
+{ols-long} has limited capabilities to filter or redact the data and information you provide to the LLM. Do not enter data and information into the {ols-long} interface that you do not want to send to the LLM provider.
 
 By sending transcripts or feedback to Red{nbsp}Hat you agree that Red{nbsp}Hat can use the data for quality assurance purposes. The transcript recording data uses the back-end of the Red{nbsp}Hat{nbsp}Insights system, and is subject to the same access restrictions and other security policies. 
 

--- a/modules/ols-about-product-coverage.adoc
+++ b/modules/ols-about-product-coverage.adoc
@@ -5,7 +5,9 @@
 [id="ols-about-product-coverage_{context}"]
 = About product coverage
 
-{ols-official} generates responses based on the content from the {ocp-product-title} product documentation.
+[role="_abstract"]
+
+{ols-official} provides answers to questions by generating responses derived directly from official {ocp-product-title} documentation.
 
 [id="product-exceptions_{context}"]
 == Product exceptions

--- a/modules/ols-about-running-openshift-lightspeed-in-disconnected-mode.adoc
+++ b/modules/ols-about-running-openshift-lightspeed-in-disconnected-mode.adoc
@@ -5,7 +5,9 @@
 [id="about-running-openshift-lightspeed-in-disconnected-mode_{context}"]
 = About running {ols-long} in disconnected mode
 
-The {ols-long} Operator and the {ols-long} service can work in a disconnected environment. A disconnected environment is an environment that does not have full access to the internet. 
+[role="_abstract"]
+
+{ols-long} supports operation in disconnected environments that do not have full internet access.
 
 In a disconnected environment, you must mirror the required container images into the environment. For more information, see "Mirroring in disconnected environments" in the {ocp-product-title} product documentation.
 

--- a/modules/ols-disabling-data-collection-operator.adoc
+++ b/modules/ols-disabling-data-collection-operator.adoc
@@ -5,7 +5,11 @@
 [id="ols-disabling-data-collection-operator_{context}"]
 = Disabling data collection on the {ols-long} Service
 
-The {ols-long} Service collects information about the questions you ask and the feedback you provide on the answers that the Service generates. You can disable data collection by modifying the `OLSConfig` custom resource (CR) file settings.
+[role="_abstract"]
+
+Disable data collection for {ols-short} by updating the telemetry settings in the `OLSConfig` custom resource (CR) file settings.
+
+By default, {ols-long} collects information about the questions you ask and the feedback you provide on the answers that the Service generates.
 
 .Prerequisites
 

--- a/modules/ols-feedback-collection-overview.adoc
+++ b/modules/ols-feedback-collection-overview.adoc
@@ -5,6 +5,10 @@
 [id="ols-feedback-collection-overview_{context}"]
 = Feedback collection overview 
 
-{ols-long} collects feedback from users who engage with the feedback feature in the virtual assistant interface. If a user submits feedback, the feedback score (thumbs up or down), text feedback (if entered), the user query, and the LLM provider response are stored and sent to {red-hat} on the same schedule as transcript collection. If you are using the filtering and redaction functionality, the filtered or redacted content is sent to {red-hat}. {red-hat} will not see the original non-redacted content, and the redaction takes place before any content is captured in logs.
+[role="_abstract"]
+
+{ols-long} collects opt-in user feedback from the virtual assistant interface to analyze response accuracy and improve service quality.
+
+If you submit feedback, the feedback score (thumbs up or down), text feedback (if entered), your query, and the LLM provider response are stored and sent to {red-hat} on the same schedule as transcript collection. If you are using the filtering and redaction functionality, the filtered or redacted content is sent to {red-hat}. {red-hat} will not see the original non-redacted content, and the redaction takes place before any content is captured in logs.
 
 Feedback is associated with the cluster from which it originated, and {red-hat} can attribute specific clusters to specific customer accounts. Feedback does not contain any information about which user submitted the feedback, and feedback cannot be tied to any individual user.

--- a/modules/ols-large-language-model-requirements.adoc
+++ b/modules/ols-large-language-model-requirements.adoc
@@ -7,16 +7,19 @@
 = Large language model (LLM) requirements
 :context: ols-large-language-model-requirements
 
-A large language model (LLM) is a type of machine learning model that interprets and generates human-like language. When an LLM is used with a virtual assistant, the LLM can accurately interpret questions and provide helpful answers in a conversational manner.
+[role="_abstract"]
+{ols-long} supports Software as a Service (SaaS) and self-hosted large language model (LLM) providers that meet defined authentication requirements.
 
-The {ols-long} service must have access to an LLM provider. The service does not provide an LLM for you, so you must configure the LLM prior to installing the {ols-long} Operator. 
+A large language model (LLM) is a type of machine learning model that interprets and generates human-like language. When an LLM is used with a virtual assistant, the LLM can accurately interpret questions and provide helpful answers in a conversational manner. The {ols-long} service must have access to an LLM provider. 
+
+The service does not provide an LLM for you, so you must configure the LLM prior to installing the {ols-long} Operator. 
 
 [NOTE]
 ====
 Red{nbsp}Hat does not provide support for any specific models or make suggestions or support statements pertaining to models.
 ====
 
-The {ols-long} service can rely on the following Software as a Service (SaaS) LLM providers: 
+The {ols-long} service can rely on the following SaaS LLM providers: 
 
 * OpenAI
 

--- a/modules/ols-minimum-cluster-resource-requirements.adoc
+++ b/modules/ols-minimum-cluster-resource-requirements.adoc
@@ -4,11 +4,11 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="ols-cluster-minimum-resource-requirements_{context}"]
-
 = Cluster resource requirements
 
 [role="_abstract"]
-{ols-long} requires access to the following resources to ensure that the service operates efficiently without affecting other cluster workloads.
+
+Ensure that {ols-long} has sufficient CPU, memory, and storage allocations to maintain service performance and cluster stability without impacting other cluster workloads.
 
 [cols="1,1,1,1"]
 |===

--- a/modules/ols-openshift-lightspeed-fips-support.adoc
+++ b/modules/ols-openshift-lightspeed-fips-support.adoc
@@ -5,7 +5,9 @@
 [id="openshift-lightspeed-fips-support_{context}"]
 = {ols-long} FIPS support
 
-{ols-official} is designed for Federal Information Processing Standards (FIPS).
+[role="_abstract"]
+
+{ols-official} supports Federal Information Processing Standards (FIPS) and can be deployed on {ocp-short-name} clusters running in FIPS mode.
 
 FIPS is a set of publicly announced standards developed by the National Institute of Standards and Technology (NIST), a part of the U.S. Department of Commerce. The primary purpose of FIPS is to ensure the security and interoperability of computer systems used by U.S. federal government agencies and their associated contractors.
 

--- a/modules/ols-openshift-lightspeed-overview.adoc
+++ b/modules/ols-openshift-lightspeed-overview.adoc
@@ -5,4 +5,6 @@
 [id="ols-openshift-lightspeed-overview_{context}"]
 = OpenShift Lightspeed overview 
 
-{ols-official} is a generative AI-powered virtual assistant for {ocp-product-title}. {ols-long} functionality uses a natural-language interface in the {ocp-short-name} web console to provide answers to questions that you ask about the product.
+[role="_abstract"]
+
+Use {ols-official} to troubleshoot and manage {ocp-short-name} clusters through a natural-language virtual assistant in the web console.

--- a/modules/ols-openshift-requirements.adoc
+++ b/modules/ols-openshift-requirements.adoc
@@ -5,7 +5,9 @@
 [id="ols-openshift-requirements_context"]
 = OpenShift Requirements 
 
-{ols-long} requires {ocp-product-title} 4.16 or later running on x86 hardware. Any installation type or deployment architecture is supported so long as the cluster is 4.16+ and x86-based.
+[role="_abstract"]
+
+Hardware and software requirements for {ols-long}, including supported {ocp-product-title} versions and CPU architectures.
 
 Telemetry is enabled on {ocp-product-title} clusters by default. 
 

--- a/modules/ols-remote-health-monitoring-overview.adoc
+++ b/modules/ols-remote-health-monitoring-overview.adoc
@@ -5,4 +5,8 @@
 [id="ols-about-remote-health-monitoring-overview_{context}"]
 = Remote health monitoring overview
 
-{red-hat} products record basic information by using the Telemeter Client and the Insights Operator, which is generally referred to as Remote Health Monitoring in {ocp-short-name} clusters. The {ocp-short-name} documentation for remote health monitoring explains data collection and includes instructions for opting out. To disable transcript or feedback collection, you must follow the procedure for opting out of remote health monitoring. For more information, see "About remote health monitoring" in the {ocp-product-title} documentation.
+[role="_abstract"]
+
+Remote Health Monitoring uses the Telemeter Client and Insights Operator to gather and report cluster information for {red-hat} analysis and support.
+
+The {ocp-short-name} documentation for remote health monitoring explains data collection and includes instructions for opting out. To disable transcript or feedback collection, you must follow the procedure for opting out of remote health monitoring. For more information, see "About remote health monitoring" in the {ocp-product-title} documentation.

--- a/modules/ols-supported-platforms.adoc
+++ b/modules/ols-supported-platforms.adoc
@@ -5,4 +5,7 @@
 [id="supported-architecture_{context}"]
 = Supported architecture
 
-{ols-long} is only available on the {ocp-product-title} x86_64 architecture.
+[role="_abstract"]
+
+{ols-long} is compatible only with {ocp-product-title} clusters running on the x86_64 architecture.
+

--- a/modules/ols-transcript-collection-overview.adoc
+++ b/modules/ols-transcript-collection-overview.adoc
@@ -5,7 +5,11 @@
 [id="ols-transcript-collection-overview_{context}"]
 = Transcript collection overview 
 
-Transcripts are sent to {red-hat} every two hours, by default. If you are using the filtering and redaction functionality, the filtered or redacted content is sent to {red-hat}. {red-hat} does not see the original non-redacted content, and the redaction takes place before any content is captured in logs.
+[role="_abstract"]
+
+{ols-long} periodically transmits chat transcripts to {red-hat} using a redaction process that ensures only filtered content is shared or logged.
+
+Transcripts are sent to {red-hat} every two hours, by default.{red-hat} does not see the original non-redacted content, and the redaction takes place before any content is captured in logs.
 
 {ols-long} temporarily logs and stores complete transcripts of conversations that users have with the virtual assistant. This includes the following information:
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue: https://issues.redhat.com/browse/OLS-2538

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
