### PR TITLE
TELCODOCS-2636: KMM 2.5.1 Release Notes

### DIFF
--- a/hardware_enablement/kmm-release-notes.adoc
+++ b/hardware_enablement/kmm-release-notes.adoc
@@ -396,3 +396,17 @@ Kernel Module Management (KMM) 2.5 is now supported on {ibm-z-title} architectur
 
 ** *Result*: The `HashAnnotationDiffer` function runs as expected. 
 
+[id="kmm-2-5-1-RN"]
+== Release notes for Kernel Module Management Operator 2.5.1
+=== Known issues
+
+// TELCODOCS-2636
+* Kernel Module Management (KMM) version 2.5 does not run on Red Hat OpenShift Service on AWS (ROSA) clusters or any other cluster that doesn't install the `MachineConfig` CRD.
+
+** Cause: This happens because the BMC controller that monitors `MachineConfig` objects on clusters cannot find these objects on ROSA clusters because they do not exist.
+
+** Consequence: Causes the BMC controller to fail and the KMM controller pods to continually restart.
+
+** Fix: In this version, the Operator verifies that the `MachineConfig` CRD is present on a cluster and runs the BMC controller on a cluster only when the `MachineConfig` CRD is present.
+
+** Result: ROSA controller pods start successfully. 


### PR DESCRIPTION
KMM 2.5.1 Release Notes

Version: 4.20+

Issue: https://issues.redhat.com/browse/TELCODOCS-2636

Preview: https://105992--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-release-notes.html#kmm-2-5-1-RN

Dev: @ybettan 
QE: @cdvultur
