### PR TITLE
[OSDOCS#17973]:  Added new entry for OSDOCS-17973 in Storage section

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -563,6 +563,10 @@ This feature is supported at the Technical Preview level.
 +
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-group-snapshots.adoc[CSI volume group snapshots].
 
+Updated release of the {secrets-store-operator}::
++
+The {secrets-store-operator} version v4.21 is now based on the upstream version v1.5.4 release of secrets-store-csi-driver.
+
 [id="ocp-release-notes-support-sigstore_{context}"]
 == Support for sigstore bring your own PKI (BYOPKI) image validation
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/OSDOCS-17973

Link to docs preview:
https://105730--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-support-sigstore_release-notes

QE review:
- [x] QE has approved this change.


