### PR TITLE
OSDOCS-17102 CQA 2.0 of MSH-AI-1: Core Concepts

### DIFF
--- a/microshift_ai/microshift-rhoai.adoc
+++ b/microshift_ai/microshift-rhoai.adoc
@@ -1,11 +1,12 @@
 :_mod-docs-content-type: ASSEMBLY
-[id="microshift-rh-openshift-ai"]
 include::_attributes/attributes-microshift.adoc[]
+[id="microshift-rh-openshift-ai"]
 = Using {rhoai-full} with {microshift-short}
 :context: microshift-rh-openshift-ai
 
 toc::[]
 
+[role="_abstract"]
 Learn how to serve artificial intelligence and machine learning (AI/ML) models with {ai-first} on your {microshift-short} edge deployments.
 
 :FeatureName: {rhoai-full}
@@ -15,23 +16,11 @@ include::modules/microshift-rhoai-con.adoc[leveloffset=+1]
 
 include::modules/microshift-rhoai-workflow.adoc[leveloffset=+1]
 
-//additional resources for rhoai-workflow module
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../microshift_networking/microshift-configuring-routes.adoc#microshift-configuring-routes[Configuring routes]
-
 include::modules/microshift-rhoai-install.adoc[leveloffset=+1]
 
 include::modules/microshift-rhoai-create-ns.adoc[leveloffset=+1]
 
 include::modules/microshift-rhoai-model-package-oci.adoc[leveloffset=+1]
-
-//additional resources for rhoai-oci module
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://kserve.github.io/website/latest/modelserving/storage/oci/[Serving models with OCI images] (KServe documentation)
 
 include::modules/microshift-rhoai-serving-ai-models-con.adoc[leveloffset=+1]
 
@@ -41,27 +30,6 @@ include::modules/microshift-rhoai-supported-mserv-runtimes.adoc[leveloffset=+2]
 
 include::modules/microshift-rhoai-servingruntimes-ex.adoc[leveloffset=+1]
 
-//additional resources for serving runtimes procedure module
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/about-model-serving_about-model-serving#about-model-serving_about-model-serving[About model serving] ({rhoai-full}  documentation)
-
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/serving-large-models_serving-large-models#servingruntime[Model-serving runtimes] ({rhoai-full} documentation)
-
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/serving-large-models_serving-large-models[Serving models on the single-model serving platform] ({rhoai-full} documentation)
-
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_cloud_service/latest/html/serving_models/serving-large-models_serving-large-models#tested-verified-runtimes_serving-large-models[Tested and verified model-serving runtimes] ({rhoai-full} documentation)
-//the `2-latest` link is not working (2-latest in place of `1`)
-
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/serving-large-models_serving-large-models#adding-a-tested-and-verified-model-serving-runtime-for-the-single-model-serving-platform_serving-large-models[Adding a tested and verified model-serving runtime for the single-model serving platform] ({rhoai-full} documentation)
-
-* link:https://kserve.github.io/website/0.8/modelserving/servingruntimes/[Serving Runtimes] (KServe documentation)
-
-* link:https://kserve.github.io/website/latest/modelserving/data_plane/v1_protocol/[V1 Inference Protocol] (KServe documentation)
-
-* link:https://kserve.github.io/website/latest/modelserving/data_plane/v2_protocol/[Open Inference Protocol (V2)] (KServe documentation)
-
 include::modules/microshift-rhoai-inferenceservice-ex.adoc[leveloffset=+1]
 
 include::modules/microshift-rhoai-export-metrics-otel.adoc[leveloffset=+2]
@@ -70,17 +38,7 @@ include::modules/microshift-inferenceservice-more-options.adoc[leveloffset=+2]
 
 include::modules/microshift-rhoai-model-serving-rt-verify.adoc[leveloffset=+1]
 
-//additional resources for inferenceservice modules
-.Additional resources
-
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/serving-large-models_serving-large-models#inferenceservice[InferenceService] ({rhoai-full} documentation)
-
 include::modules/microshift-rhoai-create-route.adoc[leveloffset=+1]
