### PR TITLE
CNV-69173: Updated release notes for web console reset button

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -98,6 +98,11 @@ With this update, cluster administrators can run a self-validation checkup on an
 +
 link:https://issues.redhat.com/browse/CNV-59284[CNV-59284]
 
+Web console *Reset* button now available::
+With this update, VM owners can force reboot their VMs by clicking *Reset* in the web console. This reboot process preserves user-customized data, such as hot plugged storage, by preserving the pod that contains the VM. This enhancement provides a more efficient and user-friendly experience, as users no longer need to manually manage the reboot process or risk losing their customized data.
++
+link:https://issues.redhat.com/browse/CNV-51003[CNV-51003]
+
 // Monitoring
 
 


### PR DESCRIPTION
Version(s):
4.21

Issue:
https://issues.redhat.com/browse/CNV-69173

Link to docs preview:
https://105948--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html#virt-4-21-new_virt-4-21-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
