### PR TITLE
OSDOCS 16929 CQA2.0 of NODES-2: Node Management and Maintenance

### DIFF
--- a/modules/adding-node-iso-configs.adoc
+++ b/modules/adding-node-iso-configs.adoc
@@ -6,14 +6,12 @@
 [id="adding-node-iso-configs_{context}"]
 = Cluster configuration reference
 
-When creating the ISO image, configurations are retrieved from the target cluster and are applied to the new nodes.
-Any configurations for your cluster are applied to the nodes unless you override the configurations in either the `nodes-config.yaml` file or any flags you add to the `oc adm node-image create` command.
+[role="_abstract"]
+When creating the ISO image, configurations are retrieved from the target cluster and are applied to the new nodes. You can override these configurations by specifying new values in either the `nodes-config.yaml` file or any flags you add to the `oc adm node-image create` command before you create the ISO image.
 
-[id="adding-node-iso-yaml-config_{context}"]
-== YAML file parameters
-
+YAML file parameters::
 Configuration parameters that can be specified in the `nodes-config.yaml` file are described in the following table:
-
++
 .`nodes-config.yaml` parameters
 [cols=".^4l,.^3,.^2",options="header"]
 |====
@@ -87,14 +85,11 @@ You must also set the `--pxe` flag to generate PXE assets instead of an ISO imag
 
 |====
 
-
-[id="adding-node-iso-flags-config_{context}"]
-== Command flag options
-
+Command flag options::
 You can use command flags with the `oc adm node-image create` command to configure the nodes you are creating.
-
++
 The following table describes command flags that are not limited to the single-node use case:
-
++
 .General command flags
 [cols=".^4,.^3,.^2",options="header"]
 |====
@@ -143,9 +138,9 @@ Bypass verification only if the registry is known to be trustworthy.
 |Boolean
 
 |====
-
++
 The following table describes command flags that can be used only when creating a single node:
-
++
 .Single-node only command flags
 [cols=".^4,.^3,.^2",options="header"]
 |====

--- a/modules/adding-node-iso-flags.adoc
+++ b/modules/adding-node-iso-flags.adoc
@@ -6,6 +6,7 @@
 [id="adding-node-iso-flags_{context}"]
 = Adding a node with command flags
 
+[role="_abstract"]
 You can add a single node to your cluster by using command flags to specify configurations for the new node.
 
 .Prerequisites

--- a/modules/adding-node-iso-yaml.adoc
+++ b/modules/adding-node-iso-yaml.adoc
@@ -6,6 +6,7 @@
 [id="adding-node-iso-yaml_{context}"]
 = Adding one or more nodes using a configuration file
 
+[role="_abstract"]
 You can add one or more nodes to your cluster by using the `nodes-config.yaml` file to specify configurations for the new nodes.
 
 .Prerequisites

--- a/modules/nodes-nodes-garbage-collection-configuring.adoc
+++ b/modules/nodes-nodes-garbage-collection-configuring.adoc
@@ -8,7 +8,8 @@
 [id="nodes-nodes-garbage-collection-configuring_{context}"]
 = Configuring garbage collection for containers and images
 
-As an administrator, you can configure how {product-title} performs garbage collection by creating a `kubeletConfig` object for each machine config pool.
+[role="_abstract"]
+As an administrator, you can configure how {product-title} performs garbage collection by creating a `kubeletConfig` object for each machine config pool. Performing garbage collection helps ensure that your nodes are running efficiently.
 
 [NOTE]
 ====
@@ -48,11 +49,13 @@ metadata:
   creationTimestamp: "2022-11-16T15:34:25Z"
   generation: 4
   labels:
-    pools.operator.machineconfiguration.openshift.io/worker: "" <1>
+    pools.operator.machineconfiguration.openshift.io/worker: ""
   name: worker
 #...
 ----
-<1> The label appears under Labels.
+where:
++
+`metadata.labels`:: Specifies a label to use with the kubelet configuration.
 +
 [TIP]
 ====
