### PR TITLE
OSDOCS#18253: Update the MicroShift z-stream RNs for 4.18.33

### DIFF
--- a/microshift_release_notes/microshift-4-18-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-18-release-notes.adoc
@@ -33,3 +33,5 @@ include::modules/microshift-4-18-2-dp.adoc[leveloffset=+2]
 include::modules/microshift-4-18-11-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-18-26-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-18-33-dp.adoc[leveloffset=+2]

--- a/modules/microshift-4-18-26-dp.adoc
+++ b/modules/microshift-4-18-26-dp.adoc
@@ -8,7 +8,7 @@
 = RHBA-2025:17912 - {microshift-short} 4.18.26 bug fix and enhancement advisory
 
 [role="_abstract"]
-Issued: 16 October 2026
+Issued: 16 October 2025
 
 {product-title} release 4.18.26 is now available, see the link:https://access.redhat.com/errata/RHBA-2025:17912[RHBA-2025:17912] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2025:17657[RHSA-2025:17657] advisory.
 

--- a/modules/microshift-4-18-33-dp.adoc
+++ b/modules/microshift-4-18-33-dp.adoc
@@ -1,0 +1,23 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-18-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-18-33-dp_{context}"]
+= RHBA-2026:2277 - {microshift-short} 4.18.33 bug fix and enhancement advisory
+
+[role="_abstract"]
+Issued: 12 February 2026
+
+{product-title} release 4.18.33 is now available, see the link:https://access.redhat.com/errata/RHBA-2026:2277[RHBA-2026:2277] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:2078[RHSA-2026:2078] advisory.
+
+See the latest images included with {microshift-short} by using the following instructions:
+
+* xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[Listing the contents of the {microshift-short} RPM release package]
+* xref:../microshift_install_bootc/microshift-install-bootc-image.adoc#microshift-install-bootc-get-published-image_microshift-install-publish-bootc-image[Getting the published bootc image for MicroShift]
+
+[id="microshift-4-18-33-bugs_{context}"]
+== Bug fix
+
+There are no notable fixed issues for this release.


### PR DESCRIPTION
Version(s):
4.18

Issue:
[OSDOCS-18253](https://issues.redhat.com//browse/OSDOCS-18253)

Link to docs preview:
[4.18.33](https://106261--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-18-release-notes.html#microshift-4-18-33-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/350#d78bd90b191b7f2da18a354aace20a27ce7edd54) (image)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.18)
