### PR TITLE
OSDOCS-17468: Updated htpasswd identity provider documentation

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -254,11 +254,11 @@ Topics:
   File: rosa-sts-creating-a-cluster-quickly
 - Name: Creating a ROSA cluster with STS using customizations
   File: rosa-sts-creating-a-cluster-with-customizations
-- Name: Creating a ROSA (classic architecture) cluster using Terraform
+- Name: Creating a Red Hat OpenShift Service on AWS (classic architecture) cluster with Terraform
   Dir: terraform
   Distros: openshift-rosa
   Topics:
-  - Name: Creating a default ROSA (classic architecture) cluster using Terraform
+  - Name: Creating a default Red Hat OpenShift Service on AWS (classic architecture) cluster with Terraform
     File: rosa-classic-creating-a-cluster-quickly-terraform
 - Name: Interactive cluster creation mode reference
   File: rosa-sts-interactive-mode-reference
@@ -615,7 +615,7 @@ Topics:
   File: managing-oauth-access-tokens
 # - Name: Understanding identity provider configuration
 #   File: understanding-identity-provider
-- Name: Configuring identity providers
+- Name: Identity providers overview
   File: sd-configuring-identity-providers
 # - Name: Configuring identity providers
 #   Dir: identity_providers

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -186,11 +186,11 @@ Topics:
   File: rosa-hcp-quickstart-guide
 - Name: Creating ROSA clusters using the default options
   File: rosa-hcp-sts-creating-a-cluster-quickly
-- Name: Creating a ROSA cluster using Terraform
+- Name: Creating a Red Hat OpenShift Service on AWS cluster with Terraform
   Dir: terraform
   Distros: openshift-rosa-hcp
   Topics:
-  - Name: Creating a default ROSA cluster using Terraform
+  - Name: Creating a default Red Hat OpenShift Service on AWS cluster with Terraform
     File: rosa-hcp-creating-a-cluster-quickly-terraform
 - Name: Creating ROSA clusters using a custom AWS KMS encryption key
   File: rosa-hcp-creating-cluster-with-aws-kms-key
@@ -500,7 +500,7 @@ Topics:
   File: managing-oauth-access-tokens
 # - Name: Understanding identity provider configuration
 #   File: understanding-identity-provider
-- Name: Configuring identity providers
+- Name: Identity providers overview
   File: sd-configuring-identity-providers
 # - Name: Configuring identity providers
 #   Dir: identity_providers

--- a/authentication/sd-configuring-identity-providers.adoc
+++ b/authentication/sd-configuring-identity-providers.adoc
@@ -1,15 +1,17 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="sd-configuring-identity-providers"]
-= Configuring identity providers
+= Identity providers overview
+
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: sd-configuring-identity-providers
 
 toc::[]
 
-After your {product-title} cluster is created, you must configure identity providers to determine how users log in to access the cluster.
+[role="_abstract"]
+After you create your {product-title} cluster, configure identity providers so users can log in and access the cluster.
 
 ifdef::openshift-rosa,openshift-rosa-hcp[]
-The following topics describe how to configure an identity provider using {cluster-manager} console. Alternatively, you can use the ROSA CLI (`rosa`) to configure an identity provider and access the cluster.
+The following topics describe how to configure an identity provider using the {cluster-manager} console. Alternatively, you can use the {rosa-cli-first} to configure an identity provider and access the cluster.
 endif::openshift-rosa,openshift-rosa-hcp[]
 
 include::modules/understanding-idp.adoc[leveloffset=+1]
@@ -20,14 +22,23 @@ include::modules/config-google-idp.adoc[leveloffset=+1]
 include::modules/config-ldap-idp.adoc[leveloffset=+1]
 include::modules/config-openid-idp.adoc[leveloffset=+1]
 include::modules/config-htpasswd-idp.adoc[leveloffset=+1]
