### PR TITLE
OSDOCS-17042 [CQA] Simplify VPA and CRO resource movement documentation

### DIFF
--- a/modules/nodes-cluster-resource-override-move-infra.adoc
+++ b/modules/nodes-cluster-resource-override-move-infra.adoc
@@ -22,6 +22,13 @@ endif::cro[]
 
 .Procedure
 
+. Determine the nodes where the Cluster Resource Override pods are running by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n clusterresourceoverride-operator -o wide
+----
+
 . Move the Cluster Resource Override Operator pod by adding a node selector to its `Subscription` custom resource (CR).
 
 .. Edit the CR by running the following command:

--- a/modules/nodes-cluster-resource-override-move-infra.adoc
+++ b/modules/nodes-cluster-resource-override-move-infra.adoc
@@ -12,75 +12,28 @@ endif::[]
 = Moving the Cluster Resource Override Operator pods
 
 [role="_abstract"]
+You can move the Cluster Resource Override Operator pods to infrastructure nodes to reduce the subscription requirements of your cluster. Move the pods by editing the `Subscription` custom resource (CR) for the Cluster Resource Override Operator and the `ClusterResourceOverride` custom resource.
+
 By default, the Cluster Resource Override Operator installation process creates an Operator pod and two Cluster Resource Override pods on nodes in the `clusterresourceoverride-operator` namespace. You can move these pods to other nodes, such as infrastructure nodes, as needed.
 
 ifdef::cro[]
 You can create and use infrastructure nodes to host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information about infrastructure nodes, see "Creating infrastructure machine sets".
 endif::cro[]
 
-The following examples shows the Cluster Resource Override pods are deployed to control plane nodes and the Cluster Resource Override Operator pod is deployed to a worker node.
-
-.Example Cluster Resource Override pods
-[source,terminal]
-----
-NAME                                                READY   STATUS    RESTARTS   AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
-clusterresourceoverride-786b8c898c-9wrdq            1/1     Running   0          23s   10.128.2.32   ip-10-0-14-183.us-west-2.compute.internal   <none>           <none>
-clusterresourceoverride-786b8c898c-vn2lf            1/1     Running   0          26s   10.130.2.10   ip-10-0-20-140.us-west-2.compute.internal   <none>           <none>
-clusterresourceoverride-operator-6b8b8b656b-lvr62   1/1     Running   0          56m   10.131.0.33   ip-10-0-2-39.us-west-2.compute.internal     <none>           <none>
-----
-
-.Example node list
-[source,terminal]
-----
-NAME                                        STATUS   ROLES                  AGE   VERSION
-ip-10-0-14-183.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.35.4
-ip-10-0-2-39.us-west-2.compute.internal     Ready    worker                 58m   v1.35.4
-ip-10-0-20-140.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.35.4
-ip-10-0-23-244.us-west-2.compute.internal   Ready    infra                  55m   v1.35.4
-ip-10-0-77-153.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.35.4
-ip-10-0-99-108.us-west-2.compute.internal   Ready    worker                 24m   v1.35.4
-ip-10-0-24-233.us-west-2.compute.internal   Ready    infra                  55m   v1.35.4
-ip-10-0-88-109.us-west-2.compute.internal   Ready    worker                 24m   v1.35.4
-ip-10-0-67-453.us-west-2.compute.internal   Ready    infra                  55m   v1.35.4
-----
-
 .Procedure
 
-. Move the Cluster Resource Override Operator pod by adding a node selector to the `Subscription` custom resource (CR) for the Cluster Resource Override Operator.
+. Move the Cluster Resource Override Operator pod by adding a node selector to its `Subscription` custom resource (CR).
 
-.. Edit the CR:
+.. Edit the CR by running the following command:
 +
 [source,terminal]
 ----
 $ oc edit -n clusterresourceoverride-operator subscriptions.operators.coreos.com clusterresourceoverride
 ----
 
-.. Add a node selector to match the node role label on the node where you want to install the Cluster Resource Override Operator pod:
+.. Add a node selector to match the node role label on the node where you want to move the Cluster Resource Override Operator pod, and add a toleration if the node uses taints:
 +
