### PR TITLE
Fixing callouts for all GitOps files

### DIFF
--- a/modules/collecting-gitops-debugging-data.adoc
+++ b/modules/collecting-gitops-debugging-data.adoc
@@ -27,9 +27,14 @@ Use the `oc adm must-gather` CLI command to collect the following details about 
 +
 [source,terminal]
 ----
-$ oc adm must-gather --image=registry.redhat.io/openshift-gitops-1/must-gather-rhel8:<image_version_tag> <1>
+$ oc adm must-gather --image=registry.redhat.io/openshift-gitops-1/must-gather-rhel8:<image_version_tag>
 ----
-<1> The must-gather image for {gitops-shortname}.
++
+--
+where:
+
+`<image_version_tag>`:: Specifies the must-gather image version tag for {gitops-shortname}.
+--
 +
 .Example command
 [source,terminal]
@@ -43,8 +48,12 @@ The `must-gather` tool creates a new directory that starts with `./must-gather.l
 +
 [source,terminal]
 ----
-$ tar -cvaf must-gather.tar.gz must-gather.local.4157245944708210399 <1>
+$ tar -cvaf must-gather.tar.gz must-gather.local.4157245944708210399
 ----
-<1> Replace `must-gather-local.4157245944708210399` with the actual directory name.
++
+--
+where:
 
+`<must-gather-local.4157245944708210399>`:: Specifies the actual directory name.
+--
 . Attach the compressed file to your support case on the link:https://access.redhat.com/[Red Hat Customer Portal].

--- a/modules/con-enabling-config-management-plugins-argo-cd-cr.adoc
+++ b/modules/con-enabling-config-management-plugins-argo-cd-cr.adoc
@@ -20,17 +20,17 @@ To configure a sidecar container in the {gitops-title} Operator, add the `.spec.
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
- name: <my_argocd> # <1>
+ name: <my_argocd>
 spec:
  repo:
    sidecarContainers:
-     - name: <my_cmp> # <2>
+     - name: <my_cmp>
        command: [/var/run/argocd/argocd-cmp-server]
        image: <my_image>
        securityContext:
          runAsNonRoot: <true>
          runAsUser: <999>
-       volumeMounts: # <3>
+       volumeMounts:
          - mountPath: /var/run/argocd
            name: <var_files>
          - mountPath: /home/argocd/cmp-server/plugins
@@ -41,6 +41,9 @@ spec:
            subPath: <plugin.yaml>
            name: <cmp_plugin>
 ----
-<1> Specifies the name of an Argo CD CR instance.
-<2> Specifies the name of a sidecar container used in the repo server.
-<3> Specifies the name of volume mounts used in the repo server.
+
+where:
+
+`metadata.name`:: Specifies the name of an Argo CD CR instance.
+`spec.repo.sidecarContainers.name`:: Specifies the name of a sidecar container used in the repo server.
+`spec.repo.sidecarContainers.volumeMounts`:: Specifies the name of volume mounts used in the repo server.

--- a/modules/con_notifications-configuration.adoc
+++ b/modules/con_notifications-configuration.adoc
@@ -49,15 +49,18 @@ The following examples define how to add templates, triggers, services, and subs
 apiVersion: argoproj.io/v1alpha1
 kind: NotificationsConfiguration
 metadata:
- name: default-notifications-configuration # <1>
+ name: default-notifications-configuration
 spec:
  templates:
-  template.my-custom-template: | # <2>
+  template.my-custom-template: |
     message: |
      Application details: {{.context.argocdUrl}}/applications/{{.app.metadata.name}}.
 ----
-<1> Default name of the `NotificationsConfiguration` CR in a cluster.
-<2> An example custom template configuration for the `NotificationsConfiguration` CR.
+
+where:
+
+`metadata.name`:: Specifies the default name of the `NotificationsConfiguration` CR in a cluster.
+`spec.template.my-custom-template`:: Specifies an example custom template configuration for the `NotificationsConfiguration` CR.
 
 .Example for `triggers`
 [source,yaml]
@@ -65,15 +68,18 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: NotificationsConfiguration
 metadata:
- name: default-notifications-configuration # <1>
+ name: default-notifications-configuration
 spec:
  triggers:
-  trigger.on-sync-status-unknown: | # <2>
+  trigger.on-sync-status-unknown: |
    - when: app.status.sync.status == 'Unknown'
    send: [my-custom-template]
 ----
-<1> Default name of the `NotificationsConfiguration` CR in a cluster.
-<2> An example custom trigger configuration for the `NotificationsConfiguration` CR.
+
+where:
+
+`metadata.name`:: Specifies the default name of the `NotificationsConfiguration` CR in a cluster.
+`spec.trigger.on-sync-status-unknown`:: Specifies an example custom trigger configuration for the `NotificationsConfiguration` CR.
 
 .Example for `services`
 [source,yaml]
@@ -81,16 +87,19 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: NotificationsConfiguration
 metadata:
- name: default-notifications-configuration # <1>
+ name: default-notifications-configuration
 spec:
  services:
   service.slack: |
-    token: $slack-token # <2>
+    token: $slack-token
     username: <override-username> # optional username
     icon: <override-icon> # optional icon for the message (supports both emoji and url notation)
 ----
-<1> Default name of the `NotificationsConfiguration` CR in a cluster.
-<2> An example custom service configuration for the `NotificationsConfiguration` CR.
+
+where:
+
+`metadata.name`:: Specifies the default name of the `NotificationsConfiguration` CR in a cluster.
+`spec.service.slack`:: Specifies an example custom service configuration for the `NotificationsConfiguration` CR.
 
 .Example for `subscriptions`
 [source,yaml]
@@ -98,9 +107,9 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: NotificationsConfiguration
 metadata:
- name: default-notifications-configuration #<1>
+ name: default-notifications-configuration
 spec:
- subscriptions: #<2>
+ subscriptions:
   subscriptions: |
     # subscription for on-sync-status-unknown trigger notifications
     - recipients:
@@ -115,7 +124,10 @@ spec:
       triggers:
       - on-sync-status-unknown
 ----
-<1> Default name of the `NotificationsConfiguration` CR in a cluster.
-<2> An example custom subscription configuration for the `NotificationsConfiguration` CR.
+
+where:
+
+`metadata.name`:: Specifies the default name of the `NotificationsConfiguration` CR in a cluster.
+`spec.subscriptions`:: Specifies an example custom subscription configuration for the `NotificationsConfiguration` CR.
 
 You can configure the `NotificationsConfiguration` CR by using the {OCP} web console or the CLI (`oc`).

--- a/modules/gitops-allowing-scm-providers.adoc
+++ b/modules/gitops-allowing-scm-providers.adoc
@@ -26,15 +26,19 @@ metadata:
   name: example-argocd
 spec:
   applicationSet:
-    sourceNamespaces: 
-      - dev 
-    scmProviders: <1>
+    sourceNamespaces:
+      - dev
+    scmProviders:
       - https://git.mydomain.com/
       - https://gitlab.mydomain.com/
 ----
-<1> The list of URLs of the allowed SCM Providers.
++
+--
+where:
 
-
+`spec.applicationSet.scmProviders`:: Specifies the list of URLs of the allowed SCM Providers.
+--
++
 [NOTE]
 ====
 If you use a URL that is not in the list of allowed SCM Providers, the Argo CD ApplicationSet Controller will reject it.

--- a/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-by-using-cli.adoc
@@ -29,10 +29,10 @@ $ oc patch argocd <argocd_instance> -n <namespace> --type=merge --patch='{"spec"
 .Example command
 [source,terminal]
 ----
-$ oc patch argocd openshift-gitops -n openshift-gitops --type=merge --patch='{"spec":{"controller":{"sharding":{"dynamicScalingEnabled":true,"minShards":1,"maxShards":3,"clustersPerShard":1}}}}' <1>
+$ oc patch argocd openshift-gitops -n openshift-gitops --type=merge --patch='{"spec":{"controller":{"sharding":{"dynamicScalingEnabled":true,"minShards":1,"maxShards":3,"clustersPerShard":1}}}}'
 ----
 +
-<1> The example command enables dynamic scaling for the `openshift-gitops` Argo CD instance in the `openshift-gitops` namespace, and sets the minimum number of shards to `1`, the maximum number of shards to `3`, and the number of clusters per shard to `1`. The values of `minShard` and `clustersPerShard` must be set to `1` or greater. The value of `maxShard` must be equal to or greater than the value of `minShard`.
+The example command enables dynamic scaling for the `openshift-gitops` Argo CD instance in the `openshift-gitops` namespace, and sets the minimum number of shards to `1`, the maximum number of shards to `3`, and the number of clusters per shard to `1`. The values of `minShard` and `clustersPerShard` must be set to `1` or greater. The value of `maxShard` must be equal to or greater than the value of `minShard`.
 +
 .Example output
 [source,terminal]
@@ -80,7 +80,7 @@ $ oc get pods -n openshift-gitops -l app.kubernetes.io/name=openshift-gitops-app
 [source,terminal]
 ----
 NAME                                           READY   STATUS    RESTARTS   AGE
-openshift-gitops-application-controller-0      1/1     Running   0          2m  <1>
+openshift-gitops-application-controller-0      1/1     Running   0          2m
 ----
 +
-<1> The number of Argo CD Application Controller pods must be greater than or equal to the value of `minShard`.
+The number of Argo CD Application Controller pods must be greater than or equal to the value of `minShard`.

--- a/modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc
+++ b/modules/gitops-argo-cd-dynamic-scaling-in-web-console.adoc
@@ -35,15 +35,20 @@ metadata:
 spec:
   controller:
     sharding:
-      dynamicScalingEnabled: true <1>
-      minShards: 1 <2>
-      maxShards: 3 <3>
-      clustersPerShard: 1 <4>
+      dynamicScalingEnabled: true
+      minShards: 1
+      maxShards: 3
+      clustersPerShard: 1
 ----
-<1> Set `dynamicScalingEnabled` to `true` to enable dynamic scaling.
-<2> Set `minShards` to the minimum number of shards that you want to have. The value must be set to `1` or greater.
-<3> Set `maxShards` to the maximum number of shards that you want to have. The value must be greater than the value of `minShards`.
-<4> Set `clustersPerShard` to the number of clusters that you want to have per shard. The value must be set to `1` or greater.
++
+--
+where:
+
+`spec.controller.sharding.dynamicScalingEnabled`:: Set to `true` to enable dynamic scaling.
+`spec.controller.sharding.minShards`:: Specifies the minimum number of shards. The value must be set to `1` or greater.
+`spec.controller.sharding.maxShards`:: Specifies the maximum number of shards. The value must be greater than the value of `minShards`.
+`spec.controller.sharding.clustersPerShard`:: Specifies the number of clusters per shard. The value must be set to `1` or greater.
+--
 
 . Click *Save*.
 +

--- a/modules/gitops-argocd-agent-install-principal-component.adoc
+++ b/modules/gitops-argocd-agent-install-principal-component.adoc
@@ -42,12 +42,12 @@ spec:
 +
 where:
 
-`<argoCDAgent>`:: Specifies the Argo CD Agent configuration.
-`<principal>`:: Specifies the Principal component configuration.
-`<auth>`:: Specifies the authentication method used in the Principal component.
-`<namespace>`:: Specifies the namespace configuration used in the Principal component.
-`<tls>`:: Specifies the configuration used for secure communication.
-`<sourceNamespaces>`:: Specifies the `sourceNamespaces` configuration.
+`<spec.argoCDAgent>`:: Specifies the Argo CD Agent configuration.
+`<spec.argoCDAgent.principal>`:: Specifies the Principal component configuration.
+`<spec.argoCDAgent.principal.auth>`:: Specifies the authentication method used in the Principal component.
+`<spec.argoCDAgent.principal.namespace>`:: Specifies the namespace configuration used in the Principal component.
+`<spec.argoCDAgent.principal.tls>`:: Specifies the configuration used for secure communication.
+`<spec.sourceNamespaces>`:: Specifies the `sourceNamespaces` configuration.
 +
 [NOTE]
 ====

--- a/modules/gitops-configure-aws-secret-manager-on-openshift-with-gitops.adoc
+++ b/modules/gitops-configure-aws-secret-manager-on-openshift-with-gitops.adoc
@@ -15,24 +15,27 @@ As an example, consider that you are using AWS Secrets Manager as your secrets s
 ├── config
 │   ├── argocd
 │   │   ├── argo-app.yaml
-│   │   ├── secret-provider-app.yaml <3>
+│   │   ├── secret-provider-app.yaml
 │   │   ├── ...
-│   └── sscsid <1>
-│       └── aws-provider.yaml <2>
+│   └── sscsid
+│       └── aws-provider.yaml
 ├── environments
-│   ├── dev <4>
+│   ├── dev
 │   │   ├── apps
-│   │   │   └── app-taxi <5>
+│   │   │   └── app-taxi
 │   │   │       ├── ...
-│   │   ├── credentialsrequest-dir-aws <6>
+│   │   ├── credentialsrequest-dir-aws
 │   │   └── env
 │   │       ├── ...
 │   ├── new-env
 │   │   ├── ...
 ----
-<1> Directory that stores the `aws-provider.yaml` file.
-<2> Configuration file that installs the AWS Secrets Manager provider and deploys resources for it.
-<3> Configuration file that creates an application and deploys resources for AWS Secrets Manager.
-<4> Directory that stores the deployment pod and credential requests.
-<5> Directory that stores the `SecretProviderClass` resources to define your secrets store provider.
-<6> Folder that stores the `credentialsrequest.yaml` file. This file contains the configuration for the credentials request to mount a secret to the deployment pod.
+
+where:
+
+`sscsid`:: Specifies the directory that stores the `aws-provider.yaml` file.
+`aws-provider.yaml`:: Specifies the configuration file that installs the AWS Secrets Manager provider and deploys resources for it.
+`secret-provider-app.yaml`:: Specifies the configuration file that creates an application and deploys resources for AWS Secrets Manager.
+`dev`:: Specifies the directory that stores the deployment pod and credential requests.
+`app-taxi`:: Specifies the directory that stores the `SecretProviderClass` resources to define your secrets store provider.
+`credentialsrequest-dir-aws`:: Specifies the folder that stores the `credentialsrequest.yaml` file. This file contains the configuration for the credentials request to mount a secret to the deployment pod.

--- a/modules/gitops-configure-hashicorp-vault-as-a-secrets-provider-on-openshift-with-gitops.adoc
+++ b/modules/gitops-configure-hashicorp-vault-as-a-secrets-provider-on-openshift-with-gitops.adoc
@@ -15,20 +15,23 @@ The following sample {gitops-shortname} repository layout is used for integratin
 .Example directory structure in {gitops-shortname} repository
 ----
 ├── config
-│   ├── argocd # <1>
+│   ├── argocd
 │   │   ├── vault-secret-provider-app.yaml
 │   │   ├── ...
 │── environments 
 │   ├── dev
 │   │   ├── apps
 │   │   │   ├── demo-app
-│   │   │       ├── manifest # <2>
+│   │   │       ├── manifest
 │   │   │       |    ├── secretProviderClass.yaml
 │   │   │       |    ├── serviceAccount.yaml
 │   │   │       |    ├── deployment.yaml
-│   │   │       ├── argocd # <3>
+│   │   │       ├── argocd
 │   │   │            ├── demo-app.yaml
 ----
-<1> `config/argocd/` - Stores Argo CD Application definitions for cluster-wide tools like the Vault CSI provider.
-<2> `environments/<env>/apps/<app-name>/manifest/`: Contains Kubernetes manifests specific to an application in a particular environment.
-<3> `environments/<env>/apps/<app-name>/argocd/`: Contains the Argo CD Application definition that deploys the application and its resources.
+
+where:
+
+`config/argocd/`:: Specifies the directory that stores Argo CD Application definitions for cluster-wide tools like the Vault CSI provider.
+`environments/<env>/apps/<app-name>/manifest/`:: Specifies the directory that contains Kubernetes manifests specific to an application in a particular environment.
+`environments/<env>/apps/<app-name>/argocd/`:: Specifies the directory that contains the Argo CD Application definition that deploys the application and its resources.

--- a/modules/gitops-configure-rollout-route-traffic-using-openshift-routes.adoc
+++ b/modules/gitops-configure-rollout-route-traffic-using-openshift-routes.adoc
@@ -34,27 +34,32 @@ metadata:
   name: rollouts-demo-route
 spec:
   port:
-    targetPort: http #<1>
-  tls: #<2>
+    targetPort: http
+  tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
   to:
     kind: Service
-    name: argo-rollouts-stable-service #<3>
-    weight: 100 # <4>
+    name: argo-rollouts-stable-service
+    weight: 100
 
   alternateBackends:
     - kind: Service
-      name: argo-rollouts-canary-service #<5>
-      weight: 0 #<6>
+      name: argo-rollouts-canary-service
+      weight: 0
 ----
-<1> Specifies the name of the port used by the application for running inside the container.
-<2> Specifies the TLS configuration used to secure the route.
-<3> The name of the targeted stable service.
-<4> This field is automatically modified to stable weight by Route Rollout plugin.
-<5> The name of the targeted canary service.
-<6> This field is automatically modified to canary weight by Route Rollout plugin.
 +