@@ -78,47 +81,49 @@ If there is one file system, or if `/var/lib/kubelet` and `/var/lib/containers/`
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
-  name: worker-kubeconfig <1>
+  name: worker-kubeconfig
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      pools.operator.machineconfiguration.openshift.io/worker: "" <2>
+      pools.operator.machineconfiguration.openshift.io/worker: ""
   kubeletConfig:
-    evictionSoft: <3>
-      memory.available: "500Mi" <4>
+    evictionSoft:
+      memory.available: "500Mi"
       nodefs.available: "10%"
       nodefs.inodesFree: "5%"
       imagefs.available: "15%"
       imagefs.inodesFree: "10%"
-    evictionSoftGracePeriod:  <5>
+    evictionSoftGracePeriod:
       memory.available: "1m30s"
       nodefs.available: "1m30s"
       nodefs.inodesFree: "1m30s"
       imagefs.available: "1m30s"
       imagefs.inodesFree: "1m30s"
-    evictionHard: <6>
+    evictionHard:
       memory.available: "200Mi"
       nodefs.available: "5%"
       nodefs.inodesFree: "4%"
       imagefs.available: "10%"
       imagefs.inodesFree: "5%"
-    evictionPressureTransitionPeriod: 3m <7>
-    imageMinimumGCAge: 5m <8>
-    imageGCHighThresholdPercent: 80 <9>
-    imageGCLowThresholdPercent: 75 <10>
+    evictionPressureTransitionPeriod: 3m
+    imageMinimumGCAge: 5m
+    imageGCHighThresholdPercent: 80
+    imageGCLowThresholdPercent: 75
 #...
 ----
-<1> Name for the object.
-<2> Specify the label from the machine config pool.
-<3> For container garbage collection: Type of eviction: `evictionSoft` or `evictionHard`.
-<4> For container garbage collection: Eviction thresholds based on a specific eviction trigger signal.
-<5> For container garbage collection: Grace periods for the soft eviction. This parameter does not apply to `eviction-hard`.
-<6> For container garbage collection: Eviction thresholds based on a specific eviction trigger signal.
-For `evictionHard` you must specify all of these parameters.  If you do not specify all parameters, only the specified parameters are applied and the garbage collection will not function properly.
-<7> For container garbage collection: The duration to wait before transitioning out of an eviction pressure condition. Setting the `evictionPressureTransitionPeriod` parameter to `0` configures the default value of 5 minutes.
-<8> For image garbage collection: The minimum age for an unused image before the image is removed by garbage collection.
-<9> For image garbage collection: Image garbage collection is triggered at the specified percent of disk usage (expressed as an integer). This value must be greater than the `imageGCLowThresholdPercent` value.
-<10> For image garbage collection: Image garbage collection attempts to free resources to the specified percent of disk usage (expressed as an integer). This value must be less than the `imageGCHighThresholdPercent` value.
+where:
++
+--
+`metadata.name`:: Specifies a name for the object.
+`spec.machineConfigPoolSelector.matchLabels`:: Specifies the label from the machine config pool.
+`spec.kubeletConfig.evictionSoft`:: Specifies a soft eviction and eviction thresholds for container garbage collection.
+`spec.kubeletConfig.evictionSoftGracePeriod`:: Specifies a grace period for the soft eviction of containers. This parameter does not apply to `eviction-hard`.
+`spec.kubeletConfig.evictionHard`:: Specifies a soft eviction and eviction thresholds for container garbage collection. For `evictionHard` you must specify all of these parameters. If you do not specify all parameters, only the specified parameters are applied and the garbage collection will not function properly.
+`spec.kubeletConfig.evictionPressureTransitionPeriod`:: Specifies the duration to wait before transitioning out of an eviction pressure condition for container garbage collection. Setting the `evictionPressureTransitionPeriod` parameter to `0` configures the default value of 5 minutes.
+`spec.kubeletConfig.imageMinimumGCAge`:: Specifies the minimum age for an unused image before the image is removed by garbage collection.
+`spec.kubeletConfig.imageGCHighThresholdPercent`:: Specifies the percent of disk usage, expressed as an integer, that triggers image garbage collection. This value must be greater than the `imageGCLowThresholdPercent` value.
+`spec.kubeletConfig.imageGCHighThresholdPercent`:: Specifies the percent of disk usage, expressed as an integer, to which image garbage collection attempts to free. This value must be less than the `imageGCHighThresholdPercent` value.
+--
 
 . Run the following command to create the CR:
 +