-[source,terminal]
-----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  name: clusterresourceoverride
-  namespace: clusterresourceoverride-operator
-# ...
-spec:
-  config:
-    nodeSelector:
-      node-role.kubernetes.io/infra: ""
-----
-+
-where:
-
-`spec.config.nodeSelector`:: Specifies the role of the node where you want to deploy the Cluster Resource Override Operator pod.
-
-+
-[NOTE]
-====
-If the infra node uses taints, you need to add a toleration to the `Subscription` CR. For example:
-
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -96,26 +49,26 @@ spec:
     - key: "node-role.kubernetes.io/infra"
       operator: "Exists"
       effect: "NoSchedule"
+# ...
 ----
-
++
 where:
-
-`spec.config.tolerations`:: Specifies a toleration for a taint on the infra node.
-
-====
++
+`nodeSelector`:: Specifies the role label on the node where you want to move the Cluster Resource Override Operator pod
+`tolerations`:: Specifies the toleration for the node where you want to move the pod. This field is only necessary if the node uses a taint.
 
 . Move the Cluster Resource Override pods by adding a node selector to the `ClusterResourceOverride` custom resource (CR):
 
-.. Edit the CR:
+.. Edit the CR by running the following command:
 +
 [source,terminal]
 ----
 $ oc edit ClusterResourceOverride cluster -n clusterresourceoverride-operator
 ----
 
-.. Add a node selector to match the node role label on the infra node:
+.. Add a node selector to match the node role label on the node, and add a toleration if the node uses taints:
 +
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operator.autoscaling.openshift.io/v1
 kind: ClusterResourceOverride
@@ -132,47 +85,19 @@ spec:
     replicas: 1
     nodeSelector:
       node-role.kubernetes.io/infra: ""
-# ...
-----
-+
-where:
-
-`spec.deploymentOverrides.replicas`:: Specifies the number of Cluster Resource Override pods to deploy. The default is `2`. Only one pod is allowed per node. This parameter is optional.
-`spec.deploymentOverrides.nodeSelector`:: Specifies the role of the node where you want to deploy the Cluster Resource Override pods. This parameter is optional.
-
-+
-[NOTE]
-====
-If the infra node uses taints, you need to add a toleration to the `ClusterResourceOverride` CR. For example:
-
-[source,terminal]
-----
-apiVersion: operator.autoscaling.openshift.io/v1
-kind: ClusterResourceOverride
-metadata:
-  name: cluster
-# ...
-spec:
-  podResourceOverride:
-    spec:
-      memoryRequestToLimitPercent: 50
-      cpuRequestToLimitPercent: 25
-      limitCPUToMemoryPercent: 200
-  deploymentOverrides:
-    replicas: 3
-    nodeSelector:
-      node-role.kubernetes.io/worker: ""
     tolerations:
     - key: "key"
       operator: "Equal"
       value: "value"
       effect: "NoSchedule"
+# ...
 ----
-
++
 where:
-
-`spec.deploymentOverrides.tolerations`:: Specifies a toleration for a taint on the infra node.
-====
++
+`replicas`:: Optional: specifies the number of Cluster Resource Override pods to deploy. The default is `2`. Only one pod is allowed per node.
+`nodeSelector`:: Specifies the role label on the node where you want to move the Cluster Resource Override Operator pod
+`tolerations`:: Specifies the toleration for the node where you want to move the pod. This field is only necessary if the node uses a taint.
 
 .Verification
 

--- a/modules/nodes-cluster-resource-override-move-infra.adoc
+++ b/modules/nodes-cluster-resource-override-move-infra.adoc
@@ -12,7 +12,7 @@ endif::[]
 = Moving the Cluster Resource Override Operator pods
 
 [role="_abstract"]
-You can move the Cluster Resource Override Operator pods to infrastructure nodes to reduce the subscription requirements of your cluster. Move the pods by editing the `Subscription` custom resource (CR) for the Cluster Resource Override Operator and the `ClusterResourceOverride` custom resource.
+To reduce the subscription requirements of your cluster, you can move the Cluster Resource Override Operator pods to infrastructure nodes. Move the pods by editing the `Subscription` custom resource (CR) for the Cluster Resource Override Operator and the `ClusterResourceOverride` CR.
 
 By default, the Cluster Resource Override Operator installation process creates an Operator pod and two Cluster Resource Override pods on nodes in the `clusterresourceoverride-operator` namespace. You can move these pods to other nodes, such as infrastructure nodes, as needed.
 
@@ -20,16 +20,13 @@ ifdef::cro[]
 You can create and use infrastructure nodes to host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information about infrastructure nodes, see "Creating infrastructure machine sets".
 endif::cro[]
 
