### PR TITLE
ROX-32797: Update docs for CRS GA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bin
 commercial_package
 .vscode
 .vale
+claude-review.sh
+.gitignore
+*.md

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -60,9 +60,9 @@ Topics:
     File: cloud-create-instance-ocp
   - Name: Creating a project on your Red Hat OpenShift secured cluster
     File: cloud-ocp-create-project
-  - Name: Generating an init bundle or cluster registration secret for secured clusters
+  - Name: Generating a cluster registration secret or init bundle for secured clusters
     File: init-bundle-cloud-ocp-generate
-  - Name: Applying an init bundle or cluster registration secret for secured clusters
+  - Name: Applying a cluster registration secret or init bundle for secured clusters
     File: init-bundle-cloud-ocp-apply
   - Name: Installing the RHACS Operator for RHACS Cloud Service
     File: cloud-install-operator
@@ -78,9 +78,9 @@ Topics:
   Topics:
   - Name: Creating a RHACS Cloud Service instance for Kubernetes clusters
     File: cloud-create-instance-other
-  - Name: Generating an init bundle for Kubernetes secured clusters
+  - Name: Generating a cluster registration secret or init bundle for Kubernetes secured clusters
     File: init-bundle-cloud-other-generate
-  - Name: Applying an init bundle for Kubernetes secured clusters
+  - Name: Applying a cluster registration secret or init bundle for Kubernetes secured clusters
     File: init-bundle-cloud-other-apply
   - Name: Installing secured cluster services from RHACS Cloud Service on Kubernetes clusters
     File: install-secured-cluster-cloud-other
@@ -125,7 +125,7 @@ Topics:
     File: install-central-ocp
   - Name: Configuring Central configuration options for RHACS using the Operator
     File: install-central-config-options-ocp
-  - Name: Generating and applying an init bundle or cluster registration secret for RHACS on Red Hat OpenShift
+  - Name: Generating and applying a cluster registration secret or init bundle for RHACS on Red Hat OpenShift
     File: init-bundle-ocp
   - Name: Installing Secured Cluster services for RHACS on Red Hat OpenShift
     File: install-secured-cluster-ocp
@@ -141,7 +141,7 @@ Topics:
     File: install-rhacs-other
   - Name: Installing Central services for RHACS on other platforms
     File: install-central-other
-  - Name: Generating and applying an init bundle or cluster registration secret for RHACS on other platforms
+  - Name: Generating and applying a cluster registration secret or init bundle for RHACS on other platforms
     File: init-bundle-other
   - Name: Installing Secured Cluster services for RHACS on other platforms
     File: install-secured-cluster-other

--- a/cloud_service/getting-started-rhacs-cloud-ocp.adoc
+++ b/cloud_service/getting-started-rhacs-cloud-ocp.adoc
@@ -16,7 +16,7 @@ toc::[]
 +
 [NOTE]
 ====
-To access the {product-title-managed-short} console, you need your Red{nbsp}Hat Single Sign-On (SSO) credentials, or credentials for another identity provider if that has been configured. See xref:../cloud_service/getting-started-rhacs-cloud-ocp.adoc#default-access-acs-console[Default access to the ACS console].
+To access the {product-title-managed-short} console, you need your Red{nbsp}Hat Single Sign-On (SSO) credentials, or credentials for another identity provider if that has been configured. See xref:../cloud_service/getting-started-rhacs-cloud-ocp.adoc#default-access-acs-console[Default access to the ACS Console].
 ====
 
 [id="installation-overview-acs-cloud"]
@@ -37,12 +37,11 @@ You can secure {osp} clusters by using the {product-title-short} Operator, Helm 
 . Verify that the clusters you want to secure meet the xref:../cloud_service/acscs-default-requirements.adoc#acscs-default-requirements[default requirements].
 . In the {cloud-console}, xref:../cloud_service/installing_cloud_ocp/cloud-create-instance-ocp.adoc#cloud-create-instance-ocp[create an *ACS Instance*].
 . On each {osp} cluster you want to secure, xref:../cloud_service/installing_cloud_ocp/cloud-ocp-create-project.adoc#cloud-ocp-create-project[create a project named `stackrox`]. This project will contain the resources for {product-title-managed-short} secured clusters.
-. Create the mechanism that the Central instance, also called Central, uses to set up communication with the secured clusters. You can either create an init bundle or a cluster registration secret (CRS). Perform one of these actions:
-* In the ACS Console, xref:../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#init-bundle-cloud-ocp-generate[generate an init bundle]. The init bundle contains secrets that allow communication between {product-title-managed-short} secured clusters and Central.
-* Log in to Central and use the `roxctl` CLI to xref:../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#roxctl-generate-init-bundle_init-bundle-cloud-ocp-generate[generate an init bundle].
+. Generate a cluster registration secret (CRS) or an init bundle, which contains secrets that are used to establish initial trust between Central and the secured clusters. Using a CRS is the preferred method. Complete only one of the following actions to generate the CRS:
+* In the ACS Console, xref:../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#portal-generate-init-bundle_init-bundle-cloud-ocp-generate[generate a CRS].
 * Log in to Central and use the `roxctl` CLI to xref:../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#crs-generate-roxctl_init-bundle-cloud-ocp-generate[generate a CRS].
-. On each {osp} cluster, xref:../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply#init-bundle-cloud-ocp-apply[apply the init bundle or CRS].
-. On each {osp} cluster, xref:../cloud_service/installing_cloud_ocp/cloud-install-operator#cloud-install-operator[install the {product-title-short} Operator].
+. On each {osp} cluster, xref:../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.adoc#init-bundle-cloud-ocp-apply[apply the CRS].
+. On each {osp} cluster, xref:../cloud_service/installing_cloud_ocp/cloud-install-operator.adoc#cloud-install-operator[install the {product-title-short} Operator].
 . On each {osp} cluster, xref:../cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc#installing-sc-operator-cloud-ocp[install secured cluster resources in the `stackrox` project] by using the Operator.
 . xref:../cloud_service/installing_cloud_ocp/verify-installation-cloud-ocp.adoc#verify-installation-cloud-ocp[Verify installation] by ensuring that your secured clusters can communicate with the ACS instance.
 
@@ -54,11 +53,10 @@ You can secure {osp} clusters by using the {product-title-short} Operator, Helm 
 . Verify that the clusters you want to secure meet the xref:../cloud_service/acscs-default-requirements.adoc#acscs-default-requirements[default requirements].
 . In the {cloud-console}, xref:../cloud_service/installing_cloud_ocp/cloud-create-instance-ocp.adoc#cloud-create-instance-ocp[create an *ACS Instance*].
 . On each {osp} cluster you want to secure, xref:../cloud_service/installing_cloud_ocp/cloud-ocp-create-project.adoc#cloud-ocp-create-project[create a project named `stackrox`]. This project will contain the resources for {product-title-managed-short} secured clusters.
-. Create the mechanism that the Central instance, also called Central, uses to set up communication with the secured clusters. You can either generate an init bundle or a cluster registration secret (CRS). Perform only one of these actions:
-* In the ACS Console, xref:../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#init-bundle-cloud-ocp-generate[generate an init bundle]. The init bundle contains secrets that allow communication between {product-title-managed-short} secured clusters and Central.
-* Log in to Central and use the `roxctl` CLI to xref:../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#roxctl-generate-init-bundle_init-bundle-cloud-ocp-generate[generate an init bundle].
+. Generate a cluster registration secret (CRS) or an init bundle, which contains secrets that are used to establish initial trust between Central and the secured clusters. Using a CRS is the preferred method. Complete only one of the following actions to generate the CRS:
+* In the ACS Console, xref:../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#portal-generate-init-bundle_init-bundle-cloud-ocp-generate[generate a CRS]. This file contains the secrets that are used to set up the initial secured communication between {product-title-managed-short} secured clusters and Central.
 * Log in to Central and use the `roxctl` CLI to xref:../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#crs-generate-roxctl_init-bundle-cloud-ocp-generate[generate a CRS].
-. On each {osp} cluster, run the `helm install` command to xref:../cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc#installing-sc-helm-cloud-ocp[install {product-title-short} by using Helm charts], specifying the path of the init bundle or CRS.
+. On each {osp} cluster, run the `helm install` command to xref:../cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc#installing-sc-helm-cloud-ocp[install {product-title-short} by using Helm charts], specifying the path of the CRS.
 . xref:../cloud_service/installing_cloud_ocp/verify-installation-cloud-ocp.adoc#verify-installation-cloud-ocp[Verify installation] by ensuring that your secured clusters can communicate with the ACS instance.
 
 [id="overview-installing-cloud-secured-clusters-osp-roxctl"]
@@ -69,8 +67,8 @@ You can secure {osp} clusters by using the {product-title-short} Operator, Helm 
 . Verify that the clusters you want to secure meet the xref:../cloud_service/acscs-default-requirements.adoc#acscs-default-requirements[default requirements].
 . In the {cloud-console}, xref:../cloud_service/installing_cloud_ocp/cloud-create-instance-ocp.adoc#cloud-create-instance-ocp[create an *ACS Instance*].
 . On each {osp} cluster you want to secure, xref:../cloud_service/installing_cloud_ocp/cloud-ocp-create-project.adoc#cloud-ocp-create-project[create a project named `stackrox`]. This project will contain the resources for {product-title-managed-short} secured clusters.
-. Perform one of the following actions:
-* In the ACS console, use the xref:../cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc#installing-manifest-web-portal_install-secured-cluster-cloud-ocp[legacy installation method] to create a cluster bundle.
+. Complete only one of the following steps:
+* In the ACS Console, use the xref:../cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc#installing-manifest-web-portal_install-secured-cluster-cloud-ocp[legacy installation method] to generate a cluster bundle.
 * From a system that has access to the monitored cluster, xref:../cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc#manifest-roxctl_install-secured-cluster-cloud-ocp[generate the configuration and extract and run the sensor script from the cluster bundle].
 . xref:../cloud_service/installing_cloud_ocp/verify-installation-cloud-ocp.adoc#verify-installation-cloud-ocp[Verify installation] by ensuring that your secured clusters can communicate with the ACS instance.
 
@@ -82,13 +80,14 @@ You can secure Kubernetes clusters by using Helm charts or the `roxctl` CLI.
 [id="overview-installing-cloud-secured-clusters-kube-helm"]
 ==== Securing Kubernetes clusters by using Helm charts
 
+.Procedure
+
 . Verify that the clusters you want to secure meet the xref:../cloud_service/acscs-default-requirements.adoc#acscs-default-requirements[default requirements].
 . In the {cloud-console}, xref:../cloud_service/installing_cloud_other/cloud-create-instance-other.adoc#cloud-create-instance-other[create an *ACS Instance*].
-. Create the mechanism that the Central instance, also called Central, uses to set up communication with the secured clusters. You can either create an init bundle or a cluster registration secret (CRS). Perform only one of these actions:
-* In the ACS Console, xref:../cloud_service/installing_cloud_other/init-bundle-cloud-other-generate.adoc#portal-generate-init-bundle_init-bundle-cloud-other-generate[generate an init bundle]. The init bundle contains secrets that allow communication between {product-title-managed-short} secured clusters and Central.
-* Log in to Central and xref:../cloud_service/installing_cloud_other/init-bundle-cloud-other-generate#roxctl-generate-init-bundle_init-bundle-cloud-other-generate[use the `roxctl` CLI to generate an init bundle].
-* Log in to Central and use the `roxctl` CLI to xref:../cloud_service/installing_cloud_other/init-bundle-cloud-other-generate#crs-generate-roxctl_init-bundle-cloud-other-generate[generate a CRS].
-. On each Kubernetes cluster, run the `helm install` command to xref:../cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.adoc#install-secured-cluster-cloud-other[install by using Helm charts], specifying the path of the init bundle or CRS.
+. Generate a cluster registration secret (CRS) or an init bundle, which contains secrets that are used to establish initial trust between Central and the secured clusters. Using a CRS is the preferred method. Complete only one of the following actions to generate the CRS: 
+* In the ACS Console, xref:../cloud_service/installing_cloud_other/init-bundle-cloud-other-generate.adoc#portal-generate-init-bundle_init-bundle-cloud-other-generate[generate a CRS]. This file contains the secrets that are used to set up the initial secured communication between {product-title-managed-short} secured clusters and Central.
+* Log in to Central and use the `roxctl` CLI to xref:../cloud_service/installing_cloud_other/init-bundle-cloud-other-generate.adoc#crs-generate-roxctl_init-bundle-cloud-other-generate[generate a CRS].
+. On each Kubernetes cluster, run the `helm install` command to xref:../cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.adoc#install-secured-cluster-cloud-other[install by using Helm charts], specifying the path of the CRS.
 . xref:../cloud_service/installing_cloud_other/verify-installation-cloud-other.adoc#verify-installation-cloud-other[Verify installation] by ensuring that your secured clusters can communicate with the ACS instance.
 
 [id="overview-installing-cloud-secured-clusters-kube-roxctl"]
@@ -97,8 +96,8 @@ You can secure Kubernetes clusters by using Helm charts or the `roxctl` CLI.
 . Verify that the clusters you want to secure meet the xref:../cloud_service/acscs-default-requirements.adoc#acscs-default-requirements[default requirements].
 . In the {cloud-console}, xref:../cloud_service/installing_cloud_other/cloud-create-instance-other.adoc#cloud-create-instance-other[create an *ACS Instance*].
 . On each cluster you want to secure, create a namespace named `stackrox`. This namespace will contain the resources for {product-title-managed-short} secured clusters.
