### PR TITLE
OSDOCS-18091:Update the z-stream RNs for 4.19.23

### DIFF
--- a/modules/zstream-4-19-23-about.adoc
+++ b/modules/zstream-4-19-23-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-19-23-about_{context}"]
+= RHSA-2026:1552 - {product-title} {product-version}.23 bug fix advisory
+
+[role="_abstract"]
+Issued: 04 February 2026
+
+{product-title} release {product-version}.23 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:1552[RHSA-2026:1552] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:1538[RHBA-2026:1538] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.19.23 --pullspecs
+----

--- a/modules/zstream-4-19-23-enhancements.adoc
+++ b/modules/zstream-4-19-23-enhancements.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-23-enhancements_{context}"]
+= Enhancements
+
+[role="_abstract"]
+The following enhancement is included with this release:
+
+* With this update, the `kubernetes-nmstate` Operator now automatically retries failed node network configuration policy (NNCP) applications with exponential backoff (up to five retries, with one- to thirty-second delays). This enhancement reduces false failures from transient network issues and improves Operator reliability. (link:https://issues.redhat.com/browse/OCPBUGS-55353[OCPBUGS-55353])

--- a/modules/zstream-4-19-23-fixed-issues.adoc
+++ b/modules/zstream-4-19-23-fixed-issues.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-23-fixed-issues_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+The following issues are fixed with this release:
+
+* Before this update, the {ocp} Web console relied on the full name for user identification, which created potential ambiguity when users shared similar names. With this release, the display logic is updated to prioritize unique identifiers. As a result, the console now shows the user name instead of the full name as the display name. (link:https://issues.redhat.com/browse/OCPBUGS-70335[OCPBUGS-70335])
+
+* Before this update, the CA certificate reference to `HelmChartRepository` caused chart installation failure. As a consequence, Helm chart installation failed because it could not find the chart. With this release, the issue has been fixed. As a result, the CA certificate configuration no longer breaks the Helm chart installation. (link:https://issues.redhat.com/browse/OCPBUGS-72399[OCPBUGS-72399])
+
+* Before this update, {aws-first} APIs returned inconsistent results regarding the existence of a `Machine`. The safeguards designed to handle this inconsistency checked the stored instance ID in the incorrect location. As a consequence, during {aws-short} API instability, virtual machines (VMs) leaked and attempted to join the cluster indefinitely. With this release, the system uses the correct provider ID for consistency checks. As a result, if an instance does not appear within 20 seconds, the machine status changes to `Failed` to prevent instance leaks. (link:https://issues.redhat.com/browse/OCPBUGS-73729[OCPBUGS-73729])
+
+* Before this update, cluster namespaces with a "nodes" suffix in their name caused the Performance Profile Creator (PPC) to fail when mistaking incorrect `namespace` directories with the must-gather `nodes` directories in the must-gather processed by the PPC. With this release, the PPC now correctly excludes the `namespaces` directory when processing the must-gather data to create a suggested `PerformanceProfile`. (link:https://issues.redhat.com/browse/OCPBUGS-73797[OCPBUGS-73797])
+
+* Before this update, the `Cluster Autoscaler` API object did not have role-based access control (RBAC) permissions for the `VolumeAttachment` API object which caused a problem on upgrade because of changes in the `Cluster Autoscaler` object that require those permissions. With this release, the `Cluster Autoscaler` is deployed with proper permissions for `VolumeAttachment` objects. (link:https://issues.redhat.com/browse/OCPBUGS-73954[OCPBUGS-73954])

--- a/modules/zstream-4-19-23-updating.adoc
+++ b/modules/zstream-4-19-23-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-19-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-19-23-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.19 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-19-release-notes.adoc
+++ b/release_notes/ocp-4-19-release-notes.adoc
@@ -2826,7 +2826,7 @@ In the following tables, features are marked with the following statuses:
 
 |VMware vSphere multiple vCenter support
 |Technology Preview
-|General Availability
+|Technology Preview
 |General Availability
 
 |Disabling/enabling storage on vSphere
@@ -2900,8 +2900,6 @@ In the following tables, features are marked with the following statuses:
 * When installing a cluster on {azure-short}, if you set any of the `compute.platform.azure.identity.type`, `controlplane.platform.azure.identity.type`, or `platform.azure.defaultMachinePlatform.identity.type` field values to `None`, your cluster is unable to pull images from the Azure Container Registry. You can avoid this issue by either providing a user-assigned identity, or by leaving the identity field blank. In both cases, the installation program generates a user-assigned identity. (link:https://issues.redhat.com/browse/OCPBUGS-56008[OCPBUGS-56008])
 
 * Previously, the kubelet would not account for probes that ran in the `syncPod` method, which periodically checks the state of a pod and does a readiness probe outside of the normal probe period. With this release, a bug is fixed for when the kubelet incorrectly calculates `readinessProbe` periods. However, pod authors might see that the readiness latency of pods configured with readiness probes might increase. This behavior is more accurate to the configured probe. For more information, see (link:https://issues.redhat.com/browse/OCPBUGS-50522[OCPBUGS-50522])
-
-* There is a known issue when the grandmaster clock (T-GM) transitions to the `Locked` state too soon. This happens before the Digital Phase-Locked Loop (DPLL) completes its transition to the `Locked-HO-Acquired` state, and after the Global Navigation Satellite Systems (GNSS) time source is restored. (link:https://issues.redhat.com/browse/OCPBUGS-49826[OCPBUGS-49826])
 
 * When installing a cluster on {aws-short}, if you do not configure {aws-short} credentials before running any `openshift-install create` command, the installation program fails. (link:https://issues.redhat.com/browse/OCPBUGS-56658[OCPBUGS-56658])
 
@@ -2992,6 +2990,18 @@ This section will continue to be updated over time to provide notes on enhanceme
 ====
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
+
+// 4.19.23 about
+include::modules/zstream-4-19-23-about.adoc[leveloffset=+2]
+
+// 4.19.23 enhancements
+include::modules/zstream-4-19-23-enhancements.adoc[leveloffset=+2]
+
+// 4.19.23 fixes
+include::modules/zstream-4-19-23-fixed-issues.adoc[leveloffset=+2]
+
+// 4.19.23 updating
+include::modules/zstream-4-19-23-updating.adoc[leveloffset=+2]
 
 // 4.19.21 about
 include::modules/zstream-4-19-22-about.adoc[leveloffset=+2]
@@ -3733,7 +3743,7 @@ $ oc adm release info 4.19.1 --pullspecs
 
 * Previously, the `delete` keyword in image names was allowed in the `ImageSetConfiguration` file, which is not supported. As a consequence, users encountered errors while mirroring images. With this release, the error for image names ending with `delete` in the `ImageSetConfiguration` file has been removed. As a result, users can now successfully mirror images with names ending in `delete`. (link:https://issues.redhat.com/browse/OCPBUGS-56798[OCPBUGS-56798])
 
-* Previously, the user interface in the *Observe Alerting* field displayed incorrect alert severity icons for information alerts. With this release, the alert severity icons match in the *Observe Alerting* field. As a result, alert icons match consistently, reducing potential confusion for users. (link:https://issues.redhat.com/browse/OCPBUGS-56470[OCPBUGS-56470])
+* Previously, the user interface displayed incorrect alert severity icons for information alerts in the *Observe Alerting* field. With this release, the alert severity icons match in the *Observe Alerting* field. As a result, alert icons match consistently, reducing potential confusion for users. (link:https://issues.redhat.com/browse/OCPBUGS-56470[OCPBUGS-56470])
 
 * Previously, if you used an unauthorized access configuration file in the `oc-mirror` command, an `Unauthorized` error was displayed when you synchronized your image sets. With this release, the Docker configuration is updated to use a custom authorization file for authentication. You can successfully synchronize your image sets without encountering the `Unauthorized` error. (link:https://issues.redhat.com/browse/OCPBUGS-55701[OCPBUGS-55701])
 


### PR DESCRIPTION
Version(s):
4.19

Issue:
https://issues.redhat.com/browse/OSDOCS-18091

Link to docs preview:
https://105708--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-19-release-notes.html#zstream-4-19-23-about_release-notes

Additional information:
4.19.23 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/336
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.19