### PR TITLE
OSDOCS 16931 CQA 2.0 of NODES-3: Infrastructure and Specialized Node Configuration

### DIFF
--- a/modules/creating-an-infra-node.adoc
+++ b/modules/creating-an-infra-node.adoc
@@ -10,10 +10,13 @@
 
 [IMPORTANT]
 ====
-See Creating infrastructure machine sets for installer-provisioned infrastructure environments or for any cluster where the control plane nodes are managed by the machine API.
+See "Creating infrastructure machine sets" for installer-provisioned infrastructure environments or for any cluster where the control plane nodes are managed by the machine API.
 ====
 
-Requirements of the cluster dictate that infrastructure (infra) nodes, be provisioned. The installation program provisions only control plane and worker nodes. Worker nodes can be designated as infrastructure nodes through labeling. You can then use taints and tolerations to move appropriate workloads to the infrastructure nodes. For more information, see "Moving resources to infrastructure machine sets".
+[role="_abstract"]
+You can use labels to configure worker nodes as infrastructure nodes, where you can move infrastructure resources. 
+
+After you create the infrastructure nodes, you can move appropriate workloads to those nodes by using taints and tolerations.
 
 You can optionally create a default cluster-wide node selector. The default node selector is applied to pods created in all namespaces and creates an intersection with any existing node selectors on a pod, which additionally constrains the pod's selector.
 
@@ -43,7 +46,8 @@ $ oc get nodes
 ----
 
 . Optional: Create a default cluster-wide node selector:
-
++
+--
 .. Edit the `Scheduler` object:
 +
 [source,terminal]
@@ -60,11 +64,13 @@ kind: Scheduler
 metadata:
   name: cluster
 spec:
-  defaultNodeSelector: node-role.kubernetes.io/infra="" <1>
+  defaultNodeSelector: node-role.kubernetes.io/infra=""
 # ...
 ----
-<1> This example node selector deploys pods on infrastructure nodes by default.
++
+This example node selector deploys pods on infrastructure nodes by default.
 
 .. Save the file to apply the changes.
-
+--
++
 You can now move infrastructure resources to the new infrastructure nodes. Also, remove any workloads that you do not want, or that do not belong, on the new infrastructure node. See the list of workloads supported for use on infrastructure nodes in "{product-title} infrastructure components".

--- a/modules/infrastructure-components.adoc
+++ b/modules/infrastructure-components.adoc
@@ -7,6 +7,9 @@
 [id="infrastructure-components_{context}"]
 = {product-title} infrastructure components
 
+[role="_abstract"]
+You can review the following information to understand which components you can move to an infrastructure node. 
+
 Each self-managed Red{nbsp}Hat OpenShift subscription includes entitlements for {product-title} and other OpenShift-related components. These entitlements are included for running {product-title} control plane and infrastructure workloads and do not need to be accounted for during sizing.
 
 To qualify as an infrastructure node and use the included entitlement, only components that are supporting the cluster, and not part of an end-user application, can run on those instances. Examples include the following components:
@@ -28,3 +31,6 @@ To qualify as an infrastructure node and use the included entitlement, only comp
 // Updated the list to match the list under "Red Hat OpenShift control plane and infrastructure nodes" in https://www.redhat.com/en/resources/openshift-subscription-sizing-guide
 
 Any node that runs any other container, pod, or component is a worker node that your subscription must cover.
+
+For information about infrastructure nodes and which components can run on infrastructure nodes, see the "Red Hat OpenShift control plane and infrastructure nodes" section in the link:https://www.redhat.com/en/resources/openshift-subscription-sizing-guide[OpenShift sizing and subscription guide for enterprise Kubernetes] document.
+

--- a/modules/nodes-edge-remote-workers-latency.adoc
+++ b/modules/nodes-edge-remote-workers-latency.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * nodes-edge-remote-workers.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="nodes-edge-remote-workers-latency_{context}"]
+= Latency spikes or temporary reduction in throughput to remote workers
+
+[role="_abstract"]
+include::snippets/worker-latency-profile-intro.adoc[]

--- a/modules/nodes-edge-remote-workers-network.adoc
+++ b/modules/nodes-edge-remote-workers-network.adoc
@@ -6,18 +6,21 @@
 [id="nodes-edge-remote-workers-network_{context}"]
 = Network separation with remote worker nodes
 
-All nodes send heartbeats to the Kubernetes Controller Manager Operator (kube controller) in the {product-title} cluster every 10 seconds. If the cluster does not receive heartbeats from a node, {product-title} responds using several default mechanisms.
+[role="_abstract"]
+You can review the following information to understand how {product-title} responds to network connection loss with remote nodes and how you can mitigate problems associated with connection loss. 
 
 {product-title} is designed to be resilient to network partitions and other disruptions. You can mitigate some of the more common disruptions, such as interruptions from software upgrades, network splits, and routing issues. Mitigation strategies include ensuring that pods on remote worker nodes request the correct amount of CPU and memory resources, configuring an appropriate replication policy, using redundancy across zones, and using Pod Disruption Budgets on workloads.
