### PR TITLE
OSDOCS-17042 [CQA] Convert callouts to definition lists in MachineSet YAML

### DIFF
--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -38,6 +38,7 @@ endif::[]
 [id="machineset-creating_{context}"]
 = Creating a compute machine set
 
+[role="_abstract"]
 In addition to the compute machine sets created by the installation program, you can create your own to dynamically manage the machine compute resources for specific workloads of your choice.
 
 ifdef::vsphere[]
@@ -111,8 +112,8 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-  name: <infrastructure_id>-<role> <2>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+  name: <infrastructure_id>-<role>
   namespace: openshift-machine-api
 spec:
   replicas: 1
@@ -128,17 +129,20 @@ spec:
         machine.openshift.io/cluster-api-machine-type: <role>
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
     spec:
-      providerSpec: <3>
+      providerSpec:
         ...
 ----
-<1> The cluster infrastructure ID.
-<2> A default node label.
+where:
+
+`<infrastructure_id>`:: Specifies the cluster infrastructure ID.
+`<infrastructure_id>_<role>`:: Specifies a default node label.
 +
 [NOTE]
 ====
 For clusters that have user-provisioned infrastructure, a compute machine set can only create `worker` and `infra` type machines.
 ====
-<3> The values in the `<providerSpec>` section of the compute machine set CR are platform-specific. For more information about `<providerSpec>` parameters in the CR, see the sample compute machine set CR configuration for your provider.
++
+The values in the `<providerSpec>` section of the compute machine set CR are platform-specific. For more information about `<providerSpec>` parameters in the CR, see the sample compute machine set CR configuration for your provider.
 --
 
 ifdef::vsphere[]
@@ -157,8 +161,8 @@ template:
       value:
         apiVersion: machine.openshift.io/v1beta1
         credentialsSecret:
-          name: vsphere-cloud-credentials <1>
-        dataDisks: <2>
+          name: <secret_name>
+        dataDisks:
         - name: <disk_name>
           provisioningMode: <mode>
           sizeGiB: 10
@@ -171,22 +175,23 @@ template:
         numCPUs: 4
         numCoresPerSocket: 4
         snapshot: ""
-        template: <vm_template_name> <3>
+        template: <vm_template_name>
         userDataSecret:
-          name: worker-user-data <4>
+          name: <ignition_secret>
         workspace:
           datacenter: <vcenter_data_center_name>
           datastore: <vcenter_datastore_name>
           folder: <vcenter_vm_folder_path>
           resourcepool: <vsphere_resource_pool>
-          server: <vcenter_server_address> <5>
+          server: <vcenter_server_address>
 ----
-<1> The name of the secret in the `openshift-machine-api` namespace that contains the required vCenter credentials.
-<2> The collection of data disk definitions. 
-For more information, see "Configuring data disks by using machine sets".
-<3> The name of the {op-system} VM template for your cluster that was created during installation.
-<4> The name of the secret in the `openshift-machine-api` namespace that contains the required Ignition configuration credentials.
-<5> The IP address or fully qualified domain name (FQDN) of the vCenter server.
+where:
+
+`<secret_name>`:: Specifies the name of the secret in the `openshift-machine-api` namespace that contains the required vCenter credentials.
+`dataDisks`:: Specifies the collection of data disk definitions. For more information, see "Configuring data disks by using machine sets".
+`<vm_template_name>`:: Specifies the name of the {op-system} VM template for your cluster that was created during installation.
+`<ignition_secret>`:: Specifies the name of the secret in the `openshift-machine-api` namespace that contains the required Ignition configuration credentials.
+`<vcenter_server_address>`:: Specifies the IP address or fully qualified domain name (FQDN) of the vCenter server.
 endif::vsphere[]
 
 . Create a `MachineSet` CR by running the following command:

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -16,8 +16,9 @@ endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="machineset-yaml-aws_{context}"]
-=  Sample YAML for a compute machine set custom resource on AWS
+= Sample YAML for a compute machine set custom resource on AWS
 
+[role="_abstract"]
 ifndef::edge[]
 The sample YAML defines a compute machine set that runs in the `us-east-1a` Amazon Web Services (AWS) Local Zone and creates nodes that are labeled with
 endif::edge[]
