### PR TITLE
OSDOCS-17504:Corrected Vale errors in OSD clusters on GCP book.

### DIFF
--- a/modules/ocm-cli-list-wif-commands.adoc
+++ b/modules/ocm-cli-list-wif-commands.adoc
@@ -20,12 +20,12 @@ You can list {product-title} clusters that have been deployed using Workload Ide
 $ ocm list clusters --parameter search="gcp.authentication.wif_config_id != ''"
 ----
 +
-** Using a specific wif-config ID to filter the clusters associated with that configuration:
+** Using a specific wif-config ID to filter the clusters associated with that configuration, replacing `<wif_config_id>` with the ID of the WIF configuration:
 +
 [source,terminal]
 ----
-$ ocm list clusters --parameter search="gcp.authentication.wif_config_id = '<wif_config_id>'" <1>
+$ ocm list clusters --parameter search="gcp.authentication.wif_config_id = '<wif_config_id>'"
 ----
-<1> Replace `<wif_config_id>` with the ID of the WIF configuration.
+
 
 

--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -7,12 +7,14 @@
 
 [id="osd-create-gcp-cluster-ccs1_{context}"]
 = Creating a cluster with Service Account authentication using {cluster-manager}
+
+[role="abstract"]
+Through {cluster-manager-url}, you can create an {product-title} cluster on {GCP} using a cloud provider account that you own with the Service Account authentication type.
+
 .Procedure
 
 . Log in to {cluster-manager-url} and click *Create cluster*.
-
 . On the *Create an OpenShift cluster* page, select *Create cluster* in the *Red Hat OpenShift Dedicated* row.
-
 . Under *Billing model*, configure the subscription type and infrastructure type:
 .. Select a subscription type. For information about {product-title} subscription options, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/1-latest/html-single/managing_clusters/index#assembly-cluster-subscriptions[Cluster subscriptions and registration] in the {cluster-manager} documentation.
 +
@@ -26,7 +28,6 @@ For more information, contact your sales representative or Red Hat support.
 +
 .. Select the *Customer Cloud Subscription* infrastructure type to deploy {product-title} in an existing cloud provider account that you own.
 .. Click *Next*.
-
 . Select *Run on {gcp-full}*.
 . Select *Service Account*  as the Authentication type.
 +

--- a/modules/osd-create-cluster-red-hat-account.adoc
+++ b/modules/osd-create-cluster-red-hat-account.adoc
@@ -7,6 +7,7 @@
 [id="osd-create-gcp-cluster-ccs_{context}"]
 = Creating a cluster on {gcp-short} with a Red Hat cloud account using {cluster-manager}
 
+[role="abstract"]
 Through {cluster-manager-url}, you can create an {product-title} cluster on {GCP} using a standard cloud provider account owned by Red Hat.
 
 .Procedure

--- a/modules/private-service-connect-prereqs.adoc
+++ b/modules/private-service-connect-prereqs.adoc
@@ -2,17 +2,18 @@
 //
 // * osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: CONCEPT
 [id="private-service-connect-prereqs"]
 = Prerequisites
 
+[role="abstract"]
 In addition to the prerequisites that you need to complete before deploying any {product-title} on {GCP} cluster, you must also complete the following prerequisites to deploy a private cluster using Private Service Connect (PSC):
 
 * A pre-created Virtual Private Cloud (VPC) with the following subnets in the same {GCP} region where your cluster will be deployed:
 
 ** A control plane subnet
 ** A worker subnet
-** A subnet used for the PSC service attachment with the purpose set to Private Service Connect.
+** A subnet used for the PSC service attachment with the purpose set to Private Service Connect
 +
 [IMPORTANT]
 ====
@@ -34,9 +35,5 @@ For more information about the prerequisites that must be completed before deplo
 PSC is supported with the Customer Cloud Subscription (CCS) infrastructure type only. To create an {product-title} on {GCP} using PSC, see _Creating a cluster on {gcp-short} with Workload Identity Federation_.
 ====
 
-// [id="prereqs-wif-authentication_{context}"]
-// == Requirements when using Workload Identity Federation authentication type
 
-// [id="prereqs-sa-authentication_{context}"]
-// == Requirements when using Service Account as the authentication type
 

--- a/modules/private-service-connect-psc-architecture.adoc
+++ b/modules/private-service-connect-psc-architecture.adoc
@@ -8,7 +8,7 @@
 = Private Service Connect architecture
 
 [role="_abstract"]
-The PSC architecture includes producer services and consumer services. Using PSC, the consumers can access producer services privately from inside their VPC network. Similarly, it allows producers to host services in their own separate VPC networks and offer a private connect to their consumers.
+The Private Service Connect (PSC) architecture includes producer services and consumer services. Using PSC, the consumers can access producer services privately from inside their VPC network. Similarly, it allows producers to host services in their own separate VPC networks and offer a private connect to their consumers.
 
 The following image depicts how Red HAT SREs and other internal resources access and support clusters created using PSC.
 