+include::modules/config-htpasswd-idp-webui.adoc[leveloffset=+2]
+ifdef::openshift-rosa-hcp,openshift-rosa[]
+include::modules/rosa-config-htpasswd-idp-cli.adoc[leveloffset=+2]
+include::modules/rosa-config-htpasswd-idp-cli-file.adoc[leveloffset=+3]
+include::modules/config-htpasswd-idp-terraform.adoc[leveloffset=+2]
+endif::openshift-rosa-hcp,openshift-rosa[]
 ifdef::openshift-dedicated[]
+include::modules/sd-config-htpasswd-idp-cli.adoc[leveloffset=+2]
 include::modules/access-cluster.adoc[leveloffset=+1]
 endif::openshift-dedicated[]
 
-ifdef::openshift-rosa[]
+
 [id="additional-resources-cluster-access-sts"]
 [role="_additional-resources"]
 == Additional resources
+ifdef::openshift-rosa[]
 * xref:../rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc#rosa-sts-accessing-cluster[Accessing a cluster]
 * xref:../rosa_getting_started/rosa-sts-getting-started-workflow.adoc#rosa-sts-understanding-the-deployment-workflow[Understanding the ROSA with STS deployment workflow]
 endif::openshift-rosa[]
+* link:https://httpd.apache.org/docs/2.2/misc/password_encryptions.html[Apache Password Formats]

--- a/modules/config-htpasswd-idp-terraform.adoc
+++ b/modules/config-htpasswd-idp-terraform.adoc
@@ -1,0 +1,169 @@
+// Module included in the following assemblies:
+//
+// * authentication/sd-configuring-identity-providers.adoc
+// * rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc
+
+:_mod-docs-content-type: PROCEDURE
+ifeval::["{context}" == "rosa-hcp-creating-a-cluster-quickly-terraform"]
+:tf-config:
+endif::[]
+
+[id="config-htpasswd-idp-terraform_{context}"]
+= Configuring an htpasswd identity provider with Terraform
+
+ifdef::tf-config[]
+[role="_abstract"]
+After creating your cluster with Terraform, you can permit users access to your cluster by using an htpasswd identity provider (IDP) with the Terraform tool.
+endif::tf-config[]
+ifndef::tf-config[]
+[role="_abstract"]
+You can create an htpasswd identity provider (IDP) with Terraform.
+endif::tf-config[]
+
+.Prerequisites
+
+* You have installed and configured the latest version of the {rosa-cli}.
+* You have installed and configured the latest version of Terraform.
+
+.Procedure
+ifndef::tf-config[]
+. Grant permissions to your account by using link:https://console.redhat.com/openshift/token[an offline {cluster-manager-first} token].
+. Copy your offline token, and set the token as an environmental variable by running the following command:
++
+[source,terminal]
+----
+$ export RHCS_TOKEN=<your_offline_token>
+----
++
+[NOTE]
+====
+This environmental variable resets at the end of each session, such as restarting your machine or closing the terminal.
+====
+endif::tf-config[]
+
+. Create the `htpasswd_idp.tf` file by running one of the following commands:
++
+** *Option 1*: To create a user with a generated, randomized password, run:
++
+[source,terminal]
+----
+$ cat<<-EOF>htpasswd_idp.tf
+  module "htpasswd_idp" {
+    source = "terraform-redhat/rosa-hcp/rhcs//modules/idp"
+    version = "1.6.2"
+
+    cluster_id         = "2odpb9p344hnkfvpkluo00qmgkika78l"
+    name               = "htpasswd-idp-tf-1"
+    idp_type           = "htpasswd"
+    htpasswd_idp_users = [{ username = "pej-user-d1", password = random_password.password.result }]
+  }
+  
+  resource "aws_secretsmanager_secret" "idp_password" {
+  name        = "idp-password-secret"
+  description = "Any description here" 
+  }
+
+  resource "random_password" "password" {
+      length           = 16
+      lower            = true
+      special          = true
+      override_special = "!#$%&*()-_=+[]{}<>:?"
+  }
+
+  # If you need to output the password, mark it as sensitive to hide from CLI logs
+  output "password_output" {
+      value     = random_password.password.result
+      sensitive = true
+  }
+  
+  # This section sends your credentials to your AWS Secrets Manager to enable you to log in to your cluster.
+  resource "aws_secretsmanager_secret_version" "idp_password_val" {
+  secret_id     = aws_secretsmanager_secret.idp_password.id
+  secret_string = random_password.password.result
+  }
+EOF
+----
++
+You must replace the `<cluster_id>` placeholder with the 32-digit ID for your cluster. To find that value, run `rosa list clusters | awk '{print $1}'`. You also must replace the `<user_name>` placeholder with the username you want to create. The randomized password is then stored in your AWS Secrets manager to be used when logging in to the cluster.
+
+*** Run the following command to view your password after setting it:
++
+[source,terminal]
+----
+$ terraform output password_output
+----
++
+The CLI returns your generated password in plain text.
+
+** *Option 2*: To specify your passwords when creating a user, run:
++
+[source,terminal]
+----
+$ cat<<-EOF>htpasswd_idp.tf
+  module "htpasswd_idp" {
+    source = "terraform-redhat/rosa-hcp/rhcs//modules/idp"
+    version = "1.6.2"
+
+    cluster_id         = "<cluster_id>"
+    name               = "htpasswd-idp"
+    idp_type           = "htpasswd"
+    htpasswd_idp_users = [{ username="<user_name>",password="<password>"}]
+  }
+EOF
+----
++
+You must replace the `<cluster_id>` placeholder with the 32-digit ID for your cluster. To find that value, run `rosa list clusters | awk '{print $1}'`. You also must replace the `<user_name>` placeholder with the username you want to create as well as a password for the `<password>` placeholder.
+
+. Run the following command to set up Terraform to create your resources based on your Terraform files:
++
+[source,terminal]
+----
+$ terraform init
+----
+
+. Verify that the Terraform you copied is correct by running the following command:
++
+[source,terminal]
+----
+$ terraform validate
+----
++
+.Example output
+[source,terminal]
+----
+Success! The configuration is valid.
+----
+
+. Create your cluster with Terraform by running the following command:
++
+[source,terminal]
+----
+$ terraform apply
+----
+
+. Enter `yes` to proceed or `no` to cancel when the Terraform interface lists the resources to be created or changed and prompts for confirmation:
++
+[source,terminal]
+----
+Do you want to perform these actions?
+  Terraform will perform the actions described above.
+  Only 'yes' will be accepted to approve.
+
+  Enter a value: yes
+----
++
+You see a confirmation that your IDP has been created.
++
+[source,terminal]
+----
+Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
+----
++
+[NOTE]
+====
+If you used the randomized password template, then the generated password is stored in your AWS Secrets manager.
+====
+
+ifeval::["{context}" == "rosa-hcp-creating-a-cluster-quickly-terraform"]
+:!tf-config:
+endif::[]

