### PR TITLE
[OBSDOCS-3002] Logging Z-Stream Release Notes - 6.0.13

### DIFF
--- a/modules/logging-release-notes-6-0-13.adoc
+++ b/modules/logging-release-notes-6-0-13.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * release_notes/logging-release-notes-6.0.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="logging-release-notes-6-0-13_{context}"]
+= Logging 6.0.13
+
+This release includes link:https://access.redhat.com/errata/RHBA-2026:2564[RHBA-2026:2564].

--- a/release_notes/logging-release-notes-6-0.adoc
+++ b/release_notes/logging-release-notes-6-0.adoc
@@ -7,6 +7,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/logging-release-notes-6-0-13.adoc[leveloffset=+1]
+
 include::modules/logging-release-notes-6-0-12.adoc[leveloffset=+1]
 
 include::modules/logging-release-notes-6-0-11.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
- _none for cherry-picking_

Issue:
- https://issues.redhat.com/browse/OBSDOCS-3002

Link to docs preview:
- [Logging 6.0 RNs](https://106353--ocpdocs-pr.netlify.app/openshift-logging/latest/release_notes/logging-release-notes-6-0.html)

QE review:
- [x] QE has approved this change.
