### PR TITLE
TELCODOCS-2645: DITA compatibility fixes for PTP about-ptp assembly

### DIFF
--- a/modules/cnf-about-ptp-and-clock-synchronization.adoc
+++ b/modules/cnf-about-ptp-and-clock-synchronization.adoc
@@ -7,6 +7,7 @@
 [id="cnf-about-ptp-and-clock-synchronization_{context}"]
 = About PTP and clock synchronization error events
 
+[role="_abstract"]
 Cloud native applications such as virtual RAN (vRAN) require access to notifications about hardware timing events that are critical to the functioning of the overall network.
 PTP clock synchronization errors can negatively affect the performance and reliability of your low-latency application, for example, a vRAN application running in a distributed unit (DU).
 

--- a/modules/nw-ptp-introduction.adoc
+++ b/modules/nw-ptp-introduction.adoc
@@ -33,3 +33,8 @@ One of the main advantages that PTP has over NTP is the hardware support present
 Hardware-based PTP provides optimal accuracy, since the NIC can timestamp the PTP packets at the exact moment they are sent and received. Compare this to software-based PTP, which requires additional processing of the PTP packets by the operating system.
 
 Before enabling PTP, ensure that NTP is disabled for the required nodes. You can disable the chrony time service (`chronyd`) using a `MachineConfig` custom resource.
+
+[IMPORTANT]
+====
+Although PTP provides superior accuracy over NTP, you can configure NTP as a backup time source for PTP Grandmaster (T-GM) clocks. In GNSS-to-NTP failover configurations, the system uses GNSS as the primary time source through PTP, but automatically fails over to NTP (`chronyd`) if the GNSS signal is lost or degraded. This provides resilient timekeeping even when the primary GNSS time source is temporarily unavailable. For more information about configuring GNSS-to-NTP failover, see _Configuring GNSS/NTP failover_.
+====

--- a/modules/ptp-dual-nics.adoc
+++ b/modules/ptp-dual-nics.adoc
@@ -6,6 +6,7 @@
 [id="ptp-dual-nics_{context}"]
 = 2-card E810 NIC configuration reference
 
+[role="_abstract"]
 {product-title} supports single and dual-NIC Intel E810 hardware for PTP timing in grandmaster clocks (T-GM) and boundary clocks (T-BC).
 
 Dual NIC grandmaster clock::

--- a/modules/ptp-dual-ports-oc.adoc
+++ b/modules/ptp-dual-ports-oc.adoc
@@ -6,6 +6,7 @@
 [id="ptp-dual-ports-oc_{context}"]
 = Using dual-port NICs to improve redundancy for PTP ordinary clocks
 
+[role="_abstract"]
 {product-title} supports single-port networking interface cards (NICs) as ordinary clocks for PTP timing. To improve redundancy, you can configure a dual-port NIC with one port as active and the other as standby.
 
 :FeatureName: Configuring linuxptp services as an ordinary clock with dual-port NIC redundancy

--- a/modules/ptp-linuxptp-introduction.adoc
+++ b/modules/ptp-linuxptp-introduction.adoc
@@ -6,6 +6,7 @@
 [id="ptp-linuxptp-introduction_{context}"]
 = Overview of linuxptp and gpsd in {product-title} nodes
 
+[role="_abstract"]
 {product-title} uses the PTP Operator with `linuxptp` and `gpsd` packages for high precision network synchronization.
 The `linuxptp` package provides tools and daemons for PTP timing in networks.
 Cluster hosts with Global Navigation Satellite System (GNSS) capable NICs use `gpsd` to interface with GNSS clock sources.

--- a/modules/ptp-overview-of-gnss-grandmaster-clock.adoc
+++ b/modules/ptp-overview-of-gnss-grandmaster-clock.adoc
@@ -6,6 +6,7 @@
 [id="ptp-overview-of-gnss-grandmaster-clock_{context}"]
 = Overview of GNSS timing for PTP grandmaster clocks
 
+[role="_abstract"]
 {product-title} supports receiving precision PTP timing from Global Navigation Satellite System (GNSS) sources and grandmaster clocks (T-GM) in the cluster.
 
 [IMPORTANT]

--- a/modules/ptp-three-card-grandmaster.adoc
+++ b/modules/ptp-three-card-grandmaster.adoc
@@ -6,6 +6,7 @@
 [id="ptp-three-card-grandmaster_{context}"]
 = 3-card Intel E810 PTP grandmaster clock
 
+[role="_abstract"]
 {product-title} supports cluster hosts with 3 Intel E810 NICs as PTP grandmaster clocks (T-GM).
 
 3-card grandmaster clock::

--- a/networking/advanced_networking/ptp/about-ptp.adoc
+++ b/networking/advanced_networking/ptp/about-ptp.adoc
@@ -35,11 +35,6 @@ include::modules/nw-ptp-introduction.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../../machine_configuration/machine-configs-configure.adoc#cnf-disable-chronyd_machine-configs-configure[Disabling chrony time service]
 
-[IMPORTANT]
-====
-Although PTP provides superior accuracy over NTP, you can configure NTP as a backup time source for PTP Grandmaster (T-GM) clocks. In GNSS-to-NTP failover configurations, the system uses GNSS as the primary time source through PTP, but automatically fails over to NTP (`chronyd`) if the GNSS signal is lost or degraded. This provides resilient timekeeping even when the primary GNSS time source is temporarily unavailable. For more information about configuring GNSS-to-NTP failover, see _Configuring GNSS/NTP failover_.
-====
-
 include::modules/ptp-linuxptp-introduction.adoc[leveloffset=+1]
 
 include::modules/ptp-overview-of-gnss-grandmaster-clock.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-2645]: [DITA compatibility fixes for PTP about-ptp assembly]

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16 > 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2645
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://106215--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/advanced_networking/ptp/about-ptp.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- Add [role="_abstract"] to 6 PTP modules for DITA short description support
- Move IMPORTANT admonition about NTP failover from assembly into nw-ptp-introduction module
- Clean up Additional resources section in assembly to contain only links
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
