### PR TITLE
OSDOCS#16663: bumping table values along to 4.21

### DIFF
--- a/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
+++ b/modules/rn-ocp-release-notes-deprecated-removed-tables.adoc
@@ -87,7 +87,7 @@
 |Confidential Computing with AMD Secure Encrypted Virtualization for {gcp-first}
 |General Availability
 |Deprecated
-|
+|Deprecated
 
 |Managing bare-metal machines using Fujitsu iRMC drivers
 |General Availability

--- a/modules/rn-ocp-release-notes-technology-preview.adoc
+++ b/modules/rn-ocp-release-notes-technology-preview.adoc
@@ -232,57 +232,57 @@ In the following tables, features are marked with the following statuses:
 |Managing machines with the Cluster API for {aws-full}
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Managing machines with the Cluster API for {gcp-full}
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Managing machines with the Cluster API for {ibm-power-server-name}
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Managing machines with the Cluster API for {azure-full}
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Managing machines with the Cluster API for {rh-openstack}
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Managing machines with the Cluster API for {vmw-full}
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Managing machines with the Cluster API for bare metal
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Cloud controller manager for {ibm-power-server-name}
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Adding multiple subnets to an existing {vmw-full} cluster by using compute machine sets
 |Technology Preview
 |Technology Preview
-|
+|Technology Preview
 
 |Configuring Trusted Launch for {azure-full} virtual machines by using machine sets
 |General Availability
 |General Availability
-|
+|General Availability
 
 |Configuring {azure-short} confidential virtual machines by using machine sets
 |General Availability
 |General Availability
-|
+|General Availability
 
 |Bare-metal nodes on {vmw-full} clusters
 |Not Available


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-16663](https://issues.redhat.com//browse/OSDOCS-16663)

Link to docs preview:


QE review:
- [ ] QE has approved this change.

Additional information:
Discussed with @sunzhaohua2 and @huali9 on [OSDOCS-16663](https://issues.redhat.com//browse/OSDOCS-16663) Jira card that there are no changes to status this release, but tagging for awareness