+.Prerequisites
+
+* You created one or more infrastructure nodes with a node label such as `node-role.kubernetes.io/infra=""`.
+
 .Procedure
 
-. Determine the nodes where the Cluster Resource Override pods are running by running the following command:
-+
-[source,terminal]
-----
-$ oc get pods -n clusterresourceoverride-operator -o wide
-----
-
-. Move the Cluster Resource Override Operator pod by adding a node selector to its `Subscription` custom resource (CR).
+. Move the Cluster Resource Override Operator pod by adding a node selector to its `Subscription` CR:
 
 .. Edit the CR by running the following command:
 +
@@ -61,8 +58,8 @@ spec:
 +
 where:
 +
-`nodeSelector`:: Specifies the role label on the node where you want to move the Cluster Resource Override Operator pod
-`tolerations`:: Specifies the toleration for the node where you want to move the pod. This field is only necessary if the node uses a taint.
+`spec.config.nodeSelector`:: Specifies the role label on the node where you want to move the Cluster Resource Override Operator pod
+`spec.config.tolerations`:: Specifies the toleration for the node where you want to move the pod. This field is only necessary if the node uses a taint.
 
 . Move the Cluster Resource Override pods by adding a node selector to the `ClusterResourceOverride` custom resource (CR):
 
@@ -102,21 +99,19 @@ spec:
 +
 where:
 +
-`replicas`:: Optional: specifies the number of Cluster Resource Override pods to deploy. The default is `2`. Only one pod is allowed per node.
-`nodeSelector`:: Specifies the role label on the node where you want to move the Cluster Resource Override Operator pod
-`tolerations`:: Specifies the toleration for the node where you want to move the pod. This field is only necessary if the node uses a taint.
+`spec.deploymentOverrides.replicas`:: Optional: specifies the number of Cluster Resource Override pods to deploy. The default is `2`. Only one pod is allowed per node.
+`spec.deploymentOverrides.nodeSelector`:: Specifies the role label on the node where you want to move the Cluster Resource Override Operator pod
+`spec.deploymentOverrides.tolerations`:: Specifies the toleration for the node where you want to move the pod. This field is only necessary if the node uses a taint.
 
 .Verification
 
-* You can verify that the pods have moved by using the following command:
+* You can verify that the pods have moved to the nodes with the label you specified by using the following command:
 +
 [source,terminal]
 ----
 $ oc get pods -n clusterresourceoverride-operator -o wide
 ----
 
-+
-The Cluster Resource Override pods are now deployed to the infra nodes.
 +
 .Example output
 [source,terminal]

--- a/modules/nodes-cluster-resource-override-move-infra.adoc
+++ b/modules/nodes-cluster-resource-override-move-infra.adoc
@@ -20,6 +20,32 @@ ifdef::cro[]
 You can create and use infrastructure nodes to host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information about infrastructure nodes, see "Creating infrastructure machine sets".
 endif::cro[]
 
+The following examples shows the Cluster Resource Override pods are deployed to control plane nodes and the Cluster Resource Override Operator pod is deployed to a worker node.
+
+.Example Cluster Resource Override pods
+[source,terminal]
+----
+NAME                                                READY   STATUS    RESTARTS   AGE   IP            NODE                                        NOMINATED NODE   READINESS GATES
+clusterresourceoverride-786b8c898c-9wrdq            1/1     Running   0          23s   10.128.2.32   ip-10-0-14-183.us-west-2.compute.internal   <none>           <none>
+clusterresourceoverride-786b8c898c-vn2lf            1/1     Running   0          26s   10.130.2.10   ip-10-0-20-140.us-west-2.compute.internal   <none>           <none>
+clusterresourceoverride-operator-6b8b8b656b-lvr62   1/1     Running   0          56m   10.131.0.33   ip-10-0-2-39.us-west-2.compute.internal     <none>           <none>
+----
+
+.Example node list
+[source,terminal]
+----
+NAME                                        STATUS   ROLES                  AGE   VERSION
+ip-10-0-14-183.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.35.4
+ip-10-0-2-39.us-west-2.compute.internal     Ready    worker                 58m   v1.35.4
+ip-10-0-20-140.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.35.4
+ip-10-0-23-244.us-west-2.compute.internal   Ready    infra                  55m   v1.35.4
+ip-10-0-77-153.us-west-2.compute.internal   Ready    control-plane,master   65m   v1.35.4
+ip-10-0-99-108.us-west-2.compute.internal   Ready    worker                 24m   v1.35.4
+ip-10-0-24-233.us-west-2.compute.internal   Ready    infra                  55m   v1.35.4
+ip-10-0-88-109.us-west-2.compute.internal   Ready    worker                 24m   v1.35.4
+ip-10-0-67-453.us-west-2.compute.internal   Ready    infra                  55m   v1.35.4
+----
+
 .Prerequisites
 
 * You created one or more infrastructure nodes with a node label such as `node-role.kubernetes.io/infra=""`.