+--
+where:
+
+`spec.port.targetPort`:: Specifies the port name that the application uses to run inside the container.
+`spec.tls`:: Specifies the TLS configuration used to secure the route.
+`spec.to.name`:: Specifies the name of the targeted stable service.
+`spec.to.weight`:: Specifies the traffic weight for the stable service. This field is automatically modified to stable weight by Route Rollout plugin.
+`spec.alternateBackends.name`:: Specifies the name of the targeted canary service.
+`spec.alternateBackends.weight`:: Specifies the traffic weight for the canary service. This field is automatically modified to canary weight by Route Rollout plugin.
+-- 
+
 .. Click *Create* to create the route. It is then displayed on the *Routes* page.
 . Create the services, canary and stable, to be referenced in the route.
 .. In the *Administrator* perspective of the web console, click *Networking* -> *Services*.
@@ -69,17 +74,22 @@ kind: Service
 metadata:
   name: argo-rollouts-canary-service
 spec:
-  ports: #<1>
+  ports:
   - port: 80
     targetPort: http
     protocol: TCP
     name: http
 
-  selector: #<2>
+  selector:
     app: rollouts-demo
 ----
-<1> Specifies the name of the port used by the application for running inside the container.
-<2> Ensure that the contents of the `selector` field are the same as in stable service and `Rollout` custom resource (CR).
++
+--
+where:
+
+`spec.ports`:: Specifies the port name that the application uses to run inside the container.
+`spec.selector`:: Specifies the selector to match pods. Ensure that the contents of the `selector` field are the same as in stable service and `Rollout` custom resource (CR).
+--
 +
 [IMPORTANT]
 ====
@@ -98,17 +108,22 @@ kind: Service
 metadata:
   name: argo-rollouts-stable-service
 spec:
-  ports: #<1>
+  ports:
   - port: 80
     targetPort: http
     protocol: TCP
     name: http
 
-  selector: #<2> 
+  selector:
     app: rollouts-demo
 ----
-<1> Specifies the name of the port used by the application for running inside the container.
-<2> Ensure that the contents of the `selector` field are the same as in canary service and `Rollout` CR .
++
+--
+where:
+
+`spec.ports`:: Specifies the port name that the application uses to run inside the container.
+`spec.selector`:: Specifies the selector to match pods. Ensure that the contents of the `selector` field are the same as in canary service and `Rollout` CR.
+--
 +
 [IMPORTANT]
 ====
@@ -129,7 +144,7 @@ kind: Rollout
 metadata:
   name: rollouts-demo
 spec:
-  template: #<1>
+  template:
     metadata:
       labels:
         app: rollouts-demo
@@ -145,33 +160,38 @@ spec:
           requests:
             memory: 32Mi
             cpu: 5m
-                
+
   revisionHistoryLimit: 2
   replicas: 5
   strategy:
     canary:
-      canaryService: argo-rollouts-canary-service #<2>
-      stableService: argo-rollouts-stable-service #<3>
+      canaryService: argo-rollouts-canary-service
+      stableService: argo-rollouts-stable-service
       trafficRouting:
         plugins:
-          argoproj-labs/openshift:          
+          argoproj-labs/openshift:
             routes:
-              - rollouts-demo-route  #<4>
-      steps: #<5>
+              - rollouts-demo-route
+      steps:
       - setWeight: 30
       - pause: {}
       - setWeight: 60
       - pause: {}
-  selector: #<6>
+  selector:
     matchLabels:
       app: rollouts-demo
 ----
-<1> Specifies the pods that are to be created.
-<2> This value must match the name of the created canary `Service`.
-<3> This value must match the name of the created stable `Service`.
-<4> This value must match the name of the created `Route` CR.
-<5> Specify the steps for the rollout. This example gradually routes 30%, 60%, and 100% of traffic to the canary version.
-<6> Ensure that the contents of the `selector` field are the same as in canary and stable service.
++
+--
+where:
+
+`spec.template`:: Specifies the pods that are to be created.
+`spec.strategy.canary.canaryService`:: Specifies the name of the canary service. This value must match the name of the created canary `Service`.
+`spec.strategy.canary.stableService`:: Specifies the name of the stable service. This value must match the name of the created stable `Service`.
+`spec.strategy.canary.trafficRouting.plugins.argoproj-labs/openshift.routes`:: Specifies the name of the route. This value must match the name of the created `Route` CR.
+`spec.strategy.canary.steps`:: Specifies the steps for the rollout. This example gradually routes 30%, 60%, and 100% of traffic to the canary version.
+`spec.selector`:: Specifies the selector to match pods. Ensure that the contents of the `selector` field are the same as in canary and stable service.
+--
 .. Click *Create*.
 .. In the *Rollout* tab, under the *Rollout* section, verify that the *Status* field of the rollout shows *Phase: Healthy*.
 
@@ -194,18 +214,23 @@ spec:
   alternateBackends:
   - kind: Service
     name: argo-rollouts-canary-service
-    weight: 0 #<1>
+    weight: 0
   # (...)
   to:
     kind: Service
     name: argo-rollouts-stable-service
-    weight: 100 #<2>
+    weight: 100
 ----
-<1> A value of `0` means that 0% of traffic is directed to the canary version.
-<2> A value of `100` means that 100% of traffic is directed to the stable version.
++
+--
+where:
+
+`alternateBackends.weight`:: Specifies the percentage of traffic directed to the canary version. A value of `0` means that 0% of traffic is directed to the canary version.
+`to.weight`:: Specifies the percentage of traffic directed to the stable version. A value of `100` means that 100% of traffic is directed to the stable version.
+--
+
 . Simulate the new canary version of the application by modifying the container image deployed in the rollout. 
 .. In the *Administrator* perspective of the web console, go to *Operators* -> *Installed Operators* -> *Red Hat OpenShift GitOps* -> *Rollout*.
-
 .. Select the existing *Rollout* and modify the `.spec.template.spec.containers.image` value from `argoproj/rollouts-demo:blue` to `argoproj/rollouts-demo:yellow`.
 +
 As a result, the container image deployed in the rollout is modified and the rollout initiates a new canary deployment.
@@ -234,9 +259,14 @@ spec:
 +
 [source,terminal]
 ----
-$ oc argo rollouts promote rollouts-demo -n <namespace> <1>
+$ oc argo rollouts promote rollouts-demo -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
+--
 +
 This increases the traffic weight to 60% in the canary version and 40% in the stable version. 
 +
@@ -254,13 +284,19 @@ spec:
     name: argo-rollouts-stable-service
     weight: 40
 ----
+
 . Increase the traffic weight in the canary version to 100% and discard the traffic in the old stable version of the application by running the following command:
 +
 [source,terminal]
 ----
-$ oc argo rollouts promote rollouts-demo -n <namespace> <1>
+$ oc argo rollouts promote rollouts-demo -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
+-- 
 +
 .Example route with 0% of traffic directed to the canary version and 100% directed to the stable version.
 [source,yaml]

--- a/modules/gitops-configure-rollout-route-traffic-using-openshift-service-mesh.adoc
+++ b/modules/gitops-configure-rollout-route-traffic-using-openshift-service-mesh.adoc
@@ -35,10 +35,10 @@ In the following example procedure, the rollout routes 20% of traffic to a canar
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: rollouts-demo-gateway #<1>
+  name: rollouts-demo-gateway
 spec:
   selector:
-    istio: ingressgateway #<2>
+    istio: ingressgateway
   servers:
   - port:
       number: 80
@@ -47,8 +47,14 @@ spec:
     hosts:
     - "*"
 ----
-<1> The name of the gateway.
-<2> Specifies the name of the ingress gateway. The gateway configures exposed ports and protocols but does not include any traffic routing configuration.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the gateway.
+`spec.selector.istio`:: Specifies the name of the ingress gateway. The gateway configures exposed ports and protocols but does not include any traffic routing configuration.
+--
+
 .. Apply the YAML file by running the following command.
 +
 [source,terminal]
@@ -71,16 +77,21 @@ kind: Service
 metadata:
   name: rollouts-demo-stable
 spec:
-  ports: #<1>
+  ports:
   - port: 80
     targetPort: http
     protocol: TCP
     name: http
-  selector: #<2>
+  selector:
     app: rollouts-demo
 ----
-<1> Specifies the name of the port used by the application for running inside the container.
-<2> Ensure that the contents of the `selector` field are the same in stable service and Rollout CR.
++
+--
+where:
+
+`spec.ports`:: Specifies the name of the port used by the application for running inside the container.
+`spec.selector`:: Specifies the selector to match pods. Ensure that the contents of the `selector` field are the same in stable service and Rollout CR.
+--
 
 .. Click *Create* to create a stable service.
 
@@ -94,16 +105,21 @@ kind: Service
 metadata:
   name: rollouts-demo-canary
 spec:
-  ports: #<1>
+  ports:
   - port: 80
     targetPort: http
     protocol: TCP
     name: http
-  selector: #<2>
+  selector:
     app: rollouts-demo
 ----
-<1> Specifies the name of the port used by the application for running inside the container.
-<2> Ensure that the contents of the `selector` field are the same in canary service and `Rollout` CR.
++
+--
+where:
+
+`spec.ports`:: Specifies the name of the port used by the application for running inside the container.
+`spec.selector`:: Specifies the selector to match pods. Ensure that the contents of the `selector` field are the same in canary service and `Rollout` CR.
+--
 
 .. Click *Create* to create the canary service.
 
@@ -120,23 +136,23 @@ metadata:
   name: rollouts-demo-vsvc
 spec:
   gateways:
-  - rollouts-demo-gateway #<1>
+  - rollouts-demo-gateway
   hosts:
   - rollouts-demo-vsvc.local
   http:
   - name: primary
     route:
     - destination:
-        host: rollouts-demo-stable #<2>
-        port:
-          number: 15372 #<3>
-      weight: 100 
-    - destination:
-        host: rollouts-demo-canary #<4>
+        host: rollouts-demo-stable
         port:
           number: 15372
-      weight: 0 
-  tls: #<5>
+      weight: 100
+    - destination:
+        host: rollouts-demo-canary
+        port:
+          number: 15372
+      weight: 0
+  tls:
   - match:
     - port: 3000
       sniHosts:
@@ -149,11 +165,16 @@ spec:
         host: rollouts-demo-canary
       weight: 0
 ----
-<1> The name of the gateway.
-<2> The name of the targeted stable service.
-<3> Specifies the port number used for listening to traffic.
-<4> The name of the targeted canary service.
-<5> Specifies the TLS configuration used to secure the VirtualService.
++
+--
+where:
+
+`spec.gateways`:: Specifies the name of the gateway.
+`spec.http.route.destination.host (stable)`:: Specifies the name of the targeted stable service.
+`spec.http.route.destination.port.number`:: Specifies the port number used for listening to traffic.
+`spec.http.route.destination.host (canary)`:: Specifies the name of the targeted canary service.
+`spec.tls`:: Specifies the TLS configuration used to secure the VirtualService.
+--
 
 .. Apply the YAML file by running the following command.
 +
@@ -179,25 +200,25 @@ spec:
   replicas: 5
   strategy:
     canary:
-      canaryService: rollouts-demo-canary #<1>
-      stableService: rollouts-demo-stable #<2>
+      canaryService: rollouts-demo-canary
+      stableService: rollouts-demo-stable
       trafficRouting:
         istio:
           virtualServices:
           - name: rollouts-demo-vsvc
             routes:
             - primary
-      steps: #<3>
+      steps:
       - setWeight: 20
       - pause: {}
       - setWeight: 40
-      - pause: {}  
+      - pause: {}
       - setWeight: 60
       - pause: {duration: 30}
       - setWeight: 80
       - pause: {duration: 60}
   revisionHistoryLimit: 2
-  selector: #<4>
+  selector:
     matchLabels:
       app: rollouts-demo
   template:
@@ -218,10 +239,15 @@ spec:
             memory: 32Mi
             cpu: 5m
 ----
-<1> This value must match the name of the created canary `Service`.
-<2> This value must match the name of the created stable `Service`.
-<3> Specify the steps for the rollout. This example gradually routes 20%, 40%, 60%, and 100% of traffic to the canary version.
-<4> Ensure that the contents of the `selector` field are the same as in canary and stable service.
++
+--
+where:
+
+`spec.strategy.canary.canaryService`:: Specifies the name of the canary service. This value must match the name of the created canary `Service`.
+`spec.strategy.canary.stableService`:: Specifies the name of the stable service. This value must match the name of the created stable `Service`.
+`spec.strategy.canary.steps`:: Specifies the steps for the rollout. This example gradually routes 20%, 40%, 60%, and 100% of traffic to the canary version.
+`spec.selector`:: Specifies the selector to match pods. Ensure that the contents of the `selector` field are the same as in canary and stable service.
+--
 
 .. Click *Create*.
 
@@ -233,9 +259,12 @@ spec:
 +
 [source,terminal]
 ----
-$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace> <1>
+$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
++
+where:
++
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 +
 .Example output
 [source,terminal]
@@ -285,13 +314,18 @@ $ oc describe virtualservice/rollouts-demo-vsvc -n <namespace>
 route
 - destination:
     host: rollouts-demo-stable
-  weight: 100 #<1>
+  weight: 100
 - destination:
     host: rollouts-demo-canary
-  weight: 0 #<2>
+  weight: 0
 ----
-<1> A value of `100` means that 100% of traffic is directed to the stable version.
-<2> A value of `0` means that 0% of traffic is directed to the canary version.
++
+--
+where:
+
+`route.weight (stable)`:: Specifies the percentage of traffic directed to the stable version. A value of `100` means that 100% of traffic is directed to the stable version.
+`route.weight (canary)`:: Specifies the percentage of traffic directed to the canary version. A value of `0` means that 0% of traffic is directed to the canary version.
+--
 
 . Simulate the new canary version of the application by modifying the container image deployed in the rollout.
 
@@ -314,9 +348,12 @@ As per the `setWeight` property defined in the `.spec.strategy.canary.steps` fie
 --
 [source,terminal]
 ----
-$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace> <1>
+$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
+
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 --
 +
 In the following example, 80% of traffic is routed to the stable service and 20% of traffic is routed to the canary service. The deployment is then paused indefinitely until you manually promote it to the next level.
@@ -360,32 +397,42 @@ NAME                                       KIND        STATUS     AGE    INFO
 route
 - destination:
     host: rollouts-demo-stable
-  weight: 80 #<1>
+  weight: 80
 - destination:
     host: rollouts-demo-canary
-  weight: 20 #<2>
+  weight: 20
 ----
-<1> A value of `80` means that 80% of traffic is directed to the stable version.
-<2> A value of `20` means that 20% of traffic is directed to the canary version.
++
+--
+where:
+
+`route.weight (stable)`:: Specifies the percentage of traffic directed to the stable version. A value of `80` means that 80% of traffic is directed to the stable version.
+`route.weight (canary)`:: Specifies the percentage of traffic directed to the canary version. A value of `20` means that 20% of traffic is directed to the canary version.
+--
 
 . Manually promote the deployment to the next promotion step.
 +
 --
 [source,terminal]
 ----
-$ oc argo rollouts promote rollouts-demo -n <namespace> <1>
+$ oc argo rollouts promote rollouts-demo -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
---
 
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
+--
 .. Watch the progression of your rollout by running the following command:
 +
 --
 [source,terminal]
 ----
-$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace> <1>
+$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
+
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 --
 +
 In the following example, 60% of traffic is routed to the stable service and 40% of traffic is routed to the canary service. The deployment is then paused indefinitely until you manually promote it to the next level.
@@ -423,20 +470,23 @@ NAME                                       KIND        STATUS     AGE    INFO
       └──□ rollouts-demo-687d76d795-xrmrj  Pod         ✔ Running  9m50s  ready:1/1
 ----
 +
---
 .Example of 60% traffic directed to the stable version and 40% directed to the canary version.
 [source,yaml]
 ----
 route
 - destination:
     host: rollouts-demo-stable
-  weight: 60 #<1>
+  weight: 60
 - destination:
     host: rollouts-demo-canary
-  weight: 40 #<2>
+  weight: 40
 ----
-<1> A value of `60` means that 60% of traffic is directed to the stable version.
-<2> A value of `40` means that 40% of traffic is directed to the canary version.
++
+--
+where:
+
+`route.weight (stable)`:: Specifies the percentage of traffic directed to the stable version. A value of `60` means that 60% of traffic is directed to the stable version.
+`route.weight (canary)`:: Specifies the percentage of traffic directed to the canary version. A value of `40` means that 40% of traffic is directed to the canary version.
 --
 
 . Increase the traffic weight in the canary version to 100% and discard the traffic in the previous stable version of the application by running the following command:
@@ -444,9 +494,12 @@ route
 --
 [source,terminal]
 ----
-$ oc argo rollouts promote rollouts-demo -n <namespace> <1>
+$ oc argo rollouts promote rollouts-demo -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
+
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 --
 
 .. Watch the progression of your rollout by running the following command:
@@ -454,9 +507,12 @@ $ oc argo rollouts promote rollouts-demo -n <namespace> <1>
 --
 [source,terminal]
 ----
-$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace> <1>
+$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
+
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
 --
 
 After successful completion, weight on the stable service is 100% and 0% on the canary service.

--- a/modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc
+++ b/modules/gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources.adoc
@@ -32,12 +32,17 @@ spec:
   config:
    env: 
     - name: NAMESPACE_SCOPED_ARGO_ROLLOUTS
-      value: 'false' #<1>
+      value: 'false'
     - name: CLUSTER_SCOPED_ARGO_ROLLOUTS_NAMESPACES
-      value: <list_of_namespaces_in_the_cluster-scoped_Argo_CD_instances> #<2>
+      value: <list_of_namespaces_in_the_cluster-scoped_Argo_CD_instances>
  ...
 ----
