### PR TITLE
OLS-2612: Create release notes for OLS 1.0.10 release

### DIFF
--- a/modules/ols-1-0-10-release-notes.adoc
+++ b/modules/ols-1-0-10-release-notes.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+// release_notes/ols-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ols-0-1-10-release-notes_{context}"]
+= {ols-long} version 1.0.10
+
+{ols-official} 1.0.10 is now available on {ocp-product-title} 4.16 and later.
+
+[id="ols-1-0-10-enhancements_{context}"]
+== Enhancements
+
+The following enhancements have been made with {ols-official} 1.0.10:
+
+* With this update, the PatternFly 5 User Interface supports Markdown table rendering, ensuring consistency and compatibility across UI versions. To achieve this, the PatternFly Chatbot extension integrates the `remark-gfm` plugin. As a result, you can now present and view data more effectively.
+
+* With this update, {ols-long} supports the rendering of Markdown tables in responses on {ocp-product-title} versions 4.16, 4.17 and 4.18. As a result, these product versions now align with {ocp-product-title} version 4.19 and later, which already support Markdown tables in responses.
+
+* With this update, {ols-long} introduces token management for tool calls, which prevents {ols-long} from exceeding the message context window size. This enhancement aims to avoid errors due to `context_window` limit during tool calls, ensuring a better user experience. It also reserves tokens for tool output, managing the amount of data displayed in a single tool output and helping to retain a smooth conversation flow without the need to end and restart sessions.
+
+* With this update, MCP headers and MCP definitions have changed. Previously {ols-long} supported three methods for the MCP client to send messages back and forth with the MCP server: Server-Sent Events (SSE), Standard Input/Output (stdio), and Streamable Hypertext Transfer Protocol (HTTP). Now, {ols-long}
+supports only Streamable HTTP.
+
+* With this update, you can enable tool filtering to control the list of tools provided to the LLM model. To enable this feature, specify the `toolFilteringConfig` field in the `OLSConfig` custom resource (CR) file.

--- a/release_notes/ols-release-notes.adoc
+++ b/release_notes/ols-release-notes.adoc
@@ -13,6 +13,7 @@ The release notes highlight what is new and what has changed with each {ols-offi
 {ols-official} is designed for Federal Information Processing Standards (FIPS). When running on {ocp-product-title} in FIPS mode, it uses the {rhel} cryptographic libraries submitted (or planned to be submitted) to NIST for FIPS validation on only the `x86_64`, `ppc64le`, and `s390X` architectures. For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status of the individual versions of {rhel} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/en/compliance[Product compliance].
 ====
 
+include::modules/ols-1-0-10-release-notes.adoc[leveloffset=+1]
 include::modules/ols-1-0-9-release-notes.adoc[leveloffset=+1]
 include::modules/ols-1-0-9-fixed-issues.adoc[leveloffset=+2]
 include::modules/ols-1-0-8-release-notes.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2612

Link to docs preview:
https://106033--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/release_notes/ols-release-notes.html#ols-0-1-10-release-notes_ols-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