-
-//additional resources for creating a route
-.Additional resources
-
-* xref:../microshift_networking/microshift-configuring-routes.adoc#microshift-configuring-routes[Configuring routes]
 
 include::modules/microshift-rhoai-query-model-con.adoc[leveloffset=+1]
 
@@ -93,3 +51,32 @@ include::modules/microshift-rhoai-query-model.adoc[leveloffset=+2]
 include::modules/microshift-rhoai-get-model-server-metrics.adoc[leveloffset=+2]
 
 include::modules/microshift-rhoai-override-kserve-config.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../microshift_networking/microshift-configuring-routes.adoc#microshift-configuring-routes[Configuring routes]
+
+* link:https://kserve.github.io/website/latest/modelserving/storage/oci/[Serving models with OCI images (KServe documentation)]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/about-model-serving_about-model-serving#about-model-serving_about-model-serving[About model serving ({rhoai-full}  documentation)]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/serving-large-models_serving-large-models#servingruntime[Model-serving runtimes ({rhoai-full} documentation)]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/serving-large-models_serving-large-models[Serving models on the single-model serving platform ({rhoai-full} documentation)]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_cloud_service/latest/html/serving_models/serving-large-models_serving-large-models#tested-verified-runtimes_serving-large-models[Tested and verified model-serving runtimes ({rhoai-full} documentation)]
+//the `2-latest` link is not working (2-latest in place of `1`)
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/serving-large-models_serving-large-models#adding-a-tested-and-verified-model-serving-runtime-for-the-single-model-serving-platform_serving-large-models[Adding a tested and verified model-serving runtime for the single-model serving platform ({rhoai-full} documentation)]
+
+* link:https://kserve.github.io/website/0.8/modelserving/servingruntimes/[Serving Runtimes (KServe documentation)]
+
+* link:https://kserve.github.io/website/latest/modelserving/data_plane/v1_protocol/[V1 Inference Protocol (KServe documentation)]
+
+* link:https://kserve.github.io/website/latest/modelserving/data_plane/v2_protocol/[Open Inference Protocol (V2) (KServe documentation)]
+
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/serving-large-models_serving-large-models#inferenceservice[InferenceService]
+
+* xref:../microshift_networking/microshift-configuring-routes.adoc#microshift-configuring-routes[Configuring routes]

--- a/modules/microshift-rhoai-con.adoc
+++ b/modules/microshift-rhoai-con.adoc
@@ -6,15 +6,18 @@
 [id="microshift-rhoai-con_{context}"]
 = How {rhoai-full} works in {microshift-short}
 
-Edge deployments are where data happens and decisions need to be made. You can use {rhoai-full} ({rhoai}) to integrate a fleet of {microshift-short}-driven edge devices into the artificial intelligence and machine learning (AI/ML) operations cycle. {microshift-short} is compatible with a single-model serving platform based on the KServe component of Kubernetes. KServe is a platform that orchestrates model serving.
+[role="_abstract"]
+Edge deployments are where data happens and decisions need to be made. You can use {rhoai-full} ({rhoai}) to integrate a fleet of {microshift-short}-driven edge devices into the artificial intelligence and machine learning (AI/ML) operations cycle.
+
+{microshift-short} is compatible with a single-model serving platform based on the KServe component of Kubernetes. KServe is a platform that orchestrates model serving.
 
 {rhoai} is a platform for data scientists and developers of AI/ML applications. First, use {rhoai} in the cloud or data center to develop, train, and test an AI model. Then, run your model in your edge deployments on {microshift-short}.
 
-After you deploy your AI model, application data can be sent to the model where the model can make data-driven decisions without a human user. This is an ideal scenario for edge applications where interaction with an administrator is naturally limited.
+After you deploy your AI model, application data can be sent to the model, so that the model can make data-driven decisions without a human user. This is an ideal scenario for edge applications where interaction with an administrator is naturally limited.
 
 Implemented with KServe::
 
-The KServe component includes model-serving runtimes that implement the loading of various types of model servers. These runtimes are configured with custom resources (CRs). KServe custom resource definitions (CRDs) also define the lifecycle of the deployment object, storage access, and networking setup.
+The KServe component includes model-serving runtimes that implement the loading of various types of model servers. These runtimes are configured with custom resources (CRs). KServe custom resource definitions (CRDs) also define the life cycle of the deployment object, storage access, and networking setup.
 
 Specifics of using {rhoai} with {microshift-short}::
 

