### PR TITLE
OSDOCS-18268 [NETOBSERV] Update Configure Operator > Resource considerations

### DIFF
--- a/modules/network-observability-resources-table.adoc
+++ b/modules/network-observability-resources-table.adoc
@@ -6,32 +6,64 @@
 = Resource considerations
 
 [role="_abstract"]
-Review the resource considerations table, which provides baseline examples for configuration settings, such as eBPF memory limits and LokiStack size, tailored to various cluster workload sizes.
+The Network Observability Operator configuration can be adjusted based on the cluster workload size. Use the following baseline examples to determine the appropriate resource limits and configuration settings for the environment.
 
-The following table outlines examples of resource considerations for clusters with certain workload sizes.
-
-[IMPORTANT]
-====
 The examples outlined in the table demonstrate scenarios that are tailored to specific workloads. Consider each example only as a baseline from which adjustments can be made to accommodate your workload needs.
-====
 
-.Resource recommendations
-[options="header"]
+The test beds used for these recommendations are:
+
+* Extra small: 10-node cluster, 4 vCPUs and 16 GiB memory per worker, `LokiStack` size `1x.extra-small`, tested on AWS M6i instances.
+* Small: 25-node cluster, 16 vCPUs and 64 GiB memory per worker, `LokiStack` size `1x.small`, tested on AWS M6i instances.
+* Large: 250-node cluster, 16 vCPUs and 64 GiB memory per worker, `LokiStack` size `1x.medium`, tested on AWS M6i instances. In addition to the worker and controller nodes, three infrastructure nodes (size `M6i.12xlarge`) and one workload node (size `M6i.8xlarge`) were tested.
+
+[id="network-observability-resource-recommendations-table_{context}"]
+.Resource recommendations for cluster sizes
+[cols="2h,1,1,1",options="header"]
 |===
-|                                     | Extra small (10 nodes) | Small (25 nodes)  | Large (250 nodes) ^[2]^
-| *Worker Node vCPU and memory*       | 4 vCPUs\| 16GiB mem ^[1]^ | 16 vCPUs\| 64GiB mem  ^[1]^  |16 vCPUs\| 64GiB Mem ^[1]^
-| *LokiStack size*                    | `1x.extra-small`         | `1x.small`          | `1x.medium`
-| *Network Observability controller memory limit* | 400Mi (default)        | 400Mi (default)    | 400Mi (default)
-| *eBPF sampling interval*                | 50 (default)           | 50 (default)      | 50 (default)
-| *eBPF memory limit*                 | 800Mi (default)        | 800Mi (default)   | 1600Mi
-| *cacheMaxSize*                      | 50,000                 | 100,000 (default) | 100,000 (default)
-| *FLP memory limit*                  | 800Mi (default)        | 800Mi (default)   | 800Mi (default)
-| *FLP Kafka partitions*              | –                    | 48                | 48
-| *Kafka consumer replicas*           | –                    | 6                 | 18
-| *Kafka brokers*                     | –                    | 3 (default)       | 3 (default)
+| Criterion | Extra small (10 nodes) | Small (25 nodes) | Large (250 nodes)
+
+| Operator memory limit: `Subscription` `spec.config.resources`
+| `400Mi` (default)
+| `400Mi` (default)
+| `400Mi` (default)
+
+| eBPF agent sampling interval: `FlowCollector` `spec.agent.ebpf.sampling`
+| `50` (default)
+| `50` (default)
+| `50` (default)
+
+| eBPF agent memory limit: `FlowCollector` `spec.agent.ebpf.resources`
+| `800Mi` (default)
+| `800Mi` (default)
+| `1600Mi`
+
+| eBPF agent cache size: `FlowCollector` `spec.agent.ebpf.cacheMaxSize`
+| `50,000`
+| `120,000` (default)
+| `120,000` (default)
+
+| Processor memory limit: `FlowCollector` `spec.processor.resources`
+| `800Mi` (default)
+| `800Mi` (default)
+| `800Mi` (default)
+
+| Processor replicas: `FlowCollector` `spec.processor.consumerReplicas`
+| `3` (default)
+| `6`
+| `18`
+
+| Deployment model: `FlowCollector` `spec.deploymentModel`
+| `Service` (default)
+| `Kafka`
+| `Kafka`
+
+| Kafka partitions: Kafka installation
+| N/A
+| `48`
+| `48`
+
+| Kafka brokers: Kafka installation
+| N/A
+| `3` (default)
+| `3` (default)
 |===
-[.small]
---
-1. Tested with AWS M6i instances.
-2. In addition to this worker and its controller, 3 infra nodes (size `M6i.12xlarge`) and 1 workload node (size `M6i.8xlarge`) were tested.
---


### PR DESCRIPTION
[OSDOCS-18268](https://issues.redhat.com//browse/OSDOCS-18268) [NETOBSERV] Update Configure Operator > Resource considerations

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Merge to only the `no-1.11` branch - no cherrypicks are required.
I will open one PR against main to incorporate all of the <no-.11> content just before its GA.

Issue:
https://issues.redhat.com/browse/OSDOCS-18268

Link to docs preview:
* Resource considerations:https://106310--ocpdocs-pr.netlify.app/openshift-enterprise/latest/observability/network_observability/configuring-operator.html#network-observability-resources-table_network_observability

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