--- a/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
@@ -16,18 +16,14 @@ You can create and use infrastructure nodes to host only infrastructure componen
 
 You can move the components to the same node or separate nodes as appropriate for your organization.
 
-The following example shows the default deployment of the VPA pods to the control plane nodes.
+.Procedure
 
+. Determine the nodes where the Vertical Pod Autoscaler pods are running by running the following command:
++
 [source,terminal]
 ----
-NAME                                                READY   STATUS    RESTARTS   AGE     IP            NODE                  NOMINATED NODE   READINESS GATES
-vertical-pod-autoscaler-operator-6c75fcc9cd-5pb6z   1/1     Running   0          7m59s   10.128.2.24   c416-tfsbj-master-1   <none>           <none>
-vpa-admission-plugin-default-6cb78d6f8b-rpcrj       1/1     Running   0          5m37s   10.129.2.22   c416-tfsbj-master-1   <none>           <none>
-vpa-recommender-default-66846bd94c-dsmpp            1/1     Running   0          5m37s   10.129.2.20   c416-tfsbj-master-0   <none>           <none>
-vpa-updater-default-db8b58df-2nkvf                  1/1     Running   0          5m37s   10.129.2.21   c416-tfsbj-master-1   <none>           <none>
+$ oc get pods -n openshift-vertical-pod-autoscaler -o wide
 ----
-
-.Procedure
 
 . Move the VPA Operator pod by adding a node selector to the `Subscription` custom resource (CR) for the VPA Operator:
 

--- a/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
@@ -8,7 +8,7 @@
 = Moving the Vertical Pod Autoscaler Operator components
 
 [role="_abstract"]
-You can move the Vertical Pod Autoscaler Operator (VPA) pods to infrastructure nodes to reduce the subscription requirements of your cluster. Move the pods by editing the `Subscription` custom resource (CR) for the VPA and the `VerticalPodAutoscaler` custom resource.
+To reduce the subscription requirements of your cluster, you can move the Vertical Pod Autoscaler Operator (VPA) pods to infrastructure nodes. Move the pods by editing the `Subscription` custom resource (CR) for the VPA and the `VerticalPodAutoscaler` CR.
 
 The Vertical Pod Autoscaler Operator (VPA) consists of three components: the recommender, updater, and admission controller. The Operator and each component has its own pod in the VPA namespace on the control plane nodes.
 
@@ -16,16 +16,13 @@ You can create and use infrastructure nodes to host only infrastructure componen
 
 You can move the components to the same node or separate nodes as appropriate for your organization.
 
+.Prerequisites
+
+* You created one or more infrastructure nodes with a node label such as `node-role.kubernetes.io/infra=""`.
+
 .Procedure
 
-. Determine the nodes where the Vertical Pod Autoscaler pods are running by running the following command:
-+
-[source,terminal]
-----
-$ oc get pods -n openshift-vertical-pod-autoscaler -o wide
-----
-
-. Move the VPA Operator pod by adding a node selector to the `Subscription` custom resource (CR) for the VPA Operator:
+. Move the VPA Operator pod by adding a node selector to the `Subscription` CR for the VPA Operator:
 
 .. Edit the CR by running the following command:
 +
@@ -57,8 +54,8 @@ spec:
 +
 where:
 +
