### PR TITLE
OSSM-11390 Document new CRD validations added in Istio 1.23 which might block 2.6->3.0 migration

### DIFF
--- a/migrating/checklists/ossm-migrating-premigration-checklists.adoc
+++ b/migrating/checklists/ossm-migrating-premigration-checklists.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+
 .Before you begin
 
 * You have read "Migrating from Service Mesh 2 to Service Mesh 3".
@@ -34,6 +36,30 @@ You must complete the following checklists before you can begin migrating your d
 
 * [ ] Disable Kiali in your `ServiceMeshControlPlane` resource: `spec.addons.kiali.enabled=false`
 ** [ ] If you did not create a standalone `Kiali` resource as part of Prometheus or tracing, see: "Using {KialiProduct}".
+
+[WARNING]
+====
+{SMProductName} 3 fails to install if outdated `ServiceEntry` custom resources are present in the cluster. The upstream {istio} version 1.24 introduced schema changes that cause installation failures for `ServiceEntry` resources that miss port numbers or exceed 256 hostnames. You can check for affected resources by running the following commands:
+
+* For `ServiceEntry` with hostnames over 256, run the following command:
++
+[source,terminal]
+----
+$ oc get serviceentries -A -o json | jq -r '.items[] | select(.spec.hosts | length > 256) | "\(.metadata.namespace)/\(.metadata.name): \(.spec.hosts | length) hosts"'
+----
+
+* For `ServiceEntry` with missing port numbers, run the following command:
++
+[source,terminal]
+----
+$ oc get serviceentries -A -o json | jq -r '.items[] | select(.spec.ports == null or (.spec.ports | length == 0)) | "\(.metadata.namespace)/\(.metadata.name)"'
+----
+
+To ensure a seamless migration to {SMProductName} 3, perform the following corrective actions before installing the OSSM 3 operator:
+
+* Split `ServiceEntry` resources: You must split any `ServiceEntry` containing more than 256 hosts into multiple smaller resources.
+* Validate port configurations: You must ensure that all the `ServiceEntry` definitions include the required port specifications.
+====
 
 [id="migrate-to-explicitly-managed-routes_{context}"]
 == Migrate to explicitly managed routes


### PR DESCRIPTION
Change type: Doc update; Document new CRD validations added in Istio 1.23 which might block 2.6->3.0 migration

Doc JIRA: https://issues.redhat.com/browse/OSSM-11390

Fix Version:

- [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
- [service-mesh-docs-3.0](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.0)

Doc Preview: https://106274--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/migrating/checklists/ossm-migrating-premigration-checklists.html#disable-add-ons-and-reconfigure-replacements_ossm-migrating-premigration-checklists

SME/QE review: @fjglira @FilipB 
Peer Review: @kaldesai 