### PR TITLE
ROX-32265: Update docs for base image detection

### DIFF
--- a/modules/base-image-vulnerabilities.adoc
+++ b/modules/base-image-vulnerabilities.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * operating/examine-images-for-vulnerabilities.adoc
+:_mod-docs-content-type: CONCEPT
+[id="base-image-vulnerabilities_{context}"]
+= Viewing vulnerabilities from base images
+
+[role="_abstract"]
+
+You can use {product-title} ({product-title-short}) to identify the base images used by the container applications that your developers build. {product-title-short} then reports vulnerabilities in both base image layers and application layers so that you can route remediation work to the teams responsible for each layer. 
+
+Because {product-title-short} can separate base image layers from application layers, you can generate reports that list vulnerabilities that are specific to base or application images. Developers can then prioritize images to update or replace to maintain a secure and trusted supply chain. Developers can also focus on fixing vulnerabilities in application layers instead of vulnerabilities in the base layers.
+

--- a/modules/base-image-vulnreport.adoc
+++ b/modules/base-image-vulnreport.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * operating/examine-images-for-vulnerabilities.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="base-image-vulnreport_{context}"]
+= Create a report of vulnerabilities in a base image
+
+[role="_abstract"]
+
+You can create a report of vulnerabilities in layers that are identified as the base image layers for an image. 
+
+.Prerequisite
+
+* A user with the `ImageAdministration` permission must configure the base image repository under *Platform Configuration* -> *Base Images* so that the system can identify and detect base images.
+
+.Procedure
+
+. Select *Vulnerability Management* -> *Results*.
+. Click *<number> Images*. 
+. Click the name of the image that you want to examine. You must select an image that has been configured as a base image in *Platform Configuration* -> *Base Images*.
+. To display the common vulnerabilities and exposures (CVEs) only in the base layer, take the following actions:
+.. In the *Observed* tab, in the filter bar, select *Image component* and *Layer type*.
+.. In the filter bar, click *Filter by Layer type* and click *Base image*. The display is filtered to show only CVEs that are contained in the base layer.
+. In the top menu, click *Create report* and select *Export report as CSV*.
+. Click *Generate report*.
+. Click *View status in reports table*.
+. Click *Report ready for download* to download the file. The report includes CVEs affecting the base image layer by component, and some CVEs might affect multiple components. Therefore, the report totals can differ from the number of CVEs for an image shown in the {product-title-short} portal when results have been filtered by using the *Base image* layer type.

--- a/modules/base-images-api.adoc
+++ b/modules/base-images-api.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * operating/examine-images-for-vulnerabilities.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="base-images-api_{context}"]
+= Configuring base images by using the API
+
+[role="_abstract"]
+
+You can use the API to set up a list of base images, add new base images, delete base images, and modify the tag pattern for a base image.
+
+.Prerequisites
+
+* You must be logged in as a user whose role has a permission set that includes the `ImageAdministration` permission; for example, the `Admin` and `Analyst` permission sets have this permission.
+
+.Procedure
+. You can take the following actions by using the Base Image Service in the v2 API:
+* Get a list of base images: Use `GetBaseImageReferences`.
+* Add a new base image: Use `CreateBaseImageReference`.
+* Delete a base image: Use `DeleteBaseImageReference`.
+* Update the tag pattern for a base image: Use `UpdateBaseImageTagPattern`.
++
+For more information about schema and valid values, see the API Reference.
+
+

