### PR TITLE
CNV-69069: Adding links to new runbook alerts in docs

### DIFF
--- a/virt/monitoring/virt-runbooks.adoc
+++ b/virt/monitoring/virt-runbooks.adoc
@@ -64,10 +64,45 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/CnaoNmstateMigration.md[View the runbook] for the `CnaoNMstateMigration` alert.
 
+[id="virt-runbook-deprecatedmachinetype_{context}"]
+== DeprecatedMachineType
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/DeprecatedMachineType.md[View the runbook] for the `DeprecatedMachineType` alert.
+
+[id="virt-runbook-duplicatewaspagentdsdetected_{context}"]
+== DuplicateWaspAgentDSDetected
+
+* The `DuplicateWaspAgentDSDetected` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/DuplicateWaspAgentDSDetected.md[deprecated].
+
+[id="virt-runbook-guestfilesystemalmostoutofspace_{context}"]
+== GuestFilesystemAlmostOutOfSpace
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestFilesystemAlmostOutOfSpace.md[View the runbook] for the `GuestFilesystemAlmostOutOfSpace` alert.
+
+[id="virt-runbook-guestvcpuqueuehighcritical_{context}"]
+== GuestVCPUQueueHighCritical
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestVCPUQueueHighCritical.md[View the runbook] for the `GuestVCPUQueueHighCritical` alert.
+
+[id="virt-runbook-guestvcpuqueuehighwarning_{context}"]
+== GuestVCPUQueueHighWarning
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/GuestVCPUQueueHighWarning.md[View the runbook] for the `GuestVCPUQueueHighWarning` alert.
+
 [id="virt-runbook-hacontrolplanedown_{context}"]
 == HAControlPlaneDown
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HAControlPlaneDown.md[View the runbook] for the `HAControlPlaneDown` alert.
+
+[id="virt-runbook-hcogoldenimagewithnoarchitectureannotation_{context}"]
+== HCOGoldenImageWithNoArchitectureAnnotation
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOGoldenImageWithNoArchitectureAnnotation.md[View the runbook] for the `HCOGoldenImageWithNoArchitectureAnnotation` alert.
+
+[id="virt-runbook-hcogoldenimagewithnosupportedarchitecture_{context}"]
+== HCOGoldenImageWithNoSupportedArchitecture
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOGoldenImageWithNoSupportedArchitecture.md[View the runbook] for the `HCOGoldenImageWithNoSupportedArchitecture` alert.
 
 [id="virt-runbook-hcoinstallationincomplete_{context}"]
 == HCOInstallationIncomplete
@@ -78,6 +113,21 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 == HCOMisconfiguredDescheduler
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOMisconfiguredDescheduler.md[View the runbook] for the `HCOMisconfiguredDescheduler` alert.
+
+[id="virt-runbook-hcomultiarchgoldenimagesdisabled_{context}"]
+== HCOMultiArchGoldenImagesDisabled
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOMultiArchGoldenImagesDisabled.md[View the runbook] for the `HCOMultiArchGoldenImagesDisabled` alert.
+
+[id="virt-runbook-hcooperatorconditionsunhealthy_{context}"]
+== HCOOperatorConditionsUnhealthy
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HCOOperatorConditionsUnhealthy.md[View the runbook] for the `HCOOperatorConditionsUnhealthy` alert.
+
+[id="virt-runbook-highnodecpufrequency_{context}"]
+== HighNodeCPUFrequency
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/HighNodeCPUFrequency.md[View the runbook] for the `HighNodeCPUFrequency` alert.
 
 [id="virt-runbook-hppnotready_{context}"]
 == HPPNotReady
@@ -107,7 +157,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-KubeMacPoolDuplicateMacsfound_{context}"]
 == KubeMacPoolDuplicateMacsFound
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeMacPoolDuplicateMacsFound.md[View the runbook] for the `KubeMacPoolDuplicateMacsFound` alert.
+*The `KubeMacPoolDuplicateMacsFound` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeMacPoolDuplicateMacsFound.md[deprecated].
 
 [id="virt-runbook-kubevirtcomponentexceedsrequestedcpu_{context}"]
 == KubeVirtComponentExceedsRequestedCPU
@@ -129,6 +179,17 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtDeprecatedAPIRequested.md[View the runbook] for the `KubeVirtDeprecatedAPIRequested` alert.
 
+[id="virt-runbook-kubevirtguestmemoryavailablelow_{context}"]
+== KubeVirtVMGuestMemoryAvailableLow
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtVMGuestMemoryAvailableLow.md[View the runbook] for the `KubeVirtVMGuestMemoryAvailableLow` alert.
+
+[id="virt-runbook-kubevirtguestmemorypressure_{context}"]
+== KubeVirtVMGuestMemoryPressure
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubeVirtVMGuestMemoryPressure.md[View the runbook] for the `KubeVirtVMGuestMemoryPressure` alert.
+
+
 [id="virt-runbook-kubevirtnoavailablenodestorunvms_{context}"]
 == KubeVirtNoAvailableNodesToRunVMs
 