@@ -142,7 +147,7 @@ kubeletconfig.machineconfiguration.openshift.io/gc-container created
 
 .Verification
 
-. Verify that garbage collection is active by entering the following command. The Machine Config Pool you specified in the custom resource appears with `UPDATING` as 'true` until the change is fully implemented:
+* Verify that garbage collection is active by entering the following command. The Machine Config Pool you specified in the custom resource appears with `UPDATING` as 'true` until the change is fully implemented:
 +
 [source,terminal]
 ----

--- a/modules/nodes-nodes-garbage-collection-containers.adoc
+++ b/modules/nodes-nodes-garbage-collection-containers.adoc
@@ -8,7 +8,8 @@
 [id="nodes-nodes-garbage-collection-containers_{context}"]
 = Understanding how terminated containers are removed through garbage collection
 
-Container garbage collection removes terminated containers by using eviction thresholds.
+[role="_abstract"]
+You can help ensure that your nodes are running efficiently by using container garbage collection to remove terminated containers.
 
 When eviction thresholds are set for garbage collection, the node tries to keep any container for any pod accessible from the API. If the pod has been deleted, the containers will be as well. Containers are preserved as long the pod is not deleted and the eviction threshold is not reached. If the node is under disk pressure, it will remove containers and their logs will no longer be accessible using `oc logs`.
 

--- a/modules/nodes-nodes-garbage-collection-images.adoc
+++ b/modules/nodes-nodes-garbage-collection-images.adoc
@@ -7,7 +7,8 @@
 [id="nodes-nodes-garbage-collection-images_{context}"]
 = Understanding how images are removed through garbage collection
 
-Image garbage collection removes images that are not referenced by any running pods.
+[role="_abstract"]
+You can help ensure that your nodes are running efficiently by using image garbage collection to removes images that are not referenced by any running pods.
 
 {product-title} determines which images to remove from a node based on the disk usage that is reported by *cAdvisor*.
 

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -8,7 +8,9 @@
 = Adding kernel arguments to nodes
 
 [role="_abstract"] 
-In some special cases, you might want to add kernel arguments to a set of nodes in your cluster. This should only be done with caution and clear understanding of the implications of the arguments you set.
+In some special cases, you can add kernel arguments to a set of nodes in your cluster to customize the kernel behavior to meet specific needs you might have. 
+
+You should add kernel arguments with caution and a clear understanding of the implications of the arguments you set.
 
 [WARNING]
 ====
@@ -79,14 +81,14 @@ metadata:
   name: 05-worker-kernelarg-selinuxpermissive
 spec:
   kernelArguments:
-    - enforcing=0<3>
+    - enforcing=0
 ----
 +
 where:
 +
-`machineconfiguration.openshift.io/role`:: Applies the new kernel argument only to worker nodes.
-`name`:: Named to identify where it fits among the machine configs (05) and what it does (adds a kernel argument to configure SELinux permissive mode).
-`kernelArguments`:: Identifies the exact kernel argument as `enforcing=0`. 
+`machineconfiguration.openshift.io/role`:: Specifies a label to apply changes to specific nodes.
+`name`:: Specifies a name to identify where it fits among the machine configs (05) and what it does (adds a kernel argument to configure SELinux permissive mode).
+`kernelArguments`:: Specifies the exact kernel argument as `enforcing=0`. 
 
 . Create the new machine config:
 +

--- a/modules/nodes-nodes-managing-about.adoc
+++ b/modules/nodes-nodes-managing-about.adoc
@@ -9,6 +9,18 @@
 [role="_abstract"] 
 To make configuration changes to a cluster, or machine pool, you must create a custom resource definition (CRD), or `kubeletConfig` object. {product-title} uses the Machine Config Controller to watch for changes introduced through the CRD to apply the changes to the cluster.
 
