### PR TITLE
OADP-7385: Add OADP 1.5.4 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -49,10 +49,10 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.5.0
+:oadp-version: 1.5.4
 :oadp-version-1-3: 1.3.6
 :oadp-version-1-4: 1.4.6
-:oadp-version-1-5: 1.5.0
+:oadp-version-1-5: 1.5.4
 :oadp-bsl-api: backupstoragelocations.velero.io
 :velero-overview: link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]
 :velero-link: link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.adoc
@@ -16,6 +16,8 @@ The release notes for {oadp-first} 1.5 describe new features and enhancements, d
 For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQ].
 ====
 
+include::modules/oadp-1-5-4-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-5-3-release-notes.adoc[leveloffset=+1]
 
 include::modules/oadp-1-5-2-release-notes.adoc[leveloffset=+1]

--- a/modules/oadp-1-5-4-release-notes.adoc
+++ b/modules/oadp-1-5-4-release-notes.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-1-5-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-5-4-release-notes_{context}"]
+= OADP 1.5.4 release notes
+
+[role="_abstract"]
+{oadp-first} 1.5.4 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.5.3. {oadp-short} 1.5.4 introduces a known issue and fixes several Common Vulnerabilities and Exposures (CVEs).
+
+
+[id="known-issues-1-5-4_{context}"]
+== Known issues
+
+Simultaneous updates to the same `NonAdminBackupStorageLocationRequest` objects cause resource conflicts::
+
+Simultaneous updates by several controllers or processes to the same `NonAdminBackupStorageLocationRequest` objects cause resource conflicts during backup creation in {oadp-short} self-service. As a consequence, reconciliation attempts fail with `object has been modified` errors. No known workaround exists.
++
+link:https://issues.redhat.com/browse/OADP-6700[OADP-6700]
+
+
+[id="resolved-issues-1-5-4_{context}"]
+== Resolved issues
+
+{oadp-short} 1.5.4 fixes the following CVEs::
+
+* link:https://access.redhat.com/security/cve/cve-2025-61729[CVE-2025-61729]
+
+* link:https://access.redhat.com/security/cve/cve-2025-52881[CVE-2025-52881]
+
+* link:https://access.redhat.com/security/cve/cve-2024-25621[CVE-2024-25621]
+
+* link:https://access.redhat.com/security/cve/cve-2025-58183[CVE-2025-58183]


### PR DESCRIPTION
Version(s):
OCP 4.19-4.22

Issue:
[OADP-7385](https://issues.redhat.com/browse/OADP-7385)

Link to docs preview:
[OADP 1.5.4 release notes](https://105908--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-5-release-notes.html#oadp-1-5-4-release-notes_oadp-1-5-release-notes)

QE review:
- [x] QE has approved this change.

Changes:
- Add OADP 1.5.4 Release Notes and change attributes
