### PR TITLE
OSDOCS-16871-3: SCALE-1 Core Scalability Planning and Resource Manage

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3445,7 +3445,7 @@ Topics:
 - Name: Managing bare metal hosts
   File: managing-bare-metal-hosts
   Distros: openshift-origin,openshift-enterprise
-- Name: What huge pages do and how they are consumed by apps
+- Name: Optimizing memory management for workloads by using huge pages
   File: what-huge-pages-do-and-how-they-are-consumed-by-apps
   Distros: openshift-origin,openshift-enterprise
 - Name: Understanding low latency

--- a/modules/about-bare-metal-hosts-and-nodes.adoc
+++ b/modules/about-bare-metal-hosts-and-nodes.adoc
@@ -6,6 +6,9 @@
 [id="about-bare-metal-hosts-and-nodes_{context}"]
 = About bare metal hosts and nodes
 
-To provision a {op-system-first} bare metal host as a node in your cluster, first create a `MachineSet` custom resource (CR) object that corresponds to the bare metal host hardware. Bare metal host compute machine sets describe infrastructure components specific to your configuration. You apply specific Kubernetes labels to these compute machine sets and then update the infrastructure components to run on only those machines.
+[role="_abstract"]
+To provision a {op-system-first} bare-metal host as a node in your cluster, first create a `MachineSet` custom resource (CR) object that corresponds to bare-metal host hardware. 
 
-`Machine` CR's are created automatically when you scale up the relevant `MachineSet` containing a `metal3.io/autoscale-to-hosts` annotation. {product-title} uses `Machine` CR's to provision the bare metal node that corresponds to the host as specified in the `MachineSet` CR.
+Bare-metal host compute machine sets describe infrastructure components specific to your configuration. You apply specific Kubernetes labels to these compute machine sets and then update the infrastructure components to run on only those machines.
+
+When you scale up the relevant `MachineSet` CR that contains a `metal3.io/autoscale-to-hosts` annotation, `Machine` CRs are created automatically. {product-title} uses `Machine` CRs to provision the bare-metal node that corresponds to the host as specified in the `MachineSet` CR.

--- a/modules/adding-bare-metal-host-to-cluster-using-web-console.adoc
+++ b/modules/adding-bare-metal-host-to-cluster-using-web-console.adoc
@@ -6,7 +6,8 @@
 [id="adding-bare-metal-host-to-cluster-using-web-console_{context}"]
 = Adding a bare metal host to the cluster using the web console
 
-You can add bare metal hosts to the cluster in the web console.
+[role="_abstract"]
+To integrate physical hardware into your cluster, you can add bare-metal hosts by using the web console. By adding these hosts, you can provision and manage these nodes directly through the web console.
 
 .Prerequisites
 
@@ -16,15 +17,22 @@ You can add bare metal hosts to the cluster in the web console.
 .Procedure
 
 . In the web console, navigate to *Compute* -> *Bare Metal Hosts*.
-. Select *Add Host* -> *New with Dialog*.
-. Specify a unique name for the new bare metal host.
-. Set the *Boot MAC address*.
-. Set the *Baseboard Management Console (BMC) Address*.
-. Enter the user credentials for the host's baseboard management controller (BMC).
-. Select to power on the host after creation, and select *Create*.
-. Scale up the number of replicas to match the number of available bare metal hosts. Navigate to *Compute* -> *MachineSets*, and increase the number of machine replicas in the cluster by selecting *Edit Machine count* from the *Actions* drop-down menu.
 
+. Select *Add Host* -> *New with Dialog*.
+
+. Specify a unique name for the new bare metal host.
+
+. Set the *Boot MAC address*.
+
+. Set the *Baseboard Management Console (BMC) Address*.
+
+. Enter the user credentials for the host's baseboard management controller (BMC).
+
+. Select to power on the host after creation, and select *Create*.
+
+. Scale up the number of replicas to match the number of available bare metal hosts. Navigate to *Compute* -> *MachineSets*, and increase the number of machine replicas in the cluster by selecting *Edit Machine count* from the *Actions* drop-down menu.
++
 [NOTE]
 ====
-You can also manage the number of bare metal nodes using the `oc scale` command and the appropriate bare metal compute machine set.
+You can also manage the number of bare-metal nodes by using the `oc scale` command and the appropriate bare-metal compute machine set.
 ====

--- a/modules/adding-bare-metal-host-to-cluster-using-yaml.adoc
+++ b/modules/adding-bare-metal-host-to-cluster-using-yaml.adoc
@@ -4,20 +4,23 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="adding-bare-metal-host-to-cluster-using-yaml_{context}"]
-= Adding a bare metal host to the cluster using YAML in the web console
+= Adding a bare-metal host to the cluster using YAML in the web console
 
-You can add bare metal hosts to the cluster in the web console using a YAML file that describes the bare metal host.
+[role="_abstract"]
+You can add bare-metal hosts to the cluster in the web console by using a YAML file that describes the bare-metal host.
 
 .Prerequisites
 
-* Install a {op-system} compute machine on bare metal infrastructure for use in the cluster.
+* Install a {op-system} compute machine on bare-metal infrastructure for use in the cluster.
 * Log in as a user with `cluster-admin` privileges.
-* Create a `Secret` CR for the bare metal host.
+* Create a `Secret` CR for the bare-metal host.
 
 .Procedure
 
 . In the web console, navigate to *Compute* -> *Bare Metal Hosts*.
+
 . Select *Add Host* -> *New from YAML*.
+
 . Copy and paste the below YAML, modifying the relevant fields with the details of your host:
 +
 [source,yaml]
@@ -30,18 +33,23 @@ spec:
   online: true
   bmc:
     address: <bmc_address>
-    credentialsName: <secret_credentials_name>  <1>
-    disableCertificateVerification: True <2>
+    credentialsName: <secret_credentials_name>
+    disableCertificateVerification: True
   bootMACAddress: <host_boot_mac_address>
+# ...
 ----
 +
-<1> `credentialsName` must reference a valid `Secret` CR. The `baremetal-operator` cannot manage the bare metal host without a valid `Secret` referenced in the `credentialsName`. For more information about secrets and how to create them, see xref:../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets-about_nodes-pods-secrets[Understanding secrets].
-<2> Setting `disableCertificateVerification` to `true` disables TLS host validation between the cluster and the baseboard management controller (BMC).
+where:
 
-. Select *Create* to save the YAML and create the new bare metal host.
-. Scale up the number of replicas to match the number of available bare metal hosts. Navigate to *Compute* -> *MachineSets*, and increase the number of machines in the cluster by selecting *Edit Machine count* from the *Actions* drop-down menu.
+`spec.bmc.credentialsName`:: Specifies a reference to a valid `Secret` CR. The Bare Metal Operator cannot manage the bare-metal host without a valid `Secret` referenced in the `credentialsName`. For more information about secrets and how to create them, see "Understanding secrets".
+
+`spec.bmc.disableCertificateVerification`:: Specifies whether to require TLS host validation between the cluster and the baseboard management controller (BMC). When this field is set to `true`, TLS host validation is disabled.
+
+. Select *Create* to save the YAML and create the new bare-metal host.
+
+. Scale up the number of replicas to match the number of available bare-metal hosts. Navigate to *Compute* -> *MachineSets*, and increase the number of machines in the cluster by selecting *Edit Machine count* from the *Actions* drop-down menu.
 +
 [NOTE]
 ====
-You can also manage the number of bare metal nodes using the `oc scale` command and the appropriate bare metal compute machine set.
+You can also manage the number of bare-metal nodes by using the `oc scale` command and the appropriate bare-metal compute machine set.
 ====

--- a/modules/automatically-scaling-machines-to-available-bare-metal-hosts.adoc
+++ b/modules/automatically-scaling-machines-to-available-bare-metal-hosts.adoc
@@ -4,28 +4,34 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="automatically-scaling-machines-to-available-bare-metal-hosts_{context}"]
-= Automatically scaling machines to the number of available bare metal hosts
+= Automatically scaling machines to the number of available bare-metal hosts
 
