### PR TITLE
OSDOCS-17042 [CQA] Update infrastructure machine set creation documentation

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -6,124 +6,83 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+[role="_abstract"]
+To reduce subscription costs, you can use infrastructure machine sets to create machines that host only infrastructure components, such as the default router, the integrated container image registry, cluster metrics, and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
 
-You can use infrastructure machine sets to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
+For information about infrastructure nodes and which components can run on infrastructure nodes, see the "Red Hat OpenShift control plane and infrastructure nodes" section in the OpenShift sizing and subscription guide for enterprise Kubernetes document.
+
+To create an infrastructure node, see "Creating a compute machine set", "Creating an infrastructure node", or "Creating an infrastructure node". Use the sample compute machine set for your cloud to deploy an infrastructure machine set. Modify the sample configuration file with the details of your environment.
+
+include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/infrastructure-components.adoc[leveloffset=+1]
 
-For information about infrastructure nodes and which components can run on infrastructure nodes, see the "Red Hat OpenShift control plane and infrastructure nodes" section in the link:https://www.redhat.com/en/resources/openshift-subscription-sizing-guide[OpenShift sizing and subscription guide for enterprise Kubernetes] document.
+[role="_additional-resources"]
+.Additional resources
+* link:https://www.redhat.com/en/resources/openshift-subscription-sizing-guide[OpenShift sizing and subscription guide for enterprise Kubernetes]
 
-To create an infrastructure node, you can xref:../machine_management/creating-infrastructure-machinesets.adoc#machineset-creating_creating-infrastructure-machinesets[use a machine set], xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-an-infra-node_creating-infrastructure-machinesets[label the node], or xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infra-machines_creating-infrastructure-machinesets[use a machine config pool].
-
-[id="creating-infrastructure-machinesets-clouds"]
-=== Creating infrastructure machine sets for different clouds
-
-Use the sample compute machine set for your cloud.
-
-include::modules/machineset-yaml-aws.adoc[leveloffset=+3]
-
-Machine sets running on AWS support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances]. You can save on costs by using Spot Instances at a lower price compared to
-On-Demand Instances on AWS. xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-aws[Configure Spot Instances] by adding `spotMarketOptions` to the `MachineSet` YAML file.
-
-include::modules/machineset-yaml-azure.adoc[leveloffset=+3]
-
-Machine sets running on Azure support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-non-guaranteed-instance_creating-machineset-azure[Spot VMs]. You can save on costs by using Spot VMs at a lower price compared to standard VMs on Azure. You can xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-azure[configure Spot VMs] by adding `spotVMOptions` to the `MachineSet` YAML file.
+include::modules/machineset-yaml-aws.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+* xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-non-guaranteed-instance_creating-machineset-aws[Machine sets that deploy machines as Spot Instances]
+
+include::modules/machineset-yaml-azure.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-non-guaranteed-instance_creating-machineset-azure[Machine sets that deploy machines as Spot VMs]
 * xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#installation-azure-marketplace-subscribe_creating-machineset-azure[Using the Azure Marketplace offering]
 
-include::modules/machineset-yaml-azure-stack-hub.adoc[leveloffset=+3]
+include::modules/machineset-yaml-azure-stack-hub.adoc[leveloffset=+1]
 
-[NOTE]
-====
-Machine sets running on Azure Stack Hub do not support non-guaranteed Spot VMs.
-====
+include::modules/machineset-yaml-ibm-cloud.adoc[leveloffset=+1]
 
-include::modules/machineset-yaml-ibm-cloud.adoc[leveloffset=+3]
+include::modules/machineset-yaml-gcp.adoc[leveloffset=+1]
 
-include::modules/machineset-yaml-gcp.adoc[leveloffset=+3]
+[role="_additional-resources"]
+.Additional resources
+* xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-non-guaranteed-instance_legacy-preempt[Machine sets that deploy machines as preemptible VM instances]
 
-Machine sets running on {gcp-short} support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-non-guaranteed-instance_creating-machineset-gcp[preemptible VM instances]. You can save on costs by using preemptible VM instances at a lower price
-compared to normal instances on {gcp-short}. You can xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-creating-non-guaranteed-instance_creating-machineset-gcp[configure preemptible VM instances] by adding `preemptible` to the `MachineSet` YAML file.
+include::modules/machineset-yaml-nutanix.adoc[leveloffset=+1]
 
-include::modules/machineset-yaml-nutanix.adoc[leveloffset=+3]
+include::modules/machineset-yaml-osp.adoc[leveloffset=+1]
 
-include::modules/machineset-yaml-osp.adoc[leveloffset=+3]
+include::modules/machineset-yaml-vsphere.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
 
