### PR TITLE
Fix broken link in term_glossary.adoc

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -446,7 +446,7 @@ Usage: Deprecated. Use link:#node[node] instead.
 Usage: node(s)
 
 A
-http://docs.openshift.org/latest/architecture/infrastructure_components/kubernetes_infrastructure.html#node[node]
+https://kubernetes.io/docs/concepts/architecture/nodes/[node]
 provides the runtime environments for containers.
 
 ''''


### PR DESCRIPTION
Changes:
- Replace broken docs.openshift.org link with the equivalent Kubernetes documentation URL for nodes ( https://kubernetes.io/docs/concepts/architecture/nodes/).

Why:
- The previous link is no longer active and returns a dead page. Updated to the official Kubernetes documentation, which covers the same topic.

Scope:
- Documentation (contributing_to_docs/term_glossary.adoc ony).

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
