### PR TITLE
[service-mesh-docs-3.0] [DOCS] OSSM-11978 3.0.8 Release notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -17,10 +17,10 @@
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProduct: OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 3.0.7
+:SMProductVersion: 3.0.8
 //service mesh v2
 //Update when there is a new 2.6.z release
-:SMv2Version: 2.6.10
+:SMv2Version: 2.6.12
 //SMv2Version must be updated with each 2.x release because users can only migrate from the latest 2.x.z version. Update 02/24/2025 for service-mesh-docs-3.0
 //Istio
 :istio: Istio

--- a/modules/ossm-release-notes-3-0-8.adoc
+++ b/modules/ossm-release-notes-3-0-8.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * service-mesh-docs-main/ossm-release-notes/ossm-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-3-0-8_{context}"]
+= {SMProductName} version 3.0.8
+
+[role="_abstract"]
+This release of {SMProductName} is included with the {SMProductName} Operator 3.0.8 and is supported on {ocp-product-title} 4.14-4.19. This release addresses enhancements and Common Vulnerabilities and Exposures (CVEs). 
+
+For supported component versions for 3.0.8, see "Service Mesh version support tables".
+
+[id="ossm-enhancements-3-0-8_{context}"]
+== Enhancements
+
+* This enhancement updates Kiali server to version 2.4.12.
+
+[id="ossm-fixed-issues-3-0-8_{context}"]
+== Fixed issues
+
+* Before this update, the `must-gather` command failed due to the lack of `rsync` and `tar` tools. As a consequence, users were unable to gather information from the cluster. With this release, the `must-gather` command now uses alternative tools for data collection. As a result, the command successfully downloads data, improving cluster information retrieval.
++
+link:https://issues.redhat.com/browse/OSSM-12404[OSSM-12404]

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -7,7 +7,39 @@
 = {SMProduct} supported versions
 
 [role="_abstract"]
-See the following table for information about {SMProduct} 3.0.6 supported versions.
+
+See the following table for information about {SMProduct} 3.0.8 supported versions.
+
+== {SMProduct} 3.0.8 supported versions
+
+[cols="1,1"]
+|===
+| Feature | Supported versions
+
+|{SMProduct} 3 Operator
+|3.0.8
+
+|{SMProduct} `Istio` control plane resource
+|1.24.6
+
+|{ocp-product-title}
+|4.14-4.19
+
+| Envoy proxy
+| 1.32.13
+
+| `IstioCNI` resource
+| 1.24.6
+
+|Kiali Operator
+|2.17.3
+
+|Kiali server
+|2.4.12
+
+|===
+
+See the following table for information about {SMProduct} 3.0.7 supported versions.
 
 == {SMProduct} 3.0.7 supported versions
 
@@ -33,7 +65,7 @@ See the following table for information about {SMProduct} 3.0.6 supported versio
 |Kiali Operator
 |2.17.2
 
-|Kiali control plane resource
+|Kiali server
 |2.4.11
 
 |===

--- a/ossm-release-notes/ossm-release-notes.adoc
+++ b/ossm-release-notes/ossm-release-notes.adoc
@@ -13,6 +13,8 @@ The {SMProductName} release notes provide details about new features and enhance
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift_operators[{ocp-short-name} Operator Life Cycles].
 ====
 
+include::modules/ossm-release-notes-3-0-8.adoc[leveloffset=+1]
+
 include::modules/ossm-release-notes-3-0-7.adoc[leveloffset=+1]
 
 include::modules/ossm-release-notes-3-0-6.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 3.0.8 (At Stage): Release Notes

Doc JIRA: https://issues.redhat.com/browse/OSSM-11978

Fix Version: [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Previews:

- Release notes: https://105858--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes#ossm-release-3-0-8_ossm-release-notes
- Version support table: https://105858--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/ossm-release-notes/ossm-release-notes-version-support-tables#openshift-service-mesh-3-0-8-supported-versions

QE Review: @ferhoyos 
Peer Review: @eromanova97 