-<1> Specify this value to enable or disable the cluster-scoped installation. If the value is set to `'false'`, it means that the you have enabled cluster-scoped installation. If it is set to `'true'`, it means that you have enabled namespace-scoped installation. If the value is empty, it is set to `false`.
-<2> Specifies a comma-separated list of namespaces that can host a cluster-scoped Argo Rollouts instance, for example `test-123-cluster-scoped,test-456-cluster-scoped`.
++
+--
+where:
+
+spec.config.env.value ('false'):: Specify this value to enable or disable the cluster-scoped installation. Set the value to `'false'` to enable cluster-scoped installation. Set to `'true'` to enable namespace-scoped installation. If this value is empty, the operator defaults to `false`.
+spec.config.env.value (list_of_namespaces):: Specifies a comma-separated list of namespaces that can host a cluster-scoped Argo Rollouts instance, for example `test-123-cluster-scoped,test-456-cluster-scoped`.
+--
 
 . Click *Save* and *Reload*.

--- a/modules/gitops-configuring-argo-cd-cr-of-your-user-defined-cluster-scoped-instance-with-target-namespaces.adoc
+++ b/modules/gitops-configuring-argo-cd-cr-of-your-user-defined-cluster-scoped-instance-with-target-namespaces.adoc
@@ -33,24 +33,28 @@ As a cluster administrator, you can define a certain set of non-control plane na
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: example # <1>
-  namespace: spring-petclinic # <2>
+  name: example
+  namespace: spring-petclinic
 spec:
-  sourceNamespaces: # <3>
-    - dev # <4>
-    - app-team-* # <5>
+  sourceNamespaces:
+    - dev
+    - app-team-*
 ----
-<1> The name of the user-defined cluster-scoped Argo CD instance.
-<2> The namespace where you want to run the user-defined cluster-scoped Argo CD instance.
-<3> The list of non-control plane namespaces for creating and managing `Application` resources.
-<4> The name of the target namespace for the Argo CD server to create and manage `Application` resources.
-<5> With wildcards (`pass:[*]`), specifies the name of the target namespaces matching the pattern `app-team-pass:[*]`, such as `app-team-1` and `app-team-2`, for the Argo CD server to create and manage `Application` resources.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the user-defined cluster-scoped Argo CD instance.
+`metadata.namespace`:: Specifies the namespace where the user-defined cluster-scoped Argo CD instance is created.
+`spec.sourceNamespaces`:: Specifies the namespaces where users can create and manage `Application` resources handled by the Argo CD instance. You can use wildcard patterns (`*`), to allow the Argo CD instance to manage `Application` resources in matching namespaces like `app-team-1` or `app-team-2`.
+--
 .. Click *Save* and *Reload*.
 +
 [NOTE]
 ====
-When a target namespace is specified under the `sourceNamespaces` field, the Operator adds the `argocd.argoproj.io/managed-by-cluster-argocd` label to the specified namespace. 
-
+When a target namespace is specified under the `sourceNamespaces` field, the Operator adds the `argocd.argoproj.io/managed-by-cluster-argocd` label to the specified namespace.
+====
++
 .Example `dev` target namespace
 [source,yaml]
 ----
@@ -59,12 +63,16 @@ kind: Namespace
 metadata:
   name: dev
   labels:
-    argocd.argoproj.io/managed-by-cluster-argocd: spring-petclinic # <1>
-    kubernetes.io/metadata.name: dev # <2>
+    argocd.argoproj.io/managed-by-cluster-argocd: spring-petclinic
+    kubernetes.io/metadata.name: dev
 ----
-<1> The namespace of the user-defined cluster-scoped Argo CD instance.
-<2> The target namespace for the Argo CD server to create and manage `Application` resources.
-====
++
+--
+where:
+
+`metadata.name`:: Specifies the namespace of the user-defined cluster-scoped Argo CD instance.
+`spec.sourceRepos` or `spec.destinations` (Application):: the target namespace for the Argo CD server to create and manage `Application` resources.
+--
 
 . Verify that Operator adds the `argocd.argoproj.io/managed-by-cluster-argocd` label to the specified namespace:
 .. Go to *Administration* -> *Namespaces* and click *Create Namespace*.
@@ -75,6 +83,7 @@ For example, to create `dev` target namespace, enter `dev` in the *Name* field. 
 The *Namespaces* page displays the created target namespaces.
 .. Click the target namespace and go to the *YAML* tab to verify the `argocd.argoproj.io/managed-by-cluster-argocd` label added by the Operator.
 
+.Verification
 . Verify that your user-defined cluster-scoped Argo CD instance is configured with a cluster role to manage cluster-scoped resources:
 .. Go to *User Management* -> *Roles* and from the *Filter* list, select *Cluster-wide Roles*.
 .. Search for the created cluster roles by using the *Search by name* field. For example, `example-spring-petclinic-argocd-application-controller` and `example-spring-petclinic-argocd-server`.

--- a/modules/gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances.adoc
+++ b/modules/gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances.adoc
@@ -42,13 +42,21 @@ spec:
   config:
     env: 
     - name: CONTROLLER_CLUSTER_ROLE 
-      value: gitops-controller-role # <1>
+      value: gitops-controller-role
     - name: SERVER_CLUSTER_ROLE
-      value: gitops-server-role # <2>
+      value: gitops-server-role
 ----
-<1> The name of the environment variable for the Argo CD Application Controller component.
-<2> The name of the environment variable for the Argo CD server component.
++
+--
+where:
 
+`metadata.name`:: Specifies the name of the `Subscription` resource.
+`metadata.namespace`:: Specifies the namespace where the `Subscription` resource is created.
+`spec.config.env`:: Specifies environment variables that are passed to the Operator.
+`spec.config.env[].name`:: Specifies the name of the environment variable.
+`spec.config.env[].value`:: Specifies the value assigned to the environment variable.
+--
++
 [TIP]
 ====
 Alternatively, you can inject the preceding environment variables directly into the Operator's `Deployment` object YAML file.

--- a/modules/gitops-configuring-gitops-managed-resources-to-use-mounted-secrets.adoc
+++ b/modules/gitops-configuring-gitops-managed-resources-to-use-mounted-secrets.adoc
@@ -26,7 +26,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: taxi                                
-  namespace: dev # <1>
+  namespace: dev
 spec:
   replicas: 1
   template:
@@ -41,7 +41,7 @@ spec:
             - containerPort: 8080
           volumeMounts:
             - name: secrets-store-inline
-              mountPath: "/mnt/secrets-store" # <2>
+              mountPath: "/mnt/secrets-store"
               readOnly: true
           resources: {}
     serviceAccountName: default
@@ -51,13 +51,20 @@ spec:
           driver: secrets-store.csi.k8s.io
           readOnly: true
           volumeAttributes:
-            secretProviderClass: "my-aws-provider" # <3>
+            secretProviderClass: "my-aws-provider"
     status: {}
 # ...
 ----
-<1> Namespace for the deployment. This must be the same namespace as the secret provider class.
-<2> The path to mount secrets in the volume mount.
-<3> Name of the secret provider class.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the deployment.
+`metadata.namespace`:: Specifies the namespace where the deployment is created. This must match the namespace of the `SecretProviderClass`.
+`spec.replicas`:: Specifies the number of pod replicas for the deployment.
+`spec.template.spec.containers[].volumeMounts[].mountPath`:: Specifies the path inside the container where the secrets are mounted.
+`spec.template.spec.volumes[].csi.volumeAttributes.secretProviderClass`:: Specifies the name of the `SecretProviderClass` used to retrieve secrets from the external provider.
+--
 
 .. Push the updated resource YAML file to your {gitops-shortname} repository.
 

--- a/modules/gitops-configuring-gitops-managed-resources-to-use-vault-mounted-secrets.adoc
+++ b/modules/gitops-configuring-gitops-managed-resources-to-use-vault-mounted-secrets.adoc
@@ -23,11 +23,11 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
          name: demo-app-creds
          namespace: demo-app
  spec:
-        provider: vault #<1>
+        provider: vault
         parameters:
-              vaultAddress: http://vault.vault-csi-provider:8200 # <name>.<namespace>:port #<2>
-              roleName: app #<3>
-        objects: | #<4>
+              vaultAddress: http://vault.vault-csi-provider:8200 # <name>.<namespace>:port
+              roleName: app
+        objects: |
            - objectName: "demoAppUsername"
              secretPath: "secret/demo/config"
              secretKey: "username"
@@ -35,11 +35,15 @@ apiVersion: secrets-store.csi.x-k8s.io/v1
             secretPath: "secret/demo/config"
              secretKey: "password"
 ----
-<1> `<provider: vault>` - Specifies the name of the HashiCorp Vault.
-<2> `<vaultAddress>` - Specifies the network address of the Vault server. Adjust this based on your Vault setup, such as, in-cluster service or an external URL.
-<3> `<roleName>` - Specifies the Vault Kubernetes authentication role used by the application Service Account.
-Describes an array that defines which secrets to retrieve and how to map them to file names.
-<4> `<objects>` - Specifies an array that defines which secrets to retrieve and how to map them to file names. The `secretPath` for KV v2 includes `/data/`.
++
+--
+where:
+
+`<spec.provider>`:: Specifies the name of the HashiCorp Vault.
+`<spec.parameters.vaultAddress>`:: Specifies the network address of the Vault server. Adjust this based on your Vault setup, such as, in-cluster service or an external URL.
+`<spec.parameters.roleName>`:: Specifies the Vault Kubernetes authentication role used by the application Service Account. Describes an array that defines which secrets to retrieve and how to map them to file names.
+`<spec.objects>` - Specifies an array that defines which secrets to retrieve and how to map them to file names. The `secretPath` for KV v2 includes `/data/`.
+--
 
 . Create an Application, such as, `ServiceAccount`.
 
@@ -65,39 +69,44 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-   name: app
-   namespace: demo-app
-   labels:
-     app: demo
+  name: app
+  namespace: demo-app
+  labels:
+    app: demo
 spec:
-   replicas: 1
-   selector:
-     matchLabels:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
         app: demo
-   template:
-      metadata:
-       labels:
-         app: demo
-   spec:
-        serviceAccountName: demo-app-sa # <1>
-        containers:
-           - name: app
-             image: nginxinc/nginx-unprivileged:latest
-             volumeMounts: # <2>
-             - name: vault-secrets
-               mountPath: /mnt/secrets-store
-               readOnly: true
-   volumes: # <3>
+    spec:
+      serviceAccountName: demo-app-sa
+      containers:
+        - name: app
+          image: nginxinc/nginx-unprivileged:latest
+          volumeMounts:
+            - name: vault-secrets
+              mountPath: /mnt/secrets-store
+              readOnly: true
+      volumes:
         - name: vault-secrets
           csi:
             driver: secrets-store.csi.k8s.io
             readOnly: true
             volumeAttributes:
-            secretProviderClass: demo-app-creds
+              secretProviderClass: demo-app-creds
 ----
-<1> `serviceAccountName` - Assigns the Kubernetes `ServiceAccount` name, for example, `demo-app-sa`, used by the application pod. This `ServiceAccount` is fundamental for authenticating with HashiCorp Vault, as it is linked to a Vault role that grants permissions to retrieve the necessary secrets.
-<2> `volumeMounts` - Mounts the vault-secrets volume into the container at the `/mnt/secrets-store` directory.
-<3> `volumes` - Defines the vault-secrets volume using the `secrets-store.csi.k8s.io` driver and references the `demo-app-creds` `SecretProviderClass`.
++
+--
+where:
+
+`spec.template.spec.serviceAccountName`:: Specifies the Kubernetes `ServiceAccount`, for example `demo-app-sa`, used by the application pod. This service account is used to authenticate with HashiCorp Vault through the configured Vault role.
+`spec.template.spec.containers[].volumeMounts[]`:: Specifies the volume mount that exposes secrets inside the container at the `/mnt/secrets-store` directory.
+`spec.template.spec.volumes[]`:: Defines the `vault-secrets` volume using the `secrets-store.csi.k8s.io` CSI driver and references the `demo-app-creds` `SecretProviderClass` to retrieve secrets from Vault.
+--
 
 . Define the Argo CD application for the workload:
 

--- a/modules/gitops-configuring-high-availability-for-argo-rollouts.adoc
+++ b/modules/gitops-configuring-high-availability-for-argo-rollouts.adoc
@@ -32,9 +32,14 @@ metadata:
   namespace: openshift-gitops
 spec:
   ha:
-    enabled: true #<1>
+    enabled: true
 ----
-<1> Specifies whether high availability is enabled or not. If the value is set to `true`, high availability is enabled.
++
+--
+where:
+
+`spec.ha.enabled`:: Specifies whether high availability is enabled or not. If the value is set to `true`, high availability is enabled.
+--
 
 . Click *Create*.
 
@@ -55,7 +60,7 @@ metadata:
   name: argo-rollouts
   namespace: openshift-gitops
 spec:
-  replicas: 2 #<1>
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: argo-rollouts
@@ -68,7 +73,12 @@ spec:
       containers:
           args:
             - '--leader-elect'
-            - 'true' #<2>
+            - 'true'
 ----
-<1> Specifies the number of pods.
-<2> Specifies that the `--leader-elect=true` flag is passed to the Rollouts deployment. Although this flag is set to `true` by default, explicitly setting it ensures that leader election remains consistently enforced.
++
+--
+where:
+
+`spec.replicas`:: Specifies the number of pods.
+`spec.template.spec.containers.args`:: Specifies that the `--leader-elect=true` flag is passed to the Rollouts deployment. Although this flag is set to `true` by default, explicitly setting it ensures that leader election remains consistently enforced.
+--

--- a/modules/gitops-configuring-namespace-management-argocd-tenants.adoc
+++ b/modules/gitops-configuring-namespace-management-argocd-tenants.adoc
@@ -31,9 +31,15 @@ spec:
   config:
     env:
     - name: ALLOW_NAMESPACE_MANAGEMENT_IN_NAMESPACE_SCOPED_INSTANCES
-      value: "true" # <1>
+      value: "true"
 ----
-<1> Specify the value to `true` to enable namespace management in the `Subscription` CR
++
+--
+where:
+
+`spec.config.env[].name`:: Specifies the environment variable `ALLOW_NAMESPACE_MANAGEMENT_IN_NAMESPACE_SCOPED_INSTANCES` used to enable namespace management for namespace-scoped Argo CD instances.
+`spec.config.env[].value`:: Specifies the value of the environment variable. Set the value to `"true"` to enable namespace management.
+--
 
 . Configure the Argo CD CR.  
 +
@@ -52,8 +58,12 @@ spec:
       allowManagedBy: true
 ----
 +
-<1> Replace `<argocd-ns>` with the Argo CD instance namespace.  
-<2> Replace `<tenant-ns>` with the namespace that you want Argo CD to manage. You can also use a glob pattern with wildcards such as `/\*` and `?` for pattern matching. For example, specifying `dev-/\*` matches any namespace with the `dev-` prefix.
+--
+where:
+
+`<metadata.namespace>`:: Specifies the `<argocd-ns>` with the Argo CD instance namespace.
+`<spec.namespaceManagement.name>`:: Specifies the `<tenant-ns>` with the namespace that you want Argo CD to manage. You can also use a glob pattern with wildcards such as `/\*` and `?` for pattern matching. For example, specifying `dev-/\*` matches any namespace with the `dev-` prefix.
+--
 
 . Create a `NamespaceManagement` CR.  
 +
@@ -70,8 +80,12 @@ spec:
   managedBy: <argocd-ns> # <2>
 ----
 +
-<1> `.metadata.namespace` - Namespace to be managed by the Argo CD instance.
-<2> `.spec.managedBy` - Namespace where the Argo CD instance runs. This value must exactly match the Argo CD namespace.
+--
+where:
+
+`<metadata.namespace>`:: Specifies the namespace to be managed by the Argo CD instance.
+`<spec.managedBy>`:: Specifies the namespace where the Argo CD instance runs. This value must exactly match the Argo CD namespace.
+--
 
 .Verification
 

--- a/modules/gitops-configuring-namespace-scoped-argo-rollouts-installation.adoc
+++ b/modules/gitops-configuring-namespace-scoped-argo-rollouts-installation.adoc
@@ -19,10 +19,10 @@ To configure a namespace-scoped instance of Argo Rollouts installation, complete
 . Search for `Subscription` and click the *Subscription* CRD.
 . Click the *Instances* tab and then click the *openshift-gitops-operator* subscription.
 . Click the *YAML* tab and edit the YAML file. 
-+
 .. Specify the `NAMESPACE_SCOPED_ARGO_ROLLOUTS` environment variable, with the value set to `true` in the `.spec.config.env` property.
 +
 .Example of configuring the namespace-scoped Argo Rollouts installation
++
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -34,9 +34,14 @@ spec:
   config:
     env:
       - name: NAMESPACE_SCOPED_ARGO_ROLLOUTS
-        value: 'true' #<1>
+        value: 'true'
 ----
-<1> The value set to `'true'` enables namespace-scoped installation. If the value is set to `'false'` or not specified the installation defaults to cluster-scoped mode.
++
+--
+where:
+
+`config.env.value`:: Set the value to `'true'` to enable namespace-scoped installation. If the value is set to `'false'` or not specified, the installation defaults to cluster-scoped mode.
+--
 
 .. Click *Save*.
 +
@@ -59,12 +64,17 @@ apiVersion: argoproj.io/v1alpha1
 kind: RolloutManager
 metadata:
   name: rollout-manager
-  namespace: my-application #<1> 
+  namespace: my-application
 spec:
   namespaceScoped: true
 ----
-<1> Specify the name of the project where you want to install the namespace-scoped Argo Rollouts instance.
 +
