### PR TITLE
TELCODOCS-2654: compatibility fixes for cnf-debugging-low-latency-tuning-status

### DIFF
--- a/modules/cnf-about-must-gather-tool.adoc
+++ b/modules/cnf-about-must-gather-tool.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/cnf-low-latency-tuning.adoc
+// * scalability_and_performance/low_latency_tuning/cnf-debugging-low-latency-tuning-status.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="cnf-about-must-gather_{context}"]
+= About the must-gather tool
+
+[role="_abstract"]
+The `oc adm must-gather` CLI command collects information from your cluster that is most likely needed for debugging issues.
+
+The command collects the following information:
+
+* Resource definitions
+* Audit logs
+* Service logs
+
+You can specify one or more images when you run the command by including the `--image` argument. When you specify an image, the tool collects data related to that feature or product. When you run `oc adm must-gather`, a new pod is created on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local`. This directory is created in your current working directory.

--- a/modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
+++ b/modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
@@ -7,25 +7,12 @@
 [id="cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support_{context}"]
 = Collecting low latency tuning debugging data for Red Hat Support
 
+[role="_abstract"]
 When opening a support case, it is helpful to provide debugging information about your cluster to Red Hat Support.
 
 The `must-gather` tool enables you to collect diagnostic information about your {product-title} cluster, including node tuning, NUMA topology, and other information needed to debug issues with low latency setup.
 
 For prompt support, supply diagnostic information for both {product-title} and low latency tuning.
-
-[id="cnf-about-must-gather_{context}"]
-== About the must-gather tool
-
-The `oc adm must-gather` CLI command collects the information from your cluster that is most likely needed for debugging issues, such as:
-
-* Resource definitions
-* Audit logs
-* Service logs
-
-You can specify one or more images when you run the command by including the `--image` argument. When you specify an image, the tool collects data related to that feature or product. When you run `oc adm must-gather`, a new pod is created on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local`. This directory is created in your current working directory.
-
-[id="cnf-about-collecting-low-latency-data_{context}"]
-== Gathering low latency tuning data
 
 Use the `oc adm must-gather` CLI command to collect information about your cluster, including features and objects associated with low latency tuning, including:
 
@@ -39,7 +26,7 @@ Use the `oc adm must-gather` CLI command to collect information about your clust
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
-* The {product-title} CLI (oc) installed.
+* The {product-title} CLI (`oc`) installed.
 
 .Procedure
 
@@ -52,7 +39,7 @@ Use the `oc adm must-gather` CLI command to collect information about your clust
 $ oc adm must-gather
 ----
 +
-.Example output
+The output shows information similar to the following:
 +
 [source,terminal]
 ----
@@ -86,10 +73,10 @@ ClusterOperators:
 +
 [source,terminal]
 ----
-$ tar cvaf must-gather.tar.gz must-gather-local.5421342344627712289// <1>
+$ tar cvaf must-gather.tar.gz <must_gather_local_directory>
 ----
 +
-<1> Replace `must-gather-local.5421342344627712289//` with the directory name created by the `must-gather` tool.
+Replace `<must_gather_local_directory>` with the directory name created by the `must-gather` tool, for example `must-gather-local.5421342344627712289`.
 +
 [NOTE]
 ====

--- a/modules/cnf-debugging-low-latency-cnf-tuning-status.adoc
+++ b/modules/cnf-debugging-low-latency-cnf-tuning-status.adoc
@@ -3,10 +3,12 @@
 // * scalability_and_performance/cnf-low-latency-tuning.adoc
 // * scalability_and_performance/low_latency_tuning/cnf-debugging-low-latency-tuning-status.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="cnf-debugging-low-latency-cnf-tuning-status_{context}"]
 = Debugging low latency CNF tuning status
 
-The `PerformanceProfile` custom resource (CR) contains status fields for reporting tuning status and debugging latency degradation issues. These fields report on conditions that describe the state of the operator's reconciliation functionality.
+[role="_abstract"]
+The `PerformanceProfile` custom resource (CR) contains status fields for reporting tuning status and debugging latency degradation issues. These fields report on conditions that describe the state of the Operator's reconciliation functionality.
 
 A typical issue can arise when the status of machine config pools that are attached to the performance profile are in a degraded state, causing the `PerformanceProfile` status to degrade. In this case, the machine config pool issues a failure message.
 