+Most https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/[Kubelet Configuration options] can be set by the user. However, you cannot overwrite the following options:
+
+* CgroupDriver
+* ClusterDNS
+* ClusterDomain
+* StaticPodPath
+
+[NOTE]
+====
+If a single node contains more than 50 images, pod scheduling might be imbalanced across nodes. This is because the list of images on a node is shortened to 50 by default. You can disable the image limit by editing the `KubeletConfig` object and setting the value of `nodeStatusMaxImages` to `-1`.
+====
+
 [NOTE]
 ====
 Because the fields in a `kubeletConfig` object are passed directly to the kubelet from upstream Kubernetes, the validation of those fields is handled directly by the kubelet itself. Please refer to the relevant Kubernetes documentation for the valid values for these fields. Invalid values in the `kubeletConfig` object can render cluster nodes unusable.
@@ -85,15 +97,3 @@ For example:
 ----
 $ oc create -f master-kube-config.yaml
 ----
-
-Most https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/[Kubelet Configuration options] can be set by the user. The following options are not allowed to be overwritten:
-
-* CgroupDriver
-* ClusterDNS
-* ClusterDomain
-* StaticPodPath
-
-[NOTE]
-====
-If a single node contains more than 50 images, pod scheduling might be imbalanced across nodes. This is because the list of images on a node is shortened to 50 by default. You can disable the image limit by editing the `KubeletConfig` object and setting the value of `nodeStatusMaxImages` to `-1`.
-====

--- a/modules/nodes-nodes-parallel-container-pulls-configure.adoc
+++ b/modules/nodes-nodes-parallel-container-pulls-configure.adoc
@@ -44,8 +44,8 @@ spec:
 +
 where:
 +
-`serializeImagePulls`:: Set to `false` to enable parallel image pulls. Set to `true` to force serial image pulling. The default is `false`.
-`maxParallelImagePulls`:: Specify the maximum number of images that can be pulled in parallel. Enter a number or set to `nil` to specify no limit. This field cannot be set if `SerializeImagePulls` is `true`. The default is `nil`.
+`serializeImagePulls`:: Specifies whether parallel pulling is enabled for the nodes in the associated machine config pool. Set to `false` to enable parallel image pulls. Set to `true` to force serial image pulling. The default is `false`.
+`maxParallelImagePulls`:: Specifies the maximum number of images that can be pulled in parallel. Enter a number or set to `nil` to specify no limit. This field cannot be set if `SerializeImagePulls` is `true`. The default is `nil`.
 
 . Create the new machine config by running a command similar to the following:
 +
@@ -69,15 +69,15 @@ NAME                                                GENERATEDBYCONTROLLER       
 00-master                                           70025364a114fc3067b2e82ce47fdb0149630e4b     3.5.0             133m
 00-worker                                           70025364a114fc3067b2e82ce47fdb0149630e4b     3.5.0             133m
 # ...
-99-parallel-generated-kubelet                       70025364a114fc3067b2e82ce47fdb0149630e4b     3.5.0             15s <1>
+99-parallel-generated-kubelet                       70025364a114fc3067b2e82ce47fdb0149630e4b     3.5.0             15s
 # ...
-rendered-parallel-c634a80f644740974ceb40c054c79e50  70025364a114fc3067b2e82ce47fdb0149630e4b     3.5.0             10s <2>
+rendered-parallel-c634a80f644740974ceb40c054c79e50  70025364a114fc3067b2e82ce47fdb0149630e4b     3.5.0             10s
 ----
 +
 where:
 +
-`99-parallel-generated-kubelet`:: The new machine config. In this example, the machine config is for the `parallel` custom machine config pool. 
-`rendered-parallel-<sha_numnber>`:: The new rendered machine config. In this example, the machine config is for the `parallel` custom machine config pool. 
+`99-parallel-generated-kubelet`:: Specifies the new machine config. In this example, the machine config is for the `parallel` custom machine config pool. 
+`rendered-parallel-<sha_numnber>`:: Specifies the new rendered machine config. In this example, the machine config is for the `parallel` custom machine config pool. 
 
 . Check to see that the nodes in the `parallel` machine config pool are being updated by running the following command:
 +

