### PR TITLE
CNV-61659: Reorg checkups docs for DITA, add self-validation checkups

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4814,6 +4814,8 @@ Topics:
     File: virt-post-install-network-config
   - Name: Storage configuration
     File: virt-post-install-storage-config
+  - Name: Self validation checkups
+    File: virt-self-validation-checkups
   - Name: Performance optimization
     File: virt-perf-optimization
   - Name: Configuring higher VM workload density
@@ -5054,6 +5056,10 @@ Topics:
     File: virt-monitoring-overview
   - Name: Cluster checkup framework
     File: virt-running-cluster-checkups
+  - Name: Latency checkups
+    File: virt-latency-checkups
+  - Name: Storage checkups
+    File: virt-storage-checkups
   - Name: Prometheus queries for virtual resources
     File: virt-prometheus-queries
   - Name: Virtual machine custom metrics

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1449,6 +1449,9 @@ Topics:
 #     File: virt-post-install-network-config
 #   - Name: Storage configuration
 #     File: virt-post-install-storage-config
+## Hiding in ROSA/OSD as Cluster checkup framework TP not supported
+##  - Name: Self validation checkups
+##    File: virt-self-validation-checkups
 # - Name: Updating
 #   Dir: updating
 #   Topics:
@@ -1640,9 +1643,13 @@ Topics:
 #   Topics:
 #   - Name: Monitoring overview
 #     File: virt-monitoring-overview
-# # Hiding in ROSA/OSD as TP not supported
-# #  - Name: Cluster checkup framework
-# #    File: virt-running-cluster-checkups
+## Hiding in ROSA/OSD as TP not supported
+##  - Name: Cluster checkup framework
+##    File: virt-running-cluster-checkups
+##  - Name: Latency checkups
+##    File: virt-latency-checkups
+##  - Name: Storage checkups
+##    File: virt-storage-checkups
 #   - Name: Prometheus queries for virtual resources
 #     File: virt-prometheus-queries
 #   - Name: Virtual machine custom metrics

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1730,6 +1730,9 @@ Topics:
     File: virt-post-install-network-config
   - Name: Storage configuration
     File: virt-post-install-storage-config
+# Hiding in ROSA/OSD as Cluster checkup framework TP not supported
+#  - Name: Self validation checkups
+#    File: virt-self-validation-checkups
   - Name: Configuring certificate rotation
     File: virt-configuring-certificate-rotation
 - Name: Updating
@@ -1940,6 +1943,10 @@ Topics:
 # Hiding in ROSA/OSD as TP not supported
 #  - Name: Cluster checkup framework
 #    File: virt-running-cluster-checkups
+#  - Name: Latency checkups
+#    File: virt-latency-checkups
+#  - Name: Storage checkups
+#    File: virt-storage-checkups
   - Name: Prometheus queries for virtual resources
     File: virt-prometheus-queries
   - Name: Virtual machine custom metrics

--- a/_topic_maps/_topic_map_rosa_hcp.yml
+++ b/_topic_maps/_topic_map_rosa_hcp.yml
@@ -1576,6 +1576,9 @@ Topics:
     File: virt-post-install-network-config
   - Name: Storage configuration
     File: virt-post-install-storage-config
+# Hiding in ROSA/OSD as Cluster checkup framework TP not supported
+#  - Name: Self validation checkups
+#    File: virt-self-validation-checkups
   - Name: Configuring certificate rotation
     File: virt-configuring-certificate-rotation
 - Name: Updating
@@ -1786,6 +1789,10 @@ Topics:
 # Hiding in ROSA/OSD as TP not supported
 #  - Name: Cluster checkup framework
 #    File: virt-running-cluster-checkups
+#  - Name: Latency checkups
+#    File: virt-latency-checkups
+#  - Name: Storage checkups
+#    File: virt-storage-checkups
   - Name: Prometheus queries for virtual resources
     File: virt-prometheus-queries
   - Name: Virtual machine custom metrics

--- a/modules/virt-run-self-validation-checkup-web-console.adoc
+++ b/modules/virt-run-self-validation-checkup-web-console.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * virt/post_installation_configuration/virt-self-validation-checkups.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-run-self-validation-checkup-web-console_{context}"]
+= Run a self validation checkup in the web console
+
+[role="_abstract"]
+Running a self validation checkup streamlines the process of running functional tests, which enables you to validate the stability, health, and compliance of an {VirtProductName} installation before deploying workloads. You can run a self validation checkup as a cluster administrator in the {product-title} web console.
+
+.Prerequisites
+
+* You have cluster administrator permissions.
+* You have access to an {product-title} cluster where {VirtProductName} is installed.
+* You are logged in to the {product-title} web console.
+
+.Procedure
+
+. In the {product-title} web console, go to *Virtualization* -> *Checkups*.
+. Go to the *Self validation* tab.
+. Click *Run checkup*.
+. Configure settings for the test that you want to run.
+. Optional: You can enable a dry run test by clicking *Advanced settings* and then toggling the *Dry run* button.
+. Click *Run*. The *Self validation checkup details* page is displayed.
++
+You can observe the self validation checkup running in real time. The test can take several hours to complete.
+
+. After the test is complete, you can view high-level results in the *Self validation checkup details* page, including the names of any failing tests.
+. Optional: You can download detailed results as a ZIP file by clicking *Download results* in the *Self validation checkup details* page.

