### PR TITLE
Vale fixes for IBM PowerVC

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -538,8 +538,8 @@ Topics:
   Dir: installing_ibm_powervc
   Distros: openshift-enterprise
   Topics:
-  - Name: Preparing to install on IBM PowerVC
-    File: preparing-to-install-on-ibm-powervc
+  - Name: Installation methods
+    File: installation-methods-ibm-powervc
   - Name: Installing a cluster on IBM PowerVC with customizations
     File: installing-ibm-powervc-installer-custom
   - Name: Installation configuration parameters for IBM PowerVC

--- a/installing/installing_ibm_powervc/installation-config-parameters-ibm-powervc.adoc
+++ b/installing/installing_ibm_powervc/installation-config-parameters-ibm-powervc.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Before you deploy an {product-title} cluster on {ibm-power-vc-title} ({ibm-power-vc}), you provide parameters to customize your cluster and the platform that hosts it. When you create the `install-config.yaml` file, you provide values for the required parameters through the command line. You can then modify the `install-config.yaml` file to customize your cluster further.
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]

--- a/installing/installing_ibm_powervc/installation-methods-ibm-powervc.adoc
+++ b/installing/installing_ibm_powervc/installation-methods-ibm-powervc.adoc
@@ -1,21 +1,16 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="preparing-to-install-on-powervc"]
-= Preparing to install on IBM PowerVC
+[id="installation-methods-ibm-powervc"]
+= Installation methods
 include::_attributes/common-attributes.adoc[]
-:context: preparing-to-install-on-powervc
+:context: installation-methods-ibm-powervc
 
 toc::[]
 
-You can install {product-title} on {ibm-power-vc-title} ({ibm-power-vc-name}) using installer-provisioned infrastructure.
-
-[id="preparing-to-install-on-powervc-prerequisites"]
-== Prerequisites
-
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* You read the documentation on xref:../../installing/overview/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+[role="_abstract"]
+You can install {product-title} on {ibm-power-vc-name} using installer-provisioned infrastructure. This process involves using the installation program to provision the underlying infrastructure for your cluster.
 
 [id="choosing-an-method-to-install-ocp-on-powervc-installer-provisioned"]
-=== Installing a cluster on installer-provisioned infrastructure
+== Installing a cluster on installer-provisioned infrastructure
 
 You can install a cluster on {ibm-power-vc-name} infrastructure that is provisioned by the {product-title} installation program, by using one of the following methods:
 

--- a/installing/installing_ibm_powervc/installing-ibm-powervc-installer-custom.adoc
+++ b/installing/installing_ibm_powervc/installing-ibm-powervc-installer-custom.adoc
@@ -6,8 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a customized cluster on
-{ibm-power-vc-name}. To customize the installation, modify parameters in the `install-config.yaml` before you install the cluster.
+[role="_abstract"]
+In {product-title} version {product-version}, you can install a customized cluster on {ibm-power-vc-name}. To customize the installation, modify parameters in the `install-config.yaml` before you install the cluster.
 
 == Prerequisites
 

--- a/installing/installing_ibm_powervc/uninstalling-cluster-powervc.adoc
+++ b/installing/installing_ibm_powervc/uninstalling-cluster-powervc.adoc
@@ -7,7 +7,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can remove a cluster that you deployed to {ibm-power-vc-name}.
+[role="_abstract"]
+You can remove a cluster that you deployed to {ibm-power-vc-name} using the installation program.
 
 // Removing a cluster that uses installer-provisioned infrastructure
 include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -165,21 +165,6 @@ You can customize the {product-title} cluster you install on
 ifdef::aws[]
 Amazon Web Services (AWS).
 endif::aws[]
-ifdef::azure[]
-Microsoft Azure.
-
-[IMPORTANT]
-====
-Do not specify `windows`, `microsoft`, or other variants of these words in the `metadata.name` parameter of the `install-config.yaml` file. Specifying one of these words for the cluster name causes the installation program to generate an error message like the following example message:
-
-[source,terminal]
-----
-The resource name 'windows-xxxx-identity' or a part of the name is a trademarked or reserved word.
-----
-
-Additionally, specifying `login` at the beginning of the name in the `metadata.name` parameter of the `install-config.yaml` file results in the generation of an error message. You can specify `login` in the middle or end of the name.
-====
-endif::azure[]
 ifdef::gcp[]
 {gcp-first}.
 endif::gcp[]
@@ -198,6 +183,21 @@ endif::nutanix[]
 ifdef::ibm-power-vc-platform[]
 {ibm-power-vc-name}.
 endif::ibm-power-vc-platform[]
+ifdef::azure[]
+Microsoft Azure.
+
+[IMPORTANT]
+====
+Do not specify `windows`, `microsoft`, or other variants of these words in the `metadata.name` parameter of the `install-config.yaml` file. Specifying one of these words for the cluster name causes the installation program to generate an error message like the following example message:
+
+[source,terminal]
+----
+The resource name 'windows-xxxx-identity' or a part of the name is a trademarked or reserved word.
+----
+
+Additionally, specifying `login` at the beginning of the name in the `metadata.name` parameter of the `install-config.yaml` file results in the generation of an error message. You can specify `login` in the middle or end of the name.
+====
+endif::azure[]
 
 .Prerequisites
 


### PR DESCRIPTION
Version(s):
4.21+

Preview: 
https://105887--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervc/installation-methods-ibm-powervc

docs-only cleanup.
* changed "preparing to install" page to "installation methods" since pre-requisites are already present in the installation assembly, and there are no additional prep steps
* Tweaked shortdescs
* Rearranged ifdefs in installation-initializing to fix new line rendering bug
```
➜  openshift-docs git:(ibm-power-vc-cleanup) asciiditavale installing/installing_ibm_powervc/*.adoc
✔ 0 errors, 0 warnings and 0 suggestions in 4 files.
➜  openshift-docs git:(ibm-power-vc-cleanup) asciiditavale modules/installation-initializing.adoc  
✔ 0 errors, 0 warnings and 0 suggestions in 1 file.
```