### PR TITLE
[OCPBUGS-76467]IBM Z changes for ABI vlan and bond support

### DIFF
--- a/modules/configuring-network-overrides-ibm-z.adoc
+++ b/modules/configuring-network-overrides-ibm-z.adoc
@@ -47,3 +47,21 @@ random.trust_cpu=on
 ====
 The `override` parameter overrides the host's network configuration settings.
 ====
+
+[IMPORTANT]
+====
+The `ip=` kernel parameter uses the following syntax:
+
+`ip=[IP]:[Gateway]:[Netmask]:[Hostname]:[Interface]:[None]:[DNS]`
+
+For VLAN configurations:
+
+* Define both the **base interface** and the **tagged VLAN interface** separately.
+* The `vlan=` parameter links the tagged interface (for example, `encbdf0.300`) to the underlying physical interface (`encbdf0`).
+
+For bonded interfaces:
+
+* No changes are required in the default kernel command-line parameters.
+* To install nodes by using bonded interfaces, provide the appropriate bond configuration in the `agent-config` file.
+====
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):  4.21 +
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: 
https://issues.redhat.com/browse/OCPBUGS-76467
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://106271--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
