### PR TITLE
OSDOCS#17852: Docs for OSSO 1.5.1

### DIFF
--- a/modules/nodes-secondary-scheduler-rn-1.5.1.adoc
+++ b/modules/nodes-secondary-scheduler-rn-1.5.1.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+
+// This release notes module is allowed to contain xrefs. It must only ever be included from one assembly.
+
+:_mod-docs-content-type: REFERENCE
+[id="secondary-scheduler-operator-release-notes-1.5.1_{context}"]
+= Release notes for {secondary-scheduler-operator-full} 1.5.1
+
+[role="_abstract"]
+Review the release notes for {secondary-scheduler-operator} 1.5.1 to learn what is new and updated with this release.
+
+Issued: 12 February 2026
+
+The following advisory is available for the {secondary-scheduler-operator-full} 1.5.1:
+
+* link:https://access.redhat.com/errata/RHBA-2026:2642[RHBA-2026:2642]
+
+[id="secondary-scheduler-1.5.1-new-features_{context}"]
+== New features and enhancements
+
+* This release of the {secondary-scheduler-operator} updates the Kubernetes version to 1.34.
+
+[id="secondary-scheduler-operator-1.5.1-known-issues_{context}"]
+== Known issues
+
+* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[WRKLDS-645])

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -13,5 +13,8 @@ The {secondary-scheduler-operator} allows you to deploy a custom secondary sched
 
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
 
+// Release notes for Secondary Scheduler Operator for Red Hat OpenShift 1.5.1
+include::modules/nodes-secondary-scheduler-rn-1.5.1.adoc[leveloffset=+1]
+
 // Release notes for Secondary Scheduler Operator for Red Hat OpenShift 1.5.0
 include::modules/nodes-secondary-scheduler-rn-1.5.0.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20/4.21 (will apply this to 4.22 too and back out before GA if needed)

Issue:
https://issues.redhat.com/browse/OSDOCS-17852

Link to docs preview:
https://105999--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html#secondary-scheduler-operator-release-notes-1.5.1_nodes-secondary-scheduler-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Advisory links will be populated closer to release date (Feb 12)