### PR TITLE
OSDOCS 17102 CQA 2.0 of MSH-AI-1: Core Concepts Part II

### DIFF
--- a/microshift_ai/microshift-rhoai.adoc
+++ b/microshift_ai/microshift-rhoai.adoc
@@ -70,17 +70,7 @@ include::modules/microshift-inferenceservice-more-options.adoc[leveloffset=+2]
 
 include::modules/microshift-rhoai-model-serving-rt-verify.adoc[leveloffset=+1]
 
-//additional resources for inferenceservice modules
-.Additional resources
-
-* link:https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/latest/html/serving_models/serving-large-models_serving-large-models#inferenceservice[InferenceService] ({rhoai-full} documentation)
-
 include::modules/microshift-rhoai-create-route.adoc[leveloffset=+1]
-
-//additional resources for creating a route
-.Additional resources
-
-* xref:../microshift_networking/microshift-configuring-routes.adoc#microshift-configuring-routes[Configuring routes]
 
 include::modules/microshift-rhoai-query-model-con.adoc[leveloffset=+1]
 

--- a/modules/microshift-inferenceservice-more-options.adoc
+++ b/modules/microshift-inferenceservice-more-options.adoc
@@ -6,7 +6,10 @@
 [id="microshift-rhoai-inferenceservice-more-options_{context}"]
 = More InferenceService CR options
 
-The inference service YAML file can include many different options. For example, you can include a `resources` section that is passed first to the deployment and then to the pod, so that the model server gets access to your hardware through the device plugin.
+[role="_abstract"]
+You can include many different options in the inference service YAML file, as described in the link:https://kserve.github.io/website/latest/reference/api/[Control Plane API Reference] (KServe documentation).  
+
+For example, you can include a `resources` section that is passed first to the deployment and then to the pod, so that the model server gets access to your hardware through the device plugin.
 
 .Example NVIDIA device `resources` snippet in an `InferenceService` CR
 [source,yaml]

--- a/modules/microshift-rhoai-create-route.adoc
+++ b/modules/microshift-rhoai-create-route.adoc
@@ -6,7 +6,8 @@
 [id="microshift-rhoai-create-route_{context}"]
 = Creating a route to use for AI queries in {microshift-short}
 
-Create a route so that your AI model can receive queries and give output. You can either use the `oc expose svc` command or create a definition in a YAML file and apply it.
+[role="_abstract"]
+You can create a route so that your AI model can receive queries and give output by using the `oc expose svc` command or creating a definition in a YAML file and apply it.
 
 .Prerequisites
 

--- a/modules/microshift-rhoai-export-metrics-otel.adoc
+++ b/modules/microshift-rhoai-export-metrics-otel.adoc
@@ -6,6 +6,7 @@
 [id="microshift-rhoai-export-metrics-otel_{context}"]
 = Exporting model-server metrics by using Open Telemetry
 
+[role="_abstract"]
 You can export model-server metrics by using Open Telemetry if you installed the `microshift-observability` RPM for {microshift-short}.
 
 [NOTE]

--- a/modules/microshift-rhoai-get-model-ready-inference.adoc
+++ b/modules/microshift-rhoai-get-model-ready-inference.adoc
@@ -6,7 +6,10 @@
 [id="microshift-rhoai-get-model-ready-inference_{context}"]
 = Getting your AI model ready for inference
 
-Before querying your AI model through the API, get the model ready to provide answers based on the training data. The following examples continue with the OVMS model.
+[role="_abstract"]
+Before querying your AI model through the API, you can get the model ready to provide answers based on the training data. 
+
+The following examples continue with the OVMS model.
 
 .Prerequisites
 
@@ -33,12 +36,13 @@ REQ=./request.json
 
 # Add an inference header
 echo -n '{"inputs" : [{"name": "0", "shape": [1], "datatype": "BYTES"}]}' > "${REQ}"
-# Get the size of the inference header <1>
+# Get the size of the inference header
 HEADER_LEN="$(stat -c %s "${REQ}")"
 # Add size of the data (image) in binary format (4 bytes, little endian) <2>
 printf "%08X" $(stat --format=%s "${IMAGE}") | sed 's/\(..\)/\1\n/g' | tac | tr -d '\n' | xxd -r -p >> "${REQ}"
 # Add the data, that is, append the image to the request file
 cat "${IMAGE}" >> "${REQ}"
 ----