@@ -137,7 +198,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-kubevirtvmhighmemoryusage_{context}"]
 == KubevirtVmHighMemoryUsage
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubevirtVmHighMemoryUsage.md[View the runbook] for the `KubevirtVmHighMemoryUsage` alert.
+* The `KubevirtVmHighMemoryUsage` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/KubevirtVmHighMemoryUsage.md[deprecated].
 
 [id="virt-runbook-kubevirtvmiexcessivemigrations_{context}"]
 == KubeVirtVMIExcessiveMigrations
@@ -214,10 +275,15 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 
 * link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/OutdatedVirtualMachineInstanceWorkloads.md[View the runbook] for the `OutdatedVirtualMachineInstanceWorkloads` alert.
 
+[id="virt-runbook-persistentvolumefillingup_{context}"]
+== PersistentVolumeFillingUp
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/PersistentVolumeFillingUp.md[View the runbook] for the `PersistentVolumeFillingUp` alert.
+
 [id="virt-runbook-singlestackipv6unsupported_{context}"]
 == SingleStackIPv6Unsupported
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SingleStackIPv6Unsupported.md[View the runbook] for the `SingleStackIPv6Unsupported` alert.
+* The `SingleStackIPv6Unsupported` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SingleStackIPv6Unsupported.md[deprecated].
 
 [id="virt-runbook-sspcommontemplatesmodificationreverted_{context}"]
 == SSPCommonTemplatesModificationReverted
@@ -242,7 +308,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-sspoperatordown_{context}"]
 == SSPOperatorDown
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPOperatorDown.md[View the runbook] for the `SSPOperatorDown` alert.
+* The `SSPOperatorDown` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/SSPOperatorDown.md[deprecated].
 
 [id="virt-runbook-ssptemplatevalidatordown_{context}"]
 == SSPTemplateValidatorDown
@@ -267,7 +333,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virtapiresterrorshigh_{context}"]
 == VirtApiRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md[View the runbook] for the `VirtApiRESTErrorsHigh` alert.
+* The `VirtApiRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtApiRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-virtcontrollerdown_{context}"]
 == VirtControllerDown
@@ -282,7 +348,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virtcontrollerresterrorshigh_{context}"]
 == VirtControllerRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md[View the runbook] for the `VirtControllerRESTErrorsHigh` alert.
+* The `VirtControllerRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtControllerRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-virthandlerdaemonsetrolloutfailing_{context}"]
 == VirtHandlerDaemonSetRolloutFailing
@@ -297,7 +363,12 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virthandlerresterrorshigh_{context}"]
 == VirtHandlerRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md[View the runbook] for the `VirtHandlerRESTErrorsHigh` alert.
+* The `VirtHandlerRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtHandlerRESTErrorsHigh.md[deprecated].
+
+[id="virt-runbook-virtlauncherpodsstuckfailed_{context}"]
+== VirtLauncherPodsStuckFailed
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtLauncherPodsStuckFailed.md[View the runbook] for the `VirtLauncherPodsStuckFailed` alert.
 
 [id="virt-runbook-virtoperatordown_{context}"]
 == VirtOperatorDown
@@ -312,7 +383,7 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 [id="virt-runbook-virtoperatorresterrorshigh_{context}"]
 == VirtOperatorRESTErrorsHigh
 
-* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md[View the runbook] for the `VirtOperatorRESTErrorsHigh` alert.
+* The `VirtOperatorRESTErrorsHigh` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtOperatorRESTErrorsHigh.md[deprecated].
 
 [id="virt-runbook-virtualmachinecrcerrors_{context}"]
 == VirtualMachineCRCErrors
@@ -320,6 +391,21 @@ Runbooks for the {VirtProductName} Operator are maintained in the link:https://g
 * The `VirtualMachineCRCErrors` alert is link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineCRCErrors.md[deprecated].
 +
 The alert is now called `VMStorageClassWarning`.
+
+[id="virt-runbook-virtualmachineinstancehasephemeralhotplugvolume_{context}"]
+== VirtualMachineInstanceHasEphemeralHotplugVolume
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineInstanceHasEphemeralHotplugVolume.md[View the runbook] for the `VirtualMachineInstanceHasEphemeralHotplugVolume` alert.
+
+[id="virt-runbook-virtualmachinestuckinunhealthystate_{context}"]
+== VirtualMachineStuckInUnhealthyState
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineStuckInUnhealthyState.md[View the runbook] for the `VirtualMachineStuckInUnhealthyState` alert.
+
+[id="virt-runbook-virtualmachinestuckonnode_{context}"]
+== VirtualMachineStuckOnNode
+
+* link:https://github.com/openshift/runbooks/blob/master/alerts/openshift-virtualization-operator/VirtualMachineStuckOnNode.md[View the runbook] for the `VirtualMachineStuckOnNode` alert.
 
 [id="virt-runbook-vmcannotbeevicted_{context}"]
 == VMCannotBeEvicted


### PR DESCRIPTION
Version(s):
Main, 4.12+

Issue:
[CNV-69069](https://issues.redhat.com/browse/CNV-69069)

[Link to docs preview](https://105845--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-runbooks.html)

QE review:
- [x] QE has approved this change.