--- a/modules/nodes-nodes-rebooting-affinity.adoc
+++ b/modules/nodes-nodes-rebooting-affinity.adoc
@@ -6,7 +6,10 @@
 [id="nodes-nodes-rebooting-affinity_{context}"]
 = Rebooting a node using pod anti-affinity
 
-Pod anti-affinity is slightly different than node anti-affinity. Node anti-affinity can be
+[role="_abstract"]
+You can use pod anti-affinity to spread the workloads on a node to other nodes before performing a graceful node restart.
+
+Pod anti-affinity is slightly different from node anti-affinity. Node anti-affinity can be
 violated if there are no other suitable locations to deploy a pod. Pod
 anti-affinity can be set to either required or preferred.
 
@@ -14,9 +17,9 @@ With this in place, if only two infrastructure nodes are available and one is re
 pod is prevented from running on the other node. `*oc get pods*` reports the pod as unready until a suitable node is available.
 Once a node is available and all pods are back in ready state, the next node can be restarted.
 
-.Procedure
+The following procedure demonstrates how to reboot a node by using pod anti-affinity.
 
-To reboot a node using pod anti-affinity:
+.Procedure
 
 . Edit the node specification to configure pod anti-affinity:
 +
@@ -28,24 +31,26 @@ metadata:
   name: with-pod-antiaffinity
 spec:
   affinity:
-    podAntiAffinity: <1>
-      preferredDuringSchedulingIgnoredDuringExecution: <2>
-      - weight: 100 <3>
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
         podAffinityTerm:
           labelSelector:
             matchExpressions:
-            - key: registry <4>
-              operator: In <5>
+            - key: registry
+              operator: In
               values:
               - default
           topologyKey: kubernetes.io/hostname
 #...
 ----
-<1> Stanza to configure pod anti-affinity.
-<2> Defines a preferred rule.
-<3> Specifies a weight for a preferred rule. The node with the highest weight is preferred.
-<4> Description of the pod label that determines when the anti-affinity rule applies. Specify a key and value for the label.
-<5> The operator represents the relationship between the label on the existing pod and the set of values in the `matchExpression` parameters in the specification for the new pod. Can be `In`, `NotIn`, `Exists`, or `DoesNotExist`.
+where:
+
+`spec.affinity.podAntiAffinity`:: Specifies the stanza to configure pod anti-affinity.
+`spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution`:: Specifies a preferred rule.
+`spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.weight`:: Specifies a weight for a preferred rule. The node with the highest weight is preferred.
+`spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.labelSelector.matchExpressions.key`:: Specifies a pod label that determines when the anti-affinity rule applies. Define a key and value for the label.
+`spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.labelSelector.matchExpressions.operator`:: Specifies the relationship between the label on the existing pod and the set of values in the `matchExpression` parameters in the specification for the new pod. Can be `In`, `NotIn`, `Exists`, or `DoesNotExist`.
 +
 This example assumes the container image registry pod has a label of
 `registry=default`. Pod anti-affinity can use any Kubernetes match

--- a/modules/nodes-nodes-rebooting-gracefully.adoc
+++ b/modules/nodes-nodes-rebooting-gracefully.adoc
@@ -13,6 +13,9 @@ endif::[]
 [id="nodes-nodes-rebooting-gracefully_{context}"]
 = Rebooting a node gracefully
 
+[role="_abstract"]
+You can perform a graceful restart of a node, where all workloads are moved to other nodes, without data loss or service disruption. 
+
 ifdef::windows[]
 The Windows Machine Config Operator (WMCO) minimizes node reboots whenever possible. However, certain operations and updates require a reboot to ensure that changes are applied correctly and securely. To safely reboot your Windows nodes, use the graceful reboot process. For information on gracefully rebooting a standard {product-title} node, see "Rebooting a node gracefully" in the Nodes documentation.
 endif::windows[]
@@ -26,9 +29,9 @@ For {sno} clusters that require users to perform the `oc login` command rather t
 In a {sno} cluster, pods cannot be rescheduled when cordoning and draining. However, doing so gives the pods, especially your workload pods, time to properly stop and release associated resources.
 ====
 
-.Procedure
+The following procedure demonstrates how to perform a graceful restart of a node.
 