-include::modules/machineset-yaml-vsphere.adoc[leveloffset=+3]
+include::modules/machineset-creating.adoc[leveloffset=+1]
+
+include::modules/creating-an-infra-node.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../machine_configuration/mco-update-boot-images-manual.adoc#mco-update-boot-images-manual[Manually updating the boot image]
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#infrastructure-components_creating-infrastructure-machinesets[{product-title} infrastructure components]
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#moving-resources-to-infrastructure-machinesets_creating-infrastructure-machinesets[Moving resources to infrastructure machine sets]
 
-include::modules/machineset-creating.adoc[leveloffset=+2]
-
-include::modules/creating-an-infra-node.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:moving-resources-to-infrastructure-machinesets[Moving resources to infrastructure machine sets]
-
-include::modules/creating-infra-machines.adoc[leveloffset=+2]
+include::modules/creating-infra-machines.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../architecture/control-plane.adoc#architecture-machine-config-pools_control-plane[Node configuration management with machine config pools].
+* xref:../architecture/control-plane.adoc#architecture-machine-config-pools_control-plane[Node configuration management with machine config pools]
 
-[id="assigning-machineset-resources-to-infra-nodes"]
-== Assigning machine set resources to infrastructure nodes
-
-After creating an infrastructure machine set, the `worker` and `infra` roles are applied to new infra nodes. Nodes with the `infra` role applied are not counted toward the total number of subscriptions that are required to run the environment, even when the `worker` role is also applied.
-
-However, with an infra node being assigned as a worker, there is a chance user workloads could get inadvertently assigned to an infra node. To avoid this, you can apply a taint to the infra node and tolerations for the pods you want to control.
-
-include::modules/binding-infra-node-workloads-using-taints-tolerations.adoc[leveloffset=+2]
+include::modules/binding-infra-node-workloads-using-taints-tolerations.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler].
-* xref:moving-resources-to-infrastructure-machinesets[Moving resources to infrastructure machine sets].
-* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations].
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#infrastructure-components_creating-infrastructure-machinesets[{product-title} infrastructure components]
+* xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler]
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#moving-resources-to-infrastructure-machinesets_creating-infrastructure-machinesets[Moving resources to infrastructure machine sets]
+* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
 
-[id="moving-resources-to-infrastructure-machinesets"]
-== Moving resources to infrastructure machine sets
-
-Some of the infrastructure resources are deployed in your cluster by default. You can move them to the infrastructure machine sets that you created by adding the infrastructure node selector, as shown:
-
-[source,yaml]
-----
-apiVersion: imageregistry.operator.openshift.io/v1
-kind: Config
-metadata:
-  name: cluster
-# ...
-spec:
-  nodePlacement: <1>
-    nodeSelector:
-      matchLabels:
-        node-role.kubernetes.io/infra: ""
-    tolerations:
-    - effect: NoSchedule
-      key: node-role.kubernetes.io/infra
-      value: reserved
-    - effect: NoExecute
-      key: node-role.kubernetes.io/infra
-      value: reserved
-----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.  If you added a taint to the infrasructure node, also add a matching toleration.
-
-Applying a specific node selector to all infrastructure components causes {product-title} to xref:../machine_management/creating-infrastructure-machinesets.adoc#moving-resources-to-infrastructure-machinesets[schedule those workloads on nodes with that label].
+include::modules/infra-machine-sets-moving.adoc[leveloffset=+1]
 
 include::modules/infrastructure-moving-router.adoc[leveloffset=+2]
 
@@ -138,3 +97,11 @@ include::modules/nodes-cluster-resource-override-move-infra.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * link:https://docs.redhat.com/en/documentation/monitoring_stack_for_red_hat_openshift/latest/html/configuring_core_platform_monitoring/configuring-performance-and-scalability#moving-monitoring-components-to-different-nodes_configuring-performance-and-scalability[Moving monitoring components to different nodes]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+* link:https://www.redhat.com/en/resources/openshift-subscription-sizing-guide[OpenShift sizing and subscription guide for enterprise Kubernetes]
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#machineset-creating_creating-infrastructure-machinesets[Create an infrastructure machine set]
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-an-infra-node_creating-infrastructure-machinesets[Label an infrastructure node]
+* xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infra-machines_creating-infrastructure-machinesets[Use a machine config pool]

--- a/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
+++ b/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
@@ -7,6 +7,10 @@
 [id="binding-infra-node-workloads-using-taints-tolerations_{context}"]
 = Binding infrastructure node workloads using taints and tolerations
 
