### PR TITLE
CNV-74970: Reformat callouts for DITA

### DIFF
--- a/modules/virt-about-aaq-operator.adoc
+++ b/modules/virt-about-aaq-operator.adoc
@@ -1,17 +1,17 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/advanced_vm_management/virt-understanding-aaq-operator.adoc              
+// * virt/virtual_machines/advanced_vm_management/virt-understanding-aaq-operator.adoc
 
-:_mod-docs-content-type: CONCEPT                                    
-[id="virt-about-aaq-operator_{context}"]                                   
+:_mod-docs-content-type: CONCEPT
+[id="virt-about-aaq-operator_{context}"]
 = About the AAQ Operator
 
 [role="_abstract"]
 The Application-Aware Quota (AAQ) Operator provides more flexible and extensible quota management compared to the native `ResourceQuota` object in the {product-title} platform.
 
-In a multi-tenant cluster environment, where multiple workloads operate on shared infrastructure and resources, using the Kubernetes native `ResourceQuota` object to limit aggregate CPU and memory consumption presents infrastructure overhead and live migration challenges for {VirtProductName} workloads. 
+In a multi-tenant cluster environment, where multiple workloads operate on shared infrastructure and resources, using the Kubernetes native `ResourceQuota` object to limit aggregate CPU and memory consumption presents infrastructure overhead and live migration challenges for {VirtProductName} workloads.
 
-{VirtProductName} requires significant compute resource allocation to handle virtual machine (VM) live migrations and manage VM infrastructure overhead. When upgrading {VirtProductName}, you must migrate VMs to upgrade the `virt-launcher` pod. However, migrating a VM in the presence of a resource quota can cause the migration, and subsequently the upgrade, to fail. 
+{VirtProductName} requires significant compute resource allocation to handle virtual machine (VM) live migrations and manage VM infrastructure overhead. When upgrading {VirtProductName}, you must migrate VMs to upgrade the `virt-launcher` pod. However, migrating a VM in the presence of a resource quota can cause the migration, and subsequently the upgrade, to fail.
 
 With AAQ, you can allocate resources for VMs without interfering with cluster-level activities such as upgrades and node maintenance. The AAQ Operator also supports non-compute resources which eliminates the need to manage both the native resource quota and AAQ API objects separately.
 
@@ -32,23 +32,23 @@ metadata:
   name: example-resource-quota
 spec:
   hard:
-    requests.memory: 1Gi 
+    requests.memory: 1Gi
     limits.memory: 1Gi
-    requests.cpu/vmi: "1" # <1>
-    requests.memory/vmi: 1Gi # <2>
+    requests.cpu/vmi: "1"
+    requests.memory/vmi: 1Gi
 # ...
 ----
-<1> The maximum amount of CPU that is allowed for VM workloads in the default namespace.
-<2> The maximum amount of RAM that is allowed for VM workloads in the default namespace.
+** `spec.hard.requests.cpu/vmi` defines the maximum amount of CPU that is allowed for VM workloads in the default namespace.
+** `spec.hard.requests.memory/vmi` defines the maximum amount of RAM that is allowed for VM workloads in the default namespace.
 
-* `ApplicationAwareClusterResourceQuota`: Mirrors the `ApplicationAwareResourceQuota` object at a cluster scope. It is compatible with the native `ClusterResourceQuota` API object and shares the same specification and status definitions. When creating an AAQ cluster quota, you can select multiple namespaces based on annotation selection, label selection, or both by editing the `spec.selector.labels` or `spec.selector.annotations` fields.
+* `ApplicationAwareClusterResourceQuota`: Mirrors the `ApplicationAwareResourceQuota` object at a cluster scope. It is compatible with the native `ClusterResourceQuota` API object and shares the same specification and status definitions. When creating an AAQ cluster quota, you can select multiple namespaces based on annotation selection, label selection, or both by editing the `spec.selector.labels` or `spec.selector.annotations` fields. You can only create an `ApplicationAwareClusterResourceQuota` object if the `spec.allowApplicationAwareClusterResourceQuota` field in the `HyperConverged` custom resource (CR) is set to `true`.
 +
 Example manifest:
 +
 [source,yaml]
 ----
 apiVersion: aaq.kubevirt.io/v1alpha1
