### PR TITLE
OSDOCS-17095: RHBoK (Kueue) - validate integration of Leader Worker Set

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3426,6 +3426,8 @@ Topics:
     File: install-kueue
   - Name: Installing Red Hat build of Kueue in a disconnected environment
     File: install-disconnected
+  - Name: Integrating the Leader Worker Set Operator
+    File: integrating-lws
   - Name: Configuring role-based permissions
     File: rbac-permissions
   - Name: Configuring quotas

--- a/ai_workloads/kueue/integrating-lws.adoc
+++ b/ai_workloads/kueue/integrating-lws.adoc
@@ -1,0 +1,32 @@
+:_mod-docs-content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="integrating-lws"]
+= Integrating the {lws-operator}
+:context: integrating-lws
+
+toc::[]
+
+[role="_abstract"]
+You can integrate the {lws-operator} with {kueue-name} so you can leverage the scheduling and resource management functionality when running LeaderWorkerSets.
+
+The {lws-operator} allows you to manage multi-node AI/ML inference deployments efficiently. {kueue-name} provides scheduling and resource management capabilities for these deployments. You can configure {lws-operator} to leverage these capabilities when running the `LeaderWorkerSet` API for deploying a group of pods as a unit of replication.
+
+include::modules/kueue-installing-lws.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../ai_workloads/leader_worker_set/index.adoc#lws-about_lws-about[About the {lws-operator}]
+
+* link:https://lws.sigs.k8s.io/docs/reference/leaderworkerset.v1/[LeaderWorkerSet API (Kubernetes documentation)]
+
+* xref:../../security/cert_manager_operator/cert-manager-operator-install.adoc#installing-the-cert-manager-operator-for-red-hat-openshift[Installing the {cert-manager-operator} by using the web console]
+
+include::modules/kueue-running-lws.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../ai_workloads/kueue/configuring-quotas.adoc#configuring-clusterqueues_configuring-quotas[Configuring a cluster queue]
+
+* xref:../../ai_workloads/kueue/configuring-quotas.adoc#configuring-resourceflavors_configuring-quotas[Configuring a resource flavor]
+
+* xref:../../ai_workloads/kueue/configuring-quotas.adoc#configuring-localqueues_configuring-quotas[Configuring a local queue]
+
+

--- a/modules/kueue-installing-lws.adoc
+++ b/modules/kueue-installing-lws.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/integrating-leader-worker-set.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kueue-installing-lws_{context}"]
+= Installing {lws-operator} with {kueue-name}
+
+[role="_abstract"]
+You can configure {kueue-name} to work with the {lws-operator}.
+
+.Prerequisites
+
+* You have installed {kueue-name} using the {kueue-op} in the software catalog.
+* You have installed {lws-operator} and Operand in the software catalog.
+* You have cluster administrator permissions and the `kueue-batch-admin-role` role.
+* You have access to the {product-title} web console.
+* You have installed the {cert-manager-operator} for Red Hat OpenShift for your cluster. 
+
+.Procedure
+
+* Add `LeaderWorkerSet` to the `config.integrations.framework` section of the {kueue-name} cluster object, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+    app.kubernetes.io/managed-by: kustomize
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks:
+      - BatchJob
+      - LeaderWorkerSet
+----
+

--- a/modules/kueue-running-lws.adoc
+++ b/modules/kueue-running-lws.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * ai_workloads/kueue/integrating-leader-worker-set.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="kueue-running-lws_{context}"]
+= Running {lws-operator} with {kueue-name}
+
+[role="_abstract"]
+You can add and run the {lws-operator} to your existing frameworks.
+
+.Prerequisites
+
+* {kueue-name} using the {kueue-op} is installed.
+* {lws-operator} and Operand are installed.
+* The {cert-manager-operator} is installed.
+* The `namespace` where `LeaderWorkerSet` will be created is labeled using `kueue.openshift.io/managed=true`.
+* Ensure that the following {kueue-name} objects have been configured:
+** `ClusterQueue`
+** `ResourceFlavor`
+** `LocalQueue`
+** `Namespace`
+
+.Procedure
+
+. Create a file named `leaderworkerset.yaml`.
++
+.Example of a `LeaderWorkerSet`
+[source,yaml]
+----
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  generation: 1
+  name: my-lws
+  namespace: my-namespace
+spec:
+  leaderWorkerTemplate:
+    leaderTemplate:
+      metadata: {}
+      spec:
+        containers:
+        - image: nginxinc/nginx-unprivileged:1.27
+          name: leader
+          resources: {}
+    restartPolicy: RecreateGroupOnPodRestart
+    size: 3
+    workerTemplate:
+      metadata: {}
+      spec:
+        containers:
+        - image: nginxinc/nginx-unprivileged:1.27
+          name: worker
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+  networkConfig:
+    subdomainPolicy: Shared
+  replicas: 2
+  rolloutStrategy:
+    rollingUpdateConfiguration:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  startupPolicy: LeaderCreated
+----
+
+. Specify the target local queue in the `metadata.labels` section of the `LeaderWorkerSet` configuration.
++
+[source,yaml]
+----
+metadata:
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+----
+
+. Apply the leader worker set configuration by running the following command: 
++
+[source,terminal]
+----
+$ oc apply -f leaderworkerset.yaml
+----
+
+


### PR DESCRIPTION
[OSDOCS-17095]: DS and RN - Docs for [OCPSTRAT-2522](https://issues.redhat.com//browse/OCPSTRAT-2522) RHBoK (Kueue) - validate integration of Leader Worker Set

Version(s): 4.21 4.22

Issue: https://issues.redhat.com/browse/OSDOCS-17095

Link to docs preview: https://106315--ocpdocs-pr.netlify.app/openshift-enterprise/latest/ai_workloads/kueue/integrating-lws.html

SME: @kannon92 
QE review: @anahas-redhat

[ ] QE has approved this change.