### PR TITLE
Ambient: fix cross namespace waypoint configuration

### DIFF
--- a/modules/ossm-enabling-cross-namespace-waypoint-usage.adoc
+++ b/modules/ossm-enabling-cross-namespace-waypoint-usage.adoc
@@ -10,6 +10,13 @@ You can use a cross-namespace waypoint to allow resources in one namespace to ro
 
 .Procedure
 
+. Add the `istio-discovery=enabled` label to the `default` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc label namespace default istio-discovery=enabled
+----
+
 . Create a `Gateway` resource that allows workloads in the `bookinfo` namespace to use the `waypoint-default` from the `default` namespace similar to the following example:
 +
 .Example configuration

--- a/modules/ossm-scoping-sm-discovery-selectors-istio-ambient-mode.adoc
+++ b/modules/ossm-scoping-sm-discovery-selectors-istio-ambient-mode.adoc
@@ -51,10 +51,10 @@ metadata:
   name: default
 spec:
   namespace: istio-system
+  profile: ambient
   values:
     pilot:
       trustedZtunnelNamespace: ztunnel
-    profile: ambient
     meshConfig:
       discoverySelectors:
       - matchLabels:


### PR DESCRIPTION
This PR fixes two issues related to cross-namespace waypoint usage

1. A required step to label the default namespace with the discovery selector was missing.
2. The profile field in the Istio CR was incorrectly configured.