+
+All nodes send heartbeats to the Kubernetes Controller Manager Operator (kube controller) in the {product-title} cluster every 10 seconds. If the cluster does not receive heartbeats from a node, {product-title} responds using several default mechanisms.
 
 If the kube controller loses contact with a node after a configured period, the node controller on the control plane updates the node health to `Unhealthy` and marks the node `Ready` condition as `Unknown`. In response, the scheduler stops scheduling pods to that node. The on-premise node controller adds a `node.kubernetes.io/unreachable` taint with a `NoExecute` effect to the node and schedules pods on the node for eviction after five minutes, by default.
 
 If a workload controller, such as a `Deployment` object or `StatefulSet` object, is directing traffic to pods on the unhealthy node and other nodes can reach the cluster, {product-title} routes the traffic away from the pods on the node. Nodes that cannot reach the cluster do not get updated with the new traffic routing. As a result, the workloads on those nodes might continue to attempt to reach the unhealthy node.
 
-You can mitigate the effects of connection loss by:
+You can mitigate the effects of connection loss by using any of the following strategies:
 
-* using daemon sets to create pods that tolerate the taints
-* using static pods that automatically restart if a node goes down
-* using Kubernetes zones to control pod eviction
-* configuring pod tolerations to delay or avoid pod eviction
-* configuring the kubelet to control the timing of when it marks nodes as unhealthy.
+* Using daemon sets to create pods that tolerate the taints.
+* Using static pods that automatically restart if a node goes down.
+* Using Kubernetes zones to control pod eviction.
+* Configuring pod tolerations to delay or avoid pod eviction.
+* Configuring the kubelet to control the timing of when it marks nodes as unhealthy.

--- a/modules/nodes-edge-remote-workers-power.adoc
+++ b/modules/nodes-edge-remote-workers-power.adoc
@@ -6,6 +6,9 @@
 [id="nodes-edge-remote-workers-power_{context}"]
 = Power loss on remote worker nodes
 
+[role="_abstract"]
+You can review the following information to understand how {product-title} responds to power loss on remote nodes and how you can mitigate problems associated with power loss. 
+
 If a remote worker node loses power or restarts ungracefully, {product-title} responds using several default mechanisms.
 
 If the Kubernetes Controller Manager Operator (kube controller) loses contact with a node after a configured period, the control plane updates the node health to `Unhealthy` and marks the node `Ready` condition as `Unknown`. In response, the scheduler stops scheduling pods to that node.  The on-premise node controller adds a `node.kubernetes.io/unreachable` taint with a `NoExecute` effect to the node and schedules pods on the node for eviction after five minutes, by default.
@@ -21,8 +24,7 @@ After the node restarts, the kubelet also restarts and attempts to restart the p
 
 You can mitigate the effects of power loss by:
 
-* using daemon sets to create pods that tolerate the taints
-* using static pods that automatically restart with a node
-* configuring pods tolerations to delay or avoid pod eviction
-* configuring the kubelet to control the timing of when the node controller marks nodes as unhealthy.
-
+* Using daemon sets to create pods that tolerate the taints.
+* Using static pods that automatically restart with a node.
+* Configuring pods tolerations to delay or avoid pod eviction.
+* Configuring the kubelet to control the timing of when the node controller marks nodes as unhealthy.

--- a/modules/nodes-edge-remote-workers-strategies.adoc
+++ b/modules/nodes-edge-remote-workers-strategies.adoc
@@ -6,17 +6,21 @@
 [id="nodes-edge-remote-workers-strategies_{context}"]
 = Remote worker node strategies
 
+[role="_abstract"]
+You can review the following information to understand how to mitigate problems associated with power or connection loss with remote worker nodes.
+
 If you use remote worker nodes, consider which objects to use to run your applications.
 
-It is recommended to use daemon sets or static pods based on the behavior you want in the event of network issues or power loss. In addition, you can use Kubernetes zones and tolerations to control or avoid pod evictions if the control plane cannot reach remote worker nodes.
+You can use daemon sets or static pods based on the behavior you want if you experience network issues or power loss. In addition, you can use Kubernetes zones and tolerations to control or avoid pod evictions if the control plane cannot reach remote worker nodes.
 
 [id="nodes-edge-remote-workers-strategies-daemonsets_{context}"]
 Daemon sets::
 Daemon sets are the best approach to managing pods on remote worker nodes for the following reasons:
++
 --
 * Daemon sets do not typically need rescheduling behavior. If a node disconnects from the cluster, pods on the node can continue to run. {product-title} does not change the state of daemon set pods, and leaves the pods in the state they last reported. For example, if a daemon set pod is in the `Running` state, when a node stops communicating, the pod keeps running and is assumed to be running by {product-title}.
 