-`<node_role>`:: Specifies the node role of the node where you want to move the VPA Operator pod, for example `infra` to move the pod to an infrastructure node.
-`<tolerations>`:: Specifies a toleration for a taint on the node where you want to move the VPA Operator pod. This parameter is only necessary if the destination node uses a taint.
+`spec.config.nodeSelector`:: Specifies the node selector of the node where you want to move the VPA Operator pod and `<node_role>` is the node role. For example, to move the pod to an infrastructure node, this value would be `node-role.kubernetes.io/infra: ""`.
+`spec.config.tolerations`:: Specifies a toleration for a taint on the node where you want to move the VPA Operator pod. This parameter is only necessary if the destination node uses a taint.
 
 . Move each VPA component by adding node selectors to the `VerticalPodAutoscaler` custom resource (CR):
 
@@ -112,8 +109,12 @@ spec:
 +
 where:
 +
-`<node_role>`:: Specifies the node role for the admission, recommender, and updater pods, for example `infra` to move the pod to an infrastructure node..
-`<tolerations>`:: Specifies a toleration for a taint on the node where you want to move the admission, recommender, and updater pods. This parameter is only necessary if the destination node uses a taint.
+`spec.deploymentOverrides.admission.nodeSelector`:: Specifies the node selector of the node where you want to move the admission pod and `<node_role>` is the node role. For example, to move the pod to an infrastructure node, this value would be `node-role.kubernetes.io/infra: ""`.
+`spec.deploymentOverrides.admission.tolerations`:: Specifies a toleration for a taint on the node where you want to move the admission pod and `<node_role>` is the node role. For example, to tolerate a taint on an infrastructure node, the toleration key value would be `node-role.kubernetes.io/infra: ""`. This parameter is only necessary if the destination node uses a taint.
+`spec.deploymentOverrides.recommender.nodeSelector`:: Specifies the node selector of the node where you want to move the recommender pod and `<node_role>` is the node role. For example, to move the pod to an infrastructure node, this value would be `node-role.kubernetes.io/infra: ""`.
+`spec.deploymentOverrides.recommender.tolerations`:: Specifies a toleration for a taint on the node where you want to move the recommender pod and `<node_role>` is the node role. For example, to tolerate a taint on an infrastructure node, the toleration key value would be `node-role.kubernetes.io/infra: ""`. This parameter is only necessary if the destination node uses a taint.
+`spec.deploymentOverrides.updater.nodeSelector`:: Specifies the node selector of the node where you want to move the updater pod and `<node_role>` is the node role. For example, to move the pod to an infrastructure node, this value would be `node-role.kubernetes.io/infra: ""`.
+`spec.deploymentOverrides.updater.tolerations`:: Specifies a toleration for a taint on the node where you want to move the updater pod and `<node_role>` is the node role. For example, to tolerate a taint on an infrastructure node, the toleration key value would be `node-role.kubernetes.io/infra: ""`. This parameter is only necessary if the destination node uses a taint.
 
 .Verification
 

--- a/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
@@ -3,35 +3,18 @@
 // * machine_management/creating-infrastructure-machinesets.adoc
 // * nodes/pods/nodes-pods-vertical-autoscaler
 
-ifeval::["{context}" == "nodes-pods-vertical-autoscaler"]
-:vpa:
-endif::[]
-ifeval::["{context}" == "creating-infrastructure-machinesets"]
-:machinemgmt:
-endif::[]
-
 :_mod-docs-content-type: PROCEDURE
 [id="infrastructure-moving-vpa_{context}"]
 = Moving the Vertical Pod Autoscaler Operator components
 
 [role="_abstract"]
-ifdef::machinemgmt[]
-You can move the VPA Operator and component pods to infrastructure nodes by adding a node selector to the VPA subscription and the `VerticalPodAutoscalerController` CR.
-endif::machinemgmt[]
-ifdef::vpa[]
-You can move the VPA Operator and component pods to infrastructure or worker nodes by adding a node selector to the VPA subscription and the `VerticalPodAutoscalerController` CR.
-endif::vpa[]
+You can move the Vertical Pod Autoscaler Operator (VPA) pods to infrastructure nodes to reduce the subscription requirements of your cluster. Move the pods by editing the `Subscription` custom resource (CR) for the VPA and the `VerticalPodAutoscaler` custom resource.
 
-ifdef::machinemgmt[]
 The Vertical Pod Autoscaler Operator (VPA) consists of three components: the recommender, updater, and admission controller. The Operator and each component has its own pod in the VPA namespace on the control plane nodes.
-endif::machinemgmt[]
-ifdef::vpa[]
-The Vertical Pod Autoscaler Operator (VPA) and each component has its own pod in the VPA namespace on the control plane nodes.
 
 You can create and use infrastructure nodes to host only infrastructure components. For example, the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment. For more information, see _Creating infrastructure machine sets_.
 
 You can move the components to the same node or separate nodes as appropriate for your organization.