--- a/modules/microshift-rhoai-create-ns.adoc
+++ b/modules/microshift-rhoai-create-ns.adoc
@@ -6,6 +6,7 @@
 [id="microshift-rhoai-create-namespace_{context}"]
 = Creating a namespace for your AI model on {microshift-short}
 
+[role="_abstract"]
 Create a namespace for your AI model and all other resources.
 
 .Prerequisites
@@ -19,23 +20,29 @@ Create a namespace for your AI model and all other resources.
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc create ns _<namespace_name>_ <1>
+$ oc create ns _<namespace_name>_
 ----
-<1> Replace `_<namespace_name>_` with the namespace name you want to use. In the following examples, `ai-demo` is used.
+where:
+
+`_<namespace_name>_`:: Specifies the namespace name to use. In the following examples, `ai-demo` is used.
 
 .Verification
 
-* Verify that you created the desired namespace by running the following command:
+* Verify that you created the namespace by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc get ns _<namespace_name>_ <1>
+$ oc get ns _<namespace_name>_
 ----
-<1> Replace `_<namespace_name>_` with the namespace name you want to use. In the following examples, `ai-demo` is used.
+where:
++
+--
+`_<namespace_name>_`:: Specifies the namespace name you want to use. In the following examples, `ai-demo` is used.
+--
 +
 .Example output
 [source,text]
 ----
 NAME                STATUS  AGE
-ai-demo   Active  1h
+ai-demo             Active  1h
 ----

--- a/modules/microshift-rhoai-install.adoc
+++ b/modules/microshift-rhoai-install.adoc
@@ -52,7 +52,7 @@ $ sudo dnf install microshift-ai-model-serving-release-info
 +
 [NOTE]
 ====
-The `microshift-ai-model-serving-release-info` RPM contains a JSON file with image references useful for offline procedures or deploying a copy of a `ServingRuntime` Custom Resource to your namespace during a bootc image build.
+The `microshift-ai-model-serving-release-info` RPM contains a JSON file with image references useful for offline procedures or deploying a copy of a `ServingRuntime` custom resource (CR) to your namespace during a bootc image build.
 ====
 
 .Verification
@@ -65,7 +65,6 @@ $ oc get pods -n redhat-ods-applications
 ----
 +
 .Example output
-+
 [source,text]
 ----
 NAME                                        READY   STATUS    RESTARTS   AGE

--- a/modules/microshift-rhoai-model-package-oci.adoc
+++ b/modules/microshift-rhoai-model-package-oci.adoc
@@ -6,6 +6,7 @@
 [id="microshift-rhoai-model-package-oci_{context}"]
 = Packaging your AI model into an OCI image
 
+[role="_abstract"]
 You can package your model into an OCI image and use the ModelCar approach to help you set up offline environments. With the ModelCar approach, your model can be embedded just like any other container image.
 
 [NOTE]
@@ -31,7 +32,6 @@ The exact directory structure depends on the model server. The following example
 . Prepare a Containerfile with a compatible model and model server.
 +
 .Example Containerfile with a ResNet-50 model used with the OVMS
-+
 [source,text]
 ----
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
@@ -46,20 +46,22 @@ RUN wget -q -P /models/1 \
 +
 [source,terminal,subs="+quotes"]
 ----
-$ IMAGE_REF=_<ovms-resnet50:test>_ <1>
+$ IMAGE_REF=_<ovms-resnet50:test>_
 ----
-<1> Replace `_<ovms-resnet50:test>_` with the name of your image reference. In this example, the `_<repo:tag>_` format is used. Your image reference name is specific to your use case.
+where:
+
+`_<ovms-resnet50:test>_`:: Specifies the name of your image reference. In this example, the `_<repo:tag>_` format is used. Your image reference name is specific to your use case.
 
 . Build the Containerfile by running the following command:
 +
 [source,terminal]
 ----
-$ sudo podman build -t $IMAGE_REF <1>
+$ sudo podman build -t $IMAGE_REF
 ----
