### PR TITLE
OSDOCS-18020: Installing New ROSA & OSD Cluster with OCP 4.20

### DIFF
--- a/modules/life-cycle-dates.adoc
+++ b/modules/life-cycle-dates.adoc
@@ -14,10 +14,11 @@ The following table lists the general availability, maintenance support end date
 [options="header"]
 |===
 |Version    |General availability   |Maintenance support ends  |Extended Update Support Add-On - Term 1 ends
+|4.21       |Feb  4, 2026           |Aug  3, 2027              |
 |4.20       |Oct 21, 2025           |Apr 21, 2027              |Oct 21, 2027
 |4.19       |Jun 17, 2025           |Dec 17, 2026              |
 |4.18       |Feb 25, 2025           |Aug 25, 2026              |Feb 25, 2027
-|4.17       |Oct 1, 2024            |Apr 1, 2026               |
+|4.17       |Oct  1, 2024           |Apr  1, 2026               |
 |4.16       |Jun 27, 2024           |Dec 27, 2025              |Jun 27, 2026
 |4.15       |Feb 27, 2024           |Aug 27, 2025              |
 |===

--- a/modules/osd-release-notes-Q1-2026.adoc
+++ b/modules/osd-release-notes-Q1-2026.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * osd-whats-new.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="osd-q1-2026_{context}"]
+= Q1 2026
+
+[role="_abstract"]
+The following items were added during the first quarter of 2026.
+
+* **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.21 is now available for new clusters.

--- a/modules/rosa-release-notes-Q1-2026.adoc
+++ b/modules/rosa-release-notes-Q1-2026.adoc
@@ -11,5 +11,7 @@ The following items were added during the first quarter of 2026.
 ifdef::openshift-rosa-hcp[]
 * **AWS Windows License Included now available for {product-title}.** You can now add a Windows License Included enabled machine pool to a {product-title} cluster. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/managing-compute-nodes-using-machine-pools#creating_a_machine_pools_cli_win_li_rosa-managing-worker-nodes[Creating a machine pool with AWS Windows License Included enabled using the {rosa-cli}].
 
-* **Updating the global pull secret now available for {product-title} clusters.** You can now modify the global pull secret to include additional pull secrets for accessing container images from private registries. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/images/managing-images#images_update_global_pull_secret_using_image_pull_secret[Updating the global cluster pull secret].
+* **Updating the global pull secret now available for {product-title} clusters.** You can now modify the global pull secret to include additional pull secrets for accessing container images from private registries. For more information, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/images/managing-images#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret].
 endif::openshift-rosa-hcp[]
+
+* **New version of {product-title} available.** {product-title} version 4.21 is now available for new clusters.

--- a/osd_whats_new/osd-whats-new.adoc
+++ b/osd_whats_new/osd-whats-new.adoc
@@ -16,6 +16,7 @@ With its foundation in Kubernetes, {product-title} is a complete {OCP} cluster p
 
 Find new additions, recent changes, and relevant updates for {product-title} listed below in quarterly increments.
 
+include::modules/osd-release-notes-Q1-2026.adoc[leveloffset=+1]
 include::modules/osd-release-notes-Q4-2025.adoc[leveloffset=+1]
 include::modules/osd-release-notes-Q3-2025.adoc[leveloffset=+1]
 include::modules/osd-release-notes-Q2-2025.adoc[leveloffset=+1]

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -12,9 +12,8 @@ toc::[]
 Find new additions, recent changes, and relevant updates for {product-title} listed below in quarterly increments.
 
 // //remove the conditional if Classic notes are added to the module
-ifdef::openshift-rosa-hcp[]
+
 include::modules/rosa-release-notes-Q1-2026.adoc[leveloffset=+1]
-endif::openshift-rosa-hcp[]
 
 include::modules/rosa-release-notes-Q4-2025.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/OSDOCS-18020

Link to docs preview:
[OSD Life Cycle Dates](https://106120--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-life-cycle.html)
[OSD Whats New](https://106120--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new.html)
[ROSA Life Cycle Dates](https://106120--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_architecture/rosa_policy_service_definition/rosa-hcp-life-cycle.html)
[ROSA Whats New](https://106120--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_release_notes/rosa-release-notes.html)
[Classic Whats New](https://106120--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html)

QE review:
QE approval is NOT required as no procedural change.