-. Perform one of the following steps:
-* In the ACS console, use the xref:../cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.adoc#installing-manifest-web-portal_install-secured-cluster-cloud-other[legacy installation method] to create a cluster bundle.
+. Complete only one of the following steps:
+* In the ACS Console, use the xref:../cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.adoc#installing-manifest-web-portal_install-secured-cluster-cloud-other[legacy installation method] to generate a cluster bundle.
 * From a system that has access to the monitored cluster, xref:../cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc#manifest-roxctl_install-secured-cluster-cloud-ocp[generate the configuration and extract and run the sensor script from the cluster bundle].
 . xref:../cloud_service/installing_cloud_ocp/verify-installation-cloud-ocp.adoc#verify-installation-cloud-ocp[Verify installation] by ensuring that your secured clusters can communicate with the ACS instance.
 
@@ -107,8 +106,7 @@ You can secure Kubernetes clusters by using Helm charts or the `roxctl` CLI.
 == Default access to the ACS Console
 
 By default, the authentication mechanism available to users is authentication by using Red{nbsp}Hat Single Sign-On (SSO).
-You cannot delete or change the Red{nbsp}Hat SSO authentication provider.
-However, you can change the minimum access role and add additional rules, or add another identity provider.
+You cannot delete or change the Red{nbsp}Hat SSO authentication provider, but you can change the minimum access role and add additional rules, or add another identity provider.
 
 [NOTE]
 ====
@@ -124,12 +122,11 @@ Claims from the token issued by `sso.redhat.com` are mapped to an ACS-issued tok
 * `sub` to `userid`
 
 The built-in Red{nbsp}Hat SSO authentication provider has the required attribute `rh_org_id` set to the organization ID assigned to account of the user who created the {product-title-managed-short} instance.
-This is the ID of the organizational account the user is a part of. This can be thought of as the "tenant" the user is under and owned by.
-Only users with the same organizational account can access the ACS console by using the Red{nbsp}Hat SSO authentication provider.
+This is the organizational account ID. Only users from the same organizational account can access the ACS Console by using the Red{nbsp}Hat SSO authentication provider. 
 
 [NOTE]
 ====
-To gain more control over access to your ACS Console, configure another identity provider instead of relying on the Red{nbsp}Hat SSO authentication provider. For more information, see xref:../operating/manage-user-access/understanding-authentication-providers.adoc#authentication-provider-structure[Understanding authentication providers]. To configure the other authentication provider to be the first authentication option on the login page, its name should be lexicographically smaller than `Red{nbsp}Hat SSO`.
+To gain more control over access to your ACS Console, configure another identity provider instead of relying on the Red{nbsp}Hat SSO authentication provider. For more information, see xref:../operating/manage-user-access/understanding-authentication-providers.adoc#authentication-provider-structure[Understanding authentication providers]. To configure another authentication provider to be the first authentication option on the login page, its name should be lexicographically smaller than `Red{nbsp}Hat SSO`.
 ====
 
 The minimum access role is set to `None`. Assigning a different value to this field gives access to the {product-title-managed-short} instance to all users with the same organizational account.

--- a/cloud_service/installing_cloud_ocp/cloud-ocp-create-project.adoc
+++ b/cloud_service/installing_cloud_ocp/cloud-ocp-create-project.adoc
@@ -14,4 +14,4 @@ include::modules/cloud-ocp-create-stackrox-project.adoc[leveloffset=+1]
 [id="next-steps_cloud-ocp-create-project"]
 == Next steps
 
-* In the ACS Console, xref:../installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#init-bundle-cloud-ocp-generate[create an init bundle] or cluster registration secret (CRS). The init bundle contains secrets that allow communication between {product-title-managed-short} secured clusters and Central. The CRS can also be used to set up this initial communication and is more flexible and secure.
+ In the ACS Console, xref:../installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#init-bundle-cloud-ocp-generate[generate a cluster registration secret or an init bundle]. These files contain the secrets that are used to set up the initial secured communication between {product-title-managed-short} secured clusters and Central.

--- a/cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.adoc
+++ b/cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.adoc
@@ -1,21 +1,21 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="init-bundle-cloud-ocp-apply"]
-= Applying an init bundle or cluster registration secret for secured clusters
+= Applying a cluster registration secret or an init bundle for secured clusters
 include::modules/common-attributes.adoc[]
 :context: init-bundle-cloud-ocp-apply
 
 toc::[]
 
 [role="_abstract"]
-Apply the init bundle or cluster registration secret (CRS) by using it to create resources.
+Apply the cluster registration secret (CRS) or the init bundle to the secured cluster.
 
 [NOTE]
 ====
-You must have the `Admin` user role to apply an init bundle or CRS.
+You must have the `Admin` user role to apply a CRS or an init bundle.
 ====
 
-include::modules/create-resource-init-bundle.adoc[leveloffset=+1]
 include::modules/crs-apply-secured-cluster.adoc[leveloffset=+1]
+include::modules/create-resource-init-bundle.adoc[leveloffset=+1]
 
 [id="next-steps_init-bundle-cloud-ocp-apply"]
 == Next steps

--- a/cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc
+++ b/cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="init-bundle-cloud-ocp-generate"]
-= Generating an init bundle or cluster registration secret for secured clusters
+= Generating a cluster registration secret or an init bundle for secured clusters
 include::modules/common-attributes.adoc[]
 :context: init-bundle-cloud-ocp-generate
 
@@ -8,38 +8,25 @@ toc::[]
 
 [role="_abstract"]
 
-Before you set up a secured cluster, you must create an init bundle or cluster registration secret (CRS). The secured cluster then uses this bundle or CRS to authenticate with the Central instance, also called Central. You can create an init bundle or CRS by using either the {product-title-short} portal or the `roxctl` CLI. You then apply the init bundle or CRS by using it to create resources.
+Before you set up a secured cluster, you must generate a cluster registration secret (CRS) or an init bundle that contains secrets for initial authentication with the Central instance, also called Central. Generate a CRS or an init bundle by using either the {product-title-short} portal or the `roxctl` CLI, and then apply the CRS or the init bundle to the secured cluster.
 
 [NOTE]
 ====
-You must have the `Admin` user role to create an init bundle.
+You must have the `Admin` user role to generate a CRS or an init bundle. Init bundles are still supported, but using a CRS is the preferred way to set up a secured cluster.
 ====
 
-{product-title-short} uses a special artifact during installation that allows the {product-title-short} Central component to communicate securely with secured clusters that you are adding. Before the 4.7 release, {product-title-short} used _init bundles_ exclusively for initiating the secure communication channel. Beginning with 4.7, {product-title-short} provides an alternative to init bundles called _cluster registration secrets_ (CRSes).
+Before you set up a secured cluster, you must generate a CRS or an init bundle. The secured cluster then uses the contained secrets for initial authentication with Central. Central is the specific service that provides the ACS Console, handles all API interactions, and manages data storage and image scanning. Use either the {product-title-short} portal or the `roxctl` CLI to generate a CRS or an init bundle.
 
-:FeatureName: Cluster registration secrets
-include::snippets/technology-preview.adoc[]
-
-include::snippets/cluster-registration-secrets.adoc[]
-
-You can use either an init bundle or a cluster registration secret (CRS) during installation of a secured cluster. However, {product-title-short} does not yet provide a way to create a CRS by using the portal. Therefore, you must create the CRS by using the `roxctl` CLI.
-
-Before you set up a secured cluster, you must create an init bundle or CRS. The secured cluster then uses this bundle or CRS to authenticate with Central. You can create an init bundle by using either the {product-title-short} portal or the `roxctl` CLI. If you are using a CRS, you must use the `roxctl` CLI to create it.
-
-You can then apply the init bundle or the CRS by using the {ocp} web console or by using the `oc` or `kubectl` CLI. If you install {product-title-short} by using Helm, you provide the init bundle or CRS when you run the `helm install` command.
+You can then apply the CRS or the init bundle by using the {ocp} web console or by using the `oc` or `kubectl` CLI. If you install {product-title-short} by using Helm, you provide the CRS or the init bundle when you run the `helm install` command.
 
 [id="generate-init-bundle-cloud-ocp"]
-== Generating an init bundle
+== Generating a CRS or an init bundle
 
 include::modules/portal-generate-init-bundle.adoc[leveloffset=+2]
-include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
-
-[id="generate-crs-cloud-ocp"]
-== Generating a CRS
-
 include::modules/crs-generate-roxctl.adoc[leveloffset=+2]
+include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
 
 [id="next-steps_init-bundle-cloud-ocp-generate"]
 == Next steps
 
-* xref:../../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.adoc#create-resource-init-bundle_init-bundle-cloud-ocp-apply[Applying an init bundle or cluster registration secret for secured clusters]
+* xref:../../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.adoc#create-resource-init-bundle_init-bundle-cloud-ocp-apply[Applying a cluster registration secret or an init bundle for secured clusters]

--- a/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
+++ b/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
@@ -13,8 +13,8 @@ You can install {product-title-managed-short} on your secured clusters by using 
 
 * During {product-title-short} installation, you noted the *Central instance* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the cloud console navigation menu, and then clicking the ACS instance you created.
 * If you are installing by using the Operator, you created your {osp} cluster that you want to secure and installed the Operator on it.
-* You created and downloaded the init bundle or cluster registration secret (CRS) by using the ACS Console or by using the `roxctl` CLI.
-* You applied the init bundle or CRS on the cluster that you want to secure, unless you are installing by using a Helm chart.
+* You generated and downloaded the cluster registration secret (CRS) or the init bundle by using the ACS Console or by using the `roxctl` CLI.
+* You applied the CRS or the init bundle on the cluster that you want to secure, unless you are installing by using a Helm chart.
 
 
 [id="installing-sc-operator-cloud-ocp"]
