### PR TITLE
OSDOCS#18114: Ties up loose ends in the 4.21 GA RN feature blurb

### DIFF
--- a/modules/machineset-creating-gp3-throughput.adoc
+++ b/modules/machineset-creating-gp3-throughput.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
-// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-config-options-aws.adoc
+// * machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="machineset-creating-gp3-throughput_{context}"]

--- a/modules/rn-ocp-release-notes-new-features.adoc
+++ b/modules/rn-ocp-release-notes-new-features.adoc
@@ -376,7 +376,9 @@ Configuration of throughput for {aws-full} gp3 volumes on EBS devices::
 +
 This release includes support for configuring the maximum throughput for gp3 drives on EBS devices for clusters installed on {aws-first}.
 +
-For more information, see xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machine-feature-aws-throughput_creating-machineset-aws[Configuring storage throughput for gp3 drives (Machine API)] and xref:../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#machine-feature-aws-throughput-capi_cluster-api-config-options-aws[Configuring storage throughput for gp3 drives (Cluster API)].
+For more information, see xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-creating-gp3-throughput_creating-machineset-aws[Configuring storage throughput for gp3 drives (Machine API)] and xref:../machine_management/cluster_api_machine_management/cluster_api_provider_configurations/cluster-api-config-options-aws.adoc#machine-feature-aws-throughput-capi_cluster-api-config-options-aws[Configuring storage throughput for gp3 drives (Cluster API)].
++
+In {product-title} version 4.21.1 and later, this feature also works with xref:../machine_management/control_plane_machine_management/cpmso_provider_configurations/cpmso-supported-features-aws.adoc#machineset-creating-gp3-throughput_cpmso-supported-features-aws[control plane machine sets].
 
 Bare-metal nodes on {vmw-full} clusters (Technology Preview)::
 +


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-18114](https://issues.redhat.com//browse/OSDOCS-18114)

Link to docs preview:
[Machine management](https://106411--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#ocp-release-notes-machine-management_release-notes) "Configuration of throughput for Amazon Web Services gp3 volumes on EBS devices"

QE review:
N/A (approved in feature docs PR)

Additional information:
Fixes links and adds connection after merge and backport of #105822