### PR TITLE
OSDOCS#18629: Update the z-stream RNs for 4.20.14

### DIFF
--- a/modules/rn-async-errata.adoc
+++ b/modules/rn-async-errata.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="ocp-release-asynchronous-errata-updates_{context}"]
+= Asynchronous errata updates
+
+Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
+
+Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified through email whenever new errata relevant to their registered systems are released.
+
+[NOTE]
+====
+Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
+====
+
+This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
+
+[IMPORTANT]
+====
+For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
+====

--- a/modules/zstream-4-20-14.adoc
+++ b/modules/zstream-4-20-14.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-20-release-notes.adoc
+
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-20-14_{context}"]
+= RHSA-2026:2119 - {product-title} {product-version}.14 fixed issues advisory
+
+[role="_abstract"]
+Issued: 11 February 2026
+
+{product-title} release {product-version}.14 is now available. The list of fixed issues that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:2119[RHSA-2026-2119] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:2076[RHBA-2026:2076] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.20.14 --pullspecs
+----
+
+////
+[id="zstream-4-20-z-enhancements_{context}"]
+== Enhancements
+////
+
+////
+[id="zstream-4-20-z-known-issues_{context}"]
+== Known issues
+
+
+This release contains the following known issues:
+////
+
+[id="zstream-4-20-14-fixed-issues_{context}"]
+== Fixed issues
+
+The following issues are fixed for this release:
+
+* Before this update, Operator deployment templates with `hostUsers: false` values were not selected by Cluster Version Operator (CVO), and caused deployments to block user access configuration. As a consequence, deployments without `hostUsers: false` affected user access. With this release, the `hostUsers` issue in Operator deployment templates is fixed, and ensures that they are selected by CVO. As a result, Operator deployment templates with `hostUsers: false` are correctly applied, ensuring consistent user access configurations. (link:https://issues.redhat.com/browse/OCPBUGS-64828[OCPBUGS-64828])
+
+* Before this update, an invalid `installConfig Override` message caused a registration failure, leading to skipped re-registration in the `assisted-service` component. As a consequence, the installation failed. With this release, the issue with the invalid `installConfig Override` messages is fixed. As a result, `assisted-service` installations do not fail due to invalid `installConfig Override` messages. (link:https://issues.redhat.com/browse/OCPBUGS-65901[OCPBUGS-65901])
+
+* Before this update, the software catalog in the *Developer* view encountered an issue due to missing `Devfiles` data when a disconnected {product-title} cluster had the `Cluster Samples` Operator removed. As a consequence, users navigating to the *+Add* page encountered an empty software catalog with an error message. With this release, the  `Devfiles` data lookup in the software catalog is disabled, avoiding the error on the *+Add* page and resolving the `Error loading Catalog items` message. (link:https://issues.redhat.com/browse/OCPBUGS-74158[OCPBUGS-74158])
+
+* Before this update, the upgrade to {product-title} 4.18 caused a loss of network connectivity for virtual machine (VM) pods using `ovn-k8s-cni-overlay` `localnet` network address translations (NAD). As a consequence, VM pod network connectivity was lost during the upgrade. With this release, the fix maintains network connectivity during cluster upgrades to {product-title} 4.18 for VMs using `ovn-k8s-cni-overlay` `localnet` NADs. As a result, the upgrade does not cause a loss of network connectivity. (link:https://issues.redhat.com/browse/OCPBUGS-74268[OCPBUGS-74268])
+
+* Before this update, static pods were terminated prematurely because the kubelet agent did not recognize the `priorityClassName` field. As a consequence, premature termination of static pods led to long shutdown times and storage layer issues in {sno} environments. With this release, static pods acknowledge the `priorityClassName` field for shutdown order in {sno} environments. As a result, static pods follow shutdown order, reducing long shutdown times and storage layer issues. (link:https://issues.redhat.com/browse/OCPBUGS-74624[OCPBUGS-74624])
+
+* Before this update, {gcp-short} installations failed due to unspecified zones in `install-config` file for regions with AI zones. With this release, the installation program supports AI zones in the `us-south1` and `us-central1` regions, and prevents installation failures. (link:https://issues.redhat.com/browse/OCPBUGS-74674[OCPBUGS-74674])
+
+* Before this update, the `Jobset-controller-manager` pod lacked the necessary permissions to list pods in the cluster scope, and prevented users from accessing the required pods. With this release, the `Jobset-controller-manager` pod is granted full access to the required resources, resolving the pod readiness issue and improving user experience. (link:https://issues.redhat.com/browse/OCPBUGS-75881[OCPBUGS-75881])
+
+
+
+[id="zstream-4-20-14-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.20 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-20-release-notes.adoc
+++ b/release_notes/ocp-4-20-release-notes.adoc
@@ -3013,28 +3013,14 @@ In both cases, the installation program generates a user-assigned identity. (lin
 
 * The loss of the upstream clock connection does not trigger the degradation of all clock state metrics due to a bug in the clock degradation logic. Consequently, 'ptp4l' and 'ts2phc' clock state metrics might not degrade as expected after degrading to the 'unlocked' state, leading to inconsistent time synchronization state reporting. To work around this issue, rely on 'dpll' and 'T-BC' clock state metrics only, and disregard 'ptp4l' and 'ts2phc' metrics. (link:https://issues.redhat.com/browse/OCPBUGS-62719[*OCPBUGS-62719*])
 
-[id="ocp-storage-core-release-known-issues_{context}"]
+// [id="ocp-storage-core-release-known-issues_{context}"]
 
 
+// 4.20.14 about async
+include::modules/rn-async-errata.adoc[leveloffset=+1]
 
-[id="ocp-release-asynchronous-errata-updates_{context}"]
-== Asynchronous errata updates
-
-Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
-
-Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified through email whenever new errata relevant to their registered systems are released.
-
-[NOTE]
-====
-Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
-====
-
-This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
-
-[IMPORTANT]
-====
-For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
-====
+// 4.20.14 RNs
+include::modules/zstream-4-20-14.adoc[leveloffset=+2]
 
 // About 4-20-12 release notes
 include::modules/zstream-4-20-13-about.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.20

Issue:
OSDOCS-18629

Link to docs preview:
[4.20.14](https://106337--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-20-release-notes.html#zstream-4-20-14_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/351#59af837f25776f93a01c5fde58291bb7c3d27257)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.20)
