### PR TITLE
CNV-74970: Removing callouts for CNV

### DIFF
--- a/modules/nw-sriov-configuring-device.adoc
+++ b/modules/nw-sriov-configuring-device.adoc
@@ -25,7 +25,7 @@ You can configure an SR-IOV network device by creating a `SriovNetworkNodePolicy
 
 [NOTE]
 =====
-When applying the configuration specified in a `SriovNetworkNodePolicy` object, the SR-IOV Operator might drain the nodes, and in some cases, reboot nodes.
+When applying the configuration specified in a `SriovNetworkNodePolicy` CR, the SR-IOV Operator might drain the nodes, and in some cases, reboot nodes.
 Reboot only happens in the following cases:
 
 * With Mellanox NICs (`mlx5` driver) a node reboot happens every time the number of virtual functions (VFs) increase on a physical function (PF).

--- a/modules/virt-applying-node-placement-rules.adoc
+++ b/modules/virt-applying-node-placement-rules.adoc
@@ -17,7 +17,7 @@ endif::openshift-rosa,openshift-dedicated[]
 
 .Prerequisites
 
-* The `oc` CLI tool is installed.
+* You have installed the {oc-first}.
 * You are logged in with cluster administrator permissions.
 
 .Procedure

--- a/modules/virt-configuring-cdiuploadproxy-routes.adoc
+++ b/modules/virt-configuring-cdiuploadproxy-routes.adoc
@@ -7,7 +7,7 @@
 = Configuring additional routes to the `cdi-uploadproxy` service
 
 [role="_abstract"]
-As a cluster administrator, you can configure additional routes to the `cdi-uploadproxy` service to allow users to upload virtual machine images from outside the cluster.
+As a cluster administrator, you can configure additional routes to the `cdi-uploadproxy` service, enabling users to upload virtual machine images from outside the cluster.
 
 .Prerequisites
 

--- a/modules/virt-configuring-secondary-network-vm-live-migration.adoc
+++ b/modules/virt-configuring-secondary-network-vm-live-migration.adoc
@@ -45,7 +45,7 @@ spec:
 where:
 +
 `metadata.name`:: Specify the name of the `NetworkAttachmentDefinition` object.
-`config.master`:: Specify the name of the NIC to be used for live migration.
+`config.master`:: Specify the name of the NIC to use for live migration.
 `config.type`:: Specify the name of the CNI plugin that provides the network for the NAD.
 `config.range`:: Specify an IP address range for the secondary network. This range must not overlap the IP addresses of the main network.
 
@@ -79,7 +79,7 @@ spec:
 +
 where:
 +
-`network`:: Specify the name of the Multus `NetworkAttachmentDefinition` object to be used for live migrations.
+`network`:: Specify the name of the Multus `NetworkAttachmentDefinition` object to use for live migrations.
 
 . Save your changes and exit the editor. The `virt-handler` pods restart and connect to the secondary network.
 

--- a/modules/virt-enabling-load-balancer-service-web.adoc
+++ b/modules/virt-enabling-load-balancer-service-web.adoc
@@ -13,12 +13,12 @@ You can enable the creation of load balancer services for a virtual machine (VM)
 .Prerequisites
 
 * You have configured a load balancer for the cluster.
-* You are logged in as a user with the `cluster-admin` role.
+* You have logged in as a user with the `cluster-admin` role.
 * You created a network attachment definition for the network.
 
 .Procedure
 
-. Navigate to *Virtualization* -> *Overview*.
+. Go to *Virtualization* -> *Overview*.
 . On the *Settings* tab, click *Cluster*.
 . Expand *General settings* and *SSH configuration*.
 . Set *SSH over LoadBalancer service* to on.

--- a/modules/virt-golden-images-namespace-cli.adoc
+++ b/modules/virt-golden-images-namespace-cli.adoc
@@ -12,7 +12,6 @@ You can configure a custom namespace for golden images in your cluster by settin
 .Prerequisites
 
 * You installed the {oc-first}.
-
 * You created a namespace to use for golden images.
 
 .Procedure
@@ -36,9 +35,12 @@ metadata:
   name: kubevirt-hyperconverged
   namespace: {CNVNamespace}
 spec:
-  commonBootImageNamespace: <custom_namespace> <1>
+  commonBootImageNamespace: <custom_namespace>
 # ...
 ----
-<1> The namespace to use for golden images.
++
+where:
++
+`spec.commonBootImageNamespace`:: Specifies the namespace to use for golden images.
 
 . Save your changes and exit the editor.

--- a/modules/virt-measuring-latency-vm-secondary-network.adoc
+++ b/modules/virt-measuring-latency-vm-secondary-network.adoc
@@ -92,9 +92,12 @@ roleRef:
 +
 [source,terminal]
 ----
-$ oc apply -n <target_namespace> -f <latency_sa_roles_rolebinding>.yaml <1>
+$ oc apply -n <target_namespace> -f <latency_sa_roles_rolebinding>.yaml
 ----
-<1> `<target_namespace>` is the namespace where the checkup is to be run. This must be an existing namespace where the `NetworkAttachmentDefinition` object resides.
++
+where:
++
+`<target_namespace>`:: Specifies the namespace where the checkup is to be run. This must be an existing namespace where the `NetworkAttachmentDefinition` object resides.
 
 . Create a `ConfigMap` manifest that contains the input parameters for the checkup.
 +
@@ -111,17 +114,20 @@ metadata:
 data:
   spec.timeout: 5m
   spec.param.networkAttachmentDefinitionNamespace: <target_namespace>
-  spec.param.networkAttachmentDefinitionName: "blue-network" <1>
-  spec.param.maxDesiredLatencyMilliseconds: "10" <2>
-  spec.param.sampleDurationSeconds: "5" <3>
-  spec.param.sourceNode: "worker1" <4>
-  spec.param.targetNode: "worker2" <5>
+  spec.param.networkAttachmentDefinitionName: "blue-network"
+  spec.param.maxDesiredLatencyMilliseconds: "10"
+  spec.param.sampleDurationSeconds: "5"
+  spec.param.sourceNode: "worker1"
+  spec.param.targetNode: "worker2"
 ----
-<1> The name of the `NetworkAttachmentDefinition` object.
-<2> Optional: The maximum desired latency, in milliseconds, between the virtual machines. If the measured latency exceeds this value, the checkup fails.
-<3> Optional: The duration of the latency check, in seconds.
-<4> Optional: When specified, latency is measured from this node to the target node. If the source node is specified, the `spec.param.targetNode` field cannot be empty.
-<5> Optional: When specified, latency is measured from the source node to this node.
++
+where:
++
+`data.spec.param.networkAttachmentDefinitionName`:: Specifies the name of the `NetworkAttachmentDefinition` object.
+`data.spec.param.maxDesiredLatencyMilliseconds`:: Optional: Specifies the maximum desired latency, in milliseconds, between the virtual machines. If the measured latency exceeds this value, the checkup fails.
+`data.spec.param.sampleDurationSeconds`:: Optional: Specifies the duration of the latency check, in seconds.
+`data.spec.param.sourceNode`:: Optional: When specified, latency is measured from this node to the target node. If the source node is specified, the `spec.param.targetNode` field cannot be empty.
+`data.spec.param.targetNode`:: Optional: When specified, latency is measured from the source node to this node.
 
 . Apply the config map manifest in the target namespace:
 +
@@ -214,13 +220,16 @@ data:
   status.completionTimestamp: "2022-01-01T09:00:00Z"
   status.startTimestamp: "2022-01-01T09:00:07Z"
   status.result.avgLatencyNanoSec: "177000"
-  status.result.maxLatencyNanoSec: "244000" <1>
+  status.result.maxLatencyNanoSec: "244000"
   status.result.measurementDurationSec: "5"
   status.result.minLatencyNanoSec: "135000"
   status.result.sourceNode: "worker1"
   status.result.targetNode: "worker2"
 ----
-<1> The maximum measured latency in nanoseconds.
++
+where:
++
+`data.status.result.maxLatencyNanoSec`:: Specifies the maximum measured latency in nanoseconds.
 
 . Optional: To view the detailed job log in case of checkup failure, use the following command:
 +

--- a/modules/virt-mod-golden-image-heterogeneous-clusters.adoc
+++ b/modules/virt-mod-golden-image-heterogeneous-clusters.adoc
@@ -2,7 +2,7 @@
 //
 // * virt/virtual_machines/advanced_vm_management/virt-creating-vms-from-rh-images-overview.adoc
 
-:_mod-docs-content-type: PROCEDURE 
+:_mod-docs-content-type: PROCEDURE
 [id="virt-mod-golden-image-heterogeneous-clusters_{context}"]
 = Modifying a common golden image source in a heterogeneous cluster
 
@@ -14,7 +14,7 @@ include::snippets/technology-preview.adoc[]
 
 .Prerequisites
 
-* You have installed the {oc-first}.   
+* You have installed the {oc-first}.
 
 .Procedure
 
@@ -35,7 +35,7 @@ spec:
   - metadata:
       name: kubevirt-hyperconverged
       annotations:
-        ssp.kubevirt.io/dict.architectures: "<architecture_list>" <1>
+        ssp.kubevirt.io/dict.architectures: "<architecture_list>"
     spec:
       schedule: "0 */12 * * *"
       template:
@@ -46,6 +46,9 @@ spec:
       managedDataSource: centos-stream8
 #...
 ----
-<1> The comma-separated list of supported architectures for this image. For example, if the image supports `amd64` and `arm64` architectures, the value would be `"amd64,arm64"`.
++
+where:
++
+`ssp.kubevirt.io/dict.architectures`:: Specifies a comma-separated list of supported architectures for this image. For example, if the image supports `amd64` and `arm64` architectures, the value would be `"amd64,arm64"`.
 
 . Save and exit the editor to update the `HyperConverged` CR.

--- a/modules/virt-modify-workload-node-heterogeneous-cluster.adoc
+++ b/modules/virt-modify-workload-node-heterogeneous-cluster.adoc
@@ -2,7 +2,7 @@
 //
 // * virt/virtual_machines/advanced_vm_management/virt-creating-vms-from-rh-images-overview.adoc
 
-:_mod-docs-content-type: PROCEDURE 
+:_mod-docs-content-type: PROCEDURE
 [id="virt-modify-workload-node-heterogeneous-cluster_{context}"]
 
 = Modifying workloads node placement in a heterogeneous cluster
@@ -11,7 +11,7 @@
 include::snippets/technology-preview.adoc[]
 
 [role="_abstract"]
-If you have a heterogeneous cluster but not want to enable multiple archiecture support, you can modify the workloads node placement in the `HyperConverged` custom resource (CR) to only include nodes with a specific architecture.
+If you have a heterogeneous cluster but do not want to enable multiple architecture support, you can modify the workloads node placement in the `HyperConverged` custom resource (CR) to include only nodes with a specific architecture.
 
 .Prerequisites
 
@@ -46,8 +46,12 @@ spec:
                   - key: kubernetes.io/arch
                     operator: In
                     values:
-                      - <node_architecture> <1>
+                      - <node_architecture>
+
 ----
-<1> Replace `<node_architecture>` with the target architecture. For example, to limit placement to AMD nodes, use `amd64`.
++
+where:
++
+`<node_architecture>`:: Specifies the target architecture. For example, to limit placement to AMD nodes, use `amd64`.
 
 . Save and exit the editor to update the `HyperConverged` CR.

--- a/modules/virt-overriding-default-fs-overhead-value.adoc
+++ b/modules/virt-overriding-default-fs-overhead-value.adoc
@@ -11,7 +11,7 @@ Change the amount of persistent volume claim (PVC) space that the {VirtProductNa
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
+* Install the {oc-first}.
 
 .Procedure
 
@@ -29,12 +29,12 @@ $ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 # ...
 spec:
   filesystemOverhead:
-    global: "<new_global_value>" <1>
+    global: "<new_global_value>"
     storageClass:
-      <storage_class_name>: "<new_value_for_this_storage_class>" <2>
+      <storage_class_name>: "<new_value_for_this_storage_class>"
 ----
-<1> The default file system overhead percentage used for any storage classes that do not already have a set value. For example, `global: "0.07"` reserves 7% of the PVC for file system overhead.
-<2> The file system overhead percentage for the specified storage class. For example, `mystorageclass: "0.04"` changes the default overhead value for PVCs in the `mystorageclass` storage class to 4%.
+** `spec.filesystemOverhead.global` specifies the default file system overhead percentage used for any storage classes that do not already have a set value. For example, `global: "0.07"` reserves 7% of the PVC for file system overhead.
+** `spec.filesystemOverhead.storageClass` specifies the file system overhead percentage for the specified storage class. For example, `mystorageclass: "0.04"` changes the default overhead value for PVCs in the `mystorageclass` storage class to 4%.
 
 . Save and exit the editor to update the `HCO` object.
 

--- a/modules/virt-preparing-container-disk-for-vms.adoc
+++ b/modules/virt-preparing-container-disk-for-vms.adoc
@@ -31,14 +31,17 @@ The following example uses the Red Hat Universal Base Image (UBI) to handle thes
 ----
 $ cat > Dockerfile << EOF
 FROM registry.access.redhat.com/ubi8/ubi:latest AS builder
-ADD --chown=107:107 <vm_image>.qcow2 /disk/ // <1>
+ADD --chown=107:107 <vm_image>.qcow2 /disk/ //
 RUN chmod 0440 /disk/*
 
 FROM scratch
 COPY --from=builder /disk/* /disk/
 EOF
 ----
-<1> Where `<vm_image>` is the image in either QCOW2 or RAW format. If you use a remote image, replace `<vm_image>.qcow2` with the complete URL.
++
+where:
++
+`<vm_image>`:: Specifies the image in either QCOW2 or RAW format. If you use a remote image, replace `<vm_image>.qcow2` with the complete URL.
 
 . Build and tag the container:
 +

--- a/modules/virt-preserving-lm-perms.adoc
+++ b/modules/virt-preserving-lm-perms.adoc
@@ -24,7 +24,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    rbac.authorization.k8s.io/aggregate-to-admin=true #<1>
+    rbac.authorization.k8s.io/aggregate-to-admin=true
   name: kubevirt.io:upgrademigrate
 rules:
 - apiGroups:
@@ -47,7 +47,8 @@ rules:
   - watch
   - deletecollection
 ----
-<1> This cluster role is aggregated into the `admin` role before you update {VirtProductName}. The update process does not modify it, ensuring the previous behavior is maintained.
++
+This cluster role is aggregated into the `admin` role before you update {VirtProductName}. The update process does not modify it, ensuring the previous behavior is maintained.
 
 . Add the cluster role manifest to the cluster by running the following command:
 +

--- a/modules/virt-preventing-nvidia-gpu-operands-from-deploying-on-nodes.adoc
+++ b/modules/virt-preventing-nvidia-gpu-operands-from-deploying-on-nodes.adoc
@@ -12,7 +12,7 @@ If you use the link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator
 
 .Prerequisites
 
-* The OpenShift CLI (`oc`) is installed.
+* The {oc-first} is installed.
 
 .Procedure
 // Cannot label nodes in ROSA/OSD, but can edit machine pools
@@ -21,17 +21,20 @@ If you use the link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator
 ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
-$ oc label node <node_name> nvidia.com/gpu.deploy.operands=false <1>
+$ oc label node <node_name> nvidia.com/gpu.deploy.operands=false
 ----
++
+where:
++
+`<node_name>`:: Specifies the name of a node where you do not want to install the NVIDIA GPU operands.
 endif::openshift-rosa,openshift-dedicated[]
 +
 ifdef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
-$ rosa edit machinepool --cluster=<cluster_name> <machinepool_ID> nvidia.com/gpu.deploy.operands=false <1>
+$ rosa edit machinepool --cluster=<cluster_name> <machinepool_ID> nvidia.com/gpu.deploy.operands=false
 ----
 endif::openshift-rosa,openshift-dedicated[]
-<1> Replace `<node_name>` with the name of a node where you do not want to install the NVIDIA GPU operands.
 
 .Verification
 

--- a/modules/virt-preventing-workload-updates-during-control-plane-only-update.adoc
+++ b/modules/virt-preventing-workload-updates-during-control-plane-only-update.adoc
@@ -118,11 +118,12 @@ Example output:
     "observedGeneration": 3,
     "reason": "ReconcileCompleted",
     "status": "True",
-    "type": "Upgradeable" <1>
+    "type": "Upgradeable"
   }
 ]
 ----
-<1> The {VirtProductName} Operator has the `Upgradeable` status.
++
+The {VirtProductName} Operator has the `Upgradeable` status.
 
 . Manually update your cluster from the source EUS version to the next minor version of {product-title}:
 +

--- a/modules/virt-pxe-booting-with-mac-address.adoc
+++ b/modules/virt-pxe-booting-with-mac-address.adoc
@@ -31,27 +31,27 @@ endif::openshift-rosa,openshift-dedicated[]
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: pxe-net-conf # <1>
+  name: pxe-net-conf
 spec:
   config: |
     {
       "cniVersion": "0.3.1",
-      "name": "pxe-net-conf", <2>
-      "type": "bridge", <3>
-      "bridge": "bridge-interface", <4>
-      "macspoofchk": false, <5>
-      "vlan": 100, <6>
+      "name": "pxe-net-conf",
+      "type": "bridge",
+      "bridge": "bridge-interface",
+      "macspoofchk": false,
+      "vlan": 100,
       "disableContainerInterface": true,
-      "preserveDefaultVlan": false <7>
+      "preserveDefaultVlan": false
     }
 ----
-<1> The name for the `NetworkAttachmentDefinition` object.
-<2> The name for the configuration. It is recommended to match the configuration name to the `name` value of the network attachment definition.
-<3> The actual name of the Container Network Interface (CNI) plugin that provides the network for this network attachment definition. This example uses a Linux bridge CNI plugin. You can also use an OVN-Kubernetes localnet or an SR-IOV CNI plugin.
-<4> The name of the Linux bridge configured on the node.
-<5> Optional: A flag to enable the MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute allows only a single MAC address to exit the pod, which provides security against a MAC spoofing attack.
-<6> Optional: The VLAN tag. No additional VLAN configuration is required on the node network configuration policy.
-<7> Optional: Indicates whether the VM connects to the bridge through the default VLAN. The default value is `true`.
+** `metadata.name` specifies the name for the `NetworkAttachmentDefinition` object.
+** `spec.config.name` specifies the name for the configuration. It is recommended to match the configuration name to the `name` value of the network attachment definition.
+** `spec.config.type` specifies the actual name of the Container Network Interface (CNI) plugin that provides the network for this network attachment definition. This example uses a Linux bridge CNI plugin. You can also use an OVN-Kubernetes localnet or an SR-IOV CNI plugin.
+** `spec.config.bridge` specifies the name of the Linux bridge configured on the node.
+** `spec.config.macspoofchk` is an optional flag to enable the MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute allows only a single MAC address to exit the pod, which provides security against a MAC spoofing attack.
+** `spec.config.vlan` is an optional VLAN tag. No additional VLAN configuration is required on the node network configuration policy.
+** `spec.config.preserveDefaultVlan` is an optional flag that indicates whether the VM connects to the bridge through the default VLAN. The default value is `true`.
 
 . Create the network attachment definition by using the file you created in the previous step:
 +
@@ -167,4 +167,3 @@ Example output:
 3. eth1: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether de:00:00:00:00:de brd ff:ff:ff:ff:ff:ff
 ----
-

--- a/modules/virt-selecting-migration-network-ui.adoc
+++ b/modules/virt-selecting-migration-network-ui.adoc
@@ -17,6 +17,6 @@ You can select a dedicated network for live migration by using the {product-titl
 
 .Procedure
 
-. Navigate to *Virtualization > Overview* in the {product-title} web console.
+. Go to *Virtualization > Overview* in the {product-title} web console.
 . Click the *Settings* tab and then click *Live migration*.
 . Select the network from the *Live migration network* list.

--- a/virt/post_installation_configuration/virt-perf-optimization.adoc
+++ b/virt/post_installation_configuration/virt-perf-optimization.adoc
@@ -7,6 +7,6 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can modify certain configurations for your {VirtProductName} deployment to improve efficiency, cost-effectiveness, and reliability.
+You can change certain configurations for your {VirtProductName} deployment to improve efficiency, cost-effectiveness, and reliability.
 
 include::modules/virt-CPU-manager-policy.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
Cherrypick as far back as possible for DITA migration.

Issue:
https://issues.redhat.com/browse/CNV-74970

Link to docs preview:
- https://105706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups#virt-measuring-latency-vm-secondary-network_virt-running-cluster-checkups
- https://105706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vms_advanced/creating_vms_advanced_web/virt-golden-image-heterogeneous-clusters#virt-mod-golden-image-heterogeneous-clusters_virt-golden-image-heterogeneous-clusters
- https://105706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vms_advanced/creating_vms_advanced_web/virt-creating-vms-from-rh-images-overview#virt-golden-images-namespace-cli_virt-creating-vms-from-rh-images-overview
- https://105706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vms_advanced/creating_vms_advanced_web/virt-golden-image-heterogeneous-clusters#virt-modify-workload-node-heterogeneous-cluster_virt-golden-image-heterogeneous-clusters
- https://105706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-reserving-pvc-space-fs-overhead#virt-overriding-default-fs-overhead-value_virt-reserving-pvc-space-fs-overhead
- https://105706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vms_advanced/creating_vms_cli/virt-creating-vms-from-container-disks#virt-preparing-container-disk-for-vms_virt-creating-vms-from-container-disks
- https://105706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-about-live-migration#virt-preserving-lm-perms_virt-about-live-migration
- https://105706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-configuring-pci-passthrough#virt-preventing-nvidia-operands-from-deploying-on-nodes_virt-configuring-pci-passthrough
- https://105706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt#virt-preventing-workload-updates-during-control-plane-only-update_upgrading-virt
- https://105706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-configuring-pxe-booting#virt-pxe-booting-with-mac-address_pxe-booting

QE review:
n/a, formatting updates only

Additional information:
Needs to be rebased once https://github.com/openshift/openshift-docs/pull/105598 merges