-<1> The inference header size must be passed to {ovms} later in the form of an HTTP header.
-<2> The {ovms} requires 4 bytes in little endian byte order.
++
+* The inference header size must be passed to {ovms} later in the form of an HTTP header.
+* The {ovms} requires 4 bytes in little endian byte order.

--- a/modules/microshift-rhoai-get-model-server-metrics.adoc
+++ b/modules/microshift-rhoai-get-model-server-metrics.adoc
@@ -6,6 +6,7 @@
 [id="microshift-rhoai-get-model-server-metrics_{context}"]
 = Getting the model-server metrics
 
+[role="_abstract"]
 After making a query, you can get the model server's metrics to identify bottlenecks, optimize resource allocation, and ensure efficient infrastructure utilization.
 
 [NOTE]

--- a/modules/microshift-rhoai-inferenceservice-ex.adoc
+++ b/modules/microshift-rhoai-inferenceservice-ex.adoc
@@ -6,7 +6,8 @@
 [id="microshift-rhoai-inferenceservice-ex_{context}"]
 = Creating an InferenceService custom resource
 
-Create an `InferenceService` custom resource (CR) to instruct KServe how to create a deployment for serving your AI model. KServe uses the `ServingRuntime` based on the `modelFormat` value specified in the `InferenceService` CR.
+[role="_abstract"]
+You can create an `InferenceService` custom resource (CR) that instructs KServe how to create a deployment for serving your AI model. KServe uses the `ServingRuntime` based on the `modelFormat` value specified in the `InferenceService` CR.
 
 .Prerequisites
 
@@ -33,17 +34,23 @@ spec:
         name: openvino_ir
       storageUri: "oci://localhost/ovms-resnet50:test"
       args:
-      - --layout=NHWC:NCHW # <1>
+      - --layout=NHWC:NCHW
 ----
-<1> An additional argument to make {ovms} ({ov}) accept the request input data in a different layout than the model was originally exported with. Extra arguments are passed through to the {ov} container.
+where:
+
+`spec.predictor.model.args.layout`:: Specifies an additional argument to make {ovms} ({ov}) accept the request input data in a different layout than the model was originally exported with. Extra arguments are passed through to the {ov} container.
 
 . Save the `InferenceService` example to a file, then create it on the cluster by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc create -n _<ai_demo>_ -f ./FILE.yaml <1>
+$ oc create -n _<ai_demo>_ -f ./FILE.yaml
 ----
-<1> Replace _<ai_demo>_ with your namespace name.
+where:
++
+--
+`_<ai_demo>_`:: Specifies your namespace name.
+--
 +
 .Example output
 [source,terminal]
@@ -56,6 +63,6 @@ inferenceservice.serving.kserve.io/ovms-resnet50 created
 A deployment and a pod are expected to appear in the specified namespace. Depending on the size of the image specified in the `ServingRuntime` CR and the size of the ModelCar OCI image, it might take several minutes for the pod to be ready.
 ====
 
-.Next step
+.Next steps
 
 * Verify that the model-serving runtime is ready.

--- a/modules/microshift-rhoai-model-serving-rt-verify.adoc
+++ b/modules/microshift-rhoai-model-serving-rt-verify.adoc
@@ -7,7 +7,8 @@
 [id="microshift-rhoai-model-serving-rt-verify_{context}"]
 = Verifying that the model-serving runtime is ready
 
-Verify that your model-serving runtime is ready for use by checking that the downstream generation activities are complete.
+[role="_abstract"]
+You can use the {oc-first} to verify that your model-serving runtime is ready for use by checking that the downstream generation activities are complete.
 
 .Prerequisites
 
@@ -59,7 +60,7 @@ NAME                                       READY   STATUS    RESTARTS      AGE
 ovms-resnet50-predictor-6fdb566b7f-bc9k5   2/2     Running   1 (72s ago)   74s
 ----
 
-. Check for the service KServe created by running the following command:
+. Check for the service that KServe created by running the following command:
 +
 [source,terminal]
 ----
@@ -73,6 +74,6 @@ NAME                      TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
 ovms-resnet50-predictor   ClusterIP   None         <none>        80/TCP    119s
 ----
 
