### PR TITLE
[OBSDOCS-3063] Update link to the standalone COO docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -252,6 +252,7 @@ endif::[]
 :coo-first: Cluster Observability Operator (COO)
 :coo-full: Cluster Observability Operator
 :coo-short: COO
+:coo-version: 1-latest
 // ODF
 :odf-first: Red Hat OpenShift Data Foundation (ODF)
 :odf-full: Red Hat OpenShift Data Foundation

--- a/about/logging-visualization.adoc
+++ b/about/logging-visualization.adoc
@@ -6,4 +6,4 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Visualization for logging is provided by deploying the link:https://docs.openshift.com/container-platform/latest/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the link:https://docs.openshift.com/container-platform/latest/observability/cluster_observability_operator/cluster-observability-operator-overview.adoc#cluster-observability-operator-overview[Cluster Observability Operator], which requires Operator installation.
+You can visualize logs by deploying the link:https://docs.openshift.com/container-platform/latest/observability/cluster_observability_operator/ui_plugins/logging-ui-plugin.adoc#logging-ui-plugin[Logging UI Plugin] of the link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/about_red_hat_openshift_cluster_observability_operator/cluster-observability-operator-overview-1[Cluster Observability Operator], which requires Operator installation.

--- a/modules/installing-the-logging-ui-plug-in-cli.adoc
+++ b/modules/installing-the-logging-ui-plug-in-cli.adoc
@@ -10,14 +10,14 @@
 = Installing the logging UI plugin by using the CLI
 
 Install the logging UI plugin by using the command-line interface (CLI) so that you can visualize logs.
- 
+
 .Prerequisites
 * You have administrator permissions.
 * You installed the {oc-first}.
 * You installed and configured {loki-op}.
 
 .Procedure
-. Install the {coo-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/cluster_observability_operator/installing-cluster-observability-operators[Installing the Cluster Observability Operator].
+. Install the {coo-full}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/installing_red_hat_openshift_cluster_observability_operator/installing-the-cluster-observability-operator[Installing the Cluster Observability Operator].
 
 . Create a `UIPlugin` custom resource (CR):
 +

--- a/modules/installing-the-logging-ui-plug-in-gui.adoc
+++ b/modules/installing-the-logging-ui-plug-in-gui.adoc
@@ -11,14 +11,14 @@
 = Installing the logging UI plugin by using the web console
 
 Install the logging UI plugin by using the web console so that you can visualize logs.
- 
+
 .Prerequisites
 * You have administrator permissions.
 * You have access to the {ocp-product-title} web console.
 * You installed and configured {loki-op}.
 
 .Procedure
-. Install the {coo-full}. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/cluster_observability_operator/installing-cluster-observability-operators[Installing the Cluster Observability Operator].
+. Install the {coo-full}. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_cluster_observability_operator/{coo-version}/html/installing_red_hat_openshift_cluster_observability_operator/installing-the-cluster-observability-operator[Installing the Cluster Observability Operator].
 
 . Navigate to the *Installed Operators* page. Under *Provided APIs*, select *ClusterObservabilityOperator*. Find the `UIPlugin` resource and click *Create Instance*.
 
@@ -57,5 +57,5 @@ These are the known issues for the logging UI plugin - for more information, see
 . Click *Create*.
 
 .Verification
-. Refresh the page when a pop-up message instructs you to do so. 
+. Refresh the page when a pop-up message instructs you to do so.
 . Navigate to the *Observe → Logs* panel, where you can run LogQL queries. You can also query logs for individual pods from the *Aggregated Logs* tab of a specific pod.


### PR DESCRIPTION
Version(s):
- `standalone-logging-docs-6.0`
- `standalone-logging-docs-6.1`
- `standalone-logging-docs-6.2`
- `standalone-logging-docs-6.3`
- `standalone-logging-docs-6.4`

Issue:
- https://issues.redhat.com/browse/OBSDOCS-3063

Link to docs preview:
- _Link in step 1 of_  [Installing the logging UI plugin by using the web console](https://106029--ocpdocs-pr.netlify.app/openshift-logging/latest/installing/installing-logging.html#installing-the-logging-ui-plugin_guiinstalling-logging)
- _COO link in_ [Visualization for logging](https://106029--ocpdocs-pr.netlify.app/openshift-logging/latest/about/logging-visualization.html)

QE review:
- [x] QE approval not needed.