### PR TITLE
[OSDOCS#18275]: Files for 4.12.85 z-stream release notes

### DIFF
--- a/modules/zstream-4-12-85-about.adoc
+++ b/modules/zstream-4-12-85-about.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="zstream-4-12-85-about_{context}"]
+= RHSA-2026:2065 - {product-title} {product-version}.85 bug fix and security update
+
+[role="_abstract"]
+Issued: 12 February 2026
+
+{product-title} release {product-version}.85, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:2065[RHSA-2026:2065] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:2063[RHBA-2026:2063] advisory.
+
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+
+You can view the container images in this release by running the following command:
+
+
+[source,terminal]
+----
+$ oc adm release info 4.12.85 --pullspecs
+----

--- a/modules/zstream-4-12-85-bug-fixes.adoc
+++ b/modules/zstream-4-12-85-bug-fixes.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-85-bug-fixes_{context}"]
+= Bug fixes
+
+[role=”_abstract”]
+There are no notable bug fixes in this release.

--- a/modules/zstream-4-12-85-updating.adoc
+++ b/modules/zstream-4-12-85-updating.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assembly:
+//
+// * release_notes/ocp-4-12-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-12-85-updating_{context}"]
+= Updating
+
+[role="_abstract"]
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -5357,3 +5357,12 @@ include::modules/zstream-4-12-84-bug-fixes.adoc[leveloffset=+2]
 
 // 4.12.84 updating
 include::modules/zstream-4-12-84-updating.adoc[leveloffset=+2]
+
+// 4.12.85 about
+include::modules/zstream-4-12-85-about.adoc[leveloffset=+2]
+
+// 4.12.85 fixes
+include::modules/zstream-4-12-85-bug-fixes.adoc[leveloffset=+2]
+
+// 4.12.85 updating
+include::modules/zstream-4-12-85-updating.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-18275

Link to docs preview:
https://106340--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#zstream-4-12-85-about_release-notes

QE review:
N/A