@@ -36,7 +38,7 @@ Status:
 
 The `Status` field contains `Conditions` that specify `Type` values that indicate the status of the performance profile:
 
-`Available`:: All machine configs and Tuned profiles have been created successfully and are available for cluster components are responsible to process them (NTO, MCO, Kubelet).
+`Available`:: All machine configs and Tuned profiles have been created successfully and are available for cluster components that are responsible to process them (Node Tuning Operator, Machine Config Operator, kubelet).
 
 `Upgradeable`:: Indicates whether the resources maintained by the Operator are in a state that is safe to upgrade.
 
@@ -57,11 +59,9 @@ Each of these types contain the following fields:
 [id="cnf-debugging-low-latency-cnf-tuning-status-machineconfigpools_{context}"]
 == Machine config pools
 
-A performance profile and its created products are applied to a node according to an associated machine config pool (MCP). The MCP holds valuable information about the progress of applying the machine configurations created by performance profiles that encompass kernel args, kube config, huge pages allocation, and deployment of rt-kernel. The Performance Profile controller monitors changes in the MCP and updates the performance profile status accordingly.
+A performance profile and its created products are applied to a node according to an associated machine config pool (MCP). The MCP holds valuable information about the progress of applying the machine configurations created by performance profiles that encompass kernel arguments, kubelet config, huge pages allocation, and deployment of rt-kernel. The Performance Profile controller monitors changes in the MCP and updates the performance profile status accordingly.
 
 The only conditions returned by the MCP to the performance profile status is when the MCP is `Degraded`, which leads to `performanceProfile.status.condition.Degraded = true`.
-
-.Example
 
 The following example is for a performance profile with an associated machine config pool (`worker-cnf`) that was created for it:
 
@@ -72,7 +72,7 @@ The following example is for a performance profile with an associated machine co
 # oc get mcp
 ----
 +
-.Example output
+The output shows information similar to the following:
 +
 [source,terminal]
 ----
@@ -89,7 +89,7 @@ worker-cnf   rendered-worker-cnf-6c838641b8a08fff08dbd8b02fb63f7c   False     Tr
 # oc describe mcp worker-cnf
 ----
 +
-.Example output
+The output shows information similar to the following:
 +
 [source,terminal]
 ----
@@ -106,7 +106,7 @@ worker-cnf   rendered-worker-cnf-6c838641b8a08fff08dbd8b02fb63f7c   False     Tr
 # oc describe performanceprofiles performance
 ----
 +
-.Example output
+The output shows information similar to the following:
 +
 [source,terminal]
 ----

--- a/scalability_and_performance/cnf-debugging-low-latency-tuning-status.adoc
+++ b/scalability_and_performance/cnf-debugging-low-latency-tuning-status.adoc
@@ -6,9 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 Use the `PerformanceProfile` custom resource (CR) status fields for reporting tuning status and debugging latency issues in the cluster node.
 
 include::modules/cnf-debugging-low-latency-cnf-tuning-status.adoc[leveloffset=+1]
+
+include::modules/cnf-about-must-gather-tool.adoc[leveloffset=+1]
 
 include::modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc[leveloffset=+1]
 
@@ -17,7 +20,7 @@ include::modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-su
 
 * xref:../support/gathering-cluster-data.adoc#gathering-cluster-data[Gathering data about your cluster with the `must-gather` tool]
 
-* xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[Managing nodes with MachineConfig and KubeletConfig CRs]
+* xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[Managing nodes with `MachineConfig` and `KubeletConfig` CRs]
 
 * xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][TELCODOCS-2654]: DITA compatibility fixes for cnf-debugging-low-latency-tuning-status

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):https://issues.redhat.com/browse/TELCODOCS-2654
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://106404--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-debugging-low-latency-tuning-status.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Split procedure module to extract "About the must-gather tool" concept
- Added _mod-docs-content-type attributes
- Added [role="_abstract"] short descriptions to all modules
- Replaced unsupported block titles with inline text
- Converted callout to placeholder explanation
- Expanded acronyms (NTO, MCO) to full names
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
