### PR TITLE
OSDOCS#18117: Update the MicroShift z-stream RNs for 4.20.13

### DIFF
--- a/microshift_release_notes/microshift-4-20-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-20-release-notes.adoc
@@ -25,3 +25,5 @@ include::modules/microshift-4-20-additional-release-notes.adoc[leveloffset=+1]
 include::modules/microshift-4-20-asynchronous-updates.adoc[leveloffset=+1]
 
 include::modules/microshift-4-20-0-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-20-13-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-20-13-dp.adoc
+++ b/modules/microshift-4-20-13-dp.adoc
@@ -1,0 +1,23 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-20-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="microshift-4-20-13-dp_{context}"]
+= RHBA-2026:1607 - {microshift-short} 4.20.13 bug fix and enhancement update
+
+[role="_abstract"]
+Issued: 03 February 2026
+
+{product-title} release 4.20.13 is now available, see the link:https://access.redhat.com/errata/RHBA-2026:1607[RHBA-2026:1607] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:1555[RHSA-2026:1555] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-bootc-image[Getting the published bootc image for {microshift-short}]
+
+[id="microshift-4-20-13-dp-bug-enhancements_{context}"]
+== Enhancements
+
+* With this update, {microshift-short} 4.20 allows using single-architecture container images for cert-manager, reducing its storage requirements. This enhancement improves the reliability and efficiency of the deployment process, and ensures a smoother experience for users building bootc-based {op-system-base} 9.6 and {microshift-short} 4.20 images in air-gapped environments. (https://issues.redhat.com/browse/OCPBUGS-74163[OCPBUGS-74163])


### PR DESCRIPTION
Version(s):
4.20

Issue:
[OSDOCS-18117](https://issues.redhat.com//browse/OSDOCS-18117)

Link to docs preview:
[4.20.13](https://105841--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-20-release-notes.html#microshift-4-20-13-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20)
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/337#2bf30caa799dcde3fbd567988028d814241aa624)
