### PR TITLE
OSDOCS#18133: rec visibility second pass

### DIFF
--- a/modules/nodes-nodes-resources-configuring-setting.adoc
+++ b/modules/nodes-nodes-resources-configuring-setting.adoc
@@ -13,18 +13,18 @@ By default, {product-title} uses a script on each worker node to automatically d
 
 [IMPORTANT]
 ====
-If you updated your cluster from a version earlier than 4.21, automatic allocation of system resources is disabled by default. To enable the feature, delete the `50-worker-auto-sizing-disabled` machine config. 
+If you updated your cluster from a version earlier than 4.21, automatic allocation of system resources is disabled by default. To enable the feature, delete the `50-worker-auto-sizing-disabled` machine config.
 ====
 
-However, you can manually set these values by using a `KubeletConfig` custom resource (CR) that includes a set of `<resource_type>=<resource_quantity>` pairs (for example, `cpu=200m,memory=512Mi`). You must use the `spec.autoSizingReserved: false` parameter in the `KubeletConfig` CR to override the default {product-title} behavior of automatically setting the `systemReserved` values.  
+However, you can manually set these values by using a `KubeletConfig` custom resource (CR) that includes a set of `<resource_type>=<resource_quantity>` pairs (for example, `cpu=200m,memory=512Mi`). You must use the `spec.autoSizingReserved: false` parameter in the `KubeletConfig` CR to override the default {product-title} behavior of automatically setting the `systemReserved` values.
 
 For `memory` and `ephemeral-storage`, you specify the resource quantity in units of bytes, such as `200Ki`, `50Mi`, or `5Gi`. By default, the `system-reserved` CPU is `500m` and `system-reserved` memory is `1Gi`. For the `cpu` type, you specify the resource quantity in units of cores, such as `200m`, `0.5`, or `1`. Note that 1000 millicores is equal to 1CPU/vCPU.
 
-For details on the recommended `system-reserved` values, refer to the link:https://access.redhat.com/solutions/5843241[recommended system-reserved values].
-
 [IMPORTANT]
 ====
-To manually set resource values, you must use a kubelet configuration. You cannot use a machine config.
+* For details on the recommended `system-reserved` values, refer to the link:https://access.redhat.com/solutions/5843241[recommended system-reserved values].
+
+* To manually set resource values, you must use a kubelet configuration. You cannot use a machine config.
 ====
 
 .Prerequisites

--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -9,6 +9,7 @@ ifndef::openshift-origin[]
 :global_ns: openshift-marketplace
 endif::[]
 
+:_mod-docs-content-type: CONCEPT
 [id="olm-catalogsource_{context}"]
 = Catalog source
 
@@ -22,8 +23,6 @@ Cluster administrators can view the full list of Operators provided by an enable
 The `spec` of a `CatalogSource` object indicates how to construct a pod or how to communicate with a service that serves the Operator Registry gRPC API.
 
 .Example `CatalogSource` object
-[%collapsible]
-====
 [source,yaml,subs="attributes+"]
 ----
 ﻿apiVersion: operators.coreos.com/v1alpha1
@@ -82,7 +81,14 @@ Set the `olm.catalogImageTemplate` annotation to your index image name and use o
 * `grpc` with an `address` field: OLM attempts to contact the gRPC API at the given address. This should not be used in most cases.
 * `configmap`: OLM parses config map data and runs a pod that can serve the gRPC API over it.
 --
-<8> Specify the value of `legacy` or `restricted`. If the field is not set, the default value is `legacy`. In a future {product-title} release, it is planned that the default value will be `restricted`. If your catalog cannot run with `restricted` permissions, it is recommended that you manually set this field to `legacy`.
+<8> Specify the value of `legacy` or `restricted`. If the field is not set, the default value is `legacy`. In a future {product-title} release, it is planned that the default value will be `restricted`.
++
+--
+[NOTE]
+====
+If your catalog cannot run with `restricted` permissions, it is recommended that you manually set this field to `legacy`.
+====
+--
 <9> Optional: For `grpc` type catalog sources, overrides the default node selector for the pod serving the content in `spec.image`, if defined.
 <10> Optional: For `grpc` type catalog sources, overrides the default priority class name for the pod serving the content in `spec.image`, if defined. Kubernetes provides `system-cluster-critical` and `system-node-critical` priority classes by default. Setting the field to empty (`""`) assigns the pod the default priority. Other priority classes can be defined manually.
 <11> Optional: For `grpc` type catalog sources, overrides the default tolerations for the pod serving the content in `spec.image`, if defined.
@@ -98,13 +104,10 @@ Set the `olm.catalogImageTemplate` annotation to your index image name and use o
 See link:https://grpc.github.io/grpc/core/md_doc_connectivity-semantics-and-api.html[States of Connectivity] in the gRPC documentation for more details.
 <14> Latest time the container registry storing the catalog image was polled to ensure the image is up-to-date.
 <15> Status information for the catalog's Operator Registry service.
-====
 
 Referencing the `name` of a `CatalogSource` object in a subscription instructs OLM where to search to find a requested Operator:
 
 .Example `Subscription` object referencing a catalog source
-[%collapsible]
-====
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -118,7 +121,6 @@ spec:
   source: example-catalog
   sourceNamespace: {global_ns}
 ----
-====
 
 ifdef::openshift-origin[]
 :!global_ns:


### PR DESCRIPTION
[OSDOCS-18133](https://issues.redhat.com/browse/OSDOCS-18133)

This PR turns two lines of the docs into notes so that their recommendations are more visible.

Version(s): 4.14+


QE review: Formatting changes only

Previews:

- [Manually allocating resources for nodes](https://105861--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring)
- [Catalog source](https://105861--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-olm.html#olm-catalogsource_olm-understanding-olm)