-kind: ApplicationAwareClusterResourceQuota # <1>
+kind: ApplicationAwareClusterResourceQuota
 metadata:
   name: example-resource-quota
 spec:
@@ -65,14 +65,13 @@ spec:
         kubernetes.io/metadata.name: default
 # ...
 ----
-<1> You can only create an `ApplicationAwareClusterResourceQuota` object if the `spec.allowApplicationAwareClusterResourceQuota` field in the `HyperConverged` custom resource (CR) is set to `true`.
 +
 [NOTE]
 ====
 If both `spec.selector.labels` and `spec.selector.annotations` fields are set, only namespaces that match both are selected.
 ====
 
-The AAQ controller uses a scheduling gate mechanism to evaluate whether there is enough of a resource available to run a workload. If so, the scheduling gate is removed from the pod and it is considered ready for scheduling. The quota usage status is updated to indicate how much of the quota is used. 
+The AAQ controller uses a scheduling gate mechanism to evaluate whether there is enough of a resource available to run a workload. If so, the scheduling gate is removed from the pod and it is considered ready for scheduling. The quota usage status is updated to indicate how much of the quota is used.
 
 If the CPU and memory requests and limits for the workload exceed the enforced quota usage limit, the pod remains in `SchedulingGated` status until there is enough quota available. The AAQ controller creates an event of type `Warning` with details on why the quota was exceeded.  You can view the event details by using the `oc get events` command.
 

--- a/modules/virt-about-instance-types.adoc
+++ b/modules/virt-about-instance-types.adoc
@@ -40,12 +40,12 @@ metadata:
   name: example-instancetype
 spec:
   cpu:
-    guest: 1 <1>
+    guest: 1
   memory:
-    guest: 128Mi <2>
+    guest: 128Mi
 ----
-<1> Required. Specifies the number of vCPUs to allocate to the guest.
-<2> Required. Specifies an amount of memory to allocate to the guest.
+* `spec.cpu.guest` is a required field that specifies the number of vCPUs to allocate to the guest.
+* `spec.memory.guest` is a required field that specifies an amount of memory to allocate to the guest.
 
 You can create an instance type manifest by using the `virtctl` CLI utility. For example:
 

--- a/modules/virt-about-storage-pools-pvc-templates.adoc
+++ b/modules/virt-about-storage-pools-pvc-templates.adoc
@@ -20,7 +20,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: iso-pvc
 spec:
-  volumeMode: Block <1>
+  volumeMode: Block
   storageClassName: my-storage-class
   accessModes:
   - ReadWriteOnce
@@ -28,7 +28,8 @@ spec:
     requests:
       storage: 5Gi
 ----
-<1> This value is only required for block volume mode PVs.
+
+The `spec.volumeMode` value is only required for block volume mode PVs.
 
 You define a storage pool using a `pvcTemplate` specification in the HPP CR. The Operator creates a PVC from the `pvcTemplate` specification for each node containing the HPP CSI driver. The PVC created from the PVC template consumes the single large PV, allowing the HPP to create smaller dynamic volumes.
 