--- a/modules/service-account-auth-overview.adoc
+++ b/modules/service-account-auth-overview.adoc
@@ -7,7 +7,10 @@
 [id="service-account-auth-overview_{context}"]
 = Service Account authentication overview
 
-The Service Account authentication type uses a private key for authentication purposes. Service accounts use RSA key pairs, which consist of a public and private key, with the private key being the service account key. The public portion of the key pair is stored on {gcp-full}, while the private key is kept by the user. The private key allows users to authenticate as a service account and gain access to assets and resources associated with that service account.
+[role="abstract"]
+The Service Account authentication type allows you to authenticate your {product-title} cluster on {GCP} using a private key for authentication purposes.
+
+Service accounts use RSA key pairs, which consist of a public and private key, with the private key being the service account key. The public portion of the key pair is stored on {gcp-full}, while the private key is kept by the user. The private key allows users to authenticate as a service account and gain access to assets and resources associated with that service account.
 
 Service account keys are a security risk if not managed carefully. Users should routinely rotate their service account keys to reduce the risk of leaked or stolen keys.
 

--- a/modules/wif-configuration-update.adoc
+++ b/modules/wif-configuration-update.adoc
@@ -48,13 +48,18 @@ $ ocm version
 +
 [source,terminal]
 ----
-ocm gcp update wif-config <wif_name> \ <1>
---version <version> <2>
---federated-project <gcp_project_id> <3>
+ocm gcp update wif-config <wif_name> \
+--version <version>
+--federated-project <gcp_project_id>
 ----
-<1> Replace `<wif_name>` with the name of the WIF configuration you want to update.
-<2> Optional: Replace `<version>` with the {product-title} y-stream version you plan to update the cluster to. If you do not specify a version, the wif-config will be updated to support the latest {product-title} y-stream version as well as the last three {product-title} supported y-stream versions (beginning with version 4.17).
-<3> Optional: Replace `<gcp_project_id>` with the ID of the dedicated project where the workload identity pools and providers will be created and managed. If the `--federated-project` flag is not specified, the workload identity pools and providers will remain in the project associated with the cluster.
++
+where:
+
+`<wif_name>`:: The name of the WIF configuration you want to update.
+
+`<version>`:: Optional: The {product-title} y-stream version you plan to update the cluster to. If you do not specify a version, the wif-config will be updated to support the latest {product-title} y-stream version as well as the last three {product-title} supported y-stream versions (beginning with version 4.17).
+
+`--federated-project <gcp_project_id>`:: Optional: A flag to specify a new dedicated project where the workload identity pools and providers will be created and managed. If this flag is not included, the workload identity pools and providers will remain in the project associated with the cluster.
 
 .Next steps
 

--- a/osd_gcp_clusters/creating-a-gcp-cluster-redhat-account.adoc
+++ b/osd_gcp_clusters/creating-a-gcp-cluster-redhat-account.adoc
@@ -6,9 +6,8 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-:_mod-docs-content-type: PROCEDURE
-
-Through {cluster-manager-url}, you can create an {product-title} cluster on {GCP} using a standard cloud provider account owned by Red Hat.
+[role="abstract"]
+Through {cluster-manager-url}, you can create an {product-title} cluster on {GCP} using a standard cloud provider account owned by Red{nbsp}Hat.
 
 [id="osd-creating-a-cluster-on-gcp-prerequisites1_{context}"]
 == Prerequisites
@@ -20,6 +19,6 @@ include::modules/osd-create-cluster-red-hat-account.adoc[leveloffset=+1]
 
 [id="next-steps-rh-account_{context}"]
 == Next steps
-* To learn about configuring identity providers for your cluster, see xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[Configuring Identity Providers].
+* xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[Configuring Identity Providers]
 
-* To learn about granting administrator privileges to a user for your cluster, see xref:../osd_getting_started/osd-getting-started.adoc#osd-grant-admin-privileges_osd-getting-started[Granting administrator privileges to a user].
+* xref:../osd_getting_started/osd-getting-started.adoc#osd-grant-admin-privileges_osd-getting-started[Granting administrator privileges to a user]

--- a/osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc
+++ b/osd_gcp_clusters/creating-a-gcp-cluster-sa.adoc
@@ -24,16 +24,15 @@ include::modules/osd-create-cluster-ccs.adoc[leveloffset=+1]
 [id="additional-resources_{context}"]
 == Additional resources
 
