### PR TITLE
OSSM-12493 DOCS Add [role-abstract] to all modules

### DIFF
--- a/modules/ossm-about-accessing-bookinfo-application-using-gateway.adoc
+++ b/modules/ossm-about-accessing-bookinfo-application-using-gateway.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-accessing-bookinfo-application-using-gateway_{context}"]
 = About accessing the Bookinfo application using a gateway
 
+[role="_abstract"]
+
 The {SMProductName} Operator does not deploy gateways. Gateways are not part of the control plane. As a security best-practice, Ingress and Egress gateways should be deployed in a different namespace than the namespace that contains the control plane.
 
 You can deploy gateways using either the Gateway API or the gateway injection method.

--- a/modules/ossm-about-bookinfo-application.adoc
+++ b/modules/ossm-about-bookinfo-application.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-bookinfo-application_{context}"]
 = About the Bookinfo application
 
+[role="_abstract"]
+
 Installing the `bookinfo` example application consists of two main tasks: deploying the application and creating a gateway so the application is accessible outside the cluster.
 
 You can use the `bookinfo` application to explore service mesh features. Using the `bookinfo` application, you can easily confirm that requests from a web browser pass through the mesh and reach the application.

--- a/modules/ossm-about-cert-manager.adoc
+++ b/modules/ossm-about-cert-manager.adoc
@@ -7,6 +7,7 @@
 = About the cert-manager Operator istio-csr agent
 
 [role="_abstract"]
+
 The {cert-manager-operator} enhances certificate management for securing workloads and control plane components in {SMProductName} and {istio}. It supports issuing, delivering, and renewing certificates used for mutual Transport Layer Security (mTLS) through cert-manager issuers.
 
 By integrating {istio} with the `istio-csr` agent that is managed by the cert-manager Operator, you enable {istio} to request and manage the certificates directly. The integration simplifies security configuration and centralizes certificate management within the cluster.

--- a/modules/ossm-about-concepts-argo-rollouts.adoc
+++ b/modules/ossm-about-concepts-argo-rollouts.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-concepts-argo-rollouts_{context}"]
 = {SMProductName} and Argo Rollouts
 
+[role="_abstract"]
+
 {SMProductName}, when used with Argo Rollouts, provides more advanced routing capabilities by using Istio, and does not require the configuration of a sidecar container.
 
 You can use {SMProduct} to split traffic between two application versions.

--- a/modules/ossm-about-concepts-cert-manager.adoc
+++ b/modules/ossm-about-concepts-cert-manager.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-concepts-cert-manager_{context}"]
 = {SMProductName} and cert-manager
 
+[role="_abstract"]
+
 The cert-manager tool is a solution for X.509 certificate management on Kubernetes. It delivers a unified API to integrate applications with private or public key infrastructure (PKI), such as Vault, Google Cloud Certificate Authority Service, Let's Encrypt, and other providers.
 
 The cert-manager tool ensures that the certificates are valid and up-to-date by attempting to renew the certificates at a configured time before they expire.

--- a/modules/ossm-about-concepts-kiali.adoc
+++ b/modules/ossm-about-concepts-kiali.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-concepts-kiali_{context}"]
 = {SMProductName} and Kiali
 
+[role="_abstract"]
+
 //Kiali attributes are in the works, and possible {KialiProduct} will refer to Kiali provided by Red Hat, and not Kiali Operator provided by Red Hat.
 //Kiali attributes are outside the scope of this PR.
 //TP1 content. IA influx, likely everything will change for GA.

--- a/modules/ossm-about-concepts-observability.adoc
+++ b/modules/ossm-about-concepts-observability.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-concepts-observability_{context}"]
 = {SMProductName} and Observability
 
+[role="_abstract"]
+
 {SMProductName} integrates with Red Hat Observability components, including:
 
 OpenShift Monitoring:: Monitoring stack components are deployed by default in every {ocp-product-title} installation and are managed by the Cluster Monitoring Operator (CMO). These components include Prometheus, Alertmanager, Thanos Querier, and so on. The CMO also deploys the Telemeter Client, which sends a subset of data from platform Prometheus instances to Red{nbsp}Hat to facilitate Remote Health Monitoring for clusters.

--- a/modules/ossm-about-concepts-resources.adoc
+++ b/modules/ossm-about-concepts-resources.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-concepts-resources_{context}"]
 = {SMProductName} resources
 
+[role="_abstract"]
+
 {SMProductName} is composed of two parts:
 
 * {SMProductName} resources

--- a/modules/ossm-about-configuring-a-gateway-to-accept-ingress-traffic.adoc
+++ b/modules/ossm-about-configuring-a-gateway-to-accept-ingress-traffic.adoc
@@ -7,6 +7,7 @@
 = About ingress traffic routing approaches
 
 [role="_abstract"]
+
 {SMProductName} offers two approaches to configure ingress traffic routing to services in the mesh. The approach depends on the service mesh deployment mode and traffic management requirements.
 
 Ingress routing with gateway injection and {istio} APIs::

--- a/modules/ossm-about-console-plugin.adoc
+++ b/modules/ossm-about-console-plugin.adoc
@@ -6,6 +6,8 @@
 [id="ossm-about-console-plugin_{context}"]
 = About {sm-plugin-full}
 
+[role="_abstract"]
+
 The {SMPlugin} is an extension to {ocp-product-title} web console that provides visibility into your {SMProductShortName}.
 
 [WARNING]

--- a/modules/ossm-about-deploying-istio-using-service-mesh-operator.adoc
+++ b/modules/ossm-about-deploying-istio-using-service-mesh-operator.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-deploying-istio-using-service-mesh-operator_{context}"]
 = About deploying Istio using the {SMProductName} Operator
 
+[role="_abstract"]
+
 To deploy {istio} using the {SMProductName} Operator, you must create an `{istio}` resource. Then, the Operator creates an `IstioRevision` resource, which represents one revision of the {istio} control plane. Based on the `IstioRevision` resource, the Operator deploys the {istio} control plane, which includes the `istiod` `Deployment` resource and other resources.
 
 The {SMProductName} Operator may create additional instances of the `IstioRevision` resource, depending on the update strategy defined in the `{istio}` resource.

--- a/modules/ossm-about-deploying-multiple-control-planes.adoc
+++ b/modules/ossm-about-deploying-multiple-control-planes.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-deploying-multiple-control-planes_{context}"]
 = About deploying multiple control planes
 
+[role="_abstract"]
+
 To configure a cluster to host two control planes, set up separate {istio} resources with unique names in independent {istio} system namespaces. Assign a unique revision name to each {istio} resource to identify the control planes, workloads, or namespaces it manages. Apply these revision names using injection or `istio.io/rev` labels to specify which control plane injects the sidecar proxy into application pods.
 
 Each `{istio}` resource must also configure discovery selectors to specify which namespaces the {istio} control plane observes. Only namespaces with labels that match the configured discovery selectors can join the mesh. Additionally, discovery selectors determine which control plane creates the `istio-ca-root-cert` config map in each namespace, which is used to encrypt traffic between services with mutual TLS within each mesh.

--- a/modules/ossm-about-directing-egress-traffic-through-a-gateway.adoc
+++ b/modules/ossm-about-directing-egress-traffic-through-a-gateway.adoc
@@ -6,6 +6,7 @@
 = About directing egress traffic through a gateway
 
 [role="_abstract"]
+
 You can configure a gateway installed through gateway injection as an exit point for traffic leaving the service mesh. It acts as a forward proxy for requests sent to services external to the mesh.
 
 Egress gateway:: An egress gateway is configured as an exit point for traffic leaving the service mesh, acting as a forward proxy for requests sent to external services. You can configure an egress gateway to fulfill security requirements:

--- a/modules/ossm-about-discovery-selectors-istio-ambient-mode.adoc
+++ b/modules/ossm-about-discovery-selectors-istio-ambient-mode.adoc
@@ -6,6 +6,8 @@
 [id="ossm-about-discovery-selectors-istio-ambient-mode_{context}"]
 = About discovery selectors and Istio ambient mode
 
+[role="_abstract"]
+
 {istio} ambient mode includes workloads when the control plane discovers each workload and the appropriate label enables traffic redirection through the Ztunnel proxy. By default, the control plane discovers workloads in all namespaces across the cluster. As a result, each proxy receives configuration for every namespace, including workloads that are not enrolled in the mesh. In shared or multi-tenant clusters, limiting mesh participation to specific namespaces helps reduce configuration overhead and supports multiple service meshes within the same cluster.
 
 For more information on discovery selectors, see "Scoping the Service Mesh with discovery selectors".

--- a/modules/ossm-about-discoveryselectors.adoc
+++ b/modules/ossm-about-discoveryselectors.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-discoveryselectors_{context}"]
 = About discovery selectors
 
+[role="_abstract"]
+
 With discovery selectors, the mesh administrator can control which namespaces the control plane can access. By using a {k8s} label selector, the administrator sets the criteria for the namespaces visible to the control plane, excluding any namespaces that do not match the specified criteria.
 
 [NOTE]

--- a/modules/ossm-about-exposing-services-to-traffic-outside-a-cluster.adoc
+++ b/modules/ossm-about-exposing-services-to-traffic-outside-a-cluster.adoc
@@ -7,6 +7,7 @@
 = About exposing services to traffic outside a cluster
 
 [role="_abstract"]
+
 To enable traffic from outside an {ocp-short-name} cluster to access services in a mesh, you must expose a gateway proxy by either setting its `Service` type to `LoadBalancer` or by using the {ocp-short-name} Router.
 
 Using Kubernetes load balancing to handle incoming traffic directly through the inbound gateway can reduce latency associated with data encryption. By managing encryption at the inbound gateway, you avoid the intermediate decryption and re-encryption steps within the mesh that often add latency. This approach allows mesh traffic to be encrypted and decrypted only once, which is generally more efficient.

--- a/modules/ossm-about-external-control-plane-topology.adoc
+++ b/modules/ossm-about-external-control-plane-topology.adoc
@@ -5,4 +5,6 @@
 [id="ossm-about-external-control-plane-topology_{context}"]
 = About external control plane topology
 
+[role="_abstract"]
+
 The external control plane topology improves security and allows the Service Mesh to be hosted as a service. In this installation configuration one cluster hosts and manages the {istio} control plane, and applications are hosted on other clusters. 

--- a/modules/ossm-about-gateway-injection.adoc
+++ b/modules/ossm-about-gateway-injection.adoc
@@ -6,5 +6,7 @@
 [id="ossm-about-gateway-injection_{context}"]
 = About gateway injection
 
+[role="_abstract"]
+
 Gateway injection relies upon the same mechanism as sidecar injection to inject the Envoy proxy into gateway pods. To install a gateway using gateway injection, you create a Kubernetes `Deployment` object and an associated Kubernetes `Service` object in a namespace that is visible to the {istio} control plane. When creating the `Deployment` object you label and annotate it so that the {istio} control plane injects a proxy, and the proxy is configured as a gateway. After installing the gateway, you configure it to control ingress and egress traffic using the {istio} `Gateway` and `VirtualService` resources.
 

--- a/modules/ossm-about-ingress-routing-ambient-mode.adoc
+++ b/modules/ossm-about-ingress-routing-ambient-mode.adoc
@@ -7,6 +7,7 @@
 = About ingress traffic routing approaches in ambient mode
 
 [role="_abstract"]
+
 When using the {istio} ambient mode, you can use the {k8s} Gateway API to configure ingress traffic routing.
 
 Waypoint proxies for Layer 7 routing::

--- a/modules/ossm-about-inplace-strategy.adoc
+++ b/modules/ossm-about-inplace-strategy.adoc
@@ -5,6 +5,8 @@
 [id="about-inplace-strategy_{context}"]
 = About InPlace strategy
 
+[role="_abstract"]
+
 The `InPlace` update strategy runs only one revision of the control plane at a time. During an update, all the workloads immediately connect to the new control plane version. To maintain compatibility between the sidecars and the control plane, you can upgrade only one minor version at a time.
 
 The `InPlace` strategy updates and restarts the existing {istio} control plane in place. During this process, only one instance of the control plane exists, eliminating the need to move workloads to a new control plane instance. To complete the update, restart the application workloads and gateways to refresh the Envoy proxies.

--- a/modules/ossm-about-istio-ambient-mode.adoc
+++ b/modules/ossm-about-istio-ambient-mode.adoc
@@ -6,6 +6,8 @@
 [id="ossm-about-istio-ambient-mode_{context}"]
 = About Istio ambient mode
 
+[role="_abstract"]
+
 To understand the {istio} ambient mode architecture, see the following definitions:
 
 ZTunnel proxy:: A per-node proxy that manages secure, transparent Transmission Control Protocol (TCP) connections for all workloads on the node. It operates at Layer 4 (L4), offloading mutual Transport Layer Security (mTLS) and L4 policy enforcement from application pods.

--- a/modules/ossm-about-istio-ambient-waypoint.adoc
+++ b/modules/ossm-about-istio-ambient-waypoint.adoc
@@ -6,6 +6,8 @@
 [id="ossm-about-istio-ambient-waypoint_{context}"]
 = About waypoint proxies in Istio ambient mode
 
+[role="_abstract"]
+
 After setting up {istio} ambient mode with ztunnel proxies, you can add waypoint proxies to enable advanced Layer 7 (L7) processing features that {istio} provides.
 
 {istio} ambient mode separates the functionality of {istio} into two layers:

