### PR TITLE
OBSDOCS-3058 Support prometheus UTF8 in prometheus-operator

### DIFF
--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -37,8 +37,6 @@ endif::openshift-dedicated,openshift-rosa[]
 
 * *Installing custom Prometheus instances on {ocp}.* A custom instance is a Prometheus custom resource (CR) managed by the Prometheus Operator.
 
-* *Using UTF-8 metrics.* Although the {ocp} monitoring stack ships with Prometheus v3, which supports UTF-8 metrics, the monitoring stack itself does not support UTF-8 metrics. The support status might change in a future release.
-
 ifdef::openshift-dedicated,openshift-rosa[]
 * *Modifying the default platform monitoring components.* You should not modify any of the components defined in the `cluster-monitoring-config` config map. Red Hat SRE uses these components to monitor the core cluster components and Kubernetes services.
 endif::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
Cherry-picking doc change to main (release notes do not reside in main, that is why for this case I am cherry-picking backwards -> from version to main)
issue: https://issues.redhat.com/browse/OBSDOCS-3058