-.Next step
+.Next steps
 
 * Create a `Route` object so that your applications can reach the {microshift-short} node.

--- a/modules/microshift-rhoai-override-kserve-config.adoc
+++ b/modules/microshift-rhoai-override-kserve-config.adoc
@@ -6,30 +6,33 @@
 [id="microshift-rhoai-override-kserve-config_{context}"]
 = Overriding KServe configuration
 
-If you want to override KServe settings to customize your model-serving environment, you can follow the general steps for your operating system.
+[role="_abstract"]
+You can override KServe settings to customize your model-serving environment. 
+
+Follow the general steps for your operating system.
 
 Option 1::
 
-. Make a copy of the existing `ConfigMap` file, `inferenceservice-config`, in the `redhat-ods-applications` namespace.
+. Make a copy of the existing `inferenceservice-config` config map file in the `redhat-ods-applications` namespace.
 
 . Edit the settings you want to change.
 
 . Overwrite the existing `ConfigMap` object.
 
-. Restart KServe by either by deleting the pod or scaling the `Deployment` pod parameter down to `0` and then back up to `1`.
+. Restart KServe by either deleting the pod or scaling the `Deployment` pod parameter down to `0` and then back up to `1`.
 
 Option 2::
 
-. Copy the `ConfigMap` file, `/usr/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/inferenceservice-config-microshift-patch.yaml`.
+. Copy the `/usr/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/inferenceservice-config-microshift-patch.yaml` config map file.
 
 . Edit the settings you want to change.
 
 . Apply the `ConfigMap` object.
 
-. Restart KServe by either by deleting the pod or scaling the `Deployment` pod parameter down to `0` and then back up to `1`.
+. Restart KServe by either deleting the pod or scaling the `Deployment` pod parameter down to `0` and then back up to `1`.
 
 For {op-system-ostree} and {op-system-image} systems::
 
-. Create a new manifest with the `ConfigMap` file, based on either of the `/usr/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/inferenceservice-config-microshift-patch.yaml` or `inferenceservice-config` files, in the `redhat-ods-applications` namespace.
+. Create a new manifest with the `ConfigMap` file, based on either the `/usr/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/inferenceservice-config-microshift-patch.yaml` or `inferenceservice-config` file, in the `redhat-ods-applications` namespace.
 
-. Ensure that the new manifest is placed in the `/usr/lib/microshift/manifests.d/` directory. Staring with prefix `011` is recommended so that your manifest is applied after the `/usr/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/` directory contents.
+. Place the new manifest in the `/usr/lib/microshift/manifests.d/` directory. Staring with prefix `011` is recommended so that your manifest is applied after the `/usr/lib/microshift/manifests.d/010-microshift-ai-model-serving-kserve/` directory contents.

--- a/modules/microshift-rhoai-query-model-con.adoc
+++ b/modules/microshift-rhoai-query-model-con.adoc
@@ -6,6 +6,7 @@
 [id="microshift-rhoai-query-model-con_{context}"]
 = About querying your AI model
 
+[role="_abstract"]
 Querying your model through the API is also called model inferencing. Model inferencing is most often used to retrieve information, automate tasks, make predictions, provide data insights, or perform actions.
 
 In general, queries must be constructed using a format compatible with the AI model being used. A model-serving runtime formats queries automatically. The model processes the query according to the underlying training and data, then provides an output. The output is expected to align with the purpose of the model itself, whether that be to give an answer, make a prediction, or perform a task.

--- a/modules/microshift-rhoai-query-model.adoc
+++ b/modules/microshift-rhoai-query-model.adoc
@@ -6,7 +6,8 @@
 [id="microshift-rhoai-query-model_{context}"]
 = Querying your AI model
 
-Make an inference request against the AI model server that is using the `ovms-resnet50` model.
+[role="_abstract"]
+You can make an inference request against the AI model server that is using the `ovms-resnet50` model.
 
 .Prerequisites
 
@@ -28,7 +29,6 @@ $ curl \
 ----
 +
 .Example inferencing output, saved to a `response.json`
-+
 [source,json]
 ----
 {
@@ -42,7 +42,8 @@ $ curl \
         }]
 }
 ----