--- a/modules/ossm-about-istio-cni-update-process.adoc
+++ b/modules/ossm-about-istio-cni-update-process.adoc
@@ -7,6 +7,7 @@
 = About the Istio CNI update process
 
 [role="_abstract"]
+
 The {istio} Container Network Interface (CNI) update process uses `Inplace` updates. When the `IstioCNI` resource changes, the daemonset automatically replaces the existing `istio-cni-node` pods with the specified version of the CNI plugin.
 
 You can use the following field to manage version updates:

--- a/modules/ossm-about-istio-control-plane-update-strategies.adoc
+++ b/modules/ossm-about-istio-control-plane-update-strategies.adoc
@@ -6,6 +6,7 @@
 = About Istio control plane update strategies
 
 [role="_abstract"]
+
 The update strategy affects how the update process is performed. The `spec.updateStrategy` field in the `{istio}` resource configuration determines how the {SMProduct} Operator updates the {istio} control plane. When the Operator detects a change in the `spec.version` field or identifies a new minor release with a configured `vX.Y-latest` alias, it initiates an upgrade procedure. For each mesh, you select one of two strategies:
 
 * `InPlace`

--- a/modules/ossm-about-istio-deployment.adoc
+++ b/modules/ossm-about-istio-deployment.adoc
@@ -5,6 +5,8 @@
 [id="about-istio-deployment_{context}"]
 = About Istio deployment
 
+[role="_abstract"]
+
 To deploy {istio}, you must create two resources: `Istio` and `IstioCNI`. The `Istio` resource deploys and configures the {istio} Control Plane. The `IstioCNI` resource deploys and configures the {istio} Container Network Interface (CNI) plugin. You should create these resources in separate projects; therefore, you must create two projects as part of the {istio} deployment process.
 
 You can use the {ocp-short-name} web console or the OpenShift CLI (oc) to create a project or a resource in your cluster.

--- a/modules/ossm-about-istio-high-availability.adoc
+++ b/modules/ossm-about-istio-high-availability.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-istio-high-availability_{context}"]
 = About Istio High Availability
 
+[role="_abstract"]
+
 Running the {istio} control plane in High Availability (HA) mode prevents single points of failure, and ensures continuous mesh operation even if an `istiod` pod fails. By using HA, if one `istiod` pod becomes unavailable, another one continues to manage and configure the {istio} data plane, preventing service outages or disruptions. HA provides scalability by distributing the control plane workload, enables graceful upgrades, supports disaster recovery operations, and protects against zone-wide mesh outages.
 
 There are two ways for a system administrator to configure HA for the {istio} deployment:

--- a/modules/ossm-about-istio-update-process.adoc
+++ b/modules/ossm-about-istio-update-process.adoc
@@ -6,6 +6,8 @@
 [id="ossm-about-istio-update-process_{context}"]
 = About Istio update process
 
+[role="_abstract"]
+
 After updating the {SMProduct} Operator, update the {istio} control plane to the latest supported version. The `{istio}` resource configuration determines how the control plane upgrade is performed, including which steps require manual action and which are handled automatically.
 
 The `{istio}` resource configuration includes the following fields that are relevant to the upgrade process:

--- a/modules/ossm-about-l7-features-ambient-mode.adoc
+++ b/modules/ossm-about-l7-features-ambient-mode.adoc
@@ -6,6 +6,8 @@
 [id="ossm-about-l7-features-ambient-mode_{context}"]
 = About Layer 7 features in ambient mode
 
+[role="_abstract"]
+
 Ambient mode includes stable Layer 7 (L7) capabilities implemented through the Gateway API `HTTPRoute` resource and the {istio} `AuthorizationPolicy` resource.
 
 The `AuthorizationPolicy` resource works in both sidecar and ambient modes. In ambient mode, authorization policies can be targeted for `ztunnel` enforcement or attached for waypoint enforcement. To attach a policy to a waypoint, include a `targetRef` that references either the waypoint itself or a Service configured to use that waypoint.

--- a/modules/ossm-about-mtls.adoc
+++ b/modules/ossm-about-mtls.adoc
@@ -6,6 +6,8 @@
 [id="ossm-about-mtls_{context}"]
 = About mutual Transport Layer Security (mTLS)
 
+[role="_abstract"]
+
 In {SMProduct} 3, you use the `Istio` resource instead of the `ServiceMeshControlPlane` resource to configure mTLS settings. 
 
 In {SMProduct} 3, you configure `STRICT` mTLS mode by using the `PeerAuthentication` and `DestinationRule` resources. You set TLS protocol versions through Istio Workload Minimum TLS Version Configuration.

--- a/modules/ossm-about-multi-cluster-mesh-topologies.adoc
+++ b/modules/ossm-about-multi-cluster-mesh-topologies.adoc
@@ -6,6 +6,8 @@
 [id="ossm-about-multi-cluster-mesh-topologies_{context}"]
 = About multi-cluster mesh topologies
 
+[role="_abstract"]
+
 In a multi-cluster mesh topology, you install and manage a single {istio} mesh across multiple {ocp-product-title} clusters, enabling communication and service discovery between the services. Two factors determine the multi-cluster mesh topology: control plane topology and network topology. There are two options for each topology. Therefore, there are four possible multi-cluster mesh topology configurations.
 
 * Multi-Primary Single Network: Combines the multi-primary control plane topology and the single network network topology models.

--- a/modules/ossm-about-operator-update-process.adoc
+++ b/modules/ossm-about-operator-update-process.adoc
@@ -6,6 +6,8 @@
 [id="ossm-about-operator-update-process_{context}"]
 = About Operator update process
 
+[role="_abstract"]
+
 The {SMProduct} Operator will upgrade automatically to the latest available version based on the selected channel when the *approval strategy* field is set to `Automatic` (default). If the *approval strategy* field is set to `Manual`, {olm-first} will generate an update request, which a cluster administrator must approve to update the Operator to the latest version.
 
 The Operator update process does not automatically update the {istio} control plane unless the `{istio}` resource version is set to an alias (for example, `vX.Y-latest`) and the `updateStrategy` is set to `InPlace`. This triggers a control plane update when a new version is available in the Operator. By default, the Operator will not update the {istio} control plane unless the `{istio}` resource is updated with a new version.

--- a/modules/ossm-about-revisionbased-strategy.adoc
+++ b/modules/ossm-about-revisionbased-strategy.adoc
@@ -5,6 +5,8 @@
 [id="about-revisionbased-strategy_{context}"]
 = About RevisionBased strategy
 
+[role="_abstract"]
+
 The `RevisionBased` strategy runs two revisions of the control plane during an upgrade. This approach supports gradual workload migration from the old control plane to the new one, enabling canary upgrades. It also supports upgrades across more than one minor version.
 
 The `RevisionBased` strategy creates a new {istio} control plane instance for each change to the `spec.version` field. The existing control plane remains active until all workloads transition to the new instance. You can move the workloads to the new control plane by updating the `istio.io/rev` labels or using the `IstioRevisionTag` resource, followed by a restart.

--- a/modules/ossm-about-service-mesh-custom-resource-definitions.adoc
+++ b/modules/ossm-about-service-mesh-custom-resource-definitions.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-service-mesh-custom-resource-definitions_{context}"]
 = About Service Mesh custom resource definitions
 
+[role="_abstract"]
+
 Installing the {SMProductName} Operator also installs custom resource definitions (CRD) that administrators can use to configure {istio} for {SMProductShortName} installations. The {olm-first} installs two categories of CRDs: {sail-operator} CRDs and {istio} CRDs.
 
 {sail-operator} CRDs define custom resources for installing and maintaining the {istio} components required to operate a service mesh. These custom resources belong to the `sailoperator.io` API group and include the `Istio`, `IstioRevision`, `IstioCNI`, and `ZTunnel` resource kinds. For more information on how to configure these resources, see the `sailoperator.io` link:https://github.com/istio-ecosystem/sail-operator/blob/main/docs/api-reference/sailoperator.io.md[API reference] documentation.

--- a/modules/ossm-about-sidecar-injection.adoc
+++ b/modules/ossm-about-sidecar-injection.adoc
@@ -5,6 +5,8 @@
 [id="ossm-about-sidecar-injection_{context}"]
 = About sidecar injection
 
+[role="_abstract"]
+
 Sidecar injection is enabled using labels at the namespace or pod level. These labels also indicate the specific control plane managing the proxy. When you apply a valid injection label to the pod template defined in a deployment, any new pods created by that deployment automatically receive a sidecar. Similarly, applying a pod injection label at the namespace level ensures any new pods in that namespace include a sidecar.
 
 [NOTE]

--- a/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
+++ b/modules/ossm-accessing-bookinfo-application-using-gateway-api.adoc
@@ -2,6 +2,8 @@
 [id="ossm-accessing-bookinfo-application-using-gateway-api"]
 = Accessing the Bookinfo application by using Gateway API
 
+[role="_abstract"]
+
 The {k8s} Gateway API deploys a gateway by creating a `Gateway` resource. In {ocp-product-title} 4.15 and later, {SMProductName} implements the Gateway API custom resource definitions (CRDs). However, in {ocp-product-title} 4.18 and earlier, the CRDs are not installed by default. Hence, in {ocp-product-title} 4.15 through 4.18, you must manually install the CRDs. Starting with {ocp-product-title} 4.19, these CRDs are automatically installed and managed, and you can no longer create, update, or delete them.
 
 For details about enabling Gateway API for Ingress in {ocp-product-title} 4.19 and later, see "Configuring ingress cluster traffic" in the {ocp-product-title} documentation.

--- a/modules/ossm-accessing-bookinfo-application-using-istio-gateway-injection.adoc
+++ b/modules/ossm-accessing-bookinfo-application-using-istio-gateway-injection.adoc
@@ -5,6 +5,8 @@
 [id="ossm-accessing-bookinfo-application-using-istio-gateway-injection_{context}"]
 = Accessing the Bookinfo application by using Istio gateway injection
 
+[role="_abstract"]
+
 Gateway injection uses the same mechanisms as {istio} sidecar injection to create a gateway from a `Deployment` resource that is paired with a `Service` resource. The `Service` resource can be made accessible from outside an {ocp-product-title} cluster.
 
 .Prerequisites

--- a/modules/ossm-adding-authorization-policy.adoc
+++ b/modules/ossm-adding-authorization-policy.adoc
@@ -6,6 +6,8 @@
 [id="ossm-adding-authorization-policy_{context}"]
 = Adding authorization policy
 
+[role="_abstract"]
+
 Use an Layer 7 (L7) authorization policy to explicitly allow the `curl` service to send `GET` requests to the `productpage` service while blocking all other operations.
 
 .Procedure

--- a/modules/ossm-api-settings-mesh-ha-autoscaling.adoc
+++ b/modules/ossm-api-settings-mesh-ha-autoscaling.adoc
@@ -5,6 +5,8 @@
 [id="ossm-api-settings-mesh-ha-autoscaling_{context}"]
 = API settings for Service Mesh HA autoscaling mode
 
+[role="_abstract"]
+
 Use the following `istio` custom resource definition (CRD) parameters when you configure a service mesh for High Availability (HA) by using autoscaling. 
 
 .HA API parameters

--- a/modules/ossm-api-settings-mesh-ha-replicacount.adoc
+++ b/modules/ossm-api-settings-mesh-ha-replicacount.adoc
@@ -5,6 +5,8 @@
 [id="ossm-api-settings-mesh-ha-replicacount_{context}"]
 = API settings for Service Mesh HA replica count mode
 
+[role="_abstract"]
+
 Use the following `istio` custom resource definition (CRD) parameters when you configure a service mesh for High Availability (HA) by using replica count. 
 
 .HA API parameters

--- a/modules/ossm-applying-certificates-to-a-multi-cluster-topology.adoc
+++ b/modules/ossm-applying-certificates-to-a-multi-cluster-topology.adoc
@@ -6,6 +6,8 @@
 [id="ossm-applying-certificates-to-a-multi-cluster-topology_{context}"]
 = Applying certificates to a multi-cluster topology 
 
+[role="_abstract"]
+
 Apply root and intermediate certificate authority (CA) certificates to the clusters in a multi-cluster topology.
 
 [NOTE]

--- a/modules/ossm-cert-manager-installing-istio-resource.adoc
+++ b/modules/ossm-cert-manager-installing-istio-resource.adoc
@@ -6,6 +6,8 @@
 [id="installing-istio-resource_{context}"]
 = Installing your Istio resource
 
+[role="_abstract"]
+
 //TP1 content influx. Title, etc may change.
 //Content is very similar to 2.x content
 //all kinds of formatting things to fix. want to see if a build will generate to have a look, and see how it fits structurally with the IA.

--- a/modules/ossm-cert-manager-istio-csr-inplace-update-strategy.adoc
+++ b/modules/ossm-cert-manager-istio-csr-inplace-update-strategy.adoc
@@ -6,6 +6,8 @@
 [id="inplace-istio-csr-installation_{context}"]
 = Installing the istio-csr agent by using the in place update strategy
 
+[role="_abstract"]
+
 Istio resources use the in place update strategy by default. Follow this procedure if you plan to leave `spec.updateStrategy` as `InPlace` when you create and install your `Istio` resource.
 
 .Procedure

--- a/modules/ossm-cert-manager-istio-csr-revisionbased-strategy.adoc
+++ b/modules/ossm-cert-manager-istio-csr-revisionbased-strategy.adoc
@@ -6,6 +6,8 @@
 [id="revision-based-istio-csr-installation_{context}"]
 = Installing the istio-csr agent by using the revision based update strategy
 
