### PR TITLE
CNV-69194: Added release note about Settings tab search bar

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -68,7 +68,12 @@ With this update, the search interface is enhanced, making it more noticeable an
 +
 link:https://issues.redhat.com/browse/CNV-70130[CNV-70130]
 
-New flag introduced to prevent unintentional VNC disconnects:: A new, optional `--preserve-session` flag has been introduced for VMs. This flag prevents an existing VNC console connection from being disconnected if you attempt to start a new session.
+Search bar added to the *Settings* page::
+With this update, a search bar is added to the *Virtualization* -> *Settings* page of the {product-title} web console. This allows users to easily search for different settings contained within the *Cluster*, *User*, or *Preview features* tabs.
++
+link:https://issues.redhat.com//browse/CNV-69189[CNV-69189]
+
+`--preserve-session` flag introduced to prevent unintentional VNC disconnects:: An optional `--preserve-session` flag has been introduced for VMs. This flag prevents an existing VNC console connection from being disconnected if you attempt to start a new session.
 +
 If you attempt to create a second connection to the VNC console by using the `virtctl` CLI when this flag is set, an error is displayed and the connection fails.
 +


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/CNV-69194

Link to docs preview:
https://105835--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html#virt-4-21-new_virt-4-21-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
