### PR TITLE
Add BIOS security hardening settings to firmware requirements

### DIFF
--- a/modules/ztp-du-host-firmware-requirements.adoc
+++ b/modules/ztp-du-host-firmware-requirements.adoc
@@ -60,6 +60,15 @@ The exact firmware configuration depends on your specific hardware and network r
 
 |Processor C6
 |Disabled
+
+|USB Boot
+|Disabled
+
+|Wireless LAN
+|Disabled
+
+|Bluetooth
+|Disabled
 |====
 
 [NOTE]


### PR DESCRIPTION
## Summary
Add BIOS security hardening requirements for RAN deployments.

## Jira
https://issues.redhat.com/browse/CNF-15900

## Changes
Updated host firmware requirements table to include:
- USB Boot: Disabled
- Wireless LAN: Disabled
- Bluetooth: Disabled

These settings align with NIST 800-53 security controls and address compliance checks:
- rhcos4-moderate-master-bios-disable-usb-boot
- rhcos4-moderate-master-wireless-disable-in-bios

## Related
Supersedes #90286 which was auto-closed due to inactivity.