+[role="_abstract"]
+
 Istio resources use the in place update strategy by default. Follow this procedure if you plan to change `spec.updateStrategy` to `RevisionBased` when you create and install your `Istio` resource.
 
 .Procedure

--- a/modules/ossm-cert-manager-update-istio-csr-revisionbased-only.adoc
+++ b/modules/ossm-cert-manager-update-istio-csr-revisionbased-only.adoc
@@ -6,6 +6,8 @@
 [id="updating-istio-csr-revision-based-only_{context}"]
 = Updating istio-csr agents with revision-based update strategies
 
+[role="_abstract"]
+
 If you deployed your Istio resource using the revision based update strategy, you must pass all revisions each time you update your control plane. You must perform the update in the following order:
 
 . Update the `istio-csr` deployment with the new revision.

--- a/modules/ossm-cert-manager-verifying-install.adoc
+++ b/modules/ossm-cert-manager-verifying-install.adoc
@@ -6,6 +6,8 @@
 [id="verifying-cert-manager-installation_{context}"]
 = Verifying cert-manager installation
 
+[role="_abstract"]
+
 //TP1 content influx. Title, etc may change.
 //Content is very similar to 2.x content
 //all kinds of formatting things to fix. want to see if a build will generate to have a look, and see how it fits structurally with the IA.

--- a/modules/ossm-cluster-wide-migration-methods.adoc
+++ b/modules/ossm-cluster-wide-migration-methods.adoc
@@ -6,6 +6,8 @@
 [id="ossm-cluster-wide-migration-methods_{context}"]
 = Cluster-wide migration methods
 
+[role="_abstract"]
+
 You can migrate the control plane from {SMProductName} {SMv2Version} to {SMProduct} 3.0 by using one of the following methods:
 
 * Applying the `istio.io/rev` label

--- a/modules/ossm-config-dt-ambient-mode.adoc
+++ b/modules/ossm-config-dt-ambient-mode.adoc
@@ -7,6 +7,7 @@
 = Configuring {TempoName} with Service Mesh ambient mode
 
 [role="_abstract"]
+
 You can configure a {TempoShortName} with {SMProduct} ambient mode by using waypoint or gateway proxies to generate Layer 7 (L7) spans. The `ztunnel` component generates only Layer 4 (L4) data, so L7 spans appear only when a workload or service uses an attached proxy.
 
 .Prerequisites

--- a/modules/ossm-config-openshift-monitoring-ambient-mode.adoc
+++ b/modules/ossm-config-openshift-monitoring-ambient-mode.adoc
@@ -7,6 +7,7 @@
 = Configuring OpenShift Monitoring with Service Mesh ambient mode
 
 [role="_abstract"]
+
 You can integrate {SMProductName} with user-workload monitoring to enable observability in your service mesh ambient mode. User-workload monitoring provides access to essential built-in tools and is required to run Kiali, the dedicated console for {istio}. 
 
 .Prerequisites

--- a/modules/ossm-config-openshift-monitoring-kiali.adoc
+++ b/modules/ossm-config-openshift-monitoring-kiali.adoc
@@ -6,6 +6,8 @@
 [id="ossm-config-openshift-monitoring-kiali_{context}"]
 = Configuring OpenShift Monitoring with Kiali
 
+[role="_abstract"]
+
 The following steps show how to integrate the {KialiProduct} with user-workload monitoring.
 
 .Prerequisites

--- a/modules/ossm-config-openshift-monitoring-only.adoc
+++ b/modules/ossm-config-openshift-monitoring-only.adoc
@@ -7,6 +7,7 @@
 = Configuring OpenShift Monitoring with Service Mesh
 
 [role="_abstract"]
+
 You can integrate {SMProductName} with user-workload monitoring to enable observability in your service mesh. User-workload monitoring provides access to essential built-in tools and is required to run Kiali, the dedicated console for {istio}.
 
 .Prerequisites

--- a/modules/ossm-config-otel-kiali.adoc
+++ b/modules/ossm-config-otel-kiali.adoc
@@ -6,6 +6,8 @@
 [id="ossm-config-otel-kiali_{context}"]
 = Configuring {DTProductName} with {KialiProduct}
 
+[role="_abstract"]
+
 After you integrate {KialiProduct} with {DTProductName}, you can view distributed traces in the Kiali console. Viewing traces provides insight into the communication between services within the service mesh, helping you understand how requests are flowing through your system and where potential issues might reside.
 
 .Prerequisites

--- a/modules/ossm-config-otel.adoc
+++ b/modules/ossm-config-otel.adoc
@@ -7,6 +7,7 @@
 = Configuring {OTELName} with Service Mesh
 
 [role="_abstract"]
+
 You can integrate {SMProductName} with {OTELName} to instrument, generate, collect, and export OpenTelemetry traces, metrics, and logs to analyze and understand the performance and behavior of the software.
 
 .Prerequisites

--- a/modules/ossm-configuring-istio-ha-autoscaling.adoc
+++ b/modules/ossm-configuring-istio-ha-autoscaling.adoc
@@ -5,6 +5,8 @@
 [id="ossm-configuring-istio-ha-autoscaling_{context}"]
 = Configuring Istio HA by using autoscaling 
 
+[role="_abstract"]
+
 Configure the {istio} control plane in High Availability (HA) mode to prevent a single point of failure, and ensure continuous mesh operation even if one of the `istiod` pods fails. Autoscaling defines the minimum and maximum number of {istio} control plane pods that can operate. {ocp-product-title} uses these values to scale the number of control planes in operation based on resource utilization, such as CPU or memory, to efficiently respond to the varying number of workloads and overall traffic patterns within the mesh.
 
 .Prerequisites

--- a/modules/ossm-configuring-istio-ha-replicacount.adoc
+++ b/modules/ossm-configuring-istio-ha-replicacount.adoc
@@ -5,6 +5,8 @@
 [id="ossm-configuring-istio-ha-replicacount_{context}"]
 = Configuring Istio HA by using replica count
 
+[role="_abstract"]
+
 Configure the {istio} control plane in High Availability (HA) mode to prevent a single point of failure, and ensure continuous mesh operation even if one of the `istiod` pods fails. The replica count defines a fixed number of {istio} control plane pods that can operate. Use replica count for mesh environments where the control plane workload is relatively stable or predictable, or when you prefer to manually scale the `istiod` pod.
 
 .Prerequisites

--- a/modules/ossm-control-plane-configuration-migration-requirements.adoc
+++ b/modules/ossm-control-plane-configuration-migration-requirements.adoc
@@ -6,6 +6,8 @@
 [id="ossm-about-cluster-wide-migration_{context}"]
 = Control plane configuration migration requirements
 
+[role="_abstract"]
+
 During the migration process, two cluster-wide control planes run in the same cluster while the data plane namespaces are gradually migrated to the {SMProductName} 3.0 installation. One control plane is associated with the {SMProductName} {SMv2Version} installation and the other is associated with the {SMProduct} 3.0 installation. You must carefully plan the migration steps to avoid possible conflicts between the two control planes.
 
 [IMPORTANT]

--- a/modules/ossm-core-features.adoc
+++ b/modules/ossm-core-features.adoc
@@ -7,6 +7,8 @@ Module included in the following assemblies:
 [id="ossm-core-features_{context}"]
 = Core features
 
+[role="_abstract"]
+
 {SMProductName} provides a number of key capabilities uniformly across a network of services:
 
 * *Traffic Management* - Control the flow of traffic and API calls between services, make calls more reliable, and make the network more robust in the face of adverse conditions.

--- a/modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces-with-cert-manager.adoc
+++ b/modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces-with-cert-manager.adoc
@@ -6,6 +6,8 @@
 [id="ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces-with-cert-manager_{context}"]
 = Creating the default revision tag and relabeling the namespaces with cert manager
 
+[role="_abstract"]
+
 You can create the default revision tag and relabel the namespaces after you have completed the {SMProduct} 2 to {SMProduct} 3 cluster-wide migration process by using the {istio} injection label.
 
 The `bookinfo` application is used as an example.

--- a/modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces.adoc
+++ b/modules/ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces.adoc
@@ -6,6 +6,8 @@
 [id="ossm-creating-a-default-revision-tag-and-relabeling-the-namespaces_{context}"]
 = Creating the default revision tag and relabeling the namespaces
 
+[role="_abstract"]
+
 You can create the default revision tag and relabel the namespaces after you have completed the {SMProduct} 2 to {SMProduct} 3 cluster-wide migration process by using the {istio} injection label.
 
 The `bookinfo` application is used as an example.

--- a/modules/ossm-creating-certificates-for-a-multi-cluster-topology.adoc
+++ b/modules/ossm-creating-certificates-for-a-multi-cluster-topology.adoc
@@ -6,6 +6,8 @@
 [id="ossm-creating-certificates-for-a-multi-cluster-topology_{context}"]
 = Creating certificates for a multi-cluster topology 
 
+[role="_abstract"]
+
 Create the root and intermediate certificate authority (CA) certificates for two clusters.
 
 .Prerequisites

--- a/modules/ossm-creating-istio-cni-project-using-console.adoc
+++ b/modules/ossm-creating-istio-cni-project-using-console.adoc
@@ -5,6 +5,8 @@
 [id="ossm-creating-istio-cni-project_{context}"]
 = Creating the IstioCNI project using the web console
 
+[role="_abstract"]
+
 The {SMProductShortName} Operator deploys the {istio} CNI plugin to a project that you create. In this example, `istio-cni` is the name of the project.
 
 .Prerequisties

--- a/modules/ossm-creating-istio-project-using-console.adoc
+++ b/modules/ossm-creating-istio-project-using-console.adoc
@@ -4,7 +4,9 @@
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-creating-istio-project_{context}"]
 = Creating the Istio project using the web console
-  
+
+[role="_abstract"]
+
 The {SMProductShortName} Operator deploys the {istio} control plane to a project that you create. In this example, `istio-system` is the name of the project.
 
 .Prerequisties

--- a/modules/ossm-creating-istio-resource-using-console.adoc
+++ b/modules/ossm-creating-istio-resource-using-console.adoc
@@ -5,6 +5,8 @@
 [id="ossm-creating-istio-resource_{context}"]
 = Creating the Istio resource using the web console
 
+[role="_abstract"]
+
 Create the {istio} resource that will contain the YAML configuration file for your {istio} deployment. The {SMProductName} Operator uses information in the YAML file to create an instance of the {istio} control plane.
 
 .Prerequisties

--- a/modules/ossm-creating-istiocni-resource-using-console.adoc
+++ b/modules/ossm-creating-istiocni-resource-using-console.adoc
@@ -5,6 +5,8 @@
 [id="ossm-creating-istiocni-resource_{context}"]
 = Creating the IstioCNI resource using the web console
 
+[role="_abstract"]
+
 Create an {istio} Container Network Interface (CNI) resource, which contains the configuration file for the Istio CNI plugin. The {SMProductShortName} Operator uses the configuration specified by this resource to deploy the CNI pod.
 
 .Prerequisties

--- a/modules/ossm-customizing-istio-configuration.adoc
+++ b/modules/ossm-customizing-istio-configuration.adoc
@@ -5,6 +5,8 @@
 [id="ossm-customizing-istio_{context}"]
 = Customizing Istio configuration
 
+[role="_abstract"]
+
 The `values` field of the `Istio` custom resource definition, which was created when the control plane was deployed, can be used to customize Istio configuration using Istio's `Helm` configuration values. When you create this resource using the OpenShift Container Platform web console, it is pre-populated with configuration settings to enable Istio to run on OpenShift.
 
 .Procedure

--- a/modules/ossm-deploy-application-workloads-in-each-mesh.adoc
+++ b/modules/ossm-deploy-application-workloads-in-each-mesh.adoc
@@ -5,6 +5,8 @@
 [id="ossm-deploy-application-workloads-in-each-mesh_{context}"]
 = Deploy application workloads in each mesh
 
+[role="_abstract"]
+
 To deploy application workloads, assign each workload to a separate namespace.
 
 .Procedure

--- a/modules/ossm-deploying-bookinfo-application-istio-ambient-mode.adoc
+++ b/modules/ossm-deploying-bookinfo-application-istio-ambient-mode.adoc
@@ -6,6 +6,8 @@
 [id="ossm-deploying-bookinfo-application-istio-ambient-mode_{context}"]
 = Deploying the Bookinfo application in Istio ambient mode
 
+[role="_abstract"]
+
 You can deploy the `bookinfo` sample application in {istio} ambient mode without sidecar injection by using the `ZTunnel` proxy. For more information on `bookinfo` application, see "About the Bookinfo application".
 
 .Prerequisites

--- a/modules/ossm-deploying-bookinfo-application.adoc
+++ b/modules/ossm-deploying-bookinfo-application.adoc
@@ -5,6 +5,8 @@
 [id="deploying-book-info_{context}"]
 = Deploying the Bookinfo application
 
+[role="_abstract"]
+
 .Prerequisites
 
 * You have deployed a cluster on {ocp-product-title} 4.15 or later.

--- a/modules/ossm-deploying-first-control-plane.adoc
+++ b/modules/ossm-deploying-first-control-plane.adoc
@@ -5,6 +5,8 @@
 [id="ossm-deploying-first-control-plane_{context}"]
 = Deploying the first control plane
 
+[role="_abstract"]
+
 You deploy the first control plane by creating its assigned namespace.
 
 .Prerequisites

--- a/modules/ossm-deploying-istio.adoc
+++ b/modules/ossm-deploying-istio.adoc
@@ -2,6 +2,8 @@
 [id="ossm-deploying-istio"]
 = Deploying Istio
 
