### PR TITLE
[service-mesh-docs-3.2] [DOCS] OSSM-11978 3.2.2 Release notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,14 +17,14 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.2.1
+:SMProductVersion: 3.2.2
 //service mesh v2
 //Update when there is a new 2.6.z release
-:SMv2Version: 2.6.10
+:SMv2Version: 2.6.12
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio
-:istio-latest: 1.27.3
+:istio-latest: 1.27.5
 //update istio-latest as necessary
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat

--- a/modules/ossm-release-notes-3-2-1.adoc
+++ b/modules/ossm-release-notes-3-2-1.adoc
@@ -7,6 +7,7 @@
 = {SMProductName} version 3.2.1
 
 [role="_abstract"]
+
 This release of {SMProductName} is included with the {SMProductName} Operator 3.2.1 and is supported on {ocp-product-title} 4.18 and later. This release addresses enhancements and Common Vulnerabilities and Exposures (CVEs).
 
 For supported component versions for 3.2.1, see "Service Mesh version support tables".
@@ -14,9 +15,7 @@ For supported component versions for 3.2.1, see "Service Mesh version support ta
 [id="ossm-enhancements-3-2-1_{context}"]
 == Enhancements
 
-* This enhancement updates Kiali Operator to version 2.17.2.
-
-* This enhancement updates Kiali control plane resource to version 2.4.11.
+* This enhancement updates Kiali Operator and Kiali server to version 2.17.2.
 
 [id="ossm-fixed-issues-3-2-1_{context}"]
 == Fixed issues

--- a/modules/ossm-release-notes-3-2-2.adoc
+++ b/modules/ossm-release-notes-3-2-2.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-2-2_{context}"]
+= {SMProductName} version 3.2.2
+
+[role="_abstract"]
+
+This release of {SMProductName} is included with the {SMProductName} Operator 3.2.2 and is supported on {ocp-product-title} 4.18-4.20. This release addresses enhancements and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.2.2, see "Service Mesh version support tables".
+
+[id="ossm-enhancements-3-2-2_{context}"]
+== Enhancements
+
+* This enhancement updates {istio} to version 1.27.5.
+
+* This enhancement updates Kiali Operator and Kiali server to version 2.17.3.
+
+* This enhancement updates Envoy to version 1.35.8.
+
+* With this update, support for multi-port `InferencePools` is added to align with the Gateway API Inference Extension version 1.1.0.
+
+[id="ossm-fixed-issues-3-2-2_{context}"]
+== Fixed issues
+
+* Before this update, the `must-gather` command failed due to the lack of `rsync` and `tar` tools. As a consequence, users were unable to gather information from the cluster. With this release, the `must-gather` command now uses alternative tools for data collection. As a result, the command successfully downloads data, improving cluster information retrieval.
++
+link:https://issues.redhat.com/browse/OSSM-12404[OSSM-12404]

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,6 +7,41 @@
 = {SMProduct} supported versions
 
 [role="_abstract"]
+
+See the following table for information about {SMProduct} 3.2.2 supported versions.
+
+== {SMProduct} 3.2.2 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.2.2
+
+|{SMProduct} `Istio` control plane resource
+|1.27.5
+
+|{ocp-product-title}
+|4.18-4.20
+
+| Envoy proxy
+| 1.35.8
+
+| `IstioCNI` resource
+| 1.27.5
+
+| `Ztunnel` resource
+| 1.27.5
+
+|Kiali Operator
+|2.17.3
+
+|Kiali server
+|2.17.3
+
+|===
+
 See the following table for information about {SMProduct} 3.2.1 supported versions.
 
 == {SMProduct} 3.2.1 supported versions
@@ -36,8 +71,8 @@ See the following table for information about {SMProduct} 3.2.1 supported versio
 |Kiali Operator
 |2.17.2
 
-|Kiali control plane resource
-|2.4.11
+|Kiali server
+|2.17.2
 
 |===
 

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -7,12 +7,15 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
+
 {SMProductName} release notes contain information about new features and enhancements, and known issues. They contain a set of tables for supported component versions and Istio features, and are organized by {SMProduct} version.
 
 [NOTE]
 ====
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[{ocp-short-name} Operator Life Cycles].
 ====
+
+include::modules/ossm-release-notes-3-2-2.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-2-1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Change type: Doc update; OSSM 3.2.2 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-11978

Fix Version: [service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)

Doc Previews:

- Release notes: https://105855--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes#ossm-release-3-2-2_ossm-release-notes
- Version support table: https://105855--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-2-2-supported-versions

QE Review: @ferhoyos 
Peer Review: @eromanova97 