### PR TITLE
CNF-15900: Add BIOS security hardening guidance to RDS docs

### DIFF
--- a/modules/telco-core-host-firmware-and-boot-loader-configuration.adoc
+++ b/modules/telco-core-host-firmware-and-boot-loader-configuration.adoc
@@ -18,4 +18,7 @@ Engineering considerations::
 When secure boot is enabled, only signed kernel modules are loaded by the kernel.
 Out-of-tree drivers are not supported.
 ====
+// https://issues.redhat.com/browse/CNF-15900
+* For enhanced security, disable USB boot, wireless LAN, and Bluetooth in the host firmware.
+These settings align with NIST 800-53 security controls.
 

--- a/modules/telco-ran-bios-tuning.adoc
+++ b/modules/telco-ran-bios-tuning.adoc
@@ -31,3 +31,6 @@ Engineering considerations::
 * Enable secure boot.
 When secure boot is enabled, only signed kernel modules are loaded by the kernel.
 Out-of-tree drivers are not supported.
+// https://issues.redhat.com/browse/CNF-15900
+* For enhanced security, disable USB boot, wireless LAN, and Bluetooth in the host firmware.
+These settings align with NIST 800-53 security controls.

--- a/modules/ztp-du-host-firmware-requirements.adoc
+++ b/modules/ztp-du-host-firmware-requirements.adoc
@@ -60,6 +60,15 @@ The exact firmware configuration depends on your specific hardware and network r
 
 |Processor C6
 |Disabled
+
+|USB Boot
+|Disabled
+
+|Wireless LAN
+|Disabled
+
+|Bluetooth
+|Disabled
 |====
 
 [NOTE]


### PR DESCRIPTION
Version(s):
- 4.18+
- main

Issue:
https://issues.redhat.com/browse/CNF-15900

Link to docs preview:
- Will be available after PR build completes

QE review:
- [ ] QE has approved this change.

Additional information:
This PR adds BIOS security hardening guidance to the Telco RAN DU and Telco Core Reference Design Specification (RDS) documentation.

This PR consolidates changes from #106048 (by @strzibny) which added the ZTP firmware requirements table entries.

## Summary
- Added recommendation to disable USB boot, wireless LAN, and Bluetooth in host firmware settings
- These settings align with NIST 800-53 security controls
- Updated both RAN DU (`telco-ran-bios-tuning.adoc`) and Core (`telco-core-host-firmware-and-boot-loader-configuration.adoc`) RDS modules
- Added entries to ZTP firmware requirements table (`ztp-du-host-firmware-requirements.adoc`)

## Files Changed
| File | Change |
|------|--------|
| `modules/telco-ran-bios-tuning.adoc` | Added BIOS security hardening bullet point |
| `modules/telco-core-host-firmware-and-boot-loader-configuration.adoc` | Added same guidance |
| `modules/ztp-du-host-firmware-requirements.adoc` | Added USB Boot, Wireless LAN, Bluetooth to firmware table |

🤖 Generated with [Claude Code](https://claude.com/claude-code)