### PR TITLE
OSDOCS#17853: Docs for KDO 5.3.2

### DIFF
--- a/modules/nodes-descheduler-rn-5.3.2.adoc
+++ b/modules/nodes-descheduler-rn-5.3.2.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+
+// This release notes module is allowed to contain xrefs. It must only ever be included from one assembly.
+
+:_mod-docs-content-type: REFERENCE
+[id="descheduler-operator-release-notes-5.3.2_{context}"]
+= Release notes for {descheduler-operator} 5.3.2
+
+[role="_abstract"]
+Review the release notes for {descheduler-operator} 5.3.2 to learn what is new and updated with this release.
+
+Issued: 12 February 2026
+
+The following advisory is available for the {descheduler-operator} 5.3.2:
+
+* link:https://access.redhat.com/errata/RHBA-2026:2641[RHBA-2026:2641]
+
+[id="descheduler-operator-5.3.2-new-features_{context}"]
+== New features and enhancements
+
+* This release of the {descheduler-operator} updates the Kubernetes version to 1.34.

--- a/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
+++ b/nodes/scheduling/descheduler/nodes-descheduler-release-notes.adoc
@@ -13,6 +13,9 @@ The {descheduler-operator} allows you to evict pods so that they can be reschedu
 
 For more information, see xref:../../../nodes/scheduling/descheduler/index.adoc#nodes-descheduler-about_nodes-descheduler-about[About the descheduler].
 
+// Release notes for Kube Descheduler Operator 5.3.2
+include::modules/nodes-descheduler-rn-5.3.2.adoc[leveloffset=+1]
+
 // Release notes for Kube Descheduler Operator 5.3.1
 include::modules/nodes-descheduler-rn-5.3.1.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.20/4.21 (Will apply to 4.22 and back out before GA if needed)

Issue:
https://issues.redhat.com/browse/OSDOCS-17853

Link to docs preview:
https://106000--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/descheduler/nodes-descheduler-release-notes.html#descheduler-operator-release-notes-5.3.2_nodes-descheduler-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Advisory links will be populated closer to release date (Feb 12)
