### PR TITLE
[service-mesh-docs-3.1] [DOCS] OSSM-11978 3.1.5 Release notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,14 +17,14 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.1.4
+:SMProductVersion: 3.1.5
 //service mesh v2
 //Update when there is a new 2.6.z release
-:SMv2Version: 2.6.10
+:SMv2Version: 2.6.12
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio
-:istio-latest: 1.26.4
+:istio-latest: 1.26.8
 //update istio-latest as necessary
 //Kiali Operator
 :KialiProduct: Kiali Operator provided by Red{nbsp}Hat

--- a/modules/ossm-release-notes-3-1-5.adoc
+++ b/modules/ossm-release-notes-3-1-5.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-1-5_{context}"]
+= {SMProductName} version 3.1.5
+
+[role="_abstract"]
+
+This release of {SMProductName} is included with the {SMProductName} Operator 3.1.5 and is supported on {ocp-product-title} 4.16-4.20. This release addresses enhancements and Common Vulnerabilities and Exposures (CVEs).
+
+For supported component versions for 3.1.5, see "Service Mesh version support tables".
+
+[id="ossm-enhancements-3-1-5_{context}"]
+== Enhancements
+
+* This enhancement updates {istio} to version 1.26.8.
+
+* This enhancement updates Kiali server to version 2.11.6.
+
+* This enhancement updates Envoy to version 1.34.12.
+
+[id="ossm-fixed-issues-3-1-5_{context}"]
+== Fixed issues
+
+* Before this update, the `must-gather` command failed due to the lack of `rsync` and `tar` tools. As a consequence, users were unable to gather information from the cluster. With this release, the `must-gather` command now uses alternative tools for data collection. As a result, the command successfully downloads data, improving cluster information retrieval.
++
+link:https://issues.redhat.com/browse/OSSM-12404[OSSM-12404]

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,6 +7,37 @@
 = {SMProduct} supported versions
 
 [role="_abstract"]
+
+See the following table for information about {SMProduct} 3.1.5 supported versions.
+
+== {SMProduct} 3.1.5 supported versions
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.1.5
+
+|{SMProduct} `Istio` control plane resource
+|1.26.8
+
+|{ocp-product-title}
+|4.16-4.20
+
+| Envoy proxy
+| 1.34.12
+
+| `IstioCNI` resource
+| 1.26.8
+
+|Kiali Operator
+|2.17.3
+
+|Kiali server
+|2.11.6
+
+|===
+
 See the following table for information about {SMProduct} 3.1.4 supported versions.
 
 == {SMProduct} 3.1.4 supported versions
@@ -32,7 +63,7 @@ See the following table for information about {SMProduct} 3.1.4 supported versio
 |Kiali Operator
 |2.17.2
 
-|Kiali control plane resource
+|Kiali server
 |2.11.5
 
 |===

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -13,6 +13,8 @@ The {SMProductName} release notes provide details about new features and enhance
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[{ocp-short-name} Operator Life Cycles].
 ====
 
+include::modules/ossm-release-notes-3-1-5.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-1-4.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-1-3.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 3.1.5 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-11978

Fix Version: [service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)

Doc Previews:

- Release notes: https://105856--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes#ossm-release-3-1-5_ossm-release-notes
- Version support table: https://105856--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-1-5-supported-versions

QE Review: @ferhoyos 
Peer Review: @eromanova97 