### PR TITLE
OSDOCS#18120: Nutanix multiple subnet network config recs

### DIFF
--- a/installing/installing_nutanix/nutanix-failure-domains.adoc
+++ b/installing/installing_nutanix/nutanix-failure-domains.adoc
@@ -58,3 +58,6 @@ include::modules/post-installation-adding-nutanix-failure-domains-compute-machin
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/creating_machinesets/creating-machineset-nutanix.adoc#creating-machineset-nutanix[Creating a compute machine set on Nutanix]
+
+//Improving reliability for multiple subnet configurations on Nutanix
+include::modules/cpmso-ts-nutanix-multiple-subnet.adoc[leveloffset=+1]

--- a/machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
@@ -41,3 +41,6 @@ include::modules/cpmso-openstack-ts-root-volume-azs.adoc[leveloffset=+2]
 
 // Post-upgrade config for ShiftStack with control plane AZs explicitly defined
 include::modules/cpmso-openstack-with-az-config.adoc[leveloffset=+2]
+
+//Improving reliability for multiple subnet configurations on Nutanix
+include::modules/cpmso-ts-nutanix-multiple-subnet.adoc[leveloffset=+1]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-nutanix.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-nutanix.adoc
@@ -20,6 +20,9 @@ include::modules/cpmso-yaml-provider-spec-nutanix.adoc[leveloffset=+1]
 //Failure domains for Nutanix clusters
 include::modules/mapi-failure-domain-nutanix.adoc[leveloffset=+1]
 
+//Improving reliability for multiple subnet configurations on Nutanix
+include::modules/cpmso-ts-nutanix-multiple-subnet.adoc[leveloffset=+1]
+
 [id="additional-resources_{context}"]
 [role="_additional-resources"]
 == Additional resources

--- a/machine_management/creating_machinesets/creating-machineset-nutanix.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-nutanix.adoc
@@ -24,6 +24,9 @@ include::modules/machineset-label-gpu-autoscaler.adoc[leveloffset=+1]
 //Failure domains for Nutanix clusters
 include::modules/mapi-failure-domain-nutanix.adoc[leveloffset=+1]
 
+//Improving reliability for multiple subnet configurations on Nutanix
+include::modules/cpmso-ts-nutanix-multiple-subnet.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/applying-autoscaling.adoc#cluster-autoscaler-cr_applying-autoscaling[Cluster autoscaler resource definition]

--- a/modules/cpmso-ts-nutanix-multiple-subnet.adoc
+++ b/modules/cpmso-ts-nutanix-multiple-subnet.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_nutanix/nutanix-failure-domains.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-nutanix.adoc
+// * machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
+// * machine_management/creating_machinesets/creating-machineset-nutanix.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="cpmso-ts-nutanix-multiple-subnet_{context}"]
+= Improving reliability for multiple subnet configurations on Nutanix
+
+[role="_abstract"]
+To improve reliability and avoid common networking problems with multiple subnet configurations on Nutanix, adhere to the configuration practices that minimize networking conflicts.
+
+The following networking configuration and management practices can help your multiple subnet configuration perform more reliably:
+
+* To avoid overlapping IP address assignments, use predefined static IP addresses in the `cloud-init` metadata.
+
+* Tag all VMs, disks, and networks with a unique cluster ID.
+
+* Avoid IP address conflicts by using dedicated subnets for each {product-title} cluster:
++
+Nutanix uses Nutanix Acropolis Hypervisor (AHV) and Nutanix Prism networking to assign IP addresses to virtual machines (VMs).
+If a single subnet provides IP addresses for more than one {product-title} cluster, AHV or Prism might assign the same IP address to a VM or pod in more than one cluster.
++
+To avoid this issue, use dedicated subnets for each {product-title} cluster, even when you have more than one cluster on a single Prism Central instance.
+You can use the Prism UI or automation tools, such as Terraform or Ansible, to create separate IP address pools for each {product-title} cluster.
+
+* Ensure that each {product-title} cluster uses distinct DNS zones and virtual IP address ranges.
+
+* Avoid DHCP conflicts by maintaining DHCP allocations:
++
+If you use Nutanix to manage DHCP allocation, objects in your cluster might have duplicate leases.
+Duplicate leases can cause DHCP conflicts when you apply changes to the control plane machine set custom resource (CR) specification.
++
+To avoid this issue, regularly remove stale DHCP leases.
+
+* Use automation tools, such as Terraform or Ansible, to isolate the infrastructure for each {product-title} cluster.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
[OSDOCS-18120](https://issues.redhat.com//browse/OSDOCS-18120) (ref: OCPBUGS-50904)

Link to docs preview:


QE review:
- [x] QE has approved this change.

Additional information:
The bug this stems from is 4.18 for a `ControlPlaneMahineSet` issue. Applies to 4.18+ and Machine API compute as well as CPMS.