### PR TITLE
[OKD] OSDOCS Incorrect link

### DIFF
--- a/disconnected/about-installing-oc-mirror-v2.adoc
+++ b/disconnected/about-installing-oc-mirror-v2.adoc
@@ -157,11 +157,14 @@ include::modules/oc-mirror-about-cache-and-workspace-dirs.adoc[leveloffset=+2]
 
 [id="next-steps_{context}"]
 == Next steps
-
 After you mirror images to your disconnected environment using oc-mirror plugin v2, you can perform any of the following actions:
 
 * xref:../disconnected/installing.adoc#installing-disconnected-environments[Installing a cluster in a disconnected environment]
 * xref:../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+ifndef::openshift-origin[]
 * xref:../disconnected/updating/disconnected-update-osus.adoc#updating-disconnected-cluster-osus[Updating a cluster in a disconnected environment using the OpenShift Update Service]
-
+endif::openshift-origin[]
 // Intentionally linking to the OSUS update procedure since we probably want to steer users to do that workflow as much as possible. But I can change to the index of the update section if I shouldn't be as prescriptive.
+ifdef::openshift-origin[]
+* xref:../disconnected/updating/disconnected-update.adoc#updating-disconnected-cluster[Updating a cluster in a disconnected environment by using the CLI]
+endif::openshift-origin[]

--- a/disconnected/about-installing-oc-mirror-v2.adoc
+++ b/disconnected/about-installing-oc-mirror-v2.adoc
@@ -123,7 +123,13 @@ include::modules/oc-mirror-proxy-support.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+ifndef::openshift-origin[]
 * xref:../disconnected/updating/disconnected-update-osus.adoc#updating-disconnected-cluster-osus[Updating a cluster in a disconnected environment using the OpenShift Update Service]
+endif::openshift-origin[]
+// Intentionally linking to the OSUS update procedure since we probably want to steer users to do that workflow as much as possible. But I can change to the index of the update section if I shouldn't be as prescriptive.
+ifdef::openshift-origin[]
+* xref:../disconnected/updating/disconnected-update.adoc#updating-disconnected-cluster[Updating a cluster in a disconnected environment by using the CLI]
+endif::openshift-origin[]
 * xref:../disconnected/about-installing-oc-mirror-v2.adoc#oc-mirror-v2-procedure-garbage-collector_about-installing-oc-mirror-v2[Resolving storage cleanup issues in the distribution registry]
 
 //signature mirroring
@@ -157,11 +163,14 @@ include::modules/oc-mirror-about-cache-and-workspace-dirs.adoc[leveloffset=+2]
 
 [id="next-steps_{context}"]
 == Next steps
-
 After you mirror images to your disconnected environment using oc-mirror plugin v2, you can perform any of the following actions:
 
 * xref:../disconnected/installing.adoc#installing-disconnected-environments[Installing a cluster in a disconnected environment]
 * xref:../disconnected/using-olm.adoc#olm-restricted-networks[Using Operator Lifecycle Manager in disconnected environments]
+ifndef::openshift-origin[]
 * xref:../disconnected/updating/disconnected-update-osus.adoc#updating-disconnected-cluster-osus[Updating a cluster in a disconnected environment using the OpenShift Update Service]
-
+endif::openshift-origin[]
 // Intentionally linking to the OSUS update procedure since we probably want to steer users to do that workflow as much as possible. But I can change to the index of the update section if I shouldn't be as prescriptive.
+ifdef::openshift-origin[]
+* xref:../disconnected/updating/disconnected-update.adoc#updating-disconnected-cluster[Updating a cluster in a disconnected environment by using the CLI]
+endif::openshift-origin[]


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/96704

4.17: The about-installing-oc-mirror-v2.adoc file is at: https://docs.okd.io/4.17/disconnected/mirroring/about-installing-oc-mirror-v2.html
4.18+: The about-installing-oc-mirror-v2.adoc file was moved up one level in 4.18. It is now: https://docs.okd.io/latest/disconnected/about-installing-oc-mirror-v2.html

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->