+--
+where:
+
+`metadata.namespace`:: Specifies the name of the project where you want to install the namespace-scoped Argo Rollouts instance.
+--
+
 .. Click *Create*. 
 +
 After the `RolloutManager` CR is created, {gitops-title} begins to install the namespace-scoped Argo Rollouts instance into the selected namespace.
@@ -80,15 +90,20 @@ spec:
   namespaceScoped: true
 status:
   conditions:
-    lastTransitionTime: '2024-07-10T14:20:5z`
+    lastTransitionTime: '2024-07-10T14:20:05Z'
     message: ''
     reason: Success
-    status: 'True' #<1>
+    status: 'True'
     type: 'Reconciled'
   phase: Available
   rolloutController: Available
 ----
-<1> This status indicates that the namespace-scoped Argo Rollouts installation is enabled successfully.
++
+--
+where:
+
+`status.rolloutController`:: Specifies the status of the Argo Rollouts controller. The value `Available` indicates that the namespace-scoped Argo Rollouts installation is successful.
+--
 +
 If you try to install a namespace-specific Argo Rollouts instance while a cluster-scoped installation already exists on the cluster, an error message is displayed:
 +
@@ -99,12 +114,17 @@ spec:
   namespaceScoped: true
 status:
   conditions:
-   lastTransitionTime: '2024-07-10T14:10:7z`
-   message: 'when Subscription has environment variable NAMESPACE_SCOPED_ARGO_ROLLOUTS set to False, there may not exist any namespace-scoped RolloutManagers: only a single cluster-scoped RolloutManager is supported'
-   reason: InvalidRolloutManagerScope
-   status: 'False' #<1>
-   type: 'Reconciled'
+    lastTransitionTime: '2024-07-10T14:10:07Z'
+    message: 'when Subscription has environment variable NAMESPACE_SCOPED_ARGO_ROLLOUTS set to False, there may not exist any namespace-scoped RolloutManagers: only a single cluster-scoped RolloutManager is supported'
+    reason: InvalidRolloutManagerScope
+    status: 'False'
+    type: 'Reconciled'
   phase: Failure
   rolloutController: Failure
 ----
-<1> This status indicates that the namespace-scoped Argo Rollouts installation is not enabled successfully. The installation defaults to cluster-scoped mode.
++
+--
+where:
+
+`status.rolloutController`:: Specifies the status of the Argo Rollouts controller. The value `Failure` indicates that the namespace-scoped Argo Rollouts installation was unsuccessful. In this case, the installation defaults to cluster-scoped mode.
+--

--- a/modules/gitops-configuring-respect-rbac-using-gitops.adoc
+++ b/modules/gitops-configuring-respect-rbac-using-gitops.adoc
@@ -31,29 +31,36 @@ You can configure the `respectRBAC` feature by using the CLI.
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: example-argocd #<1>
+  name: example-argocd
 spec:
   controller:
-    respectRBAC: strict #<2>
+    respectRBAC: strict
 ----
-<1> Specify the name of the Argo CD instance.
-<2> You can specify the value of the `.spec.controller.respectRBAC` key in the `ArgoCD` resource as `normal` or `strict`. Consider setting a value as `normal` to balance accuracy and speed as resource listing is a lightweight operation. Set the value as `strict` if Argo CD reports errors indicating that it cannot access resources when you set the value as `normal`.  Setting `strict` increases the number of API calls to the server and it is more accurate compared to `normal` as Argo CD performs additional validations of RBAC resources to determine permissions.
++
+--
+where:
+
+`metadata.name`:: Specifies the specify the name of the Argo CD instance.
+`spec.controller.respectRBAC`:: Defines the value of the `spec.controller.respectRBAC` key in the `ArgoCD` resource as `normal` or `strict`. Consider setting a value as `normal` to balance accuracy and speed as resource listing is a lightweight operation. Set the value as `strict` if Argo CD reports errors indicating that it cannot access resources when you set the value as `normal`. Setting `strict` increases the number of API calls to the server and it is more accurate compared to `normal` as Argo CD performs additional validations of RBAC resources to determine permissions.
+--
 
 . Apply the changes to the YAML file by running the following command.
 +
 [source,terminal]
 ----
-$ oc apply -f argocd-resource.yaml -n argo-cd-instance #<1>
+$ oc apply -f argocd-resource.yaml -n argo-cd-instance
 ----
-<1> Specify the name of the YAML file that includes the `ArgoCD` resource and the namespace that hosts `ArgoCD`.
++
+Specify the name of the YAML file that includes the `ArgoCD` resource and the namespace that hosts `ArgoCD`.
 +
 . Verify that the status of the `.status.phase` field is `Available` by running the following command:
 +
 [source,terminal]
 ----
-$ oc get argocd <argocd_instance_name> -n <argocd_namespace> -o jsonpath='{.status.phase}' #<1>
+$ oc get argocd <argocd_instance_name> -n <argocd_namespace> -o jsonpath='{.status.phase}'
 ----
-<1> Replace `<argocd_instance_name>` with the name of your Argo CD instance for example, `example-argocd`.
++
+Replace `<argocd_instance_name>` with the name of your Argo CD instance for example, `example-argocd`.
 
 . Verify that the `resource.respectRBAC` parameter in the `ConfigMap` resource is updated successfully:
 .. To retrieve the contents of the `argocd-cm` config map, run the following command:

--- a/modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc
+++ b/modules/gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager.adoc
@@ -55,15 +55,20 @@ spec:
       - "secretsmanager:GetSecretValue"
       - "secretsmanager:DescribeSecret"
       effect: Allow
-      resource: "<aws_secret_arn>" # <2>
+      resource: "<aws_secret_arn>"
 secretRef:
   name: aws-creds
-  namespace: dev # <1>
+  namespace: dev
 serviceAccountNames:
   - default
 ----
-<1> The namespace for the secret reference. Update the value of this `namespace` field according to your project deployment setup.
-<2> The ARN of your secret in the region where your cluster is on. The `<aws_region>` of `<aws_secret_arn>` has to match the cluster region. If it does not match, create a replication of your secret in the region where your cluster is on. 
++
+--
+where:
+
+`metadata.namespace`:: Specifies the namespace for the secret reference. Update the value of this `namespace` field according to your project deployment setup.
+`<metadata.annotations.aws_region>`:: Specifies the aRN of your secret in the region where your cluster is on. The `<aws_region>` of `<aws_secret_arn>` has to match the cluster region. If it does not match, create a replication of your secret in the region where your cluster is on.
+--
 +
 [TIP]
 ====
@@ -102,18 +107,18 @@ Copy the OIDC provider name `<oidc_provider_name>` from the output to use in the
 $ ccoctl aws create-iam-roles \
     --name my-role --region=<aws_region> \
     --credentials-requests-dir=credentialsrequest-dir-aws \
-    --identity-provider-arn arn:aws:iam::<aws_account>:oidc-provider/<oidc_provider_name> --output-dir=credrequests-ccoctl-output
+`    --identity-provider-arn arn:aws:iam`::<aws_account>:oidc-provider/<oidc_provider_name> --output-dir=credrequests-ccoctl-output
 ----
 +
 .Example output
 [source,terminal]
 ----
-2023/05/15 18:10:34 Role arn:aws:iam::<aws_account_id>:role/my-role-my-namespace-aws-creds created
+`2023/05/15 18:10:34 Role arn:aws:iam`::<aws_account_id>:role/my-role-my-namespace-aws-creds created
 2023/05/15 18:10:34 Saved credentials configuration to: credrequests-ccoctl-output/manifests/my-namespace-aws-creds-credentials.yaml
 2023/05/15 18:10:35 Updated Role policy for Role my-role-my-namespace-aws-creds
 ----
 +
-Copy the `<aws_role_arn>` from the output to use in the next step. For example, `arn:aws:iam::<aws_account_id>:role/my-role-my-namespace-aws-creds`.
+`Copy the `<aws_role_arn>` from the output to use in the next step. For example, `arn:aws:iam`::<aws_account_id>:role/my-role-my-namespace-aws-creds`.
 
 .. Check the role policy on AWS to confirm the `<aws_region>` of `"Resource"` in the role policy matches the cluster region:
 +
@@ -164,20 +169,25 @@ serviceaccount/default annotated
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: my-aws-provider # <1>
-  namespace: dev # <2>
+  name: my-aws-provider
+  namespace: dev
 spec:
-  provider: aws # <3>
-  parameters: # <4>
+  provider: aws
+  parameters:
     objects: |
-      - objectName: "testSecret" # <5>
+      - objectName: "testSecret"
         objectType: "secretsmanager"
 ----
-<1> Name of the secret provider class.
-<2> Namespace for the secret provider class. The namespace must match the namespace of the resource which will use the secret.
-<3> Name of the secret store provider.
-<4> Specifies the provider-specific configuration parameters.
-<5> The secret name you created in AWS. 
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the secret provider class.
+`metadata.namespace`:: Specifies the namespace for the secret provider class. The namespace must match the namespace of the resource which will use the secret.
+`spec.provider`:: Specifies the name of the secret store provider.
+`spec.parameters`:: Specifies the provider-specific configuration parameters.
+`spec.parameters.objects`:: Specifies the secret name you created in AWS.
+--
 
 .. Verify that after pushing this YAML file to your {gitops-shortname} repository, the namespace-scoped `SecretProviderClass` resource is populated in the target application page in the Argo CD UI.  
 +

--- a/modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc
+++ b/modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc
@@ -28,15 +28,20 @@ You can manually configure TLS encryption for Redis by creating the `argocd-oper
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: argocd <1>
-  namespace: openshift-gitops <2>
+  name: argocd
+  namespace: openshift-gitops
 spec:
   ha:
-    enabled: true <3>
+    enabled: true
 ----
-<1> The name of the Argo CD instance. 
-<2> The namespace where you want to run the Argo CD instance. 
-<3> The flag value that enables the HA feature. If you do not want to enable HA, do not include this line or set the flag value as `false`.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the Argo CD instance.
+`metadata.namespace`:: Specifies the namespace where you want to run the Argo CD instance.
+`spec.ha.enabled`:: Specifies the flag value that enables the HA feature. If you do not want to enable HA, do not include this line or set the flag value as `false`.
+--
 
 .. Click *Create*.
 
@@ -44,9 +49,14 @@ spec:
 +
 [source,terminal]
 ----
-$ oc get pods -n <namespace> <1>
+$ oc get pods -n <namespace>
 ----
-<1> Specify a namespace where the Argo CD instance is running, for example `openshift-gitops`.
++
+--
+where:
+
+`<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
+--
 +
 .Example output with HA disabled
 [source,terminal]
@@ -85,7 +95,7 @@ argocd-server-9486f88b7-dk2ks              1/1     Running   0          10m
 $ openssl req -new -x509 -sha256 \
   -subj "/C=XX/ST=XX/O=Testing/CN=redis" \
   -reqexts SAN -extensions SAN \
-  -config <(printf "\n[SAN]\nsubjectAltName=DNS:argocd-redis.<namespace>.svc.cluster.local\n[req]\ndistinguished_name=req") \ <1>
+  -config <(printf "\n[SAN]\nsubjectAltName=DNS:argocd-redis.<namespace>.svc.cluster.local\n[req]\ndistinguished_name=req") \
   -keyout /tmp/redis.key \
   -out /tmp/redis.crt \
   -newkey rsa:4096 \
@@ -93,7 +103,12 @@ $ openssl req -new -x509 -sha256 \
   -sha256 \
   -days 10
 ----
-<1> Specify a namespace where the Argo CD instance is running, for example `openshift-gitops`.
++
+--
+where:
+
+`<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
+--
 +
 .Example output
 [source,terminal]
@@ -111,7 +126,7 @@ writing new private key to '/tmp/redis.key'
 $ openssl req -new -x509 -sha256 \
   -subj "/C=XX/ST=XX/O=Testing/CN=redis" \
   -reqexts SAN -extensions SAN \
-  -config <(printf "\n[SAN]\nsubjectAltName=DNS:argocd-redis-ha-haproxy.<namespace>.svc.cluster.local\n[req]\ndistinguished_name=req") \ <1>
+  -config <(printf "\n[SAN]\nsubjectAltName=DNS:argocd-redis-ha-haproxy.<namespace>.svc.cluster.local\n[req]\ndistinguished_name=req") \
   -keyout /tmp/redis-ha.key \
   -out /tmp/redis-ha.crt \
   -newkey rsa:4096 \
@@ -119,7 +134,12 @@ $ openssl req -new -x509 -sha256 \
   -sha256 \
   -days 10
 ----
-<1> Specify a namespace where the Argo CD instance is running, for example `openshift-gitops`.
++
+--
+where:
+
+`<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
+--
 +
 .Example output
 [source,terminal]
@@ -186,9 +206,14 @@ secret/argocd-operator-redis-tls created
 +
 [source,terminal]
 ----
-$ oc annotate secret argocd-operator-redis-tls argocds.argoproj.io/name=<instance-name> <1>
+$ oc annotate secret argocd-operator-redis-tls argocds.argoproj.io/name=<instance-name>
 ----
-<1> Specify a name of the Argo CD instance, for example `argocd`.
++
+--
+where:
+
+`<instance-name>`:: Specifies a name of the Argo CD instance, for example `argocd`.
+--
 +
 .Example output
 [source,terminal]
@@ -200,9 +225,14 @@ secret/argocd-operator-redis-tls annotated
 +
 [source,terminal]
 ----
-$ oc get pods -n <namespace> <1>
+$ oc get pods -n <namespace>
 ----
-<1> Specify a namespace where the Argo CD instance is running, for example `openshift-gitops`.
++
+--
+where:
+
+`<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
+--
 +
 .Example output with HA disabled
 [source,terminal]

--- a/modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc
+++ b/modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc
@@ -33,18 +33,23 @@ By default, the `autotls` setting is disabled.
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: argocd <1>
-  namespace: openshift-gitops <2>
+  name: argocd
+  namespace: openshift-gitops
 spec:
   redis:
-    autotls: openshift <3>
+    autotls: openshift
   ha:
-    enabled: true <4>
+    enabled: true
 ----
-<1> The name of the Argo CD instance.
-<2> The namespace where you want to run the Argo CD instance.
-<3> The flag that enables the `autotls` setting and creates a TLS certificate for Redis.
-<4> The flag value that enables the HA feature. If you do not want to enable HA, do not include this line or set the flag value as `false`.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the Argo CD instance.
+`metadata.namespace`:: Specifies the namespace where you want to run the Argo CD instance.
+`spec.redis.autotls`:: Specifies the flag that enables the `autotls` setting and creates a TLS certificate for Redis.
+`spec.ha.enabled`:: Specifies the flag value that enables the HA feature. If you do not want to enable HA, do not include this line or set the flag value as `false`.
+--
 +
 [TIP]
 ====
@@ -62,9 +67,14 @@ $ oc patch argocds.argoproj.io <instance-name> --type=merge -p '{"spec":{"redis"
 +
 [source,terminal]
 ----
-$ oc get pods -n <namespace> <1>
+$ oc get pods -n <namespace>
 ----
-<1> Specify a namespace where the Argo CD instance is running, for example `openshift-gitops`.
++
+--
+where:
+
+`<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
+--
 +
 .Example output with HA disabled
 [source,terminal]
@@ -98,9 +108,14 @@ argocd-server-9486f88b7-dk2ks              1/1     Running   0          10m
 +
 [source,terminal]
 ----
-$ oc get secrets argocd-operator-redis-tls -n <namespace> <1>
+$ oc get secrets argocd-operator-redis-tls -n <namespace>
 ----
-<1> Specify a namespace where the Argo CD instance is running, for example `openshift-gitops`.
++
+--
+where:
+
+`<namespace>`:: Specifies a namespace where the Argo CD instance is running, for example `openshift-gitops`.
+--
 +
 .Example output 
 [source,terminal]

--- a/modules/gitops-creating-a-new-client-in-dex.adoc
+++ b/modules/gitops-creating-a-new-client-in-dex.adoc
@@ -21,7 +21,12 @@ spec:
   sso:
     provider: dex
     dex:
-      openShiftOAuth: true <1>
+      openShiftOAuth: true
 # ...
 ----
-<1> The `openShiftOAuth` property triggers the Operator to automatically configure the built-in {OCP} `OAuth` server when the value is set to `true`.
++
+--
+where:
+
+`spec.sso.dex.openShiftOAuth`:: Specifies the `openShiftOAuth` property that triggers the Operator to automatically configure the built-in {OCP} `OAuth` server when the value is set to `true`.
+--

--- a/modules/gitops-creating-a-new-client-using-keycloak.adoc
+++ b/modules/gitops-creating-a-new-client-using-keycloak.adoc
@@ -45,12 +45,13 @@ spec:
   sso:
     provider: keycloak
     keycloak:
-      rootCA: "<PEM-encoded-root-certificate>" <1>
+      rootCA: "<PEM-encoded-root-certificate>"
   server:
     route:
       enabled: true
 ----
-<1> A custom certificate used to verify the Keycloak's TLS certificate.
++
+A custom certificate used to verify the Keycloak's TLS certificate.
 + 
 The Operator reconciles changes in the `.spec.sso.keycloak.rootCA` parameter and updates the `oidc.config` parameter with the PEM encoded root certificate in the `argocd-cm` configuration map.
 
@@ -83,21 +84,24 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
-  name: <resource_name> #<1>
+  name: <resource_name>
   labels:
     example: route
 spec:
   sso:
     provider: keycloak
     keycloak:
-     host: <hostname> #<2>
+     host: <hostname>
   server:
     ingress:
       enabled: true
     insecure: true
 ----