@@ -29,6 +30,8 @@ This sample YAML defines a compute machine set that runs in the `us-east-1-nyc-1
 [NOTE]
 ====
 If you want to reference the sample YAML file in the context of Wavelength Zones, ensure that you replace the AWS Region and zone information with supported Wavelength Zone values.
+Machine sets running on AWS support non-guaranteed Spot Instances. You can save on costs by using Spot Instances at a lower price compared to
+On-Demand Instances on AWS. You can configure Spot Instances by adding `spotMarketOptions` to the `MachineSet` YAML file.
 ====
 endif::[]
 
@@ -44,69 +47,69 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra,edge[]
-  name: <infrastructure_id>-<role>-<zone> <2>
+  name: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
-  name: <infrastructure_id>-infra-<zone> <2>
+  name: <infrastructure_id>-infra-<zone>
 endif::infra[]
 ifdef::edge[]
-  name: <infrastructure_id>-edge-<zone> <2>
+  name: <infrastructure_id>-edge-<zone>
 endif::edge[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> 
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifdef::edge[]
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
 endif::edge[]
 ifndef::infra,edge[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> 
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> 
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> 
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra,edge[]
-        machine.openshift.io/cluster-api-machine-role: <role> <3>
-        machine.openshift.io/cluster-api-machine-type: <role> 
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> 
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra,edge[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: infra <3>
-        machine.openshift.io/cluster-api-machine-type: infra 
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> 
+        machine.openshift.io/cluster-api-machine-role: infra
+        machine.openshift.io/cluster-api-machine-type: infra
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone>
 endif::infra[]
 ifdef::edge[]
-        machine.openshift.io/cluster-api-machine-role: edge <3>
-        machine.openshift.io/cluster-api-machine-type: edge 
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone> 
+        machine.openshift.io/cluster-api-machine-role: edge
+        machine.openshift.io/cluster-api-machine-type: edge
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
 endif::edge[]
     spec:
       metadata:
         labels:
 ifndef::infra,edge[]
-          node-role.kubernetes.io/<role>: "" 
+          node-role.kubernetes.io/<role>: ""
 endif::infra,edge[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" 
+          node-role.kubernetes.io/infra: ""
 endif::infra[]
 ifdef::edge[]
           machine.openshift.io/parent-zone-name: <value_of_ParentZoneName>
           machine.openshift.io/zone-group: <value_of_GroupName>
           machine.openshift.io/zone-type: <value_of_ZoneType>
-          node-role.kubernetes.io/edge: "" 
+          node-role.kubernetes.io/edge: ""
 endif::edge[]
       providerSpec:
         value:
           ami:
-            id: ami-046fe691f52a953f9 <4>
+            id: <ami_id>
           apiVersion: machine.openshift.io/v1beta1
           blockDevices:
             - ebs:
@@ -117,12 +120,12 @@ endif::edge[]
             name: aws-cloud-credentials
           deviceIndex: 0
           iamInstanceProfile:
-            id: <infrastructure_id>-worker-profile 
+            id: <infrastructure_id>-worker-profile
           instanceType: m6i.large
           kind: AWSMachineProviderConfig
           placement:
-            availabilityZone: <zone> <5>
-            region: <region> <6>
+            availabilityZone: <zone>
+            region: <region>
           securityGroups:
             - filters:
                 - name: tag:Name
@@ -137,21 +140,21 @@ ifndef::edge[]
             filters:
               - name: tag:Name
                 values:
-                  - <infrastructure_id>-private-<zone> <7>
+                  - <infrastructure_id>-private-<zone>
 endif::edge[]
 ifdef::edge[]
-              id: <value_of_PublicSubnetIds> <7>
+              id: <value_of_PublicSubnetIds>
           publicIp: true
 endif::edge[]
           tags:
-            - name: kubernetes.io/cluster/<infrastructure_id> 
+            - name: kubernetes.io/cluster/<infrastructure_id>
               value: owned
-            - name: <custom_tag_name> <8>
-              value: <custom_tag_value> 
+            - name: <custom_tag_name>
+              value: <custom_tag_value>
           userDataSecret:
             name: worker-user-data
 ifdef::infra,edge[]
-      taints: <9>
+      taints:
 ifdef::infra[]
         - key: node-role.kubernetes.io/infra
 endif::infra[]
@@ -161,26 +164,27 @@ endif::edge[]
           effect: NoSchedule
 endif::infra,edge[]
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
 [source,terminal]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 ifndef::infra,edge[]
-<2> Specify the infrastructure ID, role node label, and zone.
-<3> Specify the role node label to add.
+`<infrastructure_id>-role-<zone>`:: Specifies the infrastructure ID, role node label, and zone.
+`<role>`:: Specifies the role node label to add.
 endif::infra,edge[]
 ifdef::infra[]
-<2> Specify the infrastructure ID, `infra` role node label, and zone.
-<3> Specify the `infra` role node label.
+`<infrastructure_id>-infra-<zone>`:: Specifies the infrastructure ID, `infra` role node label, and zone.
+`machine.openshift.io/cluster-api-machine-type`:: Requires the `infra` role node label.
 endif::infra[]
 ifdef::edge[]
-<2> Specify the infrastructure ID, `edge` role node label, and zone name.
-<3> Specify the `edge` role node label.
+`<infrastructure_id>-edge-<zone>`:: Specifies the infrastructure ID, `edge` role node label, and zone.
+`machine.openshift.io/cluster-api-machine-type`:: Requires the `edge` role node label.
 endif::edge[]
-<4> Specify a valid {op-system-first} Amazon
-Machine Image (AMI) for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
+`<ami_id>`:: Specifies a valid {op-system-first} Amazon Machine Image (AMI) for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
 +
 [source,terminal]
 ----
@@ -189,26 +193,26 @@ $ oc -n openshift-machine-api \
     get machineset/<infrastructure_id>-<role>-<zone>
 ----
 ifndef::edge[]
-<5> Specify the zone name, for example, `us-east-1a`.
+`<zone>`:: Specifies the zone name, for example, `us-east-1a`.
 endif::edge[]
 ifdef::edge[]
-<5> Specify the zone name, for example, `us-east-1-nyc-1a`.
-endif::edge[] 
-<6> Specify the region, for example, `us-east-1`.
+`<zone>`:: Specifies the zone name, for example, `us-east-1-nyc-1a`.
+endif::edge[]
+`<region>`:: Specifies the region, for example, `us-east-1`.
 ifndef::edge[]
-<7> Specify the infrastructure ID and zone.
+`<infrastructure_id>-private-<zone>`:: Specifies the infrastructure ID and zone, with the string `-private-` between them.
 endif::edge[]
 ifdef::edge[]
-<7> The ID of the public subnet that you created in AWS {zone-type}. You created this public subnet ID when you finished the procedure for "Creating a subnet in an AWS zone".
+`<value_of_PublicSubnetIds>`:: Specifies the ID of the public subnet that you created in AWS {zone-type}. You created this public subnet ID when you finished the procedure for "Creating a subnet in an AWS zone".
 endif::edge[]
-<8> Optional: Specify custom tag data for your cluster. For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
+`<custom_tag_name>`:: Optional: Specifies custom tag data for your cluster. For example, you might add an admin contact email address by specifying a `name:value` pair of `Email:\admin-email@example.com`.
 +
 [NOTE]
 ====
 Custom tags can also be specified during installation in the `install-config.yml` file. If the `install-config.yml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yml` file.
 ====
 ifdef::infra,edge[]
-<9> Specify a taint to prevent user workloads from being scheduled on
+`<taints>`:: Specifies a taint to prevent user workloads from being scheduled on
 ifdef::infra[`infra`]
 ifdef::edge[`edge`]
 nodes.

--- a/modules/machineset-yaml-azure-stack-hub.adoc
+++ b/modules/machineset-yaml-azure-stack-hub.adoc
@@ -11,6 +11,7 @@ endif::[]
 [id="machineset-yaml-azure-stack-hub_{context}"]
 = Sample YAML for a compute machine set custom resource on Azure Stack Hub
 
+[role="_abstract"]
 This sample YAML defines a compute machine set that runs in the `1` Microsoft Azure zone in a region and creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
@@ -20,85 +21,90 @@ ifndef::infra[`<role>`]
 ifdef::infra[`<infra>`]
 is the node label to add.
 
+[NOTE]
+====
+Machine sets running on Azure Stack Hub do not support non-guaranteed Spot VMs.
+====
+
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
-    machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructure_id>-<role>-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: <role>
+    machine.openshift.io/cluster-api-machine-type: <role>
+  name: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <infra> <2>
-    machine.openshift.io/cluster-api-machine-type: <infra> <2>
-  name: <infrastructure_id>-infra-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: <infra>
+    machine.openshift.io/cluster-api-machine-type: <infra>
+  name: <infrastructure_id>-infra-<region>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region>
 endif::infra[]
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: <infra>
+        machine.openshift.io/cluster-api-machine-type: <infra>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region>
 endif::infra[]
     spec:
       metadata:
         creationTimestamp: null
         labels:
 ifndef::infra[]
-          node-role.kubernetes.io/<role>: "" <2>
+          node-role.kubernetes.io/<role>: ""
 endif::infra[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <2>
-      taints: <4>
+          node-role.kubernetes.io/infra: ""
+      taints:
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
       providerSpec:
         value:
           apiVersion: machine.openshift.io/v1beta1
-          availabilitySet: <availability_set> <6>
+          availabilitySet: <availability_set>
           credentialsSecret:
             name: azure-cloud-credentials
             namespace: openshift-machine-api
           image:
             offer: ""
             publisher: ""
-            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id> <1>
+            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id>
             sku: ""
             version: ""
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
 ifndef::infra[]
-          location: <region> <4>
+          location: <region>
 endif::infra[]
 ifdef::infra[]
-          location: <region> <5>
+          location: <region>
 endif::infra[]
-          managedIdentity: <infrastructure_id>-identity <1>
+          managedIdentity: <infrastructure_id>-identity
           metadata:
             creationTimestamp: null
           natRule: null
@@ -110,22 +116,24 @@ endif::infra[]
             osType: Linux
           publicIP: false
           publicLoadBalancer: ""
-          resourceGroup: <infrastructure_id>-rg <1>
+          resourceGroup: <infrastructure_id>-rg
           sshPrivateKey: ""
           sshPublicKey: ""
-          subnet: <infrastructure_id>-<role>-subnet <1> <2>
+          subnet: <infrastructure_id>-<role>-subnet
           userDataSecret:
-            name: worker-user-data <2>
+            name: worker-user-data
           vmSize: Standard_DS4_v2
-          vnet: <infrastructure_id>-vnet <1>
+          vnet: <infrastructure_id>-vnet
 ifndef::infra[]
-          zone: "1" <5>
+          zone: "1"
 endif::infra[]
 ifdef::infra[]
-          zone: "1" <7>
+          zone: "1"
 endif::infra[]
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
 [source,terminal]
 ----
@@ -149,25 +157,24 @@ $  oc -n openshift-machine-api \
     get machineset/<infrastructure_id>-worker-centralus1
 ----
 ifndef::infra[]
-<2> Specify the node label to add.
-<3> Specify the infrastructure ID, node label, and region.
-<4> Specify the region to place machines on.
-<5> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
-<6> Specify the availability set for the cluster.
+`<role>`:: Specifies the node label to add.
+`<infrastructure_id>-<role>-<region>`:: Specifies the infrastructure ID, node label, and region.
+`<region>`:: Specifies the region to place machines on.
+`"1"`:: Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+`<availability_set>`:: Specifies the availability set for the cluster.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the `<infra>` node label.
-<3> Specify the infrastructure ID, `<infra>` node label, and region.
-<4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+`<infra>`:: Specifies the `<infra>` node label.
+`<infrastructure_id>-infra-<region>`:: Specify the infrastructure ID, `<infra>` node label, and region.
+`taints`:: Specifies a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====
 After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
 ====
-
-<5> Specify the region to place machines on.
-<6> Specify the availability set for the cluster.
-<7> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+`<region>`:: Specifies the region to place machines on.
+`<availability_set>`:: Specifies the availability set for the cluster.
+`"1"`:: Specifies the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 
 endif::infra[]
 

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -11,6 +11,7 @@ endif::[]
 [id="machineset-yaml-azure_{context}"]
 = Sample YAML for a compute machine set custom resource on Azure
 
+[role="_abstract"]
 This sample YAML defines a compute machine set that runs in the `1` Microsoft Azure zone in a region and creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
@@ -20,22 +21,24 @@ ifndef::infra[`<role>`]
 ifdef::infra[`infra`]
 is the node label to add.
 
+Machine sets running on Azure support non-guaranteed Spot VMs. You can save on costs by using Spot VMs at a lower price compared to standard VMs on Azure. You can configure Spot VMs by adding `spotVMOptions` to the `MachineSet` YAML file.
+
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> # <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> # <2>
+    machine.openshift.io/cluster-api-machine-role: <role>
     machine.openshift.io/cluster-api-machine-type: <role>
-  name: <infrastructure_id>-<role>-<region> # <3>
+  name: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: infra # <2>
+    machine.openshift.io/cluster-api-machine-role: infra
     machine.openshift.io/cluster-api-machine-type: infra
-  name: <infrastructure_id>-infra-<region> # <3>
+  name: <infrastructure_id>-infra-<region>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
@@ -81,15 +84,15 @@ endif::infra[]
           credentialsSecret:
             name: azure-cloud-credentials
             namespace: openshift-machine-api
-          image: # <4>
+          image:
             offer: ""
             publisher: ""
-            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/galleries/gallery_<infrastructure_id>/images/<infrastructure_id>-gen2/versions/latest # <5>
+            resourceID: <resource_id>
             sku: ""
             version: ""
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
-          location: <region> # <6>
+          location: <region>
           managedIdentity: <infrastructure_id>-identity
           metadata:
             creationTimestamp: null
@@ -106,21 +109,23 @@ endif::infra[]
           sshPrivateKey: ""
           sshPublicKey: ""
           tags:
-            <custom_tag_name_1>: <custom_tag_value_1> # <7>
+            <custom_tag_name_1>: <custom_tag_value_1>
             <custom_tag_name_2>: <custom_tag_value_2>
           subnet: <infrastructure_id>-<role>-subnet
           userDataSecret:
             name: worker-user-data
           vmSize: Standard_D4s_v3
           vnet: <infrastructure_id>-vnet
-          zone: "1" # <8>
+          zone: <zone>
 ifdef::infra[]
-      taints: # <9>
+      taints:
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
 [source,terminal]
 ----
@@ -144,18 +149,18 @@ $  oc -n openshift-machine-api \
     get machineset/<infrastructure_id>-worker-centralus1
 ----
 ifndef::infra[]
-<2> Specify the node label to add.
-<3> Specify the infrastructure ID, node label, and region.
+`<role>`:: Specifies the node label to add.
+`<infrastructure_id>-<role>-<region>`:: Specifies the infrastructure ID, node label, and region.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the `infra` node label.
-<3> Specify the infrastructure ID, `infra` node label, and region.
+`machine.openshift.io/cluster-api-machine-role`:: Requires the `infra` node label.
+`<infrastructure_id>-infra-<region>`:: Specifies the infrastructure ID, `infra` node label, and region.
 endif::infra[]
-<4> Specify the image details for your compute machine set. If you want to use an Azure Marketplace image, see "Using the Azure Marketplace offering".
-<5> Specify an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix.
-<6> Specify the region to place machines on.
-<7> Optional: Specify custom tags in your machine set. Provide the tag name in `<custom_tag_name>` field and the corresponding tag value in `<custom_tag_value>` field.
-<8> Specify the zone within your region to place machines on. 
+`image:`:: Specifies the image details for your compute machine set. If you want to use an Azure Marketplace image, see "Using the Azure Marketplace offering".
+`<resource_ID>`:: Specifies an image that is compatible with your instance type. The Hyper-V generation V2 images created by the installation program have a `-gen2` suffix, while V1 images have the same name without the suffix. A sample image structure is `/resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/galleries/gallery_<infrastructure_id>/images/<infrastructure_id>-gen2/versions/latest`.
+`<region>`:: Specifies the region to place machines on.
+`<custom_tag_value_1>`:: Optional: Specifies custom tags in your machine set. Provide the tag name in `<custom_tag_name>` field and the corresponding tag value in `<custom_tag_value>` field.
+`<zone>`:: Specifies the zone within your region to place machines on.
 Ensure that your region supports the zone that you specify.
 +
 [IMPORTANT]
@@ -165,7 +170,7 @@ Specifying the zone avoids volume node affinity failure when a pod requires a pe
 To do this, you can create a compute machine set for each zone in the same region.
 ====
 ifdef::infra[]
-<9> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+`taints`:: Specifies a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -9,8 +9,9 @@ endif::[]
 
 :_mod-docs-content-type: REFERENCE
 [id="machineset-yaml-gcp_{context}"]
-=  Sample YAML for a compute machine set custom resource on {gcp-short}
+= Sample YAML for a compute machine set custom resource on {gcp-short}
 
+[role="_abstract"]
 This sample YAML defines a compute machine set that runs in {gcp-first} and creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`,]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`,]
@@ -19,9 +20,8 @@ ifndef::infra[`<role>`]
 ifdef::infra[`infra`]
 is the node label to add.
 
-
-[id="cpmso-yaml-provider-spec-gcp-oc_{context}"]
-== Values obtained by using the  OpenShift CLI
+Machine sets running on {gcp-short} support non-guaranteed preemptible VM instances. You can save on costs by using preemptible VM instances at a lower price
+compared to normal instances on {gcp-short}. You can configure preemptible VM instances by adding `preemptible` to the `MachineSet` YAML file.
 
 In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI.
 
@@ -48,7 +48,7 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
   name: <infrastructure_id>-w-a
   namespace: openshift-machine-api
 spec:
@@ -63,11 +63,11 @@ spec:
       labels:
         machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
+        machine.openshift.io/cluster-api-machine-role: <role>
         machine.openshift.io/cluster-api-machine-type: <role>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
+        machine.openshift.io/cluster-api-machine-role: <infra>
         machine.openshift.io/cluster-api-machine-type: <infra>
 endif::infra[]
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a
@@ -90,11 +90,11 @@ endif::infra[]
           disks:
           - autoDelete: true
             boot: true
-            image: <path_to_image> <3>
+            image: <path_to_image>
             labels: null
             sizeGb: 128
             type: pd-ssd
-          gcpMetadata: <4>
+          gcpMetadata:
           - key: <custom_metadata_key>
             value: <custom_metadata_value>
           kind: GCPMachineProviderSpec
@@ -104,9 +104,9 @@ endif::infra[]
           networkInterfaces:
           - network: <infrastructure_id>-network
             subnetwork: <infrastructure_id>-worker-subnet
-          projectID: <project_name> <5>
+          projectID: <project_name>
           region: us-central1
-          serviceAccounts: <6>
+          serviceAccounts:
           - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
@@ -116,19 +116,21 @@ endif::infra[]
             name: worker-user-data
           zone: us-central1-a
 ifdef::infra[]
-      taints: <7>
+      taints:
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
 ----
-<1> For `<infrastructure_id>`, specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster.
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster.
 ifndef::infra[]
-<2> For `<node>`, specify the node label to add.
+`<node>`:: Specifies the node label to add.
 endif::infra[]
 ifdef::infra[]
-<2> For `<infra>`, specify the `<infra>` node label.
+`<infra>`:: Specifies the `<infra>` node label.
 endif::infra[]
-<3> Specify the path to the image that is used in current compute machine sets.
+`<path_to_image>`:: Specifies the path to the image that is used in current compute machine sets.
 +
 To use a {gcp-short} Marketplace image, specify the offer to use:
 +
@@ -137,11 +139,11 @@ To use a {gcp-short} Marketplace image, specify the offer to use:
 * {opp}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-opp-413-x86-64-202305021736`
 * {oke}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-oke-413-x86-64-202305021736`
 --
-<4> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the {gcp-short} documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
-<5> For `<project_name>`, specify the name of the {gcp-short} project that you use for your cluster.
-<6> Specifies a single service account. Multiple service accounts are not supported.
+`gcpMetadata`:: Optional: Specifies custom metadata in the form of a `key:value` pair. For example use cases, see the {gcp-short} documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
+`<project_name>`:: Specifies the name of the {gcp-short} project that you use for your cluster.
+`serviceAccounts`:: Specifies a single service account. Multiple service accounts are not supported.
 ifdef::infra[]
-<7> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+`taints`:: Specifies a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====

--- a/modules/machineset-yaml-ibm-cloud.adoc
+++ b/modules/machineset-yaml-ibm-cloud.adoc
@@ -11,6 +11,7 @@ endif::[]
 [id="machineset-yaml-ibm-cloud_{context}"]
 = Sample YAML for a compute machine set custom resource on {ibm-cloud-title}
 
+[role="_abstract"]
 This sample YAML defines a compute machine set that runs in a specified {ibm-cloud-name} zone in a region and creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
@@ -26,42 +27,42 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
-    machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructure_id>-<role>-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: <role>
+    machine.openshift.io/cluster-api-machine-type: <role>
+  name: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <infra> <2>
-    machine.openshift.io/cluster-api-machine-type: <infra> <2>
-  name: <infrastructure_id>-<infra>-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: <infra>
+    machine.openshift.io/cluster-api-machine-type: <infra>
+  name: <infrastructure_id>-<infra>-<region>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<region>
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: <infra>
+        machine.openshift.io/cluster-api-machine-type: <infra>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<region>
 endif::infra[]
     spec:
       metadata:
@@ -77,19 +78,19 @@ endif::infra[]
           apiVersion: ibmcloudproviderconfig.openshift.io/v1beta1
           credentialsSecret:
             name: ibmcloud-credentials
-          image: <infrastructure_id>-rhcos <4>
+          image: <infrastructure_id>-rhcos
           kind: IBMCloudMachineProviderSpec
           primaryNetworkInterface:
               securityGroups:
               - <infrastructure_id>-sg-cluster-wide
               - <infrastructure_id>-sg-openshift-net
-              subnet: <infrastructure_id>-subnet-compute-<zone> <5>
-          profile: <instance_profile> <6>
-          region: <region> <7>
-          resourceGroup: <resource_group> <8>
+              subnet: <infrastructure_id>-subnet-compute-<zone>
+          profile: <instance_profile>
+          region: <region>
+          resourceGroup: <resource_group>
           userDataSecret:
-              name: <role>-user-data <2>
-          vpc: <vpc_name> <9>
+              name: <role>-user-data
+          vpc: <vpc_name>
           zone: <zone> <10>
 ifdef::infra[]
         taints: <11>
@@ -97,29 +98,31 @@ ifdef::infra[]
           effect: NoSchedule
 endif::infra[]
 ----
-<1> The infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
 [source,terminal]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 ifndef::infra[]
-<2> The node label to add.
-<3> The infrastructure ID, node label, and region.
+`<role>`:: Specifies the node label to add.
+`<infrastructure_id>-<role>-<region>`:: Specifies the infrastructure ID, node label, and region.
 endif::infra[]
 ifdef::infra[]
-<2> The `<infra>` node label.
-<3> The infrastructure ID, `<infra>` node label, and region.
+`<infra>`:: Specifies the `<infra>` node label.
+`<infrastructure_id>-<infra>-<region>`:: Specifies the infrastructure ID, `<infra>` node label, and region.
 endif::infra[]
-<4> The custom {op-system-first} image that was used for cluster installation.
-<5> The infrastructure ID and zone within your region to place machines on. Be sure that your region supports the zone that you specify.
-<6> Specify the link:https://cloud.ibm.com/docs/vpc?topic=vpc-profiles&interface=ui[{ibm-cloud-name} instance profile].
-<7> Specify the region to place machines on.
-<8> The resource group that machine resources are placed in. This is either an existing resource group specified at installation time, or an installer-created resource group named based on the infrastructure ID.
-<9> The VPC name.
-<10> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+`<infrastructure_id>-rhcos`:: Specifies the custom {op-system-first} image that was used for cluster installation.
+`<infrastructure_id>-subnet-compute-<zone>`:: Specifies the infrastructure ID and zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+`<instance_profile>`:: Specifies the link:https://cloud.ibm.com/docs/vpc?topic=vpc-profiles&interface=ui[{ibm-cloud-name} instance profile].
+`<region>`:: Specifies the region to place machines on.
+`<resource_group>`:: Specifies the resource group that machine resources are placed in. This is either an existing resource group specified at installation time, or an installer-created resource group named based on the infrastructure ID.
+`<vpc_name>`:: The VPC name.
+`<zone>`:: Specifies the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 ifdef::infra[]
-<11> The taint to prevent user workloads from being scheduled on infra nodes.
+`taints`:: Specifies the taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====

--- a/modules/machineset-yaml-nutanix.adoc
+++ b/modules/machineset-yaml-nutanix.adoc
@@ -11,6 +11,7 @@ endif::[]
 [id="machineset-yaml-nutanix_{context}"]
 = Sample YAML for a compute machine set custom resource on Nutanix
 
+[role="_abstract"]
 This sample YAML defines a Nutanix compute machine set that creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
@@ -39,19 +40,19 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
+    machine.openshift.io/cluster-api-machine-role: <role>
     machine.openshift.io/cluster-api-machine-type: <role>
-  name: <infrastructure_id>-<role>-<zone> <3>
+  name: <infrastructure_id>-<role>-<zone>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <infra> <2>
+    machine.openshift.io/cluster-api-machine-role: <infra>
     machine.openshift.io/cluster-api-machine-type: <infra>
-  name: <infrastructure_id>-<infra>-<zone> <3>
+  name: <infrastructure_id>-<infra>-<zone>
 endif::infra[]
   namespace: openshift-machine-api
-  annotations: <4>
+  annotations:
     machine.openshift.io/memoryMb: "16384"
     machine.openshift.io/vCPU: "4"
 spec:
@@ -91,68 +92,70 @@ endif::infra[]
       providerSpec:
         value:
           apiVersion: machine.openshift.io/v1
-          bootType: "" <5>
-          categories: <6>
+          bootType: <boot_type>
+          categories:
           - key: <category_name>
             value: <category_value>
-          cluster: <7>
+          cluster:
             type: uuid
             uuid: <cluster_uuid>
           credentialsSecret:
             name: nutanix-credentials
           image:
-            name: <infrastructure_id>-rhcos <8>
+            name: <infrastructure_id>-rhcos
             type: name
           kind: NutanixMachineProviderConfig
-          memorySize: 16Gi <9>
-          project: <10>
+          memorySize: <memory_amount>
+          project:
             type: name
             name: <project_name>
-          subnets: <11>
+          subnets:
           - type: uuid
             uuid: <subnet_uuid>
-          systemDiskSize: 120Gi <12>
+          systemDiskSize: <system_disk_size>
           userDataSecret:
-            name: <user_data_secret> <13>
-          vcpuSockets: 4 <14>
-          vcpusPerSocket: 1 <15>
+            name: <user_data_secret>
+          vcpuSockets: <vcpu_sockets>
+          vcpusPerSocket: <vcpus_per_socket>
 ifdef::infra[]
-      taints: <16>
+      taints:
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
 ----
-<1>  For `<infrastructure_id>`, specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster.
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster.
 ifndef::infra[]
-<2> Specify the node label to add.
-<3> Specify the infrastructure ID, node label, and zone.
+`<role>`:: Specifies the node label to add.
+`<infrastructure_id>-<role>-<zone>`:: Specifies the infrastructure ID, node label, and zone.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the `<infra>` node label.
-<3> Specify the infrastructure ID, `<infra>` node label, and zone.
+`<infra>`:: Specifies the `<infra>` node label.
+`<infrastructure_id>-<infra>-<zone>`:: Specifies the infrastructure ID, `<infra>` node label, and zone.
 endif::infra[]
-<4> Annotations for the cluster autoscaler.
-<5> Specifies the boot type that the compute machines use. For more information about boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment]. Valid values are `Legacy`, `SecureBoot`, or `UEFI`. The default is `Legacy`.
+`annotations`:: Specifies annotations for the cluster autoscaler.
+`<boot_type>`:: Specifies the boot type that the compute machines use. For more information about boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment]. Valid values are `Legacy`, `SecureBoot`, or `UEFI`. The default is `Legacy`.
 +
 [NOTE]
 ====
 You must use the `Legacy` boot type in {product-title} {product-version}.
 ====
-<6> Specify one or more Nutanix Prism categories to apply to compute machines. This stanza requires `key` and `value` parameters for a category key-value pair that exists in Prism Central. For more information about categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
-<7> Specify a Nutanix Prism Element cluster configuration. In this example, the cluster type is `uuid`, so there is a `uuid` stanza.
-<8> Specify the image to use. Use an image from an existing default compute machine set for the cluster.
-<9> Specify the amount of memory for the cluster in Gi.
-<10> Specify the Nutanix project that you use for your cluster. In this example, the project type is `name`, so there is a `name` stanza.
-<11> Specify one or more UUID for the Prism Element subnet object. 
-The CIDR IP address prefix for one of the specified subnets must contain the virtual IP addresses that the {product-title} cluster uses. 
+`categories`:: Specifies one or more Nutanix Prism categories to apply to compute machines. This stanza requires `key` and `value` parameters for a category key-value pair that exists in Prism Central. For more information about categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
+`cluster`:: Specifies a Nutanix Prism Element cluster configuration. In this example, the cluster type is `uuid`, so there is a `uuid` stanza.
+`<infrastructure_id>-rhcos`:: Specifies the image to use. Use an image from an existing default compute machine set for the cluster.
+`<memory_amount>`:: Specifies the amount of memory for the cluster in Gi.
+`project`:: Specifies the Nutanix project that you use for your cluster. In this example, the project type is `name`, so there is a `name` stanza.
+`subnets`:: Specifies one or more UUID for the Prism Element subnet object.
+The CIDR IP address prefix for one of the specified subnets must contain the virtual IP addresses that the {product-title} cluster uses.
 A maximum of 32 subnets for each Prism Element failure domain in the cluster is supported.
 All subnet UUID values must be unique.
-<12> Specify the size of the system disk in Gi.
-<13> Specify the name of the secret in the user data YAML file that is in the `openshift-machine-api` namespace. Use the value that installation program populates in the default compute machine set.
-<14> Specify the number of vCPU sockets.
-<15> Specify the number of vCPUs per socket.
+`<system_disk_size>`:: Specifies the size of the system disk in Gi.
+`<user_data_secret>`:: Specifies the name of the secret in the user data YAML file that is in the `openshift-machine-api` namespace. Use the value that installation program populates in the default compute machine set.
+`<vcpu_sockets>`:: Specifies the number of vCPU sockets.
+`<vcpus_per_socket>`:: Specifies the number of vCPUs per socket.
 ifdef::infra[]
-<16> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+`taints`:: Specifies a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====

--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -11,6 +11,7 @@ endif::[]
 [id="machineset-yaml-osp_{context}"]
 =  Sample YAML for a compute machine set custom resource on {rh-openstack}
 
+[role="_abstract"]
 This sample YAML defines a compute machine set that runs on {rh-openstack-first} and creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
@@ -26,49 +27,49 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <role> <2>
-    machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructure_id>-<role> <3>
+    machine.openshift.io/cluster-api-machine-role: <role>
+    machine.openshift.io/cluster-api-machine-type: <role>
+  name: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <infra> <2>
-    machine.openshift.io/cluster-api-machine-type: <infra> <2>
-  name: <infrastructure_id>-infra <3>
+    machine.openshift.io/cluster-api-machine-role: <infra>
+    machine.openshift.io/cluster-api-machine-type: <infra>
+  name: <infrastructure_id>-infra
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas>
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <3>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
     spec:
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <3>
+        machine.openshift.io/cluster-api-machine-role: <infra>
+        machine.openshift.io/cluster-api-machine-type: <infra>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
     spec:
       metadata:
         creationTimestamp: null
         labels:
           node-role.kubernetes.io/infra: ""
-      taints: <4>
+      taints:
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
@@ -82,70 +83,71 @@ endif::infra[]
           flavor: <nova_flavor>
           image: <glance_image_name_or_location>
 ifndef::infra[]
-          serverGroupID: <optional_UUID_of_server_group> <4>
+          serverGroupID: <optional_UUID_of_server_group>
 endif::infra[]
 ifdef::infra[]
-          serverGroupID: <optional_UUID_of_server_group> <5>
+          serverGroupID: <optional_UUID_of_server_group>
 endif::infra[]
           kind: OpenstackProviderSpec
 ifndef::infra[]
-          networks: <5>
+          networks:
 endif::infra[]
 ifdef::infra[]
-          networks: <6>
+          networks:
 endif::infra[]
           - filter: {}
             subnets:
             - filter:
                 name: <subnet_name>
-                tags: openshiftClusterID=<infrastructure_id> <1>
+                tags: openshiftClusterID=<infrastructure_id>
 ifndef::infra[]
-          primarySubnet: <rhosp_subnet_UUID> <6>
+          primarySubnet: <rhosp_subnet_UUID>
 endif::infra[]
 ifdef::infra[]
-          primarySubnet: <rhosp_subnet_UUID> <7>
+          primarySubnet: <rhosp_subnet_UUID>
 endif::infra[]
           securityGroups:
           - filter: {}
-            name: <infrastructure_id>-worker <1>
+            name: <infrastructure_id>-worker
           serverMetadata:
-            Name: <infrastructure_id>-worker <1>
-            openshiftClusterID: <infrastructure_id> <1>
+            Name: <infrastructure_id>-worker
+            openshiftClusterID: <infrastructure_id>
           tags:
-          - openshiftClusterID=<infrastructure_id> <1>
+          - openshiftClusterID=<infrastructure_id>
           trunk: true
           userDataSecret:
-            name: worker-user-data <2>
+            name: worker-user-data
           availabilityZone: <optional_openstack_availability_zone>
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
 [source,terminal]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 ifndef::infra[]
-<2> Specify the node label to add.
-<3> Specify the infrastructure ID and node label.
-<4> To set a server group policy for the MachineSet, enter the value that is returned from
+`<role>`:: Specifies the node label to add.
+`<infrastructure_id>-<role>`:: Specifies the infrastructure ID and node label.
+`<optional_UUID_of_server_group>`:: To set a server group policy for the MachineSet, enter the value that is returned from
 link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/server#server_group_create[creating a server group]. For most deployments, `anti-affinity` or `soft-anti-affinity` policies are recommended.
-<5> Required for deployments to multiple networks. To specify multiple networks, add another entry in the networks array. Also, you must include the network that is used as the `primarySubnet` value.
-<6> Specify the {rh-openstack} subnet that you want the endpoints of nodes to be published on. Usually, this is the same subnet that is used as the value of `machinesSubnet` in the `install-config.yaml` file.
+`networks`:: Required for deployments to multiple networks. To specify multiple networks, add another entry in the networks array. Also, you must include the network that is used as the `primarySubnet` value.
+`<rhosp_subnet_UUID>`:: Specifies the {rh-openstack} subnet that you want the endpoints of nodes to be published on. Usually, this is the same subnet that is used as the value of `machinesSubnet` in the `install-config.yaml` file.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the `<infra>` node label.
-<3> Specify the infrastructure ID and `<infra>` node label.
-<4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+`<infra>`:: Specifies the `<infra>` node label.
+`<infrastructure_id>-infra`:: Specifies the infrastructure ID and `<infra>` node label.
+`taints`:: Specifies a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====
 After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
 ====
-
-<5> To set a server group policy for the MachineSet, enter the value that is returned from
+`<optional_UUID_of_server_group>`:: To set a server group policy for the MachineSet, enter the value that is returned from
 link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/server#server_group_create[creating a server group]. For most deployments, `anti-affinity` or `soft-anti-affinity` policies are recommended.
-<6> Required for deployments to multiple networks. If deploying to multiple networks, this list must include the network that is used as the `primarySubnet` value.
-<7> Specify the {rh-openstack} subnet that you want the endpoints of nodes to be published on. Usually, this is the same subnet that is used as the value of `machinesSubnet` in the `install-config.yaml` file.
+`networks`:: Required for deployments to multiple networks. If deploying to multiple networks, this list must include the network that is used as the `primarySubnet` value.
+`<rhosp_subnet_UUID>`:: Specifies the {rh-openstack} subnet that you want the endpoints of nodes to be published on. Usually, this is the same subnet that is used as the value of `machinesSubnet` in the `install-config.yaml` file.
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -11,6 +11,7 @@ endif::[]
 [id="machineset-yaml-vsphere_{context}"]
 = Sample YAML for a compute machine set custom resource on vSphere
 
+[role="_abstract"]
 This sample YAML defines a compute machine set that runs on VMware vSphere and creates nodes that are labeled with
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
@@ -27,12 +28,12 @@ kind: MachineSet
 metadata:
   creationTimestamp: null
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-  name: <infrastructure_id>-<role> <2>
+  name: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-  name: <infrastructure_id>-infra <2>
+  name: <infrastructure_id>-infra
 endif::infra[]
   namespace: openshift-machine-api
 spec:
@@ -52,12 +53,12 @@ endif::infra[]
       labels:
         machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <3>
+        machine.openshift.io/cluster-api-machine-role: <role>
         machine.openshift.io/cluster-api-machine-type: <role>
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: infra <3>
+        machine.openshift.io/cluster-api-machine-role: infra
         machine.openshift.io/cluster-api-machine-type: infra
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra
 endif::infra[]
@@ -76,7 +77,7 @@ endif::infra[]
           apiVersion: machine.openshift.io/v1beta1
           credentialsSecret:
             name: vsphere-cloud-credentials
-          dataDisks: <4>
+          dataDisks:
           - name: "<disk_name>"
             provisioningMode: "<mode>"
             sizeGiB: 20
@@ -87,50 +88,52 @@ endif::infra[]
             creationTimestamp: null
           network:
             devices:
-            - networkName: "<vm_network_name>" <5>
+            - networkName: "<vm_network_name>"
           numCPUs: 4
           numCoresPerSocket: 1
           snapshot: ""
-          template: <vm_template_name> <6>
+          template: <vm_template_name>
           userDataSecret:
             name: worker-user-data
           workspace:
-            datacenter: <vcenter_data_center_name> <7>
-            datastore: <vcenter_datastore_name> <8>
-            folder: <vcenter_vm_folder_path> <9>
-            resourcepool: <vsphere_resource_pool> <10>
-            server: <vcenter_server_ip> <11>
+            datacenter: <vcenter_data_center_name>
+            datastore: <vcenter_datastore_name>
+            folder: <vcenter_vm_folder_path>
+            resourcepool: <vsphere_resource_pool>
+            server: <vcenter_server_ip>
 ifdef::infra[]
-      taints: <12>
+      taints:
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
+where:
+
+`<infrastructure_id>`:: Specifies the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
 +
 [source,terminal]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
 ifndef::infra[]
-<2> Specify the infrastructure ID and node label.
-<3> Specify the node label to add.
+`<infrastructure_id>-<role>`:: Specifies the infrastructure ID and node label.
+`<role>`:: Specifies the node label to add.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the infrastructure ID and `infra` node label.
-<3> Specify the `infra` node label.
+`<infrastructure_id>-<role>`:: Specifies the infrastructure ID and `infra` node label.
+`infra`:: Specifies the `infra` node label.
 endif::infra[]
-<4> Specify one or more data disk definitions. 
+`dataDisks`:: Specifies one or more data disk definitions.
 For more information, see "Configuring data disks by using machine sets".
-<5> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
-<6> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
-<7> Specify the vCenter datacenter to deploy the compute machine set on.
-<8> Specify the vCenter datastore to deploy the compute machine set on.
-<9> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
-<10> Specify the vSphere resource pool for your VMs.
-<11> Specify the vCenter server IP or fully qualified domain name.
+`"<vm_network_name>"`:: Specifies the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
+`<vm_template_name>`:: Specifies the vSphere VM template to use, such as `user-5ddjd-rhcos`.
+`<vcenter_data_center_name>`:: Specifies the vCenter datacenter to deploy the compute machine set on.
+`<vcenter_datastore_name>`:: Specifies the vCenter datastore to deploy the compute machine set on.
+`<vcenter_vm_folder_path>`:: Specifies the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.
+`<vsphere_resource_pool>`:: Specifies the vSphere resource pool for your VMs.
+`<vcenter_server_ip>`:: Specifies the vCenter server IP or fully qualified domain name.
 ifdef::infra[]
-<12> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+`taints`:: Specifies a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Replace numbered callouts with definition list format in platform-specific machineset YAML sample files for improved readability and standardization.

Changes:
- AWS, Azure, Azure Stack Hub, GCP, IBM Cloud, Nutanix, OSP, vSphere
- Generic machineset-creating.adoc

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-17042

Link to docs preview:
[Cloud templates](https://105995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#creating-infrastructure-machinesets-clouds)
[Creating a compute machine set](https://105995--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-creating_creating-infrastructure-machinesets)


This is 1 of 3 PRs split out from https://github.com/openshift/openshift-docs/pull/103488 by Claude. The other two PRs are https://github.com/openshift/openshift-docs/pull/105996 and https://github.com/openshift/openshift-docs/pull/105997
