### PR TITLE
CNV#67878: kubevirt_vm_labels metric RN for 4.21

### DIFF
--- a/virt/release_notes/virt-4-21-release-notes.adoc
+++ b/virt/release_notes/virt-4-21-release-notes.adoc
@@ -50,7 +50,7 @@ The SVVP certification applies to:
 Installing {virtproductname} on {ibm-cloud-name} bare-metal nodes is now generally available. This update provides the ability to install {virtproductname} on {ibm-cloud-title} provisioned bare-metal nodes by using {ai-full}.
 +
 link:https://issues.redhat.com/browse/CNV-27898[CNV-27898]
- 
+
 // Networking
 Custom MAC pool range configuration:: With this update, cluster administrators can specify a custom MAC pool range for a {VirtProductName} environment, preventing potential MAC address conflicts with other virtualization solutions on the same network. This gives cluster administrators more control over network resources, ensuring greater network stability and resource management efficiency.
 +
@@ -125,6 +125,11 @@ With this update, VM owners can force reboot their VMs by clicking *Reset* in th
 link:https://issues.redhat.com/browse/CNV-51003[CNV-51003]
 
 // Monitoring
+
+New metric to list VM labels as Prometheus labels::
+The `kubevirt_vm_labels` metric shows VM labels as Prometheus labels. You can configure the metric to expose and exclude specific labels by editing the `allowlist` and `ignorelist` fields in the `kubevirt-vm-labels-config` config map.
++
+link:https://issues.redhat.com/browse/CNV-56034[CNV-56034]
 
 New alerts in the {VirtProductName} runbooks::
 The following xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbooks[alerts for the {CNVOperatorDisplayName}] are now included in the {VirtProductName} runbooks:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.21 RN
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-67878](https://issues.redhat.com//browse/CNV-67878)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://106299--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-21-release-notes.html under "New metric to list VM labels as Prometheus labels"
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
