### PR TITLE
OCPBUGS#65652: Removed_rhel_8.6

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -179,8 +179,8 @@ endif::ibm-z[]
 ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power,ibm-cloud-vpc,ipi-bare-metal[|{op-system}]
-ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere,ipi-bare-metal[|{op-system}, {op-system-base} 8.6 and later ^[3]^]
-ifdef::vsphere[|{op-system}, {op-system-base} 8.6 and later ^[2]^]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere,ipi-bare-metal[|{op-system}]
+ifdef::vsphere[|{op-system}]
 |2
 |8 GB
 |100 GB


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.19 +

Issue:
https://issues.redhat.com/browse/OCPBUGS-65652

Link to docs preview:
https://105809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic#installation-minimum-resource-requirements_installing-platform-agnostic

https://105809--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/upi/installing-bare-metal#installation-minimum-resource-requirements_installing-bare-metal

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
