### PR TITLE
OSDOCS-18012 [NETOBSERV] Update: secondary network supported topologies

### DIFF
--- a/modules/network-observability-SRIOV-configuration.adoc
+++ b/modules/network-observability-SRIOV-configuration.adoc
@@ -7,7 +7,7 @@
 = Configuring monitoring for SR-IOV interface traffic
 
 [role="_abstract"]
-Configure the `FlowCollector` resource to monitor traffic on Single Root I/O Virtualization (SR-IOV) device by setting the `spec.agent.ebpf.privileged` field to `true`, which enables the eBPF agent to monitor other network namespaces.
+You can monitor network traffic on Single Root I/O Virtualization (SR-IOV) devices by enabling `privileged` mode for the eBPF agent in the `FlowCollector` resource.
 
 The eBPF agent monitors other network namespaces in addition to the host network namespaces, which are monitored by default. When a pod with a virtual functions (VF) interface is created, a new network namespace is created. With `SRIOVNetwork` policy `IPAM` configurations specified, the VF interface is migrated from the host network namespace to the pod network namespace.
 

--- a/modules/network-observability-virtualization-configuration.adoc
+++ b/modules/network-observability-virtualization-configuration.adoc
@@ -7,7 +7,7 @@
 = Configuring virtual machine (VM) secondary network interfaces for Network Observability
 
 [role="_abstract"]
-Configure the `FlowCollector` to monitor VM secondary network traffic by setting the eBPF agent to `privileged` mode and defining the indexing for secondary networks, enabling the capture and enrichment of flows from {VirtProductName}.
+To monitor virtual machine secondary network traffic, you can configure the network observability `FlowCollector` resource to capture and enrich flows from secondary interfaces.
 
 Network flows coming from VMs that are connected to the default internal pod network are automatically captured by network observability.
 

--- a/observability/network_observability/network-observability-secondary-networks.adoc
+++ b/observability/network_observability/network-observability-secondary-networks.adoc
@@ -12,6 +12,16 @@ You can configure the Network Observability Operator to collect and enrich netwo
 // Note to tech review:
 // Is the existing SR-IOV example we have, "Configuring monitoring for SR-IOV interface traffic", an example of secondary network? If so, it is not through a VM, right?
 
+[NOTE]
+====
+The following topologies are supported:
+
+* MACVLAN
+* Layer 2
+* Bridge CNI
+* localnet
+====
+
 [id="network-observability-secondary-network-prerequisites_{context}"]
 == Prerequisites
 * Access to an {product-title} cluster with an additional network interface, such as a secondary interface or an L2 network.


### PR DESCRIPTION
[OSDOCS-18012](https://issues.redhat.com//browse/OSDOCS-18012) [NETOBSERV] Update: secondary network supported topologies

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the `no-1.11` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the <no-.11> content just before its GA.

Issue:
https://issues.redhat.com/browse/OSDOCS-18012

Link to docs preview:
* Secondary networks: https://105702--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-secondary-networks.html
* Configuring monitoring for SR-IOV interface traffic: https://105702--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-secondary-networks.html#network-observability-SR-IOV-config_network-observability-secondary-networks --> Updated abstract to meet current requirements
* Configuring virtual machine (VM) secondary network interfaces for Network Observability: https://105702--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/network-observability-secondary-networks.html#network-observability-virtualization-config_network-observability-secondary-networks --> Updated abstract to meet current requirements

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Revised [role="_abstract]" for both modules, even though outside the scope of initial Jira issue. The abstracts did not adhere to the current standard, so updated them now instead of having to do it later.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
