### PR TITLE
OSDOCS-18202 Adding private cluster instructions to custom GCP DNS

### DIFF
--- a/modules/installation-gcp-provisioning-dns-records.adoc
+++ b/modules/installation-gcp-provisioning-dns-records.adoc
@@ -13,11 +13,37 @@ Before you use this feature, you must add the `userProvisionedDNS` parameter to 
 
 .Prerequisites
 
+* You installed your cluster.
 * You installed the `gcloud` CLI tool.
 
 .Procedure
 
-. To find the IP address of the API server and then provision the corresponding DNS record, use the `gcloud` CLI to run the following command:
+. Determine the infrastructure ID of your cluster by running the following command:
++
+[source,terminal]
+----
+$ infra_id=$(jq -r .infraID <installation_directory>/metadata.json)
+----
++
+where:
++
+`<installation_directory>`:: Specifies the directory where you ran the installation program.
+
+. Find the IP address of the API server:
+
+.. If you installed a private cluster, determine the IP address of the API server by running the following command:
++
+[source,terminal]
+----
+$ gcloud compute forwarding-rules describe "${infra_id}-api-internal" --project=<project_name> --region <region_name> --format json | jq -r .IPAddress
+----
++
+where:
++
+`<project_name>`:: Specifies the name of your {gcp-full} project.
+`<region_name>`:: Specifies the region where you installed your cluster.
+
+.. If you installed a public cluster, determine the IP address of the API server by running the following command:
 +
 [source,terminal]
 ----
@@ -25,17 +51,38 @@ $ gcloud compute forwarding-rules describe --global "${infra_id}-apiserver" --fo
 ----
 . Use the IP address to provision your own DNS record with the `api.<cluster_name>.<base_domain>.` hostname by using your cluster name and base cluster domain.
 
-. Use the `gcloud` CLI to find the IP address of the Ingress service and then provision the corresponding DNS record.
-.. To find the forwarding rule for the Ingress service, run the following command:
+. Find the IP address of the Ingress service:
+
+.. If you installed a private cluster, find the IP address of the Ingress service by running the following command:
++
+[source,terminal]
+----
+$ gcloud compute forwarding-rules list --project=<project_name> --filter="subnetwork:(projects/<project_name>/regions/<region_name>/subnetworks/<compute_subnet_name>)" --format="json" | jq -r '.[].IPAddress'
+----
++
+where:
++
+`<project_name>`:: Specifies the name of your {gcp-full} project.
+`<region_name>`:: Specifies the region where you installed your cluster.
+`<compute_subnet_name>`:: Specifies the name of the subnet that contains your compute nodes.
+
+.. If you installed a public cluster, find the IP address by using the forwarding rule:
+
+... Find the forwarding rule for the Ingress service by running the following command:
 +
 [source,terminal]
 ----
 $ ingress_forwarding_rule=$(gcloud compute target-pools list --format=json --filter="instances[]~${infra_id}" | jq -r .[].name)
 ----
-.. To use the forwarding rule value to find the IP address of the Ingress service, run the following command:
+... Use the forwarding rule value to find the IP address of the Ingress service by running the following command:
 +
 [source,terminal]
 ----
-$ ingress_ip_address=$(gcloud compute forwarding-rules describe --region "${region}" "${ingress_forwarding_rule}" --format json | jq -r .IPAddress)
+$ gcloud compute forwarding-rules describe --region "<region_name>" "${ingress_forwarding_rule}" --format json | jq -r .IPAddress
 ----
++
+where:
++
+`<region_name>`:: Specifies the region where you installed your cluster.
+
 . Use the IP address to provision your own DNS record with the `*.apps.<cluster_name>.<base_domain>.` hostname by using your cluster name and base cluster domain.


### PR DESCRIPTION
Version(s):
4.21+

Issue:
https://issues.redhat.com/browse/OSDOCS-18202

Link to docs preview:
https://106401--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-provisioning-own-dns-records_installing-gcp-customizations

QE review:
- [x] QE has approved this change.
