### PR TITLE
OSDOCS-18123: Content issue pointing to a wrong operator role

### DIFF
--- a/modules/rosa-hcp-sharing-vpc-hosted-zones.adoc
+++ b/modules/rosa-hcp-sharing-vpc-hosted-zones.adoc
@@ -43,7 +43,7 @@ include::snippets/rosa-long-cluster-name.adoc[]
 	  	"AWS": [
           "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-ingress-operator-cloud-credentials",
           "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-hcp-Installer-Role",
-          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-control-plane-operator-cloud-credentials"
+          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-control-plane-operator"
         ]
 	  },
 	  "Action": "sts:AssumeRole"
@@ -65,7 +65,7 @@ include::snippets/rosa-long-cluster-name.adoc[]
 	  "Principal": {
 	  	"AWS": [
           "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-hcp-Installer-Role",
-          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-control-plane-operator-cloud-credentials"
+          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-control-plane-operator"
         ]
 	  },
 	  "Action": "sts:AssumeRole"


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-18123

Link to docs preview:
https://106078--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_hcp/rosa-hcp-shared-vpc-config.html


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