-<1> Replace `<resource_name>` with the name of the `ArgoCD` CR.
-<2> Replace `<hostname>` with the name of the host key, for example, `sso.test.example.com`.
++
+where:
++
+`<metadata.name>`:: Specifies the replace `<resource_name>` with the name of the `ArgoCD` CR.
+`<spec.sso.keycloak.host>`:: Specifies the replace `<hostname>` with the name of the host key, for example, `sso.test.example.com`.
 +
 ** To create the `ArgoCD CR`, run the following command:
 +
@@ -135,17 +139,20 @@ $ oc get route keycloak -n <your_namespace> -o yaml
 ----
 kind: Route
 metadata:
-  name: keycloak #<1>
+  name: keycloak
   labels:
     application: keycloak
 spec:
   host: sso.test.example.com
 status:
   ingress:
-    - host: sso.test.example.com #<2>
+    - host: sso.test.example.com
 ----
-<1> Specifies the name of the route.
-<2> Specifies the name of the host key.
++
+where:
++
+`metadata.name`:: Specifies the name of the route.
+`metadata.labels`:: Specifies the name of the host key.
 +
 [NOTE]
 ====

--- a/modules/gitops-creating-and-configuring-the-app-cr-to-reference-the-target-namespace-and-user-defined-appproject-instance.adoc
+++ b/modules/gitops-creating-and-configuring-the-app-cr-to-reference-the-target-namespace-and-user-defined-appproject-instance.adoc
@@ -25,15 +25,20 @@ As a cluster administrator, you can define a certain set of non-control plane na
 kind: Application
 apiVersion: argoproj.io/v1alpha1
 metadata:
-  name: cluster-configs # <1>
-  namespace: dev # <2>
+  name: cluster-configs
+  namespace: dev
 spec:
-  project: project-one # <3>
+  project: project-one
   # ...
 ----
-<1> The name of the application.
-<2> The name of the target namespace for the Argo CD server to create and manage `Application` resources.
-<3> The name of the user-defined `AppProject` instance.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the application.
+`spec.project` (Application):: the name of the target namespace for the Argo CD server to create and manage `Application` resources.
+`spec.project` (AppProject):: the name of the user-defined `AppProject` instance.
+--
 .. Click *Create*.
 +
 The *Applications* page displays the created application. 