-To perform a graceful restart of a node:
+.Procedure
 
 . Mark the node as unschedulable:
 +

--- a/modules/nodes-nodes-rebooting-infrastructure.adoc
+++ b/modules/nodes-nodes-rebooting-infrastructure.adoc
@@ -6,6 +6,7 @@
 [id="nodes-nodes-rebooting-infrastructure_{context}"]
 = About rebooting nodes running critical infrastructure
 
+[role="_abstract"]
 When rebooting nodes that host critical {product-title} infrastructure components, such as router pods, registry pods, and monitoring pods, ensure that there are at least three nodes available to run these components.
 
 The following scenario demonstrates how service interruptions can occur with applications running on {product-title} when only two nodes are available:

--- a/modules/nodes-nodes-rebooting-router.adoc
+++ b/modules/nodes-nodes-rebooting-router.adoc
@@ -6,6 +6,9 @@
 [id="nodes-nodes-rebooting-router_{context}"]
 = Understanding how to reboot nodes running routers
 
+[role="_abstract"]
+Review the following information to learn how to reboot a node that hosts a router pod. 
+
 In most cases, a pod running an {product-title} router exposes a host port.
 
 The `PodFitsPorts` scheduler predicate ensures that no router pods using the

--- a/modules/nodes-nodes-rtkernel-arguments.adoc
+++ b/modules/nodes-nodes-rtkernel-arguments.adoc
@@ -7,10 +7,13 @@
 [id="nodes-nodes-rtkernel-arguments_{context}"]
 = Adding a real-time kernel to nodes
 
-Some {product-title} workloads require a high degree of determinism.While Linux is not a real-time operating system, the Linux real-time
-kernel includes a preemptive scheduler that provides the operating system with real-time characteristics.
+[role="_abstract"]
+If your {product-title} workloads require real-time operating system characteristics, you can switch your machines to the Linux real-time kernel. Switching to the real-time kernel provides a higher degree of determinism for your {product-title} workloads. 
 
-If your {product-title} workloads require these real-time characteristics, you can switch your machines to the Linux real-time kernel. For {product-title}, {product-version} you can make this switch using a `MachineConfig` object. Although making the change is as simple as changing a machine config `kernelType` setting to `realtime`, there are a few other considerations before making the change:
+Even though Linux is not a real-time operating system, the Linux real-time
+kernel includes a preemptive scheduler that provides the operating system with real-time characteristics. For {product-title}, {product-version} you can make the switch to real-time kernel by using a `MachineConfig` object. 
+
+Although making the change is as simple as changing a machine config `kernelType` setting to `realtime`, there are a few other considerations before making the change:
 
 * Currently, real-time kernel is supported only on worker nodes, and only for radio access network (RAN) use.
 * The following procedure is fully supported with bare metal installations that use systems that are certified for Red Hat Enterprise Linux for Real Time 8.

--- a/modules/nodes-nodes-working-master-schedulable.adoc
+++ b/modules/nodes-nodes-working-master-schedulable.adoc
@@ -7,9 +7,9 @@
 = Configuring control plane nodes as schedulable
 
 [role="_abstract"] 
-You can configure control plane nodes to be schedulable, meaning that new pods are allowed for placement on the control plane nodes. By default, control plane nodes are not schedulable.
+You can configure control plane nodes to be schedulable, meaning that new pods are allowed for placement on the control plane nodes.
 
-You can set the control plane nodes to be schedulable, but must retain the compute nodes.
+By default, control plane nodes are not schedulable. You can set the control plane nodes to be schedulable, but you must retain the compute nodes.
 
 [NOTE]
 ====
@@ -53,6 +53,6 @@ status: {}
 +
 where:
 +
-`mastersSchedulable`:: Set to `true` to allow control plane nodes to be schedulable, or `false` to disallow control plane nodes to be schedulable.
+`spec.mastersSchedulable`:: Specifies whether the control plane nodes are schedulable. Set to `true` to allow control plane nodes to be schedulable, or `false` to disallow control plane nodes from being schedulable.
 
 . Save the file to apply the changes.