--- a/modules/config-htpasswd-idp-webui.adoc
+++ b/modules/config-htpasswd-idp-webui.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * osd_install_access_delete_cluster/config-identity-providers.adoc
+// * rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+ifeval::["{context}" == "config-identity-providers"]
+:osd-distro:
+endif::[]
+ifeval::["{context}" == "rosa-sts-config-identity-providers"]
+:rosa-distro:
+endif::[]
+ifeval::["{context}" == "rosa-config-identity-providers"]
+:rosa-distro:
+endif::[]
+
+[id="config-htpasswd-idp-webui_{context}"]
+= Configuring an htpasswd identity provider
+
+[role="_abstract"]
+You can create an htpasswd identity provider with the {cluster-manager} web user interface (UI).
+
+.Procedure
+
+. Select your cluster from the the *Cluster List* page on {cluster-manager-url}.
+
+. Select *Access control* -> *Identity providers*.
+
+. Click *Add identity provider*.
+
+. Select *HTPasswd* from the *Identity Provider* list.
+
+. Add a unique name in the *Name* field for the identity provider.
+
+. Use the suggested username and password for the static user, or create your own.
++
+[NOTE]
+====
+You cannot retrieve the credentials defined in this step after you select *Add* in the following step. If you lose the credentials, you must recreate the identity provider and define the credentials again.
+====
+
+. Select *Add* to create the htpasswd identity provider and the single, static user.
+
+. Grant the static user permission to manage the cluster:
+.. Select *Access control* -> *Cluster Roles and Access* > *Add user*.
+.. Enter the User ID of the static user that you created in the preceding step.
+ifdef::osd-distro[]
+.. Select a *Group.*
+** If you are installing {product-title} using the Customer Cloud Subscription (CCS) infrastructure type, choose either the `dedicated-admins` or `cluster-admins` group. Users in the `dedicated-admins` group have standard administrative privileges for {product-title}. Users in the `cluster-admins` group have full administrative access to the cluster.
+** If you are installing {product-title} using the Red{nbsp}Hat cloud account infrastructure type, the `dedicated-admins` group is automatically selected.
+endif::osd-distro[]
+ifdef::rosa-distro[]
+.. Select a *Group*. Users in the `dedicated-admins` group have standard administrative privileges for {product-title}. Users in the `cluster-admins` group have full administrative access to the cluster.
+endif::rosa-distro[]
+.. Select *Add user* to grant the administration privileges to the user.
+
+.Verification
+
+* The configured htpasswd identity provider is visible on the *Access control* -> *Identity providers* page.
++
+[NOTE]
+====
+After creating the identity provider, synchronization usually completes within two minutes. You can log in to the cluster as the user after the htpasswd identity provider becomes available.
+====
+* The single, administrative user is visible on the *Access control* -> *Cluster Roles and Access* page. The administration group membership of the user is also displayed.
+
+ifeval::["{context}" == "config-identity-providers"]
+:!osd-distro:
+endif::[]
+ifeval::["{context}" == "rosa-sts-config-identity-providers"]
+:!rosa-distro:
+endif::[]
+ifeval::["{context}" == "rosa-config-identity-providers"]
+:!rosa-distro:
+endif::[]