+[role="_abstract"]
+To avoid user workloads being inadvertently assigned to an infra node, you can apply a taint to the infra node and tolerations for the pods you want to control. After creating an infrastructure machine set, the `worker` and `infra` roles are applied to new infra nodes.
+
+Nodes with the `infra` role applied are not counted toward the total number of subscriptions that are required to run the environment, even when the `worker` role is also applied.
 If you have an infrastructure node that has the `infra` and `worker` roles assigned, you must configure the node so that user workloads are not assigned to it.
 
 [IMPORTANT]
@@ -22,7 +26,7 @@ It is recommended that you preserve the dual `infra,worker` label that is create
 
 . Add a taint to the infrastructure node to prevent scheduling user workloads on it:
 
-.. Determine if the node has the taint:
+.. Determine if the node has the taint by running the following command:
 +
 [source,terminal]
 ----
@@ -42,7 +46,7 @@ Taints:             node-role.kubernetes.io/infra=reserved:NoSchedule
 +
 This example shows that the node has a taint. You can proceed with adding a toleration to your pod in the next step.
 
-.. If you have not configured a taint to prevent scheduling user workloads on it:
+.. If you have not configured a taint to prevent scheduling user workloads on it, configure a taint by running the following command:
 +
 [source,terminal]
 ----
@@ -76,8 +80,7 @@ spec:
 ----
 ====
 +
-These examples place a taint on `node1` that has the `node-role.kubernetes.io/infra` key and the `NoSchedule` taint effect. Nodes with the `NoSchedule` effect schedule only pods that tolerate the taint, but allow existing pods to remain scheduled on the node. 
-+
+These examples place a taint on `node1` that has the `node-role.kubernetes.io/infra` key and the `NoSchedule` taint effect. Nodes with the `NoSchedule` effect schedule only pods that tolerate the taint, but allow existing pods to remain scheduled on the node.
 If you added a `NoSchedule` taint to the infrastructure node, any pods that are controlled by a daemon set on that node are marked as `misscheduled`. You must either delete the pods or add a toleration to the pods as shown in the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods]. Note that you cannot add a toleration to a daemon set object that is managed by an operator.
 +
 [NOTE]
@@ -98,15 +101,17 @@ metadata:
 spec:
 # ...
   tolerations:
-    - key: node-role.kubernetes.io/infra <1>
-      value: reserved <2>
-      effect: NoSchedule <3>
-      operator: Equal <4>
+    - key: <node_taint_key>
+      value: <node_taint_value>
+      effect: <taint_effect>
+      operator: Equal
 ----
-<1> Specify the key that you added to the node.
-<2> Specify the value of the key-value pair taint that you added to the node.
-<3> Specify the effect that you added to the node.
-<4> Specify the `Equal` Operator to require a taint with the key `node-role.kubernetes.io/infra` to be present on the node.
+where:
+
+`<node_taint_key>`:: Specifies the key that you added to the taint on the node.
+`<node_taint_value>`:: Specifies the value of the key-value pair taint that you added to the node.
+`<taint_effect>`:: Specifies the effect that you added to the node.
+`Equal`:: Specifies that a taint with a key matching `<node_taint_key>` is required to be present on the node.
 +
 This toleration matches the taint created by the `oc adm taint` command. A pod with this toleration can be scheduled onto the infrastructure node.
 +
@@ -117,4 +122,4 @@ Moving pods for an Operator installed via OLM to an infrastructure node is not a
 
 . Schedule the pod to the infrastructure node by using a scheduler. See the documentation for "Controlling pod placement using the scheduler" for details.
 
-. Remove any workloads that you do not want, or that do not belong, on the new infrastructure node. See the list of workloads supported for use on infrastructure nodes in "{product-title} infrastructure components". 	
+. Remove any workloads that you do not want, or that do not belong, on the new infrastructure node. See the list of workloads supported for use on infrastructure nodes in "{product-title} infrastructure components".

--- a/modules/creating-an-infra-node.adoc
+++ b/modules/creating-an-infra-node.adoc
@@ -9,50 +9,49 @@
 = Creating an infrastructure node
 
 [role="_abstract"]
-You can use labels to configure compute nodes as infrastructure nodes, where you can move infrastructure resources. After you create the infrastructure nodes, you can move appropriate workloads to those nodes by using taints and tolerations.
+To reduce subscription costs, you can use labels to configure compute nodes as infrastructure nodes, where you can move infrastructure resources.
 