-endif::vpa[]
 
 The following example shows the default deployment of the VPA pods to the control plane nodes.
 
@@ -46,168 +29,9 @@ vpa-updater-default-db8b58df-2nkvf                  1/1     Running   0         
 
 .Procedure
 
-ifdef::machinemgmt[]
 . Move the VPA Operator pod by adding a node selector to the `Subscription` custom resource (CR) for the VPA Operator:
 
-.. Edit the CR:
-+
-[source,terminal]
-----
-$ oc edit Subscription vertical-pod-autoscaler -n openshift-vertical-pod-autoscaler
-----
-
-.. Add a node selector to match the node role label on the infra node:
-+
-[source,terminal]
-----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  labels:
-    operators.coreos.com/vertical-pod-autoscaler.openshift-vertical-pod-autoscaler: ""
-  name: vertical-pod-autoscaler
-# ...
-spec:
-  config:
-    nodeSelector:
-      node-role.kubernetes.io/infra: ""
-----
-where:
-+
---
-`spec.config.nodeSelector.node-role.kubernetes.io/infra`:: Specifies the node role of an infra node.
---
-+
-[NOTE]
-====
-If the infra node uses taints, you need to add a toleration to the `Subscription` CR.
-
-For example:
-
-[source,terminal]
-----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  labels:
-    operators.coreos.com/vertical-pod-autoscaler.openshift-vertical-pod-autoscaler: ""
-  name: vertical-pod-autoscaler
-# ...
-spec:
-  config:
-    nodeSelector:
-      node-role.kubernetes.io/infra: ""
-    tolerations:
-    - key: "node-role.kubernetes.io/infra"
-      operator: "Exists"
-      effect: "NoSchedule"
-----
-where:
-
-`spec.config.tolerations`:: Specifies a toleration for a taint on the infra node.
-====
-
-. Move each VPA component by adding node selectors to the `VerticalPodAutoscaler` custom resource (CR):
-
-.. Edit the CR:
-+
-[source,terminal]
-----
-$ oc edit VerticalPodAutoscalerController default -n openshift-vertical-pod-autoscaler
-----
-
-.. Add node selectors to match the node role label on the infra node:
-+
-[source,terminal]
-----
-apiVersion: autoscaling.openshift.io/v1
-kind: VerticalPodAutoscalerController
-metadata:
-  name: default
-  namespace: openshift-vertical-pod-autoscaler
-# ...
-spec:
-  deploymentOverrides:
-    admission:
-      container:
-        resources: {}
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-    recommender:
-      container:
-        resources: {}
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-    updater:
-      container:
-        resources: {}
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-----
-where:
-+
---
-`spec.deploymentOverrides.admission.nodeselector`:: Optional: Specifies the node role for the VPA admission pod.
-`spec.deploymentOverrides.recommender.nodeselector`:: Optional: Specifies the node role for the VPA recommender pod.
-`spec.deploymentOverrides.updater.nodeselector`:: Optional: Specifies the node role for the VPA updater pod.
---
-+
-[NOTE]
-====
-If a target node uses taints, you need to add a toleration to the `VerticalPodAutoscalerController` CR.
-
-For example:
-
-[source,terminal]
-----
-apiVersion: autoscaling.openshift.io/v1
-kind: VerticalPodAutoscalerController
-metadata:
-  name: default
-  namespace: openshift-vertical-pod-autoscaler
-# ...
-spec:
-  deploymentOverrides:
-    admission:
-      container:
-        resources: {}
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-      tolerations: <1>
-      - key: "my-example-node-taint-key"
-        operator: "Exists"
-        effect: "NoSchedule"
-    recommender:
-      container:
-        resources: {}
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-      tolerations: <2>
-      - key: "my-example-node-taint-key"
-        operator: "Exists"
-        effect: "NoSchedule"
-    updater:
-      container:
-        resources: {}
-      nodeSelector:
-        node-role.kubernetes.io/infra: ""
-      tolerations: <3>
-      - key: "my-example-node-taint-key"
-        operator: "Exists"
-        effect: "NoSchedule"
-----
-where:
-
-`spec.deploymentOverrides.admission.tolerations`:: Specifies a toleration for the admission controller pod for a taint on the infra node.
-`spec.deploymentOverrides.recommender.tolerations`:: Specifies a toleration for the recommender pod for a taint on the infra node.
-`spec.deploymentOverrides.updater.tolerations`:: Specifies a toleration for the updater pod for a taint on the infra node.
-====
-endif::machinemgmt[]
-
-ifdef::vpa[]
-. Move the VPA Operator pod by adding a node selector to the `Subscription` custom resource (CR) for the VPA Operator:
-
-.. Edit the CR:
+.. Edit the CR by running the following command:
 +
 [source,terminal]
 ----
