### PR TITLE
OSDOCS-17824 [NETOBSERV] Update API docs

### DIFF
--- a/modules/network-observability-flowcollector-api-specifications.adoc
+++ b/modules/network-observability-flowcollector-api-specifications.adoc
@@ -94,11 +94,15 @@ Type::
 | `string`
 | `deploymentModel` defines the desired type of deployment for flow processing. Possible values are: +
 
-- `Direct` (default) to make the flow processor listen directly from the agents. Only recommended on small clusters, below 15 nodes. +
+- `Service` (default) to make the flow processor listen as a Kubernetes Service, backed by a scalable Deployment. +
 
 - `Kafka` to make flows sent to a Kafka pipeline before consumption by the processor. +
 
-Kafka can provide better scalability, resiliency, and high availability (for more details, see https://www.redhat.com/en/topics/integration/what-is-apache-kafka).
+- `Direct` to make the flow processor listen directly from the agents using the host network, backed by a DaemonSet. Only recommended on small clusters, below 15 nodes. +
+
+Kafka can provide better scalability, resiliency, and high availability (for more details, see https://www.redhat.com/en/topics/integration/what-is-apache-kafka). +
+
+`Direct` is not recommended on large clusters as it is less memory efficient.
 
 | `exporters`
 | `array`
@@ -185,13 +189,13 @@ override the default Linux capabilities from there.
 
 | `cacheActiveTimeout`
 | `string`
-| `cacheActiveTimeout` is the max period during which the reporter aggregates flows before sending.
+| `cacheActiveTimeout` is the period during which the agent aggregates flows before sending.
 Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load,
 however you can expect higher memory consumption and an increased latency in the flow collection.
 
 | `cacheMaxFlows`
 | `integer`
-| `cacheMaxFlows` is the max number of flows in an aggregate; when reached, the reporter sends the flows.
+| `cacheMaxFlows` is the maximum number of flows in an aggregate; when reached, the reporter sends the flows.
 Increasing `cacheMaxFlows` and `cacheActiveTimeout` can decrease the network traffic overhead and the CPU load,
 however you can expect higher memory consumption and an increased latency in the flow collection.
 
@@ -802,7 +806,8 @@ such as `GOGC` and `GOMAXPROCS` environment variables. Set these values at your 
 
 | `autoscaler`
 | `object`
-| `autoscaler` spec of a horizontal pod autoscaler to set up for the plugin Deployment. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
+| `autoscaler` [deprecated (*)] spec of a horizontal pod autoscaler to set up for the plugin Deployment.
+Deprecation notice: managed autoscaler will be removed in a future version. You might configure instead an autoscaler of your choice, and set `spec.consolePlugin.unmanagedReplicas` to `true`. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
 
 | `enable`
 | `boolean`
@@ -810,19 +815,20 @@ such as `GOGC` and `GOMAXPROCS` environment variables. Set these values at your 
 
 | `imagePullPolicy`
 | `string`
-| `imagePullPolicy` is the Kubernetes pull policy for the image defined above
+| `imagePullPolicy` is the Kubernetes pull policy for the image defined above.
 
 | `logLevel`
 | `string`
-| `logLevel` for the console plugin backend
+| `logLevel` for the console plugin backend.
 
 | `portNaming`
 | `object`
-| `portNaming` defines the configuration of the port-to-service name translation
+| `portNaming` defines the configuration of the port-to-service name translation.
 
 | `quickFilters`
 | `array`
-| `quickFilters` configures quick filter presets for the Console plugin
+| `quickFilters` configures quick filter presets for the Console plugin.
+Filters for external traffic assume the subnet labels are configured to distinguish internal and external traffic (see `spec.processor.subnetLabels`).
 
 | `replicas`
 | `integer`
@@ -831,7 +837,17 @@ such as `GOGC` and `GOMAXPROCS` environment variables. Set these values at your 
 | `resources`
 | `object`
 | `resources`, in terms of compute resources, required by this container.
-For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/.
+
+| `standalone`
+| `boolean`
+| Deploy as a standalone console, instead of a plugin of the {product-title} Console.
+This is not recommended when using with {product-title}, as it doesn't provide an integrated experience.
+[Unsupported (*)].
+
+| `unmanagedReplicas`
+| `boolean`
+| If `unmanagedReplicas` is `true`, the operator will not reconcile `replicas`. This is useful when using a pod autoscaler.
 
 |===
 == .spec.consolePlugin.advanced
@@ -950,7 +966,8 @@ Type::
 Description::
 +
 --
-`autoscaler` spec of a horizontal pod autoscaler to set up for the plugin Deployment. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
+`autoscaler` [deprecated (*)] spec of a horizontal pod autoscaler to set up for the plugin Deployment.
+Deprecation notice: managed autoscaler will be removed in a future version. You might configure instead an autoscaler of your choice, and set `spec.consolePlugin.unmanagedReplicas` to `true`. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
 --
 
 Type::
@@ -963,7 +980,7 @@ Type::
 Description::
 +
 --
-`portNaming` defines the configuration of the port-to-service name translation
+`portNaming` defines the configuration of the port-to-service name translation.
 --
 
 Type::
@@ -990,7 +1007,8 @@ for example, `portNames: {"3100": "loki"}`.
 Description::
 +
 --
-`quickFilters` configures quick filter presets for the Console plugin
+`quickFilters` configures quick filter presets for the Console plugin.
+Filters for external traffic assume the subnet labels are configured to distinguish internal and external traffic (see `spec.processor.subnetLabels`).
 --
 
 Type::
@@ -1038,7 +1056,7 @@ Description::
 +
 --
 `resources`, in terms of compute resources, required by this container.
-For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/.
 --
 
 Type::
@@ -1124,6 +1142,7 @@ Type::
   `object`
 
 Required::
+  - `enterpriseID`
   - `targetHost`
   - `targetPort`
 
@@ -1132,6 +1151,12 @@ Required::
 [cols="1,1,1",options="header"]
 |===
 | Property | Type | Description
+
+| `enterpriseID`
+| `integer`
+| EnterpriseID, or Private Enterprise Number (PEN). To date, Network Observability does not own an assigned number,
+so it is left open for configuration. The PEN is needed to collect non standard data, such as Kubernetes names,
+RTT, etc.
 
 | `targetHost`
 | `string`
@@ -2521,6 +2546,12 @@ Type::
 |===
 | Property | Type | Description
 
+| `installDemoLoki`
+| `boolean`
+| Set `installDemoLoki` to `true` to automatically create Loki deployment, service and storage.
+This is useful for development and demo purposes. Do not use it in production.
+[Unsupported (*)].
+
 | `tenantID`
 | `string`
 | `tenantID` is the Loki `X-Scope-OrgID` header that identifies the tenant for each request.
@@ -2698,7 +2729,7 @@ Type::
 
 | `addZone`
 | `boolean`
-| `addZone` allows availability zone awareness by labelling flows with their source and destination zones.
+| `addZone` allows availability zone awareness by labeling flows with their source and destination zones.
 This feature requires the "topology.kubernetes.io/zone" label to be set on nodes.
 
 | `advanced`
@@ -2710,6 +2741,11 @@ such as `GOGC` and `GOMAXPROCS` environment variables. Set these values at your 
 | `clusterName`
 | `string`
 | `clusterName` is the name of the cluster to appear in the flows data. This is useful in a multi-cluster context. When using {product-title}, leave empty to make it automatically determined.
+
+| `consumerReplicas`
+| `integer`
+| `consumerReplicas` defines the number of replicas (pods) to start for `flowlogs-pipeline`, default is 3.
+This setting is ignored when `spec.deploymentModel` is `Direct` or when `spec.processor.unmanagedReplicas` is `true`.
 
 | `deduper`
 | `object`
@@ -2727,8 +2763,9 @@ but with a lesser improvement in performance.
 
 | `kafkaConsumerAutoscaler`
 | `object`
-| `kafkaConsumerAutoscaler` is the spec of a horizontal pod autoscaler to set up for `flowlogs-pipeline-transformer`, which consumes Kafka messages.
-This setting is ignored when Kafka is disabled. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
+| `kafkaConsumerAutoscaler` [deprecated (*)] is the spec of a horizontal pod autoscaler to set up for `flowlogs-pipeline-transformer`, which consumes Kafka messages.
+This setting is ignored when Kafka is disabled.
+Deprecation notice: managed autoscaler will be removed in a future version. You might configure instead an autoscaler of your choice, and set `spec.processor.unmanagedReplicas` to `true`. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
 
 | `kafkaConsumerBatchSize`
 | `integer`
@@ -2740,8 +2777,9 @@ This setting is ignored when Kafka is disabled. Refer to HorizontalPodAutoscaler
 
 | `kafkaConsumerReplicas`
 | `integer`
-| `kafkaConsumerReplicas` defines the number of replicas (pods) to start for `flowlogs-pipeline-transformer`, which consumes Kafka messages.
+| `kafkaConsumerReplicas` [deprecated (*)] defines the number of replicas (pods) to start for `flowlogs-pipeline-transformer`, which consumes Kafka messages.
 This setting is ignored when Kafka is disabled.
+Deprecation notice: use `spec.processor.consumerReplicas` instead.
 
 | `logLevel`
 | `string`
@@ -2773,10 +2811,18 @@ This setting is ignored when Kafka is disabled.
 | `resources` are the compute resources required by this container.
 For more information, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
+| `slicesConfig`
+| `object`
+| Global configuration managing FlowCollectorSlices custom resources.
+
 | `subnetLabels`
 | `object`
-| `subnetLabels` allows to define custom labels on subnets and IPs or to enable automatic labelling of recognized subnets in {product-title}, which is used to identify cluster external traffic.
+| `subnetLabels` allows to define custom labels on subnets and IPs or to enable automatic labeling of recognized subnets in {product-title}, which is used to identify cluster external traffic.
 When a subnet matches the source or destination IP of a flow, a corresponding field is added: `SrcSubnetLabel` or `DstSubnetLabel`.
+
+| `unmanagedReplicas`
+| `boolean`
+| If `unmanagedReplicas` is `true`, the operator will not reconcile `consumerReplicas`. This is useful when using a pod autoscaler.
 
 |===
 == .spec.processor.advanced
@@ -3043,8 +3089,9 @@ Type::
 Description::
 +
 --
-`kafkaConsumerAutoscaler` is the spec of a horizontal pod autoscaler to set up for `flowlogs-pipeline-transformer`, which consumes Kafka messages.
-This setting is ignored when Kafka is disabled. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
+`kafkaConsumerAutoscaler` [deprecated (*)] is the spec of a horizontal pod autoscaler to set up for `flowlogs-pipeline-transformer`, which consumes Kafka messages.
+This setting is ignored when Kafka is disabled.
+Deprecation notice: managed autoscaler will be removed in a future version. You might configure instead an autoscaler of your choice, and set `spec.processor.unmanagedReplicas` to `true`. Refer to HorizontalPodAutoscaler documentation (autoscaling/v2).
 --
 
 Type::
@@ -3070,18 +3117,18 @@ Type::
 |===
 | Property | Type | Description
 
-| `alerts`
-| `array`
-| `alerts` is a list of alerts to be created for Prometheus AlertManager, organized by templates and variants [Unsupported (*)].
-This is currently an experimental feature behind a feature gate. To enable, edit `spec.processor.advanced.env` by adding `EXPERIMENTAL_ALERTS_HEALTH` set to `true`.
-More information on alerts: https://github.com/netobserv/network-observability-operator/blob/main/docs/Alerts.md
-
 | `disableAlerts`
 | `array (string)`
 | `disableAlerts` is a list of alert groups that should be disabled from the default set of alerts.
 Possible values are: `NetObservNoFlows`, `NetObservLokiError`, `PacketDropsByKernel`, `PacketDropsByDevice`, `IPsecErrors`, `NetpolDenied`,
-`LatencyHighTrend`, `DNSErrors`, `ExternalEgressHighTrend`, `ExternalIngressHighTrend`, `CrossAZ`.
-More information on alerts: https://github.com/netobserv/network-observability-operator/blob/main/docs/Alerts.md
+`LatencyHighTrend`, `DNSErrors`, `DNSNxDomain`, `ExternalEgressHighTrend`, `ExternalIngressHighTrend`, `Ingress5xxErrors`, `IngressHTTPLatencyTrend`.
+More information on alerts: https://github.com/netobserv/network-observability-operator/blob/main/docs/HealthRules.md
+
+| `healthRules`
+| `array`
+| `healthRules` is a list of health rules to be created for Prometheus, organized by templates and variants.
+Each health rule can be configured to generate either alerts or recording rules based on the mode field.
+More information on health rules: https://github.com/netobserv/network-observability-operator/blob/main/docs/HealthRules.md
 
 | `includeList`
 | `array (string)`
@@ -3101,13 +3148,13 @@ More information, with full list of available metrics: https://github.com/netobs
 | Metrics server endpoint configuration for Prometheus scraper
 
 |===
-== .spec.processor.metrics.alerts
+== .spec.processor.metrics.healthRules
 Description::
 +
 --
-`alerts` is a list of alerts to be created for Prometheus AlertManager, organized by templates and variants [Unsupported (*)].
-This is currently an experimental feature behind a feature gate. To enable, edit `spec.processor.advanced.env` by adding `EXPERIMENTAL_ALERTS_HEALTH` set to `true`.
-More information on alerts: https://github.com/netobserv/network-observability-operator/blob/main/docs/Alerts.md
+`healthRules` is a list of health rules to be created for Prometheus, organized by templates and variants.
+Each health rule can be configured to generate either alerts or recording rules based on the mode field.
+More information on health rules: https://github.com/netobserv/network-observability-operator/blob/main/docs/HealthRules.md
 --
 
 Type::
@@ -3116,7 +3163,7 @@ Type::
 
 
 
-== .spec.processor.metrics.alerts[]
+== .spec.processor.metrics.healthRules[]
 Description::
 +
 --
@@ -3136,19 +3183,28 @@ Required::
 |===
 | Property | Type | Description
 
+| `mode`
+| `string`
+| Mode defines whether this health rule should be generated as an alert or a recording rule.
+Possible values are: `Alert` (default), `Recording`.
+Recording rules violations are visible in the Network Health dashboard without generating any Prometheus alert.
+This provides an alternative way of getting Health information for SRE and cluster admins who might find
+many new alerts burdensome.
+
 | `template`
 | `string`
-| Alert template name.
+| Health rule template name.
 Possible values are: `PacketDropsByKernel`, `PacketDropsByDevice`, `IPsecErrors`, `NetpolDenied`,
-`LatencyHighTrend`, `DNSErrors`, `ExternalEgressHighTrend`, `ExternalIngressHighTrend`, `CrossAZ`.
-More information on alerts: https://github.com/netobserv/network-observability-operator/blob/main/docs/Alerts.md
+`LatencyHighTrend`, `DNSErrors`, `DNSNxDomain`, `ExternalEgressHighTrend`, `ExternalIngressHighTrend`, `Ingress5xxErrors`, `IngressHTTPLatencyTrend`.
+Note: `NetObservNoFlows` and `NetObservLokiError` are alert-only and cannot be used as health rules.
+More information on health rules: https://github.com/netobserv/network-observability-operator/blob/main/docs/HealthRules.md
 
 | `variants`
 | `array`
 | A list of variants for this template
 
 |===
-== .spec.processor.metrics.alerts[].variants
+== .spec.processor.metrics.healthRules[].variants
 Description::
 +
 --
@@ -3161,7 +3217,7 @@ Type::
 
 
 
-== .spec.processor.metrics.alerts[].variants[]
+== .spec.processor.metrics.healthRules[].variants[]
 Description::
 +
 --
@@ -3190,26 +3246,34 @@ Required::
 It is provided as an absolute rate (bytes per second or packets per second, depending on the context).
 When provided, it must be parsable as a float.
 
+| `mode`
+| `string`
+| Mode overrides the health rule mode for this specific variant.
+If not specified, inherits from the parent health rule's mode.
+Possible values are: `Alert`, `Recording`.
+
 | `thresholds`
 | `object`
-| Thresholds of the alert per severity.
+| Thresholds of the health rule per severity.
 They are expressed as a percentage of errors above which the alert is triggered. They must be parsable as floats.
+Required for both alert and recording modes
 
 | `trendDuration`
 | `string`
-| For trending alerts, the duration interval for baseline comparison. For example, "2h" means comparing against a 2-hours average. Defaults to 2h.
+| For trending health rules, the duration interval for baseline comparison. For example, "2h" means comparing against a 2-hours average. Defaults to 2h.
 
 | `trendOffset`
 | `string`
-| For trending alerts, the time offset for baseline comparison. For example, "1d" means comparing against yesterday. Defaults to 1d.
+| For trending health rules, the time offset for baseline comparison. For example, "1d" means comparing against yesterday. Defaults to 1d.
 
 |===
-== .spec.processor.metrics.alerts[].variants[].thresholds
+== .spec.processor.metrics.healthRules[].variants[].thresholds
 Description::
 +
 --
-Thresholds of the alert per severity.
+Thresholds of the health rule per severity.
 They are expressed as a percentage of errors above which the alert is triggered. They must be parsable as floats.
+Required for both alert and recording modes
 --
 
 Type::
@@ -3407,11 +3471,50 @@ otherwise to an implementation-defined value. Requests cannot exceed Limits.
 More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 
 |===
+== .spec.processor.slicesConfig
+Description::
++
+--
+Global configuration managing FlowCollectorSlices custom resources.
+--
+
+Type::
+  `object`
+
+Required::
+  - `enable`
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `collectionMode`
+| `string`
+| `collectionMode` determines how the FlowCollectorSlice custom resources impacts the flow collection process: +
+
+- When set to `AlwaysCollect`, all flows are collected regardless of the presence of FlowCollectorSlice. +
+
+- When set to `AllowList`, only the flows related to namespaces where a FlowCollectorSlice resource is present, or configured via the global `namespacesAllowList`, are collected. +
+
+
+| `enable`
+| `boolean`
+| `enable` determines if the FlowCollectorSlice feature is enabled. If not, all resources of kind FlowCollectorSlice are simply ignored.
+
+| `namespacesAllowList`
+| `array (string)`
+| `namespacesAllowList` is a list of namespaces for which flows are always collected, regardless of the presence of FlowCollectorSlice in those namespaces.
+An entry enclosed by slashes, such as `/openshift-.*/`, is matched as a regular expression.
+This setting is ignored if `collectionMode` is different from `AllowList`.
+
+|===
 == .spec.processor.subnetLabels
 Description::
 +
 --
-`subnetLabels` allows to define custom labels on subnets and IPs or to enable automatic labelling of recognized subnets in {product-title}, which is used to identify cluster external traffic.
+`subnetLabels` allows to define custom labels on subnets and IPs or to enable automatic labeling of recognized subnets in {product-title}, which is used to identify cluster external traffic.
 When a subnet matches the source or destination IP of a flow, a corresponding field is added: `SrcSubnetLabel` or `DstSubnetLabel`.
 --
 
@@ -3427,8 +3530,13 @@ Type::
 
 | `customLabels`
 | `array`
-| `customLabels` allows to customize subnets and IPs labelling, such as to identify cluster-external workloads or web services.
-If you enable `openShiftAutoDetect`, `customLabels` can override the detected subnets in case they overlap.
+| `customLabels` allows you to customize subnets and IPs labeling, such as to identify cluster external workloads or web services.
+External subnets must be labeled with the prefix `EXT:`, or not labeled at all, in order to work with default quick filters and some metrics examples provided. +
+
+If `openShiftAutoDetect` is disabled or you are not using {product-title}, it is recommended to manually configure labels for the cluster subnets, to distinguish internal traffic from external traffic. +
+
+If `openShiftAutoDetect` is enabled, `customLabels` overrides the detected subnets when they overlap. +
+
 
 | `openShiftAutoDetect`
 | `boolean`
@@ -3441,8 +3549,13 @@ external traffic: flows that are not labeled for those subnets are external to t
 Description::
 +
 --
-`customLabels` allows to customize subnets and IPs labelling, such as to identify cluster-external workloads or web services.
-If you enable `openShiftAutoDetect`, `customLabels` can override the detected subnets in case they overlap.
+`customLabels` allows you to customize subnets and IPs labeling, such as to identify cluster external workloads or web services.
+External subnets must be labeled with the prefix `EXT:`, or not labeled at all, in order to work with default quick filters and some metrics examples provided. +
+
+If `openShiftAutoDetect` is disabled or you are not using {product-title}, it is recommended to manually configure labels for the cluster subnets, to distinguish internal traffic from external traffic. +
+
+If `openShiftAutoDetect` is enabled, `customLabels` overrides the detected subnets when they overlap. +
+
 --
 
 Type::
@@ -3478,6 +3591,8 @@ Required::
 | `name`
 | `string`
 | Label name, used to flag matching flows.
+External subnets must be labeled with the prefix `EXT:`, or not labeled at all, in order to work with default quick filters and some metrics examples provided. +
+
 
 |===
 == .spec.prometheus
@@ -3539,9 +3654,9 @@ If they are both disabled, the Console plugin is not deployed.
 | `string`
 | `mode` must be set according to the type of Prometheus installation that stores Network Observability metrics: +
 
-- Use `Auto` to try configuring automatically. In {product-title}, it uses the Thanos querier from {product-title} Cluster Monitoring +
+- Use `Auto` to try configuring automatically. In {product-title}, it uses the Thanos querier from {product-title} Cluster Monitoring. +
 
-- Use `Manual` for a manual setup +
+- Use `Manual` for a manual setup. +
 
 
 | `timeout`
@@ -3567,6 +3682,12 @@ Type::
 |===
 | Property | Type | Description
 
+| `alertManager`
+| `object`
+| AlertManager configuration. This is used in the console to query silenced alerts, for displaying health information.
+When used in {product-title} it can be left empty to use the Console API instead.
+[Unsupported (*)].
+
 | `forwardUserToken`
 | `boolean`
 | Set `true` to forward logged in user token in queries to Prometheus
@@ -3578,6 +3699,147 @@ Type::
 | `url`
 | `string`
 | `url` is the address of an existing Prometheus service to use for querying metrics.
+
+|===
+== .spec.prometheus.querier.manual.alertManager
+Description::
++
+--
+AlertManager configuration. This is used in the console to query silenced alerts, for displaying health information.
+When used in {product-title} it can be left empty to use the Console API instead.
+[Unsupported (*)].
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `tls`
+| `object`
+| TLS client configuration for Prometheus AlertManager URL.
+
+| `url`
+| `string`
+| `url` is the address of an existing Prometheus AlertManager service to use for querying alerts.
+
+|===
+== .spec.prometheus.querier.manual.alertManager.tls
+Description::
++
+--
+TLS client configuration for Prometheus AlertManager URL.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `caCert`
+| `object`
+| `caCert` defines the reference of the certificate for the Certificate Authority.
+
+| `enable`
+| `boolean`
+| Enable TLS
+
+| `insecureSkipVerify`
+| `boolean`
+| `insecureSkipVerify` allows skipping client-side verification of the server certificate.
+If set to `true`, the `caCert` field is ignored.
+
+| `userCert`
+| `object`
+| `userCert` defines the user certificate reference and is used for mTLS. When you use one-way TLS, you can ignore this property.
+
+|===
+== .spec.prometheus.querier.manual.alertManager.tls.caCert
+Description::
++
+--
+`caCert` defines the reference of the certificate for the Certificate Authority.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| `certFile` defines the path to the certificate file name within the config map or secret.
+
+| `certKey`
+| `string`
+| `certKey` defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| Name of the config map or secret containing certificates.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the certificate reference: `configmap` or `secret`.
+
+|===
+== .spec.prometheus.querier.manual.alertManager.tls.userCert
+Description::
++
+--
+`userCert` defines the user certificate reference and is used for mTLS. When you use one-way TLS, you can ignore this property.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `certFile`
+| `string`
+| `certFile` defines the path to the certificate file name within the config map or secret.
+
+| `certKey`
+| `string`
+| `certKey` defines the path to the certificate private key file name within the config map or secret. Omit when the key is not necessary.
+
+| `name`
+| `string`
+| Name of the config map or secret containing certificates.
+
+| `namespace`
+| `string`
+| Namespace of the config map or secret containing certificates. If omitted, the default is to use the same namespace as where Network Observability is deployed.
+If the namespace is different, the config map or the secret is copied so that it can be mounted as required.
+
+| `type`
+| `string`
+| Type for the certificate reference: `configmap` or `secret`.
 
 |===
 == .spec.prometheus.querier.manual.tls

--- a/modules/network-observability-flowmetric-api-specifications.adoc
+++ b/modules/network-observability-flowmetric-api-specifications.adoc
@@ -110,6 +110,10 @@ Refer to the documentation for the list of available fields: https://docs.redhat
 | `flatten` is a list of array-type fields that must be flattened, such as Interfaces or NetworkEvents. Flattened fields generate one metric per item in that field.
 For instance, when flattening `Interfaces` on a bytes counter, a flow having Interfaces [br-ex, ens5] increases one counter for `br-ex` and another for `ens5`.
 
+| `help`
+| `string`
+| Help text of the metric, as it appears in Prometheus.
+
 | `labels`
 | `array (string)`
 | `labels` is a list of fields that should be used as Prometheus labels, also known as dimensions (for example: `SrcK8S_Namespace`).

--- a/modules/network-observability-flows-format.adoc
+++ b/modules/network-observability-flows-format.adoc
@@ -57,6 +57,13 @@ The "Cardinality" column gives information about the implied metric cardinality 
 | no
 | avoid
 | dns.latency
+| `DnsName`
+| string
+| DNS queried name
+| `dns_name`
+| no
+| careful
+| n/a
 | `Dscp`
 | number
 | Differentiated Services Code Point (DSCP) value

--- a/modules/network-observability-operator-release-notes-1-4-0-new-features-and-enhancements.adoc
+++ b/modules/network-observability-operator-release-notes-1-4-0-new-features-and-enhancements.adoc
@@ -37,7 +37,7 @@ For more information, see:
 For more information, see:
 
 * xref:../../../observability/network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource]
-* xref:../../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference]
+* xref:../../../observability/network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[FlowCollector API reference]
 
 
 [id="network-observability-without-loki-1.4_{context}"]


### PR DESCRIPTION
[OSDOCS-17824](https://issues.redhat.com//browse/OSDOCS-17824) [NETOBSERV] Update API docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the `no-1.11` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the <no-.11> content just before its GA.

Issue:
https://issues.redhat.com/browse/OSDOCS-17824

Link to docs preview:
* FlowCollector API: https://105853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/flowcollector-api.html
* FlowMetric API: https://105853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/flowmetric-api.html
* FlowsFormat API: https://105853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/json-flows-format-reference.html
* Rel notes 1.4 > New features and enhancements: https://105853--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/release_notes_archive/network-observability-operator-release-notes-archive.html#configuration-enhancements-1.4_network-observability-operator-archived-release-notes --> minor xref update to API docs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Per OCP Core, do not make DITA updates to automatically generated docs until further notice.
* Minor update to xref in another file discovered during troubleshooting build errors. Not part of original Jira issue, but xref is to API docs.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