--- a/modules/config-htpasswd-idp.adoc
+++ b/modules/config-htpasswd-idp.adoc
@@ -3,6 +3,7 @@
 // * osd_install_access_delete_cluster/config-identity-providers.adoc
 // * rosa_install_access_delete_clusters/rosa-sts-config-identity-providers.adoc
 
+:_mod-docs-content-type: CONCEPT
 ifeval::["{context}" == "config-identity-providers"]
 :osd-distro:
 endif::[]
@@ -13,60 +14,16 @@ ifeval::["{context}" == "rosa-config-identity-providers"]
 :rosa-distro:
 endif::[]
 
-:_mod-docs-content-type: PROCEDURE
 [id="config-htpasswd-idp_{context}"]
 = Configuring an htpasswd identity provider
 
-Configure an htpasswd identity provider to create a single, static user with cluster administration privileges. You can log in to your cluster as the user to troubleshoot issues.
+[role="_abstract"]
+Configure an htpasswd identity provider to create a single, static user with cluster administration privileges. You can log in to your cluster as the user to troubleshoot problems. You can use the web user interface (UI) or your command-line interface (CLI) to create an htpasswd identity provider.
 
 [IMPORTANT]
 ====
-The htpasswd identity provider option is included only to enable the creation of a single, static administration user. htpasswd is not supported as a general-use identity provider for {product-title}.
+The htpasswd identity provider option is included only to create a single, static administration user. htpasswd is not supported as a general-use identity provider for {product-title}.
 ====
