### PR TITLE
RHDEVDOCS-7245: OCP version change in RN and content gateway incorrect link fix

### DIFF
--- a/modules/gitops-installing-argocd-cli-on-linux.adoc
+++ b/modules/gitops-installing-argocd-cli-on-linux.adoc
@@ -10,7 +10,7 @@ For Linux distributions, you can download the {gitops-shortname} `argocd` CLI as
 
 .Procedure
 
-. Download the latest version of the CLI tool from the link:https://developers.redhat.com/content-gateway/rest/browse/pub/openshift-v4/clients/openshift-gitops/latest/[content gateway] for your operating system and architecture.
+. Download the latest version of the CLI tool from the link:https://developers.redhat.com/content-gateway/rest/browse/pub/cgw/openshift-gitops/[content gateway] for your operating system and architecture.
 +
 [options="header"]
 |===

--- a/modules/gitops-installing-argocd-cli-on-macos.adoc
+++ b/modules/gitops-installing-argocd-cli-on-macos.adoc
@@ -10,7 +10,7 @@ For macOS, you can download the {gitops-shortname} `argocd` CLI as a `tar.gz` ar
 
 .Procedure
 
-. Download the latest version of the CLI tool from the link:https://developers.redhat.com/content-gateway/rest/browse/pub/openshift-v4/clients/openshift-gitops/latest/[content gateway] for your operating system and architecture.
+. Download the latest version of the CLI tool from the link:https://developers.redhat.com/content-gateway/rest/browse/pub/cgw/openshift-gitops/[content gateway] for your operating system and architecture.
 +
 [options="header"]
 |===

--- a/modules/gitops-installing-argocd-cli-on-windows.adoc
+++ b/modules/gitops-installing-argocd-cli-on-windows.adoc
@@ -10,7 +10,7 @@ For Windows, you can download the {gitops-shortname} `argocd` CLI as a compresse
 
 .Procedure
 
-. Download the latest version of the CLI tool from the link:https://developers.redhat.com/content-gateway/rest/browse/pub/openshift-v4/clients/openshift-gitops/latest/[content gateway] for your operating system and architecture.
+. Download the latest version of the CLI tool from the link:https://developers.redhat.com/content-gateway/rest/browse/pub/cgw/openshift-gitops/[content gateway] for your operating system and architecture.
 +
 [options="header"]
 |===

--- a/modules/gitops-release-notes-1-19-0.adoc
+++ b/modules/gitops-release-notes-1-19-0.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-19-0_{context}"]
 = Release notes for {gitops-title} 1.19.0
 
-{gitops-title} 1.19.0 is available on {OCP} 4.14, 4.16, 4.17, 4.18, 4.19 and 4.20.
+{gitops-title} 1.19.0 is available on {OCP} 4.14, 4.16, 4.17, 4.18, 4.19, 4.20, and 4.21.
 
 [id="errata-updates-1-19-0_{context}"]
 == Errata updates


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

none for CP

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/RHDEVDOCS-7245

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Added the OCP 4.21 version number support in the [Release notes for Red Hat OpenShift GitOps 1.19.0](https://106380--ocpdocs-pr.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes-1-19#gitops-release-notes-1-19-0_gitops-release-notes) content

Fixed the incorrect link for content gateway in the following sections:

- [Installing the Red Hat OpenShift GitOps CLI on Linux](https://106380--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/installing-argocd-gitops-cli.html#gitops-installing-argocd-cli-on-linux-using-rpm)
- [Installing the Red Hat OpenShift GitOps CLI on Windows](https://106380--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/installing-argocd-gitops-cli.html#gitops-installing-argocd-cli-on-windows)
- [Installing the Red Hat OpenShift GitOps CLI on macOS](https://106380--ocpdocs-pr.netlify.app/openshift-gitops/latest/installing_gitops/installing-argocd-gitops-cli.html#gitops-installing-argocd-cli-on-macos)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME review: @svghadi 
QE review: @varshab1210 
Peer review: @shivanisathe25 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