-[IMPORTANT]
-====
-See "Creating infrastructure machine sets" for installer-provisioned infrastructure environments or for any cluster where the control plane nodes are managed by the machine API.
-====
+After you create the infrastructure nodes, you can move appropriate workloads to those nodes by using taints and tolerations.
 
 You can optionally create a default cluster-wide node selector. The default node selector is applied to pods created in all namespaces and creates an intersection with any existing node selectors on a pod, which additionally constrains the pod's selector.
 
 [IMPORTANT]
 ====
-If the default node selector key conflicts with the key of a pod's label, then the default node selector is not applied.
+* See "Creating infrastructure machine sets" for installer-provisioned infrastructure environments or for any cluster where the control plane nodes are managed by the Machine API.
 
+* If the default node selector key conflicts with the key of a pod's label, then the default node selector is not applied.
++
 However, do not set a default node selector that might cause a pod to become unschedulable. For example, setting the default node selector to a specific node role, such as `node-role.kubernetes.io/infra=""`, when a pod's label is set to a different node role, such as `node-role.kubernetes.io/master=""`, can cause the pod to become unschedulable. For this reason, use caution when setting the default node selector to specific node roles.
-
++
 You can alternatively use a project node selector to avoid cluster-wide node selector key conflicts.
 ====
 
 .Procedure
 
-. Add a label to the compute nodes that you want to act as infrastructure nodes:
+. Add a label to the compute nodes that you want to act as infrastructure nodes by running the following command:
 +
 [source,terminal]
 ----
 $ oc label node <node-name> node-role.kubernetes.io/infra=""
 ----
 
-. Check to see if applicable nodes now have the `infra` role:
+. Check to see if applicable nodes now have the `infra` role by running the following command:
 +
 [source,terminal]
 ----
 $ oc get nodes
 ----
 
-. Optional: Create a default cluster-wide node selector:
+. Optional: Create a default cluster-wide node selector.
 
-.. Edit the `Scheduler` object:
+.. Edit the `Scheduler` object by running the following command:
 +
 [source,terminal]
 ----
 $ oc edit scheduler cluster
 ----
 
-.. Add the `defaultNodeSelector` field with the appropriate node selector:
+.. Add the `defaultNodeSelector` field with the appropriate node selector by running the following command:
 +
 [source,yaml]
 ----
@@ -70,4 +69,4 @@ This example node selector deploys pods on infrastructure nodes by default.
 .. Save the file to apply the changes.
 
 +
-You can now move infrastructure resources to the new infrastructure nodes. Also, remove any workloads that you do not want, or that do not belong, on the new infrastructure node. See the list of workloads supported for use on infrastructure nodes in "{product-title} infrastructure components".
+You can now move infrastructure resources to the new infrastructure nodes and remove any workloads that you do not want, or that do not belong, on the new infrastructure node. See the list of workloads supported for use on infrastructure nodes in "{product-title} infrastructure components".

--- a/modules/creating-infra-machines.adoc
+++ b/modules/creating-infra-machines.adoc
@@ -7,7 +7,8 @@
 [id="creating-infra-machines_{context}"]
 = Creating a machine config pool for infrastructure machines
 
-If you need infrastructure machines to have dedicated configurations, you must create an infra pool.
+[role="_abstract"]
+You can create a machine configuration pool for infrastructure machines to apply dedicated configuration to infra machines. You might want to apply dedicated configuration to infra machines because they run distinct workloads from other nodes in the cluster.
 
 [IMPORTANT]
 ====
@@ -16,26 +17,19 @@ Creating a custom machine configuration pool overrides default worker pool confi
 
 .Procedure
 
-. Add a label to the node you want to assign as the infra node with a specific label:
+. Add a label to the node you want to assign as the infra node by running the following command:
 +
 [source,terminal]
 ----
-$ oc label node <node_name> <label>
+$ oc label node <node_name> node-role.kubernetes.io/infra=
 ----
 +
-[source,terminal]
-----
-$ oc label node ci-ln-n8mqwr2-f76d1-xscn2-worker-c-6fmtx node-role.kubernetes.io/infra=
-----
+where:
++
+`<node_name>`:: Specifies the name of the node you want to assign as an infra node.
 
-. Create a machine config pool that contains both the worker role and your custom role as machine config selector:
+. Create a YAML file that defines the machine config pool, as in the following example:
 +
-[source,terminal]
-----
-$ cat infra.mcp.yaml
-----
-+
-.Example output
 [source,yaml]
 ----
 apiVersion: machineconfiguration.openshift.io/v1
@@ -45,27 +39,28 @@ metadata:
 spec:
   machineConfigSelector:
     matchExpressions:
-      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,infra]} <1>
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,infra]}
   nodeSelector:
     matchLabels:
-      node-role.kubernetes.io/infra: "" <2>
+      node-role.kubernetes.io/infra: ""
 ----
-<1> Add the worker role and your custom role.
-<2> Add the label you added to the node as a `nodeSelector`.
++
+* Add the worker role and your custom role in the `spec.machineConfigSelector.matchExpressions[]` field.
+* Add the label you added to the node in the `spec.nodeSelector.matchLabels` field.
 +
 [NOTE]
 ====
 Custom machine config pools inherit machine configs from the worker pool. Custom pools use any machine config targeted for the worker pool, but add the ability to also deploy changes that are targeted at only the custom pool. Because a custom pool inherits resources from the worker pool, any change to the worker pool also affects the custom pool.
 ====
 
-. After you have the YAML file, you can create the machine config pool:
+. After you have the YAML file, you can create the machine config pool by specifying the file you created in the following command:
 +
 [source,terminal]
 ----
-$ oc create -f infra.mcp.yaml
+$ oc create -f <filename>
 ----
 
-. Check the machine configs to ensure that the infrastructure configuration rendered successfully:
+. Check the machine configs to ensure that the infrastructure configuration rendered successfully by running the following command:
 +
 [source,terminal]
 ----
@@ -78,27 +73,8 @@ $ oc get machineconfig
 NAME                                                        GENERATEDBYCONTROLLER                      IGNITIONVERSION   CREATED
 00-master                                                   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             31d
 00-worker                                                   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             31d
-01-master-container-runtime                                 365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             31d
-01-master-kubelet                                           365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             31d
-01-worker-container-runtime                                 365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             31d
-01-worker-kubelet                                           365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             31d
-99-master-1ae2a1e0-a115-11e9-8f14-005056899d54-registries   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             31d
-99-master-ssh                                                                                          3.2.0             31d
-99-worker-1ae64748-a115-11e9-8f14-005056899d54-registries   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             31d
-99-worker-ssh                                                                                          3.2.0             31d
+# ...
 rendered-infra-4e48906dca84ee702959c71a53ee80e7             365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             23m
-rendered-master-072d4b2da7f88162636902b074e9e28e            5b6fb8349a29735e48446d435962dec4547d3090   3.5.0             31d
-rendered-master-3e88ec72aed3886dec061df60d16d1af            02c07496ba0417b3e12b78fb32baf6293d314f79   3.5.0             31d
-rendered-master-419bee7de96134963a15fdf9dd473b25            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             17d
-rendered-master-53f5c91c7661708adce18739cc0f40fb            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             13d
-rendered-master-a6a357ec18e5bce7f5ac426fc7c5ffcd            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             7d3h
-rendered-master-dc7f874ec77fc4b969674204332da037            5b6fb8349a29735e48446d435962dec4547d3090   3.5.0             31d
-rendered-worker-1a75960c52ad18ff5dfa6674eb7e533d            5b6fb8349a29735e48446d435962dec4547d3090   3.5.0             31d
-rendered-worker-2640531be11ba43c61d72e82dc634ce6            5b6fb8349a29735e48446d435962dec4547d3090   3.5.0             31d
-rendered-worker-4e48906dca84ee702959c71a53ee80e7            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             7d3h
-rendered-worker-4f110718fe88e5f349987854a1147755            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             17d
-rendered-worker-afc758e194d6188677eb837842d3b379            02c07496ba0417b3e12b78fb32baf6293d314f79   3.5.0             31d
-rendered-worker-daa08cc1e8f5fcdeba24de60cd955cc3            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.5.0             13d
 ----
 +
 You should see a new machine config, with the `rendered-infra-*` prefix.
@@ -110,7 +86,7 @@ You should see a new machine config, with the `rendered-infra-*` prefix.
 After you create the new machine config pool, the MCO generates a new rendered config for that pool, and associated nodes of that pool reboot to apply the new configuration.
 ====
 
-.. Create a machine config:
+.. Create a YAML file that defines the machine config pool, as in the following example:
 +
 [source,terminal]
 ----
@@ -125,7 +101,7 @@ kind: MachineConfig
 metadata:
   name: 51-infra
   labels:
-    machineconfiguration.openshift.io/role: infra <1>
+    machineconfiguration.openshift.io/role: <role>
 spec:
   config:
     ignition:
@@ -137,16 +113,19 @@ spec:
         contents:
           source: data:,infra
 ----
-<1> Add the label you added to the node as a `nodeSelector`.
++
+where:
++
+`role`:: Specifies the label you added to the node as a `nodeSelector`.
 
