### PR TITLE
CNV: 78850 - Migration fails with Migration name longer than 63 characters

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -82,16 +82,11 @@ You can now start a virtual machine (VM) console session by clicking on the name
 link:https://issues.redhat.com/browse/CNV-70942[CNV-70942]
 
 Define OVS bonding in the Node network configuration wizard::
-You can now define an Open vSwitch (OVS) Source Load Balancing (SLB) bonding interface when creating a node network configuration policy in the {product-title} web console. Use the *Uplink connection* tab in the Node network configuration wizard to configure bond network interfaces that provide access to the external physical network to multiple VMs across shared bonded links.
+You can now define an Open vSwitch (OVS) Source Load Balancing (SLB) bonding interface when creating a node network configuration policy in the {product-title} web console. Use the *Uplink connection* tab in the Node network configuration wizard to configure bond network interfaces that provide access to the external physical network to multiple VMs across shared bonded links. 
 +
 For more information, see xref:../../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-node-network-config-console_k8s-nmstate-updating-node-network-config[Managing policy from the web console].
 +
 link:https://issues.redhat.com/browse/CNV-70202[CNV-70202]
-
-*Self validation* tab added to the *Checkups* page::
-With this update, cluster administrators can run a self-validation checkup on an {product-title} cluster from the *Self validation* tab in the *Virtualization* -> *Checkups* page of the web console. Users can download detailed results from the checkup as a ZIP file. This feature enables cluster administrators to execute extensive test suites on their clusters, helping to identify and address potential issues in advanced features and configurations.
-+
-link:https://issues.redhat.com/browse/CNV-59284[CNV-59284]
 
 // Monitoring
 
@@ -229,3 +224,9 @@ To work around this problem, manually delete the stale boot source resources:
 . Delete the older, non-suffixed `DataSource` objects and the PVCs or `VolumeSnapshots` they reference.
 +
 link:https://issues.redhat.com/browse/CNV-75084[CNV-75084]
+//CNV-78850
+Storage migrations fail for block disks with fractional sizes::
+
+When migrating virtual machines, storage migrations from block disks with fractional sizes fail on certain storage provider combinations, such as moving from {rh-storage} to a hostpath provisioner.
+
+To work around this issue, use the KubeVirt storage migration APIs to migrate to a custom-created Persistent Volume Claim (PVC) with a capacity larger than the original disk. For more information, see the link:https://kubevirt.io/user-guide/storage/volume_migration/[KubeVirt Volume Migration user guide].


### PR DESCRIPTION
Version(s):
 v4.21

Issue:
https://issues.redhat.com/browse/CNV-77645

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
