### PR TITLE
OCPBUGS#37959: Lingering MAPI subnet ref

### DIFF
--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -59,49 +59,49 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> 
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifdef::edge[]
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
 endif::edge[]
 ifndef::infra,edge[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> 
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> 
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> 
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra,edge[]
         machine.openshift.io/cluster-api-machine-role: <role> <3>
-        machine.openshift.io/cluster-api-machine-type: <role> 
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> 
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
         machine.openshift.io/cluster-api-machine-role: infra <3>
-        machine.openshift.io/cluster-api-machine-type: infra 
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> 
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
 ifdef::edge[]
         machine.openshift.io/cluster-api-machine-role: edge <3>
-        machine.openshift.io/cluster-api-machine-type: edge 
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone> 
+        machine.openshift.io/cluster-api-machine-type: edge
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
 endif::edge[]
     spec:
       metadata:
         labels:
 ifndef::infra,edge[]
-          node-role.kubernetes.io/<role>: "" 
+          node-role.kubernetes.io/<role>: ""
 endif::infra,edge[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" 
+          node-role.kubernetes.io/infra: ""
 endif::infra[]
 ifdef::edge[]
           machine.openshift.io/parent-zone-name: <value_of_ParentZoneName>
           machine.openshift.io/zone-group: <value_of_GroupName>
           machine.openshift.io/zone-type: <value_of_ZoneType>
-          node-role.kubernetes.io/edge: "" 
+          node-role.kubernetes.io/edge: ""
 endif::edge[]
       providerSpec:
         value:
@@ -117,7 +117,7 @@ endif::edge[]
             name: aws-cloud-credentials
           deviceIndex: 0
           iamInstanceProfile:
-            id: <infrastructure_id>-worker-profile 
+            id: <infrastructure_id>-worker-profile
           instanceType: m6i.large
           kind: AWSMachineProviderConfig
           placement:
@@ -137,17 +137,17 @@ ifndef::edge[]
             filters:
               - name: tag:Name
                 values:
-                  - <infrastructure_id>-private-<zone> <7>
+                  - <infrastructure_id>-subnet-private-<zone> <7>
 endif::edge[]
 ifdef::edge[]
               id: <value_of_PublicSubnetIds> <7>
           publicIp: true
 endif::edge[]
           tags:
-            - name: kubernetes.io/cluster/<infrastructure_id> 
+            - name: kubernetes.io/cluster/<infrastructure_id>
               value: owned
             - name: <custom_tag_name> <8>
-              value: <custom_tag_value> 
+              value: <custom_tag_value>
           userDataSecret:
             name: worker-user-data
 ifdef::infra,edge[]
@@ -193,7 +193,7 @@ ifndef::edge[]
 endif::edge[]
 ifdef::edge[]
 <5> Specify the zone name, for example, `us-east-1-nyc-1a`.
-endif::edge[] 
+endif::edge[]
 <6> Specify the region, for example, `us-east-1`.
 ifndef::edge[]
 <7> Specify the infrastructure ID and zone.


### PR DESCRIPTION
Version(s):
4.16+

Issue:
OCPBUGS-37959

Link to docs preview:


QE review:
- [x] QE has approved this change.

Additional information:
Last param fix from OCPBUGS-37959; the rest were handled in earlier work. This topic has not had a CQA yet and will get callouts scrubbed later (out of scope to close this follow-up to a bug).