-* For information about Workload Identity Federation, see xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on {gcp-short} with Workload Identity Federation authentication].
-
-* For information about Private Service Connect (PSC), see xref:../osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.adoc#creating-a-gcp-psc-enabled-private-cluster[Private Service Connect overview].
-* For information about configuring a proxy with {product-title}, see xref:../networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.adoc#configuring-a-cluster-wide-proxy[Configuring a cluster-wide proxy].
-* For information about persistent storage for {product-title}, see the xref:../osd_architecture/osd_policy/osd-service-definition.adoc#sdpolicy-storage_osd-service-definition[Storage] section in the {product-title} service definition.
-* For information about load balancers for {product-title}, see the xref:../osd_architecture/osd_policy/osd-service-definition.adoc#load-balancers_osd-service-definition[Load balancers] section in the {product-title} service definition.
-* For more information about etcd encryption, see the xref:../osd_architecture/osd_policy/osd-service-definition.adoc#etcd-encryption_osd-service-definition[etcd encryption service definition].
-* For information about the end-of-life dates for {product-title} versions, see the xref:../osd_architecture/osd_policy/osd-life-cycle.adoc#osd-life-cycle[{product-title} update life cycle].
-* For general information about Cloud network address translation(NAT) that is required for cluster-wide proxy, see link:https://cloud.google.com/nat/docs/overview[Cloud NAT overview] in the Google documentation.
-* For general information about Cloud routers that are required for the cluster-wide proxy, see link:https://cloud.google.com/network-connectivity/docs/router/concepts/overview[Cloud Router overview] in the Google documentation.
-* For information about creating VPCs within your {gcp-full} Provider account, see link:https://cloud.google.com/vpc/docs/create-modify-vpc-networks[Create and manage VPC networks] in the Google documentation.
-* For information about configuring identity providers, see xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[Configuring identity providers].
-* For information about revoking cluster privileges, see xref:../authentication/osd-revoking-cluster-privileges.adoc#osd-revoking-cluster-privileges[Revoking privileges and access to an {product-title} cluster].
+* xref:../osd_gcp_clusters/creating-a-gcp-cluster-with-workload-identity-federation.adoc#osd-creating-a-cluster-on-gcp-with-workload-identity-federation[Creating a cluster on {gcp-short} with Workload Identity Federation authentication]
+* xref:../osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.adoc#creating-a-gcp-psc-enabled-private-cluster[Private Service Connect overview]
+* xref:../networking/ovn_kubernetes_network_provider/configuring-cluster-wide-proxy.adoc#configuring-a-cluster-wide-proxy[Configuring a cluster-wide proxy]
+* xref:../osd_architecture/osd_policy/osd-service-definition.adoc#sdpolicy-storage_osd-service-definition[Storage {product-title} service definition]
+* xref:../osd_architecture/osd_policy/osd-service-definition.adoc#load-balancers_osd-service-definition[Load balancers {product-title} service definition]
+* xref:../osd_architecture/osd_policy/osd-service-definition.adoc#etcd-encryption_osd-service-definition[etcd encryption service definition]
+* xref:../osd_architecture/osd_policy/osd-life-cycle.adoc#osd-life-cycle[{product-title} update life cycle]
+* link:https://cloud.google.com/nat/docs/overview[Cloud NAT overview in the Google documentation]
+* link:https://cloud.google.com/network-connectivity/docs/router/concepts/overview[Cloud Router overview in the Google documentation]
+* link:https://cloud.google.com/vpc/docs/create-modify-vpc-networks[Create and manage VPC networks in the Google documentation]
+* xref:../authentication/sd-configuring-identity-providers.adoc#sd-configuring-identity-providers[Configuring identity providers]
+* xref:../authentication/osd-revoking-cluster-privileges.adoc#osd-revoking-cluster-privileges[Revoking privileges and access to an {product-title} cluster]

--- a/osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.adoc
+++ b/osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster.adoc
@@ -1,10 +1,13 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="creating-a-gcp-psc-enabled-private-cluster"]
 = Private Service Connect overview
+
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: osd-creating-a-gcp-psc-enabled-private-cluster
 
 toc::[]
+
+[role="abstract"]
 You can create a private {product-title} cluster on {GCP} using {gcp-full}'s security-enhanced networking feature Private Service Connect (PSC).
 
 include::modules/osd-understanding-private-service-connect.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-17504](https://issues.redhat.com//browse/OSDOCS-17504)

Link to docs preview:
[OpenShift Dedicated clusters on Google Cloud ](https://106368--ocpdocs-pr.netlify.app/openshift-dedicated/latest/osd_gcp_clusters/creating-a-gcp-psc-enabled-private-cluster)

Peer review:
- [ ] Peer reviewer has approved this change.

QE review:
- QE approval is required to merge this PR.
