### PR TITLE
OLS-2613:Update OLS docs for MCP header and definition changes

### DIFF
--- a/modules/ols-enabling-custom-mcp-server.adoc
+++ b/modules/ols-enabling-custom-mcp-server.adoc
@@ -39,33 +39,31 @@ spec:
   featureGates:
     - MCPServer <1>
   mcpServers:
-    - name: mcp-server-1 <2>
-      streamableHTTP:
-        url: http://localhost:8080/mcp <3>
-        timeout: 30
-        sseReadTimeout: 10
-        headers:
-          - Authorization: kubernetes <4>        
-          - Authorization1: <name_of_the_secret_containing_the_header_content>
-        enableSSE: true
-    - name: mcp-server-2
-      streamableHTTP:
-        url: http://localhost:8080/mcp
-        timeout: 30 <5>
-        sseReadTimeout: 10 <6>
-        headers:
-          - <key1>: <value1> <7>
-          - <key2>: <value2>
-        enableSSE: true <8>
+  - name: mcp-server-1 <2>
+    url: https://mcp.example.com <3> 
+    timeout: 30 <4> 
+    headers: <5> 
+      - name: Authorization <6>
+        valueFrom:
+         type: kubernetes <7>
+  - name: mcp-server-2
+    url: https://mcp.example.com 
+    timeout: 30 
+    headers: 
+      - name: X-Special
+        valueFrom:
+          type: secret 
+          secretRef:
+            name: <secret_name> <8>
 ----
 <1> Specifies the MCP server functionality.
 <2> Specifies the name of the MCP server.
 <3> Specifies the URL path that the MCP server uses to communicate.
-<4> If you want to pass the kubernetes token in the header, specify a string `kubernetes` instead of the secret name.
-<5> Specifies the time that the MCP server has to respond to a query. If the client does not receive a query within the time specified, the MCP server times out. In this example, the timeout is 30 seconds.
-<6> Specifies the amount of time a client waits for new data from a Server-Sent Events (SSE) connection. If the client does not receive data within that time, the client closes the connection.
-<7> Specifies the additional header that the HTTP request sends to the MCP server. 
-<8> When you set `enableSSE` to `true`, the MCP server establishes a one-way channel that the MCP server uses to push updates to the client whenever the server has new information. The default setting is `false`. 
+<4> Specifies the time that the MCP server has to respond to a query. If the client does not receive a query within the time specified, the MCP server times out. In this example, the timeout is 30 seconds.
+<5> Define MCP headers as an array of structured objects containing the key-value pairs required for server authentication and context.
+<6> Specifies the name of the header that gets sent to the MCP server.
+<7> Specify the string `kubernetes` to specify the user's bearer token. 
+<8> Specifies the name of the secret that contains the header value. Ensure that the secret has the key name `header`.
 
 . Click *Save*. 
 +

--- a/modules/ols-enabling-postgresql-persistence.adoc
+++ b/modules/ols-enabling-postgresql-persistence.adoc
@@ -54,7 +54,7 @@ ols:
   storage:
     size: 768Mi <1>
     class: gp2-csi <2>
-----  
+----
 <1> Specifies the size of the Requested Volume. If the size is not specified, the default value is 1 GB.
 <2> Specifies the Storage Class of the Requested Volume. If no class is specified, the storage class uses the default storage class setting for the cluster.
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2613

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
