### PR TITLE
OSDOCS-18115:Added info about OSD listing in Google Cloud console.

### DIFF
--- a/modules/ccs-gcp-customer-requirements.adoc
+++ b/modules/ccs-gcp-customer-requirements.adoc
@@ -9,6 +9,8 @@
 [role="_abstract"]
 {product-title} clusters using a Customer Cloud Subscription (CCS) model on {gcp-first} must meet several prerequisites before they can be deployed.
 
+As a {gcp-short} user, you can validate many of these requirements directly within the link:https://console.cloud.google.com/redhat-openshift/landing[{gcp-short} console] before deployment.
+
 [id="ccs-gcp-requirements-account_{context}"]
 == Account
 

--- a/modules/ccs-gcp-understand.adoc
+++ b/modules/ccs-gcp-understand.adoc
@@ -9,8 +9,12 @@
 [role="_abstract"]
 Red{nbsp}Hat {product-title} provides a Customer Cloud Subscription (CCS) model that allows Red{nbsp}Hat to deploy and manage {product-title} into a customer's existing {GCP} account. Red{nbsp}Hat requires several prerequisites be met in order to provide this service.
 
+{product-title} link:https://console.cloud.google.com/redhat-openshift/verify[cluster prerequisite integration] is available within the {GCP} console. This integration allows {GCP} users to discover and validate cluster prerequisites directly from the {GCP} interface. The prerequisites validation ensures your environment is ready before you transition to the {hybrid-console} for cluster creation.
+
 Red{nbsp}Hat recommends the usage of a {gcp-short} project, managed by the customer, to organize all of your {gcp-short} resources. A project consists of a set of users and APIs, as well as billing, authentication, and monitoring settings for those APIs.
 
-It is recommended for the {product-title} cluster using a CCS model to be hosted in a {gcp-short} project within a {gcp-short} organization. The organization resource is the root node of the {gcp-short} resource hierarchy and all resources that belong to an organization are grouped under the organization node. Customers have the choice of using service account keys or Workload Identity Federation when creating the roles and credentials necessary to access {gcp-full} resources within a {gcp-short} project.
+It is recommended for the {product-title} cluster using a CCS model to be hosted in a {gcp-short} project within a {gcp-short} organization. The organization resource is the root node of the {gcp-short} resource hierarchy and all resources that belong to an organization are grouped under the organization node. Customers have the choice of using service account keys or Workload Identity Federation (WIF) when creating the roles and credentials necessary to access {gcp-full} resources within a {gcp-short} project.
+
+Red{nbsp}Hat and {gcp-short} recommend using WIF as the authentication type as it provides enhanced security through the use of short-lived credentials, whereas service account authentication uses long-lived credentials which are less secure.
 
 For more information about creating and managing organization resources within {gcp-short}, see link:https://cloud.google.com/resource-manager/docs/creating-managing-organization[Creating and managing organization resources].

--- a/modules/osd-release-notes-Q1-2026.adoc
+++ b/modules/osd-release-notes-Q1-2026.adoc
@@ -8,6 +8,19 @@
 [role="_abstract"]
 The following items were added during the first quarter of 2026.
 
-* **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.21 is now available for new clusters.
+* **{product-title} now available in {GCP} console.**
+{product-title} is now available directly within the link:https://console.cloud.google.com/redhat-openshift/landing[{GCP} console], making it easier to find and deploy alongside native {GCP} services. This integration simplifies the initial setup by allowing you to validate environment prerequisites for {product-title} cluster deployment.
++
+**Key improvements:**
++
+** Improved discoverability: Locate {product-title} quickly within the {GCP} console alongside Google's native compute and container offerings, allowing you to start creating clusters immediately.
+** Streamlined onboarding: Validate your {GCP} configuration directly in the console before transitioning to a guided deployment flow in the {hybrid-console}.
+** Unified billing and procurement: Use the {GCP} Marketplace to simplify setup and apply your existing {GCP} committed spend, negotiated discounts, or pay-as-you-go pricing.
+
++
+For more information about deploying {product-title} on {GCP}, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/planning_your_environment/gcp-ccs#ccs-gcp-understand_gcp-ccs[Understanding Customer Cloud Subscriptions on Google Cloud].
 
 * **Cluster admins can now create multiple users with htpasswd identity providers.** Cluster administrators can now add multiple users to an htpasswd identity providers (IDPs) for {product-title} clusters using the command-line interface (CLI). You can add multiple users to a single htpasswd IDP, streamlining managing user identities. Using the CLI, administrators can add multiple users interactively and noninteractively. For more information, see link:https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/authentication_and_authorization/sd-configuring-identity-providers#config-htpasswd-idp_sd-configuring-identity-providers[Configuring an htpasswd identity provider].
+
+* **New version of {product-title} available.** {product-title} on {gcp} and {product-title} on {aws} versions 4.21 are now available for new clusters.
+


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-18115](https://issues.redhat.com//browse/OSDOCS-18115)

Link to docs preview:

- [Understanding Customer Cloud Subscriptions on Google Cloud](https://106124--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs.html#ccs-gcp-understand_gcp-ccs)

- [Q1 2026](https://106124--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_whats_new/osd-whats-new#osd-q1-2026_osd-whats-new)

Peer review:
- [x] Peer reviewer has approved this change.

SME review:
- [x] SME has approved this change.

QE review:
- QE approval is not required to merge this PR.

Additional information:
Note to reviewers: placeholder links are there until OpenShift listing goes live in Google Cloud console.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