-<1> Because CRI-O and Podman share storage, using `sudo` is required to make the image part of the root's container storage and usable by {microshift-short}.
++
+Because CRI-O and Podman share storage, using `sudo` is required to make the image part of the root's container storage and usable by {microshift-short}.
 +
 .Example output
-+
 [source,text]
 ----
 STEP 1/4: FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
@@ -92,7 +94,7 @@ $ sudo podman push $IMAGE_REF
 +
 [IMPORTANT]
 ====
-For offline use cases, include a tag other than `latest`. If the `latest` tag is used, the container that fetches and sets up the model is configured with the `imagePullPolicy:` parameter set to `Always` and the local image is ignored. If you use any other tag than `latest`, the `imagePullPolicy:` parameter is set to `IfNotPresent`.
+For offline use cases, include a tag other than `latest`. If you use the `latest` tag, the container that fetches and sets up the model is configured with the `imagePullPolicy:` parameter set to `Always` and the local image is ignored. If you use any other tag than `latest`, the `imagePullPolicy:` parameter is set to `IfNotPresent`.
 ====
 
 .Verification
@@ -101,8 +103,13 @@ For offline use cases, include a tag other than `latest`. If the `latest` tag is
 +
 [source,terminal]
 ----
-$ sudo podman images ovms-resnet50
+$ sudo podman images _<ovms-resnet50:test>_
 ----
+where:
++
+--
+`_<ovms-resnet50>_`:: Specifies the name of your image reference. 
+--
 +
 .Example output
 [source,text]

--- a/modules/microshift-rhoai-serving-ai-models-con.adoc
+++ b/modules/microshift-rhoai-serving-ai-models-con.adoc
@@ -6,7 +6,8 @@
 [id="microshift-rhoai-serving-ai-models-con_{context}"]
 = Serving AI models on {microshift-short}
 
-You can serve models on the {rhoai} single-model serving platform in {microshift-short} by configuring a model-serving runtime using the `ServingRuntime` and `InferenceService` custom resource (CRs).
+[role="_abstract"]
+You can review the following information to learn how to serve models on the {rhoai} single-model serving platform in {microshift-short} by configuring a model-serving runtime using the `ServingRuntime` and `InferenceService` custom resource (CRs).
 
 Model-serving runtimes for AI models in {microshift-short}::
 

--- a/modules/microshift-rhoai-servingruntimes-ex.adoc
+++ b/modules/microshift-rhoai-servingruntimes-ex.adoc
@@ -6,7 +6,10 @@
 [id="microshift-rhoai-servingruntimes-ex_{context}"]
 = Creating a ServingRuntime CR for use in {microshift-short}
 
-Create a `ServingRuntime` custom resource (CR) based on installed manifests and release information. The included steps are an example of reusing the included `microshift-ai-model-serving` manifest files to re-create the {ovms} ({ov}) model-serving runtime in the workload namespace.
+[role="_abstract"]
+You can create a `ServingRuntime` custom resource (CR) based on installed manifests and release information. 
+
+The included steps are an example of reusing the included `microshift-ai-model-serving` manifest files to re-create the {ovms} ({ov}) model-serving runtime in the workload namespace.
 
 [NOTE]
 ====
@@ -25,9 +28,10 @@ This approach does not require a live node, so it can be part of CI/CD automatio
 +
 [source,terminal]
 ----
-$ OVMS_IMAGE="$(jq -r '.images | with_entries(select(.key == "ovms-image")) | .[]' /usr/share/microshift/release/release-ai-model-serving-"$(uname -i)".json)" <1>
+$ OVMS_IMAGE="$(jq -r '.images | with_entries(select(.key == "ovms-image")) | .[]' /usr/share/microshift/release/release-ai-model-serving-"$(uname -i)".json)"
 ----
-<1> In this example, the image reference for the {ov} model-serving runtime is extracted.
++
+In this example, the image reference for the {ov} model-serving runtime is extracted.
 
 . Copy the original `ServingRuntime` YAML file by running the following command:
 +
