### PR TITLE
OSDOCS-17829 Run Once Duration Override 1.4.0 RNs

### DIFF
--- a/modules/rodoo-rn-1-4-0.adoc
+++ b/modules/rodoo-rn-1-4-0.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="rodoo-rn-1-4-0_{context}"]
+= {run-once-operator} 1.4.0
+
+[role="_abstract"]
+Review the features, enhancements, and advisory for the release of {run-once-operator} 1.4.0.
+
+Issued: 12 February 2026
+
+The following advisory is available for the {run-once-operator} 1.4.0:
+
+* link:https://access.redhat.com/errata/RHBA-2026:2649[RHBA-2026:2649]
+
+[id="rodoo-1-4-0-new-features-and-enhancements_{context}"]
+== New features and enhancements
+
+* This release of the {run-once-operator} updates the Kubernetes version to 1.34.
+
+* Users should set `.spec.managementState: Managed` in {run-once-operator} 1.4.0 custom resources (CR). In a future release, the `spec.managementState` field in the {run-once-operator} CR will be required to be set to `Managed`.
+
+[id="rodoo-rn-1-4-0-bug-fixes_{context}"]
+== Bug fixes
+
+* This release of the {run-once-operator} addresses several Common Vulnerabilities and Exposures (CVEs).

--- a/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
+++ b/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.adoc
@@ -15,5 +15,5 @@ These release notes track the development of the {run-once-operator} for {produc
 
 For an overview of the {run-once-operator}, see xref:../../../nodes/pods/run_once_duration_override/index.adoc#run-once-about_run-once-duration-override-about[About the {run-once-operator}].
 
-:operator-name: The {run-once-operator}
-include::snippets/operator-not-available.adoc[]
+//1.4.0 release notes
+include::modules/rodoo-rn-1-4-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.21+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-17829](https://issues.redhat.com//browse/OSDOCS-17829)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://105863--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-release-notes.html#rodoo-rn-1-4-0_run-once-duration-override-release-notes 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: GA is February 12, 2026.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