-<1> The contents of `.outputs[0].data` were omitted from the example for brevity.
++
+The contents of `.outputs[0].data` were omitted from the example for brevity.
 
 .Verification
 
@@ -61,9 +62,10 @@ print(argmax)
 .Example output
 [source,text]
 ----
-309 <1>
+309
 ----
-<1> In this example, the element labeled `309` is the model's response.
++
+In this example, the element labeled `309` is the model's response.
 
 . Validate the output against link:https://github.com/openvinotoolkit/model_server/blob/main/client/common/resnet_input_images.txt[resnet's input data], for example:
 +

--- a/modules/microshift-rhoai-verify-model-connected.adoc
+++ b/modules/microshift-rhoai-verify-model-connected.adoc
@@ -6,7 +6,10 @@
 [id="microshift-rhoai-verify-model-connected_{context}"]
 = Verifying that your AI model is accessible
 
-Before querying the model through the API, you can check to be certain that the model is accessible and ready to provide answers based on the connected data. The following examples continue with the {ovms}.
+[role="_abstract"]
+Before querying the model through the API, you can verify that the model is accessible and ready to provide answers based on the connected data. 
+
+The following examples continue with the {ovms}.
 
 .Prerequisites
 
@@ -28,25 +31,30 @@ $ IP=$(oc get nodes -o json | jq -r '.items[0].status.addresses[0].address')
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc get route -n ai-test _<route_name>_ -o yaml <1>
+$ oc get route -n ai-test _<route_name>_ -o yaml
 ----
-<1> Replace `_<route_name>_` with the actual name of your route.
+where:
+
+`_<route_name>_`:: Specifies the actual name of your route.
 
 . Extract and assign the `HOST` value of the route to the `DOMAIN` variable by running the following command:
 +
 [source,terminal,subs="+quotes"]
 ----
-DOMAIN=$(oc get route -n ai-test _<route_name>_ -o=jsonpath="{ .status.ingress[0].host }") <1>
+DOMAIN=$(oc get route -n ai-test _<route_name>_ -o=jsonpath="{ .status.ingress[0].host }")
 ----
-<1> Replace `_<route_name>_` with the actual name of your route.
+where:
+
+`_<route_name>_`:: Specifies the actual name of your route.
 
 . Enable data transfer from the route to the {microshift-short} IP address by running the following command:
 +
 [source,terminal]
 ----
-$ curl -i "${DOMAIN}/v2/models/ovms-resnet50/ready" --connect-to "${DOMAIN}::${IP}:" <1>
+$ curl -i "${DOMAIN}/v2/models/ovms-resnet50/ready" --connect-to "${DOMAIN}::${IP}:"
 ----
-<1> Instead of using the `--connect-to "${DOMAIN}::${IP}:"` flag, you can also use real DNS, or add the IP address and the domain to the `/etc/hosts` file.
++
+Instead of using the `--connect-to "${DOMAIN}::${IP}:"` flag, you can also use real DNS, or add the IP address and the domain to the `/etc/hosts` file.
 +
 .Example output
 [source,text]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-17102

[Creating an InferenceService custom resource](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-inferenceservice-ex_microshift-rh-openshift-ai)
[Exporting model-server metrics by using Open Telemetry](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-export-metrics-otel_microshift-rh-openshift-ai)
[More InferenceService CR options](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-inferenceservice-more-options_microshift-rh-openshift-ai)
[Verifying that the model-serving runtime is ready](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-model-serving-rt-verify_microshift-rh-openshift-ai)
[Creating a route to use for AI queries in MicroShift](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-create-route_microshift-rh-openshift-ai)
[About querying your AI model](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-query-model-con_microshift-rh-openshift-ai)
[Verifying that your AI model is accessible](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-verify-model-connected_microshift-rh-openshift-ai)
[Getting your AI model ready for inference](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-get-model-ready-inference_microshift-rh-openshift-ai)
[Querying your AI model](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-query-model_microshift-rh-openshift-ai)
[Getting the model-server metrics](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-get-model-server-metrics_microshift-rh-openshift-ai)
[Overriding KServe configuration](https://106317--ocpdocs-pr.netlify.app/microshift/latest/microshift_ai/microshift-rhoai.html#microshift-rhoai-override-kserve-config_microshift-rh-openshift-ai)