-
-.Procedure
-
-. From {cluster-manager-url}, navigate to the *Cluster List* page and select your cluster.
-
-. Select *Access control* -> *Identity providers*.
-
-. Click *Add identity provider*.
-
-. Select *HTPasswd* from the *Identity Provider* drop-down menu.
-
-. Add a unique name in the *Name* field for the identity provider.
-
-. Use the suggested username and password for the static user, or create your own.
-+
-[NOTE]
-====
-The credentials defined in this step are not visible after you select *Add* in the following step. If you lose the credentials, you must recreate the identity provider and define the credentials again.
-====
-
-. Select *Add* to create the htpasswd identity provider and the single, static user.
-
-. Grant the static user permission to manage the cluster:
-.. Under *Access control* -> *Cluster Roles and Access*, select *Add user*.
-.. Enter the *User ID* of the static user that you created in the preceding step.
-ifdef::osd-distro[]
-.. Select a *Group.*
-** If you are installing {product-title} using the Customer Cloud Subscription (CCS) infrastructure type, choose either the `dedicated-admins` or `cluster-admins` group. Users in the `dedicated-admins` group have standard administrative privileges for {product-title}. Users in the `cluster-admins` group have full administrative access to the cluster.
-** If you are installing {product-title} using the Red{nbsp}Hat cloud account infrastructure type, the `dedicated-admins` group is automatically selected.
-endif::osd-distro[]
-ifdef::rosa-distro[]
-.. Select a *Group*. Users in the `dedicated-admins` group have standard administrative privileges for {product-title}. Users in the `cluster-admins` group have full administrative access to the cluster.
-endif::rosa-distro[]
-.. Select *Add user* to grant the administration privileges to the user.
-
-.Verification
-
-* The configured htpasswd identity provider is visible on the *Access control* -> *Identity providers* page.
-+
-[NOTE]
-====
-After creating the identity provider, synchronization usually completes within two minutes. You can log in to the cluster as the user after the htpasswd identity provider becomes available.
-====
-* The single, administrative user is visible on the *Access control* -> *Cluster Roles and Access* page. The administration group membership of the user is also displayed.
 
 ifeval::["{context}" == "config-identity-providers"]
 :!osd-distro:

--- a/modules/osd-release-notes-Q1-2026.adoc
+++ b/modules/osd-release-notes-Q1-2026.adoc
@@ -9,3 +9,5 @@
 The following items were added during the first quarter of 2026.
 
 * **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.21 is now available for new clusters.
+
+* **Cluster admins can now create multiple users with htpasswd identity providers.** Cluster administrators can now add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI, administrators can add multiple users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].

--- a/modules/rosa-config-htpasswd-idp-cli-file.adoc
+++ b/modules/rosa-config-htpasswd-idp-cli-file.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * authentication/sd-configuring-identity-providers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+ifeval::["{context}" == "config-identity-providers"]
+:osd-distro:
+endif::[]
+ifeval::["{context}" == "rosa-sts-config-identity-providers"]
+:rosa-distro:
+endif::[]
+ifeval::["{context}" == "rosa-config-identity-providers"]
+:rosa-distro:
+endif::[]
+
+[id="rosa-config-htpasswd-idp-cli-file_{context}"]
+= Configuring an htpasswd identity provider with an htpasswd file
+
+[role="_abstract"]
+You can create an htpasswd identity provider (IDP) with the {rosa-cli-first} tool and a well-formed htpasswd file.
+
+.Prerequisites
+
+* You have installed and configured the latest version of the {rosa-cli}.
+
+.Procedure
+
+* Create a text file with a new row for each set of credentials with the username and password being colon separated like the following example:
++
+[source,text]
+----
+johndoe:$apr1$hRY7OJWH$km1EYH.UIRj00000000/
+janedoe:$apr1$Q58SO804$B/fECNWfn5F00000000/
+----
++
+[NOTE]
+====
+The htpasswd file is encrypted using APR1 hashing. For more information, see "Apache Password Formats" in the _Additional resources_.
+====
++
+[source,terminal]
+----
+$ rosa create idp --type=htpasswd -c <cluster_name> --from-file=myhtpassfile.txt
+----
+
+ifeval::["{context}" == "config-identity-providers"]
+:!osd-distro:
+endif::[]
+ifeval::["{context}" == "rosa-sts-config-identity-providers"]
+:!rosa-distro:
+endif::[]
+ifeval::["{context}" == "rosa-config-identity-providers"]
+:!rosa-distro:
+endif::[]

