### PR TITLE
OSDOCS#17046: Retitles config ref assemblies

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2482,25 +2482,25 @@ Topics:
   - Name: Configuration options for control plane machines
     Dir: cpmso_provider_configurations
     Topics:
-    - Name: Changing control plane configuration options for Amazon Web Services
+    - Name: Control plane configuration options for Amazon Web Services
       File: cpmso-config-options-aws
     - Name: Configuring Amazon Web Services features for control plane machines
       File: cpmso-supported-features-aws
-    - Name: Changing control plane configuration options for Microsoft Azure
+    - Name: Control plane configuration options for Microsoft Azure
       File: cpmso-config-options-azure
     - Name: Configuring Microsoft Azure features for control plane machines
       File: cpmso-supported-features-azure
-    - Name: Changing control plane configuration options for Google Cloud
+    - Name: Control plane configuration options for Google Cloud
       File: cpmso-config-options-gcp
     - Name: Configuring Google Cloud features for control plane machines
       File: cpmso-supported-features-gcp
-    - Name: Changing control plane configuration options for Nutanix
+    - Name: Control plane configuration options for Nutanix
       File: cpmso-config-options-nutanix
-    - Name: Changing control plane configuration options for Red Hat OpenStack Platform
+    - Name: Control plane configuration options for Red Hat OpenStack Platform
       File: cpmso-config-options-openstack
     - Name: Configuring Red Hat OpenStack Platform features for control plane machines
       File: cpmso-supported-features-openstack
-    - Name: Changing control plane configuration options for VMware vSphere
+    - Name: Control plane configuration options for VMware vSphere
       File: cpmso-config-options-vsphere
     - Name: Configuring VMware vSphere features for control plane machines
       File: cpmso-supported-features-vsphere

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="cpmso-config-options-aws"]
-= Changing control plane configuration options for {aws-full}
+= Control plane configuration options for {aws-full}
 :context: cpmso-config-options-aws
 
 toc::[]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="cpmso-config-options-azure"]
-= Changing control plane configuration options for {azure-full}
+= Control plane configuration options for {azure-full}
 :context: cpmso-config-options-azure
 
 toc::[]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="cpmso-config-options-gcp"]
-= Changing control plane configuration options for {gcp-full}
+= Control plane configuration options for {gcp-full}
 :context: cpmso-config-options-gcp
 
 toc::[]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-nutanix.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-nutanix.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="cpmso-config-options-nutanix"]
-= Changing control plane configuration options for Nutanix
+= Control plane configuration options for Nutanix
 :context: cpmso-config-options-nutanix
 
 toc::[]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="cpmso-config-options-openstack"]
-= Changing control plane configuration options for {rh-openstack-first}
+= Control plane configuration options for {rh-openstack-first}
 :context: cpmso-config-options-openstack
 
 toc::[]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="cpmso-config-options-vsphere"]
-= Changing control plane configuration options for VMware vSphere
+= Control plane configuration options for VMware vSphere
 include::_attributes/common-attributes.adoc[]
 :context: cpmso-config-options-vsphere
 

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.adoc
@@ -48,4 +48,4 @@ include::modules/machineset-capacity-reservation.adoc[leveloffset=+1,tag=!comput
 [role="_additional-resources"]
 == Additional resources
 * xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
-* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc#cpmso-config-options-aws[Changing control plane configuration options for {aws-full}]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc#cpmso-config-options-aws[Control plane configuration options for {aws-full}]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-azure.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-azure.adoc
@@ -65,4 +65,4 @@ include::modules/machineset-azure-enabling-accelerated-networking-existing.adoc[
 [role="_additional-resources"]
 == Additional resources
 * xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
-* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#cpmso-config-options-azure[Changing control plane configuration options for {azure-full}]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-azure.adoc#cpmso-config-options-azure[Control plane configuration options for {azure-full}]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-gcp.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-gcp.adoc
@@ -37,4 +37,4 @@ include::modules/machineset-gcp-enabling-customer-managed-encryption.adoc[levelo
 [role="_additional-resources"]
 == Additional resources
 * xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
-* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc#cpmso-config-options-gcp[Changing control plane configuration options for {gcp-full}]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-gcp.adoc#cpmso-config-options-gcp[Control plane configuration options for {gcp-full}]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-openstack.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-openstack.adoc
@@ -19,4 +19,4 @@ include::modules/cpms-changing-openstack-flavor-type.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 * xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
-* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc#cpmso-config-options-openstack[Changing control plane configuration options for {rh-openstack-full}]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-openstack.adoc#cpmso-config-options-openstack[Control plane configuration options for {rh-openstack-full}]

--- a/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-vsphere.adoc
+++ b/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-vsphere.adoc
@@ -26,4 +26,4 @@ include::modules/machineset-vsphere-data-disks.adoc[leveloffset=+1,tag=!compute]
 [role="_additional-resources"]
 == Additional resources
 * xref:../../../machine_management/control_plane_machine_management/cpmso-managing-machines.adoc#cpmso-feat-config-update_cpmso-managing-machines[Updating the control plane configuration]
-* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc#cpmso-config-options-vsphere[Changing control plane configuration options for {vmw-full}]
+* xref:../../../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-vsphere.adoc#cpmso-config-options-vsphere[Control plane configuration options for {vmw-full}]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-17046](https://issues.redhat.com//browse/OSDOCS-17046)

Link to docs preview:
TOC and assembly titles in this subdir: https://105990--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws

QE review:
N/A

Additional information:
These assemblies are mid-CQA but I want to make this title update as a separate PR to keep things aligned overall.