--- a/modules/base-images.adoc
+++ b/modules/base-images.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * operating/examine-images-for-vulnerabilities.adoc
+:_mod-docs-content-type: CONCEPT
+[id="base-images_{context}"]
+= Defining base images used in application development
+
+[role="_abstract"]
+
+{product-title} ({product-title-short}) lets DevSecOps engineers in your organization to identify base images that are used in the container applications that your developers build. {product-title-short} can then provide information about vulnerabilities that exist in base image layers so that application developers can address these vulnerabilities and use trusted, secure images when building applications. Developers can also focus on fixing vulnerabilities in application layers instead of vulnerabilities in the base layers.
+
+When you configure a list of base images, {product-title-short} pulls information about those images from the repositories and stores it in a database. When you scan images, {product-title-short} tries to match the container images against the images in that database. {product-title-short} then provides information about the base image layer in the {product-title-short} portal.
+
+[NOTE]
+====
+You can configure {product-title-short} to pull multiple tags for an image by using a wildcard. However, to prevent undue system resource use, {product-title-short} only tracks information for the most recent 100 tags.
+====
+
+//Do we need to say anything about the architecture/manifest lists issue discussed in demo? (around 21 minutes) - Which manifest list is picked based on the architecture
+

--- a/modules/define-base-images.adoc
+++ b/modules/define-base-images.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * operating/examine-images-for-vulnerabilities.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="define-base-images_{context}"]
+= Defining base images by using the {product-title-short} portal
+
+[role="_abstract"]
+
+You can set up a list of base images in {product-title} ({product-title-short}) that are used in the applications that your DevOps users build. {product-title-short} then uses this list to identify those base images in the images that it scans. Using this information, you can separate vulnerabilities contained in the base image layer from vulnerabilities contained in the application layers. 
+
+.Prerequisites
+
+* To define base images, you must be logged in as a user with the `ImageAdministration` permission; for example, as the `Admin` or `Analyst` user.
+
+
+.Procedure
+
+. Select *Platform Configuration* -> *Base Images* and click *Add base image*.
+. Enter the path to the base image repository, including the repository address and the image tag, in the format `<hostname>/<project-id>/<repository-name>:<tag>.` You can include a pattern to filter the tag, including using `\*` to match any sequence of nonseparator characters or `?` to match any single nonseparator character. For more filtering syntax information, see the link:https://pkg.go.dev/path/filepath#Match[Go filepath match] documentation. For example, `registry.redhat.io/ubi9:9.*` would add Red Hat Universal Base Image 9 images with tags starting with `9`. 
++
+[NOTE]
+====
+To prevent undue system resource use, {product-title-short} only tracks information for the most recent 100 tags.
+====
+. Click *Save*. The list of base images is compared against the repository and tags are updated every 4 hours. 
+

--- a/modules/view-base-image-vuln.adoc
+++ b/modules/view-base-image-vuln.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * operating/examine-images-for-vulnerabilities.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="view-base-image-vuln_{context}"]
+= Viewing vulnerabilities in a base image layer
+
+[role="_abstract"]
+
+You can view vulnerabilities by layer in an image and filter vulnerabilities to show only the vulnerabilities that exist in the base image layer.
+
+.Prerequisite
+
+* A user with the `ImageAdministration` permission must configure the base image repository under *Platform Configuration* -> *Base Images* so that the system can identify and detect base images.
+
+.Procedure
+
+. Select *Vulnerability Management* -> *Results*.
+. Click *<number> Images*. 
+. Click the name of the image that you want to examine. 
+. To display the CVEs only in the base image layer, take the following actions:
+.. In the *Observed* tab, in the filter bar, select *Image component* and *Layer type*.
+.. In the filter bar, click *Filter by Layer type* and click *Base image*. The display is filtered to only show CVEs contained in the base image layer.
+
+
+

--- a/modules/view-base-imageinfo-portal.adoc
+++ b/modules/view-base-imageinfo-portal.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * operating/examine-images-for-vulnerabilities.adoc
+:_mod-docs-content-type: PROCEDURE
+[id="view-base-imageinfo-portal_{context}"]
+= Viewing base image information for an image in the {product-title-short} portal
+
+[role="_abstract"]
+
+{product-title-short} can provide information about the base images identified in your application, such as the base image name, digest, and age. You can use the {product-title-short} portal to view this information.
+
+.Procedure
+
+. Select *Vulnerability Management* -> *Results*.
+. Click *<number> Images*. 
+. Optional: To filter the display to only show base images, take the following actions:
+.. In the filter bar, select *Image component* and *Layer type*.
+.. In the filter bar, click *Filter by Layer type* and click *Base image*. 
+. Click the name of the image that you want to examine. 
+. Click the arrow to expand *Base image assessment*. The image name, digest, and image age are shown. 
++
+[NOTE]
+====
+{product-title-short} only displays this information when a base image was detected. To view vulnerabilities by application layer, you must use the filter bar to filter CVEs by layer type. See "View vulnerabilities in a base image layer". If the system did not detect any base image, all layers are considered application layers.
+====
+
+