@@ -42,8 +42,8 @@ include::modules/acs-quick-install-secured-cluster-using-helm.adoc[leveloffset=+
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#init-bundle-cloud-ocp-generate[Generating an init bundle for secured clusters]
-* xref:../../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.adoc#init-bundle-cloud-ocp-apply[Applying an init bundle for secured clusters]
+* xref:../../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#init-bundle-cloud-ocp-generate[Generating a cluster registration secret or an init bundle for secured clusters]
+* xref:../../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.adoc#init-bundle-cloud-ocp-apply[Applying a cluster registration secret or an init bundle for secured clusters]
 
 [id="configure-secured-cluster-services-helm-chart-customizations-cloud-ocp"]
 === Configuring the secured-cluster-services Helm chart with customizations
@@ -66,8 +66,8 @@ include::modules/install-secured-cluster-services-helm-chart.adoc[leveloffset=+3
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#init-bundle-cloud-ocp-generate[Generating an init bundle for secured clusters]
-* xref:../../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.adoc#init-bundle-cloud-ocp-apply[Applying an init bundle for secured clusters]
+* xref:../../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.adoc#init-bundle-cloud-ocp-generate[Generating a cluster registration secret or an init bundle for secured clusters]
+* xref:../../cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.adoc#init-bundle-cloud-ocp-apply[Applying a cluster registration secret or an init bundle for secured clusters]
 
 include::modules/change-config-options-after-deployment.adoc[leveloffset=+2]
 

--- a/cloud_service/installing_cloud_other/init-bundle-cloud-other-apply.adoc
+++ b/cloud_service/installing_cloud_other/init-bundle-cloud-other-apply.adoc
@@ -7,7 +7,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Apply the init bundle by using it to create resources.
+Apply the cluster registration secret (CRS) or the init bundle to the secured cluster.
 
 include::modules/create-resource-init-bundle.adoc[leveloffset=+1]
 

--- a/cloud_service/installing_cloud_other/init-bundle-cloud-other-generate.adoc
+++ b/cloud_service/installing_cloud_other/init-bundle-cloud-other-generate.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="init-bundle-cloud-other-generate"]
-= Generating an init bundle or cluster registration secret for Kubernetes secured clusters
+= Generating a cluster registration secret or an init bundle for Kubernetes secured clusters
 include::modules/common-attributes.adoc[]
 :context: init-bundle-cloud-other-generate
 
@@ -8,30 +8,25 @@ toc::[]
 
 [role="_abstract"]
 
-Before you set up a secured cluster, you must create an init bundle or cluster registration secret (CRS). The secured cluster then uses this bundle or CRS to authenticate with the Central instance, also called Central. You can create an init bundle by using either the {product-title-short} portal or the `roxctl` CLI. You then apply the init bundle by using it to create resources.
+Before you set up a secured cluster, you must generate a cluster registration secret (CRS) or an init bundle. The secured cluster then uses the contained secrets for initial authentication with the Central instance, also called Central. To set up the secured connection between Central and your secured clusters, you can use either a CRS or an init bundle, but using a CRS is the preferred method. 
 
+You can generate a CRS or an init bundle by using either of the following methods:
 
-:FeatureName: Cluster registration secrets
-include::snippets/technology-preview.adoc[]
+* In the {product-title-short} portal, go to *Platform Configuration* -> *Clusters* and select *Cluster Registration Secrets* (preferred) or *Init bundles*.
+* Use the `roxctl` CLI to generate a CRS or an init bundle by using the following commands:
+** `roxctl central crs generate` 
+** `roxctl central init-bundles generate` 
 
-You can use either an init bundle or a cluster registration secret (CRS) during installation of a secured cluster. However, {product-title-short} does not yet provide a way to create a CRS by using the portal. Therefore, you must create the CRS by using the `roxctl` CLI.
-
-Before you set up a secured cluster, you must create an init bundle or CRS. The secured cluster then uses this bundle or CRS to authenticate with Central. You can create an init bundle by using either the {product-title-short} portal or the `roxctl` CLI. If you are using a CRS, you must use the `roxctl` CLI to create it.
-
-You can then apply the init bundle or the CRS by using the {ocp} `kubectl` CLI. If you install {product-title-short} by using Helm, you provide the init bundle or CRS when you run the `helm install` command.
+After you generate a CRS or an init bundle, you provide the CRS or the init bundle when you run the `helm install` command.
 
 [id="generate-init-bundle-cloud-kube"]
-== Generating an init bundle
+== Generating a CRS or an init bundle
 
 include::modules/portal-generate-init-bundle.adoc[leveloffset=+2]
-include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
-
-[id="generate-crs-cloud-kube"]
-== Generating a CRS
-
 include::modules/crs-generate-roxctl.adoc[leveloffset=+2]
+include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
 
 [id="next-steps_init-bundle-cloud-other-generate"]
 == Next steps
 
-* xref:../../cloud_service/installing_cloud_other/init-bundle-cloud-other-apply.adoc#create-resource-init-bundle_init-bundle-cloud-other-apply[Creating resources by using the init bundle]
+* xref:../../cloud_service/installing_cloud_other/init-bundle-cloud-other-apply.adoc#create-resource-init-bundle_init-bundle-cloud-other-apply[Creating resources by using the CRS or the init bundle]

--- a/configuration/reissue-internal-certificates.adoc
+++ b/configuration/reissue-internal-certificates.adoc
@@ -47,8 +47,8 @@ These components communicate with each other, and with Central by using certific
 
 Choose the appropriate method to reissue the internal certificates:
 
-* Use the automatic certificate renewal feature. This is the recommended method for Operator and Helm deployments.
-* Create, download, and install an init bundle on the secured cluster. You must have the `Admin` user role to create an init bundle. This method is only recommended for Operator and Helm deployments if the certificates have already expired and the secured cluster can no longer connect to Central.
+* Use the automatic certificate renewal feature. This is the recommended method for Operator and Helm deployments. It is the only supported method for installations if you used a cluster registration secret (CRS) to set up communication between Central and secured clusters.
+* Generate, download, and install an init bundle on the secured cluster. You must have the `Admin` user role to generate an init bundle. This method is only recommended for Operator and Helm deployments if the certificates have already expired and the secured cluster can no longer connect to Central.
 * Use the automatic upgrades feature, which is only available for static manifest deployments by using the `roxctl` CLI. This method is only recommended if you have a specific installation requirement that necessitates the use of this method.
 
 //automatic certificate renewal
@@ -57,16 +57,23 @@ include::modules/reissuing-internal-certificates-for-secured-clusters-by-using-a
 //Verifying the status of automatic certificate renewal
 include::modules/verifying-the-status-of-automatic-certificate-renewal.adoc[leveloffset=+3]
 
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../configuration/reissue-internal-certificates.adoc#applying-the-latest-internal-certificates_reissue-internal-certificates[Applying the latest internal certificates]
-
 //Applying the latest internal certificates
 include::modules/applying-the-latest-internal-certificates.adoc[leveloffset=+3]
 
 //create and install an init bundle
 include::modules/reissue-internal-certificates-secured-clusters.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_ocp/init-bundle-ocp.adoc#init-bundle-ocp[Generating and applying a cluster registration secret or an init bundle for RHACS on Red Hat OpenShift]
+* xref:../installing/installing_other/init-bundle-other.adoc#init-bundle-other[Generating and applying a cluster registration secret or an init bundle for RHACS on other platforms]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_ocp/init-bundle-ocp.adoc#init-bundle-ocp[Generating and applying a cluster registration secret or an init bundle for RHACS on Red Hat OpenShift]
+* xref:../installing/installing_other/init-bundle-other.adoc#init-bundle-other[Generating and applying a cluster registration secret or an init bundle for RHACS on other platforms]
 
 //reissue internal certificates for secured clusters by using automatic upgrades
 include::modules/reissue-internal-certificates-secured-clusters-automatic-upgrades.adoc[leveloffset=+2]

--- a/installing/acs-high-level-overview.adoc
+++ b/installing/acs-high-level-overview.adoc
@@ -7,17 +7,14 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title} ({product-title-short}) provides security services for your self-managed {osp} Kubernetes systems or platforms such as {ocp}, Amazon Elastic Kubernetes Service (Amazon EKS), Google Kubernetes Engine (Google GKE), and Microsoft Azure Kubernetes Service (Microsoft AKS).
+{product-title} ({product-title-short}) provides security services for your self-managed {osp} Kubernetes systems or platforms such as {ocp}, Amazon Elastic Kubernetes Service (Amazon EKS), Google Kubernetes Engine (Google GKE), and Microsoft Azure Kubernetes Service (Microsoft AKS). There are several methods of installation available, depending on the type of platform you are using.
 
 For information about supported platforms and architecture, see the link:https://access.redhat.com/articles/7045053[{product-title} Support Matrix]. For life cycle support information for {product-title-short}, see the link:https://access.redhat.com/support/policy/updates/rhacs[{product-title} Support Policy].
 
-[id="general-guidelines_{context}"]
-== General installation guidelines
-
 To ensure the best installation experience, follow these guidelines:
 
-. Understand the installation platforms and methods described in this module.
-. Understand xref:../architecture/acs-architecture.adoc#acs-architecture_acs-architecture[{product-title} architecture].
+. Understand the installation platforms and methods that are available.
+. Understand the xref:../architecture/acs-architecture.adoc#acs-architecture_acs-architecture[{product-title} architecture].
 . Check the xref:../installing/acs-default-requirements.adoc#acs-default-requirements[default resource requirements].
 
 
@@ -75,7 +72,8 @@ Not all installation methods are supported for all platforms. See the link:https
 
 include::modules/installation-methods-for-different-architectures.adoc[leveloffset=+1]
 
-//browser support info removed - this info is in the support matrix
+include::modules/installation-secrets-auth.adoc[leveloffset=+1]
 
 include::modules/installing-rhacs-ocp-steps.adoc[leveloffset=+1]
+
 include::modules/installing-rhacs-kubernetes-steps.adoc[leveloffset=+1]

--- a/installing/installing_helm/install-helm-quick.adoc
+++ b/installing/installing_helm/install-helm-quick.adoc
@@ -15,7 +15,7 @@ The following steps represent the high-level installation flow for quickly insta
 
 . Add the RHACS Helm chart repository.
 . Install the `central-services` Helm chart to install the xref:../../architecture/acs-architecture.adoc#centralized-components_acs-architecture[centralized components] (Central and Scanner).
-. Generate an init bundle or CRS.
+. Generate a CRS or an init bundle.
 . Install the `secured-cluster-services` Helm chart to install the xref:../../architecture/acs-architecture.adoc#per-cluster-components_acs-architecture[per-cluster] and xref:../../architecture/acs-architecture.adoc#per-node-components_acs-architecture[per-node] components (Sensor, Admission controller, Collector, and Scanner-slim).
 
 Before you install:
@@ -38,7 +38,7 @@ include::modules/crs-generate-roxctl.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../cli/installing-the-roxctl-cli.adoc#installing-the-roxctl-cli[Installing the `roxctl` CLI]
-* xref:../../installing/installing_helm/install-helm-customization.adoc#portal-generate-init-bundle_acs-install-helm-customization[Generating an init bundle by using the {product-title-short} portal]
+* xref:../../installing/installing_helm/install-helm-customization.adoc#portal-generate-init-bundle_acs-install-helm-customization[Generating a CRS or an init bundle by using the {product-title-short} portal]
 
 include::modules/acs-quick-install-secured-cluster-using-helm.adoc[leveloffset=+1]
 

--- a/installing/installing_ocp/init-bundle-ocp.adoc
+++ b/installing/installing_ocp/init-bundle-ocp.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="init-bundle-ocp"]
-= Generating and applying an init bundle or cluster registration secret for RHACS on Red Hat OpenShift
+= Generating and applying a cluster registration secret or an init bundle for RHACS on Red Hat OpenShift
 :context: init-bundle-ocp
 :topic-helm:
 :topic-operator:
@@ -10,16 +10,21 @@
 toc::[]
 
 [role="_abstract"]
-To authenticate your secured clusters with Central in Red{nbsp}Hat Advanced Cluster Security for Kubernetes (RHACS), you must generate and apply valid credentials. You can create an init bundle by using the RHACS portal for interactive management, or use the `roxctl` CLI to generate a cluster registration secret (CRS) for automation. Applying the resulting YAML file to your cluster enables secure communication between services.
+To authenticate your secured clusters with Central in Red{nbsp}Hat Advanced Cluster Security for Kubernetes (RHACS), you must generate and apply valid credentials. You can generate a cluster registration secret (CRS) or an init bundle by using the RHACS portal for interactive management. You can also use the `roxctl` CLI, or the API with `curl` to the Central endpoints, to generate these files for automation. Applying the resulting YAML file to your cluster enables secure communication between services.
 
 include::modules/common-attributes.adoc[]
-
-:FeatureName: Cluster registration secrets
-include::snippets/technology-preview.adoc[]
 
 include::snippets/cluster-registration-secrets.adoc[]
 
 include::modules/secured-cluster-authentication-options.adoc[leveloffset=+1]
+
+include::modules/cluster-registration-secrets-overview.adoc[leveloffset=+1]
+
+include::modules/portal-generate-crs.adoc[leveloffset=+2]
+
+include::modules/crs-generate-roxctl.adoc[leveloffset=+2]
+
+include::modules/crs-apply-secured-cluster.adoc[leveloffset=+1]
 
 include::modules/init-bundle-generation-methods.adoc[leveloffset=+1]
 
@@ -28,12 +33,6 @@ include::modules/portal-generate-init-bundle.adoc[leveloffset=+2]
 include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
 
 include::modules/create-resource-init-bundle.adoc[leveloffset=+1]
-
-include::modules/cluster-registration-secrets-overview.adoc[leveloffset=+1]
-
-include::modules/crs-generate-roxctl.adoc[leveloffset=+2]
-
-include::modules/crs-apply-secured-cluster.adoc[leveloffset=+1]
 
 include::modules/next-steps-init-bundle-ocp.adoc[leveloffset=+1]
 