+[role="_abstract"]
 To automatically create the number of `Machine` objects that matches the number of available `BareMetalHost` objects, add a `metal3.io/autoscale-to-hosts` annotation to the `MachineSet` object.
 
 .Prerequisites
 
-* Install {op-system} bare metal compute machines for use in the cluster, and create corresponding `BareMetalHost` objects.
-* Install the {product-title} CLI (`oc`).
+* Install {op-system} bare-metal compute machines for use in the cluster, and create corresponding `BareMetalHost` objects.
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
 
-. Annotate the compute machine set that you want to configure for automatic scaling by adding the `metal3.io/autoscale-to-hosts` annotation. Replace `<machineset>` with the name of the compute machine set.
+. To configure automatic scaling for a compute machine set, annotate the compute machine set by running the following command:
 +
 [source,terminal]
 ----
 $ oc annotate machineset <machineset> -n openshift-machine-api 'metal3.io/autoscale-to-hosts=<any_value>'
 ----
-+
-Wait for the new scaled machines to start.
+** `<machineset>`: Specifies the name of the compute machine set that you want to configure for automatic scaling.
+** `<any_value>` Specifies is a value, such as `true` or `""`.
 
+. Wait for the new scaled machines to start.
++
 [NOTE]
 ====
-When you use a `BareMetalHost` object to create a machine in the cluster and labels or selectors are subsequently changed on the `BareMetalHost`, the `BareMetalHost` object continues be counted against the `MachineSet` that the `Machine` object was created from.
+The `BareMetalHost` object continues to be counted against the `MachineSet` that the `Machine` object was created from when the following conditions are met:
+
+* You use a `BareMetalHost` object to create a machine in the cluster.
+* You subsequently change labels or selectors on the `BareMetalHost`.
 ====

--- a/modules/configuring-huge-pages.adoc
+++ b/modules/configuring-huge-pages.adoc
@@ -7,13 +7,21 @@
 [id="configuring-huge-pages_{context}"]
 = Configuring huge pages at boot time
 
-Nodes must pre-allocate huge pages used in an {product-title} cluster. There are two ways of reserving huge pages: at boot time and at run time. Reserving at boot time increases the possibility of success because the memory has not yet been significantly fragmented. The Node Tuning Operator currently supports boot time allocation of huge pages on specific nodes.
+[role="_abstract"]
+To ensure nodes in your {product-title} cluster pre-allocate memory for specific workloads, reserve huge pages at boot time. This configuration sets aside memory resources during system startup, offering a distinct alternative to run-time allocation.
+
+There are two ways of reserving huge pages: at boot time and at run time. Reserving at boot time increases the possibility of success because the memory has not yet been significantly fragmented. The Node Tuning Operator currently supports boot-time allocation of huge pages on specific nodes.
+
+ifndef::openshift-origin[]
+[NOTE]
+====
+The TuneD boot-loader plugin only supports {op-system-first} compute nodes.
+====
+endif::openshift-origin[]
 
 .Procedure
 
-To minimize node reboots, the order of the steps below needs to be followed:
-
-. Label all nodes that need the same huge pages setting by a label.
+. Label all nodes that need the same huge pages setting by a label by entering the following command:
 +
 [source,terminal]
 ----
@@ -27,30 +35,34 @@ $ oc label node <node_using_hugepages> node-role.kubernetes.io/worker-hp=
 apiVersion: tuned.openshift.io/v1
 kind: Tuned
 metadata:
-  name: hugepages <1>
+  name: hugepages
   namespace: openshift-cluster-node-tuning-operator
 spec:
-  profile: <2>
+  profile:
   - data: |
       [main]
       summary=Boot time configuration for hugepages
       include=openshift-node
       [bootloader]
-      cmdline_openshift_node_hugepages=hugepagesz=2M hugepages=50 <3>
+      cmdline_openshift_node_hugepages=hugepagesz=2M hugepages=50
     name: openshift-node-hugepages
 
   recommend:
-  - machineConfigLabels: <4>
+  - machineConfigLabels:
       machineconfiguration.openshift.io/role: "worker-hp"
     priority: 30
     profile: openshift-node-hugepages
+# ...
 ----
-<1> Set the `name` of the Tuned resource to `hugepages`.
-<2> Set the `profile` section to allocate huge pages.
-<3> Note the order of parameters is important as some platforms support huge pages of various sizes.
-<4> Enable machine config pool based matching.
++
+where:
++
+`metadata.name`:: Specifies the `name` of the Tuned resource to `hugepages`.
+`spec.profile`:: Specifies the `profile` section to allocate huge pages.
+`spec.profile.data`:: Specifies the order of parameters. The order is important as some platforms support huge pages of various sizes.
+`spec.recommend.machineConfigLabels`:: Specifies the enablement of a machine config pool based matching.
 
-. Create the Tuned `hugepages` object
+. Create the Tuned `hugepages` object by entering the following command:
 +
 [source,terminal]
 ----
@@ -76,27 +88,22 @@ spec:
       node-role.kubernetes.io/worker-hp: ""
 ----
 
-. Create the machine config pool:
+. Create the machine config pool by entering the following command:
 +
 [source,terminal]
 ----
 $ oc create -f hugepages-mcp.yaml
 ----
 
-Given enough non-fragmented memory, all the nodes in the `worker-hp` machine config pool should now have 50 2Mi huge pages allocated.
+.Verification
 
+* To check that enough non-fragmented memory exists and that all the nodes in the `worker-hp` machine config pool now have 50 2Mi huge pages allocated, enter the following command:
++
 [source,terminal]
 ----
 $ oc get node <node_using_hugepages> -o jsonpath="{.status.allocatable.hugepages-2Mi}"
 100Mi
 ----
-
-ifndef::openshift-origin[]
-[NOTE]
-====
-The TuneD bootloader plugin only supports {op-system-first} worker nodes.
-====
-endif::openshift-origin[]
 
 ////
 For run-time allocation, kubelet changes are needed, see BZ1819719.
@@ -118,10 +125,10 @@ $ oc label node <node_using_hugepages> hugepages=true
 apiVersion: tuned.openshift.io/v1
 kind: Tuned
 metadata:
-  name: hugepages <1>
+  name: hugepages
   namespace: openshift-cluster-node-tuning-operator
 spec:
-  profile: <2>
+  profile:
   - data: |
       [main]
       summary=Run time configuration for hugepages
@@ -133,14 +140,17 @@ spec:
     name: node-hugepages
 
   recommend:
-  - match: <3>
+  - match:
     - label: hugepages
     priority: 30
     profile: node-hugepages
 ----
-<1> Set the `name` of the Tuned resource to `hugepages`.
-<2> Set the `profile` section to allocate huge pages.
-<3> Set the `match` section to associate the profile to nodes with the `hugepages` label.
++
+where:
++
+`metadata.name`:: Specifies the `name` of the Tuned resource to `hugepages`.
+`spec.profile`:: Specifies the `profile` section to allocate huge pages.
+`spec.recommend.match`:: Specifies the `match` section that associates the profile to nodes with the `hugepages` label.
 
 . Create the custom `hugepages` tuned profile by using the `hugepages-tuned-runtime.yaml` file:
 +
@@ -162,5 +172,4 @@ $ oc logs <tuned_pod_on_node_using_hugepages> \
 ----
 2019-08-08 07:20:41,286 INFO     tuned.daemon.daemon: static tuning from profile 'node-hugepages' applied
 ----
-
 ////

--- a/modules/consuming-huge-pages-resource-using-the-downward-api.adoc
+++ b/modules/consuming-huge-pages-resource-using-the-downward-api.adoc
@@ -8,7 +8,8 @@
 [id="consuming-huge-pages-resource-using-the-downward-api_{context}"]
 = Consuming huge pages resources using the Downward API
 