--- a/modules/vulnerability-management20-view-workload-cve.adoc
+++ b/modules/vulnerability-management20-view-workload-cve.adoc
@@ -75,6 +75,9 @@ a|
 ** Infrastructure
 
 * *Version*: Version of the image component; for example, `3.4.21`. You can use this to search for a specific version of a component, for example, in conjunction with a component name.
+
+* *Layer type*: Indicates whether the layer belongs to the application or the base image. Base image layers are shown only for images that are detected as being built from known base images. These base images are configured under *Platform Configuration* -> *Base Images*.
+
 |Deployment
 a|
 * *Name*: Name of the deployment.

--- a/operating/examine-images-for-vulnerabilities.adoc
+++ b/operating/examine-images-for-vulnerabilities.adoc
@@ -198,6 +198,27 @@ include::modules/understanding-vulnerability-scores.adoc[leveloffset=+2]
 
 include::modules/disable-language-specific-vulnerability-scanning.adoc[leveloffset=+1]
 
+include::modules/base-images.adoc[leveloffset=+1]
+//We may want to move this to a different location after we complete the part of the feature that includes policy enforcement.
+
+//Define approved base images
+include::modules/define-base-images.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../operating/manage-user-access/manage-role-based-access-control-3630.adoc#rbac-permission-sets_manage-role-based-access-control[System permission sets]
+* xref:../operating/manage-vulnerabilities/common-vuln-management-tasks.adoc#base-image-vulnerabilities_other[Viewing vulnerabilities in base images]
+
+include::modules/base-images-api.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../operating/manage-user-access/manage-role-based-access-control-3630.adoc#rbac-permission-sets_manage-role-based-access-control[System permission sets]
+* xref:../operating/manage-vulnerabilities/common-vuln-management-tasks.adoc#base-image-vulnerabilities_other[Viewing vulnerabilities in base images]
+//ADD API REFERENCE AFTER API DOCS ARE PUBLISHED
+
 [id="additional-resources_examine-images-for-vulnerabilities"]
 == Additional resources
 

--- a/operating/manage-vulnerabilities/common-vuln-management-tasks.adoc
+++ b/operating/manage-vulnerabilities/common-vuln-management-tasks.adoc
@@ -126,6 +126,19 @@ include::modules/vulnerability-management-accept-deferrals-false-positives.adoc[
 //other
 include::modules/identify-dockerfile-line-component-cve.adoc[leveloffset=+1]
 
+include::modules/base-image-vulnerabilities.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operating/examine-images-for-vulnerabilities.adoc#base-images_examine-images-for-vulnerabilities[Defining base images used in application development]
+
+include::modules/view-base-imageinfo-portal.adoc[leveloffset=+2]
+
+include::modules/view-base-image-vuln.adoc[leveloffset=+3]
+
+include::modules/base-image-vulnreport.adoc[leveloffset=+3]
+
 include::modules/vulnerability-management-upgrade-component.adoc[leveloffset=+1]
 
 include::modules/vulnerability-management-export-workloads.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.10

[Issue
](https://issues.redhat.com/browse/ROX-32665)

Links to docs previews: 

https://106054--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities.html#base-images_examine-images-for-vulnerabilities

https://106054--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/manage-vulnerabilities/common-vuln-management-tasks#base-image-vulnerabilities_other

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