-..  Apply the machine config to the infra-labeled nodes:
+..  Apply the machine config to the infra-labeled nodes by running the following command:
 +
 [source,terminal]
 ----
 $ oc create -f infra.mc.yaml
 ----
 
-. Confirm that your new machine config pool is available:
+. Confirm that your new machine config pool is available by running the following command:
 +
 [source,terminal]
 ----
@@ -162,4 +141,4 @@ master   rendered-master-9360fdb895d4c131c7c4bebbae099c90   True      False     
 worker   rendered-worker-60e35c2e99f42d976e084fa94da4d0fc   True      False      False      2              2                   2                     0                      91m
 ----
 +
-In this example, a worker node was changed to an infra node.
+In this example, the role of the node was changes from `worker` to `infra`.

--- a/modules/infra-machine-sets-moving.adoc
+++ b/modules/infra-machine-sets-moving.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating-infrastructure-machinesets.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="moving-resources-to-infrastructure-machinesets_{context}"]
+= Moving resources to infrastructure machine sets
+
+[role="_abstract"]
+Some of the infrastructure resources are deployed in your cluster by default. You can move them to the infrastructure machine sets that you created by adding the infrastructure node selector.
+
+Applying a specific node selector to all infrastructure components causes {product-title} to schedule those workloads on nodes with that label.
+
+.Procedure
+. Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. See the following example:
++
+[source,yaml]
+----
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: Config
+metadata:
+  name: cluster
+# ...
+spec:
+  nodePlacement:
+    nodeSelector:
+      matchLabels:
+        node-role.kubernetes.io/infra: ""
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/infra
+      value: reserved
+    - effect: NoExecute
+      key: node-role.kubernetes.io/infra
+      value: reserved
+----
+
+. If you added a taint to the infrastructure node, also add a matching toleration.

--- a/modules/infrastructure-components.adoc
+++ b/modules/infrastructure-components.adoc
@@ -8,7 +8,7 @@
 = {product-title} infrastructure components
 
 [role="_abstract"]
-You can review the following information to understand which components you can move to an infrastructure node. Components that you move to an infrastructure node do not need to be accounted for during sizing.
+To reduce subscription costs, you can review the following information to understand which components you can move to an infrastructure node. Components that you move to an infrastructure node do not need to be accounted for during sizing.
 
 Each self-managed Red{nbsp}Hat OpenShift subscription includes entitlements for {product-title} and other OpenShift-related components. These entitlements are included for running {product-title} control plane and infrastructure workloads and do not need to be accounted for during sizing.
 
@@ -32,5 +32,4 @@ To qualify as an infrastructure node and use the included entitlement, only comp
 
 Any node that runs any other container, pod, or component is a worker node that your subscription must cover.
 
-For information about infrastructure nodes and which components can run on infrastructure nodes, see the "Red Hat OpenShift control plane and infrastructure nodes" section in the link:https://www.redhat.com/en/resources/openshift-subscription-sizing-guide[OpenShift sizing and subscription guide for enterprise Kubernetes] document.
-
+For information about infrastructure nodes and which components can run on infrastructure nodes, see the "Red Hat OpenShift control plane and infrastructure nodes" section in the OpenShift sizing and subscription guide for enterprise Kubernetes document.

--- a/modules/infrastructure-moving-monitoring.adoc
+++ b/modules/infrastructure-moving-monitoring.adoc
@@ -6,8 +6,8 @@
 [id="infrastructure-moving-monitoring_{context}"]
 = Moving the monitoring solution
 
-The monitoring stack includes multiple components, including Prometheus, Thanos Querier, and Alertmanager.
-The {cmo-full} manages this stack. To redeploy the monitoring stack to infrastructure nodes, you can create and apply a custom config map.
+[role="_abstract"]
+Redeploy the monitoring stack to infrastructure nodes to reduce your subscription requirements. Create and apply a custom config map to move the monitoring stack to infrastructure nodes. The monitoring stack includes Prometheus, Thanos Querier, and Alertmanager, and is managed by the {cmo-first}.
 
 .Prerequisites
 
@@ -17,7 +17,7 @@ The {cmo-full} manages this stack. To redeploy the monitoring stack to infrastru
 
 .Procedure
 
-. Edit the `cluster-monitoring-config` config map and change the `nodeSelector` to use the `infra` label:
+. Edit the `cluster-monitoring-config` config map and change the `nodeSelector` to use the `infra` label by running the following command:
 +
 [source,terminal]
 ----
@@ -34,7 +34,7 @@ metadata:
 data:
   config.yaml: |+
     alertmanagerMain:
-      nodeSelector: <1>
+      nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:
       - key: node-role.kubernetes.io/infra