--- a/modules/gitops-creating-and-configuring-user-defined-appproject-instance-with-target-namespaces.adoc
+++ b/modules/gitops-creating-and-configuring-user-defined-appproject-instance-with-target-namespaces.adoc
@@ -30,26 +30,31 @@ Applications in the {gitops-shortname} control plane namespace (`openshift-gitop
 kind: AppProject
 apiVersion: argoproj.io/v1alpha1
 metadata:
-  name: project-one # <1>
-  namespace: openshift-gitops # <2>
+  name: project-one
+  namespace: openshift-gitops
 spec:
-  sourceNamespaces: # <3>
-  - dev # <4>
-  - app-team-* # <5>
-  destinations: # <6>
+  sourceNamespaces:
+  - dev
+  - app-team-*
+  destinations:
     - name: '*'
       namespace: '*'
       server: '*'
-   sourceRepos: # <7>
+   sourceRepos:
     - '*'     
 ----
-<1> The name of the user-defined `AppProject` instance.
-<2> The control plane namespace where you want to run the user-defined `AppProject` instance.
-<3> The list of non-control plane namespaces for creating and managing `Application` resources.
-<4> The name of the target namespace for the Argo CD server to create and manage `Application` resources.
-<5> With wildcards (`pass:[*]`), specifies the name of the target namespaces matching the pattern `app-team-pass:[*]`, such as `app-team-1` and `app-team-2`, for the Argo CD server to create and manage `Application` resources.
-<6> References to the clusters and namespaces into which applications within the user-defined `AppProject` instance can deploy.
-<7> References to the repositories from which applications within the user-defined `AppProject` instance can pull manifests.
++
+--
+where:
+
+`kind` (AppProject):: Specifies the name of the user-defined `AppProject` instance.
+`kind` (AppProject):: Specifies the control plane namespace where you want to run the user-defined `AppProject` instance.
+`spec` (Application):: Specifies the list of non-control plane namespaces for creating and managing `Application` resources.
+`spec` (Application):: Specifies the name of the target namespace for the Argo CD server to create and manage `Application` resources.
+`spec.sourceRepos` or `spec.destinations` (wildcard [*]):: Specifies a wildcard (`[*]`), that contains the name of the target namespaces matching the pattern `app-team-pass:[*]`, such as `app-team-1` and `app-team-2`, for the Argo CD server to create and manage `Application` resources.
+`kind` (AppProject):: Specifies the references to the clusters and namespaces into which applications within the user-defined `AppProject` instance can deploy.
+`kind` (AppProject):: Specifies the references to the repositories from which applications within the user-defined `AppProject` instance can pull manifests.
+--
 .. Click *Create*.
 +
 The *AppProjects* page displays the created user-defined `AppProject` instance.

--- a/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
+++ b/modules/gitops-creating-user-defined-cluster-roles-and-configuring-user-defined-permissions-for-application-controller.adoc
@@ -26,10 +26,12 @@ As a cluster administrator, to add user-defined permissions to your aggregated c
 $ oc apply -n <namespace> -f <cluster_role_name>.yaml
 ----
 +
+--
 where:
 
 `<namespace>`:: Specifies the name of your defined namespace.
 `<cluster_role_name>`:: Specifies the name of your defined cluster role YAML file.
+--
 +
 .Example user-defined cluster role YAML
 [source,yaml]
@@ -37,13 +39,13 @@ where:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata: 
-  name: user-application-controller # <1>
-  labels: # <2>
+  name: user-application-controller
+  labels:
     app.kubernetes.io/managed-by: spring-petclinic
     app.kubernetes.io/name: example
     app.kubernetes.io/part-of: argocd
     argocd/aggregate-to-admin: 'true'
-rules: # <3>
+rules:
   - verbs:
       - '*'
     apiGroups:
@@ -60,9 +62,14 @@ rules: # <3>
     resources:
       - scansettingbindings
 ----
-<1> The name of the user-defined cluster role.
-<2> The labels match the predefined list of an existing `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role.
-<3> The user-defined permissions that are to be added into the aggregated cluster role through the `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the user-defined cluster role.
+`metadata.labels.argocd/aggregate-to-admin`:: Specifies that the cluster role is aggregated into the Argo CD application controller admin cluster role, allowing the permissions defined in this role to be included automatically.
+`rules`:: Specifies the list of permissions granted by the cluster role, including allowed API groups, resources, and verbs.
+--
 +
 [TIP]
 ====
@@ -84,10 +91,12 @@ A user-defined cluster role is created.
 $ oc get ClusterRole/<argocd_name>-<argocd_namespace>-argocd-application-controller-admin -o yaml
 ----
 +
+--
 where:
 
 `<argocd_name>`:: Specifies the name of your user-defined cluster-scoped Argo CD instance.
 `<argocd_namespace>`:: Specifies the namespace where Argo CD is installed.
+--
 +
 .Example output
 [source,terminal]
@@ -144,10 +153,12 @@ Alternatively, you can use the {OCP} web console to verify from the *Administrat
 $ oc get ClusterRole/<argocd_name>-<argocd_namespace>-argocd-application-controller -o yaml
 ----
 +
+--
 where:
 
 `<argocd_name>`:: Specifies the name of your user-defined cluster-scoped Argo CD instance.
 `<argocd_namespace>`:: Specifies the namespace where Argo CD is installed.
+--
 +
 .Example output of the aggregated cluster role
 [source,terminal]

--- a/modules/gitops-customizing-permissions-for-cluster-scoped-instances.adoc
+++ b/modules/gitops-customizing-permissions-for-cluster-scoped-instances.adoc
@@ -23,7 +23,7 @@ For example purposes, the following instructions focus only on user-defined clus
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: example-spring-petclinic-argocd-application-controller # <1>
+  name: example-spring-petclinic-argocd-application-controller
 rules:
   - verbs:
       - get
@@ -37,13 +37,17 @@ rules:
       - '*'
     apiGroups:
       - ''
-    resources: # <2>
+    resources:
       - namespaces 
       - persistentvolumes 
 ----
-<1> The name of the cluster role according to the <argocd_name>-<argocd_namespace>-<control_plane_component> naming convention.
-<2> The resources to which you want to grant permissions at the cluster level.
++
+--
+where:
 
+`metadata.name`:: Specifies the name of the cluster role according to the <argocd_name>-<argocd_namespace>-<control_plane_component> naming convention.
+`metadata.rules`:: Specifies the resources to which you want to grant permissions at the cluster level.
+--
 . Click *Create* to add the cluster role.
 
 . Find the service account used by the control plane component you are customizing permissions for, by performing the following steps:

--- a/modules/gitops-deploy-argocd-application-in-autonomous-mode.adoc
+++ b/modules/gitops-deploy-argocd-application-in-autonomous-mode.adoc
@@ -48,7 +48,7 @@ spec:
 +
 where:
 
-`namespace: openshift-gitops`:: Specifies the namespace where the Argo CD instance (Agent) is running on the spoke cluster. This controller manages the Application resource.
+`metadata.namespace`:: Specifies the namespace where the Argo CD instance (Agent) is running on the spoke cluster. This controller manages the Application resource.
 `source.repoURL`:: Specifies the Git repository that stores the application manifests.
 `source.targetRevision`:: Specifies the Git revision Argo CD should track.
 `source.path`:: Specifies the directory inside the repository containing the application manifests.

--- a/modules/gitops-deploy-argocd-application-in-managed-mode.adoc
+++ b/modules/gitops-deploy-argocd-application-in-managed-mode.adoc
@@ -48,8 +48,8 @@ spec:
 +
 where:
 
-`<namespace>`:: Specifies the namespace on the principal cluster where the Agent's managed applications are stored.
-`<name>`:: Specifies the name of the Agent cluster on the hub.
+`<metadata.name>`:: Specifies the name of the Agent cluster on the hub.
+`<metadata.namespace>`:: Specifies the namespace on the principal cluster where the Agent's managed applications are stored.
 
 . Apply the configuration in the hub cluster by running the following command:
 +

--- a/modules/gitops-deploying-a-rollout.adoc
+++ b/modules/gitops-deploying-a-rollout.adoc
@@ -27,21 +27,21 @@ metadata:
 spec:
   replicas: 5
   strategy:
-    canary: #<1>        
-      steps: #<2>
-      - setWeight: 20 #<3>       
-      - pause: {}  #<4>         
-      - setWeight: 40 
-      - pause: {duration: 45}  #<5>     
+    canary:
+      steps:
+      - setWeight: 20
+      - pause: {}
+      - setWeight: 40
+      - pause: {duration: 45}
       - setWeight: 60
-      - pause: {duration: 20}       
+      - pause: {duration: 20}
       - setWeight: 80
       - pause: {duration: 10}
   revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: rollouts-demo
-  template: #<6>
+  template:
     metadata:
       labels:
         app: rollouts-demo
@@ -58,12 +58,17 @@ spec:
             memory: 32Mi
             cpu: 5m
 ----
-<1> The deployment strategy that the rollout must use.
-<2> Specify the steps for the rollout. This example gradually routes 20%, 40%, 60%, and 80% of traffic to the canary version.
-<3> The percentage of traffic that must be directed to the canary version. A value of 20 means that 20% of traffic is directed to the canary version.
-<4> Specify to the Argo Rollouts controller to pause indefinitely until it finds a request for promotion.
-<5> Specify to the Argo Rollouts controller to pause for a duration of 45 seconds. You can set the duration value in seconds (`s`), minutes (`m`), or hours (`h`). For example, you can specify `1h` for an hour. If no value is specified, the duration value defaults to seconds.
-<6> Specifies the pods that are to be created.
++
+--
+where:
+
+`spec.strategy.canary`:: Specifies the deployment strategy that the rollout must use.
+`spec.strategy.canary.steps`:: Specifies the steps for the rollout. This example gradually routes 20%, 40%, 60%, and 80% of traffic to the canary version.
+`spec.strategy.canary.steps.setWeight`:: Specifies the percentage of traffic that must be directed to the canary version. A value of 20 means that 20% of traffic is directed to the canary version.
+`spec.strategy.canary.steps.pause`:: Specifies to the Argo Rollouts controller to pause indefinitely until it finds a request for promotion.
+`spec.strategy.canary.steps.pause.duration`:: Specifies to the Argo Rollouts controller to pause for a specified duration. You can set the duration value in seconds (`s`), minutes (`m`), or hours (`h`). For example, you can specify `1h` for an hour. If no value is specified, the duration value defaults to seconds.
+`spec.template`:: Specifies the pods that are to be created.
+--
 
 . Click *Create*.
 +
@@ -76,9 +81,14 @@ To ensure that the rollout becomes available quickly on creation, the Argo Rollo
 +
 [source,terminal]
 ----
-$ oc argo rollouts list rollouts -n <namespace> <1>
+$ oc argo rollouts list rollouts -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
+--
 +
 .Example output
 [source,terminal]
@@ -98,17 +108,22 @@ kind: Service
 metadata:
   name: rollouts-demo
 spec:
-  ports: #<1>
+  ports:
   - port: 80
     targetPort: http
     protocol: TCP
     name: http
 
-  selector: #<2>
+  selector:
     app: rollouts-demo
 ----
-<1> Specifies the name of the port used by the application for running inside the container.
-<2> Ensure that the contents of the `selector` field are the same as in the `Rollout` custom resource (CR).
++
+--
+where:
+
+`spec.ports`:: Specifies the name of the port used by the application for running inside the container.
+`spec.selector`:: Specifies the selector to match pods. Ensure that the contents of the `selector` field are the same as in the `Rollout` custom resource (CR).
+--
 .. Click *Create*.
 +
 Rollouts automatically update the created service with pod template hash of the canary `ReplicaSet`. For example, `rollouts-pod-template-hash: 687d76d795`.
@@ -117,9 +132,14 @@ Rollouts automatically update the created service with pod template hash of the 
 +
 [source,terminal]
 ----
-$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace> <1>
+$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
+--
 +
 .Example output
 [source,terminal]
@@ -160,9 +180,10 @@ Alternatively, you can verify that the rollout is healthy by running the followi
 
 [source,terminal]
 ----
-$ oc argo rollouts status rollouts-demo -n <namespace> <1>
+$ oc argo rollouts status rollouts-demo -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
++
+Specify the namespace where the `Rollout` resource is defined.
 
 .Example output
 [source,terminal]

--- a/modules/gitops-disabling-automatic-scraping-of-metrics-for-argo-cd-instances.adoc
+++ b/modules/gitops-disabling-automatic-scraping-of-metrics-for-argo-cd-instances.adoc
@@ -40,14 +40,19 @@ As a cluster administrator, by disabling metric scraping for individual instance
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
- name: example  # <1>
- namespace: spring-petclinic # <2>
+ name: example
+ namespace: spring-petclinic
 spec:
  monitoring:
    disableMetrics: true
 ----
-<1> The name of the user-defined Argo CD instance.
-<2> The namespace where you want to run the user-defined Argo CD instance.
++
+--
+where:
+
+`name`:: Specifies the name of the user-defined Argo CD instance.
+`namespace`:: Specifies the namespace where you want to run the user-defined Argo CD instance.
+--
 +
 [TIP]
 ====

--- a/modules/gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance.adoc
+++ b/modules/gitops-disabling-the-creation-of-the-default-cluster-roles-for-the-cluster-scoped-instance.adoc
@@ -19,16 +19,21 @@ To add or remove permissions to cluster-wide resources, as needed, you must disa
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: example # <1>
-  namespace: spring-petclinic # <2>
+  name: example
+  namespace: spring-petclinic
 # ...
 spec:
-  defaultClusterScopedRoleDisabled: true # <3>
+  defaultClusterScopedRoleDisabled: true
 # ...
 ----
-<1> The name of the cluster-scoped instance.
-<2> The namespace where you want to run the cluster-scoped instance.
-<3> The flag value that disables the creation of the default cluster roles for the cluster-scoped instance. If you want the Operator to recreate the default cluster roles and cluster role bindings for the cluster-scoped instance, set the field value to `false`.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the cluster-scoped instance.
+`metadata.namespace`:: Specifies the namespace where you want to run the cluster-scoped instance.
+`spec.defaultClusterScopedRoleDisabled`:: Specifies the flag value that disables the creation of the default cluster roles for the cluster-scoped instance. If you want the Operator to recreate the default cluster roles and cluster role bindings for the cluster-scoped instance, set the field value to `false`.
+--
 +
 .Sample output
 [source,terminal]

--- a/modules/gitops-enable-traffic-management-and-metric-plugins-in-argo-rollouts.adoc
+++ b/modules/gitops-enable-traffic-management-and-metric-plugins-in-argo-rollouts.adoc
@@ -32,18 +32,23 @@ metadata:
 spec:
   plugins:
     trafficManagement:
-      - name: argoproj-labs/gatewayAPI #<1>
-        location: https://github.com/sample-metric-plugin #<2>
+      - name: argoproj-labs/gatewayAPI
+        location: https://github.com/sample-metric-plugin
     metric:
-      - name: argoproj-labs/sample-prometheus #<3>
-        location: https://github.com/sample-trafficrouter-plugin #<4>
-        sha256: dac10cbf57633c9832a17f8c27d2ca34aa97dd3d #<5>
+      - name: argoproj-labs/sample-prometheus
+        location: https://github.com/sample-trafficrouter-plugin
+        sha256: dac10cbf57633c9832a17f8c27d2ca34aa97dd3d
 ----
-<1> Specifies the name of the `trafficManagement` plugin.
-<2> Specifies the location of the `trafficManagement` plugin.
-<3> Specifies the name of the `metric` plugin.
-<4> Specifies the location of the `metric` plugin.
-<5> Optional: Specifies the SHA256 signature of the plugin binary, which is downloaded and installed by the Rollouts controller.
++
+--
+where:
+
+`spec.plugins.trafficManagement.name`:: Specifies the name of the `trafficManagement` plugin.
+`spec.plugins.trafficManagement.location`:: Specifies the location of the `trafficManagement` plugin.
+`spec.plugins.metric.name`:: Specifies the name of the `metric` plugin.
+`spec.plugins.metric.location`:: Specifies the location of the `metric` plugin.
+`spec.plugins.metric.sha256`:: Specifies the SHA256 signature of the plugin binary that is downloaded and installed by the Rollouts controller. Optional.
+--
 
 . Click *Create*.
 
@@ -55,7 +60,7 @@ spec:
 +
 As a result, the plugins defined in the `RolloutManager` CR are updated in the *argo-rollouts-config* config map.
 +
-.Example updated traffic management and metric plugins in the *argo-rollouts-config* `ConfigMap`
+.Example updated traffic management and metric plugins in the argo-rollouts-config config map
 [source,yaml]
 ----
 kind: ConfigMap
@@ -69,27 +74,28 @@ metadata:
     app.kubernetes.io/part-of: argo-rollouts
 data:
   metricPlugins: |
-      - name: "argoproj-labs/sample-prometheus" #<1>
-        location: https://github.com/sample-metric-plugin #<2>
-        sha256: dac10cbf57633c9832a17f8c27d2ca34aa97dd3d #<3>
+      - name: "argoproj-labs/sample-prometheus"
+        location: https://github.com/sample-metric-plugin
+        sha256: dac10cbf57633c9832a17f8c27d2ca34aa97dd3d
   trafficRouterPlugins: |
-    - name: argoproj-labs/gatewayAPI #<4>
-      location: https://github.com/sample-metric-plugin #<5>
-      sha256: "" #<6>
-    - name: argoproj-labs/openshift #<7>
-      location: file:/plugins/rollouts-trafficrouter-openshift/openshift-route-plugin #<8>
-      sha256: "" #<9>
+    - name: argoproj-labs/gatewayAPI
+      location: https://github.com/sample-metric-plugin
+      sha256: ""
+    - name: argoproj-labs/openshift
+      location: file:/plugins/rollouts-trafficrouter-openshift/openshift-route-plugin
+      sha256: ""
 
 ----
-<1> Specifies the name of the `metric` plugin.
-<2> Specifies the location of the `metric` plugin.
-<3> Specifies the sha256 signature of the `metric` plugin.
-<4> Specifies the name of the `trafficmanagement` plugin.
-<5> Specifies the location of the `trafficmanagement` plugin.
-<6> Specifies the sha256 signature of the `trafficmanagement` plugin.
-<7> Specifies the name of the default `trafficmanagement` plugin.
-<8> Specifies the location of the default `trafficmanagement` plugin.
-<9> Specifies the sha256 signature of the `trafficmanagement` plugin.
++
+--
+where:
 
+`data.metricPlugins.name`:: Specifies the name of the `metric` plugin.
+`data.metricPlugins.location`:: Specifies the location of the `metric` plugin.
+`data.metricPlugins.sha256`:: Specifies the sha256 signature of the `metric` plugin.
+`data.trafficRouterPlugins.name`:: Specifies the name of the `trafficmanagement` plugin.
+`data.trafficRouterPlugins.location`:: Specifies the location of the `trafficmanagement` plugin.
+`data.trafficRouterPlugins.sha256`:: Specifies the sha256 signature of the `trafficmanagement` plugin.
+--
 +
 By configuring traffic and metric plugins directly through the `RolloutManager` CR, you streamline the rollout process, reduce the chance of errors, and ensure consistent plugin management across your environment. This enhances control and flexibility while simplifying deployment procedures.

--- a/modules/gitops-enabling-argo-rollouts-ui-on-an-argo-cd-instance.adoc
+++ b/modules/gitops-enabling-argo-rollouts-ui-on-an-argo-cd-instance.adoc
@@ -37,10 +37,14 @@ metadata:
   name: argocd
 spec:  
   server:    
-    enableRolloutsUI: true <1>
+    enableRolloutsUI: true
 ----
-<1> Set this value to `true` to configure the `enableRolloutsUI` field.
++
+--
+where:
 
+`spec.server.enableRolloutsUI`:: Specifies the value of `enableRolloutsUI` field to configure the Rollouts UI.
+--
 . Click *Save*.
 
 . In the *Administrator* perspective of the web console, navigate to the {rh-app-icon} menu -> *OpenShift GitOps* -> *Cluster Argo CD*. The login page of the Argo CD Web UI is displayed in a new window.

--- a/modules/gitops-enabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
+++ b/modules/gitops-enabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
@@ -47,7 +47,7 @@ spec:
     - name: ArgoCDComponentStatus
       rules:
        # ...
-        - alert: ApplicationSetControllerNotReady <1>
+        - alert: ApplicationSetControllerNotReady
           annotations:
             message: >-
               applicationSet controller deployment for Argo CD instance in
@@ -61,4 +61,9 @@ spec:
           labels:
             severity: critical
 ----
-<1> Alert rule in the PrometheusRule that checks whether the workloads created by the Argo CD instances are running as expected.
++
+--
+where:
+
+`rules.alert`:: Specifies the alert rule used in the `PrometheusRule` that checks whether the workloads created by the Argo CD instances are running as expected.
+--

--- a/modules/gitops-enabling-the-application-set-resources-in-non-control-plane-namespaces.adoc
+++ b/modules/gitops-enabling-the-application-set-resources-in-non-control-plane-namespaces.adoc
@@ -22,11 +22,15 @@ metadata:
   namespace: spring-petclinic
 spec:
   applicationSet:
-    sourceNamespaces: <1>
-      - dev <2>
+    sourceNamespaces:
+      - dev
 ----
-<1> List of non-control plane namespaces for creating and managing `ApplicationSet` resources.
-<2> Name of the target namespace for the Argo CD server to create and manage `ApplicationSet` resources.
++
+--
+where:
+
+`spec.applicationSet`:: Specifies the list of non-control plane namespaces for creating and managing `ApplicationSet` resources.
+--
 +
 [NOTE]
 ====

--- a/modules/gitops-enabling-the-creation-of-aggregated-cluster-roles.adoc
+++ b/modules/gitops-enabling-the-creation-of-aggregated-cluster-roles.adoc
@@ -18,16 +18,21 @@ To enable the creation of aggregated cluster roles for the Argo CD Application C
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: example # <1>
-  namespace: spring-petclinic # <2>
+  name: example
+  namespace: spring-petclinic
 # ...
 spec:
-  aggregatedClusterRoles: true # <3>
+  aggregatedClusterRoles: true
 # ...
 ----
-<1> The name of the cluster-scoped instance.
-<2> The namespace where you want to run the cluster-scoped instance.
-<3> The value set to `true` enables the creation of aggregated cluster roles. If you do not want to enable the creation of aggregated cluster roles, either do not include this line or set the value to `false`.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the cluster-scoped instance.
+`metadata.namespace`:: Specifies the namespace where you want to run the cluster-scoped instance.
+`spec.aggregatedClusterRoles`:: Specifies the value of the cluster roles to enable the creation of aggregated cluster roles. If you do not want to enable the creation of aggregated cluster roles, either do not include this line or set the value to `false`.
+--
 +
 .Example output
 [source,terminal]
@@ -64,14 +69,15 @@ Spec:
 Status:
   Application Controller:      Running
   Application Set Controller:  Unknown
-  Phase:                       Available # <1>
+  Phase:                       Available
   Redis:                       Running
   Repo:                        Running
   Server:                      Running
   Sso:                         Unknown
 Events:                        <none>
 ----
-<1> The `Available` status indicates that the cluster-scoped Argo CD instance is healthy and available.
++
+The `Available` status indicates that the cluster-scoped Argo CD instance is healthy and available.
 +
 [NOTE]
 ====
@@ -123,11 +129,17 @@ Alternatively, you can use the {OCP} web console to verify from the *Administrat
 +
 [source,terminal]
 ----
-$ oc get ClusterRole/<cluster_role_name> -o yaml # <1>
+$ oc get ClusterRole/<cluster_role_name> -o yaml
 ----
-<1> Replace `<cluster_role_name>` with the name of the role created.
++
+--
+where:
+
+`<cluster_role_name>`:: Specifies the name of the role created.
+--
 +
 .Example output of the aggregated cluster role
++
 [source,terminal]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -144,21 +156,27 @@ metadata:
     app.kubernetes.io/managed-by: spring-petclinic
     app.kubernetes.io/name: example
     app.kubernetes.io/part-of: argocd 
-  name: example-spring-petclinic-argocd-application-controller # <1>
+  name: example-spring-petclinic-argocd-application-controller
   resourceVersion: "78640"
   uid: aeeb2ef5-b531-4fe3-a61a-b5ad8dd8ca6e
-aggregationRule: # <2>
+aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       app.kubernetes.io/managed-by: spring-petclinic
       argocd/aggregate-to-controller: "true"
-rules: [] # <3>
+rules: []
 ----
-<1> The name of the aggregated cluster role.
-<2> The predefined list of labels indicates that the aggregated cluster role can inherit permissions from the other user-defined cluster roles.
-<3> No predefined permissions are set. However, when the Operator immediately creates a `<argocd_name>-<argocd_namespace>-argocd-application-controller-view` cluster role, the corresponding predefined `view` permissions are added into the aggregated cluster role.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the aggregated cluster role.
+`aggregationRule.clusterRoleSelectors`:: Specifies the predefined list of labels indicates that the aggregated cluster role can inherit permissions from the other user-defined cluster roles.
+`rules`:: Specifies the predefined permissions. However, when the Operator immediately creates a `<argocd_name>-<argocd_namespace>-argocd-application-controller-view` cluster role, the corresponding predefined `view` permissions are added into the aggregated cluster role.
+--
 +
 .Example output of the `view` cluster role
++
 [source,terminal]
 ----
 apiVersion: rbac.authorization.k8s.io/v1
@@ -170,15 +188,15 @@ metadata:
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"argoproj.io/v1beta1","kind":"ArgoCD","metadata":{"annotations":{},"name":"example","namespace":"spring-petclinic"},"spec":{"aggregatedClusterRoles":true}}
   creationTimestamp: "2024-08-14T09:59:14Z"
-  labels: # <1>
+  labels:
     app.kubernetes.io/managed-by: spring-petclinic
     app.kubernetes.io/name: example
     app.kubernetes.io/part-of: argocd
     argocd/aggregate-to-controller: "true"
-  name: example-spring-petclinic-argocd-application-controller-view # <2>
+  name: example-spring-petclinic-argocd-application-controller-view
   resourceVersion: "78639"
   uid: 068b8867-7a0c-4af3-a17a-0560a00eba41
-rules: # <3>
+rules:
 - apiGroups:
   - '*'
   resources:
@@ -193,9 +211,14 @@ rules: # <3>
   - get
   - list
 ----
-<1> The labels match the predefined list of an existing aggregated cluster role.
-<2> The name of the `view` cluster role.
-<3> The predefined `view` permissions. These permissions are added into the existing aggregated cluster role.
++
+--
+where:
+
+`metadata.labels`:: Defines the labels to match the predefined list of an existing aggregated cluster role.
+`metadata.name`:: Specifies the name of the `view` cluster role.
+`rules`:: Specifies the predefined `view` permissions. These permissions are added into the existing aggregated cluster role.
+--
 +
 .Example output of the `admin` cluster role
 [source,terminal]
@@ -210,25 +233,30 @@ metadata:
       {"apiVersion":"argoproj.io/v1beta1","kind":"ArgoCD","metadata":{"annotations":{},"name":"example","namespace":"spring-petclinic"},"spec":{"aggregatedClusterRoles":true}}
     rbac.authorization.kubernetes.io/autoupdate: "true"
   creationTimestamp: "2024-08-14T09:59:15Z"
-  labels: # <1>
+  labels:
     app.kubernetes.io/managed-by: spring-petclinic
     app.kubernetes.io/name: example
     app.kubernetes.io/part-of: argocd
     argocd/aggregate-to-controller: "true"
-  name: example-spring-petclinic-argocd-application-controller-admin # <2>
+  name: example-spring-petclinic-argocd-application-controller-admin
   resourceVersion: "78642"
   uid: e2d35b6f-0832-4993-8b24-915a725454f9
-aggregationRule: # <3>
+aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
       app.kubernetes.io/managed-by: spring-petclinic
       argocd/aggregate-to-admin: "true"
-rules: null # <4>
+rules: null
 ----
-<1> The labels match the predefined list of an existing aggregated cluster role.
-<2> The name of the `admin` cluster role.
-<3> The predefined list of labels indicates that the existing `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role can inherit permissions from the other user-defined cluster roles.
-<4> Specifies that no permissions are defined yet in one or more user-defined cluster roles.
++
+--
+where:
+
+`metadata.labels`:: Specifies the labels to match the predefined list of an existing aggregated cluster role.
+`metadata.name`:: Specifies the name of the `admin` cluster role.
+`aggregationRule.clusterRoleSelectors`:: Specifies the predefined list of labels indicates that the existing `<argocd_name>-<argocd_namespace>-argocd-application-controller-admin` cluster role can inherit permissions from the other user-defined cluster roles.
+`rules`:: Specifies that no permissions are defined yet in one or more user-defined cluster roles.
+--
 +
 [TIP]
 ====

--- a/modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc
+++ b/modules/gitops-enabling-the-round-robin-sharding-algorithm-in-web-console.adoc
@@ -34,17 +34,23 @@ metadata:
 spec:
   controller:
     sharding:
-      enabled: true <1>
-      replicas: 3 <2>
-    env: <3>
+      enabled: true
+      replicas: 3
+    env:
       - name: ARGOCD_CONTROLLER_SHARDING_ALGORITHM 
         value: round-robin
-    logLevel: debug <4>
+    logLevel: debug
 ----
-<1> Set the `sharding.enabled` parameter to `true` to enable sharding.
-<2> Set the number of replicas to the wanted value, for example, `3`.
-<3> Set the sharding algorithm to `round-robin`.
-<4> Set the log level to `debug` so that you can verify to which shard each cluster is attached.
++
+--
+where:
+
+`spec.controller.sharding.enabled`:: Specifies the value of the `sharding.enabled` parameter to enable sharding.
+`spec.controller.sharding.replicas`:: Specifies the number of controller replicas, for example, `3`.
+`spec.controller.env.name`:: Specifies the environment variable `ARGOCD_CONTROLLER_SHARDING_ALGORITHM`.
+`spec.controller.env.value`:: Specifies the sharding algorithm to `round-robin`.
+`spec.controller.logLevel`:: Specifies the log level as `debug` so that you can verify to which shard each cluster is attached.
+--
 
 . Click *Save*.
 +
@@ -72,11 +78,12 @@ If you edit the default `openshift-gitops` instance, the *Managed resource* dial
 ----
 time="2023-12-13T09:05:34Z" level=info msg="ArgoCD Application Controller is starting" built="2023-12-01T19:21:49Z" commit=a3vd5c3df52943a6fff6c0rg181fth3248976299 namespace=openshift-gitops version=v2.9.2+c5ea5c4
 time="2023-12-13T09:05:34Z" level=info msg="Processing clusters from shard 1"
-time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin" <1>
+time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin"
 time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin"
 time="2023-12-13T09:05:34Z" level=info msg="appResyncPeriod=3m0s, appHardResyncPeriod=0s"
 ----
-<1> Look for the `"Using filter function:  round-robin"` message.
++
+Look for the `"Using filter function:  round-robin"` message.
 
 .. In the log *Search* field, search for `processed by shard` to verify that the cluster distribution across shards is even, as shown in the following example.
 +
@@ -92,11 +99,12 @@ time="2023-12-13T09:05:34Z" level=debug msg="ClustersList has 3 items"
 time="2023-12-13T09:05:34Z" level=debug msg="Adding cluster with id= and name=in-cluster to cluster's map"
 time="2023-12-13T09:05:34Z" level=debug msg="Adding cluster with id=068d8b26-6rhi-4w23-jrf6-wjjfyw833n23 and name=in-cluster2 to cluster's map"
 time="2023-12-13T09:05:34Z" level=debug msg="Adding cluster with id=836d8b53-96k4-f68r-8wq0-sh72j22kl90w and name=in-cluster3 to cluster's map"
-time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id= will be processed by shard 0" <1>
-time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=068d8b26-6rhi-4w23-jrf6-wjjfyw833n23 will be processed by shard 1" <1>
-time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=836d8b53-96k4-f68r-8wq0-sh72j22kl90w will be processed by shard 2" <1>
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id= will be processed by shard 0"
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=068d8b26-6rhi-4w23-jrf6-wjjfyw833n23 will be processed by shard 1"
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=836d8b53-96k4-f68r-8wq0-sh72j22kl90w will be processed by shard 2"
 ----
-<1> In this example, 3 clusters are attached consecutively to shard 0, shard 1, and shard 2.
++
+In this example, 3 clusters are attached consecutively to shard 0, shard 1, and shard 2.
 +
 [NOTE]
 ====

--- a/modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc
+++ b/modules/gitops-enabling-the-round-robin-sharding-algorithm-using-cli.adoc
@@ -68,11 +68,14 @@ $ oc logs <argocd_application_controller_pod> -n <namespace>
 ----
 time="2023-12-13T09:05:34Z" level=info msg="ArgoCD Application Controller is starting" built="2023-12-01T19:21:49Z" commit=a3vd5c3df52943a6fff6c0rg181fth3248976299 namespace=<namespace> version=v2.9.2+c5ea5c4
 time="2023-12-13T09:05:34Z" level=info msg="Processing clusters from shard 1"
-time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin" <1>
+time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin"
 time="2023-12-13T09:05:34Z" level=info msg="Using filter function:  round-robin"
 time="2023-12-13T09:05:34Z" level=info msg="appResyncPeriod=3m0s, appHardResyncPeriod=0s"
 ----
-<1> Look for the `"Using filter function:  round-robin"` message.
++
+--
+Verify that the `"Using filter function:  round-robin"` message appears in the output. This message confirms that the Argo CD Application Controller is using the `round-robin` sharding algorithm.
+--
 
 . Verify that the cluster distribution across shards is even by performing the following steps:
 
@@ -99,11 +102,12 @@ $ oc logs <argocd_application_controller_pod> -n <namespace> | grep "processed b
 .Example output snippet
 [source,terminal]
 ----
-time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id= will be processed by shard 0" <1>
-time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=068d8b26-6rhi-4w23-jrf6-wjjfyw833n23 will be processed by shard 1" <1>
-time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=836d8b53-96k4-f68r-8wq0-sh72j22kl90w will be processed by shard 2" <1>
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id= will be processed by shard 0"
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=068d8b26-6rhi-4w23-jrf6-wjjfyw833n23 will be processed by shard 1"
+time="2023-12-13T09:05:34Z" level=debug msg="Cluster with id=836d8b53-96k4-f68r-8wq0-sh72j22kl90w will be processed by shard 2"
 ----
-<1> In this example, 3 clusters are attached consecutively to shard 0, shard 1, and shard 2.
++
+In this example, 3 clusters are attached consecutively to shard 0, shard 1, and shard 2.
 +
 [NOTE]
 ====

--- a/modules/gitops-installing-argo-rollouts-cli-on-linux.adoc
+++ b/modules/gitops-installing-argo-rollouts-cli-on-linux.adoc
@@ -51,13 +51,18 @@ $ oc argo rollouts version
 [source,terminal]
 ----
 kubectl-argo-rollouts: v1.6.6+737ca89
-  BuildDate: 2024-02-13T15:39:31Z #<1>
+  BuildDate: 2024-02-13T15:39:31Z
   GitCommit: 737ca89b42e4791e96e05b438c2b8540737a2a1a
   GitTreeState: clean
-  GoVersion: go1.20.14 #<2>
+  GoVersion: go1.20.14
   Compiler: gc
-  Platform: linux/amd64 #<3>
+  Platform: linux/amd64
 ----
-<1> The build date information of the Argo Rollouts binary.
-<2> The version of the Go language used for building the Argo Rollouts binary.
-<3> The platform used for building the Argo Rollouts binary.
++
+--
+where:
+
+`kubectl-argo-rollouts`:: Specifies the build date information of the Argo Rollouts binary.
+`kubectl-argo-rollouts.BuildDate`:: Specifies the version of the Go language used for building the Argo Rollouts binary.
+`kubectl-argo-rollouts.GitCommit`:: Specifies the platform used for building the Argo Rollouts binary.
+--

--- a/modules/gitops-installing-argocd-agent-in-autonomous-mode-by-using-helm-chart.adoc
+++ b/modules/gitops-installing-argocd-agent-in-autonomous-mode-by-using-helm-chart.adoc
@@ -37,9 +37,9 @@ spec:
 +
 where:
 
-`<podSelector>`:: Selects the pods this policy applies to, for example, the Redis pod labeled `app.kubernetes.io/name: <ArgoCD Instance Name>-redis`.
-`<ingress>`:: Defines the allowed inbound traffic rules for the selected pods.
-`<policyTypes>`:: Indicates that this policy is an Ingress policy, meaning it only checks incoming connections.
+`<spec.podSelector>`:: Selects the pods this policy applies to, for example, the Redis pod labeled `app.kubernetes.io/name: <ArgoCD Instance Name>-redis`.
+`<spec.ingress>`:: Defines the allowed inbound traffic rules for the selected pods.
+`<spec.policyTypes>`:: Indicates that this policy is an Ingress policy, meaning it only checks incoming connections.
 
 . Apply the network policy by using the following command:
 +

--- a/modules/gitops-installing-argocd-agent-in-managed-mode-by-using-helm-chart.adoc
+++ b/modules/gitops-installing-argocd-agent-in-managed-mode-by-using-helm-chart.adoc
@@ -37,9 +37,9 @@ spec:
 +
 where:
 
-`<podSelector>`:: Selects the pods this policy applies to, for example, the Redis pod labeled `app.kubernetes.io/name: <ArgoCD Instance Name>-redis`.
-`<ingress>`:: Defines the allowed inbound traffic rules for the selected pods.
-`<policyTypes>`:: Indicates that this policy is an Ingress policy, meaning it only checks incoming connections.
+`<spec.podSelector>`:: Selects the pods this policy applies to, for example, the Redis pod labeled `app.kubernetes.io/name: <ArgoCD Instance Name>-redis`.
+`<spec.ingress>`:: Defines the allowed inbound traffic rules for the selected pods.
+`<spec.policyTypes>`:: Indicates that this policy is an Ingress policy, meaning it only checks incoming connections.
 
 .. Apply the network policy by using the following command:
 +

--- a/modules/gitops-installing-argocd-cli-on-linux-using-rpm.adoc
+++ b/modules/gitops-installing-argocd-cli-on-linux-using-rpm.adoc
@@ -125,6 +125,12 @@ argocd: v2.9.5+f943664
   GoVersion: go1.20.10
   Compiler: gc
   Platform: linux/amd64
-  ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024 <1>
+  ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024
 ----
-<1> The build information of {gitops-title} built by Red Hat.
++
+--
+where:
+
+`ExtraBuildInfo: openshift-gitops-version`:: Specifies the build information of {gitops-title} built by Red Hat.
+--
+

--- a/modules/gitops-installing-argocd-cli-on-linux.adoc
+++ b/modules/gitops-installing-argocd-cli-on-linux.adoc
@@ -65,6 +65,11 @@ argocd: v2.9.5+f943664
   GoVersion: go1.20.10
   Compiler: gc
   Platform: linux/amd64
-  ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024 <1>
+  ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024
 ----
-<1> The build information of {gitops-title} built by Red Hat.
++
+--
+where:
+
+`ExtraBuildInfo: openshift-gitops-version`:: Specifies the build information of {gitops-title} built by Red Hat.
+--

--- a/modules/gitops-installing-argocd-cli-on-macos.adoc
+++ b/modules/gitops-installing-argocd-cli-on-macos.adoc
@@ -63,6 +63,11 @@ argocd: v2.9.5+f943664
   GoVersion: go1.20.10
   Compiler: gc
   Platform: linux/amd64
-  ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024 <1>
+  ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024
 ----
-<1> The build information of {gitops-title} built by Red Hat.
++
+--
+where:
+
+`ExtraBuildInfo: openshift-gitops-version`:: Specifies the build information of {gitops-title} built by Red Hat.
+--

--- a/modules/gitops-installing-argocd-cli-on-windows.adoc
+++ b/modules/gitops-installing-argocd-cli-on-windows.adoc
@@ -50,6 +50,11 @@ argocd: v2.9.5+f943664
   GoVersion: go1.20.10
   Compiler: gc
   Platform: linux/amd64
-  ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024 <1>
+  ExtraBuildInfo: openshift-gitops-version: 1.12.0, release: 0015022024
 ----
-<1> The build information of {gitops-title} built by Red Hat.
++
+--
+where:
+
+`ExtraBuildInfo: openshift-gitops-version`:: Specifies the build information of {gitops-title} built by Red Hat.
+--

--- a/modules/gitops-manually-aborting-the-rollout.adoc
+++ b/modules/gitops-manually-aborting-the-rollout.adoc
@@ -20,9 +20,14 @@ The following example procedure deploys a new `red` canary version of your appli
 +
 [source,terminal]
 ----
-$ oc argo rollouts set image rollouts-demo rollouts-demo=argoproj/rollouts-demo:red -n <namespace> <1>
+$ oc argo rollouts set image rollouts-demo rollouts-demo=argoproj/rollouts-demo:red -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` custom resource (CR) is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` custom resource (CR) is defined.
+--
 +
 .Example output
 [source,terminal]
@@ -38,9 +43,14 @@ The container image deployed in the rollout is modified and the rollout initiate
 +
 [source,terminal]
 ----
-$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace> <1>
+$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` CR is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
+--
 +
 .Example output
 [source,terminal]
@@ -81,9 +91,14 @@ NAME                                       KIND        STATUS        AGE    INFO
 +
 [source,terminal]
 ----
-$ oc argo rollouts abort rollouts-demo -n <namespace> <1>
+$ oc argo rollouts abort rollouts-demo -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` CR is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
+--
 +
 .Example output
 [source,terminal]
@@ -97,9 +112,14 @@ The Argo Rollouts controller deletes the canary resources of the application, an
 +
 [source,terminal]
 ----
-$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace> <1>
+$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` CR is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
+--
 +
 .Example output
 [source,terminal]
@@ -146,9 +166,14 @@ The `Degraded` status does not reflect the health of the application. It only in
 +
 [source,terminal]
 ----
-$ oc argo rollouts set image rollouts-demo rollouts-demo=argoproj/rollouts-demo:yellow -n <namespace> <1>
+$ oc argo rollouts set image rollouts-demo rollouts-demo=argoproj/rollouts-demo:yellow -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` CR is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
+--
 +
 .Example output
 [source,terminal]
@@ -162,9 +187,14 @@ The rollout skips the analysis and promotion steps, rolls back to the previous s
 +
 [source,terminal]
 ----
-$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace> <1>
+$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` CR is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
+--
 +
 .Example output
 [source,terminal]

--- a/modules/gitops-monitoring-argo-cd-health-using-prometheus-metrics.adoc
+++ b/modules/gitops-monitoring-argo-cd-health-using-prometheus-metrics.adoc
@@ -17,7 +17,11 @@ You can monitor the health status of an Argo CD application by running Prometheu
 .Example
 [source, terminal]
 ----
-sum(argocd_app_info{dest_namespace=~"<your_defined_namespace>",health_status!=""}) by (health_status) <1>
+sum(argocd_app_info{dest_namespace=~"<your_defined_namespace>",health_status!=""}) by (health_status)
 ----
-<1> Replace the `<your_defined_namespace>` variable with the actual name of your defined namespace, for example `openshift-gitops`.
++
+--
+where:
 
+`<your_defined_namespace>`:: Specifies the variable with the actual name of your defined namespace, for example `openshift-gitops`.
+--

--- a/modules/gitops-promoting-the-rollout.adoc
+++ b/modules/gitops-promoting-the-rollout.adoc
@@ -14,9 +14,14 @@ Because your rollout is now in a paused status, as a cluster administrator, you 
 +
 [source,terminal]
 ----
-$ oc argo rollouts promote rollouts-demo -n <namespace> <1>
+$ oc argo rollouts promote rollouts-demo -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
+--
 +
 .Example output
 [source,terminal]
@@ -29,9 +34,14 @@ This increases the traffic weight to 40% in the canary version.
 +
 [source,terminal]
 ----
-$ oc argo rollouts get rollout rollouts-demo -n <namespace> --watch <1>
+$ oc argo rollouts get rollout rollouts-demo -n <namespace> --watch
 ----
-<1> Specify the namespace where the `Rollout` resource is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` resource is defined.
+--
 +
 Because the rest of the steps as defined in the `Rollout` CR have set durations, for example, `pause: {duration: 45}`, the Argo Rollouts controller waits that duration and then automatically moves to the next step.
 +

--- a/modules/gitops-release-notes-1-17-0.adoc
+++ b/modules/gitops-release-notes-1-17-0.adoc
@@ -12,7 +12,7 @@
 [id="errata-updates-1-17-0_{context}"]
 == Errata updates
 
-RHEA-2025:13453 - {gitops-title} 1.17.0 security update advisory::
+`RHEA-2025:13453 - {gitops-title} 1.17.0 security update advisory`::
 Issued: 2025-08-07
 +
 The list of enhancements that are included in this release are documented in the following advisory:
@@ -44,7 +44,7 @@ With this update, a productized container image of the Argo CD Agent is availabl
 +
 --
 :FeatureName: The {gitops-shortname} Argo CD Agent feature
-include::snippets/technology-preview.adoc[]
+`include`::snippets/technology-preview.adoc[]
 --
 +
 link:https://issues.redhat.com/browse/GITOPS-5016[GITOPS-5016]
@@ -132,10 +132,15 @@ metadata:
 spec:
   # ...
   extraConfig:
-    server.rbac.disableApplicationFineGrainedRBACInheritance: true # <1>
+    server.rbac.disableApplicationFineGrainedRBACInheritance: true
   # ...
 ----
-<1> Set `server.rbac.disableApplicationFineGrainedRBACInheritance` to `true` to maintain Argo CD v3.0 behavior.
++
+--
+where:
+
+`server.rbac.disableApplicationFineGrainedRBACInheritance`:: Specifies the value to maintain Argo CD v3.0 behavior.
+--
 +
 For more information, see link:https://argocd-operator.readthedocs.io/en/latest/reference/argocd/#fine-grained-rbac-for-application-update-and-delete-sub-resources-v30[Fine-Grained RBAC for application update and delete sub-resources].
 +

--- a/modules/gitops-storing-aws-secret-manager-resources-in-gitops-repository.adoc
+++ b/modules/gitops-storing-aws-secret-manager-resources-in-gitops-repository.adoc
@@ -151,13 +151,18 @@ spec:
   project: default
   source:
     path: path/to/aws-provider/resources
-    repoURL: https://github.com/<my-domain>/<gitops>.git # <1>
+    repoURL: https://github.com/<my-domain>/<gitops>.git
   syncPolicy:
     automated:
     prune: true
     selfHeal: true
 ----
-<1> Update the value of the `repoURL` field to point to your {gitops-shortname} repository.
++
+--
+where:
+
+`spec.source.repoURL`:: Defines the repository URL value to point to your {gitops-shortname} repository.
+--
 
 . Synchronize resources with the default Argo CD instance to deploy them in the cluster:
 

--- a/modules/gitops-updating-the-rollout.adoc
+++ b/modules/gitops-updating-the-rollout.adoc
@@ -28,24 +28,34 @@ As per the `setWeight` property defined in the `.spec.strategy.canary.steps` fie
 spec:
   replicas: 5
   strategy:
-    canary: #<1>        
-      steps: #<2>
-      - setWeight: 20 #<3>       
-      - pause: {}  #<4>         
+    canary:
+      steps:
+      - setWeight: 20
+      - pause: {}
   # (...)
 ----
-<1> The deployment strategy that the rollout must use.
-<2> The steps for the rollout. This example gradually routes 20%, 40%, 60%, and 80% of traffic to the canary version.
-<3> The percentage of traffic that must be directed to the canary version. A value of 20 means that 20% of traffic is directed to the canary version.
-<4> Specification to the Argo Rollouts controller to pause indefinitely until it finds a request for promotion.
++
+--
+where:
+
+`<spec.strategy.canary>`:: Specifies the deployment strategy that the rollout must use.
+`<spec.strategy.canary.steps>`:: Specifies the steps for the rollout. This example gradually routes 20%, 40%, 60%, and 80% of traffic to the canary version.
+`<spec.strategy.canary.steps.setWeight>`:: Specifies the percentage of traffic that must be directed to the canary version. A value of 20 means that 20% of traffic is directed to the canary version.
+`<spec.strategy.canary.steps.pause>`:: Requests the Argo Rollouts controller to pause indefinitely until it finds a request for promotion.
+--
 
 . Watch the progression of your rollout by running the following command:
 +
 [source,terminal]
 ----
-$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace> <1>
+$ oc argo rollouts get rollout rollouts-demo --watch -n <namespace>
 ----
-<1> Specify the namespace where the `Rollout` CR is defined.
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace where the `Rollout` CR is defined.
+--
 +
 .Example output
 [source,terminal]

--- a/modules/gitops_enabling_sensitive_annotations_in_the_argo_cd_web_ui.adoc
+++ b/modules/gitops_enabling_sensitive_annotations_in_the_argo_cd_web_ui.adoc
@@ -30,9 +30,14 @@ metadata:
   name: example
 spec:
   extraConfig:
-    resource.sensitive.mask.annotations: openshift.io/token-secret.value, api-key, token # <1>
+    resource.sensitive.mask.annotations: openshift.io/token-secret.value, api-key, token
 ----
-<1> Specify a comma-separated list of sensitive annotation values, such as `openshift.io/token-secret.value`, `api-key`, and `token`.
++
+--
+where:
+
+`<spec.extraConfig.resource.sensitive.mask.annotations>`:: Specifies a comma-separated list of sensitive annotation values, such as `openshift.io/token-secret.value`, `api-key`, and `token`.
+--
 +
 . To verify that the value in the Argo CD resource has been updated successfully, complete the following steps:
 .. In the *Administrator* perspective of the web console, click *Operators* -> *Installed Operators*.

--- a/modules/go-settings-for-environment-labels-and-annotations.adoc
+++ b/modules/go-settings-for-environment-labels-and-annotations.adoc
@@ -30,7 +30,7 @@ spec:
 apiVersion: argoproj.io/v1beta1
 kind: Application
 metadata:
-  name: dev-env <1>
+  name: dev-env
   namespace: openshift-gitops
 spec:
   labels:
@@ -39,7 +39,12 @@ spec:
     namespace: dev-env
 # ...
 ----
-<1> The name of the environment application manifest. The value set is the same as the value of the `<environment_name>` variable.
+
+--
+where:
+
+`<metadata.name>`:: Specifies the name of the environment application manifest. The value set is the same as the value of the `<environment_name>` variable.
+--
 
 [discrete]
 == Environment annotations
@@ -54,10 +59,15 @@ metadata:
   annotations:
     app.openshift.io/vcs-uri: <application_source_url>
     app.openshift.io/vcs-ref: <branch_reference>
-  name: <environment_name> <1>
+  name: <environment_name>
 # ...
 ----
-<1> The name of the environment namespace manifest. The value set is the same as the value of the `<environment_name>` variable.
+
+--
+where:
+
+`<metadata.name>`:: Specifies the name of the environment namespace manifest. The value set is the same as the value of the `<environment_name>` variable.
+--
 
 .Example of an environment namespace manifest
 [source,yaml]

--- a/modules/installing-gitops-operator-using-cli.adoc
+++ b/modules/installing-gitops-operator-using-cli.adoc
@@ -88,16 +88,21 @@ metadata:
   name: openshift-gitops-operator
   namespace: openshift-gitops-operator
 spec:
-  channel: latest <1>
+  channel: latest
   installPlanApproval: Automatic
-  name: openshift-gitops-operator <2>
-  source: redhat-operators <3>
-  sourceNamespace: openshift-marketplace <4> 
+  name: openshift-gitops-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
 ----
-<1> Specify the channel name from where you want to subscribe the Operator.
-<2> Specify the name of the Operator to subscribe to.
-<3> Specify the name of the CatalogSource that provides the Operator.
-<4> The namespace of the CatalogSource. Use `openshift-marketplace` for the default OperatorHub CatalogSources.
++
+--
+where:
+
+`metadata.name`:: Specifies the specify the channel name from where you want to subscribe the Operator.
+`metadata.namespace`:: Specifies the specify the name of the Operator to subscribe to.
+`spec.channel`:: Specifies the specify the name of the CatalogSource that provides the Operator.
+`spec.source` (openshift-marketplace namespace):: Specifies the namespace of the CatalogSource. Use `openshift-marketplace` for the default OperatorHub CatalogSources.
+--
 
 . Apply the `Subscription` to the cluster:
 +

--- a/modules/moving-the-gitops-operator-pod-to-infrastructure-nodes.adoc
+++ b/modules/moving-the-gitops-operator-pod-to-infrastructure-nodes.adoc
@@ -2,7 +2,7 @@
 //
 // * gitops_workloads_infranodes/running-gitops-control-plane-workloads-on-infrastructure-nodes.adoc
 
-:_content-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="moving-the-gitops-operator-pod-to-infrastructure-nodes_{context}"]
 = Moving the {gitops-shortname} Operator pod to infrastructure nodes
 
