### PR TITLE
OSDOCS MCO fix support wording between on- and off-cluster image mode

### DIFF
--- a/machine_configuration/mco-coreos-layering.adoc
+++ b/machine_configuration/mco-coreos-layering.adoc
@@ -28,7 +28,7 @@ With {image-mode-os-lower}, you can install RPMs into your base image, and your 
 Installing realtime kernel and extensions RPMs as custom layered content is not recommended. This is because these RPMs can conflict with RPMs installed by using a machine config. If there is a conflict, the MCO enters a `degraded` state when it tries to install the machine config RPM. You need to remove the conflicting extension from your machine config before proceeding.
 ====
 
-As soon as you apply the custom layered image to your cluster, you effectively _take ownership_ of your custom layered images and those nodes. While Red Hat remains responsible for maintaining and updating the base {op-system} image on standard nodes, you are responsible for maintaining and updating images on nodes that use a custom layered image. You assume the responsibility for the package you applied with the custom layered image and any issues that might arise with the package.
+When you apply the custom layered image to your cluster, you assume the responsibility for the package you applied with the custom layered image and any issues that might arise with the package.
 
 There are three methods for deploying a custom layered image onto your nodes:
 

--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -14,7 +14,7 @@ To apply a custom layered image to your cluster, you must have the custom layere
 
 [IMPORTANT]
 ====
-When you configure a custom layered image, {product-title} no longer automatically updates any node that uses the custom layered image. You become responsible for manually updating your nodes as appropriate. If you roll back the custom layer, {product-title} will again automatically update the node. See the Additional resources section that follows for important information about updating nodes that use a custom layered image.
+As soon as you apply an out-of-cluster custom image to your cluster, you effectively _take ownership_ of your custom layered images and those nodes. {product-title} no longer automatically updates any node that uses the custom layered image. You become responsible for maintaining and updating your nodes as appropriate. If you roll back the custom layer, {product-title} resumes automatically updating the node. See the "Updating with a RHCOS custom layered image" for important information about updating nodes that use a custom layered image.
 ====
 
 .Prerequisites


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16864

Email from Mark Russell:
```
Can you take a look at the [image mode docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/machine_configuration/mco-coreos-layering#coreos-layering-about_mco-coreos-layering) and clarify that the language around taking on responsibility for OS upgrades is only applicable to off-cluster?

This part probably needs to be teased apart a little:

    As soon as you apply the custom layered image to your cluster, you effectively take ownership of your custom layered images and those nodes. While Red Hat remains responsible for maintaining and updating the base RHCOS image on standard nodes, you are responsible for maintaining and updating images on nodes that use a custom layered image. You assume the responsibility for the package you applied with the custom layered image and any issues that might arise with the package.


 Of course the user is still responsible for the packages using on-cluster, but OCP keeps things updated etc. so the first two sentences were there mostly to get off-cluster users to pay attention.

```

Link to docs preview:
[Using Out-of-cluster image mode to apply a custom layered image](https://105768--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring_mco-coreos-layering) -- Updated important note with text from About image mode for OpenShift.
[About image mode for OpenShift](https://105768--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_configuration/mco-coreos-layering.html#coreos-layering-configuring_mco-coreos-layering) -- Removed text from paragraph 4.  [Current docs](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/machine_configuration/mco-coreos-layering#coreos-layering-about_mco-coreos-layering). 


QE review:
No QE, policy wording only. 