### PR TITLE
CNV-69070: RN for new runbook alerts in virtualization

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -105,7 +105,28 @@ link:https://issues.redhat.com/browse/CNV-51003[CNV-51003]
 
 // Monitoring
 
+New alerts in the {VirtProductName} runbooks::
+The following xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbooks[alerts for the {CNVOperatorDisplayName}] are now included in the {VirtProductName} runbooks:
 
+* `DeprecatedMachineType`
+* `GuestFilesystemAlmostOutOfSpace`
+* `GuestVCPUQueueHighCritical`
+* `GuestVCPUQueueHighWarning`
+* `HCOGoldenImageWithNoArchitectureAnnotation`
+* `HCOGoldenImageWithNoSupportedArchitecture`
+* `HCOMultiArchGoldenImagesDisabled`
+* `HCOOperatorConditionsUnhealthy`
+* `HighNodeCPUFrequency`
+* `KubeVirtVMGuestMemoryAvailableLow`
+* `KubeVirtVMGuestMemoryPressure`
+* `PersistentVolumeFillingUp`
+* `VirtLauncherPodsStuckFailed`
+* `VirtualMachineInstanceHasEphemeralHotplugVolume`
+* `VirtualMachineStuckInUnhealthyState`
+* `VirtualMachineStuckOnNode`
+
++
+link:https://issues.redhat.com/browse/CNV-69069[CNV-69069]
 
 // Documentation improvements
 


### PR DESCRIPTION
Version(s):
4.21

Issue: [CNV-69070](https://issues.redhat.com/browse/CNV-69070)

[Link to docs preview](https://106009--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html#virt-4-21-new_virt-4-21-release-notes)

QE review:
- [x] QE has approved this change.