### PR TITLE
CNV-61660: Add release note for UI self-validation checkup

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -82,11 +82,16 @@ You can now start a virtual machine (VM) console session by clicking on the name
 link:https://issues.redhat.com/browse/CNV-70942[CNV-70942]
 
 Define OVS bonding in the Node network configuration wizard::
-You can now define an Open vSwitch (OVS) Source Load Balancing (SLB) bonding interface when creating a node network configuration policy in the {product-title} web console. Use the *Uplink connection* tab in the Node network configuration wizard to configure bond network interfaces that provide access to the external physical network to multiple VMs across shared bonded links. 
+You can now define an Open vSwitch (OVS) Source Load Balancing (SLB) bonding interface when creating a node network configuration policy in the {product-title} web console. Use the *Uplink connection* tab in the Node network configuration wizard to configure bond network interfaces that provide access to the external physical network to multiple VMs across shared bonded links.
 +
 For more information, see xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-node-network-config-console_k8s-nmstate-updating-node-network-config[Managing policy from the web console].
 +
 link:https://issues.redhat.com/browse/CNV-70202[CNV-70202]
+
+*Self validation* tab added to the *Checkups* page::
+With this update, cluster administrators can run a self-validation checkup on an {product-title} cluster from the *Self validation* tab in the *Virtualization* -> *Checkups* page of the web console. Users can download detailed results from the checkup as a ZIP file. This feature enables cluster administrators to execute extensive test suites on their clusters, helping to identify and address potential issues in advanced features and configurations.
++
+link:https://issues.redhat.com/browse/CNV-59284[CNV-59284]
 
 // Monitoring
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/CNV-61660

Link to docs preview:
https://105862--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html#virt-4-21-new_virt-4-21-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