--- a/snippets/virt-about-running-checkups.adoc
+++ b/snippets/virt-about-running-checkups.adoc
@@ -5,6 +5,8 @@
 // Text snippet included in the following assemblies:
 //
 // * /virt/monitoring/virt-running-cluster-checkups.adoc
+// * virt/monitoring/virt-storage-checkups.adoc
+// * virt/monitoring/virt-latency-checkups.adoc
 
 :_mod-docs-content-type: SNIPPET
 

--- a/virt/install/installing-virt.adoc
+++ b/virt/install/installing-virt.adoc
@@ -69,4 +69,9 @@ endif::openshift-dedicated[]
 [id="installing-virt-web-next-steps"]
 == Next steps
 
+// Until cluster checkup framework is supported in ROSA/OSD this is just for OCP
+ifdef::openshift-enterprise[]
+* As a cluster administrator, you can run a xref:../../virt/post_installation_configuration/virt-self-validation-checkups.adoc#virt-self-validation-checkups[self validation checkup] to verify that the environment is fully functional and self-sustained before you deploy production workloads.
+endif::openshift-enterprise[]
+
 * The xref:../../virt/storage/virt-configuring-local-storage-with-hpp.adoc#virt-creating-hpp-basic-storage-pool_virt-configuring-local-storage-with-hpp[hostpath provisioner] is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.

--- a/virt/monitoring/virt-latency-checkups.adoc
+++ b/virt/monitoring/virt-latency-checkups.adoc
@@ -1,0 +1,21 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="virt-latency-checkups"]
+= Latency checkups
+:context: virt-latency-checkups
+
+toc::[]
+
+[role="_abstract"]
+You can use a latency checkup to verify network connectivity and measure latency between two virtual machines (VMs) that are attached to a secondary network interface. The predefined latency checkup uses the ping utility.
+
+[IMPORTANT]
+=====
+Before you run a latency checkup, you must first xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[create a bridge interface] on the cluster nodes to connect the VM's secondary interface to any interface on the node. If you do not create a bridge interface, the VMs do not start and the job fails.
+=====
+
+include::snippets/virt-about-running-checkups.adoc[]
+
+include::modules/virt-latency-checkup-web-console.adoc[leveloffset=+1]
+
+include::modules/virt-measuring-latency-vm-secondary-network.adoc[leveloffset=+1]

--- a/virt/monitoring/virt-running-cluster-checkups.adoc
+++ b/virt/monitoring/virt-running-cluster-checkups.adoc
@@ -14,43 +14,7 @@ include::snippets/technology-preview.adoc[]
 
 As a developer or cluster administrator, you can use predefined checkups to improve cluster maintainability, troubleshoot unexpected behavior, minimize errors, and save time. You can review the results of the checkup and share them with experts for further analysis. Vendors can write and publish checkups for features or services that they provide and verify that their customer environments are configured correctly.
 
-[id="virt-running-cluster-checkups-latency"]
-== Running predefined latency checkups
-
-You can use a latency checkup to verify network connectivity and measure latency between two virtual machines (VMs) that are attached to a secondary network interface. The predefined latency checkup uses the ping utility.
-
-[IMPORTANT]
-=====
-Before you run a latency checkup, you must first xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[create a bridge interface] on the cluster nodes to connect the VM's secondary interface to any interface on the node. If you do not create a bridge interface, the VMs do not start and the job fails.
-=====
-
 include::snippets/virt-about-running-checkups.adoc[]