@@ -18,9 +18,14 @@ You can move the {gitops-shortname} Operator pod to the infrastructure nodes.
 +
 [source,terminal]
 ----
-$ oc label node <node_name> node-role.kubernetes.io/infra= <1>
+$ oc label node <node_name> node-role.kubernetes.io/infra=
 ----
-<1> Replace <node_name> with the name of the node you want to label as infrastructure node.
++
+--
+where:
+
+`<node_name>`:: Specifies the name of the node you want to label as infrastructure node.
+--
 +
 .Example output
 [source,terminal]
@@ -47,15 +52,20 @@ metadata:
   namespace: openshift-gitops-operator
 spec:
   config:
-    nodeSelector: # <1>
+    nodeSelector:
       node-role.kubernetes.io/infra: ""
-    tolerations: # <2>
+    tolerations:
     - key: node-role.kubernetes.io/infra
       operator: Exists
       effect: NoSchedule
 ----
-<1> This ensures that the operator pod is only scheduled on an infrastructure node.
-<2> This ensures that the pod is accepted by the infrastructure node.
++
+--
+where:
+
+`<metadata.name>`:: Specifies that the operator pod is only scheduled on an infrastructure node.
+`<metadata.namespace>`:: Defines the namespace of the pod to be accepted by the infrastructure node.
+--
 +
 .Example output
 [source,terminal]