@@ -47,10 +51,14 @@ $ sed -i "s,image: ovms-image,image: ${OVMS_IMAGE}," ./ovms-kserve.yaml
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc create -n _<ai_demo>_ -f ./ovms-kserve.yaml <1>
+$ oc create -n _<ai_demo>_ -f ./ovms-kserve.yaml
 ----
-<1> Replace `_<ai_demo>_` with the name of your namespace.
-
+where:
++
+--
+`_<ai_demo>_`:: Specifies the name of your namespace.
+--
++
 [IMPORTANT]
 ====
 If the `ServingRuntime` CR is part of a new manifest, set the namespace in the `kustomization.yaml` file, for example:
@@ -72,4 +80,4 @@ resources:
 * Create the `InferenceService` object.
 * Verify that your model is ready for inferencing.
 * Query the model.
-* Optional: examine the model metrics.
+* Optional: Examine the model metrics.

--- a/modules/microshift-rhoai-supported-crds.adoc
+++ b/modules/microshift-rhoai-supported-crds.adoc
@@ -6,7 +6,8 @@
 [id="microshift-rhoai-supported-crds_{context}"]
 = Supported {rhoai} custom resource definitions
 
-The following {rhoai} custom resource definitions (CRDs) are supported:
+[role="_abstract"]
+You can review following information to learn about the {rhoai} custom resource definitions (CRDs) that are supported:
 
 * `InferenceServices`
 * `TrainedModels`

--- a/modules/microshift-rhoai-supported-mserv-runtimes.adoc
+++ b/modules/microshift-rhoai-supported-mserv-runtimes.adoc
@@ -6,7 +6,8 @@
 [id="microshift-rhoai-supported-models_{context}"]
 = Supported {rhoai} model-serving runtimes
 
-The following {rhoai} model-serving runtimes are verified for {microshift-short} deployments:
+[role="_abstract"]
+You can review following information to learn about the {rhoai} model-serving runtimes that are verified for {microshift-short} deployments:
 
 * vLLM ServingRuntime for KServe
 * {ovms}

--- a/modules/microshift-rhoai-workflow.adoc
+++ b/modules/microshift-rhoai-workflow.adoc
@@ -6,12 +6,13 @@
 [id="microshift-rhoai-workflow_{context}"]
 = Workflow for using {rhoai} with {microshift-short}
 
-Using {rhoai} with {microshift-short} requires the following general workflow:
+[role="_abstract"]
+You can review the following information to learn about the workflow for using {rhoai} with {microshift-short}.
 
 Getting your AI model ready::
 
 * Choose the artificial intelligence (AI) model that best aligns with your edge application and the decisions that need to be made at {microshift-short} deployment sites.
-* In the cloud or data center, develop, train, and test your model.
+* Develop, train, and test your model in your cloud or data center.
 * Plan for the system requirements and additional resources your AI model requires to run.
 
 Setting up the deployment environment::
@@ -24,7 +25,7 @@ Setting up the deployment environment::
 +
 [TIP]
 ====
-Using only a driver and device plugin instead of an Operator might be more resource efficient.
+Using only a driver and device plugin instead of an Operator might be more resource-efficient.
 ====
 
 Installing the {microshift-short} {rhoai} RPM::


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17102

Link to docs preview:
[How Red Hat OpenShift AI works in MicroShift](https://106259--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-con_microshift-rh-openshift-ai)
[Workflow for using RHOAI with MicroShift](https://106259--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-workflow_microshift-rh-openshift-ai)
[Installing the Red Hat OpenShift AI RPM](https://106259--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-install_microshift-rh-openshift-ai)
[Creating a namespace for your AI model on MicroShift](https://106259--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-create-namespace_microshift-rh-openshift-ai)
[Packaging your AI model into an OCI image](https://106259--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-model-package-oci_microshift-rh-openshift-ai)
[Serving AI models on MicroShift](https://106259--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-serving-ai-models-con_microshift-rh-openshift-ai)
[Supported RHOAI custom resource definitions](https://106259--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-supported-crds_microshift-rh-openshift-ai)
[Supported RHOAI model-serving runtimes](https://106259--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-supported-models_microshift-rh-openshift-ai)
[Creating a ServingRuntime CR for use in MicroShift](https://106259--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-servingruntimes-ex_microshift-rh-openshift-ai)