-You can use the Downward API to inject information about the huge pages resources that are consumed by a container.
+[role="_abstract"]
+To inject information about the huge pages resources consumed by a container, use the Downward API. This configuration enables applications to retrieve and use their own memory usage data directly.
 
 You can inject the resource allocation as environment variables, a volume plugin, or both. Applications that you develop and run in the container can determine the resources that are available by reading the environment variables or files in the specified volumes.
 
@@ -47,7 +48,7 @@ spec:
       requests:
         hugepages-1Gi: 2Gi
     env:
-    - name: REQUESTS_HUGEPAGES_1GI \ <1>
+    - name: REQUESTS_HUGEPAGES_1GI
       valueFrom:
         resourceFieldRef:
           containerName: example
@@ -59,16 +60,19 @@ spec:
   - name: podinfo
     downwardAPI:
       items:
-        - path: "hugepages_1G_request" \ <2>
+        - path: "hugepages_1G_request"
           resourceFieldRef:
             containerName: example
             resource: requests.hugepages-1Gi
             divisor: 1Gi
 ----
-<1> Specifies to read the resource use from `requests.hugepages-1Gi` and expose the value as the `REQUESTS_HUGEPAGES_1GI` environment variable.
-<2> Specifies to read the resource use from `requests.hugepages-1Gi` and expose the value as the file `/etc/podinfo/hugepages_1G_request`.
++
+where:
++
+`spec.containers.securityContext.env.name`:: Specifies what resource to read and use from `requests.hugepages-1Gi` and expose the value as the `REQUESTS_HUGEPAGES_1GI` environment variable.
+`spec.volumes.name.items.path`:: Specifies what resource to read and use from `requests.hugepages-1Gi` and expose the value as the file `/etc/podinfo/hugepages_1G_request`.
 
-. Create the pod from the `{file-name}` file:
+. Create the pod from the `{file-name}` file by entering the following command:
 +
 [source,terminal,subs="attributes+"]
 ----

--- a/modules/disabling-transparent-huge-pages.adoc
+++ b/modules/disabling-transparent-huge-pages.adoc
@@ -4,9 +4,12 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="disable-thp_{context}"]
-= Disabling Transparent Huge Pages
+= Disabling transparent huge pages
 
-Transparent Huge Pages (THP) attempt to automate most aspects of creating, managing, and using huge pages. Since THP automatically manages the huge pages, this is not always handled optimally for all types of workloads. THP can lead to performance regressions, since many applications handle huge pages on their own. Therefore, consider disabling THP. The following steps describe how to disable THP using the Node Tuning Operator (NTO).
+[role="_abstract"]
+If your application can handle huge pages on its own, you can disable transparent huge pages (THP) to optimally handle huge pages for all types of workloads and avoid the performance regressions that THP can cause.
+
+Disabling THP prevents them from attempting to automate most aspects of creating, managing, and using huge pages. You can disable THP by using the Node Tuning Operator (NTO).
 
 .Procedure
 
@@ -35,16 +38,17 @@ spec:
     - label: node-role.kubernetes.io/worker
     priority: 25
     profile: openshift-thp-never-worker
+# ...
 ----
 
-. Create the Tuned object:
+. Create the Tuned object by entering the following command:
 +
 [source,terminal]
 ----
 $ oc create -f thp-disable-tuned.yaml
 ----
 
-. Check the list of active profiles:
+. Check the list of active profiles by entering the following command::
 +
 [source,terminal]
 ----

--- a/modules/how-huge-pages-are-consumed-by-apps.adoc
+++ b/modules/how-huge-pages-are-consumed-by-apps.adoc
@@ -7,14 +7,10 @@
 [id="how-huge-pages-are-consumed-by-apps_{context}"]
 = How huge pages are consumed by apps
 
-Nodes must pre-allocate huge pages in order for the node to report its huge page
-capacity. A node can only pre-allocate huge pages for a single size.
+[role="_abstract"]
+To enable applications to consume huge pages, nodes must pre-allocate these memory segments to report capacity. Because a node can only pre-allocate huge pages for a single size, you must align this configuration with your specific workload requirements.
 
-Huge pages can be consumed through container-level resource requirements using the
-resource name `hugepages-<size>`, where size is the most compact binary
-notation using integer values supported on a particular node. For example, if a
-node supports 2048KiB page sizes, it exposes a schedulable resource
-`hugepages-2Mi`. Unlike CPU or memory, huge pages do not support over-commitment.
+Huge pages can be consumed through container-level resource requirements by using the resource name `hugepages-<size>`, where size is the most compact binary notation by using integer values supported on a particular node. For example, if a node supports 2048 KiB page sizes, the node exposes a schedulable resource `hugepages-2Mi`. Unlike CPU or memory, huge pages do not support over-commitment.
 
 [source,yaml]
 ----
@@ -36,7 +32,7 @@ spec:
       name: hugepage
     resources:
       limits:
-        hugepages-2Mi: 100Mi <1>
+        hugepages-2Mi: 100Mi
         memory: "1Gi"
         cpu: "1"
   volumes:
@@ -44,31 +40,25 @@ spec:
     emptyDir:
       medium: HugePages
 ----
-<1> Specify the amount of memory for `hugepages` as the exact amount to be
-allocated. Do not specify this value as the amount of memory for `hugepages`
-multiplied by the size of the page. For example, given a huge page size of 2MB,
-if you want to use 100MB of huge-page-backed RAM for your application, then you
-would allocate 50 huge pages. {product-title} handles the math for you. As in
-the above example, you can specify `100MB` directly.
+** `spec.containers.resources.limits.hugepages-2Mi`: Specifies the amount of memory for `hugepages` as the exact amount to be allocated. 
++
+[IMPORTANT]
+====
+Do not specify this value as the amount of memory for `hugepages` multiplied by the size of the page. For example, given a huge page size of 2 MB, if you want to use 100 MB of huge-page-backed RAM for your application, then you would allocate 50 huge pages. {product-title} handles the math for you. As in the above example, you can specify `100MB` directly.
+====
 
-*Allocating huge pages of a specific size*
+[id="huge-pages-allocating-specific-size_{context}"]
+== Allocating huge pages of a specific size
 
-Some platforms support multiple huge page sizes. To allocate huge pages of a
-specific size, precede the huge pages boot command parameters with a huge page
-size selection parameter `hugepagesz=<size>`. The `<size>` value must be
-specified in bytes with an optional scale suffix [`kKmMgG`]. The default huge
-page size can be defined with the `default_hugepagesz=<size>` boot parameter.
+Some platforms support multiple huge page sizes. To allocate huge pages of a specific size, precede the huge pages boot command parameters with a huge page size selection parameter `hugepagesz=<size>`. The `<size>` value must be specified in bytes with an optional scale suffix [`kKmMgG`]. The default huge page size can be defined with the `default_hugepagesz=<size>` boot parameter.
 
-*Huge page requirements*
+[id="huge-pages-requirements_{context}"]
+== Huge page requirements
 
-* Huge page requests must equal the limits. This is the default if limits are
-specified, but requests are not.
+* Huge page requests must equal the limits. This is the default if limits are specified, but requests are not.
 
-* Huge pages are isolated at a pod scope. Container isolation is planned in a
-future iteration.
+* Huge pages are isolated at a pod scope. Container isolation is planned in a future iteration.
 
-* `EmptyDir` volumes backed by huge pages must not consume more huge page memory
-than the pod request.
+* `EmptyDir` volumes backed by huge pages must not consume more huge page memory than the pod request.
 
-* Applications that consume huge pages via `shmget()` with `SHM_HUGETLB` must run
-with a supplemental group that matches *_proc/sys/vm/hugetlb_shm_group_*.
+* Applications that consume huge pages via `shmget()` with `SHM_HUGETLB` must run with a supplemental group that matches *_proc/sys/vm/hugetlb_shm_group_*.

--- a/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
+++ b/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
@@ -6,6 +6,9 @@
 [id="how-to-plan-according-to-application-requirements_{context}"]
 = How to plan your environment according to application requirements
 