--- a/modules/tls-profiles-kubelet-configuring.adoc
+++ b/modules/tls-profiles-kubelet-configuring.adoc
@@ -11,7 +11,10 @@ endif::[]
 [id="tls-profiles-kubelet-configuring_{context}"]
 = Configuring the TLS security profile for the kubelet
 
-To configure a TLS security profile for the kubelet when it is acting as an HTTP server, create a `KubeletConfig` custom resource (CR) to specify a predefined or custom TLS security profile for specific nodes. If a TLS security profile is not configured, the default TLS security profile is `Intermediate`.
+[role="_abstract"]
+You can configure a TLS security profile for the kubelet when it is acting as an HTTP server by creating a `KubeletConfig` custom resource (CR) to specify a predefined or custom TLS security profile for specific nodes. 
+
+If a TLS security profile is not configured, the default TLS security profile, `Intermediate`, is used.
 
 ifdef::tls[]
 The kubelet uses its HTTP/GRPC server to communicate with the Kubernetes API server, which sends commands to pods, gathers logs, and run exec commands on pods through the kubelet.
@@ -57,9 +60,9 @@ metadata:
   name: set-kubelet-tls-security-profile
 spec:
   tlsSecurityProfile:
-    type: Custom <1>
-    custom: <2>
-      ciphers: <3>
+    type: Custom
+    custom:
+      ciphers:
       - ECDHE-ECDSA-CHACHA20-POLY1305
       - ECDHE-RSA-CHACHA20-POLY1305
       - ECDHE-RSA-AES128-GCM-SHA256
@@ -67,18 +70,22 @@ spec:
       minTLSVersion: VersionTLS11
   machineConfigPoolSelector:
     matchLabels:
-      pools.operator.machineconfiguration.openshift.io/worker: "" <4>
+      pools.operator.machineconfiguration.openshift.io/worker: ""
 #...
 ----
+where:
+
+`spec.tlsSecurityProfile.type`:: Specifies the TLS security profile type (`Old`, `Intermediate`, or `Custom`). The default is `Intermediate`.
+`spec.tlsSecurityProfile.type.custom`:: Specifies the appropriate field for the selected type:
 +
-<1> Specify the TLS security profile type (`Old`, `Intermediate`, or `Custom`). The default is `Intermediate`.
-<2> Specify the appropriate field for the selected type:
+--
 * `old: {}`
 * `intermediate: {}`
 * `modern: {}`
 * `custom:`
-<3> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
-<4> Optional: Specify the machine config pool label for the nodes you want to apply the TLS security profile.
+--
+`spec.tlsSecurityProfile.type.custom`:: For the `custom` type, specifies a list of TLS ciphers and the minimum accepted TLS version.
+`spec.machineConfigPoolSelector.matchLabels.custom`:: Specifies the machine config pool label for the nodes you want to apply the TLS security profile. This parameter is optional.
 
 . Create the `KubeletConfig` object:
 +

--- a/modules/tls-profiles-understanding.adoc
+++ b/modules/tls-profiles-understanding.adoc
@@ -7,7 +7,10 @@
 [id="tls-profiles-understanding_{context}"]
 = Understanding TLS security profiles
 
-You can use a TLS (Transport Layer Security) security profile to define which TLS ciphers are required by various {product-title} components. The {product-title} TLS security profiles are based on link:https://wiki.mozilla.org/Security/Server_Side_TLS[Mozilla recommended configurations].
+[role="_abstract"]
+You can use a TLS (Transport Layer Security) security profile, as described in this section, to define which TLS ciphers are required by various {product-title} components. 
+
+The {product-title} TLS security profiles are based on link:https://wiki.mozilla.org/Security/Server_Side_TLS[Mozilla recommended configurations].
 
 You can specify one of the following TLS security profiles for each component:
 

--- a/nodes/nodes/nodes-nodes-adding-node-iso.adoc
+++ b/nodes/nodes/nodes-nodes-adding-node-iso.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-For on-premise clusters, you can add worker nodes by using the xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI (`oc`)] to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
+[role="_abstract"]
+You can add worker nodes to on-premise clusters by using the OpenShift CLI (`oc`) to generate an ISO image, which can then be used to boot one or more nodes in your target cluster.
 This process can be used regardless of how you installed your cluster.
 
 You can add one or more nodes at a time while customizing each node with more complex configurations, such as static network configuration, or you can specify only the MAC address of each node.
