### PR TITLE
OSDOCS-3818 RN Document Kernel PSI Enablement in OpenShift 4.21

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -397,6 +397,10 @@ Automatically calculate and apply CPU and memory resources for system components
 +
 {product-title} now automatically calculates and reserves a portion of the CPU and memory resources for use by the underlying node and system components. Previously, you needed to enable the feature by creating a `KubeletConfig` custom resource (CR) with the `autoSizingReserved: true` parameter. For clusters updated to {product-title} 4.21, you can enable the feature by deleting the `50-worker-auto-sizing-disabled` machine config. After you delete the machine config, the nodes reboot with the new resource settings. If you manually configured system reserved CPU or memory resources, these settings remain upon update and do not change. For more information on this new feature, see xref:../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-auto_nodes-nodes-resources-configuring[Automatically allocating resources for nodes].
 
+Linux PSI monitoring is now enabled by default::
++
+Linux Pressure Stall Information (PSI) monitoring, which makes PSI metrics for CPU, memory, and I/O available for your cluster, is now enabled by default. Before this update, you needed to manually enable PSI. For more information, see xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-psi-enable_nodes-nodes-managing[Enabling Pressure Stall Information (PSI) monitoring].
+
 [id="ocp-release-notes-ocp-cli_{context}"]
 == OpenShift CLI (oc)
 


### PR DESCRIPTION
Release note for https://github.com/openshift/openshift-docs/pull/104869

Link to docs preview:
New features -> [Nodes -> Linux PSI monitoring is now enabled by default](https://105697--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-nodes_release-notes)