+[role="_abstract"]
+To ensure your infrastructure handles workload demands efficiently, plan your environment according to application requirements. By planning in this way, you can determine the necessary compute, storage, and networking resources to maintain performance and stability.
+
 Consider an example application environment:
 
 [options="header",cols="5"]
@@ -39,11 +42,7 @@ Consider an example application environment:
 
 Extrapolated requirements: 550 CPU cores, 450GB RAM, and 1.4TB storage.
 
-Instance size for nodes can be modulated up or down, depending on your
-preference. Nodes are often resource overcommitted. In this deployment
-scenario, you can choose to run additional smaller nodes or fewer larger nodes
-to provide the same amount of resources. Factors such as operational agility and
-cost-per-instance should be considered.
+Instance size for nodes can be modulated up or down, depending on your preference. Nodes are often resource overcommitted. In this deployment scenario, you can choose to run additional smaller nodes or fewer larger nodes to provide the same amount of resources. Factors such as operational agility and cost-per-instance should be considered.
 
 [options="header",cols="4"]
 |===
@@ -71,19 +70,13 @@ of applications that would not allow for overcommitment. That memory can not be
 used for other applications. In the example above, the environment would be
 roughly 30 percent overcommitted, a common ratio.
 
-The application pods can access a service either by using environment variables or DNS.
-If using environment variables, for each active service the variables are injected by the
-kubelet when a pod is run on a node. A cluster-aware DNS server watches the Kubernetes API
-for new services and creates a set of DNS records for each one. If DNS is enabled throughout
-your cluster, then all pods should automatically be able to resolve services by their DNS name.
-Service discovery using DNS can be used in case you must go beyond 5000 services. When using
-environment variables for service discovery, the argument list exceeds the allowed length after
-5000 services in a namespace, then the pods and deployments will start failing. Disable the service
-links in the deployment's service specification file to overcome this:
+The application pods can access a service either by using environment variables or DNS. If using environment variables, for each active service the variables are injected by the kubelet when a pod is run on a node. A cluster-aware DNS server watches the Kubernetes API for new services and creates a set of DNS records for each one. 
+
+If DNS is enabled throughout your cluster, then all pods should automatically be able to resolve services by their DNS name. Service discovery using DNS can be used in case you must go beyond 5000 services. When using environment variables for service discovery, the argument list exceeds the allowed length after
+5000 services in a namespace, then the pods and deployments will start failing. Disable the service links in the deployment's service specification file to overcome this:
 
 [source,yaml]
 ----
----
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
@@ -169,7 +162,7 @@ labels:
   template: deployment-config-template
 ----
 
-The number of application pods that can run in a namespace is dependent on the number of services and the length of the service name when the environment variables are used for service discovery. `ARG_MAX` on the system defines the maximum argument length for a new process and it is set to 2097152 bytes (2 MiB) by default. The Kubelet injects environment variables in to each pod scheduled to run in the namespace including:
+The number of application pods that can run in a namespace is dependent on the number of services and the length of the service name when the environment variables are used for service discovery. `ARG_MAX` on the system defines the maximum argument length for a new process and the variable is set to 2097152 bytes (2 MiB) by default. The Kubelet injects environment variables in to each pod scheduled to run in the namespace including the following variables:
 
 * `<SERVICE_NAME>_SERVICE_HOST=<IP>`
 * `<SERVICE_NAME>_SERVICE_PORT=<PORT>`
@@ -179,6 +172,4 @@ The number of application pods that can run in a namespace is dependent on the n
 * `<SERVICE_NAME>_PORT_<PORT>_TCP_PORT=<PORT>`
 * `<SERVICE_NAME>_PORT_<PORT>_TCP_ADDR=<ADDR>`
 
-The pods in the namespace will start to fail if the argument length exceeds the allowed value and the number of
-characters in a service name impacts it. For example, in a namespace with 5000 services, the limit on the service name
-is 33 characters, which enables you to run 5000 pods in the namespace.
+The pods in the namespace will start to fail if the argument length exceeds the allowed value and the number of characters in a service name impacts it. For example, in a namespace with 5000 services, the limit on the service name is 33 characters, which enables you to run 5000 pods in the namespace.

--- a/modules/how-to-plan-your-environment-according-to-cluster-maximums.adoc
+++ b/modules/how-to-plan-your-environment-according-to-cluster-maximums.adoc
@@ -6,6 +6,9 @@
 [id="how-to-plan-according-to-cluster-maximums_{context}"]
 = How to plan your environment according to tested cluster maximums
 
+[role="_abstract"]
+To ensure your infrastructure meets operational requirements, plan your {product-title} environment according to tested cluster maximums. Designing your cluster within these validated limits ensures that you can maintain stability and ensures your deployment remains supported
+
 [IMPORTANT]
 ====
 Oversubscribing the physical resources on a node affects resource guarantees the Kubernetes scheduler makes during pod placement. Learn what measures you can take to avoid memory swapping.
@@ -15,32 +18,36 @@ Some of the tested maximums are stretched only in a single dimension. They will 
 The numbers noted in this documentation are based on Red Hat's test methodology, setup, configuration, and tunings. These numbers can vary based on your own individual setup and environments.
 ====
 
-While planning your environment, determine how many pods are expected to fit per node:
+While planning your environment, determine how many pods are expected to fit per node by using the following formula:
 
+[source,text]
 ----
 required pods per cluster / pods per node = total number of nodes needed
 ----
 
 The default maximum number of pods per node is 250. However, the number of pods that fit on a node is dependent on the application itself. Consider the application's memory, CPU, and storage requirements, as described in "How to plan your environment according to application requirements".
 
-.Example scenario
+Example scenario::
 
-If you want to scope your cluster for 2200 pods per cluster, you would need at least five nodes, assuming that there are 500 maximum pods per node:
-
+If you want to scope your cluster for 2200 pods per cluster, you would need at least five nodes, assuming that there are 500 maximum pods per node. The following formula shows the calculation:
++
+[source,text]
 ----
 2200 / 500 = 4.4
 ----
-
-If you increase the number of nodes to 20, then the pod distribution changes to 110 pods per node:
-
++
+If you increase the number of nodes to 20, then the pod distribution changes to 110 pods per node. The following formula shows the calculation:
++
+[source,text]
 ----
 2200 / 20 = 110
 ----
-
++
 Where:
-
++
+[source,text]
 ----
 required pods per cluster / total number of nodes = expected pods per node
 ----
-
-{product-title} comes with several system pods, such as OVN-Kubernetes, DNS, Operators, and others, which run across every worker node by default. Therefore, the result of the above formula can vary.
++
+{product-title} includes several system pods, such as OVN-Kubernetes, DNS, Operators, and others, which run across every compute node by default. Therefore, the result of the above formula can vary.

--- a/modules/maintaining-bare-metal-hosts.adoc
+++ b/modules/maintaining-bare-metal-hosts.adoc
@@ -2,19 +2,31 @@
 //
 // scalability_and_performance/managing-bare-metal-hosts.adoc
 
-:_mod-docs-content-type: CONCEPT
+:_mod-docs-content-type: PROCEDURE
 [id="maintaining-bare-metal-hosts_{context}"]
 = Maintaining bare metal hosts
 
-You can maintain the details of the bare metal hosts in your cluster from the {product-title} web console. Navigate to *Compute* -> *Bare Metal Hosts*, and select a task from the *Actions* drop down menu. Here you can manage items such as BMC details, boot MAC address for the host, enable power management, and so on. You can also review the details of the network interfaces and drives for the host.
+[role="_abstract"]
+To ensure your cluster inventory accurately reflects your physical infrastructure, maintain the details of the bare-metal host configurations by using the {product-title} web console.
 
-You can move a bare metal host into maintenance mode. When you move a host into maintenance mode, the scheduler moves all managed workloads off the corresponding bare metal node. No new workloads are scheduled while in maintenance mode.
+.Procedure
 