-* Daemon set pods, by default, are created with `NoExecute` tolerations for the `node.kubernetes.io/unreachable` and `node.kubernetes.io/not-ready` taints with no `tolerationSeconds` value. These default values ensure that daemon set pods are never evicted if the control plane cannot reach a node. For example:
+* Daemon set pods, by default, are created with `NoExecute` tolerations for the `node.kubernetes.io/unreachable` and `node.kubernetes.io/not-ready` taints with no `tolerationSeconds` value, as shown in the following example. These default values ensure that daemon set pods are never evicted if the control plane cannot reach a node.
 +
 .Tolerations added to daemon set pods by default
 [source,yaml]
@@ -45,17 +49,17 @@ Daemon sets are the best approach to managing pods on remote worker nodes for th
 * Daemon sets can use labels to ensure that a workload runs on a matching worker node.
 
 * You can use an {product-title} service endpoint to load balance daemon set pods.
-
+--
++
 [NOTE]
 ====
 Daemon sets do not schedule pods after a reboot of the node if {product-title} cannot reach the node.
 ====
---
 
 [id="nodes-edge-remote-workers-strategies-static_{context}"]
 Static pods::
-If you want pods restart if a node reboots, after a power loss for example, consider link:https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/[static pods]. The kubelet on a node automatically restarts static pods as node restarts.
-
+If you want pods to restart if a node reboots, such as after a power loss, you might use link:https://kubernetes.io/docs/tasks/configure-pod-container/static-pod/[static pods]. The kubelet on a node automatically restarts static pods as the node restarts.
++
 [NOTE]
 ====
 Static pods cannot use secrets and config maps.
@@ -64,15 +68,15 @@ Static pods cannot use secrets and config maps.
 [id="nodes-edge-remote-workers-strategies-zones_{context}"]
 Kubernetes zones::
 link:https://kubernetes.io/docs/setup/best-practices/multiple-zones/[Kubernetes zones] can slow down the rate or, in some cases, completely stop pod evictions.
-
++
 When the control plane cannot reach a node, the node controller, by default, applies `node.kubernetes.io/unreachable` taints and evicts pods at a rate of 0.1 nodes per second. However, in a cluster that uses Kubernetes zones, pod eviction behavior is altered.
-
-If a zone is fully disrupted, where all nodes in the zone have a `Ready` condition that is `False` or `Unknown`, the control plane does not apply the `node.kubernetes.io/unreachable` taint to the nodes in that zone.
-
++
+If a zone is fully disrupted, where all nodes in the zone have a `False` or `Unknown` ready condition, the control plane does not apply the `node.kubernetes.io/unreachable` taint to the nodes in that zone.
++
 For partially disrupted zones, where more than 55% of the nodes have a `False` or `Unknown` condition, the pod eviction rate is reduced to 0.01 nodes per second. Nodes in smaller clusters, with fewer than 50 nodes, are not tainted. Your cluster must have more than three zones for these behavior to take effect.
-
++
 You assign a node to a specific zone by applying the `topology.kubernetes.io/region` label in the node specification.
-
++
 .Sample node labels for Kubernetes zones
 [source,yaml]
 ----
@@ -84,14 +88,13 @@ metadata:
 ----
 
 [id="nodes-edge-remote-workers-strategies-kubeconfig_{context}"]
-`KubeletConfig` objects::
---
+Kubelet config objects::
 You can adjust the amount of time that the kubelet checks the state of each node.
-
++
 To set the interval that affects the timing of when the on-premise node controller marks nodes with the `Unhealthy` or `Unreachable` condition, create a `KubeletConfig` object that contains the `node-status-update-frequency` and `node-status-report-frequency` parameters.
-
++
 The kubelet on each node determines the node status as defined by the `node-status-update-frequency` setting and reports that status to the cluster based on the `node-status-report-frequency` setting. By default, the kubelet determines the pod status every 10 seconds and reports the status every minute. However, if the node state changes, the kubelet reports the change to the cluster immediately. {product-title} uses the `node-status-report-frequency` setting only when the Node Lease feature gate is enabled, which is the default state in {product-title} clusters. If the Node Lease feature gate is disabled, the node reports its status based on the `node-status-update-frequency` setting.
-
++
 .Example kubelet config
 [source,yaml]
 ----
@@ -102,45 +105,47 @@ metadata:
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      machineconfiguration.openshift.io/role: worker <1>
+      machineconfiguration.openshift.io/role: worker
   kubeletConfig:
-    node-status-update-frequency: <2>
+    node-status-update-frequency:
       - "10s"
-    node-status-report-frequency: <3>
+    node-status-report-frequency:
       - "1m"
 ----
