### PR TITLE
OSDOCS-18206: adds or updates content type to attributes files

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -1,3 +1,5 @@
+:_mod-docs-content-type: ATTRIBUTES
+//adding attribute content type to silence vale
 // common attributes
 :toc:
 :toc-title:

--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -1,4 +1,5 @@
-:_mod-docs-content-type: SNIPPET
+:_mod-docs-content-type: ATTRIBUTES
+//adding attribute content type to silence vale
 // General Service Delivery Attributes attributes
 :toc:
 :toc-title:

--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -1,4 +1,4 @@
-:_mod-docs-content-type: SNIPPET
+:_mod-docs-content-type: ATTRIBUTES
 // The {product-title} attribute provides the context-sensitive name of the relevant OpenShift distribution, for example, "OpenShift Container Platform" or "OKD". The {product-version} attribute provides the product version relative to the distribution, for example "4.9".
 // {product-title} and {product-version} are parsed when AsciiBinder queries the _distro_map.yml file in relation to the base branch of a pull request.
 // See https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#product-name-and-version for more information on this topic.

--- a/_attributes/servicebinding-document-attributes.adoc
+++ b/_attributes/servicebinding-document-attributes.adoc
@@ -1,4 +1,6 @@
-// Standard document attributes to be used in the documentation
+:_mod-docs-content-type: ATTRIBUTES
+//adding content type to silence vale
+// Standard document attributes to be used in documentation
 //
 // The following are shared by all documents:
 :toc:


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-18206](https://issues.redhat.com/browse/OSDOCS-18206)

Link to docs preview:
N/A

Additional information:
Core OpenShift Implementation Tiger team task; see also https://github.com/redhat-documentation/vale-at-red-hat/pull/1009

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
