### PR TITLE
4.21 RN heading fix

### DIFF
--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -4,8 +4,8 @@
 
 This release adds improvements related to the following components and concepts:
 
-// [id="ocp-release-notes-api_{context}"]
-// == API server
+[id="ocp-release-notes-api_{context}"]
+== API server
 
 ////
 Instructions: Add entries in the following format:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.21

This PR adds back API server heading in the 4.21 RNs due to a last minute merge adding something to the section. 

Preview: [API server](https://105824--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-api_release-notes)

