### PR TITLE
CNV#62020 Web UI adding a cluster-wide user-defined localnet

### DIFF
--- a/modules/virt-creating-a-localnet-cudn-web.adoc
+++ b/modules/virt-creating-a-localnet-cudn-web.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="virt-creating-a-localnet-cudn-web_{context}"]
+= Creating a cluster-scoped network to connect pods directly to an external network
+
+[role="_abstract"]
+You can connect one or more projects to a physical network for direct layer 2 access to data center resources through a `ClusterUserDefinedNetwork` custom resource in the {product-title} web console.
+
+.Prerequisites
+* You have access to the {product-title} web console as a user with `cluster-admin` permissions.
+
+.Procedure
+
+. In the {product-title} web console, go to *Virtualization* -> *Networking*. 
+. Click *Virtual machine networks* in the navigation pane.
+. Click *Create*. The *Create virtual machine network* wizard is displayed.
+. Give details about the network on the *Network definition* page:
+.. Enter a name for the network in the *Name* field.
+.. Select a physical network through an `OpenvSwitch` bridge from the *Select physical network* list.
+.. Enter the maximum transmission unit (MTU).
++
+[NOTE]
+====
+An MTU, measured in bytes, is the largest allowable size of a data packet. Ensure that all underlying physical network equipment supports this MTU, or higher.
+====
+.. Optional: Select the *VLAN ID* checkbox to enter VLAN tagging information. If you tag traffic with a VLAN ID, you must configure your physical switch with a VLAN trunk that includes the VLAN ID that you choose.
+. Click *Next*.
+. Select the projects that the network should be made available to on the *Project mapping* page. By default, all projects have access to the network.
+. Click *Create*.
+
+.Verification
+
+. Navigate to the *Virtualization* -> *Virtual machine networks* page.
+. Click the *OVN localnet* tab.
+. Verify that your new network is displayed in the list.
+

--- a/modules/virt-creating-a-primary-udn.adoc
+++ b/modules/virt-creating-a-primary-udn.adoc
@@ -32,8 +32,8 @@ spec:
     subnets:
       - "10.0.0.0/24"
       - "2001:db8::/60" 
-  ipam:
-    lifecycle: Persistent # <5>
+    ipam:
+      lifecycle: Persistent # <5>
 ----
 <1> Specifies the name of the `UserDefinedNetwork` custom resource. 
 <2> Specifies the namespace in which the VM is located. The namespace must have the `k8s.ovn.org/primary-user-defined-network` label. The namespace must not be `default`, an `openshift-*` namespace, or match any global namespaces that are defined by the Cluster Network Operator (CNO).

--- a/virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-primary-udn.adoc
@@ -38,6 +38,8 @@ include::modules/virt-creating-udn-namespace-web.adoc[leveloffset=+2]
 
 include::modules/virt-creating-primary-udn-web.adoc[leveloffset=+2]
 
+include::modules/virt-creating-a-localnet-cudn-web.adoc[leveloffset=+2]
+
 include::modules/virt-creating-primary-cluster-udn-web.adoc[leveloffset=+2]
 
 [id="next-steps-web_{context}"]


### PR DESCRIPTION
CNV#62020 Web UI adding a cluster-wide user-defined localnet


Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/CNV-62020


Link to docs preview:


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
