### PR TITLE
PR for SRVCOM-4165: Release notes, known issues and bug fixes for 1.37.1

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -29,6 +29,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 // Release notes included, most to least recent
 
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-37-1.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-37-0.adoc[leveloffset=+1]
 
 // OCP + OSD + ROSA

--- a/modules/serverless-rn-1-37-1.adoc
+++ b/modules/serverless-rn-1-37-1.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="serverless-rn-1-37-1_{context}"]
+= Red{nbsp}Hat {ServerlessProductName} 1.37.1
+
+[role="_abstract"]
+{ServerlessProductName} 1.37.1 is now available. This release of {ServerlessProductName} addresses identified Common Vulnerabilities and Exposures (CVEs) to enhance security and reliability. Fixed issues and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="fixed-issues-1-37-1_{context}"]
+== Fixed issues
+
+3scale Kourier gateway crash due to file descriptor limits on {ocp-product-title} 4.21::
+
+Before this update, {ocp-product-title} 4.21 and later used a reduced default soft limit for the number of open files when running the `3scale Kourier gateway` with {ServerlessProductName} 1.37.0 and earlier. As a consequence, the `3scale Kourier gateway` could crash with the `socket(2) failed, got error: Too many open files` error. With this release, the `3scale Kourier gateway` deployment sets the soft limit for the maximum number of open files to the value of the hard limit.
+As a result, the `3scale Kourier gateway` no longer crashes due to file descriptor limits on {ocp-product-title} 4.21.
+
+link:https://issues.redhat.com/browse/SRVKS-1343[SRVKS-1343]
+
+[id="known-issues-1-37-1_{context}"]
+== Known issues
+
+Python runtime limited to 1024 open files on {ocp-product-title} 4.21::
+
+On {ocp-product-title} 4.21, the default `ulimit -n` soft limit for the number of open files is set to 1024, reduced from 1048576 in earlier {ocp-product-title} releases up to version 4.20. The hard limit remains 524288. As a result, Serverless functions that use the Python runtime cannot open more than 1024 file descriptors, such as open files or TCP sockets.
+
+link:https://issues.redhat.com/browse/SRVOCF-788[SRVOCF-788]


### PR DESCRIPTION
**Affected versions:** `serverless-docs-1.37`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-4165

**Doc preview:**

- [1.37.1 Serverless release notes](https://105894--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-37-1_serverless-release-notes)

**Reviews:**
- [x] SME or QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

- [x] Peer has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->