### PR TITLE
WMCO 10.21.0 release notes link to errata

### DIFF
--- a/modules/windows-containers-release-notes-10-21-0.adoc
+++ b/modules/windows-containers-release-notes-10-21-0.adoc
@@ -8,7 +8,7 @@
 
 Issued: 03 February 2026
 
-// The components of the Red Hat Windows Machine Config Operator (WMCO) 10.21.0 were released in TBD.
+The components of the Red Hat Windows Machine Config Operator (WMCO) 10.21.0 were released in https://access.redhat.com/errata/RHSA-2026:TBD[RHSA-2026:TBD].
 
 [id="wmco-10-21-0-new-features"]
 == New features and improvements


### PR DESCRIPTION
Add link to errata. Not available before release.

[Release notes PR merged](https://github.com/openshift/openshift-docs/pull/104959).

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