--- a/installing/installing_ocp/install-secured-cluster-ocp.adoc
+++ b/installing/installing_ocp/install-secured-cluster-ocp.adoc
@@ -37,7 +37,7 @@ include::modules/acs-quick-install-secured-cluster-using-helm.adoc[leveloffset=+
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_ocp/init-bundle-ocp.adoc#init-bundle-ocp[Generating and applying an init bundle or cluster registration secret for {product-title-short} on {osp}]
+* xref:../../installing/installing_ocp/init-bundle-ocp.adoc#init-bundle-ocp[Generating and applying a cluster registration secret or an init bundle for {product-title-short} on {osp}]
 
 include::modules/install-rhacs-on-secured-clusters-by-using-helm-charts-with-customizations.adoc[leveloffset=+2]
 
@@ -47,7 +47,7 @@ include::modules/install-secured-cluster-services-helm-chart.adoc[leveloffset=+3
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_ocp/init-bundle-ocp.adoc#init-bundle-ocp[Generating and applying an init bundle or cluster registration secret for {product-title-short} on {osp}]
+* xref:../../installing/installing_ocp/init-bundle-ocp.adoc#init-bundle-ocp[Generating and applying a cluster registration secret or an init bundle for {product-title-short} on {osp}]
 
 include::modules/change-config-options-after-deployment.adoc[leveloffset=+2]
 

--- a/installing/installing_other/init-bundle-other.adoc
+++ b/installing/installing_other/init-bundle-other.adoc
@@ -1,6 +1,6 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="init-bundle-other"]
-= Generating and applying an init bundle or cluster registration secret for RHACS on other platforms
+= Generating and applying a cluster registration secret or an init bundle for RHACS on other platforms
 :context: init-bundle-other
 :topic-helm:
 :toc: macro
@@ -9,16 +9,21 @@
 toc::[]
 
 [role="_abstract"]
-Red{nbsp}Hat Advanced Cluster Security for Kubernetes (RHACS) uses a special artifact during installation that allows Central to communicate securely with the secured clusters that you are adding.
+Red{nbsp}Hat Advanced Cluster Security for Kubernetes (RHACS) uses a special artifact during installation that allows Central to communicate securely with the secured clusters that you are adding. This file is called a cluster registration secret (CRS) or an init bundle. Init bundles are still supported, but using a CRS is the preferred way to set up a secured cluster.
 
 include::modules/common-attributes.adoc[]
-
-:FeatureName: Cluster registration secrets
-include::snippets/technology-preview.adoc[]
 
 include::snippets/cluster-registration-secrets.adoc[]
 
 include::modules/init-bundles-and-cluster-registration-secrets.adoc[leveloffset=+1]
+
+include::modules/cluster-registration-secrets.adoc[leveloffset=+1]
+
+include::modules/portal-generate-crs.adoc[leveloffset=+1]
+
+include::modules/crs-generate-roxctl.adoc[leveloffset=+2]
+
+include::modules/crs-apply-secured-cluster.adoc[leveloffset=+2]
 
 include::modules/init-bundles-for-secured-cluster-authentication.adoc[leveloffset=+1]
 
@@ -27,12 +32,6 @@ include::modules/portal-generate-init-bundle.adoc[leveloffset=+2]
 include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
 
 include::modules/create-resource-init-bundle.adoc[leveloffset=+2]
-
-include::modules/cluster-registration-secrets.adoc[leveloffset=+1]
-
-include::modules/crs-generate-roxctl.adoc[leveloffset=+2]
-
-include::modules/crs-apply-secured-cluster.adoc[leveloffset=+2]
 
 include::modules/next-steps-init-bundle.adoc[leveloffset=+1]
 

--- a/installing/installing_other/install-rhacs-other.adoc
+++ b/installing/installing_other/install-rhacs-other.adoc
@@ -18,5 +18,5 @@ Before you install:
 The following list provides a high-level overview of installation steps:
 
 . Install xref:../installing_other/install-central-other.adoc#install-central-other[Central services] on a cluster using Helm charts or the `roxctl` CLI.
-. Generate and apply an xref:../installing_other/init-bundle-other.adoc#init-bundle-other[init bundle].
+. Generate and apply a xref:../installing_other/init-bundle-other.adoc#init-bundle-other[cluster registration secret or an init bundle].
 . Install xref:../installing_other/install-secured-cluster-other.adoc#install-secured-cluster-other[secured cluster resources] on each of your secured clusters.

--- a/installing/installing_other/install-secured-cluster-other.adoc
+++ b/installing/installing_other/install-secured-cluster-other.adoc
@@ -28,7 +28,7 @@ include::modules/acs-quick-install-secured-cluster-using-helm.adoc[leveloffset=+
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_other/init-bundle-other.adoc#init-bundle-other[Generating and applying an init bundle or cluster registration secret for {product-title-short} on other platforms]
+* xref:../../installing/installing_other/init-bundle-other.adoc#init-bundle-other[Generating and applying a cluster registration secret or init bundle for {product-title-short} on other platforms]
 
 [id="configure-secured-cluster-services-helm-chart-customizations-other"]
 === Configuring the secured-cluster-services Helm chart with customizations
@@ -52,7 +52,7 @@ include::modules/install-secured-cluster-services-helm-chart.adoc[leveloffset=+3
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_other/init-bundle-other.adoc#init-bundle-other[Generating and applying an init bundle or cluster registration secret for {product-title-short} on other platforms]
+* xref:../../installing/installing_other/init-bundle-other.adoc#init-bundle-other[Generating and applying a cluster registration secret or an init bundle for {product-title-short} on other platforms]
 
 include::modules/change-config-options-after-deployment.adoc[leveloffset=+2]
 

--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -28,7 +28,7 @@ endif::[]
 Use the following instructions to install the `secured-cluster-services` Helm chart to deploy the per-cluster and per-node components (Sensor, Admission controller, Collector, and Scanner-slim).
 
 .Prerequisites
-* You must have generated an {product-title-short} init bundle or CRS for your cluster.
+* You must have generated a {product-title-short} cluster registration secret (CRS) or an init bundle for your cluster.
 * You must have access to the Red{nbsp}Hat Container Registry and a pull secret for authentication. For information about downloading images from `registry.redhat.io`, see link:https://access.redhat.com/RegistryAuthentication[Red{nbsp}Hat Container Registry Authentication].
 ifndef::cloud-svc[]
 * You must have the address that you are exposing the Central service on.
@@ -42,29 +42,6 @@ endif::[]
 //do not show for openshift, cloud
 ifndef::openshift,cloud-svc[]
 * Run one of the following commands on your Kubernetes-based clusters:
-** If you are using an init bundle, run the following command:
-+
-[source,terminal]
-----
-$ helm install -n stackrox --create-namespace \
-    stackrox-secured-cluster-services rhacs/secured-cluster-services \
-    -f <path_to_cluster_init_bundle.yaml> \
-    -f <path_to_pull_secret.yaml> \
-    --set clusterName=<name_of_the_secured_cluster> \
-    --set centralEndpoint=<endpoint_of_central_service> \
-    --set imagePullSecrets.username=<your redhat.com username> \
-    --set imagePullSecrets.password=<your redhat.com password>
-----
-+
-where:
-+
---
-`<path_to_cluster_init_bundle.yaml>`:: Specifies the path for the init bundle.
-`<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
-`<endpoint_of_central_service>`:: Specifies the address and port number for Central. For example, `acs.domain.com:443`.
-`<your redhat.com username>`:: Specifies the user name for your pull secret for Red{nbsp}Hat Container Registry authentication.
-`<your redhat.com password>`:: Specifies the password for your pull secret for Red{nbsp}Hat Container Registry authentication.
---
 ** If you are using a CRS, run the following command:
 +
 [source,terminal]
@@ -74,25 +51,16 @@ $ helm install -n stackrox --create-namespace \
     --set-file crs.file=<crs_file_name.yaml> \
     -f <path_to_pull_secret.yaml> \
     --set clusterName=<name_of_the_secured_cluster> \
-    --set centralEndpoint=<endpoint_of_central_service> \
-    --set imagePullSecrets.username=<your redhat.com username> \
-    --set imagePullSecrets.password=<your redhat.com password>
+    --set centralEndpoint=<endpoint_of_central_service> 
 ----
 +
 where:
 +
 --
 `<crs_file_name.yaml>`:: Specifies the name of the file in which the generated CRS has been stored.
-`<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
+`<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication. Or, you can specify `--set imagePullSecrets.username=<your redhat.com username>` and `--set imagePullSecrets.password=<your redhat.com password>` in the command.
 `<endpoint_of_central_service>`:: Specifies the address and port number for Central. For example, `acs.domain.com:443`.
-`<your redhat.com username>`:: Specifies the user name for your pull secret for Red{nbsp}Hat Container Registry authentication.
-`<your redhat.com password>`:: Specifies the password for your pull secret for Red{nbsp}Hat Container Registry authentication.
 --
-endif::openshift,cloud-svc[]
-
-//Procedure for kubernetes - cloud
-ifdef::cloud-svc[]
-* Run the following command on your Kubernetes-based clusters:
 ** If you are using an init bundle, run the following command:
 +
 [source,terminal]
@@ -102,16 +70,59 @@ $ helm install -n stackrox --create-namespace \
     -f <path_to_cluster_init_bundle.yaml> \
     -f <path_to_pull_secret.yaml> \
     --set clusterName=<name_of_the_secured_cluster> \
-    --set centralEndpoint=<endpoint_of_central_service> \
-    --set imagePullSecrets.username=<your redhat.com username> \
-    --set imagePullSecrets.password=<your redhat.com password>
+    --set centralEndpoint=<endpoint_of_central_service> 
 ----
 +
 where:
 +
 --
 `<path_to_cluster_init_bundle.yaml>`:: Specifies the path for the init bundle.
-`<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
+`<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication. Or, you can specify `--set imagePullSecrets.username=<your redhat.com username>` and `--set imagePullSecrets.password=<your redhat.com password>` in the command.
+`<endpoint_of_central_service>`:: Specifies the address and port number for Central. For example, `acs.domain.com:443`.
+--
+endif::openshift,cloud-svc[]
+
+//Procedure for kubernetes - cloud
+ifdef::cloud-svc[]
+* Run the following command on your Kubernetes-based clusters:
+** If you are using a CRS, run the following command:
++
+[source,terminal]
+----
+$ helm install -n stackrox --create-namespace \
+    stackrox-secured-cluster-services rhacs/secured-cluster-services \
+    --set-file crs.file=<crs_file_name.yaml> \
+    -f <path_to_pull_secret.yaml> \
+    --set clusterName=<name_of_the_secured_cluster> \
+    --set centralEndpoint=<endpoint_of_central_service> 
+----
++
+where:
++
+--
+`<crs_file_name.yaml>`:: Specifies the name of the file in which the generated CRS has been stored.
+`<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication. Or, you can specify `--set imagePullSecrets.username=<your redhat.com username>` and `--set imagePullSecrets.password=<your redhat.com password>` in the command.
+`<endpoint_of_central_service>`:: Specifies the address and port number for Central. For example, `acs.domain.com:443`.
+`<your redhat.com username>`:: Specifies the user name for your pull secret for Red{nbsp}Hat Container Registry authentication.
+`<your redhat.com password>`:: Specifies the password for your pull secret for Red{nbsp}Hat Container Registry authentication.
+--
+** If you are using an init bundle, run the following command:
++
+[source,terminal]
+----
+$ helm install -n stackrox --create-namespace \
+    stackrox-secured-cluster-services rhacs/secured-cluster-services \
+    -f <path_to_cluster_init_bundle.yaml> \
+    -f <path_to_pull_secret.yaml> \
+    --set clusterName=<name_of_the_secured_cluster> \
+    --set centralEndpoint=<endpoint_of_central_service> 
+----
++
+where:
++
+--
+`<path_to_cluster_init_bundle.yaml>`:: Specifies the path for the init bundle.
+`<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication. Or, you can specify `--set imagePullSecrets.username=<your redhat.com username>` and `--set imagePullSecrets.password=<your redhat.com password>` in the command.
 `<endpoint_of_central_service>`:: Specifies the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, and then clicking the {product-title-short} instance you created.
 `<your redhat.com username>`:: Specifies the user name for your pull secret for Red{nbsp}Hat Container Registry authentication.
 `<your redhat.com password>`:: Specifies the password for your pull secret for Red{nbsp}Hat Container Registry authentication.
@@ -123,6 +134,27 @@ endif::cloud-svc[]
 ifndef::cloud-svc[]
 
 * Run one of the following commands on an {ocp} cluster:
+** If you are using a CRS, run the following command:
++
+[source,terminal]
+----
+$ helm install -n stackrox --create-namespace \
+    stackrox-secured-cluster-services rhacs/secured-cluster-services \
+    --set-file crs.file=<crs_file_name.yaml> \
+    -f <path_to_pull_secret.yaml> \
+    --set clusterName=<name_of_the_secured_cluster> \
+    --set centralEndpoint=<endpoint_of_central_service> \
+    --set scanner.disable=false
+----
++
+where:
++
+--
+`<crs_file_name.yaml>`:: Specifies the name of the file in which the generated CRS has been stored.
+`<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication. Or, you can specify `--set imagePullSecrets.username=<your redhat.com username>` and `--set imagePullSecrets.password=<your redhat.com password>` in the command.
+`<endpoint_of_central_service>`:: Specifies specify the address and port number for Central. For example, `acs.domain.com:443`.
+`--set scanner.disable=false`:: Sets the value of the `scanner.disable` parameter to `false`, which means that Scanner-slim will be enabled during the installation. In Kubernetes, the secured cluster services now include Scanner-slim.
+--
 ** If you are using an init bundle, run the following command:
 +
 [source,terminal]
@@ -142,8 +174,14 @@ where:
 `<path_to_cluster_init_bundle.yaml>`:: Specifies the path for the init bundle.
 `<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
 `<endpoint_of_central_service>`:: Specifies the address and port number for Central. For example, `acs.domain.com:443`.
-`--set`:: Sets the value of the `scanner.disable` parameter to `false`, which means that Scanner-slim will be enabled during the installation. In Kubernetes, the secured cluster services now include Scanner-slim.
+`--set scanner.disable=false`:: Sets the value of the `scanner.disable` parameter to `false`, which means that Scanner-slim will be enabled during the installation. In Kubernetes, the secured cluster services now include Scanner-slim.
 --
+endif::cloud-svc[]
+
+//Procedure for OpenShift cloud
+ifdef::cloud-svc[]
+
+* Run one of the following commands on an {ocp} cluster:
 ** If you are using a CRS, run the following command:
 +
 [source,terminal]
@@ -161,16 +199,10 @@ where:
 +
 --
 `<crs_file_name.yaml>`:: Specifies the name of the file in which the generated CRS has been stored.
-`<path_to_pull_secret.yaml>`:: Specifies the `-f` option to specify the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
-`<endpoint_of_central_service>`:: Specifies specify the address and port number for Central. For example, `acs.domain.com:443`.
-`--set`:: Sets the value of the `scanner.disable` parameter to `false`, which means that Scanner-slim will be enabled during the installation. In Kubernetes, the secured cluster services now include Scanner-slim.
+`<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
+`<endpoint_of_central_service>`:: Specifies the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, then clicking the {product-title-short} instance you created.
+`--set scanner.disable=false`:: Sets the value of the `scanner.disable` parameter to `false`, which means that Scanner-slim will be enabled during the installation. In Kubernetes, the secured cluster services now include Scanner-slim.
 --
-endif::cloud-svc[]
-
-//Procedure for OpenShift cloud
-ifdef::cloud-svc[]
-
-* Run one of the following commands on an {ocp} cluster:
 ** If you are using an init bundle, run the following command:
 +
 [source,terminal]
@@ -190,27 +222,6 @@ where:
 `<path_to_cluster_init_bundle.yaml>`:: Specifies the path for the init bundle.
 `<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
 `<endpoint_of_central_service>`:: Specifies the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, then clicking the {product-title-short} instance you created.
-`--set`:: Sets the value of the `scanner.disable` parameter to `false`, which means that Scanner-slim will be enabled during the installation. In Kubernetes, the secured cluster services now include Scanner-slim.
---
-** If you are using a CRS, run the following command:
-+
-[source,terminal]
-----
-$ helm install -n stackrox --create-namespace \
-    stackrox-secured-cluster-services rhacs/secured-cluster-services \
-    --set-file crs.file=<crs_file_name.yaml> \
-    -f <path_to_pull_secret.yaml> \
-    --set clusterName=<name_of_the_secured_cluster> \
-    --set centralEndpoint=<endpoint_of_central_service> \
-    --set scanner.disable=false
-----
-+
-where:
-+
---
-`<crs_file_name.yaml>`:: Specifies the name of the file in which the generated CRS has been stored.
-`<path_to_pull_secret.yaml>`:: Specifies the path for the pull secret for Red{nbsp}Hat Container Registry authentication.
-`<endpoint_of_central_service>`:: Specifies the *Central API Endpoint* address. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the Red{nbsp}Hat Hybrid Cloud Console navigation menu, then clicking the {product-title-short} instance you created.
-`--set`:: Sets the value of the `scanner.disable` parameter to `false`, which means that Scanner-slim will be enabled during the installation. In Kubernetes, the secured cluster services now include Scanner-slim.
+`--set` scanner.disable=false:: Sets the value of the `scanner.disable` parameter to `false`, which means that Scanner-slim will be enabled during the installation. In Kubernetes, the secured cluster services now include Scanner-slim.
 --
 endif::cloud-svc[]

--- a/modules/acs-quick-install-using-helm.adoc
+++ b/modules/acs-quick-install-using-helm.adoc
@@ -7,7 +7,7 @@
 = Installing the central-services Helm chart without customizations
 
 [role="_abstract"]
-You can install the `central-services` Helm chart to deploy the centralized components, Central and Scanner.
+You can install the `central-services` Helm chart to deploy the centralized components: Central and Scanner.
 
 The output of the installation command includes:
 

--- a/modules/authentication-credentials-for-secured-clusters.adoc
+++ b/modules/authentication-credentials-for-secured-clusters.adoc
@@ -7,13 +7,13 @@
 = Authentication credentials for secured clusters
 
 [role="_abstract"]
-To secure communication between Central and the services running on a secured cluster, you must provide authentication credentials during the installation of the secured cluster. {rh-rhacs-first} supports different methods for generating these credentials depending on your installation method and requirements.
+To secure communication between Central and the services running on a secured cluster, you must use authentication credentials during the installation of the secured cluster. {rh-rhacs-first} supports different methods for generating these credentials depending on your installation method and requirements.
 
 You can generate the following authentication credentials by using the `roxctl` CLI:
 
-Init bundles:: An init bundle contains the secrets required to authenticate a secured cluster with Central. You commonly use init bundles for installations managed by Helm charts or the Operator. The bundle includes certificates and keys that establish the trust relationship.
+Cluster registration secret (CRS):: A CRS is a specific type of secret that allows a new secured cluster to connect to Central. It contains data that authenticates the cluster and establishes a secure connection. A CRS includes metadata such as an expiration date and the ID of the creator. A CRS is the preferred way to set up a secured cluster.
 
-Cluster registration secret (CRS):: A CRS is a specific type of secret that allows a new secured cluster to connect to Central. It contains data that authenticates the cluster and establishes a secure connection. A CRS includes metadata such as an expiration date and the ID of the creator.
+Init bundles:: An init bundle contains the secrets required to authenticate a secured cluster with Central. The bundle includes certificates and keys that establish the trust relationship.
 
 [IMPORTANT]
 ====

--- a/modules/cluster-registration-secrets-overview.adoc
+++ b/modules/cluster-registration-secrets-overview.adoc
@@ -3,13 +3,13 @@
 = Cluster registration secrets overview
 
 [role="_abstract"]
-A cluster registration secret (CRS) is a credential used to authenticate secured clusters with Central. You generate CRSes exclusively by using the `roxctl` CLI.
+A cluster registration secret (CRS) is a credential used to authenticate secured clusters with Central. You can generate a CRS by using the {product-title-short} portal or by using the `roxctl` CLI.
 
-When you run the generation command, the CLI provides the CRS in the form of a YAML file. You must manage this file according to the following security considerations:
+When you generate a CRS, it is provided as a YAML file. You must manage this file according to the following security considerations:
 
-Irretrievability:: You cannot retrieve a previously generated CRS from Central. Central stores metadata about the CRS, but it does not retain the secret data itself. If you lose the generated file, you must generate a new CRS.
+Retrieval:: You cannot retrieve a previously generated CRS from Central. Central stores metadata about the CRS, but it does not retain the secret data itself. If you lose the generated file, you must generate a new CRS.
 Secure storage:: Because the generated file contains sensitive secrets and cannot be recovered if lost, you must store it in a secure location.
-Reusability:: You can use a single CRS file to configure and authenticate multiple secured clusters.
+Reuse:: You can use a single CRS file to configure and authenticate more than one secured cluster.
 
 [NOTE]
 ====

--- a/modules/cluster-registration-secrets.adoc
+++ b/modules/cluster-registration-secrets.adoc
@@ -7,17 +7,15 @@
 = Cluster registration secrets
 
 [role="_abstract"]
-A cluster registration secret (CRS) is a security artifact that allows a secured cluster to authenticate with Central.  You create a CRS by using the `roxctl` CLI.
+A cluster registration secret (CRS) is a security artifact that allows a secured cluster to authenticate with Central. You generate a CRS by using the `roxctl` CLI.
 
-The CRS ensures that the services on the secured cluster such as Sensor and Collector are authorized to communicate with your Central instance. Unlike init bundles, which can be created in the {rh-rhacs-first} portal, you must use the `roxctl` CLI to generate a CRS.
-
-When you generate a CRS, the output is a standard Kubernetes Secret YAML file. You must apply this secret to the project namespace on the cluster where you intend to install the secured cluster services.
+The CRS ensures that the services on the secured cluster such as Sensor and Collector are authorized to communicate with your Central instance. When you generate a CRS, the output is a standard Kubernetes Secret YAML file. You must apply this secret to the project namespace on the cluster where you intend to install the secured cluster services.
 
 The following are the key characteristics of a CRS:
 
 Security:: The generated file contains sensitive credentials and must be stored securely.
 One-time generation:: You cannot retrieve a previously generated CRS from Central. If you lose the file, you must generate a new one.
-Reusability:: You can use a single CRS to authenticate multiple secured clusters.
+Reuse:: You can use a single CRS to authenticate more than one secured cluster.
 Expiration:: The secret includes an expiration date, after which it is no longer valid for registering new clusters.
 
 [NOTE]

--- a/modules/configure-the-central-services-helm-chart.adoc
+++ b/modules/configure-the-central-services-helm-chart.adoc
@@ -7,7 +7,7 @@
 = Configure the central-services Helm chart
 
 [role="_abstract"]
-You can configure the Helm chart parameters to customize the {rh-rhacs-first} installation for your specific environment. You must create separate configuration files to securely isolate sensitive credentials from standard settings for components like Central and Scanner. Accurately defining these values ensures successful service authentication and proper resource allocation within your cluster.
+You can configure the Helm chart parameters to customize the {rh-rhacs-first} installation for your specific environment. You must create separate configuration files to securely isolate sensitive credentials from standard settings for components such as Central and Scanner. Accurately defining these values ensures successful service authentication and proper resource allocation within your cluster.
 
 Create the following files for configuring the Helm chart for installing {product-title}:
 

--- a/modules/create-resource-init-bundle.adoc
+++ b/modules/create-resource-init-bundle.adoc
@@ -42,18 +42,22 @@ ifeval::["{context}" == "init-bundle-cloud-other-apply"]
 :cloud-other-apply:
 endif::[]
 
+ifeval::["{context}" == "init-bundle-cloud-ocp-generate"]
+:cloud:
+endif::[]
+
 :_mod-docs-content-type: PROCEDURE
 [id="create-resource-init-bundle_{context}"]
 = Applying the init bundle on the secured cluster
 
 //Do not show for ACSCS
 ifndef::cloud[]
-Before you configure a secured cluster, you must apply the init bundle by using it to create the required resources on the cluster. Applying the init bundle allows the services on the secured cluster to communicate with Central.
+Before you configure a secured cluster, you must apply the init bundle to the secured cluster. Applying the init bundle allows the services on the secured cluster to communicate with Central.
 endif::cloud[]
 
 //Show for ACSCS
 ifdef::cloud[]
-Before you configure a secured cluster, you must apply the init bundle by using it to create the required resources on the secured cluster. Applying the init bundle allows the services on the secured cluster to communicate with {product-title-managed-short}.
+Before you configure a secured cluster, you must apply the init bundle to the secured cluster. Applying the init bundle allows the services on the secured cluster to communicate with {product-title-managed-short}.
 endif::cloud[]
 
 [NOTE]
@@ -63,7 +67,7 @@ If you are installing by using Helm charts, do not perform this step. Complete t
 ====
 
 .Prerequisites
-* You must have generated an init bundle containing secrets.
+* You must have generated an init bundle containing secrets. The preferred way to set up a secured cluster is by using a CRS.
 * You must have created the `stackrox` project, or namespace, on the cluster where secured cluster services will be installed. Using `stackrox` for the project is not required, but ensures that vulnerabilities for {product-title-short} processes are not reported when scanning your clusters.
 
 .Procedure
@@ -71,7 +75,10 @@ If you are installing by using Helm charts, do not perform this step. Complete t
 ifdef::openshift[]
 To create resources, perform only one of the following steps:
 
-* Create resources using the {ocp} web console: In the {ocp} web console, make sure that you are in the `stackrox` namespace. In the top menu, click *+* to open the *Import YAML* page. You can drag the init bundle file or copy and paste its contents into the editor, and then click *Create*. When the command is complete, the display shows that the `collector-tls`, `sensor-tls`, and `admission-control-tls` resources were created.
+* Create resources using the {ocp} web console: 
+.. In the {ocp} web console, make sure that you are in the `stackrox` namespace. 
+.. In the top menu, click *+* to open the *Import YAML* page. 
+.. You can drag the init bundle file or copy and paste its contents into the editor, and then click *Create*. When the command is complete, the display shows that the `collector-tls`, `sensor-tls`, and `admission-control-tls` resources were created.
 
 * Create resources using the {osp} CLI: Using the {osp} CLI, run the following command to create the resources:
 +

--- a/modules/crs-apply-secured-cluster.adoc
+++ b/modules/crs-apply-secured-cluster.adoc
@@ -70,7 +70,10 @@ If you are installing by using Helm charts, do not perform this step. Complete t
 ifdef::openshift[]
 To create resources, perform only one of the following steps:
 
-* Create resources using the {ocp} web console: In the {ocp} web console, go to the `stackrox` project or the project where you want to install the secured cluster services. In the top menu, click *+* to open the *Import YAML* page. You can drag the CRS file or copy and paste its contents into the editor, and then click *Create*. When the command is complete, the display shows that the secret named `cluster-registration-secret` was created.
+* Create resources using the {ocp} web console: 
+.. In the {ocp} web console, go to the `stackrox` project or the project where you want to install the secured cluster services. 
+.. In the top menu, click *+* to open the *Import YAML* page. 
+.. You can drag the CRS file or copy and paste its contents into the editor, and then click *Create*. When the command is complete, the display shows that the secret named `cluster-registration-secret` was created.
 
 * Create resources using the {osp} CLI: Using the {osp} CLI, run the following command to create the resources:
 +

--- a/modules/crs-generate-roxctl.adoc
+++ b/modules/crs-generate-roxctl.adoc
@@ -23,11 +23,11 @@ ifeval::["{context}" == "init-bundle-cloud-other-generate"]
 :cloud-other-generate:
 endif::[]
 
-You can create a cluster registration secret by using the `roxctl` CLI.
+You can generate a cluster registration secret by using the `roxctl` CLI.
 
 [NOTE]
 ====
-You must have the `Admin` user role to create a CRS.
+You must have the `Admin` user role to generate a CRS.
 ====
 
 .Prerequisites
@@ -74,7 +74,7 @@ where:
 [IMPORTANT]
 ====
 Ensure that you store this file securely because it contains secrets.
-You can use the same file to set up multiple secured clusters. You cannot retrieve a previously-generated CRS.
+You can use the same file to set up more than one secured cluster. You cannot retrieve a previously-generated CRS.
 ====
 
 Depending on the output that you select, the command might return some INFO messages about the CRS and the YAML file.

--- a/modules/enabling-scanner-v4-after-helm-installation-secured-cluster.adoc
+++ b/modules/enabling-scanner-v4-after-helm-installation-secured-cluster.adoc
@@ -10,7 +10,7 @@ You can enable Scanner V4 when upgrading by using Helm.
 
 .Prerequisites
 
-* You set up Central and the secured cluster by using an init bundle or CRS so that they can communicate with each other.
+* You set up Central and the secured cluster by using a CRS or an init bundle so that they can communicate with each other.
 
 .Procedure
 

--- a/modules/enabling-scanner-v4-after-operator-installation-secured-cluster.adoc
+++ b/modules/enabling-scanner-v4-after-operator-installation-secured-cluster.adoc
@@ -10,7 +10,7 @@ You can enable Scanner V4 after installation.
 
 .Prerequisite
 
-* You set up Central and the secured cluster by using an init bundle or CRS so that they can communicate with each other.
+* You set up Central and the secured cluster by using a CRS or an init bundle so that they can communicate with each other.
 
 .Procedure
 

--- a/modules/enabling-scanner-v4-helm-central.adoc
+++ b/modules/enabling-scanner-v4-helm-central.adoc
@@ -34,4 +34,4 @@ Central Services Configuration Summary:
     Scanner V4 DB Volume:                        PVC (scanner-v4-db)
 ----
 
-. Configure your init bundle or cluster registration secret (CRS) so that Central and the secured cluster can communicate. For more information, see "Generating and applying an init bundle or cluster registration secret for RHACS on Red Hat OpenShift" or "Generating and applying an init bundle or cluster registration secret for RHACS on other platforms".
+. Generate a CRS or an init bundle so that Central and the secured cluster can communicate. For more information, see "Generating and applying a cluster registration secret or an init bundle for RHACS on Red Hat OpenShift" or "Generating and applying a cluster registration secret or an init bundle on other platforms".

--- a/modules/enabling-scanner-v4-helm-secured-cluster.adoc
+++ b/modules/enabling-scanner-v4-helm-secured-cluster.adoc
@@ -10,7 +10,7 @@ Scanner V4 is not enabled by default, but you can enable it during installation.
 
 .Prerequisite
 
-* You set up Central and the secured cluster by using an init bundle or CRS so that they can communicate with each other.
+* You set up Central and the secured cluster by using a CRS or an init bundle so that they can communicate with each other.
 
 .Procedure
 

--- a/modules/enabling-scanner-v4-operator-central.adoc
+++ b/modules/enabling-scanner-v4-operator-central.adoc
@@ -20,4 +20,4 @@ Scanner V4 is not enabled by default, but you can enable it during installation.
     scannerComponent: Enabled
 ----
 
-. Configure your init bundle or cluster registration secret (CRS) to allow communication between Central and the secured cluster. For more information, see "Generating and applying an init bundle or cluster registration secret for RHACS on Red Hat OpenShift".
+. Generate a cluster registration secret (CRS) or an init bundle to allow communication between Central and the secured cluster. For more information, see "Generating and applying a cluster registration secret (CRS) or an init bundle for RHACS on Red Hat OpenShift".

--- a/modules/enabling-scanner-v4-operator-secured-cluster.adoc
+++ b/modules/enabling-scanner-v4-operator-secured-cluster.adoc
@@ -10,7 +10,7 @@ Scanner V4 is not enabled by default, but you can enable it during installation.
 
 .Prerequisite
 
-* You set up Central and the secured cluster by using an init bundle or CRS so that they can communicate with each other.
+* You set up Central and the secured cluster by using a cluster registration secret (CRS) or an init bundle so that they can communicate with each other.
 
 .Procedure
 

--- a/modules/generate-an-init-bundle-or-crs.adoc
+++ b/modules/generate-an-init-bundle-or-crs.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="generate-init-bundle-helm_{context}"]
-= Generate an init bundle or CRS
+= Generate an init bundle or cluster registration secret
 
 [role="_abstract"]
-Before you set up a secured cluster, you must create an init bundle or CRS. The secured cluster then uses this bundle or CRS to authenticate with Central.
+Before you set up a secured cluster, you must generate a cluster registration secret (CRS) or an init bundle. The secured cluster then uses the contained secrets for initial authentication with Central.
 
-You can create an init bundle by using the `roxctl` CLI or from the {rh-rhacs-first} portal. You can use the `roxctl` CLI to create a CRS.
+You can generate a CRS or an init bundle by using the `roxctl` CLI or from the {rh-rhacs-first} portal. 

--- a/modules/helm-chart-installation-overview.adoc
+++ b/modules/helm-chart-installation-overview.adoc
@@ -7,16 +7,16 @@
 = Helm chart installation overview
 
 [role="_abstract"]
-You can install {rh-rhacs-first} by configuring and deploying the provided Helm charts. This process involves installing the `central-services` chart to set up Central and Scanner, followed by the `secured-cluster-services` chart to deploy per-cluster components like the Sensor and Collector. Follow this workflow to ensure you generate the necessary init bundles and correctly register your clusters.
+You can install {rh-rhacs-first} by configuring and deploying the provided Helm charts. This process involves installing the `central-services` chart to set up Central and Scanner, followed by the `secured-cluster-services` chart to deploy per-cluster components like the Sensor and Collector. Follow this workflow to ensure you generate the necessary cluster registration secret (CRS) or init bundle and correctly register your clusters.
 
 High-level installation flow:
 
 . Add the {rh-rhacs-first} Helm chart repository.
 . Configure the `central-services` Helm chart.
 . Install the `central-services` Helm chart to install the Central and Scanner.
-. Generate an init bundle or cluster registration secret (CRS).
+. Generate a cluster registration secret (CRS) or an init bundle.
 . Configure the `secured-cluster-services` Helm chart.
-. Install the `secured-cluster-services` Helm chart to install the per-cluster and per-node components, such as, Sensor, Admission controller, Collector, and Scanner-slim.
+. Install the `secured-cluster-services` Helm chart to install the per-cluster and per-node components, such as Sensor, Admission controller, Collector, and Scanner-slim.
 
 Before you install:
 

--- a/modules/init-bundle-generation-methods.adoc
+++ b/modules/init-bundle-generation-methods.adoc
@@ -4,15 +4,15 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="generate-init-bundle_{context}"]
-= Init bundle generation methods
+= Cluster registration secret or init bundle generation methods
 
 [role="_abstract"]
-You can generate an init bundle to authenticate your secured clusters by using either the {rh-rhacs-first} portal or the `roxctl` CLI. Both methods produce a YAML file that contains secrets required for the secured cluster to communicate with Central.
+You can generate a cluster registration secret (CRS) or an init bundle to authenticate your secured clusters by using either the {rh-rhacs-first} portal or the `roxctl` CLI. Both methods produce a YAML file that contains secrets. This file is required to establish the secure communication channel between Central and secured clusters and perform the initial secured cluster registration.
 
 {product-title-short} portal:: This web-based method is suitable for interactive generation. You can select your target platform and installation method through the *Platform Configuration* menu.
 `roxctl` CLI:: This command-line method is suitable for scripting and automation. It requires the configuration of the `ROX_API_TOKEN` and `ROX_CENTRAL_ADDRESS` environment variables. You can specify the output format for Helm or Operator installations by using specific command flags.
 
-Regardless of the method used, the generated init bundle contains sensitive secrets. You must store the generated YAML file securely. You can reuse a single init bundle for multiple secured clusters that use the same installation method.
+Regardless of the method used, the generated init bundle contains sensitive secrets. You must store the generated YAML file securely. You can reuse a single init bundle to set up more than one secured cluster if the clusters use the same installation method.
 
 [NOTE]
 ====

--- a/modules/init-bundles-and-cluster-registration-secrets.adoc
+++ b/modules/init-bundles-and-cluster-registration-secrets.adoc
@@ -7,13 +7,13 @@
 = Init bundles and cluster registration secrets
 
 [role="_abstract"]
-To establish a secure communication channel between {product-title-short} Central and your secured clusters, you must generate and apply authentication artifacts. You can create an init bundle by using the {product-title-short} portal or CLI to provision the required TLS certificates for services like Sensor and Collector.
+To establish a secure communication channel between {product-title-short} Central and your secured clusters, you must generate and apply authentication artifacts. You can generate a cluster registration secret (CRS) or an init bundle by using the {product-title-short} portal or CLI.
 
-Alternatively, you can use the `roxctl` CLI to generate a cluster registration secret (CRS) if you need a reusable, time-bound token to register multiple clusters.
+Although init bundles are still supported, using a CRS to establish the connection between Central and your secured clusters is the preferred method because it offers a reusable, time-bound token that you can use to register multiple clusters.
 
-You can then apply the init bundle or the CRS by using the {ocp} web console or by using the `oc` or `kubectl` CLI. If you install {product-title-short} by using Helm, you provide the init bundle or CRS when you run the `helm install` command.
+After creating a CRS or an init bundle, you provide the CRS or the init bundle when you run the `helm install` command.
 
 [NOTE]
 ====
-You must have the `Admin` user role to create an init bundle.
+You must have the `Admin` user role to generate a CRS or an init bundle.
 ====

--- a/modules/init-bundles-for-secured-cluster-authentication.adoc
+++ b/modules/init-bundles-for-secured-cluster-authentication.adoc
@@ -15,7 +15,7 @@ When you apply the init bundle to a secured cluster, it creates the necessary TL
 * `sensor-tls`
 * `admission-control-tls`
 
-You can generate init bundles using either the {product-title-short} portal or the `roxctl` CLI. The bundle is generated as a YAML file containing the required secrets. Because this file contains sensitive credentials, it must be stored securely.
+You can generate init bundles by using either the {product-title-short} portal or the `roxctl` CLI. The bundle is generated as a YAML file containing the required secrets. Because this file contains sensitive credentials, it must be stored securely.
 
 [NOTE]
 ====

--- a/modules/install-central-operator-external-db.adoc
+++ b/modules/install-central-operator-external-db.adoc
@@ -103,5 +103,5 @@ If you are using the cluster-wide proxy, {product-title} uses that proxy configu
 .Next Steps
 . Verify Central installation.
 . Optional: Configure Central options.
-. Generate an init bundle containing the cluster secrets that allows communication between the `Central` and `SecuredCluster` resources. You need to download this bundle, use it to generate resources on the clusters you want to secure, and securely store it.
+. Generate a CRS or an init bundle containing the cluster secrets that allows communication between the `Central` and `SecuredCluster` resources. You need to download this file, use it to generate resources on the clusters you want to secure, and securely store it.
 . Install secured cluster services on each cluster you want to monitor.

--- a/modules/install-central-operator.adoc
+++ b/modules/install-central-operator.adoc
@@ -125,5 +125,5 @@ If you are using the cluster-wide proxy, {product-title} uses that proxy configu
 .Next Steps
 . Verify Central installation.
 . Optional: Configure Central options.
-. Generate an init bundle containing the cluster secrets that allows communication between the `Central` and `SecuredCluster` resources. You need to download this bundle, use it to generate resources on the clusters you want to secure, and securely store it.
+. Generate a CRS or an init bundle containing the cluster secrets that allows communication between the `Central` and `SecuredCluster` resources. You need to download this file, use it to generate resources on the clusters you want to secure, and securely store it.
 . Install secured cluster services on each cluster you want to monitor.

--- a/modules/install-secured-cluster-operator.adoc
+++ b/modules/install-secured-cluster-operator.adoc
@@ -27,7 +27,7 @@ When you install {product-title}:
 .Prerequisites
 * If you are using {ocp}, you must install version {ocp-supported-version} or later.
 * You have installed the {product-title-short} Operator on the cluster that you want to secure, called the secured cluster.
-* You have generated an init bundle or cluster registration secret (CRS) and applied it to the cluster in the recommended `stackrox` namespace.
+* You have generated a cluster registration secret (CRS) or an init bundle and applied it to the cluster in the recommended `stackrox` namespace.
 
 .Procedure
 . On the {ocp} web console for the secured cluster, go to the *Ecosystem* -> *Installed Operators* page.
@@ -39,7 +39,7 @@ When you install {product-title}:
 * If you installed the Operator in a different namespace, {ocp} lists the name of that namespace instead of `rhacs-operator`.
 ====
 . Click *Installed Operators*.
-. You should have created the `stackrox` namespace when you applied the init bundle or the CRS. Make sure that you are in this namespace by verifying that *Project:stackrox* is selected in the menu.
+. You should have created the `stackrox` namespace when you applied the CRS or the init bundle. Make sure that you are in this namespace by verifying that *Project:stackrox* is selected in the menu.
 . In *Provided APIs*, click *Secured Cluster*.
 . Click *Create SecuredCluster*.
 . Select one of the following options in the *Configure via* field:
@@ -58,7 +58,7 @@ endif::cloud-svc[]
 . Click *Create*.
 . After a brief pause, the *SecuredClusters* page displays the status of `stackrox-secured-cluster-services`. You might see the following conditions:
 * *Conditions: Deployed, Initialized*: The secured cluster services have been installed and the secured cluster is communicating with Central.
-* *Conditions: Initialized, Irreconcilable*: The secured cluster is not communicating with Central. Make sure that you applied the init bundle you created in the {product-title-short} web portal to the secured cluster.
+* *Conditions: Initialized, Irreconcilable*: The secured cluster is not communicating with Central. Make sure that you applied the CRS or the init bundle you created in the {product-title-short} web portal to the secured cluster.
 
 .Next steps
 . Configure additional secured cluster settings (optional).

--- a/modules/install-secured-cluster-services-helm-chart.adoc
+++ b/modules/install-secured-cluster-services-helm-chart.adoc
@@ -15,7 +15,7 @@ After you configure the `values-public.yaml` and `values-private.yaml` files, in
 * Scanner V4 Indexer and Scanner V4 DB: optional for secured clusters when Scanner V4 is installed
 
 .Prerequisites
-* You must have generated an {product-title-short} init bundle for your cluster.
+* You must have generated a cluster registration secret (CRS) or an init bundle for your cluster.
 * You must have access to the Red{nbsp}Hat Container Registry and a pull secret for authentication. For information about downloading images from `registry.redhat.io`, see link:https://access.redhat.com/RegistryAuthentication[Red{nbsp}Hat Container Registry Authentication].
 ifndef::cloud-svc[]
 * You must have the address and the port number that you are exposing the Central service on.
@@ -50,7 +50,7 @@ where:
 +
 [NOTE]
 ====
-To deploy `secured-cluster-services` Helm chart by using a continuous integration (CI) system, pass the init bundle YAML file as an environment variable to the `helm install` command:
+To deploy `secured-cluster-services` Helm chart by using a continuous integration (CI) system, pass the CRS or the init bundle YAML file as an environment variable to the `helm install` command:
 
 [source,terminal]
 ----

--- a/modules/installation-secrets-auth.adoc
+++ b/modules/installation-secrets-auth.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * installing/acs-high-level-overview.adoc
+:_mod-docs-content-type: CONCEPT
+[id="installation-secrets-auth_{context}"]
+= Setting up authentication between Central and secured clusters
+
+[role="_abstract"]
+When you install {product-title} ({product-title-short}), you must generate a component that is used between Central and the secured clusters to set up secure communication. Central, also called the Central instance in {rh-rhacscs-first}, is the specific service that provides the ACS Console, handles all API interactions, and manages data storage and image scanning. The user interface is called the {product-title-short} portal for {product-title-short} and is called the ACS Console for {product-title-managed-short}.
+
+The original component used to authenticate when establishing the connection between Central and secured clusters is called an init bundle. A later component, called a cluster registration secret (CRS), provides a more secure mechanism to set up this communication. You generate an init bundle or a CRS in the cluster where Central is located, and then you install it onto the secured clusters.
+
+An init bundle is a YAML file that contains security secrets that allow a new Kubernetes cluster to connect securely to Central. This file is used to create the specific Kubernetes secrets of `sensor-tls`, `collector-tls`, and `admission-control-tls`. These services contain certificates and private keys required for mutual TLS (mTLS) authentication. The certificates inside an init bundle are valid for one year by default. If they expire, the secured cluster will disconnect, and you must generate and apply a new bundle.
+
+A single init bundle can be used to connect multiple different clusters to the same Central instance, although using unique bundles for different groups of clusters can make revoking access easier if credentials are compromised. You can reapply an init bundle to a secured cluster to provide an existing secured cluster with new or updated certificates. 
+
+Beginning with {product-title-short} version 4.7, {product-title-short} provides a more secure alternative to init bundles, called Cluster Registration Secrets (CRSes). Unlike an init bundle, which contains long-lived certificates, a CRS contains a token that the secured cluster uses to request its own certificates. Therefore, you can revoke the CRS immediately after installation without breaking the cluster's connection. Unlike init bundles, you cannot put a new CRS on the cluster and have the secured cluster use this CRS to reestablish the communication with Central. You must generate a new CRS in Central and then reapply the new CRS to the secured cluster and reestablish the secured connection.

--- a/modules/installing-rhacs-kubernetes-steps.adoc
+++ b/modules/installing-rhacs-kubernetes-steps.adoc
@@ -10,34 +10,13 @@
 
 . Add the {product-title-short} Helm charts repository.
 . Install the `central-services` Helm chart on the cluster that will contain Central, called the Central cluster.
-. Log in to the {product-title-short} web console from the Central cluster and create an init bundle or cluster registration secret (CRS) that you need to apply to the cluster that you want to secure, called the secured cluster. The init bundle or the CRS contains the cryptographic artifacts that {product-title-short} uses to establish trusted connections between Central and secured clusters.
+. Log in to the {product-title-short} web console from the Central cluster and generate a cluster registration secret (CRS). You need to apply the CRS to the cluster that you want to secure, called the secured cluster. The CRS contains the cryptographic artifacts that {product-title-short} uses to establish trusted connections between Central and secured clusters. 
 +
---
-:FeatureName: Cluster registration secret
-include::snippets/technology-preview.adoc[]
---
+[NOTE]
+====
+Init bundles are still supported, but using a CRS is the preferred method for securing your cluster. 
+====
 . For each secured cluster, install the `secured-cluster-services` Helm chart by running one of the following commands:
-* For an init bundle, run the following command:
-+
-[source,terminal]
-----
-$ helm install -n stackrox \
-  --create-namespace stackrox-secured-cluster-services rhacs/secured-cluster-services \
-  -f <name_of_cluster_init_bundle.yaml> \
-  -f <path_to_values_public.yaml> \
-  -f <path_to_values_private.yaml> \
-  --set imagePullSecrets.username=<username> \
-  --set imagePullSecrets.password=<password>
-----
-+
-where:
-+
---
-`<path_to_values_public.yaml>`:: Specifies the path to your public YAML configuration file.
-`<path_to_values_private.yaml>`:: Specifies the path to your private YAML configuration file.
-`<username>`:: Specifies the user name for your pull secret for Red{nbsp}Hat Container Registry authentication.
-`<password>`:: Specifies the password for your pull secret for Red{nbsp}Hat Container Registry authentication.
---
 * For a CRS, run the following command:
 +
 [source,terminal]
@@ -55,6 +34,28 @@ where:
 +
 --
 `<crs_file_name.yaml>`:: Specifies the name of the file in which the generated CRS has been stored.
+`<path_to_values_public.yaml>`:: Specifies the path to your public YAML configuration file.
+`<path_to_values_private.yaml>`:: Specifies the path to your private YAML configuration file.
+`<username>`:: Specifies the user name for your pull secret for Red{nbsp}Hat Container Registry authentication.
+`<password>`:: Specifies the password for your pull secret for Red{nbsp}Hat Container Registry authentication.
+--
+
+* For an init bundle, run the following command:
++
+[source,terminal]
+----
+$ helm install -n stackrox \
+  --create-namespace stackrox-secured-cluster-services rhacs/secured-cluster-services \
+  -f <name_of_cluster_init_bundle.yaml> \
+  -f <path_to_values_public.yaml> \
+  -f <path_to_values_private.yaml> \
+  --set imagePullSecrets.username=<username> \
+  --set imagePullSecrets.password=<password>
+----
++
+where:
++
+--
 `<path_to_values_public.yaml>`:: Specifies the path to your public YAML configuration file.
 `<path_to_values_private.yaml>`:: Specifies the path to your private YAML configuration file.
 `<username>`:: Specifies the user name for your pull secret for Red{nbsp}Hat Container Registry authentication.

--- a/modules/installing-rhacs-ocp-steps.adoc
+++ b/modules/installing-rhacs-ocp-steps.adoc
@@ -10,14 +10,19 @@
 
 . On the {osp} cluster, install the {product-title-short} Operator into the `rhacs-operator` project, or namespace.
 . On the {osp} cluster that will contain Central, called the central cluster, use the {product-title-short} Operator to install Central services into the `stackrox` project. One central cluster can secure multiple clusters.
-. Log in to the {product-title-short} web console from the central cluster, and then create an init bundle or cluster registration secret (CRS) and download it. The init bundle is then installed on the cluster that you want to secure, called the secured cluster.
+. Log in to the {product-title-short} web console from the central cluster, and generate a cluster registration secret (CRS) or an init bundle and download it. The CRS or the init bundle is then installed on the cluster that you want to secure, called the secured cluster. The CRS or the init bundle contains the cryptographic artifacts that {product-title-short} uses to establish trusted connections between Central and secured clusters. 
++
+[NOTE]
+====
+Init bundles are still supported, but using a CRS is the preferred method for securing your cluster. 
+====
 . For the secured cluster:
 .. Install the {product-title-short} Operator into the `rhacs-operator` namespace.
-.. On the secured cluster, apply the init bundle or CRS that you created in {product-title-short} by performing one of these steps:
-* Use the {ocp} web console to import the YAML file of the init bundle or CRS that you created. Make sure you are in the `stackrox` namespace.
+.. Apply the CRS or the init bundle that you generated in {product-title-short} to the secured cluster by performing one of these steps:
+* Use the {ocp} web console to import the YAML file of the CRS or the init bundle that you generated. Make sure you are in the `stackrox` namespace.
 * Use the OpenShift CLI to perform one of the following actions:
-** If you created an init bundle, in the terminal window, run the `oc create -f <init_bundle.yaml> -n <stackrox>` command, specifying the path to the downloaded YAML file of the init bundle.
-** If you created a CRS, in the terminal window, run the `oc create -f <file_name.yaml> -n <stackrox>` command, specifying the path to the downloaded CRS.
+** If you generated a CRS, in the terminal window, run the `oc create -f <file_name.yaml> -n <stackrox>` command, specifying the path to the downloaded CRS.
+** If you generated an init bundle, in the terminal window, run the `oc create -f <init_bundle.yaml> -n <stackrox>` command, specifying the path to the downloaded YAML file of the init bundle.
 .. On the secured cluster, use the {product-title-short} Operator to install Secured Cluster services into the `stackrox` namespace. When creating these services, be sure to enter the address of Central in the *Central Endpoint* field so that the secured cluster can communicate with Central.
 
 [id="installing-ocp-helm-steps"]
@@ -25,8 +30,8 @@
 
 . Add the {product-title-short} Helm charts repository.
 . Install the `central-services` Helm chart on the {osp} cluster that will contain Central, called the central cluster.
-. Log in to the {product-title-short} web console on the Central cluster and create an init bundle or CRS.
-. For each cluster that you want to secure, log in to the secured cluster and use the `helm install` command to install the `secured-cluster-services` Helm chart, specifying the path to the init bundle or CRS that you created.
+. Log in to the {product-title-short} web console on the Central cluster and generate a CRS or an init bundle.
+. For each cluster that you want to secure, log in to the secured cluster and use the `helm install` command to install the `secured-cluster-services` Helm chart, specifying the path to the CRS or the init bundle that you generated.
 
 [id="installing-ocp-roxctl-steps"]
 == Installing {product-title-short} on {osp} by using the `roxctl` CLI

--- a/modules/installing-rhacs-on-secured-clusters-by-using-the-roxctl-cli.adoc
+++ b/modules/installing-rhacs-on-secured-clusters-by-using-the-roxctl-cli.adoc
@@ -7,7 +7,7 @@
 = Installing {product-title-short} on secured clusters by using the roxctl CLI
 
 [role="_abstract"]
-To secure your infrastructure, deploy the Sensor component to install {rh-rhacs-first} on your {ocp} secured clusters. Use the `roxctl` CLI to generate the necessary installation files and execute the sensor installation script. This method enables you to provision the sensor by creating the required configuration files and running the deployment script manually.
+To secure your infrastructure, deploy the Sensor component to install {rh-rhacs-first} on your {ocp} secured clusters. Use the `roxctl` CLI to generate the necessary installation files and run the sensor installation script. This method enables you to provision the sensor by creating the required configuration files and running the deployment script manually.
 
 .Prerequisites
 

--- a/modules/next-steps-init-bundle.adoc
+++ b/modules/next-steps-init-bundle.adoc
@@ -7,6 +7,6 @@
 = Next steps
 
 [role="_abstract"]
-After you have generated and applied the init bundle or cluster registration secret (CRS), you can proceed to install the services.
+After you have generated and applied the cluster registration secret (CRS) or the init bundle, you can proceed to install the services.
 
 Install {rh-rhacs-first} secured cluster services in all clusters that you want to monitor.

--- a/modules/portal-generate-crs.adoc
+++ b/modules/portal-generate-crs.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_helm/install-helm-customization.adoc
+// * installing/installing_ocp/init-bundle-ocp.adoc
+// * installing/installing_other/init-bundle-other.adoc
+//
+// You must declare the `topic-helm` or `topic-operator` attribute when using this module.
+:_mod-docs-content-type: PROCEDURE
+[id="portal-generate-crs_{context}"]
+= Generating a cluster registration secret by using the RHACS portal
+
+
+ifeval::["{context}" == "init-bundle-cloud-other"]
+:cloud-svc:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-ocp"]
+:cloud-svc:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-ocp"]
+:openshift:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-ocp"]
+:openshift:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-ocp"]
+:openshift:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-ocp-generate"]
+:cloud-svc:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-other-generate"]
+:cloud-svc:
+endif::[]
+
+ifndef::cloud-svc[]
+You can generate a cluster registration secret (CRS) by using the {product-title-short} portal.
+endif::cloud-svc[]
+
+ifdef::cloud-svc[]
+You can generate a cluster registration secret (CRS) using the {product-title-short} portal, also called the ACS Console.
+endif::cloud-svc[]
+
+[NOTE]
+====
+You must have the `Admin` user role to generate a CRS.
+====
+
+.Procedure
+
+ifndef::cloud-svc[]
+. Find the address of the {product-title-short} portal as described in "Verifying Central installation using the Operator method".
+endif::cloud-svc[]
+. Log in to the {product-title-short} portal. If you do not have secured clusters or an existing CRS, the *Platform Configuration* -> *Clusters* page appears. 
+. Click *Create cluster registration secret*.
+. Enter a name for the CRS and click *Download* to generate and download it. The CRS is created in the form of a YAML file and you can use it to secure all of your clusters if you are using the same installation method.
++
+[IMPORTANT]
+====
+Store this file securely because it contains secrets.
+====
+
+.Next steps
+. Apply the CRS to the secured cluster.
+. Install secured cluster services on each cluster.
+
+ifeval::["{context}" == "init-bundle-cloud-other"]
+:!cloud-svc:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-ocp"]
+:!cloud-svc:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-ocp"]
+:!openshift:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-ocp"]
+:!openshift:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-ocp"]
+:!openshift:
+endif::[]

--- a/modules/portal-generate-init-bundle.adoc
+++ b/modules/portal-generate-init-bundle.adoc
@@ -5,7 +5,7 @@
 // You must declare the `topic-helm` or `topic-operator` attribute when using this module.
 :_mod-docs-content-type: PROCEDURE
 [id="portal-generate-init-bundle_{context}"]
-= Generating an init bundle by using the RHACS portal
+= Generating a cluster registration secret or init bundle by using the RHACS portal
 
 
 ifeval::["{context}" == "init-bundle-cloud-other"]
@@ -28,17 +28,25 @@ ifeval::["{context}" == "init-bundle-ocp"]
 :openshift:
 endif::[]
 
+ifeval::["{context}" == "init-bundle-cloud-ocp-generate"]
+:cloud-svc:
+endif::[]
+
+ifeval::["{context}" == "init-bundle-cloud-other-generate"]
+:cloud-svc:
+endif::[]
+
 ifndef::cloud-svc[]
-You can create an init bundle containing secrets by using the {product-title-short} portal.
+You can generate a cluster registration secret (CRS) or an init bundle containing secrets by using the {product-title-short} portal.
 endif::cloud-svc[]
 
 ifdef::cloud-svc[]
-You can create an init bundle containing secrets by using the {product-title-short} portal, also called the ACS Console.
+You can generate a cluster registration secret (CRS) or an init bundle containing secrets by using the {product-title-short} portal, also called the ACS Console.
 endif::cloud-svc[]
 
 [NOTE]
 ====
-You must have the `Admin` user role to create an init bundle.
+You must have the `Admin` user role to generate a CRS or an init bundle.
 ====
 
 .Procedure
@@ -46,19 +54,34 @@ You must have the `Admin` user role to create an init bundle.
 ifndef::cloud-svc[]
 . Find the address of the {product-title-short} portal as described in "Verifying Central installation using the Operator method".
 endif::cloud-svc[]
-. Log in to the {product-title-short} portal. 
-. If you do not have secured clusters or existing init bundles, the *Platform Configuration* -> *Clusters* page appears. Click *Create init bundle*.
-. Enter a name for the cluster init bundle.
-. Select your platform.
-. Select the installation method you will use for your secured clusters: *Operator* or *Helm chart*.
-. Click *Download* to generate and download the init bundle, which is created in the form of a YAML file. You can use one init bundle and its corresponding YAML file for all secured clusters if you are using the same installation method.
+. Log in to the {product-title-short} portal. If you do not have secured clusters, or an existing CRS or an init bundle, the *Platform Configuration* -> *Clusters* page appears. 
+. Click *Create cluster registration secret* or *Init bundles installation method*.
++
+[NOTE]
+====
+Init bundles are still supported, but using a CRS to secure clusters is the preferred method.
+====
+Complete only one of the following actions:
+
+* If you chose to generate a CRS, enter a name for the CRS and click *Download* to generate and download it. The CRS is created in the form of a YAML file and you can use it to secure all of your clusters if you are using the same installation method.
 +
 [IMPORTANT]
 ====
-Store this bundle securely because it contains secrets.
+Store this file securely because it contains secrets.
 ====
+* If you chose to generate an init bundle, complete these steps:
+.. Enter a name for the cluster init bundle.
+.. Select your platform.
+.. Select the installation method you will use for your secured clusters: Operator or Helm chart.
+.. Click *Download* to generate and download the init bundle, which is created in the form of a YAML file. You can use one init bundle and its corresponding YAML file for all secured clusters if you are using the same installation method.
++
+[IMPORTANT]
+====
+Store this file securely because it contains secrets.
+====
+
 .Next steps
-. Apply the init bundle by using it to create resources on the secured cluster.
+. Apply the CRS or the init bundle to the secured cluster.
 . Install secured cluster services on each cluster.
 
 ifeval::["{context}" == "init-bundle-cloud-other"]

--- a/modules/preparing-for-deployments-and-upgrades.adoc
+++ b/modules/preparing-for-deployments-and-upgrades.adoc
@@ -17,7 +17,11 @@ The following table lists the actions you must take for each deployment scenario
 |No action is needed if Central is also Operator-managed. The Operator automates rotation.
 
 |Helm-managed secured clusters
-|Re-register with a new init bundle or cluster registration secret before the 5-year CA expires.
+a|Remove the cluster and re-register it with a new cluster registration secret (CRS) or init bundle before the 5-year CA expires. Follow these steps:
+
+. Delete the cluster from Central.
+. Remove the Secured Cluster CR (or delete all the `tls-cert-*` certificates and redeploy the cluster. 
+. Register the secured cluster with a new CRS.
 
 |Upgrading a Central instance older than 4 years to {rh-rhacs-first} 4.9
 a|

--- a/modules/reissue-internal-certificates-secured-clusters.adoc
+++ b/modules/reissue-internal-certificates-secured-clusters.adoc
@@ -23,54 +23,9 @@ The information banner only appears 15 days before the certificate expiry date.
 [IMPORTANT]
 ====
 Store the init bundle securely because it contains secrets.
-You can use the same bundle on multiple secured clusters.
+You can use the same bundle to set up more than one secured cluster.
 ====
 
 .Procedure
 
-. Choose the appropriate method to generate an init bundle:
-
-** To generate an init bundle by using the user interface (UI), perform the following steps:
-... In the {product-title-short} portal, click *Platform Configuration* -> *Clusters*.
-... Click *Init bundles*.
-... To create a new init bundle, click *Create bundle*.
-... Enter a name for the cluster init bundle.
-... Choose the appropriate platform of the secured clusters:
-+
-The following values are associated with the platform of the secured clusters:
-
-**** `OpenShift`
-**** `EKS`
-**** `AKS`
-**** `GKE`
-
-... Choose the appropriate installation method for the secured cluster services from the drop-down list:
-+
-The following values are associated with the installation method for the secured cluster services:
-
-**** `Operator (recommended)`
-**** `Helm chart`
-
-... Click *Download*.
-+
-[IMPORTANT]
-====
-You can only download the YAML file once when you create an init bundle.
-Store the YAML file securely because it contains secrets.
-====
-
-** To generate an init bundle by using the `roxctl` CLI, run the following command:
-+
-[source,terminal]
-----
-$ roxctl -e <endpoint> -p <admin_password> central \
-  init-bundles generate --output-secrets <bundle_name> \
-  init-bundle.yaml
-----
-
-. To create the necessary resources on each secured cluster, run the following command:
-+
-[source,terminal]
-----
-$ oc -n stackrox apply -f <init-bundle.yaml>
-----
+. Generate an init bundle by using the {product-title-short} portal or by using the `roxctl CLI`, and then apply the bundle to the secured cluster. For more information, see "Generating and applying a cluster registration secret or an init bundle for RHACS on Red Hat OpenShift" or "Generating and applying a cluster registration secret or an init bundle for RHACS on other platforms".

--- a/modules/roxctl-central-crs.adoc
+++ b/modules/roxctl-central-crs.adoc
@@ -8,9 +8,6 @@
 
 Manage cluster registration secrets that allow communication between Central and secured clusters for the initial setup.
 
-:FeatureName: Cluster registration secrets
-include::snippets/technology-preview.adoc[]
-
 .Usage
 [source,terminal]
 ----

--- a/modules/roxctl-generate-init-bundle.adoc
+++ b/modules/roxctl-generate-init-bundle.adoc
@@ -24,7 +24,7 @@ ifeval::["{context}" == "init-bundle-cloud-other-generate"]
 :cloud-other-generate:
 endif::[]
 
-You can create an init bundle with secrets by using the `roxctl` CLI.
+You can generate an init bundle with secrets by using the `roxctl` CLI.
 
 [NOTE]
 ====
@@ -77,7 +77,7 @@ $ roxctl -e "$ROX_CENTRAL_ADDRESS" \
 [IMPORTANT]
 ====
 Ensure that you store this bundle securely because it contains secrets.
-You can use the same bundle to set up multiple secured clusters.
+You can use the same bundle to set up more than one secured cluster.
 ====
 
 ifeval::["{context}" == "init-bundle-cloud-other"]

--- a/modules/secured-cluster-authentication-options.adoc
+++ b/modules/secured-cluster-authentication-options.adoc
@@ -7,13 +7,13 @@
 = Secured cluster authentication options
 
 [role="_abstract"]
-You can use either an init bundle or a cluster registration secret (CRS) during installation of a secured cluster. This allows Central and secured clusters to securely communicate.
+You can use either a cluster registration secret (CRS) or an init bundle during installation of a secured cluster. This allows Central and secured clusters to securely communicate.
 
-Before you set up a secured cluster, you must create an init bundle or CRS. The secured cluster then uses this bundle or CRS to authenticate with Central. You can create an init bundle by using either the {product-title-short} portal or the `roxctl` CLI. If you are using a CRS, you must use the `roxctl` CLI to create it.
+Before you set up a secured cluster, you must generate a CRS or an init bundle. The secured cluster then uses the contained secrets for initial authentication with Central. You can generate a CRS or an init bundle by using either the {product-title-short} portal or the `roxctl` CLI. 
 
-You can then apply the init bundle or the CRS by using the {ocp} web console or by using the `oc` or `kubectl` CLI. If you install {product-title-short} by using Helm, you provide the init bundle or CRS when you run the `helm install` command.
+You can then apply the CRS or the init bundle by using the {ocp} web console or by using the `oc` or `kubectl` CLI. If you install {product-title-short} by using Helm, you provide the CRS or the init bundle when you run the `helm install` command.
 
 [NOTE]
 ====
-You must have the `Admin` user role to create an init bundle or CRS.
+You must have the `Admin` user role to generate a CRS or an init bundle.
 ====

--- a/modules/verify-central-install-operator.adoc
+++ b/modules/verify-central-install-operator.adoc
@@ -34,5 +34,5 @@ Alternatively, you can use the {product-title} web console to find the link to t
 
 .Next Steps
 . Optional: Configure central settings.
-. Generate an init bundle or CRS containing the cluster secrets that allows communication between the `Central` and `SecuredCluster` resources. You need to download this file, use it to generate resources on the clusters you want to secure, and securely store it.
+. Generate a CRS or an init bundle containing the cluster secrets that allows communication between the `Central` and `SecuredCluster` resources. You need to download this file, use it to generate resources on the clusters you want to secure, and securely store it.
 . Install secured cluster services on each cluster you want to monitor.

--- a/snippets/cluster-registration-secrets.adoc
+++ b/snippets/cluster-registration-secrets.adoc
@@ -6,8 +6,11 @@
 
 :_mod-docs-content-type: SNIPPET
 
-Cluster registration secrets (CRSes) offer improved security and are easier to use. CRSes contain a single token that can be used when installing {product-title-short} by using both Operator and Helm installation methods.
+A cluster registration secret (CRS) is an authentication secret that offers improved security and are easier to use than init bundles. A CRS contain a single token that can be used when installing {product-title-short} by using both Operator and Helm installation methods.
 
-CRSes provide better security because they are only used for registering a new secured cluster. If leaked, the certificates and keys in an init bundle can be used to impersonate services running on a secured cluster. By contrast, the certificate and key in a CRS can only be used for _registering_ a new cluster.
+A CRS provides better security because it is only used for registering a new secured cluster. If leaked, the certificates and keys in an init bundle can be used to impersonate services running on a secured cluster. By contrast, the certificate and key in a CRS can only be used for _registering_ a new cluster.
 
 After the cluster is set up by using the CRS, service-specific certificates are issued by Central and sent to the new secured cluster. These service certificates are used for communication between Central and secured clusters. Therefore, a CRS can be revoked after the cluster is registered without disconnecting secured clusters.
+
+Unlike init bundles, which can be re-applied on an existing secured cluster if secrets on the secured cluster need to be manually refreshed, you cannot apply a new CRS to a cluster and re-establish communication between Central and the secured cluster. If there is a problem with the CRS on a secured cluster, for example, if the certificate and keys are deleted, you must revoke the original CRS in Central and remove it from the secured cluster. Then, you create a new CRS in Central, and apply the new CRS to the secured clusters.
+


### PR DESCRIPTION
Version(s):

4.10

[Issue](https://issues.redhat.com/browse/ROX-32797)

Link to docs preview:

- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/cli/command-reference/roxctl-central.html - remove tech preview wording

Installing Cloud Service:

- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/getting-started-rhacs-cloud-ocp.html

Installing/securing clusters in Cloud Service for OCP:

- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/cloud-ocp-create-project.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-generate.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/install-secured-cluster-cloud-ocp.html

Installing/securing clusters in Cloud Service for Kubernetes:

- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/init-bundle-cloud-other-apply.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/init-bundle-cloud-other-generate.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.html

Installing/securing clusters for OCP:

- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/init-bundle-ocp.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp.html

Installing/securing clusters for Kubernetes:

 https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/init-bundle-other.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-rhacs-other.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other.html

Certificate Authority Rotation:
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/internal-certificate-authority-rotation-for-rhacs.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/configuration/reissue-internal-certificates.html
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/acs-high-level-overview.html

Prereq for Scanner V4:
- https://106314--ocpdocs-pr.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities.html

QE review: **ACS has no QE, approved by SME**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