@@ -216,7 +40,7 @@ $ oc edit Subscription vertical-pod-autoscaler -n openshift-vertical-pod-autosca
 
 .. Add a node selector to match the node role label on the node where you want to install the VPA Operator pod:
 +
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -228,46 +52,21 @@ metadata:
 spec:
   config:
     nodeSelector:
-      node-role.kubernetes.io/<node_role>: "" <1>
-----
-where:
-+
---
-`spec.config.nodeSelector.node-role.kubernetes.io/infra`:: Specifies the node role of an infra node. Specifies the node role of the node where you want to move the VPA Operator pod.
---
-+
-[NOTE]
-====
-If the infra node uses taints, you need to add a toleration to the `Subscription` CR.
-
-For example:
-
-[source,terminal]
-----
-apiVersion: operators.coreos.com/v1alpha1
-kind: Subscription
-metadata:
-  labels:
-    operators.coreos.com/vertical-pod-autoscaler.openshift-vertical-pod-autoscaler: ""
-  name: vertical-pod-autoscaler
-# ...
-spec:
-  config:
-    nodeSelector:
-      node-role.kubernetes.io/infra: ""
-    tolerations: <1>
-    - key: "node-role.kubernetes.io/infra"
+      node-role.kubernetes.io/<node_role>: ""
+    tolerations:
+    - key: "node-role.kubernetes.io/<node_role>"
       operator: "Exists"
       effect: "NoSchedule"
 ----
-====
++
 where:
-
-`spec.config.tolerations`:: Specifies a toleration for a taint on the node where you want to move the VPA Operator pod.
++
+`<node_role>`:: Specifies the node role of the node where you want to move the VPA Operator pod, for example `infra` to move the pod to an infrastructure node.
+`<tolerations>`:: Specifies a toleration for a taint on the node where you want to move the VPA Operator pod. This parameter is only necessary if the destination node uses a taint.
 
 . Move each VPA component by adding node selectors to the `VerticalPodAutoscaler` custom resource (CR):
 
-.. Edit the CR:
+.. Edit the CR by running the following command:
 +
 [source,terminal]
 ----
@@ -276,7 +75,7 @@ $ oc edit VerticalPodAutoscalerController default -n openshift-vertical-pod-auto
 
 .. Add node selectors to match the node role label on the node where you want to install the VPA components:
 +
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: autoscaling.openshift.io/v1
 kind: VerticalPodAutoscalerController
@@ -290,77 +89,35 @@ spec:
       container:
         resources: {}
       nodeSelector:
-        node-role.kubernetes.io/<node_role>: "" <1>
-    recommender:
-      container:
-        resources: {}
-      nodeSelector:
-        node-role.kubernetes.io/<node_role>: "" <2>
-    updater:
-      container:
-        resources: {}
-      nodeSelector:
-        node-role.kubernetes.io/<node_role>: "" <3>
-----
-where:
-+
---
-`spec.deploymentOverrides.admission.nodeselector`:: Optional: Specifies the node role for the VPA admission pod.
-`spec.deploymentOverrides.recommender.nodeselector`:: Optional: Specifies the node role for the VPA recommender pod.
-`spec.deploymentOverrides.updater.nodeselector`:: Optional: Specifies the node role for the VPA updater pod.
---
-+
-[NOTE]
-====
-If a target node uses taints, you need to add a toleration to the `VerticalPodAutoscalerController` CR.
-
-For example:
-
-[source,terminal]
-----
-apiVersion: autoscaling.openshift.io/v1
-kind: VerticalPodAutoscalerController
-metadata:
-  name: default
-  namespace: openshift-vertical-pod-autoscaler
-# ...
-spec:
-  deploymentOverrides:
-    admission:
-      container:
-        resources: {}
-      nodeSelector:
-        node-role.kubernetes.io/worker: ""
+        node-role.kubernetes.io/<node_role>: ""
       tolerations:
-      - key: "my-example-node-taint-key"
+      - key: "node-role.kubernetes.io/<node_role>"
         operator: "Exists"
         effect: "NoSchedule"
     recommender:
       container:
         resources: {}
       nodeSelector:
-        node-role.kubernetes.io/worker: ""
+        node-role.kubernetes.io/<node_role>: ""
       tolerations:
-      - key: "my-example-node-taint-key"
+      - key: "node-role.kubernetes.io/<node_role>"
         operator: "Exists"
         effect: "NoSchedule"
     updater:
       container:
         resources: {}
       nodeSelector:
-        node-role.kubernetes.io/worker: ""
+        node-role.kubernetes.io/<node_role>: ""
       tolerations:
-      - key: "my-example-node-taint-key"
+      - key: "node-role.kubernetes.io/<node_role>"
         operator: "Exists"
         effect: "NoSchedule"
 ----
-====
++
 where:
-
-`spec.deploymentOverrides.admission.tolerations`:: Specifies a toleration for the admission controller pod for a taint on the node where you want to install the pod.
-`spec.deploymentOverrides.recommender.tolerations`:: Specifies a toleration for the recommender pod for a taint on the node where you want to install the pod.
-`spec.deploymentOverrides.updater.tolerations`:: Specifies a toleration for the updater pod for a taint on the node where you want to install the pod.
-endif::vpa[]
++
+`<node_role>`:: Specifies the node role for the admission, recommender, and updater pods, for example `infra` to move the pod to an infrastructure node..
+`<tolerations>`:: Specifies a toleration for a taint on the node where you want to move the admission, recommender, and updater pods. This parameter is only necessary if the destination node uses a taint.
 
 .Verification
 
@@ -382,10 +139,3 @@ vpa-admission-plugin-default-6cb78d6f8b-rpcrj       1/1     Running   0         
 vpa-recommender-default-66846bd94c-dsmpp            1/1     Running   0          5m37s   10.129.2.20   c416-tfsbj-infra-eastus1-lrgj8   <none>           <none>
 vpa-updater-default-db8b58df-2nkvf                  1/1     Running   0          5m37s   10.129.2.21   c416-tfsbj-infra-eastus1-lrgj8   <none>           <none>
 ----
-
-ifeval::["{context}" == "nodes-pods-vertical-autoscaler"]
-:!vpa:
-endif::[]
-ifeval::["{context}" == "creating-infrastructure-machinesets"]
-:!machinemgmt:
-endif::[]

--- a/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-moving-vpa.adoc
@@ -16,6 +16,17 @@ You can create and use infrastructure nodes to host only infrastructure componen
 
 You can move the components to the same node or separate nodes as appropriate for your organization.
 
+The following example shows the default deployment of the VPA pods to the control plane nodes.
+
+[source,terminal]
+----
+NAME                                                READY   STATUS    RESTARTS   AGE     IP            NODE                  NOMINATED NODE   READINESS GATES
+vertical-pod-autoscaler-operator-6c75fcc9cd-5pb6z   1/1     Running   0          7m59s   10.128.2.24   c416-tfsbj-master-1   <none>           <none>
+vpa-admission-plugin-default-6cb78d6f8b-rpcrj       1/1     Running   0          5m37s   10.129.2.22   c416-tfsbj-master-1   <none>           <none>
+vpa-recommender-default-66846bd94c-dsmpp            1/1     Running   0          5m37s   10.129.2.20   c416-tfsbj-master-0   <none>           <none>
+vpa-updater-default-db8b58df-2nkvf                  1/1     Running   0          5m37s   10.129.2.21   c416-tfsbj-master-1   <none>           <none>
+----
+
 .Prerequisites
 
 * You created one or more infrastructure nodes with a node label such as `node-role.kubernetes.io/infra=""`.


### PR DESCRIPTION
Refactor and consolidate the documentation for moving Vertical Pod Autoscaler (VPA) and Cluster Resource Override (CRO) resources to infrastructure nodes.

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-17042

Link to docs preview:
[Moving VPA](https://105996--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-vpa_creating-infrastructure-machinesets)
[Moving CRO](https://105996--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#nodes-cluster-resource-override-move-infra_creating-infrastructure-machinesets)