### PR TITLE
Update the file for the 4.21 version

### DIFF
--- a/modules/monitoring-alert-reference-for-the-cluster-monitoring-operator.adoc
+++ b/modules/monitoring-alert-reference-for-the-cluster-monitoring-operator.adoc
@@ -26,10 +26,6 @@ Learn about alerting rules that are managed by the {cmo-first} and are included 
 | `ClusterMonitoringOperatorDeprecatedConfig` | info | 1h | The configuration field $labels.field in $labels.configmap was deprecated in $labels.deprecation_version and has no effect.
 | `ClusterMonitoringOperatorReconciliationErrors` | warning | 1h | Errors are occurring during reconciliation cycles. Inspect the cluster-monitoring-operator log for potential root causes.
 | `ConfigReloaderSidecarErrors` | warning | 10m | Errors encountered while the $labels.pod config-reloader sidecar attempts to sync config in $labels.namespace namespace. As a result, configuration for service running in $labels.pod may be stale and cannot be updated anymore.
-| `KubeAggregatedAPIDown` | warning | 15m | Kubernetes aggregated API $labels.name/$labels.name has been only $value% available over the last 10m.
-| `KubeAggregatedAPIErrors` | warning | 10m | Kubernetes aggregated API $labels.instance/$labels.name has reported $labels.reason errors.
-| `KubeAPIDown` | critical | 15m | KubeAPI has disappeared from Prometheus target discovery.
-| `KubeAPITerminatedRequests` | warning | 5m | The kubernetes apiserver has terminated $value of its incoming requests.
 | `KubeClientErrors` | warning | 15m | Kubernetes API server client '$labels.job/$labels.instance' is experiencing $value errors.
 | `KubeContainerWaiting` | warning | 1h | pod/$labels.pod in namespace $labels.namespace on container $labels.container has been in waiting state for longer than 1 hour. (reason: "$labels.reason").
 | `KubeCPUOvercommit` | warning | 10m | Cluster has overcommitted CPU resource requests for Pods by $value CPU shares and cannot tolerate node failure.
@@ -80,7 +76,7 @@ Learn about alerting rules that are managed by the {cmo-first} and are included 
 | `NodeFilesystemFilesFillingUp` | critical | 1h | Filesystem on $labels.device, mounted on $labels.mountpoint, at $labels.instance has only $value% available inodes left and is filling up fast.
 | `NodeFilesystemSpaceFillingUp` | warning | 1h | Filesystem on $labels.device, mounted on $labels.mountpoint, at $labels.instance has only $value% available space left and is filling up.
 | `NodeFilesystemSpaceFillingUp` | critical | 1h | Filesystem on $labels.device, mounted on $labels.mountpoint, at $labels.instance has only $value% available space left and is filling up fast.
-| `NodeHighNumberConntrackEntriesUsed` | warning | 0s | $value of conntrack entries are used.
+| `NodeHighNumberConntrackEntriesUsed` | warning | 0s | $labels.instance $value of conntrack entries are used.
 | `NodeMemoryMajorPagesFaults` | warning | 15m | Memory major pages are occurring at very high rate at $labels.instance, 500 major page faults per second for the last 15 minutes, is currently at $value. Please check that there is enough memory available at this instance.
 | `NodeNetworkInterfaceFlapping` | warning | 2m | Network interface "$labels.device" changing its up status often on node-exporter $labels.namespace/$labels.pod
 | `NodeNetworkReceiveErrs` | warning | 1h | $labels.instance interface $labels.device has encountered $value receive errors in the last two minutes.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): made for 4.21, see https://github.com/openshift/openshift-docs/pull/104437 for more info.
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-3075
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://106204--ocpdocs-pr.netlify.app/openshift-monitoring/latest/alert-reference/alert-reference-for-the-cluster-monitoring-operator.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