+[role="_abstract"]
+
 .Procedure
 
 . Create the project where Istio is going to be deployed. In the following examaple, the project is called `istio-system`:  

--- a/modules/ossm-deploying-second-control-plane.adoc
+++ b/modules/ossm-deploying-second-control-plane.adoc
@@ -5,6 +5,8 @@
 [id="ossm-deploying-second-control-plane_{context}"]
 = Deploying the second control plane
 
+[role="_abstract"]
+
 After deploying the first control plane, you can deploy the second control plane by creating its assigned namespace.
 
 .Procedure

--- a/modules/ossm-deploying-waypoint-proxy.adoc
+++ b/modules/ossm-deploying-waypoint-proxy.adoc
@@ -6,6 +6,8 @@
 [id="ossm-deploying-waypoint-proxy_{context}"]
 = Deploying a waypoint proxy
 
+[role="_abstract"]
+
 You can deploy a waypoint proxy in the `bookinfo` application namespace to route traffic through the {istio} ambient data plane and enforce L7 policies.
 
 .Prerequisites

--- a/modules/ossm-deploying-waypoint-using-gateway-api.adoc
+++ b/modules/ossm-deploying-waypoint-using-gateway-api.adoc
@@ -6,6 +6,8 @@
 [id="ossm-deploying-waypoint-using-gateway-api_{context}"]
 = Deploying waypoint proxies using gateway API
 
+[role="_abstract"]
+
 You can deploy waypoint proxies using {k8s} Gateway resource.
 
 .Prerequisites

--- a/modules/ossm-directing-egress-traffic-through-a-gateway-kubernetes-gateway-api-ambient-mode.adoc
+++ b/modules/ossm-directing-egress-traffic-through-a-gateway-kubernetes-gateway-api-ambient-mode.adoc
@@ -6,6 +6,7 @@
 = Directing egress traffic through a gateway using the {k8s} Gateway API in ambient mode
 
 [role="_abstract"]
+
 Use the {k8s} Gateway API and waypoint proxy to direct outbound HTTP traffic through an egress gateway.
 
 .Prerequisites

--- a/modules/ossm-directing-egress-traffic-through-a-gateway-using-istio-apis.adoc
+++ b/modules/ossm-directing-egress-traffic-through-a-gateway-using-istio-apis.adoc
@@ -6,6 +6,7 @@
 = Directing egress traffic through a gateway using Istio APIs
 
 [role="_abstract"]
+
 Use {istio} APIs to direct outbound HTTP traffic through a gateway that was installed using gateway injection.
 
 .Prerequisites

--- a/modules/ossm-directing-egress-traffic-through-a-gateway-using-kubernetes-gateway-api.adoc
+++ b/modules/ossm-directing-egress-traffic-through-a-gateway-using-kubernetes-gateway-api.adoc
@@ -6,6 +6,7 @@
 = Directing egress traffic through a gateway by using the {k8s} Gateway API
 
 [role="_abstract"]
+
 Use the {k8s} Gateway API to direct outbound HTTP traffic through an egress gateway.
 
 .Prerequisites

--- a/modules/ossm-enabling-cross-namespace-waypoint-usage.adoc
+++ b/modules/ossm-enabling-cross-namespace-waypoint-usage.adoc
@@ -6,6 +6,8 @@
 [id="ossm-enabling-cross-namespace-waypoint-usage_{context}"]
 = Enabling cross-namespace waypoint usage
 
+[role="_abstract"]
+
 You can use a cross-namespace waypoint to allow resources in one namespace to route traffic through a waypoint deployed in a different namespace.
 
 .Procedure

--- a/modules/ossm-enabling-sidecar-injection-istio-revision-tag-resource.adoc
+++ b/modules/ossm-enabling-sidecar-injection-istio-revision-tag-resource.adoc
@@ -5,6 +5,8 @@
 [id="ossm-enabling-sidecar-injection-istio-revision-tag-resource_{context}"]
 = Enabling sidecar injection with namespace labels and an IstioRevisionTag resource
 
+[role="_abstract"]
+
 To use the `istio-injection=enabled` label when your revision name is not `default`, you must create an `IstioRevisionTag` resource with the name `default` that references your `Istio` resource.
 
 //Prereqs lifted from existing content https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/installing/ossm-sidecar-injection

--- a/modules/ossm-enabling-sidecar-injection.adoc
+++ b/modules/ossm-enabling-sidecar-injection.adoc
@@ -5,6 +5,8 @@
 [id="ossm-enabling-sidecar-injection_{context}"]
 = Enabling sidecar injection
 
+[role="_abstract"]
+
 To demonstrate different approaches for configuring sidecar injection, the following procedures use the Bookinfo application.
 
 .Prerequisites

--- a/modules/ossm-enabling-strict-mtls-namespace.adoc
+++ b/modules/ossm-enabling-strict-mtls-namespace.adoc
@@ -6,6 +6,8 @@
 [id="ossm-enabling-strict-mtls-namespace_{context}"]
 = Enabling strict mTLS mode by using the namespace
 
+[role="_abstract"]
+
 You can restrict workloads to accept only encrypted mTLS traffic by enabling the `STRICT` mode in `PeerAuthentication`.
 
 .Example `PeerAuthentication` policy for a namespace

--- a/modules/ossm-enabling-strict-mtls-whole-service-mesh.adoc
+++ b/modules/ossm-enabling-strict-mtls-whole-service-mesh.adoc
@@ -6,6 +6,8 @@
 [id="ossm-enabling-strict-mtls-whole-service-mesh_{context}"]
 = Enabling strict mTLS across the whole service mesh
 
+[role="_abstract"]
+
 You can configure mTLS across the entire mesh by applying the `PeerAuthentication` policy to the `istiod` namespace, such as `istio-system`. The `istiod` namespace name must match to the `spec.namespace` field of your `Istio` resource.
 
 .Example `PeerAuthentication` policy for the whole mesh

--- a/modules/ossm-exposing-a-gateway-to-traffic-outside-the-cluster-using-openshift-routes.adoc
+++ b/modules/ossm-exposing-a-gateway-to-traffic-outside-the-cluster-using-openshift-routes.adoc
@@ -6,6 +6,7 @@
 = Exposing a gateway to traffic outside the cluster by using OpenShift Routes
 
 [role="_abstract"]
+
 You can expose a gateway to traffic outside the cluster by using {ocp-short-name} Routes. This approach provides an alternative to using Kubernetes load balancer service when you have to expose gateways to traffic outside the cluster.
 
 .Prerequisites

--- a/modules/ossm-exposing-a-service-by-using-the-kubernetes-gateway-api-in-ambient-mode.adoc
+++ b/modules/ossm-exposing-a-service-by-using-the-kubernetes-gateway-api-in-ambient-mode.adoc
@@ -6,6 +6,7 @@
 = Exposing a service by using the {k8s} Gateway API in ambient mode
 
 [role="_abstract"]
+
 You can use the {k8s} Gateway API to create `Gateway` and `HTTPRoute` resources and deploy a gateway in ambient mode. The resources configure the gateway to expose a service in the mesh to traffic outside the mesh.
 
 .Prerequisites

--- a/modules/ossm-exposing-a-service-by-using-the-kubernetes-gateway-api.adoc
+++ b/modules/ossm-exposing-a-service-by-using-the-kubernetes-gateway-api.adoc
@@ -6,6 +6,7 @@
 = Exposing a service by using the {k8s} Gateway API in sidecar mode
 
 [role="_abstract"]
+
 You can use the {k8s} Gateway API to create `Gateway` and `HTTPRoute` resources and deploy a gateway. The resources configure the gateway to expose a service in the mesh to traffic outside the mesh.
 
 .Prerequisites

--- a/modules/ossm-exposing-service-using-istio-gateway-and-virtualservice.adoc
+++ b/modules/ossm-exposing-service-using-istio-gateway-and-virtualservice.adoc
@@ -6,6 +6,7 @@
 = Exposing a service by using the {istio} Gateway and VirtualService resources
 
 [role="_abstract"]
+
 You can use the {istio} `Gateway` and `VirtualService` resources to configure a gateway that was deployed by using gateway injection. The resources expose a service in the mesh to traffic outside the mesh. You can set the gateway `Service` type to `LoadBalancer` to allow traffic from outside the cluster.
 
 .Prerequisites

--- a/modules/ossm-identifying-revision-name.adoc
+++ b/modules/ossm-identifying-revision-name.adoc
@@ -5,6 +5,8 @@
 [id="ossm-identifying-revision-name_{context}"]
 = Identifying the revision name
 
+[role="_abstract"]
+
 The label required to enable sidecar injection is determined by the specific control plane instance, known as a revision. Each revision is managed by an `IstioRevision` resource, which is automatically created and managed by the `{istio}` resource, so manual creation or modification of `IstioRevision` resources is generally unnecessary.
 
 The naming of an `IstioRevision` depends on the `spec.updateStrategy.type` setting in the `{istio}` resource. If set to `InPlace`, the revision shares the `{istio}` resource name. If set to `RevisionBased`, the revision name follows the format `<Istio resource name>-v<version>`. Typically, each `{istio}` resource corresponds to a single `IstioRevision`. However, during a revision-based upgrade, multiple `IstioRevision` resources may exist, each representing a distinct control plane instance.

--- a/modules/ossm-install-console-plugin-ocp-cli.adoc
+++ b/modules/ossm-install-console-plugin-ocp-cli.adoc
@@ -6,6 +6,8 @@
 [id="ossm-install-console-plugin-ocp-cli_{context}"]
 = Installing {SMPluginShort} by using the CLI
 
+[role="_abstract"]
+
 You can install the {SMPlugin} by using the {ocp-short-name} CLI.
 
 .Prerequisites

--- a/modules/ossm-install-console-plugin-ocp-web-console.adoc
+++ b/modules/ossm-install-console-plugin-ocp-web-console.adoc
@@ -6,6 +6,8 @@
 [id="ossm-install-console-plugin-ocp-web-console_{context}"]
 = Installing {SMPluginShort} by using the {ocp-product-title} web console
 
+[role="_abstract"]
+
 You can install the {SMPlugin} by using the {ocp-product-title} web console.
 
 .Prerequisites

--- a/modules/ossm-install-kiali-operator.adoc
+++ b/modules/ossm-install-kiali-operator.adoc
@@ -6,6 +6,8 @@
 [id="ossm-install-kiali-operator_{context}"]
 = Installing the {KialiProduct}
 
+[role="_abstract"]
+
 The following steps show how to install the {KialiProduct}.
 
 [WARNING]

--- a/modules/ossm-installing-cert-manager.adoc
+++ b/modules/ossm-installing-cert-manager.adoc
@@ -6,6 +6,8 @@
 [id="ossm-installing-cert-manager_{context}"]
 = Integrating Service Mesh with the cert-manager Operator by using the istio-csr agent
 
+[role="_abstract"]
+
 You can integrate the cert-manager Operator with {SMProduct} by deploying the `istio-csr` agent and configuring an `{istio}` resource that uses the `istio-csr` agent to process workload and control plane certificate signing requests. The following procedure creates a self-signed `issuer` object.
 
 .Prerequisites

--- a/modules/ossm-installing-external-control-plane.adoc
+++ b/modules/ossm-installing-external-control-plane.adoc
@@ -5,6 +5,8 @@
 [id="ossm-installing-external-control-plane_{context}"]
 = Installing the control plane and data plane on separate clusters
 
+[role="_abstract"]
+
 Install {istio} on a control plane cluster and a separate data plane cluster. This installation approach provides increased security.
 
 [NOTE]

--- a/modules/ossm-installing-gateway-using-gateway-injection.adoc
+++ b/modules/ossm-installing-gateway-using-gateway-injection.adoc
@@ -2,6 +2,8 @@
 [id="ossm-installing-gateway-using-gateway-injection_{context}"]
 = Installing a gateway by using gateway injection
 
+[role="_abstract"]
+
 This procedure explains how to install a gateway by using gateway injection.
 
 [NOTE]

--- a/modules/ossm-installing-istio-ambient-mode.adoc
+++ b/modules/ossm-installing-istio-ambient-mode.adoc
@@ -6,6 +6,8 @@
 [id="ossm-installing-istio-ambient-mode_{context}"]
 = Installing Istio ambient mode
 
+[role="_abstract"]
+
 You can install {istio} ambient mode on {ocp-product-title} 4.19 or later and {SMProductName} 3.1.0 or later with the required Gateway API custom resource definitions (CRDs).
 
 .Prerequisites

--- a/modules/ossm-installing-istio-with-inplace-strategy.adoc
+++ b/modules/ossm-installing-istio-with-inplace-strategy.adoc
@@ -5,6 +5,8 @@
 [id="installing-istio-with-inplace-strategy_{context}"]
 = Installing with InPlace update strategy
 
+[role="_abstract"]
+
 You can install the {istio} control plane, {istio} CNI, and the Bookinfo demo application using the `Inplace` update strategy.
 
 [NOTE]

--- a/modules/ossm-installing-istio-with-revisionbased-strategy-istiorevisiontag.adoc
+++ b/modules/ossm-installing-istio-with-revisionbased-strategy-istiorevisiontag.adoc
@@ -6,6 +6,8 @@
 [id="installing-istio-with-revisionbased-strategy-istiorevisiontag_{context}"]
 = Installing Istio with RevisionBased strategy and IstioRevisionTag
 
