### PR TITLE
OSSM-12349 2.6.13 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -215,7 +215,7 @@ endif::[]
 :product-rosa: Red{nbsp}Hat OpenShift Service on AWS
 :SMProductName: Red{nbsp}Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.6.12
+:SMProductVersion: 2.6.13
 :MaistraVersion: 2.6
 :KialiProduct: Kiali Operator provided by Red Hat
 :SMPlugin: OpenShift Service Mesh Console (OSSMC) plugin

--- a/modules/ossm-release-2-6-12.adoc
+++ b/modules/ossm-release-2-6-12.adoc
@@ -7,11 +7,10 @@
 = {SMProductName} version 2.6.12
 
 [role="_abstract"]
+
 This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.12, and includes the `ServiceMeshControlPlane` resource version updates for 2.6.12.
 
 This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
-
-include::snippets/ossm-current-version-support-snippet.adoc[]
 
 You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
 

--- a/modules/ossm-release-2-6-13.adoc
+++ b/modules/ossm-release-2-6-13.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/servicemesh-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ossm-release-2-6-13_{context}"]
+= {SMProductName} version 2.6.13
+
+[role="_abstract"]
+
+This release of {SMProductName} updates the {SMProductName} Operator version to 2.6.13, and includes the `ServiceMeshControlPlane` resource version updates for 2.6.13.
+
+This release addresses Common Vulnerabilities and Exposures (CVEs) and is supported on {product-title} 4.14 and later.
+
+include::snippets/ossm-current-version-support-snippet.adoc[]
+
+You can use the most current version of the {KialiProduct} with all supported versions of {SMProductName}. The version of {SMProductShortName} automatically ensures a compatible version of Kiali.
+
+[id="ossm-release-2-6-13-components_{context}"]
+== Component updates
+
+|===
+|Component |Version
+
+|Istio
+|1.20.8
+
+|Envoy Proxy
+|1.28.8
+
+|Kiali Server
+|1.73
+|===
+
+[id="ossm-fixed-issues-2-6-13_{context}"]
+== Fixed issues
+
+* Before this update, the `Kiali` Custom Resource (CR) went temporarily to an invalid state after switching Service Mesh Control Plane (SMCP) from `MultiTenant` to `ClusterWide` mode. As a consequence, there was a brief service disruption for users. With this release, the changes in `accessible_namespaces` and `cluster_wide_access` settings when updating from `MultiTenant` to `ClusterWide` avoid the temporary invalid state of `Kiali` CR, ensuring a smoother transition.
++
+https://issues.redhat.com/browse/OSSM-12223[OSSM-12223]
+
+* Before this update, the `must-gather` command failed due to the lack of `rsync` and `tar` tools. As a consequence, users were unable to gather information from the cluster. With this release, the `must-gather` command now uses alternative tools for data collection. As a result, the command successfully downloads data, improving cluster information retrieval.
++
+link:https://issues.redhat.com/browse/OSSM-12405[OSSM-12405]

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 // The following include statements pull in the module files that comprise 2.x release notes.
 
+include::modules/ossm-release-2-6-13.adoc[leveloffset=+1]
+
 include::modules/ossm-release-2-6-12.adoc[leveloffset=+1]
 
 include::modules/ossm-release-2-6-11.adoc[leveloffset=+1]


### PR DESCRIPTION
Change type: Doc update; OSSM 2.6.13 (At Stage): [DOC] Release Notes, Known Issues and Bug Fixes

Doc JIRA: https://issues.redhat.com/browse/OSSM-12349

Fix Version: 4.14+

Doc Previews: https://106170--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-release-2-6-13_ossm-release-notes

QE Review: @mkralik3 @pbajjuri20 
Peer Review: @kaldesai 