--- a/modules/rosa-config-htpasswd-idp-cli.adoc
+++ b/modules/rosa-config-htpasswd-idp-cli.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * authentication/sd-configuring-identity-providers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="rosa-config-htpasswd-idp-cli_{context}"]
+= Configuring an htpasswd identity provider with the CLI
+
+[role="_abstract"]
+You can create an htpasswd identity provider (IDP) with the {rosa-cli-first} tool.
+
+.Prerequisites
+
+* You have installed and configured the latest version of the {rosa-cli}.
+
+.Procedure
+
+* Run the following command to create an htpasswd IDP by passing the usernames and passwords in the command-line interface:
++
+[source,terminal]
+----
+$ rosa create idp --type=htpasswd -c  <cluster_name> --users='user1:password1,user2:password2,user3:password3'
+----
++
+[NOTE]
+====
+The `--users` string value must be a comma separated list of `username:password,` within quotes like `"user1:password"` to create a user account with a name of `user1` and a password of `password`. The quotes prevent your password from disrupting the Bash commands.
+
+Passwords must include uppercase letters, lowercase letters, and numbers or symbols, specifically, ASCII-standard characters only. The password must be at least 14 characters.
+====

--- a/modules/rosa-release-notes-Q1-2026.adoc
+++ b/modules/rosa-release-notes-Q1-2026.adoc
@@ -8,6 +8,8 @@
 [role="_abstract"]
 The following items were added during the first quarter of 2026.
 
+* **Cluster admins can now create multiple users with htpasswd identity providers.** Cluster administrators can now add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI or Terraform, administrators can add users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].
+
 ifdef::openshift-rosa-hcp[]
 * **Platform monitoring using the Cluster Monitoring Operator.** You can now configure the in-cluster monitoring stack components, metrics, and alerts to monitor both core platform components and user-defined projects. Previously, you could only monitor user-defined projects. This change applies to both new and existing {product-title} clusters. However, it affects them differently.
 +

--- a/modules/rosa-sts-cluster-terraform-destroy.adoc
+++ b/modules/rosa-sts-cluster-terraform-destroy.adoc
@@ -3,23 +3,23 @@
 // * rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc
 // * rosa_install_access_delete_clusters/terraform/rosa-classic-creating-a-cluster-quickly-terraform.adoc
 
+:_mod-docs-content-type: PROCEDURE
 ifeval::["{context}" == "rosa-classic-creating-a-cluster-quickly-terraform"]
 :tf-defaults:
 endif::[]
 ifeval::["{context}" == "rosa-hcp-creating-a-cluster-quickly-terraform"]
 :tf-rosa-hcp:
 endif::[]
-:_mod-docs-content-type: PROCEDURE
 
 [id="sd-terraform-cluster-destroy_{context}"]
 = Deleting your {product-title} cluster with Terraform
 
 [role="_abstract"]
-Use the `terraform destroy` command to remove all of the resources that were created with the `terraform apply` command.
+Use the `terraform destroy` command to remove all resources you create with the `terraform apply` command.
 
 [NOTE]
 ====
-Do not modify your Terraform `.tf` files before destroying your resources. These variables are matched to resources to delete.
+Keep your Terraform .tf files unchanged before destroying your resources. These variables are matched to resources to delete.
 ====
 
 .Procedure
@@ -116,6 +116,7 @@ $ rosa list operator-roles
 I: Fetching operator roles
 I: No operator roles available
 ----
+
 ifeval::["{context}" == "rosa-classic-creating-a-cluster-quickly-terraform"]
 :tf-defaults:
 endif::[]