-<1> Specify the type of node type to which this `KubeletConfig` object applies using the label from the `MachineConfig` object.
-<2> Specify the frequency that the kubelet checks the status of a node associated with this `MachineConfig` object. The default value is `10s`. If you change this default, the `node-status-report-frequency` value is changed to the same value.
-<3> Specify the frequency that the kubelet reports the status of a node associated with this `MachineConfig` object. The default value is `1m`.
-
+where:
++
+--
+`spec.machineConfigPoolSelector.matchLabels.machineconfiguration.openshift.io/role`:: Specifies the type of node type to which this `KubeletConfig` object applies by using the label from the `MachineConfig` object.
+`spec.kubeletConfig.node-status-update-frequency`:: Specifies the frequency that the kubelet checks the status of a node associated with this `MachineConfig` object. The default value is `10s`. If you change this default, the `node-status-report-frequency` value is changed to the same value.
+`spec.kubeletConfig.node-status-report-frequency`:: Specifies the frequency that the kubelet reports the status of a node associated with this `MachineConfig` object. The default value is `1m`.
+--
++
 The `node-status-update-frequency` parameter works with the `node-monitor-grace-period` parameter.
-
-* The `node-monitor-grace-period` parameter specifies how long {product-title} waits after a node associated with a `MachineConfig` object is marked `Unhealthy` if the controller manager does not receive the node heartbeat. Workloads on the node continue to run after this time. If the remote worker node rejoins the cluster after `node-monitor-grace-period` expires, pods continue to run. New pods can be scheduled to that node. The `node-monitor-grace-period` interval is `40s`. The `node-status-update-frequency` value must be lower than the `node-monitor-grace-period` value.
-
++
+The `node-monitor-grace-period` parameter specifies how long {product-title} waits after a node associated with a `MachineConfig` object is marked `Unhealthy` if the controller manager does not receive the node heartbeat. Workloads on the node continue to run after this time. If the remote worker node rejoins the cluster after `node-monitor-grace-period` expires, pods continue to run. New pods can be scheduled to that node. The `node-monitor-grace-period` interval is `40s`. The `node-status-update-frequency` value must be lower than the `node-monitor-grace-period` value.
++
 [NOTE]
 ====
 Modifying the `node-monitor-grace-period` parameter is not supported.
 ====
 
---
-
 [id="nodes-edge-remote-workers-strategies-tolerations_{context}"]
 Tolerations::
 You can use pod tolerations to mitigate the effects if the on-premise node controller adds a `node.kubernetes.io/unreachable` taint with a `NoExecute` effect to a node it cannot reach.
-
++
 A taint with the `NoExecute` effect affects pods that are running on the node in the following ways:
-
++
 * Pods that do not tolerate the taint are queued for eviction.
 * Pods that tolerate the taint without specifying a `tolerationSeconds` value in their toleration specification remain bound forever.
 * Pods that tolerate the taint with a specified `tolerationSeconds` value remain bound for the specified amount of time. After the time elapses, the pods are queued for eviction.
-
++
 [NOTE]
 ====
 Unless tolerations are explicitly set, Kubernetes automatically adds a toleration for `node.kubernetes.io/not-ready` and `node.kubernetes.io/unreachable` with `tolerationSeconds=300`, meaning that pods remain bound for 5 minutes if either of these taints is detected.
 ====
-
++
 You can delay or avoid pod eviction by configuring pods tolerations with the `NoExecute` effect for the `node.kubernetes.io/unreachable` and `node.kubernetes.io/not-ready` taints.
-
++
 .Example toleration in a pod spec
 [source,yaml]
 ----