+[role="_abstract"]
+
 You can install the {istio} control plane, `IstioRevisionTag` resource, {istio} CNI, and the Bookinfo demo application using the `RevisionBased` update strategy.
 
 [NOTE]

--- a/modules/ossm-installing-istio-with-revisionbased-strategy.adoc
+++ b/modules/ossm-installing-istio-with-revisionbased-strategy.adoc
@@ -6,6 +6,8 @@
 [id="installing-istio-with-revisionbased-strategy_{context}"]
 = Installing Istio with RevisionBased strategy
 
+[role="_abstract"]
+
 You can install the {istio} control plane, {istio} CNI, and the Bookinfo demo application using the `RevisionBased` update strategy.
 
 [NOTE]

--- a/modules/ossm-installing-kiali-multi-cluster-mesh.adoc
+++ b/modules/ossm-installing-kiali-multi-cluster-mesh.adoc
@@ -5,6 +5,8 @@
 [id="ossm-installing-kiali-multi-cluster-mesh_{context}"]
 = Installing Kiali in a multi-cluster mesh
 
+[role="_abstract"]
+
 Install Kiali in a multi-cluster mesh configuration on two {ocp-product-title} clusters.
 
 [NOTE]

--- a/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
+++ b/modules/ossm-installing-multi-primary-multi-network-mesh.adoc
@@ -6,6 +6,7 @@
 = Installing a multi-primary multi-network mesh
 
 [role="_abstract"]
+
 Install {istio} in the multi-primary multi-network topology on two {ocp-product-title} clusters.
 
 [NOTE]

--- a/modules/ossm-installing-operator.adoc
+++ b/modules/ossm-installing-operator.adoc
@@ -5,6 +5,8 @@
 [id="ossm-installing-operator_{context}"]
 = Installing the {SMProductShortName} Operator
 
+[role="_abstract"]
+
 [WARNING]
 ====
 For clusters without {SMProduct} instances, install the {SMProductShortName} Operator. {SMProduct} operates cluster-wide and needs a scope configuration to prevent conflicts between {istio} control planes. For clusters with {SMProduct} 3 or later, see "Deploying multiple service meshes on a single cluster".

--- a/modules/ossm-installing-primary-remote-multi-network-mesh.adoc
+++ b/modules/ossm-installing-primary-remote-multi-network-mesh.adoc
@@ -5,6 +5,8 @@
 [id="ossm-installing-primary-remote-multi-network-mesh_{context}"]
 = Installing a primary-remote multi-network mesh
 
+[role="_abstract"]
+
 Install {istio} in a primary-remote multi-network topology on two {ocp-product-title} clusters.
 
 [NOTE]

--- a/modules/ossm-installing-the-istioctl-tool.adoc
+++ b/modules/ossm-installing-the-istioctl-tool.adoc
@@ -6,6 +6,8 @@
 [id="ossm-installing-the-istioctl-tool_{context}"]
 = Installing the Istioctl tool
 
+[role="_abstract"]
+
 Install the `istioctl` command-line utility to debug and diagnose {istio} service mesh deployments.
 
 .Prerequisites

--- a/modules/ossm-integrating-kiali-otel.adoc
+++ b/modules/ossm-integrating-kiali-otel.adoc
@@ -6,6 +6,8 @@
 [id="ossm-integrating-kiali-otel_{context}"]
 = Integrating {DTProductName} with {KialiProduct}
 
+[role="_abstract"]
+
 You can integrate {DTProductName} with {KialiProduct}, which enables the following features:
 
 * Display trace overlays and details on the graph.

--- a/modules/ossm-kiali-about.adoc
+++ b/modules/ossm-kiali-about.adoc
@@ -6,6 +6,8 @@
 [id="ossm-kiali-about_{context}"]
 = About Kiali
 
+[role="_abstract"]
+
 // there is only 1 attribute for Kiali at this time
 You can use {KialiProduct} to view configurations, monitor traffic, and analyze traces in a single console. It is based on the open source link:https://www.kiali.io/[Kiali] project.
 

--- a/modules/ossm-kiali-ambient-mode.adoc
+++ b/modules/ossm-kiali-ambient-mode.adoc
@@ -6,6 +6,8 @@
 [id="ossm-kiali-ambient-mode_{context}"]
 = About Kiali and Istio ambient mode
 
+[role="_abstract"]
+
 When running in {istio} ambient mode, Kiali introduces new behaviors and visualizations to support the Ambient data plane. The following information describes key aspects of Kiali in this context:
 
 Access requirements:: Kiali requires access to the `ztunnel` namespace to detect whether ambient mode is enabled. Without this access, Kiali does not display ambient-related features.

--- a/modules/ossm-migrating-2-and-3-differences.adoc
+++ b/modules/ossm-migrating-2-and-3-differences.adoc
@@ -9,6 +9,8 @@
 [id="ossm-2-and-3-differences_{context}"]
 = Differences between OpenShift Service Mesh 2 and OpenShift Service Mesh 3
 
+[role="_abstract"]
+
 If you are a current {SMProductName} user, there are a number of important differences you need to understand between {SMProduct} 2 and {SMProduct} 3 before you migrate, including the following:
 
 * A new Operator

--- a/modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-injection-label-with-cert-manager.adoc
+++ b/modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-injection-label-with-cert-manager.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-a-cluster-wide-deployment-using-the-istio-injection-label-with-cert-manager_{context}"]
 = Migrating a cluster-wide deployment by using the Istio injection label with cert-manager
 
+[role="_abstract"]
+
 You can perform a canary upgrade with the gradual migration of data plane namespaces for a cluster-wide deployment by using the `istio-injection=enabled` label and the `default` revision tag. 
 
 You must relabel all of the data plane namespaces. However, it is safe to restart any of the workloads at any point during the migration process. 

--- a/modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revision-label-with-cert-manager.adoc
+++ b/modules/ossm-migrating-a-cluster-wide-deployment-using-the-istio-revision-label-with-cert-manager.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-a-cluster-wide-deployment-using-the-istio-revision-label-with-cert-manager_{context}"]
 = Migrating a cluster-wide deployment by using the Istio revision label with cert-manager
 
+[role="_abstract"]
+
 You can perform a canary upgrade with the gradual migration of data plane namespaces for a cluster-wide deployment by using the `istio.io/rev` label with cert-manager.
 
 The `bookinfo` application is used as an example for the `Istio` resource. For more information on configuration differences between the {SMProduct} 2 `ServiceMeshControlPlane` resource and the {SMProduct} 3 `Istio` resource, see "Configuration fields mapping between Service Mesh 2 and Service Mesh 3."

--- a/modules/ossm-migrating-a-cluster-wide-deployment-using-the-simple-migration-method.adoc
+++ b/modules/ossm-migrating-a-cluster-wide-deployment-using-the-simple-migration-method.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-a-cluster-wide-deployment-using-the-simple-migration-method_{context}"]
 = Migrating a cluster-wide deployment by using the simple migration method 
 
+[role="_abstract"]
+
 You can perform a canary upgrade with the gradual migration of data plane namespaces for a cluster-wide deployment by using the simple migration method. In an {SMProduct} {SMv2Version} installation, if the `istio-injection=enabled` label is already applied to the data plane namespaces, the simple migration method is the easiest way to migrate from the {SMProduct} 2 installation to the {SMProduct} 3 installation. 
 
 The simple migration method should not be used in production environments. 