--- a/modules/virt-accessing-exported-vm-manifests.adoc
+++ b/modules/virt-accessing-exported-vm-manifests.adoc
@@ -29,9 +29,10 @@ After you export a virtual machine (VM) or snapshot, you can get the `VirtualMac
 +
 [source,terminal]
 ----
-$ oc get vmexport <export_name> -o jsonpath={.status.links.external.cert} > cacert.crt <1>
+$ oc get vmexport <export_name> -o jsonpath={.status.links.external.cert} > cacert.crt
 ----
-<1> Replace `<export_name>` with the `metadata.name` value from the `VirtualMachineExport` object.
++
+Replace `<export_name>` with the `metadata.name` value from the `VirtualMachineExport` object.
 
 .. Copy the `cacert.crt` file to the target cluster.
 
@@ -39,9 +40,10 @@ $ oc get vmexport <export_name> -o jsonpath={.status.links.external.cert} > cace
 +
 [source,terminal]
 ----
-$ oc get secret export-token-<export_name> -o jsonpath={.data.token} | base64 --decode > token_decode <1>
+$ oc get secret export-token-<export_name> -o jsonpath={.data.token} | base64 --decode > token_decode
 ----
-<1> Replace `<export_name>` with the `metadata.name` value from the `VirtualMachineExport` object.
++
+Replace `<export_name>` with the `metadata.name` value from the `VirtualMachineExport` object.
 
 . Copy the `token_decode` file to the target cluster.
 
@@ -73,22 +75,21 @@ status:
 #...
       manifests:
       - type: all
-        url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1beta1/namespaces/example/virtualmachineexports/example-export/external/manifests/all <1>
+        url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1beta1/namespaces/example/virtualmachineexports/example-export/external/manifests/all
       - type: auth-header-secret
-        url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1beta1/namespaces/example/virtualmachineexports/example-export/external/manifests/secret <2>
+        url: https://vmexport-proxy.test.net/api/export.kubevirt.io/v1beta1/namespaces/example/virtualmachineexports/example-export/external/manifests/secret
     internal:
 #...
       manifests:
       - type: all
-        url: https://virt-export-export-pvc.default.svc/internal/manifests/all <3>
+        url: https://virt-export-export-pvc.default.svc/internal/manifests/all
       - type: auth-header-secret
         url: https://virt-export-export-pvc.default.svc/internal/manifests/secret
   phase: Ready
   serviceName: virt-export-example-export
 ----
-<1> Contains the `VirtualMachine` manifest, `DataVolume` manifest, if present, and a `ConfigMap` manifest that contains the public certificate for the external URL's ingress or route.
-<2> Contains a secret containing a header that is compatible with Containerized Data Importer (CDI). The header contains a text version of the export token.
-<3> Contains the `VirtualMachine` manifest, `DataVolume` manifest, if present, and a `ConfigMap` manifest that contains the certificate for the internal URL's export server.
+** `status.links.external.manifests.url` where the `type` is `all` contains the `VirtualMachine` manifest, `DataVolume` manifest, if present, and a `ConfigMap` manifest that contains the public certificate for the external URL's ingress or route.
+** `status.links.external.manifests.url` where the `type` is `auth-header-secret` contains a secret containing a header that is compatible with Containerized Data Importer (CDI). The header contains a text version of the export token.
 
 . Log in to the target cluster.
 
@@ -96,12 +97,12 @@ status:
 +
 [source,terminal]
 ----
-$ curl --cacert cacert.crt <secret_manifest_url> -H \ <1>
-"x-kubevirt-export-token:token_decode" -H \ <2>
+$ curl --cacert cacert.crt <secret_manifest_url> -H \
+"x-kubevirt-export-token:token_decode" -H \
 "Accept:application/yaml"
 ----
-<1> Replace `<secret_manifest_url>` with an `auth-header-secret` URL from the `VirtualMachineExport` YAML output.
-<2> Reference the `token_decode` file that you created earlier.
+** Replace `<secret_manifest_url>` with an `auth-header-secret` URL from the `VirtualMachineExport` YAML output.
+** Reference the `token_decode` file that you created earlier.
 +
 For example:
 +
@@ -114,12 +115,12 @@ $ curl --cacert cacert.crt https://vmexport-proxy.test.net/api/export.kubevirt.i
 +
 [source,terminal]
 ----
-$ curl --cacert cacert.crt <all_manifest_url> -H \ <1>
-"x-kubevirt-export-token:token_decode" -H \ <2>
+$ curl --cacert cacert.crt <all_manifest_url> -H \
+"x-kubevirt-export-token:token_decode" -H \
 "Accept:application/yaml"
 ----
-<1> Replace `<all_manifest_url>` with a URL from the `VirtualMachineExport` YAML output.
-<2> Reference the `token_decode` file that you created earlier.
+** Replace `<all_manifest_url>` with a URL from the `VirtualMachineExport` YAML output.
+** Reference the `token_decode` file that you created earlier.
 +
 For example:
 +


### PR DESCRIPTION
Version(s):
Cherrypick back to as many supported versions as possible without major conflicts. TBC.

Issue:
https://issues.redhat.com/browse/CNV-74970

Link to docs preview:
* https://106125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/advanced_vm_management/virt-understanding-aaq-operator.html
* https://106125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/creating_vm/virt-creating-vms-from-instance-types.html#required-attributes_virt-creating-vms-from-instance-types
* https://106125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-configuring-local-storage-with-hpp.html#virt-about-storage-pools-pvc-templates_virt-configuring-local-storage-with-hpp
* https://106125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/managing_vms/virt-exporting-vms.html

QE review:
N/A - formatting changes only

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