-You can deprovision a bare metal host in the web console. Deprovisioning a host does the following actions:
+. From the web console, comlete the following steps:
++
+.. Navigate to *Compute* -> *Bare Metal Hosts*.
++
+.. Select a task from the *Actions* drop-down menu. 
++
+.. Manage items such as baseboard management controller (BMC) details, boot MAC address for the host, enable power management, and so on. You can also review the details of the network interfaces and drives for the host.
 
-. Annotates the bare metal host CR with `cluster.k8s.io/delete-machine: true`
-. Scales down the related compute machine set
+. Move a bare-metal host into maintenance mode. When you move a host into maintenance mode, the scheduler moves all managed workloads off the corresponding bare-metal node. No new workloads are scheduled while in maintenance mode.
 
+. Deprovision a bare-metal host in the web console. Deprovisioning a host does the following actions:
++
+.. Annotates the bare-metal host CR with `cluster.k8s.io/delete-machine: true`.
++
+.. Scales down the related compute machine set.
++
 [NOTE]
 ====
 Powering off the host without first moving the daemon set and unmanaged static pods to another node can cause service disruption and loss of data.

--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -6,13 +6,17 @@
 [id="cluster-maximums-environment_{context}"]
 = {product-title} environment and configuration on which the cluster maximums are tested
 
-== AWS cloud platform
+[role="_abstract"]
+To validate your deployment limits, review the environment and configuration details for the cloud platforms on which {product-title} cluster maximums are tested. This reference ensures your infrastructure aligns with the specific scenarios used to validate scalability limits.
+
+[id="aws-cloud-platform-cluster-maximums_{context}"]
+== AWS cloud platform cluster maximums
 
 [options="header",cols="8*"]
 |===
-| Node |Flavor |vCPU |RAM(GiB) |Disk type|Disk size(GiB)/IOS |Count |Region
+| Node |Flavor |vCPU |RAM (GiB) |Disk type|Disk size (GiB) or IOS |Count |Region
 
-| Control plane/etcd ^[1]^
+| Control plane/etcd
 | r5.4xlarge
 | 16
 | 128
@@ -21,7 +25,7 @@
 | 3
 | us-west-2
 
-| Infra ^[2]^
+| Infra
 | m5.12xlarge
 | 48
 | 192
@@ -30,12 +34,12 @@
 | 3
 | us-west-2
 
-| Workload ^[3]^
+| Workload
 | m5.4xlarge
 | 16
 | 64
 | gp3
-| 500 ^[4]^
+| 500
 | 1
 | us-west-2
 
@@ -45,44 +49,49 @@
 | 32
 | gp3
 | 100
-| 3/25/250/500 ^[5]^
+| 3/25/250/500
 | us-west-2
 
 |===
-[.small]
---
-1. gp3 disks with a baseline performance of 3000 IOPS and 125 MiB per second are used for control plane/etcd nodes because etcd is latency sensitive. gp3 volumes do not use burst performance.
-2. Infra nodes are used to host Monitoring, Ingress, and Registry components to ensure they have enough resources to run at large scale.
-3. Workload node is dedicated to run performance and scalability workload generators.
-4. Larger disk size is used so that there is enough space to store the large amounts of data that is collected during the performance and scalability test run.
-5. Cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.
---
 
-== {ibm-power-title} platform
+where:
+
+Control plane/etcd:: Control plane/etcd nodes use gp3 disks with a baseline performance of 3000 IOPS and 125 MiB per second because etcd is latency sensitive. The gp3 volumes do not use burst performance.
+
+Infra:: Infra nodes are used to host Monitoring, Ingress, and Registry components to ensure they have enough resources to run at large scale.
+
+Workload:: The workload node is dedicated to run performance and scalability workload generators.
++ 
+Using a larger disk size of 500 GiB ensures that there is enough space to store the large amounts of data that is collected during the performance and scalability test run.
+
+Compute:: The cluster is scaled in iterations of 3, 25, 250, and 500 compute nodes. Performance and scalability tests are executed at the specified node counts.
+
+[id="ibm-power-platform-cluster-maximums_{context}"]
+== IBM Power platform cluster maximums
 
 [options="header",cols="6*"]
 |===
-| Node |vCPU |RAM(GiB) |Disk type|Disk size(GiB)/IOS |Count
+| Node |vCPU |RAM (GiB) |Disk type |Disk size (GiB) or IOS |Count
 
-| Control plane/etcd ^[1]^
+| Control plane/etcd
 | 16
 | 32
 | io1
 | 120 / 10 IOPS per GiB
 | 3
 
-| Infra ^[2]^
+| Infra
 | 16
 | 64
 | gp2
 | 120
 | 2
 
-| Workload ^[3]^
+| Workload
 | 16
 | 256
 | gp2
-| 120 ^[4]^
+| 120
 | 1
 
 | Compute
@@ -90,32 +99,37 @@
 | 64
 | gp2
 | 120
-| 2 to 100 ^[5]^
+| 2 to 100
 
 |===
-[.small]
---
-1. io1 disks with 120 / 10 IOPS per GiB are used for control plane/etcd nodes as etcd is I/O intensive and latency sensitive.
-2. Infra nodes are used to host Monitoring, Ingress, and Registry components to ensure they have enough resources to run at large scale.
-3. Workload node is dedicated to run performance and scalability workload generators.
-4. Larger disk size is used so that there is enough space to store the large amounts of data that is collected during the performance and scalability test run.
-5. Cluster is scaled in iterations.
---
 
-== {ibm-z-title} platform
+where:
+
+Control plane/etcd:: io1 disks with 120 / 10 IOPS per GiB are used for control plane/etcd nodes as etcd is I/O intensive and latency sensitive.
+
+Infra:: Infra nodes are used to host Monitoring, Ingress, and Registry components to ensure they have enough resources to run at large scale.
+
+Workload:: Workload node is dedicated to run performance and scalability workload generators.
+
+Workload.120:: Larger disk size is used so that there is enough space to store the large amounts of data that is collected during the performance and scalability test run.
+
+Compute.2 to 100:: Cluster is scaled in iterations.
+
+[id="ibm-z-platform-cluster-maximums_{context}"]
+== IBM Z platform cluster maximums
 
 [options="header",cols="6*"]
 |===
-| Node |vCPU ^[4]^ |RAM(GiB)^[5]^|Disk type|Disk size(GiB)/IOS |Count
+| Node |vCPU |RAM (GiB) |Disk type |Disk size (GiB) or IOS |Count
 
-| Control plane/etcd ^[1,2]^
+| Control plane/etcd
 | 8
 | 32
 | ds8k
 | 300 / LCU 1
 | 3
 
-| Compute ^[1,3]^
+| Compute
 | 8
 | 32
 | ds8k
@@ -123,11 +137,14 @@
 | 4 nodes (scaled to 100/250/500 pods per node) 
 
 |===
-[.small]
---
-1. Nodes are distributed between two logical control units (LCUs) to optimize disk I/O load of the control plane/etcd nodes as etcd is I/O intensive and latency sensitive. Etcd I/O demand should not interfere with other workloads.
-2. Four compute nodes are used for the tests running several iterations with 100/250/500 pods at the same time. First, idling pods were used to evaluate if pods can be instanced. Next, a network and CPU demanding client/server workload were used to evaluate the stability of the system under stress. Client and server pods were pairwise deployed and each pair was spread over two compute nodes.
-3. No separate workload node was used. The workload simulates a microservice workload between two compute nodes.
-4. Physical number of processors used is six Integrated Facilities for Linux (IFLs).
-5. Total physical memory used is 512 GiB.
---
+
+where:
+
+Control plane/etcd:: Nodes are distributed between two logical control units (LCUs) to optimize disk I/O load of the control plane/etcd nodes as etcd is I/O intensive and latency sensitive. Etcd I/O demand should not interfere with other workloads. Four compute nodes are used for the tests running several iterations with 100/250/500 pods at the same time. First, idling pods were used to evaluate if pods can be instanced. Next, a network and CPU demanding client/server workload were used to evaluate the stability of the system under stress. Client and server pods were pairwise deployed and each pair was spread over two compute nodes.
+
+Compute:: No separate workload node was used. The workload simulates a microservice workload between two compute nodes.
+
+vCPU:: Physical number of processors used is six Integrated Facilities for Linux (IFLs).
+
+RAM (GiB):: Total physical memory used is 512 GiB.
+

