### PR TITLE
[OSDOCS#15574] Fix bad attr in MS docs

### DIFF
--- a/modules/microshift-low-latency-llc.adoc
+++ b/modules/microshift-low-latency-llc.adoc
@@ -7,7 +7,7 @@
 = Enabling last-level cache locality in {microshift-short}
 
 [role="_abstract"]
-You can align workloads with CPU cores that share the same last-level cache (LLC) to improve performance for latency-sensitive applications. To apply this alignment, enable the Kubernetes CPU Manager option `prefer-align-cpus-by-uncorecache` in {microshift}.
+You can align workloads with CPU cores that share the same last-level cache (LLC) to improve performance for latency-sensitive applications. To apply this alignment, enable the Kubernetes CPU Manager option `prefer-align-cpus-by-uncorecache`.
 
 :FeatureName: Last-level cache (LLC) locality
 include::snippets/technology-preview.adoc[]
@@ -15,7 +15,7 @@ include::snippets/technology-preview.adoc[]
 
 [WARNING]
 ====
-This feature is part of a feature gate. After you enable feature gates, you cannot disable them or update {microshift-short}, and your cluster can become unstable or lose data. Enable feature gates only in non-production environments.
+This feature is part of a feature gate. After you enable feature gates, you cannot disable them or update {microshift-first}, and your cluster can become unstable or lose data. Enable feature gates only in non-production environments.
 ====
 
 .Procedure


### PR DESCRIPTION
This fixes a bad attribute in a previously merged PR. I don't think the specificity from fixing the attribute is necessary, as this module is only ever going to be used in the MicroShift docs--hence deletion rather than revision.

Version(s): 4.21
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-15574](https://issues.redhat.com//browse/OSDOCS-15574)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://105775--ocpdocs-pr.netlify.app/microshift/latest/microshift_configuring/microshift_low_latency/microshift-low-latency.html#microshift-low-latency-llc-enable_microshift-low-latency
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: n/a
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
