### PR TITLE
OSDOCS#18225: Update the z-stream RNs for 4.15.61

### DIFF
--- a/modules/zstream-4-15-60-about.adoc
+++ b/modules/zstream-4-15-60-about.adoc
@@ -10,7 +10,7 @@
 [role="_abstract"]
 Issued: 07 January 2026
 
-{product-title} release {product-version}.60 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:23114[RHBA-2026:23114] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2025:23112[RHBA-2025:23112] advisory.
+{product-title} release {product-version}.60 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:23114[RHBA-2026:23114] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:23112[RHBA-2026:23112] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 

--- a/modules/zstream-4-15-61-about.adoc
+++ b/modules/zstream-4-15-61-about.adoc
@@ -1,0 +1,22 @@
+
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-15-61-about_{context}"]
+= RHSA-2026:1549 - {product-title} {product-version}.61 bug fix advisory
+
+[role="_abstract"]
+Issued: 05 February 2026
+
+{product-title} release {product-version}.61 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:1549[RHSA-2026:1549] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:1540[RHSA-2026:1540] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.15.61--pullspecs
+----

--- a/modules/zstream-4-15-61-bug-fixes.adoc
+++ b/modules/zstream-4-15-61-bug-fixes.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-15-61-bug-fixes_{context}"]
+= Fixed issues
+
+[role="_abstract"]
+There are no notable fixed issues for this release.
+

--- a/modules/zstream-4-15-61-updating.adoc
+++ b/modules/zstream-4-15-61-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-15-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-15-61-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an {product-title} 4.15 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -2812,14 +2812,23 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
 ====
 
+//  4.15.61 about
+include::modules/zstream-4-15-61-about.adoc[leveloffset=+2]
+
+//4.15.61 bug fixes
+include::modules/zstream-4-15-61-bug-fixes.adoc[leveloffset=+3]
+
+//4.15.61 bug fixes
+include::modules/zstream-4-15-61-updating.adoc[leveloffset=+3]
+
 //  4.15.60 about
 include::modules/zstream-4-15-60-about.adoc[leveloffset=+2]
 
 //4.15.60 bug fixes
-include::modules/zstream-4-15-60-bug-fixes.adoc[leveloffset=+2]
+include::modules/zstream-4-15-60-bug-fixes.adoc[leveloffset=+3]
 
 //4.15.60 bug fixes
-include::modules/zstream-4-15-60-updating.adoc[leveloffset=+2]
+include::modules/zstream-4-15-60-updating.adoc[leveloffset=+3]
 
 // 4.15.59
 [id="ocp-4-15-59_{context}"]


### PR DESCRIPTION
Version(s):
4.15

Issue:
[OSDOCS-18225](https://issues.redhat.com//browse/OSDOCS-18225)

Link to docs preview:
[4.15.61](https://106091--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-15-release-notes.html#zstream-4-15-61-about_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/335#cac3640b9bcce1a9c55ca6eca87ec7d722c6ec0c)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.15)