@@ -97,16 +97,17 @@ data:
         value: reserved
         effect: NoSchedule
 ----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` parameter in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. If you added a taint to the infrastructure node, also add a matching toleration.
++
+Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` parameter in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. If you added a taint to the infrastructure node, also add a matching toleration.
 
-. Watch the monitoring pods move to the new machines:
+. Watch the monitoring pods move to the new machines by running the following command:
 +
 [source,terminal]
 ----
 $ watch 'oc get pod -n openshift-monitoring -o wide'
 ----
 
-. If a component has not moved to the `infra` node, delete the pod with this component:
+. If a component has not moved to the `infra` node, delete the pod with this component by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/infrastructure-moving-registry.adoc
+++ b/modules/infrastructure-moving-registry.adoc
@@ -6,7 +6,8 @@
 [id="infrastructure-moving-registry_{context}"]
 = Moving the default registry
 
-You configure the registry Operator to deploy its pods to different nodes.
+[role="_abstract"]
+Deploying the registry pod on an infrastructure node can reduce your {product-title} subscription size. Move the registry pod by editing the `configs.imageregistry.operator.openshift.io/cluster` config object.
 
 .Prerequisites
 
@@ -14,50 +15,14 @@ You configure the registry Operator to deploy its pods to different nodes.
 
 .Procedure
 
-. View the `config/instance` object:
-+
-[source,terminal]
-----
-$ oc get configs.imageregistry.operator.openshift.io/cluster -o yaml
-----
-+
-.Example output
-[source,yaml]
-----
-apiVersion: imageregistry.operator.openshift.io/v1
-kind: Config
-metadata:
-  creationTimestamp: 2019-02-05T13:52:05Z
-  finalizers:
-  - imageregistry.operator.openshift.io/finalizer
-  generation: 1
-  name: cluster
-  resourceVersion: "56174"
-  selfLink: /apis/imageregistry.operator.openshift.io/v1/configs/cluster
-  uid: 36fd3724-294d-11e9-a524-12ffeee2931b
-spec:
-  httpSecret: d9a012ccd117b1e6616ceccb2c3bb66a5fed1b5e481623
-  logging: 2
-  managementState: Managed
-  proxy: {}
-  replicas: 1
-  requests:
-    read: {}
-    write: {}
-  storage:
-    s3:
-      bucket: image-registry-us-east-1-c92e88cad85b48ec8b312344dff03c82-392c
-      region: us-east-1
-status:
-...
-----
-
-. Edit the `config/instance` object:
+. Edit the `configs.imageregistry.operator.openshift.io/cluster` object by running the following command:
 +
 [source,terminal]
 ----
 $ oc edit configs.imageregistry.operator.openshift.io/cluster
 ----
+
+. Add a `nodeSelector` parameter with the appropriate value to the component you want to move, as shown in the following example.
 +
 [source,yaml]
 ----
@@ -69,18 +34,21 @@ metadata:
 spec:
   logLevel: Normal
   managementState: Managed