--- a/modules/ossm-migrating-a-multitenant-deployment.adoc
+++ b/modules/ossm-migrating-a-multitenant-deployment.adoc
@@ -6,6 +6,8 @@
 [id="migrating-a-multitenant-deployment_{context}""]
 = Migrating a multitenant deployment
 
+[role="_abstract"]
+
 The `bookinfo` example application is being used for demonstration purposes with a minimal example for the `Istio` resource. For more information on configuration differences between the {SMProduct} 2 `ServiceMeshControlPlane` resource and the {SMProduct} 3 `Istio` resource, see "ServiceMeshControlPlane resource to Istio resource fields mapping".
 
 You can follow these same steps with your own workloads.

--- a/modules/ossm-migrating-complete-multitenant-cert-manager.adoc
+++ b/modules/ossm-migrating-complete-multitenant-cert-manager.adoc
@@ -7,6 +7,8 @@
 [id="migrating-complete-multitenant-cert-manager_{context}""]
 = Completing a multitenant deployment with cert-manager
 
+[role="_abstract"]
+
 .Prerequisites
 
 * You have migrated a multitenant deployment with the cert-manager and istio-csr tools.

--- a/modules/ossm-migrating-complete-remove-2-6-control-plane.adoc
+++ b/modules/ossm-migrating-complete-remove-2-6-control-plane.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-remove-2-6-control-plane_{context}"]
 = Remove the Service Mesh 2.6 control plane
 
+[role="_abstract"]
+
 After you have migrated all your workloads and gateways, you can remove the {SMproduct} 2.x control plane.
 
 .Prerequisites

--- a/modules/ossm-migrating-complete-remove-2-6-operator-crds.adoc
+++ b/modules/ossm-migrating-complete-remove-2-6-operator-crds.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-complete-remove-2-6-operator-crds_{context}"]
 = Remove the Service Mesh 2.6 operator and custom resource definitions
 
+[role="_abstract"]
+
 After you remove the {SMProductName} 2 `ServiceMeshControlplane` resource, and all other {SMProduct} 2 resources, you can remove the {SMproduct} 2.6 Operator and custom resource definitions (CRDs).
 
 .Prerequisites

--- a/modules/ossm-migrating-complete-remove-maistra-labels.adoc
+++ b/modules/ossm-migrating-complete-remove-maistra-labels.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-complete-remove-maistra-labels_{context}"]
 = Remove the Maistra labels
 
+[role="_abstract"]
+
 After you have removed all {SMProduct} 2 resources, removed the {SMProduct} 2 Operator, and {SMProduct} 2 custom resource definitions (CRDs), you can choose to remove namespace labels created during the migration.
 
 .Prerequisites

--- a/modules/ossm-migrating-done-network-policies.adoc
+++ b/modules/ossm-migrating-done-network-policies.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-network-policies-security_{context}"]
 = Migrating network policies after migrating deployment and workloads
 
+[role="_abstract"]
+
 If you did not re-create your network policies before you migrated your deployment and workloads, you can re-create your network policies after migrating.
 
 .Prerequisites

--- a/modules/ossm-migrating-gateways-canary.adoc
+++ b/modules/ossm-migrating-gateways-canary.adoc
@@ -7,6 +7,8 @@
 [id="ossm-migrating-gateways-canary_{context}"]
 = Gateway canary migration
 
+[role="_abstract"]
+
 Use the gateway canary migration method when you want a gradual rollout. It uses multiple gateway versions with maximum control over your gateway rollout.
 
 [NOTE]

--- a/modules/ossm-migrating-gateways-in-place.adoc
+++ b/modules/ossm-migrating-gateways-in-place.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-gateways-in-place_{context}"]
 = Gateway in place migration
 
+[role="_abstract"]
+
 If you need less detailed control over your gateway migration, you can perform gateway in place migration. This method applies to namespaces with dedicated gateways and to environments using a centralized gateway shared across multiple namespaces.
 
 [NOTE]

--- a/modules/ossm-migrating-hub-completing-your-migration.adoc
+++ b/modules/ossm-migrating-hub-completing-your-migration.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-hub-completing-your-migration_{context}"]
 = Completing your migration
 
+[role="_abstract"]
+
 Depending on your deployment model, you might need to take extra steps to complete the migration. For example, when you migrate with the cert-manager tool, you need to take additional steps before you can remove {SMProduct} 2 resources.
 
 After you complete your migration, you can add new workloads, re-create network policies, and remove {SMProduct} 2 resources.

--- a/modules/ossm-migrating-hub-deployment-workloads.adoc
+++ b/modules/ossm-migrating-hub-deployment-workloads.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-hub-deployment-and-workloads_{context}"]
 = Migrating your deployment and workloads
 
+[role="_abstract"]
+
 After you complete the premigration checklists, you can migrate your workloads and gateways, based on your deployment model:
 
 * Mulitenant

--- a/modules/ossm-migrating-hub-premigration-checklists.adoc
+++ b/modules/ossm-migrating-hub-premigration-checklists.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-hub-premigration-checklists_{context}"]
 = Premigration checklists
 
+[role="_abstract"]
+
 Before you can begin your migration, complete the premigration checklists.
 
 These checklists include steps for managing your network policies and configuration updates to set up add ons such as {kialiproduct} and {temposhortname}.

--- a/modules/ossm-migrating-hub-recommendations-for-migrating.adoc
+++ b/modules/ossm-migrating-hub-recommendations-for-migrating.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-hub-recommendations-for-migrating_{context}"]
 = Recommendations for migrating
 
+[role="_abstract"]
+
 Consider the following recommendations to limit the risk of misconfigurations or possible conflicts:
 
 * If you have automated updates configured in the {ocp-product-title} web console, change them to **Manual**. By switching to manual updates, you can prevent updates to the {SMProduct} 2 Operator and control planes during your migration.

--- a/modules/ossm-migrating-multitenant-with-cert-manager.adoc
+++ b/modules/ossm-migrating-multitenant-with-cert-manager.adoc
@@ -7,6 +7,8 @@
 [id="migrating-multitenant-with-cert-manager_{context}""]
 = Migrating a multitenant deployment with cert-manager
 
+[role="_abstract"]
+
 The `bookinfo` example application is being used for demonstration purposes with a minimal example for the `Istio` resource. For more information on configuration differences between the {SMProduct} 2 `ServiceMeshControlPlane` resource and the {SMProduct} 3 `Istio` resource, see "ServiceMeshControlPlane resource to Istio resource fields mapping".
 
 You can follow these same steps with your own workloads.

--- a/modules/ossm-migrating-multitenant-workloads-with-cert-manager.adoc
+++ b/modules/ossm-migrating-multitenant-workloads-with-cert-manager.adoc
@@ -6,6 +6,8 @@
 [id="migrating-multitenant-workloads-with-cert-manager_{context}""]
 = Migrating workloads in a multitenant deployment with cert-manager
 
+[role="_abstract"]
+
 Now you can migrate your workloads from the {SMProduct} 2.6 control plane to the {SMproduct} 3.0 control plane.
 
 [NOTE]

--- a/modules/ossm-migrating-multitenant-workloads.adoc
+++ b/modules/ossm-migrating-multitenant-workloads.adoc
@@ -6,6 +6,8 @@
 [id="migrating-multitenant-workloads_{context}""]
 = Migrating workloads in a multitenant deployment
 
+[role="_abstract"]
+
 Now you can migrate your workloads from the {SMProduct} 2.6 control plane to the {SMproduct} 3.0 control plane.
 
 [NOTE]

--- a/modules/ossm-migrating-network-policies-setup-during-migration.adoc
+++ b/modules/ossm-migrating-network-policies-setup-during-migration.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-network-policies-setup-during-migration_{context}"]
 = Set up network policies to use during migration
 
+[role="_abstract"]
+
 You can set up network policies to use during your migration.
 
 [IMPORTANT]

--- a/modules/ossm-migrating-premigration-checklists-resource-files.adoc
+++ b/modules/ossm-migrating-premigration-checklists-resource-files.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-premigration-checklists-resource-files_{context}"]
 = Example resource files
 
+[role="_abstract"]
+
 After you have completed the premigration procedures, your {SMProduct} 2 resources might be similar to the following examples:
 
 [id="service-mesh-control-plane-resource-file_{context}"]

--- a/modules/ossm-migrating-premigration-checklists-using-the-cert-manager-tool-with-your-deployment.adoc
+++ b/modules/ossm-migrating-premigration-checklists-using-the-cert-manager-tool-with-your-deployment.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-premigration-checklists-using-the-cert-manager-tool-with-your-deployment_{context}"]
 = Using the cert-manager tool with your deployment
 
+[role="_abstract"]
+
 You must check if your deployment uses the cert-manager tool. If you are using the cert-manager tool with {SMProduct} 2, you must perform additional configurations before you can start migrating your deployments and workloads.
 
 .Procedure

--- a/modules/ossm-migrating-read-me-explicitly-create-openshift-routes.adoc
+++ b/modules/ossm-migrating-read-me-explicitly-create-openshift-routes.adoc
@@ -8,6 +8,9 @@
 :_mod-docs-content-type: CONCEPT
 [id="explicitly-create-openshift-routes_{context}"]
 = Explicitly create OpenShift Routes
+
+[role="_abstract"]
+
 //In the ocp-docs repo, there is no attribute for OpenShift Container Platform Ingress Operator so followed https://docs.openshift.com/container-platform/4.17/networking/ingress-operator.html
 An OpenShift `Route` resource allows an application to be exposed with a public URL using {ocp-product-title} Ingress Operator for managing HAProxy based Ingress controllers.
 

--- a/modules/ossm-migrating-read-me-independently-managed-gateways.adoc
+++ b/modules/ossm-migrating-read-me-independently-managed-gateways.adoc
@@ -9,6 +9,8 @@
 [id="ossm-migrating-read-me-independently-managed-istio-gateways_{context}"]
 = Independently managed Istio gateways
 
+[role="_abstract"]
+
 In Istio, gateways are used to manage traffic entering (ingress) and exiting (egress) the mesh. {SMProductName} 2 deployed and managed an ingress gateway and an egress gateway with the Service Mesh control plane. Both an ingress gateway and an egress gateway were configured using the `ServiceMeshControlPlane` resource.
 
 The {SMProduct} 3 Operator does not create or manage gateways.

--- a/modules/ossm-migrating-read-me-introducing-canary-updates.adoc
+++ b/modules/ossm-migrating-read-me-introducing-canary-updates.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-read-me-introducing-canary-updatess_{context}"]
 = Introducing canary updates
 
+[role="_abstract"]
+
 {SMProductName} 2 supported only in-place style updates, which created risk for large meshes where, after the control plane was updated, all workloads must update to the new control plane version without a simple way to roll back if something goes wrong.
 
 {SMProduct} 3 retains support for simple in-place style updates, and adds support for canary-style updates of the Istio control plane using Istio's revision feature.

--- a/modules/ossm-migrating-read-me-kubernetes-network-policy-management.adoc
+++ b/modules/ossm-migrating-read-me-kubernetes-network-policy-management.adoc
@@ -9,6 +9,8 @@
 [id="ossm-migrating-read-me-kubernetes-network-policy-management_{context}"]
 = Kubernetes network policy management
 
+[role="_abstract"]
+
 By default, {SMProductName} 2 created Kubernetes `NetworkPolicy` resources with the following behavior:
 
 * Ensured network applications and the control plane could communicate with each other.

--- a/modules/ossm-migrating-read-me-new-operator.adoc
+++ b/modules/ossm-migrating-read-me-new-operator.adoc
@@ -9,6 +9,8 @@
 [id="ossm-migrating-read-me-new-operator_{context}"]
 = New Operator: The {SMProductName} 3 Operator
 
+[role="_abstract"]
+
 {SMProductName} 3 is a major update with a feature set closer to the link:https://istio.io/[Istio project]. Whereas {SMProduct} 2 was based on the midstream Maistra project, {SMProduct} 3 is based directly on Istio. This means {SMProduct} 3 is managed using a different, simplified Operator and provides greater support for the latest stable features of Istio.
 
 This alignment with the Istio project along with lessons learned in the first two major releases of {SMProduct} have resulted in the following changes:

--- a/modules/ossm-migrating-read-me-new-resources.adoc
+++ b/modules/ossm-migrating-read-me-new-resources.adoc
@@ -9,6 +9,8 @@
 [id="ossm-migrating-read-me-new-resources_{context}"]
 = New resources in {SMProduct} 3
 
+[role="_abstract"]
+
 {SMProductName} 3 uses the following two new resources:
 
 * `{istio}`

--- a/modules/ossm-migrating-read-me-observability-integrations.adoc
+++ b/modules/ossm-migrating-read-me-observability-integrations.adoc
@@ -9,6 +9,8 @@
 [id="ossm-migrating-read-me-observability-integrations_{context}"]
 = Independent Red{nbsp}Hat OpenShift Observability component integrations and configurations
 
+[role="_abstract"]
+
 A significant change in {SMProductName} 3 is that the Operator no longer installs and manages observability components such as Prometheus and Grafana with the Istio control plane. It also no longer installs and manages {DTProductName} components such as {TempoShortName} and {OTELName} (previously Jaeger and Elasticsearch), or Kiali.
 
 The {SMProduct} 3 Operator limits its scope to Istio-related resources, with observability components supported and managed by the independent Operators that make up Red{nbsp}Hat OpenShift Observability, such as the following:

--- a/modules/ossm-migrating-read-me-scoping-discovery-selectors.adoc
+++ b/modules/ossm-migrating-read-me-scoping-discovery-selectors.adoc
@@ -9,6 +9,8 @@
 [id="ossm-migrating-read-me-scoping-discovery-selectors_{context}"]
 = Scoping of the mesh with discoverySelectors and labels
 
+[role="_abstract"]
+
 In {SMProduct} 2.4, a _cluster-wide_ mode was introduced to allow a mesh to be cluster-scoped, with the option to limit the mesh using an Istio feature called `discoverySelectors`. Using `discoverySelectors` limits the Istio control plane's visibility to a set of namespaces defined with a label selector. This aligned with how community Istio worked, and allowed Istio to manage cluster-level resources. For more information, see "Labels and Selectors".
 
 {SMProduct} 3 makes all meshes cluster-wide by default. This change means that Istio control planes are all cluster-scoped resources and the resources `ServiceMeshMemberRoll` and `ServiceMeshMember` are no longer present, with control planes watching, or _discovering_, the entire cluster by default. The control plane's discovery of namespaces can be limited using the `discoverySelectors` feature.

--- a/modules/ossm-migrating-read-me-sidecar-injection-considerations.adoc
+++ b/modules/ossm-migrating-read-me-sidecar-injection-considerations.adoc
@@ -9,6 +9,8 @@
 [id="ossm-migrating-read-me-sidecar-injection-considerations_{context}"]
 = New considerations for sidecar injection
 
+[role="_abstract"]
+
 {SMProductName} 2 supported using pod annotations and labels to configure sidecar injection and there was no need to indicate which control plane a workload belonged to.
 
 With {SMProduct} 3, even though the Istio control plane discovers a namespace, the workloads present in that namespace still require sidecar proxies to be included as workloads in the service mesh, and to be able to use Istio's many features.

--- a/modules/ossm-migrating-read-me-support-for-istioctl.adoc
+++ b/modules/ossm-migrating-read-me-support-for-istioctl.adoc
@@ -9,6 +9,8 @@
 [id="ossm-migrating-read-me-support-for-istioctl_{context}"]
 = Support for Istioctl
 
+[role="_abstract"]
+
 {SMProductName} 1 and 2 did not include support for Istioctl, the command line utility for the Istio project that includes many diagnostic and debugging utilities. {SMProduct} 3 introduces support for Istioctl for select commands.
 
 .Supported Istioctl commands

--- a/modules/ossm-migrating-read-me-support-for-multiple-control-planes.adoc
+++ b/modules/ossm-migrating-read-me-support-for-multiple-control-planes.adoc
@@ -9,6 +9,8 @@
 [id="ossm-migrating-read-me-support-multiple-control-planes_{context}"]
 = Support for multiple control planes
 
+[role="_abstract"]
+
 {SMProductName} 3 supports multiple service meshes in the same cluster, but in a different manner than in {SMProduct} 2. A cluster administrator must create multiple `Istio` instances and then configure `discoverySelectors` appropriately to ensure that there is no overlap between mesh namespaces.
 
 As `Istio` resources are cluster-scoped, they must have unique names to represent unique meshes within the same cluster. The {SMProduct} 3 Operator uses this unique name to create a resource called `IstioRevision` with a name in the format of `{Istio name}` or `{Istio name}-{Istio version}`.

--- a/modules/ossm-migrating-read-me-supported-multi-cluster-topologies.adoc
+++ b/modules/ossm-migrating-read-me-supported-multi-cluster-topologies.adoc
@@ -9,6 +9,8 @@
 [id="ossm-migrating-read-me-supported-multi-cluster-topologies_{context}"]
 = Supported multi-cluster topologies
 
+[role="_abstract"]
+
 {SMProductName} 2 supported one form of multi-cluster, _federation_, which was introduced in {SMProduct} 2.1. Each cluster maintained its own independent control plane in this topology, with services only shared between those meshes on an as-needed basis.
 
 Communication between federated meshes is through Istio gateways, so there was no need for Service Mesh control planes to watch remote Kubernetes control planes, as is the case with Istio's multi-cluster service mesh topologies. Federation is ideal where service meshes are loosely coupled, such as those managed by different administrative teams.

--- a/modules/ossm-migrating-read-me-tls-configuration-change.adoc
+++ b/modules/ossm-migrating-read-me-tls-configuration-change.adoc
@@ -10,6 +10,8 @@
 [id="ossm-migrating-read-me-transport-layer-security-configuration-change_{context}"]
 = Transport layer security (TLS) configuration change
 
+[role="_abstract"]
+
 In {SMProductName} 2, you created the `ServiceMeshControlPlane` resource, and enabled mTLS strict mode by setting `spec.security.dataPlane.mtls` to `true`.
 
 You were able to set the minimum and maximum TLS protocol versions by setting the `spec.security.controlPlane.tls.minProtocolVersion` or `spec.security.controlPlane.tls.maxProtocolVersion` in your `ServiceMeshControlPlane` resource.

--- a/modules/ossm-migrating-reference-smcp-configurations.adoc
+++ b/modules/ossm-migrating-reference-smcp-configurations.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-reference-smcp-configurations_{context}"]
 = Configuration fields mapping between Service Mesh 2 and Service Mesh 3
 
+[role="_abstract"]
+
 Many of the `spec` fields in the {SMProduct} 2 `ServiceMeshControlPlane` can be configured in the the {SMProduct} 3 `Istio` resource.
 
 The following tables provide guidance for configuring your `Istio` resource in {SMProduct} 3.

--- a/modules/ossm-migrating-reference-unsupported-configurations.adoc
+++ b/modules/ossm-migrating-reference-unsupported-configurations.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-reference-unsupported-configurations_{context}"]
 = Unsupported configuration fields in Service Mesh 3
 
+[role="_abstract"]
+
 The following tables list {SMProduct} 2 `ServiceMeshControlPlane` configuration fields that are not supported in {SMProductName} 3. This does not necessarily mean the functionality has been removed. In some cases, such as add ons, you need to install the application separately and configure it separately.
 
 [id="unsupported-add-on-configurations_{context}"]

--- a/modules/ossm-migrating-workloads-using-the-istio-injection-label-with-cert-manager.adoc
+++ b/modules/ossm-migrating-workloads-using-the-istio-injection-label-with-cert-manager.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-workloads-using-the-istio-injection-label-with-cert-manager_{context}"]
 = Migrating workloads by using the Istio injection label with cert-manager
 
+[role="_abstract"]
+
 After migrating a cluster-wide deployment, you can migrate your workloads from the {SMProduct} 2.6 control plane to the {SMproduct} 3.0 control plane.
 
 [NOTE]

--- a/modules/ossm-migrating-workloads-using-the-istio-revision-label-with-cert-manager.adoc
+++ b/modules/ossm-migrating-workloads-using-the-istio-revision-label-with-cert-manager.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-workloads-using-the-istio-revision-label-with-cert-manager_{context}"]
 = Migrating workloads by using the Istio revision label with cert-manager
 
+[role="_abstract"]
+
 After migrating a cluster-wide deployment, you can migrate your workloads workloads from the {SMProduct} 2.6 control plane to the {SMproduct} 3.0 control plane.
 
 To maintain simplicity, revision tags are not used in this example. When migrating large meshes, you can use revision tags to avoid re-labeling all namespaces during future 3.y.z upgrades.

--- a/modules/ossm-migrating-workloads-using-the-simple-migration-method.adoc
+++ b/modules/ossm-migrating-workloads-using-the-simple-migration-method.adoc
@@ -6,6 +6,8 @@
 [id="ossm-migrating-workloads-using-the-simple-migration-method_{context}"]
 = Migrating workloads by using the simple migration method
 
+[role="_abstract"]
+
 After migrating a cluster-wide deployment, you can migrate your workloads from the {SMProduct} 2.6 control plane to the {SMproduct} 3.0 control plane.
 
 [NOTE]

--- a/modules/ossm-multi-cluster-configuration-overview.adoc
+++ b/modules/ossm-multi-cluster-configuration-overview.adoc
@@ -6,6 +6,8 @@
 [id="ossm-multi-cluster-configuration-overview_{context}"]
 = Multi-Cluster configuration overview 
 
+[role="_abstract"]
+
 To configure a multi-cluster topology you must perform the following actions:
 
 * Install the {SMProduct} Operator for each cluster.

--- a/modules/ossm-multiple-control-planes-single-cluster.adoc
+++ b/modules/ossm-multiple-control-planes-single-cluster.adoc
@@ -5,4 +5,6 @@
 [id="ossm-multiple-control-planes-single-cluster_{context}"]
 = Using multiple control planes on a single cluster
 
+[role="_abstract"]
+
 You can use discovery selectors to limit the visibility of an {istio} control plane to specific namespaces in a cluster. By combining discovery selectors with control plane revisions, you can deploy multiple control planes in a single cluster, ensuring that each control plane manages only its assigned namespaces. This approach avoids conflicts between control planes and enables soft multi-tenancy for service meshes.

--- a/modules/ossm-release-notes-consoles-and-dashboards.adoc
+++ b/modules/ossm-release-notes-consoles-and-dashboards.adoc
@@ -7,6 +7,8 @@ Module included in the following assemblies:
 [id="consoles-and-dashboards_{context}"]
 = Consoles and dashboards
 
+[role="_abstract"]
+
 [cols="1,1"]
 |===
 | Feature | Status

--- a/modules/ossm-release-notes-extensibility-features.adoc
+++ b/modules/ossm-release-notes-extensibility-features.adoc
@@ -7,6 +7,8 @@ Module included in the following assemblies:
 [id="extensibility-features_{context}"]
 = Extensibility features
 
+[role="_abstract"]
+
 [cols="1,1"]
 |===
 | Feature | Status

--- a/modules/ossm-release-notes-istio-ambient-mode.adoc
+++ b/modules/ossm-release-notes-istio-ambient-mode.adoc
@@ -7,6 +7,8 @@ Module included in the following assemblies:
 [id="istio-ambient-mode_{context}"]
 = Istio Ambient mode (sidecarless) data plane
 
+[role="_abstract"]
+
 [cols="1,1"]
 |===
 | Feature | Status

--- a/modules/ossm-release-notes-istio-deployment-lifecycle.adoc
+++ b/modules/ossm-release-notes-istio-deployment-lifecycle.adoc
@@ -7,6 +7,8 @@ Module included in the following assemblies:
 [id="istio-deployment-and-lifecycle_{context}"]
 = Istio deployment and lifecycle
 
+[role="_abstract"]
+
 [cols="1,1"]
 |===
 | Feature | Status

--- a/modules/ossm-release-notes-istio-traffic-management.adoc
+++ b/modules/ossm-release-notes-istio-traffic-management.adoc
@@ -9,6 +9,8 @@ Module included in the following assemblies:
 [id="istio-traffic-management_{context}"]
 = Istio traffic management
 
+[role="_abstract"]
+
 [cols="1,1"]
 |===
 | Feature | Status

--- a/modules/ossm-release-notes-kubernetes-gateway-api.adoc
+++ b/modules/ossm-release-notes-kubernetes-gateway-api.adoc
@@ -7,6 +7,8 @@ Module included in the following assemblies:
 [id="kubernetes-gateway-api_{context}"]
 = Kubernetes Gateway API
 
+[role="_abstract"]
+
 [cols="1,1"]
 |===
 | Feature | Status

--- a/modules/ossm-release-notes-making-open-source-inclusive.adoc
+++ b/modules/ossm-release-notes-making-open-source-inclusive.adoc
@@ -8,4 +8,6 @@ Module included in the following assemblies:
 [id="making-open-source-more-inclusive_{context}"]
 = Making open source more inclusive
 
+[role="_abstract"]
+
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].

--- a/modules/ossm-release-notes-observability-features.adoc
+++ b/modules/ossm-release-notes-observability-features.adoc
@@ -7,6 +7,8 @@ Module included in the following assemblies:
 [id="observability-features_{context}"]
 = Observability features
 
+[role="_abstract"]
+
 {SMProduct} 3 provides end-to-end support for observability, including logs, metrics, and distributed tracing with {ObservabilityLongName} and the {KialiProduct}.
 
 +Integrations with other community projects (including community Prometheus) and third-party solutions can be configurable through Istio or {ObservabilityShortName} operators, but those solutions are not supported by Red Hat.

--- a/modules/ossm-release-notes-sail-operator-apis.adoc
+++ b/modules/ossm-release-notes-sail-operator-apis.adoc
@@ -9,6 +9,8 @@ Module included in the following assemblies:
 [id="sail-operator-apis_{context}"]
 = Sail Operator APIs
 
+[role="_abstract"]
+
 [cols="1,1"]
 |===
 | Feature | Status

--- a/modules/ossm-release-notes-security-features.adoc
+++ b/modules/ossm-release-notes-security-features.adoc
@@ -7,6 +7,8 @@ Module included in the following assemblies:
 [id="security-features_{context}"]
 = Security features
 
+[role="_abstract"]
+
 [id="encryption-and-certificate-management_{context}"]
 == Encryption and certificate management
 

--- a/modules/ossm-release-notes-supported-versions.adoc
+++ b/modules/ossm-release-notes-supported-versions.adoc
@@ -6,6 +6,8 @@
 [id="ossm-release-notes-supported-versions_{context}"]
 = {SMProduct} supported versions
 
+[role="_abstract"]
+
 See the following table for information about {SMProduct} 3.1.2 supported versions.
 
 == {SMProduct} 3.1.2 supported versions

--- a/modules/ossm-removing-multi-cluster-installation-from-development-environment.adoc
+++ b/modules/ossm-removing-multi-cluster-installation-from-development-environment.adoc
@@ -5,6 +5,8 @@
 [id="ossm-removing-multi-cluster-installation-from-development-environment_{context}"]
 = Removing a multi-cluster topology from a development environment
 
+[role="_abstract"]
+
 After experimenting with the multi-cluster functionality in a development environment, remove the multi-cluster topology from all the clusters. 
 
 [NOTE]

--- a/modules/ossm-routing-traffic-using-waypoint-proxies.adoc
+++ b/modules/ossm-routing-traffic-using-waypoint-proxies.adoc
@@ -6,6 +6,8 @@
 [id="ossm-routing-traffic-using-waypoint-proxies_{context}"]
 = Routing traffic using waypoint proxies
 
+[role="_abstract"]
+
 You can use a deployed waypoint proxy to split traffic between different versions of the Bookinfo `reviews` service for feature testing or A/B testing.
 
 .Procedure

--- a/modules/ossm-running-v2-v3-cluster-wide-deployment-model.adoc
+++ b/modules/ossm-running-v2-v3-cluster-wide-deployment-model.adoc
@@ -5,6 +5,9 @@
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-running-v2-v3-cluster-wide-deployment-model_{context}"]
 = Running {SMProductName} 2.6 and {SMProductName} 3 using cluster-wide deployment model
+
+[role="_abstract"]
+
 //TP1 content influx. Title, etc may change.
 //No IA as of 10/23/2024 so this content is likely to move.
 

--- a/modules/ossm-running-v2-v3-multitenant-deployment-model.adoc
+++ b/modules/ossm-running-v2-v3-multitenant-deployment-model.adoc
@@ -5,6 +5,9 @@
 :_mod-docs-content-type: PROCEDURE
 [id="ossm-running-v2-v3-multitenant-deployment-model_{context}"]
 = Running {SMProduct} 2.6 and {SMProduct} 3 using multi-tenant deployment model
+
+[role="_abstract"]
+
 //TP1 content influx. Title, etc may change.
 //No IA as of 10/23/2024 so this content is likely to move.
 

--- a/modules/ossm-scoping-service-mesh-with-discoveryselectors.adoc
+++ b/modules/ossm-scoping-service-mesh-with-discoveryselectors.adoc
@@ -5,6 +5,8 @@
 [id="ossm-scoping-service-mesh-with-discoveryselectors_{context}"]
 = Scoping the Service Mesh with discovery selectors
 
+[role="_abstract"]
+
 {SMProductShortName} includes workloads that meet the following criteria:
 
 * The control plane has discovered the workload.

--- a/modules/ossm-scoping-sm-discovery-selectors-istio-ambient-mode.adoc
+++ b/modules/ossm-scoping-sm-discovery-selectors-istio-ambient-mode.adoc
@@ -6,6 +6,8 @@
 [id="ossm-scoping-sm-discovery-selectors-istio-ambient-mode_{context}"]
 = Scoping the Service Mesh with discovery selectors in Istio ambient mode
 
+[role="_abstract"]
+
 To limit the scope of the {SMProduct} in {istio} ambient mode, you can configure `discoverySelectors` parameter in the `meshConfig` section of the `{istio}` resource. The configuration controls which namespaces the control plane discovers based on label selectors.
 
 .Prerequisites

--- a/modules/ossm-selecting-inplace-strategy.adoc
+++ b/modules/ossm-selecting-inplace-strategy.adoc
@@ -5,6 +5,8 @@
 [id="selecting-inplace-strategy_{context}"]
 = Selecting InPlace strategy
 
+[role="_abstract"]
+
 To select the `InPlace` strategy, set the `spec.updateStrategy.type` value in the {istio} resource to `InPlace`.
 
 .Example specification to select InPlace update strategy

--- a/modules/ossm-selecting-revisionbased-strategy.adoc
+++ b/modules/ossm-selecting-revisionbased-strategy.adoc
@@ -5,6 +5,8 @@
 [id="selecting-revision-based-strategy_{context}"]
 = Selecting RevisionBased strategy
 
+[role="_abstract"]
+
 To deploy {istio} with the `RevisionBased` strategy, create the `{istio}` resource with the following `spec.updateStrategy` value:
 
 .Example specification to select `RevisionBased` strategy

--- a/modules/ossm-service-mesh-overview.adoc
+++ b/modules/ossm-service-mesh-overview.adoc
@@ -7,6 +7,8 @@ Module included in the following assemblies:
 [id="ossm-servicemesh-overview_{context}"]
 = Introduction to {SMProductName}
 
+[role="_abstract"]
+
 {SMProductName} adds a transparent layer on existing distributed applications without requiring any changes to the application code. The mesh introduces an easy way to create a network of deployed services that provides discovery, load balancing, service-to-service authentication, failure recovery, metrics, and monitoring. A service mesh also provides more complex operational functionality, including A/B testing, canary releases, access control, and end-to-end authentication.
 
 Microservice architectures split the work of enterprise applications into modular services, which can make scaling and maintenance easier. However, as an enterprise application built on a microservice architecture grows in size and complexity, it becomes difficult to understand and manage. {SMProductShortName} can address those architecture problems by capturing or intercepting traffic between services and can modify, redirect, or create new requests to other services.

--- a/modules/ossm-support-for-istioctl.adoc
+++ b/modules/ossm-support-for-istioctl.adoc
@@ -6,6 +6,8 @@
 [id="ossm-support-for-istioctl_{context}"]
 = Support for Istioctl
 
+[role="_abstract"]
+
 {SMProduct} 3 supports a selection of Istioctl commands.
 
 .Supported Istioctl commands

--- a/modules/ossm-understanding-operator-updates-and-channels.adoc
+++ b/modules/ossm-understanding-operator-updates-and-channels.adoc
@@ -6,6 +6,8 @@
 [id="ossm-understanding-operator-updates-and-channels_{context}"]
 = Understanding Operator updates and channels
 
+[role="_abstract"]
+
 The {olm-first} manages Operators and their associated services by using channels to organize and distribute updates. Channels are a way to group related updates.
 
 To ensure that your {SMProduct} stays current with the latest security patches, bug fixes, and software updates, keep the {SMProduct} Operator up to date. The upgrade process depends on the configured channel and approval strategy.

--- a/modules/ossm-understanding-sm-istio-versions.adoc
+++ b/modules/ossm-understanding-sm-istio-versions.adoc
@@ -6,4 +6,6 @@
 [id="ossm-understanding-sm-istio-versions_{context}"]
 = Understanding Service Mesh and Istio versions
 
+[role="_abstract"]
+
 The most current {SMProduct} Operator version is {SMProductVersion}. This version supports the features listed in the "{SMProductShortName} {SMProductVersion} feature support tables". The {SMProduct} Operator includes additional {istio} releases for upgrades but supports only the latest {istio} version available for each Operator version. See the "{SMProductShortName} version support tables" to identify the supported {istio} version for each Operator release.

--- a/modules/ossm-understanding-versioning.adoc
+++ b/modules/ossm-understanding-versioning.adoc
@@ -7,6 +7,7 @@
 = Understanding versioning
 
 [role="_abstract"]
+
 {product-title} follows Semantic Versioning for all product releases. Semantic Versioning uses a three-part version number in the format `X.Y.Z` to communicate the nature of changes in each release.
 
 X (Major version):: Indicates significant updates that might include breaking changes, such as architectural shifts, API changes, or schema modifications.

--- a/modules/ossm-uninstall-console-plugin-ocp-cli.adoc
+++ b/modules/ossm-uninstall-console-plugin-ocp-cli.adoc
@@ -6,6 +6,8 @@
 [id="ossm-uninstall-console-plugin-ocp-cli_{context}"]
 = Uninstalling {SMPluginShort} by using the CLI
 
+[role="_abstract"]
+
 You can uninstall the {SMPlugin} by using the {oc-first}.
 
 .Procedure

--- a/modules/ossm-uninstall-console-plugin-ocp-web-console.adoc
+++ b/modules/ossm-uninstall-console-plugin-ocp-web-console.adoc
@@ -6,6 +6,8 @@
 [id="ossm-uninstall-console-plugin-ocp-web-console_{context}"]
 = Uninstalling {SMPluginShort} by using the web console
 
+[role="_abstract"]
+
 You can uninstall the {SMPlugin} by using the {ocp-product-title} web console.
 
 .Procedure

--- a/modules/ossm-uninstalling-cert-manager.adoc
+++ b/modules/ossm-uninstalling-cert-manager.adoc
@@ -6,6 +6,8 @@
 [id="ossm-uninstalling-cert-manager_{context}"]
 = Uninstalling Service Mesh with the cert-manager Operator by using the istio-csr agent
 
+[role="_abstract"]
+
 You can uninstall the cert-manager Operator with {SMProduct} by completing the following procedure. Before you remove the following resources, verify that no {SMProductName} or {istio} components reference the `Istio-CSR` agent or the certificates it issued. Removing these resources while they are still in use might disrupt mesh functionality.
 
 .Procedure

--- a/modules/ossm-uninstalling-delete-istio-crds.adoc
+++ b/modules/ossm-uninstalling-delete-istio-crds.adoc
@@ -6,6 +6,8 @@
 [id="uninstalling-service-mesh-delete-istio-crds_{context}"]
 = Delete Istio custom resource definitions
 
+[role="_abstract"]
+
 Deleting Istio custom resource definitions (CRDs) are optional.
 
 .Procedure

--- a/modules/ossm-uninstalling-service-mesh-operator-control-plane-cli.adoc
+++ b/modules/ossm-uninstalling-service-mesh-operator-control-plane-cli.adoc
@@ -6,6 +6,8 @@
 [id="uninstalling-service-mesh-operator-control-plane-cli_{context}"]
 = Uninstall {SMProduct} by using the CLI
 
+[role="_abstract"]
+
 Uninstalling {SMProductName} Operator 3 and the {Istio} control plane from an existing {ocp-product-title} instance requires removing the following:
 
 * `Istio` resource

--- a/modules/ossm-uninstalling-service-mesh-operator-control-plane-web-console.adoc
+++ b/modules/ossm-uninstalling-service-mesh-operator-control-plane-web-console.adoc
@@ -5,6 +5,9 @@
 :_mod-docs-content-type: PROCEDURE
 [id="uninstalling-service-mesh-operator-control-plane-web-console_{context}"]
 = Uninstalling {SMProduct} Operator 3 and the Istio control plane using the web console
+
+[role="_abstract"]
+
 //TP1 content. 3 may be removed for GA. Using now to help users distinguish between OSSM 2.x and OSSM 3 as the uninstall instructions for each Operator are different.
 //Possible uninstall procedures for Kiali, OpenShift Service Mesh Console (OSSMC), and other integrations may be added, or linked to, for GA.
 

--- a/modules/ossm-updating-cross-namespace-waypoint.adoc
+++ b/modules/ossm-updating-cross-namespace-waypoint.adoc
@@ -6,6 +6,7 @@
 = Updating cross-namespace waypoint
 
 [role="_abstract"]
+
 If you are using cross-namespace waypoints, verify that the `istio.io/use-waypoint-namespace` and `istio.io/use-waypoint` labels are correctly applied to the relevant namespaces before updating.
 
 . Verify the namespace with any of the waypoint labels by running the following command:

--- a/modules/ossm-updating-istio-cni-resource-version.adoc
+++ b/modules/ossm-updating-istio-cni-resource-version.adoc
@@ -6,6 +6,8 @@
 [id="ossm-updating-istio-cni-resource-version_{context}"]
 = Updating the Istio CNI resource version
 
+[role="_abstract"]
+
 You can update the {istio} Container Network Interface (CNI) resource version by changing the version in the resource. Then, the {SMProductShortName} Operator deploys a new version of the CNI plugin that replaces the old version of the CNI plugin. The `istio-cni-node` pods automatically reconnect to the new CNI plugin.
 
 .Prerequisites

--- a/modules/ossm-updating-istio-control-plane-with-inplace.adoc
+++ b/modules/ossm-updating-istio-control-plane-with-inplace.adoc
@@ -5,6 +5,8 @@
 [id="ossm-updating-istio-control-plane-with-inplace_{context}"]
 = Updating Istio control plane with InPlace strategy
 
+[role="_abstract"]
+
 When updating {istio} using the `InPlace` strategy, you can increment the version by only one minor release at a time. To update by more than one minor version, you must increment the version and restart the workloads after each update. Restarting workloads ensures compatibility between the sidecar and control plane versions. The update process is complete after restarting all workloads.
 
 .Prerequisites

--- a/modules/ossm-updating-istio-control-plane-with-revisionbased-istiorevisiontag.adoc
+++ b/modules/ossm-updating-istio-control-plane-with-revisionbased-istiorevisiontag.adoc
@@ -6,6 +6,8 @@
 [id="updating-istio-control-plane-with-revisionbased-istiorevisiontag_{context}"]
 = Updating Istio control plane with RevisionBased strategy and IstioRevisionTag
 
+[role="_abstract"]
+
 When updating {istio} using the `RevisionBased` strategy, you can create an `IstioRevisionTag` resource to tag a specific `IstioRevision` resource. You can use the `IstioRevisionTag` resource to attach workloads to a specific `IstioRevision` resource without modifying the `istio.io/rev` label on namespaces or pods.
 
 .Prerequisites

--- a/modules/ossm-updating-istio-control-plane-with-revisionbased.adoc
+++ b/modules/ossm-updating-istio-control-plane-with-revisionbased.adoc
@@ -5,6 +5,8 @@
 [id="updating-istio-control-plane-with-revisionbased_{context}"]
 = Updating Istio control plane with RevisionBased strategy
 
+[role="_abstract"]
+
 When updating {istio} using the `RevisionBased` strategy, you can upgrade by more than one minor version at a time. The {SMProductName} Operator creates a new `IstioRevision` resource for each change to the `.spec.version` field and deploys a corresponding control plane instance. To migrate workloads to the new control plane, set the `istio.io/rev` label on the namespace to match the name of the `IstioRevision` resource, and then restart the workloads.
 
 .Prerequisites

--- a/modules/ossm-updating-waypoint-proxies-with-inplace-strategy.adoc
+++ b/modules/ossm-updating-waypoint-proxies-with-inplace-strategy.adoc
@@ -6,6 +6,7 @@
 = Updating waypoint proxies with InPlace strategy in ambient mode
 
 [role="_abstract"]
+
 During an `InPlace` update in ambient mode, waypoint proxies are going to be updated to the latest control plane version without restarting application workloads because they are deployed and managed as separate Gateway API resources that scale and upgrade independently.
 
 .Prerequisites

--- a/modules/ossm-updating-waypoint-proxies-with-revisionbased-strategy.adoc
+++ b/modules/ossm-updating-waypoint-proxies-with-revisionbased-strategy.adoc
@@ -6,6 +6,7 @@
 = Updating waypoint proxies with RevisionBased strategy in ambient mode
 
 [role="_abstract"]
+
 In ambient mode, you can update waypoint proxies by using the `RevisionBased` update strategy. During the migration period, the proxies remain compatible with many control plane versions and automatically connect to the active control plane revision.
 
 [NOTE]

--- a/modules/ossm-using-discoveryselectors-scope-service-mesh.adoc
+++ b/modules/ossm-using-discoveryselectors-scope-service-mesh.adoc
@@ -5,6 +5,8 @@
 [id="ossm-discoveryselectors-scope-service-mesh_{context}"]
 = Scoping a Service Mesh by using discovery selectors
 
+[role="_abstract"]
+
 If you know which namespaces to include in the {SMProductShortName}, configure `discoverySelectors` during or after installation by adding the required selectors to the `meshConfig.discoverySelectors` section of the `{istio}` resource. For example, configure {istio} to discover only namespaces labeled `istio-discovery=enabled`.
 
 .Prerequisites

--- a/modules/ossm-verifying-cert-manager.adoc
+++ b/modules/ossm-verifying-cert-manager.adoc
@@ -6,6 +6,8 @@
 [id="ossm-verifying-cert-manager_{context}"]
 = Verifying Service Mesh with the cert-manager Operator using the istio-csr agent
 
+[role="_abstract"]
+
 You can use the sample `httpbin` service and `sleep` application to verify traffic between workloads. Check the workload proxy certificate to verify that the cert-manager Operator is installed correctly.
 
 . Create the namespaces:

--- a/modules/ossm-verifying-l7-features-with-authorization-policies.adoc
+++ b/modules/ossm-verifying-l7-features-with-authorization-policies.adoc
@@ -6,6 +6,7 @@
 = Verifying Layer 7 (L7) features with authorization policies
 
 [role="_abstract"]
+
 After updating the waypoint proxies, verify that the Layer 7 (L7) authorization policies are enforced correctly. In this example, the `AuthorizationPolicy` resource named `productpage-waypoint` allows only requests from the `default/sa/curl` service account to send `GET` requests to the `productpage` service.
 
 .Prerequisites

--- a/modules/ossm-verifying-l7-features-with-traffic-routing.adoc
+++ b/modules/ossm-verifying-l7-features-with-traffic-routing.adoc
@@ -6,6 +6,7 @@
 = Verifying Layer 7 (L7) features with traffic routing
 
 [role="_abstract"]
+
 After updating the waypoint proxies, verify that Layer 7 (L7) features function as expected.
 If you use traffic routing rules such as `HTTPRoute`, confirm that they continue to enforce the intended behavior.
 

--- a/modules/ossm-verifying-metrics-ambient-mode.adoc
+++ b/modules/ossm-verifying-metrics-ambient-mode.adoc
@@ -7,6 +7,7 @@
 = Verifying metrics in ambient mode
 
 [role="_abstract"]
+
 You can verify that the metrics for your application available in the OpenShift Console.
 
 .Prerequisites

--- a/modules/ossm-verifying-multi-cluster-topology.adoc
+++ b/modules/ossm-verifying-multi-cluster-topology.adoc
@@ -5,6 +5,8 @@
 [id="ossm-verifying-multi-cluster-topology_{context}"]
 = Verifying a multi-cluster topology
 
+[role="_abstract"]
+
 Deploy sample applications and verify traffic on a multi-cluster topology on two {ocp-product-title} clusters.
 
 [NOTE]

--- a/modules/ossm-verifying-multiple-control-planes.adoc
+++ b/modules/ossm-verifying-multiple-control-planes.adoc
@@ -5,6 +5,8 @@
 [id="ossm-verifying-multiple-control-planes_{context}"]
 = Verifying multiple control planes
 
+[role="_abstract"]
+
 Verify that both of the {istio} control planes are deployed and running properly. You can validate that the `istiod` pod is successfully running in each {istio} system namespace.
 
 . Verify that the workloads are assigned to the control plane in `istio-system-1` by running the following command:

--- a/modules/ossm-verifying-traces-ambient-mode.adoc
+++ b/modules/ossm-verifying-traces-ambient-mode.adoc
@@ -7,6 +7,7 @@
 = Verifying traces in ambient mode
 
 [role="_abstract"]
+
 You can verify that the traces for your application are in ambient mode. The following example uses the Bookinfo application.
 
 .Prerequisites


### PR DESCRIPTION
Change type: Doc update; Perform CQA and update all assemblies in OSSM 3x

Doc JIRA: https://issues.redhat.com/browse/OSSM-12493

Fix Version: [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
NOTE: Will create manual CPs for the following branches:

[service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)
[service-mesh-docs-3.1](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.1)
[service-mesh-docs-3.2](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.2)
[service-mesh-docs-3.3](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.3) This branch can be automatically CP'd.

Also, I left out release notes file to perform clean-up and changes to every version individually.

Doc Preview: @kaldesai 

Peer Review: 