@@ -148,27 +153,29 @@ You can delay or avoid pod eviction by configuring pods tolerations with the `No
 tolerations:
 - key: "node.kubernetes.io/unreachable"
   operator: "Exists"
-  effect: "NoExecute" <1>
+  effect: "NoExecute"
 - key: "node.kubernetes.io/not-ready"
   operator: "Exists"
-  effect: "NoExecute" <2>
-  tolerationSeconds: 600 <3>
+  effect: "NoExecute"
+  tolerationSeconds: 600
 ...
 ----
-<1> The `NoExecute` effect without `tolerationSeconds` lets pods remain forever if the control plane cannot reach the node.
-<2> The `NoExecute` effect with `tolerationSeconds`: 600 lets pods remain for 10 minutes if the control plane marks the node as `Unhealthy`.
-<3> You can specify your own `tolerationSeconds` value.
++
+--
+* In the first example, the `NoExecute` effect without `tolerationSeconds` lets pods remain forever if the control plane cannot reach the node.
+* In the second example, the `NoExecute` effect with `tolerationSeconds`: 600 lets pods remain for 10 minutes if the control plane marks the node as `Unhealthy`. You can specify your own `tolerationSeconds` value.
+--
 
 [id="nodes-edge-remote-workers-strategies-objects_{context}"]
 Other types of {product-title} objects::
 You can use replica sets, deployments, and replication controllers. The scheduler can reschedule these pods onto other nodes after the node is disconnected for five minutes. Rescheduling onto other nodes can be beneficial for some workloads, such as REST APIs, where an administrator can guarantee a specific number of pods are running and accessible.
-
++
 [NOTE]
 ====
 When working with remote worker nodes, rescheduling pods on different nodes might not be acceptable if remote worker nodes are intended to be reserved for specific functions.
 ====
-
++
 [id="nodes-edge-remote-workers-strategies-statefulset_{context}"]
 https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/[stateful sets] do not get restarted when there is an outage. The pods remain in the `terminating` state until the control plane can acknowledge that the pods are terminated.
-
++
 To avoid scheduling a to a node that does not have access to the same type of persistent storage, {product-title} cannot migrate pods that require persistent volumes to other zones in the case of network separation.

--- a/modules/nodes-nodes-managing-max-pods-proc.adoc
+++ b/modules/nodes-nodes-managing-max-pods-proc.adoc
@@ -7,49 +7,14 @@
 [id="nodes-nodes-managing-max-pods-proc_{context}"]
 = Configuring the maximum number of pods per node
 
-Two parameters control the maximum number of pods that can be scheduled to a node: `podsPerCore` and `maxPods`. If you use both options, the lower of the two limits the number of pods on a node.
+[role="_abstract"]
+You can use the `podsPerCore` and `maxPods` parameters in a kublet configuration to control the maximum number of pods that can be scheduled to a node. If you use both options, the lower of the two limits the number of pods on a node. Setting an appropriate maximum can help ensure your nodes run efficiently.
 
 For example, if `podsPerCore` is set to `10` on a node with 4 processor cores, the maximum number of pods allowed on the node will be 40.
 
 .Prerequisites
 
-. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure by entering the following command:
-+
-[source,terminal]
-----
-$ oc edit machineconfigpool <name>
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ oc edit machineconfigpool worker
-----
-+
-.Example output
-[source,yaml]
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfigPool
-metadata:
-  creationTimestamp: "2022-11-16T15:34:25Z"
-  generation: 4
-  labels:
-    pools.operator.machineconfiguration.openshift.io/worker: "" <1>
-  name: worker
-#...
-----
-<1> The label appears under Labels.
-+
-[TIP]
-====
-If the label is not present, add a key/value pair such as:
-
-----
-$ oc label machineconfigpool worker custom-kubelet=small-pods
-----
-====
+* You have the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure.
 
 .Procedure
 
@@ -61,20 +26,23 @@ $ oc label machineconfigpool worker custom-kubelet=small-pods
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
-  name: set-max-pods <1>
+  name: set-max-pods
 spec:
   machineConfigPoolSelector:
     matchLabels:
-      pools.operator.machineconfiguration.openshift.io/worker: "" <2>
+      pools.operator.machineconfiguration.openshift.io/worker: ""
   kubeletConfig:
-    podsPerCore: 10 <3>
-    maxPods: 250 <4>
+    podsPerCore: 10
+    maxPods: 250
 #...
 ----
-<1> Assign a name to CR.
-<2> Specify the label from the machine config pool.
-<3> Specify the number of pods the node can run based on the number of processor cores on the node.
-<4> Specify the number of pods the node can run to a fixed value, regardless of the properties of the node.
+where:
++
+--
+`metadata.name`:: Specifies a name for the CR.
+`spec.machineConfigPoolSelector.matchLabels`:: Specifies the label from the machine config pool.
+`spec.kubeletConfig.podsPerCore`:: Specifies the number of pods the node can run based on the number of processor cores on the node.
+`spec.kubeletConfig.maxPods`:: Specifies the number of pods the node can run to a fixed value, regardless of the properties of the node.
 +
 [NOTE]
 ====
@@ -82,6 +50,7 @@ Setting `podsPerCore` to `0` disables this limit.
 ====
 +
 In the above example, the default value for `podsPerCore` is `10` and the default value for `maxPods` is `250`. This means that unless the node has 25 cores or more, by default, `podsPerCore` will be the limiting factor.
+--
 
 . Run the following command to create the CR:
 +
@@ -92,7 +61,7 @@ $ oc create -f <file_name>.yaml
 
 .Verification
 
-. List the `MachineConfigPool` CRDs to see if the change is applied. The `UPDATING` column reports `True` if the change is picked up by the Machine Config Controller:
+* List the `MachineConfigPool` CRDs to check if the change is applied. The `UPDATING` column reports `True` if the change is picked up by the Machine Config Controller:
 +
 [source,terminal]
 ----
@@ -107,7 +76,7 @@ master   master-9cc2c72f205e103bb534   False     False      False
 worker   worker-8cecd1236b33ee3f8a5e   False     True       False
 ----
 +
-Once the change is complete, the `UPDATED` column reports `True`.
+After the change is complete, the `UPDATED` column reports `True`.
 +
 [source,terminal]
 ----

--- a/modules/nodes-rwn_con_adding-remote-worker-nodes.adoc
+++ b/modules/nodes-rwn_con_adding-remote-worker-nodes.adoc
@@ -6,7 +6,8 @@
 [id="nodes-rwn_con_adding-remote-worker-nodes_{context}"]
 = Adding remote worker nodes
 
-Adding remote worker nodes to a cluster involves some additional considerations.
+[role="_abstract"]
+You can review the following information to understand some additional considerations when adding remote worker nodes to a cluster.
 
 * You must ensure that a route or a default gateway is in place to route traffic between the control plane and every remote worker node.
 
@@ -16,4 +17,4 @@ Adding remote worker nodes to a cluster involves some additional considerations.
 
 * To add remote worker nodes to an installer-provisioned cluster at install time, specify the subnet for each worker node in the `install-config.yaml` file before installation. There are no additional settings required for the DHCP server. You must use virtual media, because the remote worker nodes will not have access to the local provisioning network.
 
-* To add remote worker nodes to an installer-provisioned cluster deployed with a provisioning network, ensure that `virtualMediaViaExternalNetwork` flag is set to `true` in the `install-config.yaml` file so that it will add the nodes using virtual media. Remote worker nodes will not have access to the local provisioning network. They must be deployed with virtual media rather than PXE. Additionally, specify each subnet for each group of remote worker nodes and the control plane nodes in the DHCP server.
+* To add remote worker nodes to an installer-provisioned cluster deployed with a provisioning network, ensure that `virtualMediaViaExternalNetwork` flag is set to `true` in the `install-config.yaml` file so that it adds the nodes using virtual media. Remote worker nodes will not have access to the local provisioning network. They must be deployed with virtual media rather than PXE. Additionally, specify each subnet for each group of remote worker nodes and the control plane nodes in the DHCP server.

--- a/modules/risks-setting-higher-process-id-limits.adoc
+++ b/modules/risks-setting-higher-process-id-limits.adoc
@@ -1,12 +1,15 @@
 // Module included in the following assemblies:
 //
 // * rosa_cluster_admin/rosa-configuring-pid-limits.adoc
+// * nodes/nodes-nodes-resources-configuring.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="risks-setting-higher-process-id-limits_{context}"]
 = Risks of setting higher process ID limits for {product-title} pods
 
-The `podPidsLimit` parameter for a pod controls the maximum number of processes and threads that can run simultaneously in that pod.
+[role="_abstract"]
+You can review the following information to learn about some considerations about allowing a high maximum number of processes to run on your nodes. Configuring an appropriate number of processes can help keep the nodes in your cluster running efficiently. 
+
 
 You can increase the value for `podPidsLimit` from the default of 4,096 to a maximum of 16,384. Changing this value might incur downtime for applications, because changing the `podPidsLimit` requires rebooting the affected node.
 

--- a/modules/sd-understanding-process-id-limits.adoc
+++ b/modules/sd-understanding-process-id-limits.adoc
@@ -1,10 +1,14 @@
 // Module included in the following assemblies:
 //
 // * rosa_cluster_admin/rosa-configuring-pid-limits.adoc
+// * nodes/nodes-nodes-resources-configuring.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="understanding-process-id-limits_{context}"]
 = Understanding process ID limits
+
+[role="_abstract"]
+You can review the following information to learn how to limit the number of processes running on your nodes. Configuring an appropriate number of processes can help keep the nodes in your cluster running efficiently. 
 
 ifdef::openshift-enterprise,openshift-origin[]
 A process identifier (PID) is a unique identifier assigned by the Linux kernel to each process or thread currently running on a system. The number of processes that can run simultaneously on a system is limited to 4,194,304 by the Linux kernel. This number might also be affected by limited access to other system resources such as memory, CPU, and disk space.

--- a/nodes/edge/nodes-edge-remote-workers.adoc
+++ b/nodes/edge/nodes-edge-remote-workers.adoc
@@ -7,7 +7,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-You can configure {product-title} clusters with nodes located at your network edge. In this topic, they are called _remote worker nodes_. A typical cluster with remote worker nodes combines on-premise master and worker nodes with worker nodes in other locations that connect to the cluster. This topic is intended to provide guidance on best practices for using remote worker nodes and does not contain specific configuration details.
+[role="_abstract"]
+You can configure {product-title} clusters with nodes located at your network edge, called _remote worker nodes_. A typical cluster with remote worker nodes combines on-premise master and worker nodes with worker nodes in other locations that connect to the cluster. This topic is intended to provide guidance on best practices for using remote worker nodes and does not contain specific configuration details.
 
 There are multiple use cases across different industries, such as retail, manufacturing, and government, for using a deployment pattern with remote worker nodes. For example, you can separate and isolate your projects and workloads by combining the remote worker nodes into xref:../../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers-strategies-zones_nodes-edge-remote-workers[Kubernetes zones].
 
@@ -31,7 +32,17 @@ Note the following limitations when planning a cluster with remote worker nodes:
 
 include::modules/nodes-rwn_con_adding-remote-worker-nodes.adoc[leveloffset=+1]
 
-.Additional resources
+include::modules/nodes-edge-remote-workers-network.adoc[leveloffset=+1]
+
+include::modules/nodes-edge-remote-workers-power.adoc[leveloffset=+1]
+
+include::modules/nodes-edge-remote-workers-latency.adoc[leveloffset=+1]
+
+include::modules/nodes-edge-remote-workers-strategies.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
 * xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#ipi-install-establishing-communication-between-subnets_ipi-install-installation-workflow[Establishing communications between subnets]
 
@@ -39,39 +50,20 @@ include::modules/nodes-rwn_con_adding-remote-worker-nodes.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_bare_metal/ipi/ipi-install-installation-workflow.adoc#configure-network-components-to-run-on-the-control-plane_ipi-install-installation-workflow[Configuring network components to run on the control plane]
 
+* xref:../../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers-strategies_nodes-edge-remote-workers[About remote worker node strategies]
 
-include::modules/nodes-edge-remote-workers-network.adoc[leveloffset=+1]
+* xref:../../nodes/clusters/nodes-cluster-worker-latency-profiles.adoc#nodes-cluster-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles]
 
-For more information on using these objects in a cluster with remote worker nodes, see xref:../../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers-strategies_nodes-edge-remote-workers[About remote worker node strategies].
+* xref:../../nodes/jobs/nodes-pods-daemonsets.adoc#nodes-pods-daemonsets[DaemonSets]
 
-include::modules/nodes-edge-remote-workers-power.adoc[leveloffset=+1]
+* xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
 
-For more information on using these objects in a cluster with remote worker nodes, see xref:../../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers-strategies_nodes-edge-remote-workers[About remote worker node strategies].
+* xref:../../post_installation_configuration/node-tasks.adoc#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_post-install-node-tasks[Creating a KubeletConfig CRD]
 
-[id="nodes-edge-remote-workers-latency"]
-== Latency spikes or temporary reduction in throughput to remote workers
+* xref:../../applications/deployments/what-deployments-are.adoc#deployments-repliasets_what-deployments-are[ReplicaSets]
 
-include::snippets/worker-latency-profile-intro.adoc[]
+* xref:../../applications/deployments/what-deployments-are.adoc#deployments-kube-deployments_what-deployments-are[Deployments]
 
-.Additional resources
+* xref:../../applications/deployments/what-deployments-are.adoc#deployments-replicationcontrollers_what-deployments-are[Replication controllers]
 
-* xref:../../nodes/clusters/nodes-cluster-worker-latency-profiles.adoc#nodes-cluster-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles ]
-
-include::modules/nodes-edge-remote-workers-strategies.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* For more information on Daemonesets, see xref:../../nodes/jobs/nodes-pods-daemonsets.adoc#nodes-pods-daemonsets[DaemonSets].
-
-* For more information on  taints and tolerations, see xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
-
-* For more information on configuring `KubeletConfig` objects, see xref:../../post_installation_configuration/node-tasks.adoc#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_post-install-node-tasks[Creating a KubeletConfig CRD].
-
-* For more information on replica sets, see xref:../../applications/deployments/what-deployments-are.adoc#deployments-repliasets_what-deployments-are[ReplicaSets].
-
-* For more information on deployments, see xref:../../applications/deployments/what-deployments-are.adoc#deployments-kube-deployments_what-deployments-are[Deployments].
-
-* For more information on replication controllers, see xref:../../applications/deployments/what-deployments-are.adoc#deployments-replicationcontrollers_what-deployments-are[Replication controllers].
-
-* For more information on the controller manager, see xref:../../operators/operator-reference.adoc#kube-controller-manager-operator_operator-reference[Kubernetes Controller Manager Operator].
+* xref:../../operators/operator-reference.adoc#kube-controller-manager-operator_operator-reference[Kubernetes Controller Manager Operator]

--- a/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc
+++ b/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 include::snippets/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
-
+[role="_abstract"]
 You can use infrastructure machine sets to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
 
 [NOTE]
@@ -18,14 +18,14 @@ After adding the `NoSchedule` taint on the infrastructure node, existing DNS pod
 
 include::modules/infrastructure-components.adoc[leveloffset=+1]
 
-For information about infrastructure nodes and which components can run on infrastructure nodes, see the "Red Hat OpenShift control plane and infrastructure nodes" section in the link:https://www.redhat.com/en/resources/openshift-subscription-sizing-guide[OpenShift sizing and subscription guide for enterprise Kubernetes] document.
-
-To create an infrastructure node, you can xref:../../machine_management/creating-infrastructure-machinesets.adoc#machineset-creating_creating-infrastructure-machinesets[use a machine set], xref:../../nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc#creating-an-infra-node_creating-infrastructure-nodes[label the node], or xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infra-machines_creating-infrastructure-machinesets[use a machine config pool].
-
 include::modules/creating-an-infra-node.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_{context}"]
+== Additional resources
 
 * xref:../../machine_management/creating-infrastructure-machinesets.adoc#moving-resources-to-infrastructure-machinesets[Moving resources to infrastructure machine sets]
-
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets]
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#machineset-creating_creating-infrastructure-machinesets[Creating a compute machine set]
+* xref:../../nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc#creating-an-infra-node_creating-infrastructure-nodes[Creating an infrastructure node] 
+* xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infra-machines_creating-infrastructure-machinesets[Creating a machine config pool for infrastructure machines]

--- a/nodes/nodes/nodes-nodes-managing-max-pods.adoc
+++ b/nodes/nodes/nodes-nodes-managing-max-pods.adoc
@@ -6,9 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 In {product-title}, you can configure the number of pods that can run on a node based on the number of
-processor cores on the node, a hard limit or both. If you use both options,
-the lower of the two limits the number of pods on a node.
+processor cores on the node, a hard limit, or both. If you use both options,
+the lower of the two limits the number of pods on a node. Setting a maximum number of pods can prevent a node from running more pods than its underlying hardware can handle.
 
 include::snippets/nodes-pods-core-max-pods.adoc[]
 

--- a/snippets/nodes-pods-core-max-pods.adoc
+++ b/snippets/nodes-pods-core-max-pods.adoc
@@ -6,7 +6,7 @@
 :_mod-docs-content-type: SNIPPET
 
 When both options are in use, the lower of the two values limits the number of
-pods on a node. Exceeding these values can result in:
+pods on a node. Exceeding these values can result in the following conditions:
 
 * Increased CPU utilization.
 * Slow pod scheduling.
@@ -30,10 +30,9 @@ the nodes. It is recommended that you monitor the disk I/O on the nodes and use 
 with sufficient throughput for the workload.
 ====
 
-The `podsPerCore` parameter sets the number of pods the node can run based on the number of
+The `podsPerCore` parameter sets the number of pods that the node can run based on the number of
 processor cores on the node. For example, if `podsPerCore` is set to `10` on a
-node with 4 processor cores, the maximum number of pods allowed on the node will
-be `40`.
+node with 4 processor cores, the maximum number of pods allowed on the node is `40`.
 
 [source,yaml]
 ----
@@ -44,7 +43,7 @@ kubeletConfig:
 Setting `podsPerCore` to `0` disables this limit. The default is `0`.
 The value of the `podsPerCore` parameter cannot exceed the value of the `maxPods` parameter.
 
-The `maxPods` parameter sets the number of pods the node can run to a fixed value, regardless
+The `maxPods` parameter sets the number of pods that the node can run to a fixed value, regardless
 of the properties of the node.
 
 [source,yaml]

--- a/snippets/worker-latency-profile-intro.adoc
+++ b/snippets/worker-latency-profile-intro.adoc
@@ -1,7 +1,7 @@
 // Text snippet included in the following modules:
 //
 // * nodes/clusters/nodes-cluster-worker-latency-profiles
-// * nodes/edge/nodes-edge-remote-workers
+// * nodes/edge/nodes-edge-remote-workers/nodes-edge-remote-workers-latency
 // * post_installation_configuration/cluster-tasks
 // * scalability_and_performance/scaling-worker-latency-profiles.adoc
 
@@ -9,7 +9,7 @@
 :_mod-docs-content-type: SNIPPET
 
 
-
+[role="_abstract"]
 If the cluster administrator has performed latency tests for platform verification, they can discover the need to adjust the operation of the cluster to ensure stability in cases of high latency. The cluster administrator needs to change only one parameter, recorded in a file, which controls four parameters affecting how supervisory processes read status and interpret the health of the cluster. Changing only the one parameter provides cluster tuning in an easy, supportable manner.
 
 The `Kubelet` process provides the starting point for monitoring cluster health. The `Kubelet` sets status values for all nodes in the {product-title} cluster. The Kubernetes Controller Manager (`kube controller`) reads the status values every 10 seconds, by default.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16931

Remote worker nodes on the network edge -> [Using remote worker nodes at the network edge](https://106408--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/edge/nodes-edge-remote-workers.html)
Working with nodes -> [Creating infrastructure nodes](https://106408--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-creating-infrastructure-nodes)
Working with nodes -> [Managing the maximum number of pods per node](https://106408--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing-max-pods)
Working with nodes ->  Allocating resources for nodes -> [Understanding process ID limits](https://106408--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring#understanding-process-id-limits_nodes-nodes-resources-configuring)
Working with nodes ->  Allocating resources for nodes -> [Risks of setting higher process ID limits for OpenShift Container Platform pods](https://106408--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring#risks-setting-higher-process-id-limits_nodes-nodes-resources-configuring)