### PR TITLE
OSDOCS#16676: Add the Kube bugs for 4.21 RN bug batching

### DIFF
--- a/modules/rn-ocp-release-notes-fixed-issues.adoc
+++ b/modules/rn-ocp-release-notes-fixed-issues.adoc
@@ -90,6 +90,12 @@ Instructions: Add entries in the following format under the appropriate heading:
 [id="rn-ocp-release-note-kube-controller-manager-fixed-issues_{context}"]
 == Kube Controller Manager
 
+* Before this update, `relatedObjects` in the `ClusterOperator` Custom Resource object omitted the `ClusterRoleBinding` object, resulting in incomplete debugging information. With this release, the related objects for `ClusterOperator` are expanded to include `ClusterRoleBinding`. As a result, the `kube-controller-manager` `ClusterRoleBinding` is included in the `ClusterOperator` output. (link:https://issues.redhat.com/browse/OCPBUGS-65502[OCPBUGS-65502])
+
+[id="rn-ocp-release-note-kube-scheduler-fixed-issues_{context}"]
+== Kube Scheduler
+
+* Before this update, the `ClusterOperator` object failed to reference `ClusterRoleBinding` in the `relatedObjects` array, and caused the `Kube-scheduler` `ClusterRoleBinding` to be omitted in the `ClusterOperator` output. As a consequence, debugging difficulties occurred. With this release, the `ClusterRoleBinding` for the `kube-scheduler` Operator is added to the `ClusterOperator` `relatedObjects`. (link:https://issues.redhat.com/browse/OCPBUGS-65503[OCPBUGS-65503])
 
 [id="rn-ocp-release-note-kube-api-server-fixed-issues_{context}"]
 == Kubernetes API Server


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-16676](https://issues.redhat.com//browse/OSDOCS-16676)

Link to docs preview:
[Kube scheduler](https://105715--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-note-kube-scheduler-fixed-issues_release-notes)
[Kube controller manager](https://105715--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#rn-ocp-release-note-kube-controller-manager-fixed-issues_release-notes)

QE review:
- [ ] QE has approved this change.
N/A 