-  nodeSelector: <1>
+  nodeSelector:
     node-role.kubernetes.io/infra: ""
   tolerations:
   - effect: NoSchedule
     key: node-role.kubernetes.io/infra
     value: reserved
 ----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` parameter in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. If you added a taint to the infrasructure node, also add a matching toleration.
-
-. Verify the registry pod has been moved to the infrastructure node.
 +
-.. Run the following command to identify the node where the registry pod is located:
+You can use a `nodeSelector` parameter in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. If you added a taint to the infrastructure node, also add a matching toleration.
+
+.Verification
+
+* Verify the registry pod has been moved to the infrastructure node.
++
+.. Identify the node where the registry pod is located by running the following command:
 +
 [source,terminal]
 ----
@@ -94,4 +62,6 @@ $ oc get pods -o wide -n openshift-image-registry
 $ oc describe node <node_name>
 ----
 +
-Review the command output and confirm that `node-role.kubernetes.io/infra` is in the `LABELS` list.
+where:
+
+`<node_name>`:: Specifies the name of the node that you modified. Review the command output and confirm that `node-role.kubernetes.io/infra` is in the `LABELS` list.

--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -6,7 +6,8 @@
 [id="infrastructure-moving-router_{context}"]
 = Moving the router
 
-You can deploy the router pod to a different compute machine set. By default, the pod is deployed to a worker node.
+[role="_abstract"]
+Deploying the router pod on an infrastructure node can reduce your {product-title} subscription size. Move the router pod by editing the `IngressController` object in the `openshift-ingress-operator` namespace. By default, the pod is deployed to a worker node.
 
 .Prerequisites
 
@@ -14,15 +15,14 @@ You can deploy the router pod to a different compute machine set. By default, th
 
 .Procedure
 
-. View the `IngressController` custom resource for the router Operator:
+. View the `IngressController` custom resource for the router Operator by running the following command:
 +
 [source,terminal]
 ----
 $ oc get ingresscontroller default -n openshift-ingress-operator -o yaml
 ----
 +
-The command output resembles the following text:
-+
+.Example output
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -50,13 +50,14 @@ status:
   selector: ingresscontroller.operator.openshift.io/deployment-ingresscontroller=default
 ----
 
-. Edit the `ingresscontroller` resource and change the `nodeSelector` to use the `infra` label:
+. Edit the `ingresscontroller` resource and change the `nodeSelector` to use the `infra` label by running the following command:
 +
 [source,terminal]
 ----
 $ oc edit ingresscontroller default -n openshift-ingress-operator
 ----
 +
+.Example output
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
@@ -70,7 +71,7 @@ metadata:
 # ...
 spec:
   nodePlacement:
-    nodeSelector: <1>
+    nodeSelector:
       matchLabels:
         node-role.kubernetes.io/infra: ""
     tolerations:
@@ -79,10 +80,12 @@ spec:
       value: reserved
 # ...
 ----
-<1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` parameter in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. If you added a taint to the infrastructure node, also add a matching toleration.
++
+Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` parameter in the format shown or use `<key>: <value>` pairs, based on the value specified for the node. If you added a taint to the infrastructure node, also add a matching toleration.
 
-. Confirm that the router pod is running on the `infra` node.
-.. View the list of router pods and note the node name of the running pod:
+.Verification
+* Confirm that the router pod is running on the `infra` node.
+.. View the list of router pods and note the node name of the running pod by running the following command:
 +
 [source,terminal]
 ----
@@ -99,13 +102,14 @@ router-default-955d875f4-255g8    0/1      Terminating   0          19h       10
 +
 In this example, the running pod is on the `ip-10-0-217-226.ec2.internal` node.
 
-.. View the node status of the running pod:
+.. View the node status of the running pod by running the following command:
 +
 [source,terminal]
 ----
-$ oc get node <node_name> <1>
+$ oc get node <node_name>
 ----
-<1> Specify the `<node_name>` that you obtained from the pod list.
++
+Specify the `<node_name>` that you obtained from the pod list.
 +
 .Example output
 [source,terminal]

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -39,7 +39,7 @@ endif::[]
 = Creating a compute machine set
 
 [role="_abstract"]
-In addition to the compute machine sets created by the installation program, you can create your own compute machine sets to dynamically manage the machine compute resources for specific workloads of your choice. Use the {product-title} CLI to automate node provisioning.
+To dynamically manage machine compute resources, you can create your own compute machine sets in addition to the compute machine sets created by the installation program. Use the {product-title} CLI to automate node provisioning.
 
 ifdef::vsphere[]
 [NOTE]

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -224,6 +224,10 @@ endif::edge[]
 Custom tags can also be specified during installation in the `install-config.yaml` file. If the `install-config.yaml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yaml` file.
 ====
 
+ifdef::infra[]
+Machine sets running on {aws-short} support non-guaranteed Spot Instances. You can save on costs by using Spot Instances at a lower price compared to On-Demand Instances on {aws-short}. For more information, see "Machine sets that deploy machines as Spot Instances".
+endif::[]
+
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :!infra:
 endif::[]

--- a/modules/machineset-yaml-azure-stack-hub.adoc
+++ b/modules/machineset-yaml-azure-stack-hub.adoc
@@ -189,6 +189,11 @@ The `spec.template.spec.providerSpec.value.zone` specifies the zone within your 
 `<image>`:: Specifies the boot image to use. You should use the use the latest image when adding a new machine set.
 endif::infra[]
 
+[NOTE]
+====
+Machine sets running on Azure Stack Hub do not support non-guaranteed Spot VMs.
+====
+
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :!infra:
 endif::[]

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -153,6 +153,8 @@ ifdef::infra[]
 ====
 After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
 ====
+
+Machine sets running on {gcp-short} support non-guaranteed preemptible VM instances. You can save on costs by using preemptible VM instances at a lower price compared to normal instances on {gcp-short}. You can configure preemptible VM instances by adding `preemptible` to the `MachineSet` YAML file.
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]


### PR DESCRIPTION
Update and reorganize the infrastructure machine set documentation per [OSDOCS-17042](https://issues.redhat.com//browse/OSDOCS-17042).

Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17042

Link to docs preview:
[Main assembly](https://105997--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html)