--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -6,78 +6,85 @@
 [id="cluster-maximums-major-releases_{context}"]
 = {product-title} tested cluster maximums for major releases
 
+[role="_abstract"]
+To ensure your deployment remains supported, plan your cluster configuration by using tested cluster maximums. {product-title} validates these specific limits for major releases rather than theoretical absolute cluster maximums, ensuring stability for your environment.
+
 [NOTE]
 ====
-Red Hat does not provide direct guidance on sizing your {product-title} cluster. This is because determining whether your cluster is within the supported bounds of {product-title} requires careful consideration of all the multidimensional factors that limit the cluster scale.
+Red{nbsp}Hat does not provide direct guidance on sizing your {product-title} cluster. This is because determining whether your cluster is within the supported bounds of {product-title} requires careful consideration of all the multidimensional factors that limit the cluster scale.
 ====
 
-{product-title} supports tested cluster maximums rather than absolute cluster maximums. Not every combination of {product-title} version, control plane workload, and network plugin are tested, so the following table does not represent an absolute expectation of scale for all deployments. It might not be possible to scale to a maximum on all dimensions simultaneously. The table contains tested maximums for specific workload and deployment configurations, and serves as a scale guide as to what can be expected with similar deployments.
+{product-title} supports tested cluster maximums rather than absolute cluster maximums. Not every combination of {product-title} version, control plane workload, and network plugin are tested, so the following table does not represent an absolute expectation of scale for all deployments. Scaling to a maximum on all dimensions simultaneously might not be possible. The table contains tested maximums for specific workloads and deployments, and serves as a scale guide as to what can be expected with similar deployments.
 
-[options="header",cols="2*"]
+[options="header",cols="3*"]
 |===
-| Maximum type |4.x tested maximum
+| Maximum type |4.x tested maximum |Notes
 
 | Number of nodes
-| 2,000 ^[1]^
+| 2,000
+| Pause pods were deployed to stress the control plane components of {product-title} at 2000 node scale. The ability to scale to similar numbers will vary depending upon specific deployment and workload parameters.
 
-| Number of pods ^[2]^
+| Number of pods
 | 150,000
+| The pod count displayed here is the number of test pods. The actual number of pods depends on the application's memory, CPU, and storage requirements.
 
 | Number of pods per node
-| 2,500 ^[3]^
+| 2,500
+| This was tested on a cluster with 31 servers: 3 control planes, 2 infrastructure nodes, and 26 compute nodes. If you need 2,500 user pods, you need both a `hostPrefix` of `20`, which allocates a network large enough for each node to contain more than 2000 pods, and a custom kubelet config with `maxPods` set to `2500`. For more information, see link:https://cloud.redhat.com/blog/running-2500-pods-per-node-on-ocp-4.13[Running 2500 pods per node on OCP 4.13].
 
-| Number of namespaces ^[4]^
+| Number of namespaces
 | 10,000
+| When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentation, is highly recommended to free etcd storage.
 
 | Number of builds
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
+| -
 
-| Number of pods per namespace ^[5]^
+| Number of pods per namespace
 | 25,000
+| here are several control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
 
 | Number of routes per default 2-router deployment
 | 9,000
+| -
 
 | Number of secrets
 | 80,000
+| -
 
 | Number of config maps
 | 90,000
+| -
 
-| Number of services ^[6]^
+| Number of services
 | 10,000
+| Each service port and each service back-end has a corresponding entry in `iptables`. The number of back-ends of a given service impact the size of the `Endpoints` objects, which impacts the size of data that is being sent all over the system.
 
 | Number of services per namespace
 | 5,000
+| -
 
 | Number of back-ends per service
 | 5,000
+| -
 
-| Number of deployments per namespace ^[5]^
+| Number of deployments per namespace
 | 2,000
+| -
 
 | Number of build configs
 | 12,000
+| -
 
 | Number of custom resource definitions (CRD)
-| 1,024 ^[7]^
+| 1,024
+| Tested on a cluster with 29 servers: 3 control planes, 2 infrastructure nodes, and 24 compute nodes. The cluster had 500 namespaces. {product-title} has a limit of 1,024 total custom resource definitions (CRD), including those installed by {product-title}, products integrating with {product-title}, and user-created CRDs. If there are more than 1,024 CRDs created, then there is a possibility that `oc` command requests might be throttled.
 
 |===
-[.small]
---
-1. Pause pods were deployed to stress the control plane components of {product-title} at 2000 node scale. The ability to scale to similar numbers will vary depending upon specific deployment and workload parameters.
-2. The pod count displayed here is the number of test pods. The actual number of pods depends on the application's memory, CPU, and storage requirements.
-3. This was tested on a cluster with 31 servers: 3 control planes, 2 infrastructure nodes, and 26 worker nodes. If you need 2,500 user pods, you need both a `hostPrefix` of `20`, which allocates a network large enough for each node to contain more than 2000 pods, and a custom kubelet config with `maxPods` set to `2500`. For more information, see link:https://cloud.redhat.com/blog/running-2500-pods-per-node-on-ocp-4.13[Running 2500 pods per node on OCP 4.13].
-4. When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentation, is highly recommended to free etcd storage.
-5. There are several control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
-6. Each service port and each service back-end has a corresponding entry in `iptables`. The number of back-ends of a given service impact the size of the `Endpoints` objects, which impacts the size of data that is being sent all over the system.
-7. Tested on a cluster with 29 servers: 3 control planes, 2 infrastructure nodes, and 24 worker nodes. The cluster had 500 namespaces. {product-title} has a limit of 1,024 total custom resource definitions (CRD), including those installed by {product-title}, products integrating with {product-title} and user-created CRDs. If there are more than 1,024 CRDs created, then there is a possibility that `oc` command requests might be throttled.
---
 
-[id="cluster-maximums-major-releases-example-scenario_{context}"]
-== Example scenario
+Example scenario::
 
-As an example, 500 worker nodes (m5.2xl) were tested, and are supported, using {product-title} {product-version}, the OVN-Kubernetes network plugin, and the following workload objects:
+As an example, 500 compute nodes (m5.2xl) were tested, and are supported, by using {product-title} {product-version}, the OVN-Kubernetes network plugin, and the following workload objects:
 
 * 200 namespaces, in addition to the defaults
 * 60 pods per node; 30 server and 30 client pods (30k total)