@@ -19,9 +20,7 @@ Any required configurations that are not specified during ISO generation are ret
 
 Preflight validation checks are also performed when booting the ISO image to inform you of failure-causing issues before you attempt to boot each node.
 
-[id="supported-platforms_{context}"]
-== Supported platforms
-
+Supported platforms::
 The following platforms are supported for this method of adding nodes:
 
 * `baremetal`
@@ -29,9 +28,7 @@ The following platforms are supported for this method of adding nodes:
 * `nutanix`
 * `none`
 
-[id="supported-architectures_{context}"]
-== Supported architectures
-
+Supported architectures::
 The following architecture combinations have been validated to work when adding worker nodes using this process:
 
 * `amd64` worker nodes on `amd64` or `arm64` clusters
@@ -39,8 +36,7 @@ The following architecture combinations have been validated to work when adding 
 * `s390x` worker nodes on `s390x` clusters
 * `ppc64le` worker nodes on `ppc64le` clusters
 
-[id="adding-nodes-cluster_{context}"]
-== Adding nodes to your cluster
+Adding nodes to your cluster::
 You can add nodes with this method in the following two ways:
 
 * Adding one or more nodes using a configuration file.
@@ -53,15 +49,16 @@ This is useful if you want to add more than one node at a time, or if you are sp
 You can add a node by running the `oc adm node-image create` command with flags to specify your configurations.
 This is useful if you want to add only a single node at a time, and have only simple configurations to specify for that node.
 
+// Cluster configuration reference
+include::modules/adding-node-iso-configs.adoc[leveloffset=+1]
+
 // Adding one or more nodes using a configuration file
 include::modules/adding-node-iso-yaml.adoc[leveloffset=+2]
 
 // Adding a single node with command flags
 include::modules/adding-node-iso-flags.adoc[leveloffset=+2]
 
-// Cluster configuration reference
-include::modules/adding-node-iso-configs.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 * xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#root-device-hints_ipi-install-installation-workflow[Root device hints]

--- a/nodes/nodes/nodes-nodes-garbage-collection.adoc
+++ b/nodes/nodes/nodes-nodes-garbage-collection.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 As an administrator, you can use {product-title} to ensure that your nodes are running efficiently
 by freeing up resources through garbage collection.
 

--- a/nodes/nodes/nodes-nodes-rebooting.adoc
+++ b/nodes/nodes/nodes-nodes-rebooting.adoc
@@ -7,10 +7,11 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
+[role="_abstract"]
+Review the following information to learn about rebooting a node without causing an outage for applications running on the
+platform by first evacuating the pods on the node. 
 
-To reboot a node without causing an outage for applications running on the
-platform, it is important to first evacuate the pods. For pods that are
-made highly available by the routing tier, nothing
+For pods that are made highly available by the routing tier, nothing
 else needs to be done. For other pods needing storage, typically databases, it
 is critical to ensure that they can remain in operation with one pod
 temporarily going offline. While implementing resiliency for stateful pods
@@ -29,16 +30,15 @@ process applies, though it is important to understand certain edge cases.
 
 include::modules/nodes-nodes-rebooting-infrastructure.adoc[leveloffset=+1]
 
-.Additional information
-
-* For more information on pod anti-affinity, see xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules].
-
 include::modules/nodes-nodes-rebooting-affinity.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-rebooting-router.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-rebooting-gracefully.adoc[leveloffset=+1]
 
-.Additional information
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
-For information on etcd data backup, see xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd data].
+* xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
+* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd data]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16930

[Adding worker nodes to an on-premise cluster (ISO)](https://105873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-adding-node-iso)
[Freeing node resources using garbage collection](https://105873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-garbage-collection)
[Managing nodes](https://105873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing)
[Understanding node rebooting](https://105873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-rebooting)
[Enabling TLS security profiles for the kubelet](https://105873--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-tls)