### PR TITLE
OSDOCS-3818 update Kernel PSI Enablement docs for 4.21

### DIFF
--- a/modules/nodes-nodes-psi-enable.adoc
+++ b/modules/nodes-nodes-psi-enable.adoc
@@ -4,12 +4,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="nodes-nodes-psi-enable_{context}"]
-= Enabling Pressure Stall Information (PSI) monitoring
+= Configuring Pressure Stall Information (PSI) monitoring
 
 [role="_abstract"]
-You can enable or disable Linux Pressure Stall Information (PSI) monitoring by using a `MachineConfig` object. PSI monitoring makes PSI metrics for CPU, memory, and I/O available for your cluster.  You can use the metrics to help identify disruptions caused by CPU, memory, and I/O resource issues for better scheduling and eviction decisions. 
+You can enable or disable Linux Pressure Stall Information (PSI) monitoring by using a `MachineConfig` object. PSI monitoring makes PSI metrics for CPU, memory, and I/O available for your cluster. You can use the metrics to help identify disruptions caused by CPU, memory, and I/O resource issues for better scheduling and eviction decisions. 
 
-PSI monitoring is enabled by default. 
+In {product-title} 4.21 and later, PSI monitoring is enabled by default. 
 
 The performance impact of enabling PSI is negligible. However, if PSI monitoring is disabled in a latency-sensitive environment, and you want to re-enable PSI monitoing, you might use a test environment. This allows you to determine its impact before enabling it on production clusters. Or, you can re-enable the PSI on one worker node and monitor for the performance impact. Then, gradually enable the feature on more worker nodes.
 

--- a/modules/nodes-nodes-psi-enable.adoc
+++ b/modules/nodes-nodes-psi-enable.adoc
@@ -7,11 +7,15 @@
 = Enabling Pressure Stall Information (PSI) monitoring
 
 [role="_abstract"]
-You can enable Linux Pressure Stall Information (PSI) monitoring by using a `MachineConfig` object. Enabling PSI monitoring makes PSI metrics for CPU, memory, and I/O available for your cluster. You can use the metrics to help identify disruptions caused by CPU, memory, and I/O resource issues for better scheduling and eviction decisions.
+You can enable or disable Linux Pressure Stall Information (PSI) monitoring by using a `MachineConfig` object. PSI monitoring makes PSI metrics for CPU, memory, and I/O available for your cluster.  You can use the metrics to help identify disruptions caused by CPU, memory, and I/O resource issues for better scheduling and eviction decisions. 
+
+PSI monitoring is enabled by default. 
+
+The performance impact of enabling PSI is negligible. However, if PSI monitoring is disabled in a latency-sensitive environment, and you want to re-enable PSI monitoing, you might use a test environment. This allows you to determine its impact before enabling it on production clusters. Or, you can re-enable the PSI on one worker node and monitor for the performance impact. Then, gradually enable the feature on more worker nodes.
 
 [IMPORTANT]
 ====
-The performance impact of enabling PSI is negligible. However, for latency-sensitive environments, you can enable PSI in a test environment to determine its impact before enabling it on production clusters. Or, you can enable the PSI on one worker node and monitor for the performance impact. Then, gradually enable the feature on more worker nodes. Enabling PSI introduces new container metrics that can increase the RSS memory usage of `prometheus-k8s` pods. On a cluster with a large number of containers, monitor the memory usage of the `prometheus-k8s` pods and adjust resource as needed.
+Enabling PSI introduces new container metrics that can increase the RSS memory usage of `prometheus-k8s` pods. On a cluster with a large number of containers, monitor the memory usage of the `prometheus-k8s` pods and adjust resource as needed.
 ====
 
 .Prerequisites


### PR DESCRIPTION
Linux Pressure Stall Information (PSI) monitoring was changed to [enabled in 4.21](https://issues.redhat.com/browse/OSDOCS-17899). As a result, we got a request to [document how to enable the feature](https://github.com/openshift/openshift-docs/pull/104869), principally for earlier OCP versions.  However, a module to enable a feature that is enabled by default seemed odd. This PR attempts to clarify things for 4.21.


Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
