### PR TITLE
CNV-28727: Release Note for IBM Cloud functionality

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -46,7 +46,11 @@ The SVVP certification applies to:
 {ibm-name} Secure Execution for VMs on {ibm-z-name} and {ibm-linuxone-name} is generally available::
 {ibm-name} Secure Execution for VMs on {ibm-z-name} and {ibm-linuxone-name} is now generally available. This capability provides hardware based memory encryption that protects virtual machine workloads from access by the host or hypervisor environment. For more information, see xref:../../virt/creating_vm/virt-configuring-ibm-secure-execution-vms-ibm-z.adoc#virt-configuring-ibm-secure-execution-vms-ibm-z[Configuring {ibm-name} Secure Execution virtual machines on {ibm-z-name} and {ibm-linuxone-name}].
 
-
+{virtproductname} on {ibm-cloud-name} bare-metal nodes is generally available::
+Installing {virtproductname} on {ibm-cloud-name} bare-metal nodes is now generally available. This update provides the ability to install {virtproductname} on {ibm-cloud-title} provisioned bare-metal nodes by using {ai-full}.
++
+link:https://issues.redhat.com/browse/CNV-27898[CNV-27898]
+ 
 // Networking
 Custom MAC pool range configuration:: With this update, cluster administrators can specify a custom MAC pool range for a {VirtProductName} environment, preventing potential MAC address conflicts with other virtualization solutions on the same network. This gives cluster administrators more control over network resources, ensuring greater network stability and resource management efficiency.
 +
@@ -56,6 +60,7 @@ Import VMs into {VirtProductName} while maintaining their previously assigned IP
 With this update, you can import VMs into {VirtProductName}, preserving their original IP and MAC addresses when connected to custom, primary layer 2 networks. This enhancement streamlines the import process, ensuring network consistency and a seamless transition of VMs, resulting in minimal disruption.
 +
 link:https://issues.redhat.com/browse/CNV-61227[CNV-61227]
+
 
 // Storage
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Release Note entry for the GA availability of the functionality described in [PR# 104533](https://github.com/openshift/openshift-docs/pull/104533).

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.21

Issue:
[CNV-28727](https://issues.redhat.com/browse/CNV-28727)

Link to docs preview:
[OpenShift Virtualization release notes](https://106116--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html)

QE review:
- [x] QE has approved this change.


Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