--- a/modules/sd-config-htpasswd-idp-cli.adoc
+++ b/modules/sd-config-htpasswd-idp-cli.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * authentication/sd-configuring-identity-providers.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="sd-config-htpasswd-idp-cli_{context}"]
+= Configuring an htpasswd identity provider with the CLI
+
+[role="_abstract"]
+You can create an htpasswd identity provider (IDP) with the OCM CLI (`ocm`) tool.
+
+.Prerequisites
+
+* You have installed and configured the latest version of the OCM CLI (`ocm`).
+
+.Procedure
+
+* Run the following command to create an htpasswd IDP by passing the usernames and passwords in the command-line interface:
++
+[source,terminal]
+----
+$ ocm create idp --type htpasswd --cluster <cluster_name> --name <idp_name> --username <user_name> --password '<password>'
+----
++
+[NOTE]
+====
+You must include the password within quotes like `'password'` to prevent your password from disrupting the Bash commands.
+
+Passwords must include uppercase letters, lowercase letters, and numbers or symbols, specifically, ASCII-standard characters only. The password must be at least 14 characters.
+====

--- a/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc
+++ b/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.adoc
@@ -1,17 +1,17 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="rosa-hcp-creating-a-cluster-quickly-terraform"]
-= Creating a default {product-title} cluster using Terraform
+= Creating a default {product-title} cluster with Terraform
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-creating-a-cluster-quickly-terraform
 
 toc::[]
 
 [role="_abstract"]
-Create a {product-title} cluster quickly by using a Terraform cluster template that is configured with the default cluster options.
+Create a {product-title} cluster with a Terraform cluster template that is configured with the default cluster options.
 
-The cluster creation process described below uses a Terraform configuration that prepares a {product-title} cluster with the following resources:
+The following process for creating a cluster uses a Terraform configuration that prepares a {product-title} cluster with these resources:
 
-* An OIDC provider with a managed `oidc-config` configuration
+* An OpenID Connect (OIDC) provider with a managed `oidc-config` configuration
 * Prerequisite IAM Operator roles with associated AWS Managed {product-title} Policies
 * IAM account roles with associated AWS Managed {product-title} Policies
 * All other AWS resources required to create a {product-title} cluster
@@ -37,9 +37,13 @@ include::modules/rosa-sts-cluster-terraform-execute.adoc[leveloffset=+2]
 // include::modules/rosa-sts-cluster-terraform-mirror-image.adoc[leveloffset=+2]
 // endif::openshift-rosa-hcp[]
 
+
+include::modules/config-htpasswd-idp-terraform.adoc[leveloffset=+2]
+
 include::modules/rosa-sts-cluster-terraform-destroy.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources_rosa-hcp-creating-a-cluster-quickly-terraform"]
 == Additional resources
 * xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference]
+* link:https://httpd.apache.org/docs/2.2/misc/password_encryptions.html[Apache Password Formats]


### PR DESCRIPTION
Version(s):
`enterprise-4.21+`

Issue:

- **[OSDOCS-17468](https://issues.redhat.com/browse/OSDOCS-17468)**
- **[ROSA-489](https://issues.redhat.com/browse/ROSA-489)**
- **[OSDOCS-9658](https://issues.redhat.com/browse/OSDOCS-9658)**

Link to docs preview:

- [Configuring an htpasswd identity provider for ROSA with HCP](https://105838--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/sd-configuring-identity-providers.html#config-htpasswd-idp_sd-configuring-identity-providers)
    - [What's New](https://105838--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes#rosa-q1-2026_rosa-whats-new)
- [Configuring an htpasswd identity provider for ROSA Classic](https://105838--ocpdocs-pr.netlify.app/openshift-rosa/latest/authentication/sd-configuring-identity-providers.html#config-htpasswd-idp_sd-configuring-identity-providers)
    - [What's New](https://105838--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes#rosa-q1-2026_rosa-whats-new)
- [Configuring an htpasswd identity provider for OSD](https://105838--ocpdocs-pr.netlify.app/openshift-dedicated/latest/authentication/sd-configuring-identity-providers.html#config-htpasswd-idp_sd-configuring-identity-providers)
     - [What's New](https://105838--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new#osd-q1-2026_osd-whats-new) 
- [Terraform cluster with identity provider](https://105838--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/terraform/rosa-hcp-creating-a-cluster-quickly-terraform.html#config-htpasswd-idp-terraform_rosa-hcp-creating-a-cluster-quickly-terraform)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds instructions for configuring an htpasswd identity provider with the CLI as well as Terraform.