@@ -89,7 +96,7 @@ As an example, 500 worker nodes (m5.2xl) were tested, and are supported, using {
 * 6 network policies/ns, including deny-all, allow-from ingress and intra-namespace rules
 * 57 builds/ns
 
-The following factors are known to affect cluster workload scaling, positively or negatively, and should be factored into the scale numbers when planning a deployment.  For additional information and guidance, contact your sales representative or link:https://access.redhat.com/support/[Red Hat support].
+The following factors are known to affect cluster workload scaling, positively or negatively, and should be factored into the scale numbers when planning a deployment. For additional information and guidance, contact your sales representative or link:https://access.redhat.com/support/[Red{nbsp}Hat support].
 
 * Number of pods per node
 * Number of containers per pod

--- a/modules/powering-off-bare-metal-hosts-cli.adoc
+++ b/modules/powering-off-bare-metal-hosts-cli.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/managing-bare-metal-hosts.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="powering-off-bare-metal-hosts-cli_{context}"]
+= Powering off bare-metal hosts by using the CLI
+
+[role="_abstract"]
+You can power off bare-metal cluster hosts by applying a patch in the cluster by using the {oc-first}. Before you power off a host, mark the node as unschedulable and drain all pods and workloads from the node.
+
+.Prerequisites
+
+* You have installed a {op-system} compute machine on bare-metal infrastructure for use in the cluster.
+* You have logged in as a user with `cluster-admin` privileges.
+* You have configured the host to be managed and have added Baseboard Management Console credentials for the cluster host. You can add BMC credentials by applying a `Secret` custom resource (CR) in the cluster or by logging in to the web console and configuring the bare-metal host to be managed.
+
+.Procedure
+
+. Get the name of the managed bare-metal host by entering the following command:
++
+[source,terminal]
+----
+$ oc get baremetalhosts -n openshift-machine-api -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.provisioning.state}{"\n"}{end}'
+----
++
+.Example output
+[source,terminal]
+----
+master-0.example.com  managed
+master-1.example.com  managed
+master-2.example.com  managed
+worker-0.example.com  managed
+worker-1.example.com  managed
+worker-2.example.com  managed
+----
+
+. Mark the node as unschedulable by entering the following command:
++
+[source,terminal]
+----
+$ oc adm cordon <bare_metal_host>
+----
+** `<bare_metal_host>`: Specifies the name of the host that you want to shut down. For example, `worker-2.example.com`.
+
+. Drain all pods on the node by entering the following command:
++
+[source,terminal]
+----
+$ oc adm drain <bare_metal_host> --force=true
+----
++
+Pods that are backed by replication controllers are rescheduled to other available nodes in the cluster.
+
+. Safely power off the bare-metal host by entering the following command:
++
+[source,terminal]
+----
+$ oc patch <bare_metal_host> --type json -p '[{"op": "replace", "path": "/spec/online", "value": false}]'
+----
+
+. After you power on the host, make the node schedulable for workloads by entering the following command:
++
+[source,terminal]
+----
+$ oc adm uncordon <bare_metal_host>
+----

--- a/modules/powering-off-bare-metal-hosts-web-console.adoc
+++ b/modules/powering-off-bare-metal-hosts-web-console.adoc
@@ -4,80 +4,25 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="powering-off-bare-metal-hosts-web-console_{context}"]
-= Powering off bare-metal hosts
+= Powering off bare-metal hosts by using the web console
 
-You can power off bare-metal cluster hosts in the web console or by applying a patch in the cluster by using the OpenShift CLI (`oc`).
-Before you power off a host, you should mark the node as unschedulable and drain all pods and workloads from the node.
+[role="_abstract"]
+You can power off bare-metal cluster hosts in the web console. Before you power off a host, mark the node as unschedulable and drain all pods and workloads from the node.
 
 .Prerequisites
+
 * You have installed a {op-system} compute machine on bare-metal infrastructure for use in the cluster.
 * You have logged in as a user with `cluster-admin` privileges.
-* You have configured the host to be managed and have added BMC credentials for the cluster host.
-You can add BMC credentials by applying a `Secret` custom resource (CR) in the cluster or by logging in to the web console and configuring the bare-metal host to be managed.
+* You have configured the host to be managed and have added Baseboard Management Console credentials for the cluster host. You can add BMC credentials by applying a `Secret` custom resource (CR) in the cluster or by logging in to the web console and configuring the bare-metal host to be managed.
 
 .Procedure
-. In the web console, mark the node that you want to power off as unschedulable. Perform the following steps:
 
-.. Navigate to *Nodes* and select the node that you want to power off. Expand the *Actions* menu and select *Mark as unschedulable*.
+. Navigate to *Nodes* and select the node that you want to power off. Expand the *Actions* menu and select *Mark as unschedulable*.
 
-.. Manually delete or relocate running pods on the node by adjusting the pod deployments or scaling down workloads on the node to zero.
-Wait for the drain process to complete.
+. Manually delete or relocate running pods on the node by adjusting the pod deployments or scaling down workloads on the node to zero. Wait for the drain process to complete.
 
-.. Navigate to *Compute* -> *Bare Metal Hosts*.
+. Navigate to *Compute* -> *Bare Metal Hosts*.
 
-.. Expand the *Options menu* for the bare-metal host that you want to power off, and select *Power Off*.
-Select *Immediate power off*.
+. Expand the *Options menu* for the bare-metal host that you want to power off, and select *Power Off*.
 
-. Alternatively, you can patch the `BareMetalHost` resource for the host that you want to power off by using `oc`.
-
-.. Get the name of the managed bare-metal host.
-Run the following command:
-+
-[source,terminal]
-----
-$ oc get baremetalhosts -n openshift-machine-api -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.provisioning.state}{"\n"}{end}'
-----
-+
-.Example output
-[source,terminal]
-----
-master-0.example.com  managed
-master-1.example.com  managed
-master-2.example.com  managed
-worker-0.example.com  managed
-worker-1.example.com  managed
-worker-2.example.com  managed
-----
-
-.. Mark the node as unschedulable:
-+
-[source,terminal]
-----
-$ oc adm cordon <bare_metal_host> <1>
-----
-<1> `<bare_metal_host>` is the host that you want to shut down, for example, `worker-2.example.com`.
-
-.. Drain all pods on the node:
-+
-[source,terminal]
-----
-$ oc adm drain <bare_metal_host> --force=true
-----
-+
-Pods that are backed by replication controllers are rescheduled to other available nodes in the cluster.
-
-.. Safely power off the bare-metal host.
-Run the following command:
-+
-[source,terminal]
-----
-$ oc patch <bare_metal_host> --type json -p '[{"op": "replace", "path": "/spec/online", "value": false}]'
-----
-
-.. After you power on the host, make the node schedulable for workloads.
-Run the following command:
-+
-[source,terminal]
-----
-$ oc adm uncordon <bare_metal_host>
-----
+. Select *Immediate power off*.

--- a/modules/removing-bare-metal-hosts-from-provisioner.adoc
+++ b/modules/removing-bare-metal-hosts-from-provisioner.adoc
@@ -4,26 +4,27 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="removing-bare-metal-hosts-from-provisioner_{context}"]
-= Removing bare metal hosts from the provisioner node
+= Removing bare-metal hosts from the provisioner node
 
-In certain circumstances, you might want to temporarily remove bare metal hosts from the provisioner node.
-For example, during provisioning when a bare metal host reboot is triggered by using the {product-title} administration console or as a result of a Machine Config Pool update, {product-title} logs into the integrated Dell Remote Access Controller (iDrac) and issues a delete of the job queue.
+[role="_abstract"]
+In certain circumstances, you might want to temporarily remove bare-metal hosts from the provisioner node. For example, to prevent the management of the number of `Machine` objects that matches the number of available `BareMetalHost` objects, add a `baremetalhost.metal3.io/detached` annotation to the `MachineSet` object.
 
-To prevent the management of the number of `Machine` objects that matches the number of available `BareMetalHost` objects, add a `baremetalhost.metal3.io/detached` annotation to the `MachineSet` object.
+Consider an example during provisioning when a bare-metal host reboot is triggered by using the {product-title} administration console or as a result of a Machine Config Pool update. In this case, {product-title} logs into the integrated Dell Remote Access Controller (iDRAC) and issues a delete of the job queue.
+
 [NOTE]
 ====
-This annotation has an effect for only `BareMetalHost` objects that are in either `Provisioned`, `ExternallyProvisioned` or `Ready/Available` state.
+This annotation has an effect for only `BareMetalHost` objects that are in either `Provisioned`, `ExternallyProvisioned`, or `Ready/Available` states.
 ====
 
 .Prerequisites
 
-* Install {op-system} bare metal compute machines for use in the cluster and create corresponding `BareMetalHost` objects.
-* Install the {product-title} CLI (`oc`).
+* Install {op-system} bare-metal compute machines for use in the cluster and create corresponding `BareMetalHost` objects.
+* Install the {oc-first}.
 * Log in as a user with `cluster-admin` privileges.
 
 .Procedure
 