-
-include::modules/virt-latency-checkup-web-console.adoc[leveloffset=+2]
-
-include::modules/virt-measuring-latency-vm-secondary-network.adoc[leveloffset=+2]
-
-[id="virt-running-cluster-checkups-storage"]
-== Running predefined storage checkups
-
-You can use a storage checkup to verify that the cluster storage is optimally configured for {VirtProductName}.
-
-include::snippets/virt-about-running-checkups.adoc[]
-
-include::modules/virt-retain-storage-checkup-resources.adoc[leveloffset=+2]
-
-include::modules/virt-storage-checkup-web-console.adoc[leveloffset=+2]
-
-include::modules/virt-checking-storage-configuration.adoc[leveloffset=+2]
-
-include::modules/virt-troubleshoot-storage-checkup.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../virt/support/virt-collecting-virt-data.adoc#virt-collecting-virt-data[Collecting data for Red{nbsp}Hat Support]
-* xref:../../virt/support/virt-collecting-virt-data.adoc#virt-using-virt-must-gather_virt-collecting-virt-data[Using the `must-gather` tool for {VirtProductName}]
-
-include::modules/virt-troubleshoot-storage-checkup-error-codes.adoc[leveloffset=+2]
 
 ifndef::openshift-rosa,openshift-dedicated,openshift-rosa-hcp[]
 [role="_additional-resources"]

--- a/virt/monitoring/virt-storage-checkups.adoc
+++ b/virt/monitoring/virt-storage-checkups.adoc
@@ -1,0 +1,27 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="virt-storage-checkups"]
+= Storage checkups
+:context: virt-storage-checkups
+
+toc::[]
+
+[role="_abstract"]
+You can use a storage checkup to verify that the cluster storage is optimally configured for {VirtProductName}.
+
+include::snippets/virt-about-running-checkups.adoc[]
+
+include::modules/virt-retain-storage-checkup-resources.adoc[leveloffset=+1]
+
+include::modules/virt-storage-checkup-web-console.adoc[leveloffset=+1]
+
+include::modules/virt-checking-storage-configuration.adoc[leveloffset=+1]
+
+include::modules/virt-troubleshoot-storage-checkup.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../virt/support/virt-collecting-virt-data.adoc#virt-collecting-virt-data[Collecting data for Red{nbsp}Hat Support]
+* xref:../../virt/support/virt-collecting-virt-data.adoc#virt-using-virt-must-gather_virt-collecting-virt-data[Using the `must-gather` tool for {VirtProductName}]
+
+include::modules/virt-troubleshoot-storage-checkup-error-codes.adoc[leveloffset=+1]

--- a/virt/post_installation_configuration/virt-self-validation-checkups.adoc
+++ b/virt/post_installation_configuration/virt-self-validation-checkups.adoc
@@ -1,0 +1,16 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="virt-self-validation-checkups"]
+= Self validation checkup
+:context: virt-self-validation-checkups
+
+toc::[]
+
+[role="_abstract"]
+As a cluster administrator, you can run a self validation checkup to validate the stability, health, and compliance of an {VirtProductName} installation. A self validation checkup enables you to run conformance tests on critical subsystems, such as networking and storage, to verify that the environment is fully functional and self-sustained before you deploy production workloads.
+
+Running a self validation checkup streamlines the process of running functional tests, which are fully aligned with the exact build version of {VirtProductName} currently installed on the cluster.
+
+You can view high-level summaries and detailed logs in a downloaded results file, or run tier 2 tests, enabling you to identify and resolve configuration issues without requiring external support immediately.
+
+include::modules/virt-run-self-validation-checkup-web-console.adoc[leveloffset=+1]

--- a/virt/vm_networking/virt-using-dpdk-with-sriov.adoc
+++ b/virt/vm_networking/virt-using-dpdk-with-sriov.adoc
@@ -30,8 +30,7 @@ include::modules/virt-configuring-vm-project-dpdk.adoc[leveloffset=+1]
 
 [role="_additional-resources_configuring-project-dpdk"]
 .Additional resources
-* xref:../../applications/projects/working-with-projects.adoc#working-with-projects[Working with projects] 
-* xref:../../virt/monitoring/virt-running-cluster-checkups.adoc#virt-measuring-latency-vm-secondary-network_virt-running-cluster-checkups[Virtual machine latency checkup]
+* xref:../../applications/projects/working-with-projects.adoc#working-with-projects[Working with projects]
+* xref:../../virt/monitoring/virt-latency-checkups.adoc#virt-measuring-latency-vm-secondary-network_virt-latency-checkups[Virtual machine latency checkup]
 
 include::modules/virt-configuring-vm-dpdk.adoc[leveloffset=+1]
-


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/CNV-61659

Link to docs preview:
- New content
  - https://105867--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-self-validation-checkups.html
  - https://105867--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/install/installing-virt.html#installing-virt-web-next-steps

- Moved existing content
  - https://105867--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups
  - https://105867--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-latency-checkups
  - https://105867--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-storage-checkups

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
For DITA migration, assemblies cannot have text in between `include` statements, so I split the original checkups assembly into different assemblies for different checkup types to align with the DITA requirements.
This was before I realized that it probably made more sense for the self validation checkup to actually be in the postinstallation docs section, since this should be run before any workloads are deployed.
