### PR TITLE
OSDOCS-17810-main: Clarify VolumeAttributesClass behavior without version gating

### DIFF
--- a/modules/storage-persistent-storage-pvc-volumeattributesclass.adoc
+++ b/modules/storage-persistent-storage-pvc-volumeattributesclass.adoc
@@ -10,6 +10,8 @@
 [role="_abstract"]
 Volume Attributes Classes provide a way for administrators to describe "classes" of storage they offer. These different classes can correspond to different quality-of-service levels. You can then apply Volume Attributes Classes to a persistent volume claim (PVC). If needed, you can apply new Volume Attributes Classes that become available in the cluster to the PVC.
 
+You can assign a VolumeAttributesClass to a persistent volume claim to modify storage performance characteristics such as IOPS or throughput. This update does not require volume reprovisioning or application downtime and allows on-demand performance tuning for supported storage providers.
+
 == Limitations
 Volume Attributes Classes have the following limitations:
 


### PR DESCRIPTION
Version(s):
Applies to current (4.21) and future OpenShift versions.

Issue:
https://issues.redhat.com/browse/OSDOCS-17810

Description:
Removes version-specific wording to document VolumeAttributesClass as a stable, ongoing capability rather than a 4.21-only feature.

Related PR:
SME and QE reviews for this content were done in #105668
