### PR TITLE
[enterprise-4.18] OSDOCS#18041 Update mco-update-boot-images-disable.adoc

### DIFF
--- a/modules/mco-update-boot-images-disable.adoc
+++ b/modules/mco-update-boot-images-disable.adoc
@@ -46,7 +46,6 @@ apiVersion: operator.openshift.io/v1
 kind: MachineConfiguration
 metadata:
   name: cluster
-  namespace: openshift-machine-config-operator
 spec:
 # ...
   managedBootImages: <1>


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/105539