@@ -74,6 +84,7 @@ $ oc -n openshift-gitops-operator get po -owide
 [source,terminal]
 ----
 NAME                                                            READY   STATUS    RESTARTS   AGE   IP              NODE            NOMINATED NODE   READINESS GATES
-openshift-gitops-operator-controller-manager-abcd               2/2     Running   0          11m   94.142.44.126   <node_name>     <none>           <none> <1>
+openshift-gitops-operator-controller-manager-abcd               2/2     Running   0          11m   94.142.44.126   <node_name>     <none>           <none>
 ----
-<1> Ensure that the listed `<node_name>` is the node with the `node-role.kubernetes.io/infra` label.
++
+Ensure that the listed `<node_name>` is the node with the `node-role.kubernetes.io/infra` label.

--- a/modules/proc_configuring-annotation-based-tracking-in-multiple-argo-cd-instances.adoc
+++ b/modules/proc_configuring-annotation-based-tracking-in-multiple-argo-cd-instances.adoc
@@ -41,15 +41,20 @@ When you follow these steps, replace the example values with the actual values.
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: argocd-instance-demo-1 # <1>
-  namespace: argocd-test-demo-1 # <2>
+  name: argocd-instance-demo-1
+  namespace: argocd-test-demo-1
 spec:
-  installationID: "instance-demo-1" # <3>
+  installationID: "instance-demo-1"
   resourceTrackingMethod: "annotation+label"
 ----
-<1> Specifies the name of the first Argo CD instance.
-<2> Specifies the namespace used for the first Argo CD instance.
-<3> Specifies the name of the `installationID` object for the first Argo CD instance.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the first Argo CD instance.
+`metadata.namespace`:: Specifies the namespace used for the first Argo CD instance.
+`spec.installationID`:: Specifies the name of the `installationID` object for the first Argo CD instance.
+--
 +
 .Example second Argo CD instance with an annotation label
 [source,yaml]
@@ -57,16 +62,20 @@ spec:
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
-  name: argocd-instance-demo-2 # <1>
-  namespace: argocd-test-demo-2 # <2>
+  name: argocd-instance-demo-2
+  namespace: argocd-test-demo-2
 spec:
-  installationID: "instance-demo-2" # <3>
+  installationID: "instance-demo-2"
   resourceTrackingMethod: "annotation+label"
 ----
 +
-<1> Specifies the name of the second Argo CD instance.
-<2> Specifies the namespace used for the second Argo CD instance.
-<3> Specifies the name of the `installationID` object for the second Argo CD instance.
+--
+where:
+
+`metadata.name`:: Specifies the name of the second Argo CD instance.
+`metadata.namespace`:: Specifies the namespace used for the second Argo CD instance.
+`spec.installationID`:: Specifies the name of the `installationID` object for the second Argo CD instance.
+--
 
 . Configure and label target namespaces to associate namespaces with their Argo CD instances.
 .. Navigate to *Administration* -> *Namespaces*.
@@ -99,8 +108,8 @@ $ oc label namespace app-ns-2 argocd.argoproj.io/managed-by=argocd-test-demo-2
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: sprint-petclinic # <1>
-  namespace: argocd-test-demo-1 # <2>
+  name: sprint-petclinic
+  namespace: argocd-test-demo-1
 spec:
   project: default
   source:
@@ -113,8 +122,13 @@ spec:
   syncPolicy:
     automated: {}
 ----
-<1> Specifies the name of the first application.
-<2> Specifies the namespace used for the first application.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the first application.
+`metadata.namespace`:: Specifies the namespace used for the first application.
+--
 +
 .Example second application using Argo CD
 [source,yaml]
@@ -122,8 +136,8 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: sprint-petclinic # <1>
-  namespace: argocd-test-demo-2 # <2>
+  name: sprint-petclinic
+  namespace: argocd-test-demo-2
 spec:
   project: default
   source:
@@ -136,8 +150,13 @@ spec:
   syncPolicy:
     automated: {}
 ----
-<1> Specifies the name of the second application that is created with the same name as the first application.
-<2> Specifies the namespace used for the second application.
++
+--
+where:
+
+`metadata.name`:: Specifies the name of the second application that is created with the same name as the first application.
+`metadata.namespace`:: Specifies the namespace used for the second application.
+--
 
 .Verification
 . Navigate to *Workloads* -> *Pods* in the {OCP} web console.

--- a/modules/sizing-requirements-for-gitops.adoc
+++ b/modules/sizing-requirements-for-gitops.adoc
@@ -46,18 +46,23 @@ $ oc get argocd -n openshift-gitops openshift-gitops -o json | jq '.spec.redis.r
 [source,terminal]
 ----
 {
-    "limits": { #<1>
+    "limits": {
         "cpu": "500m",
         "memory": "256Mi"
   },
-  "requests": { #<2>
+  "requests": {
     "cpu": "250m",
     "memory": "128Mi"
   }
 }
 ----
-<1> The highest resource limit threshold allocated to the pod.
-<2> The lowest resource limit threshold allocated to the pod.
+
+--
+where:
+
+`limits`:: Specifies the highest resource limit threshold allocated to the pod.
+`requests`:: Specifies the lowest resource limit threshold allocated to the pod.
+--
 
 The following example command changes the memory configuration for a Redis pod. The highest resource limit threshold is set to 8 GiB and the lowest is set to 256 MiB.
 [source,terminal]


### PR DESCRIPTION
This is not a feature request-related PR. It contains fixes for callouts and file(s) which do not include the, :_mod-docs-content-type, tag.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

gitops-docs-1.20, gitops-docs-1.19

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-7309

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

1. [Deploying a rollout](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/getting-started-with-argo-rollouts#gitops-deploying-a-rollout_getting-started-with-argo-cd-rollouts)
2. [Disabling automatic scraping of metrics for Argo CD instances](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/observability/monitoring/monitoring-argo-cd-instances#gitops-disabling-automatic-scraping-of-metrics-for-argo-cd-instances_monitoring-argo-cd-instances)
3. [Collecting debugging data for Red Hat OpenShift GitOps](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support#collecting-debugging-data-for-gitops_gathering-gitops-diagnostic-information-for-support)
4. [Enabling Config Management Plugins in an Argo CD CR](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties#enabling-config-management-plugins-argocd_argo-cd-cr-component-properties)
5. [NotificationsConfiguration custom resource properties](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/argo-cd-cr-component-properties#notifications-configuration-custom-resource-properties_argo-cd-cr-component-properties)
6. [Allowing Source Code Manager Providers](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_application_sets/managing-app-sets-in-non-control-plane-namespaces#gitops-allowing-scm-providers_managing-app-sets-in-non-control-plane-namespaces)
7. [Enabling dynamic scaling of shards in the web console](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas#gitops-argo-cd-dynamic-scaling-in-web-console_sharding-clusters-across-argo-cd-application-controller-replicas)
8. [Enabling dynamic scaling of shards by using the CLI](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/sharding-clusters-across-argo-cd-application-controller-replicas#gitops-argo-cd-dynamic-scaling-by-using-cli_sharding-clusters-across-argo-cd-application-controller-replicas)
9. [Configure AWS Secrets Manager on OpenShift with GitOps](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops#gitops-configure-aws-secret-manager-on-openshift-with-gitops_managing-secrets-securely-using-sscsid-with-gitops)
10. [Configure HashiCorp Vault as a secrets provider on OpenShift with GitOps](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops#gitops-configure-hashicorp-vault-as-a-secrets-provider-on-openshift-with-gitops_managing-secrets-securely-using-sscsid-with-gitops)
11. [Configuring Argo Rollouts to route traffic by using OpenShift Routes](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/routing-traffic-by-using-argo-rollouts#gitops-configure-rollout-route-traffic-using-openshift-routes_routing-traffic-by-using-argo-rollouts)
12. [Configuring Argo Rollouts to route traffic by using OpenShift Service Mesh](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/routing-traffic-by-using-argo-rollouts-for-openshift-service-mesh)
13. [Configuring a cluster-scoped Argo Rollouts instance to manage rollout resources](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources#gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources_using-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources)
14. [Configuring the Argo CD CR of your user-defined cluster-scoped Argo CD instance with the target namespaces](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/using-cluster-scoped-rollouts-instance-to-manage-rollouts-resources#gitops-configuring-a-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources_using-cluster-scoped-argo-rollouts-instance-to-manage-rollouts-resources)
15. [Configuring common cluster roles by specifying user-defined cluster roles for namespace-scoped instances](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_instance/setting-up-argocd-instance#gitops-configuring-common-cluster-roles-by-specifying-user-defined-cluster-roles-for-namespace-scoped-instances_setting-up-argocd-instance)
16. [Configuring GitOps managed resources to use Vault-mounted secrets](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops#gitops-configuring-gitops-managed-resources-to-use-vault-mounted-secrets_managing-secrets-securely-using-sscsid-with-gitops)
17. [Configuring GitOps managed resources to use mounted secrets](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops#gitops-configuring-gitops-managed-resources-to-use-mounted-secrets_managing-secrets-securely-using-sscsid-with-gitops)
18. [Configuring high availability for Argo Rollouts](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/enabling-ha-support-for-argo-rollouts#gitops-configuring-high-availability-for-argo-rollouts_enabling-ha-support-for-argo-rollouts)
19. [Configuring namespace management for Argo CD tenants](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/multitenancy/multitenancy-support-in-gitops#configuring-namespace-management-argocd-tenants_multitenancy-support-in-gitops)
20. [Configuring a namespace-scoped Argo Rollouts installation](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/enable-support-for-namespace-scoped-argo-rollouts-installation#configuring-namespace-scoped-argo-rollouts-installation_enable-support-for-namespace-scoped-argo-rollouts-installation)
21. [Configuring respectRBAC using the CLI](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations#configuring-respectRBAC-using-the-cli_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations)
22. [Configuring SSCSI driver to mount secrets from AWS Secrets Manager](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/managing-secrets-securely-using-sscsid-with-gitops#gitops-configuring-sscsi-driver-to-mount-secrets-from-aws-secrets-manager_managing-secrets-securely-using-sscsid-with-gitops)
23. [Configuring TLS for Redis with autotls disabled](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/configuring-secure-communication-with-redis#gitops-configuring-tls-for-redis-with-autotls-disabled_configuring-secure-communication-with-redis)
24. [Configuring TLS for Redis with autotls enabled](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/securing_openshift_gitops/configuring-secure-communication-with-redis#gitops-configuring-tls-for-redis-with-autotls-enabled_configuring-secure-communication-with-redis)
25. [Creating and configuring the Application CR to reference the target namespace and user-defined AppProject instance](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_applications/managing-apps-in-non-control-plane-namespaces#gitops-creating-and-configuring-user-defined-appproject-instance-with-target-namespaces_managing-apps-in-non-control-plane-namespaces)

1. [ Configuration to enable the Dex OpenShift OAuth Connector](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex#gitops-creating-a-new-client-in-dex_configuring-sso-for-argo-cd-using-dex)
2. [Creating and configuring a user-defined AppProject instance with the target namespaces](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argocd_applications/managing-apps-in-non-control-plane-namespaces#gitops-creating-and-configuring-user-defined-appproject-instance-with-target-namespaces_managing-apps-in-non-control-plane-namespaces)
3. [Customizing permissions for cluster-scoped instances](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances#gitops-customizing-permissions-for-cluster-scoped-instances_customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances)
4. [Enabling traffic management and metric plugins in Argo Rollouts](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/configuring_traffic_management_and_metric_plugins_in_argo_rollouts#enable-traffic-management-and-metric-plugins-in-argo-rollouts_enable-support-for-namespace-scoped-argo-rollouts-installation)
5. [Installing Argo Rollouts CLI on Linux](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery#gitops-installing-argo-rollouts-cli-on-linux_using-argo-rollouts-for-progressive-deployment-delivery)
6. [Monitoring Argo CD health using Prometheus metrics](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/observability/monitoring/monitoring-argo-cd-instances#gitops-monitoring-argo-cd-health-using-promethous-metrics_monitoring-argo-cd-instances)
7. [Installing GitOps Operator using the CLI](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/installing-openshift-gitops#installing-gitops-operator-using-cli_installing-openshift-gitops)
8.[ Enabling the creation of aggregated cluster roles](https://106119--ocpdocs-pr.netlify.app/openshift-gitops/latest/declarative_clusterconfig/customizing-permissions-by-creating-aggregated-cluster-roles#gitops-enabling-the-creation-of-aggregated-cluster-roles_customizing-permissions-by-creating-aggregated-cluster-roles)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Peer review: @shivanisathe25 

Additional information:
<!--- Optional: Include additional context or expand the description here.---> 

1. The section titled Configuring Argo CD OIDC, file name: gitops-configuring-argo-cd-oidc.adoc, shows up as modified in the Files changed column, but its content is no longer applicable. These changes were only applicable when the GitOps content was also included in the OCP doc set. Since GitOps is a layered product, it has no dependencies on the OCP doc set; we do not require this topic to be displayed anywhere. A similar case is for Registering an additional Oauth client, file name: gitops-registering-an-additional-oauth-client.adoc.
9. The file titled gitops-creating-a-new-client-using-keycloak.adoc contains content that has been removed from the doc repo a few releases ago.

The following files will be removed from the content as they are files for archived releases:

1. gitops-release-notes-1-1.adoc
2. gitops-release-notes-1-12-2.adoc
3. gitops-release-notes-1-14-0.adoc
4. gitops-release-notes-1-14-1.adoc
5. gitops-release-notes-1-15-0.adoc
6. gitops-release-notes-1-9-0.adoc

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
