### PR TITLE
CNV#62546: Release Notes: Use CNV APIs for bulk storage class migration

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -59,6 +59,12 @@ link:https://issues.redhat.com/browse/CNV-61227[CNV-61227]
 
 // Storage
 
+Migrate VM disks to different storage classes::
+Previously, installation of {mtc-first} was required before migrating VM disks to different storage classes. This requirement no longer exists, as VM disk storage class migration is now native to {virtproductname}.
++
+In addition, it is no longer a requirement that the VMs you select for each bulk migration be in the same namespace.
++
+link:https://issues.redhat.com/browse/CNV-61829[CNV-61829]
 
 
 // Web console
@@ -99,12 +105,7 @@ link:https://issues.redhat.com/browse/CNV-59284[CNV-59284]
 
 // Documentation improvements
 
-
-
 // Notable technical changes
-
-
-
 
 
 [id="virt-4-21-deprecated_{context}"]


### PR DESCRIPTION
Version(s): 4.21

Issue: [CNV-62546](https://issues.redhat.com/browse/CNV-62546)

Link to docs preview: Migrate VM disks to different storage classes in [New features and enhancements](https://106081--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html#virt-4-21-new_virt-4-21-release-notes)

QE review:
- [x] QE has approved this change.


