### PR TITLE
OSDOCS-18019-2: fixes  compatibility and versions 1.2

### DIFF
--- a/_attributes/attributes.adoc
+++ b/_attributes/attributes.adoc
@@ -22,7 +22,7 @@
 :ocp-2: 4.18
 
 :service-mesh: OpenShift Service Mesh
-:service-mesh-version: 3.2
+:service-mesh-version: 3.1
 :api-controller: API controller
 :api-controller-version: 1.0 Developer Preview
 :apicurio-studio: API Designer

--- a/introduction/introduction.adoc
+++ b/introduction/introduction.adoc
@@ -34,5 +34,5 @@ include::modules/con-connectivity-link-supported-configs.adoc[leveloffset=+1]
 
 * link:https://developers.redhat.com/products/red-hat-connectivity-link[Red Hat Connectivity Link]
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html-single/ingress_and_load_balancing/index#ingress-gateway-api[Gateway API with OpenShift Container Platform networking]
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/[Red Hat OpenShift Service Mesh 3.2 documentation]
+* link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.1[Red Hat OpenShift Service Mesh 3.1 documentation]
 

--- a/modules/con-about-connectivity-link.adoc
+++ b/modules/con-about-connectivity-link.adoc
@@ -41,5 +41,5 @@ The following diagram shows a high-level overview of the {prodname} architecture
 .{prodname} architecture
 image::connectivity-link-architecture.png[{prodname} architecture, 600, 575]
 
-{prodname} supports link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/latest/html-single/about/index[{service-mesh} {service-mesh-version}] as the Gateway API provider.
+{prodname} supports link:https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.1[{service-mesh} {service-mesh-version}] as the Gateway API provider.
 

--- a/modules/con-connectivity-link-supported-configs.adoc
+++ b/modules/con-connectivity-link-supported-configs.adoc
@@ -20,19 +20,12 @@
 |*{rh} OpenShift Service on AWS*
 |*Microsoft Azure Red Hat OpenShift*
 
-|Version 1.3
-|4.21, 4.20, 4.19
-|4.21, 4.20, 4.19
-|4.21, 4.20, 4.19
-|4.17
-//TODO need to verify 1.3
-
 |Version 1.2
 |4.20, 4.19, 4.18
 |4.20, 4.19, 4.18
 |4.20, 4.19, 4.18
 |4.17
-//is 1.1 still supported when 1.3 releases, or do we drop this table?
+
 |Version 1.1
 |4.19, 4.18, 4.17
 |4.19, 4.18, 4.17
@@ -50,11 +43,6 @@ For Microsoft Azure, see the link:https://learn.microsoft.com/en-us/azure/opensh
 |*{product-title}*
 |*{rh} {service-mesh}*
 |*cert-manager Operator for Red Hat OpenShift*
-
-|Version 1.3
-|3.1
-|1.17
-//TBD 1.3
 
 |Version 1.2
 |3.1
@@ -101,11 +89,6 @@ For rate limiting policies, {prodname} supports the following Redis-based data s
 |*Amazon Elasticache*
 |*Dragonfly Community or Cloud*
 
-|Version 1.3
-|latest
-|latest
-|latest
-
 |Version 1.2
 |latest
 |latest
@@ -130,9 +113,6 @@ For authentication policies, {prodname} supports API keys and the following prod
 |*{product-title} Version*
 |*{rh} build of Keycloak*
 
-|Version 1.3
-|Version 26.4
-//TODO verify version for 1.3
 |Version 1.2
 |Version 26.4
 


### PR DESCRIPTION
Version(s):
RHCL 1.2

Issue:
[OSDOCS-18019](https://issues.redhat.com/browse/OSDOCS-18019)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Rolls back 1.3-specific changes introduced with https://github.com/openshift/openshift-docs/pull/106278

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