-. Annotate the compute machine set that you want to remove from the provisioner node by adding the `baremetalhost.metal3.io/detached` annotation.
+. To configure automatic scaling for a compute machine set, annotate the compute machine set by running the following command:
 +
 [source,terminal]
 ----
@@ -34,7 +35,7 @@ Wait for the new machines to start.
 +
 [NOTE]
 ====
-When you use a `BareMetalHost` object to create a machine in the cluster and labels or selectors are subsequently changed on the `BareMetalHost`, the `BareMetalHost` object continues be counted against the `MachineSet` that the `Machine` object was created from.
+When you use a `BareMetalHost` object to create a machine in the cluster and labels or selectors are subsequently changed on the `BareMetalHost`, the `BareMetalHost` object continues to be counted against the `MachineSet` that the `Machine` object was created from.
 ====
 
 . In the provisioning use case, remove the annotation after the reboot is complete by using the following command:

--- a/modules/what-huge-pages-do.adoc
+++ b/modules/what-huge-pages-do.adoc
@@ -16,38 +16,20 @@ endif::[]
 [id="what-huge-pages-do_{context}"]
 = What huge pages do
 
-Memory is managed in blocks known as pages. On most systems, a page is 4Ki. 1Mi
-of memory is equal to 256 pages; 1Gi of memory is 256,000 pages, and so on. CPUs
-have a built-in memory management unit that manages a list of these pages in
-hardware. The Translation Lookaside Buffer (TLB) is a small hardware cache of
-virtual-to-physical page mappings. If the virtual address passed in a hardware
-instruction can be found in the TLB, the mapping can be determined quickly. If
-not, a TLB miss occurs, and the system falls back to slower, software-based
-address translation, resulting in performance issues. Since the size of the TLB
-is fixed, the only way to reduce the chance of a TLB miss is to increase the
-page size.
+[role="_abstract"]
+To optimize memory mapping efficiency, understand the function of huge pages. Unlike standard 4Ki blocks, huge pages are larger memory segments that reduce the tracking load on the translation lookaside buffer (TLB) hardware cache.
 
-A huge page is a memory page that is larger than 4Ki. On x86_64 architectures,
-there are two common huge page sizes: 2Mi and 1Gi. Sizes vary on other
-architectures. To use huge pages, code must be written so that
-applications are aware of them. Transparent Huge Pages (THP) attempt to automate
-the management of huge pages without application knowledge, but they have
-limitations. In particular, they are limited to 2Mi page sizes. THP can lead to
-performance degradation on nodes with high memory utilization or fragmentation
-due to defragmenting efforts of THP, which can lock memory pages. For this
-reason, some applications may be designed to (or recommend) usage of
-pre-allocated huge pages instead of THP.
+Memory is managed in blocks known as pages. On most systems, a page is 4Ki; 1Mi of memory is equal to 256 pages; 1Gi of memory is 256,000 pages, and so on. CPUs have a built-in memory management unit that manages a list of these pages in hardware. The translation lookaside buffer (TLB) is a small hardware cache of virtual-to-physical page mappings. If the virtual address passed in a hardware instruction can be found in the TLB, the mapping can be determined quickly. If not, a TLB miss occurs, and the system falls back to slower, software-based address translation, resulting in performance issues. Since the size of the TLB is fixed, the only way to reduce the chance of a TLB miss is to increase the page size.
+
+A huge page is a memory page that is larger than 4Ki. On x86_64 architectures, there are two common huge page sizes: 2Mi and 1Gi. Sizes vary on other architectures. To use huge pages, code must be written so that applications are aware of them. Transparent huge pages (THP) attempt to automate the management of huge pages without application knowledge, but they have limitations. In particular, they are limited to 2Mi page sizes. THP can lead to performance degradation on nodes with high memory utilization or fragmentation because of defragmenting efforts of THP, which can lock memory pages. For this reason, some applications might be designed to or recommend usage of pre-allocated huge pages instead of THP.
 
 ifdef::ocp-hugepages[]
-In {product-title}, applications in a pod can allocate and consume pre-allocated
-huge pages.
+In {product-title}, applications in a pod can allocate and consume pre-allocated huge pages.
 endif::ocp-hugepages[]
 
 ifdef::virt-hugepages[]
-In {VirtProductName}, virtual machines can be configured to consume pre-allocated
-huge pages.
+In {VirtProductName}, virtual machines can be configured to consume pre-allocated huge pages.
 endif::virt-hugepages[]
-
 
 ifeval::["{context}" == "huge-pages"]
 :ocp-hugepages!:

--- a/scalability_and_performance/managing-bare-metal-hosts.adoc
+++ b/scalability_and_performance/managing-bare-metal-hosts.adoc
@@ -6,7 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-When you install {product-title} on a bare-metal cluster, you can provision and manage bare-metal nodes by using `machine` and `machineset` custom resources (CRs) for bare-metal hosts that exist in the cluster.
+[role="_abstract"]
+You can configure bare-metal hosts directly within {product-title}. To provision and manage nodes in a bare-metal cluster, use `Machine` and `MachineSet` custom resources (CRs).
 
 include::modules/about-bare-metal-hosts-and-nodes.adoc[leveloffset=+1]
 
@@ -21,6 +22,11 @@ include::modules/adding-bare-metal-host-to-cluster-using-web-console.adoc[levelo
 
 include::modules/adding-bare-metal-host-to-cluster-using-yaml.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets-about_nodes-pods-secrets[Understanding secrets]
+
 include::modules/automatically-scaling-machines-to-available-bare-metal-hosts.adoc[leveloffset=+2]
 
 include::modules/removing-bare-metal-hosts-from-provisioner.adoc[leveloffset=+2]
@@ -32,3 +38,7 @@ include::modules/removing-bare-metal-hosts-from-provisioner.adoc[leveloffset=+2]
 * xref:../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-bare-metal_deploying-machine-health-checks[MachineHealthChecks on bare metal]
 
 include::modules/powering-off-bare-metal-hosts-web-console.adoc[leveloffset=+2]
+
+include::modules/powering-off-bare-metal-hosts-cli.adoc[leveloffset=+2]
+
+

--- a/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
+++ b/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
@@ -6,11 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Consider the following tested object maximums when you plan your {product-title} cluster.
+[role="_abstract"]
+To ensure your cluster meets performance and scalability requirements, plan your environment according to tested object maximums. By reviewing these limits, you can design a {product-title} deployment that operates reliably within supported boundaries.
 
-These guidelines are based on the largest possible cluster. For smaller clusters, the maximums are lower. There are many factors that influence the stated thresholds, including the etcd version or storage data format.
-
-In most cases, exceeding these numbers results in lower overall performance. It does not necessarily mean that the cluster will fail.
+The example guidelines are based on the largest possible cluster. For smaller clusters, the maximums are lower. There are many factors that influence the stated thresholds, including the etcd version or storage data format. In most cases, exceeding these numbers results in lower overall performance but might not cause your cluster to fail.
 
 [WARNING]
 ====

--- a/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc
+++ b/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc
@@ -1,10 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id='what-huge-pages-do-and-how-they-are-consumed']
-= What huge pages do and how they are consumed by applications
+= Optimizing memory management for workloads by using huge pages
 include::_attributes/common-attributes.adoc[]
 :context: huge-pages
 
 toc::[]
+
+[role="_abstract"]
+To optimize memory management for specific workloads, configure huge pages. By using these Linux-based system page sizes, you can maintain manual control over memory allocation and override automatic system behaviors.
 
 include::modules/what-huge-pages-do.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Next PR: openshift-docs/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc'

Version(s):
4.16+

Issue:
[OSDOCS-16871](https://issues.redhat.com/browse/OSDOCS-16871)

Links:

* https://106034--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html
* https://106034--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/managing-bare-metal-hosts.html
* https://106034--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html
* https://106034--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.html
* https://106034--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-using-huge-pages-with-vms.html
