### PR TITLE
OSDOCS 16931 CQA 2.0 of NODES-3: Infrastructure and Specialized Node Configuration Part II

### DIFF
--- a/modules/ai-adding-worker-nodes-to-cluster.adoc
+++ b/modules/ai-adding-worker-nodes-to-cluster.adoc
@@ -6,13 +6,14 @@
 [id="ai-adding-worker-nodes-to-cluster_{context}"]
 = Adding worker nodes using the Assisted Installer REST API
 
-You can add worker nodes to clusters using the Assisted Installer REST API.
+[role="_abstract"]
+You can add worker nodes to clusters by writing command-line commands against the Assisted Installer REST API. This method provides an alternative to using the web console.
 
 .Prerequisites
 
 * Install the OpenShift Cluster Manager CLI (`ocm`).
 
-* Log in to link:https://console.redhat.com/openshift/assisted-installer/clusters[{cluster-manager}] as a user with cluster creation privileges.
+* Log in to {cluster-manager-url} as a user with cluster creation privileges.
 
 * Install `jq`.
 
@@ -26,9 +27,10 @@ You can add worker nodes to clusters using the Assisted Installer REST API.
 +
 [source,terminal]
 ----
-$ export API_URL=<api_url> <1>
+$ export API_URL=<api_url>
 ----
-<1> Replace `<api_url>` with the Assisted Installer API URL, for example, `https://api.openshift.com`
++
+Replace `<api_url>` with the Assisted Installer API URL, for example, `https://api.openshift.com`
 
 . Import the {sno} cluster by running the following commands:
 +
@@ -44,14 +46,16 @@ $ export OPENSHIFT_CLUSTER_ID=$(oc get clusterversion -o jsonpath='{.items[].spe
 [source,terminal]
 ----
 $ export CLUSTER_REQUEST=$(jq --null-input --arg openshift_cluster_id "$OPENSHIFT_CLUSTER_ID" '{
-  "api_vip_dnsname": "<api_vip>", <1>
+  "api_vip_dnsname": "<api_vip>",
   "openshift_cluster_id": $openshift_cluster_id,
-  "name": "<openshift_cluster_name>" <2>
+  "name": "<openshift_cluster_name>"
 }')
 ----
-<1> Replace `<api_vip>` with the hostname for the cluster's API server. This can be the DNS domain for the API server or the IP address of the single node which the worker node can reach. For example, `api.compute-1.example.com`.
-<2> Replace `<openshift_cluster_name>` with the plain text name for the cluster. The cluster name should match the cluster name that was set during the Day 1 cluster installation.
-+
+where:
+
+`<api_vip>`:: Specifies the hostname for the cluster's API server. This can be the DNS domain for the API server or the IP address of the single node which the worker node can reach. For example, `api.compute-1.example.com`.
+`<openshift_cluster_name>`:: Specifies the plain text name for the cluster. The cluster name should match the cluster name that was set during the Day 1 cluster installation.
+
 .. Import the cluster and set the `$CLUSTER_ID` variable. Run the following command:
 +
 [source,terminal]
@@ -62,28 +66,30 @@ $ CLUSTER_ID=$(curl "$API_URL/api/assisted-install/v2/clusters/import" -H "Autho
 
 . Generate the `InfraEnv` resource for the cluster and set the `$INFRA_ENV_ID` variable by running the following commands:
 +
-.. Download the pull secret file from Red Hat OpenShift Cluster Manager at link:console.redhat.com/openshift/install/pull-secret[console.redhat.com].
+.. Download the {cluster-manager-url-pull}.
 +
 .. Set the `$INFRA_ENV_REQUEST` variable:
 +
 [source,terminal]
 ----
 export INFRA_ENV_REQUEST=$(jq --null-input \
-    --slurpfile pull_secret <path_to_pull_secret_file> \//<1>
-    --arg ssh_pub_key "$(cat <path_to_ssh_pub_key>)" \//<2>
+    --slurpfile pull_secret <path_to_pull_secret_file> \//
+    --arg ssh_pub_key "$(cat <path_to_ssh_pub_key>)" \//
     --arg cluster_id "$CLUSTER_ID" '{
-  "name": "<infraenv_name>", <3>
+  "name": "<infraenv_name>",
   "pull_secret": $pull_secret[0] | tojson,
   "cluster_id": $cluster_id,
   "ssh_authorized_key": $ssh_pub_key,
-  "image_type": "<iso_image_type>" <4>
+  "image_type": "<iso_image_type>"
 }')
 ----
-<1> Replace `<path_to_pull_secret_file>` with the path to the local file containing the downloaded pull secret from Red Hat OpenShift Cluster Manager at link:console.redhat.com/openshift/install/pull-secret[console.redhat.com].
-<2> Replace `<path_to_ssh_pub_key>` with the path to the public SSH key required to access the host. If you do not set this value, you cannot access the host while in discovery mode.
-<3> Replace `<infraenv_name>` with the plain text name for the `InfraEnv` resource.
-<4> Replace `<iso_image_type>` with the ISO image type, either `full-iso` or `minimal-iso`.
-+
+where:
+
+`<path_to_pull_secret_file>`:: Specifies the path to the local file containing the downloaded {cluster-manager-url-pull}.
+`<path_to_ssh_pub_key>`:: Specifies the path to the public SSH key required to access the host. If you do not set this value, you cannot access the host while in discovery mode.
+`<infraenv_name>`:: Specifies the plain text name for the `InfraEnv` resource.
+`<iso_image_type>`:: Specifies the ISO image type, either `full-iso` or `minimal-iso`.
+
 .. Post the `$INFRA_ENV_REQUEST` to the link:https://api.openshift.com/?urls.primaryName=assisted-service%20service#/installer/RegisterInfraEnv[/v2/infra-envs] API and set the `$INFRA_ENV_ID` variable:
 +
 [source,terminal]
@@ -108,9 +114,10 @@ https://api.openshift.com/api/assisted-images/images/41b91e72-c33e-42ee-b80f-b5c
 +
 [source,terminal]
 ----
-$ curl -L -s '<iso_url>' --output rhcos-live-minimal.iso <1>
+$ curl -L -s '<iso_url>' --output rhcos-live-minimal.iso
 ----
-<1> Replace `<iso_url>` with the URL for the ISO from the previous step.
++
+Replace `<iso_url>` with the URL for the ISO from the previous step.
 
 . Boot the new worker host from the downloaded `rhcos-live-minimal.iso`.
 
@@ -131,9 +138,10 @@ $ curl -s "$API_URL/api/assisted-install/v2/clusters/$CLUSTER_ID" -H "Authorizat
 +
 [source,terminal]
 ----
-$ HOST_ID=<host_id> <1>
+$ HOST_ID=<host_id>
 ----
-<1> Replace `<host_id>` with the host ID from the previous step.
++
+Replace `<host_id>` with the host ID from the previous step.
 
 . Check that the host is ready to install by running the following command:
 +

--- a/modules/ai-adding-worker-nodes-using-the-assisted-installer-api.adoc
+++ b/modules/ai-adding-worker-nodes-using-the-assisted-installer-api.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/nodes-sno-worker-nodes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ai-adding-worker-nodes-using-the-assisted-installer-api_{context}"]
+= Adding worker nodes using the Assisted Installer API
+
+[role="_abstract"]
+You can add worker nodes to clusters by writing command-line commands against the Assisted Installer REST API. This method provides an alternative to using the web console.
+
+Before you add worker nodes, you must log in to link:https://console.redhat.com/openshift/token/show[{cluster-manager}] and authenticate against the API. After you authenticate, you can use the Assisted Installer REST API to add the nodes.

--- a/modules/ai-authenticating-against-ai-rest-api.adoc
+++ b/modules/ai-authenticating-against-ai-rest-api.adoc
@@ -6,6 +6,7 @@
 [id="ai-authenticating-against-ai-rest-api_{context}"]
 = Authenticating against the Assisted Installer REST API
 
+[role="_abstract"]
 Before you can use the Assisted Installer REST API, you must authenticate against the API using a JSON web token (JWT) that you generate.
 
 .Prerequisites

--- a/modules/ai-sno-requirements-for-installing-worker-nodes.adoc
+++ b/modules/ai-sno-requirements-for-installing-worker-nodes.adoc
@@ -6,6 +6,9 @@
 [id="ai-sno-requirements-for-installing-worker-nodes_{context}"]
 = Requirements for installing {sno} worker nodes
 
+[role="_abstract"]
+You can review the following information to understand the requirements that you must meet before you install a {sno} worker node.
+
 To install a {sno} worker node, you must address the following requirements:
 
 * *Administration host:* You must have a computer to prepare the ISO and to monitor the installation.

--- a/modules/nodes-nodes-resources-cpus-reserve.adoc
+++ b/modules/nodes-nodes-resources-cpus-reserve.adoc
@@ -6,39 +6,18 @@
 [id="nodes-nodes-resources-cpus-reserve_{context}"]
 = Reserving CPUs for nodes
 
-To explicitly define a list of CPUs that are reserved for specific nodes, create a `KubeletConfig` custom resource (CR) to define the `reservedSystemCPUs` parameter. This list supersedes the CPUs that might be reserved using the `systemReserved` parameter.
+[role="_abstract"]
+You can explicitly define a list of CPUs that are reserved for critical system processes on specific nodes by creating a `KubeletConfig` custom resource (CR) to define the `reservedSystemCPUs` parameter. Reserving CPUs for critical system processes can help ensure cluster stability.
+
+This list supersedes the CPUs that might be reserved by using the `systemReserved` parameter.
 
 For more information on the `systemReserved` parameter, see "Allocating resources for nodes in an {product-title} cluster".
 
-.Procedure
+.Prerequisites
 
-. Obtain the label associated with the machine config pool (MCP) for the type of node you want to configure:
-+
-[source,terminal]
-----
-$ oc describe machineconfigpool <name>
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ oc describe machineconfigpool worker
-----
-+
-.Example output
-[source,yaml]
-----
-Name:         worker
-Namespace:
-Labels:       machineconfiguration.openshift.io/mco-built-in=
-              pools.operator.machineconfiguration.openshift.io/worker= <1>
-Annotations:  <none>
-API Version:  machineconfiguration.openshift.io/v1
-Kind:         MachineConfigPool
-#...
-----
-<1> Get the MCP label.
+. You have the label associated with the machine config pool (MCP) for the type of node you want to configure:
+
+.Procedure
 
 . Create a YAML file for the `KubeletConfig` CR:
 +
@@ -47,18 +26,20 @@ Kind:         MachineConfigPool
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 metadata:
-  name: set-reserved-cpus <1>
+  name: set-reserved-cpus
 spec:
   kubeletConfig:
-    reservedSystemCPUs: "0,1,2,3" <2>
+    reservedSystemCPUs: "0,1,2,3"
   machineConfigPoolSelector:
     matchLabels:
-      pools.operator.machineconfiguration.openshift.io/worker: "" <3>
+      pools.operator.machineconfiguration.openshift.io/worker: ""
 #...
 ----
-<1> Specify a name for the CR.
-<2> Specify the core IDs of the CPUs you want to reserve for the nodes associated with the MCP.
-<3> Specify the label from the MCP.
+where:
+
+`metadata.name`:: Specifies a name for the CR.
+`spec.kubeletConfig.reservedSystemCPUs`:: Specifies the core IDs of the CPUs you want to reserve for the nodes associated with the MCP.
+`spec.machineConfigPoolSelector.matchLabels`:: Specifies the label from the MCP.
 
 . Create the CR object:
 +

--- a/modules/rosa-creating-node-tuning.adoc
+++ b/modules/rosa-creating-node-tuning.adoc
@@ -6,7 +6,8 @@
 [id="rosa-creating-node-tuning_{context}"]
 = Creating node tuning configurations
 
-You can create tuning configurations using the {product-title} (ROSA) CLI, `rosa`.
+[role="_abstract"]
+You can create tuning configurations by using the {product-title} (ROSA) CLI, `rosa`.
 
 .Prerequisites
 
@@ -35,7 +36,7 @@ $ I: Tuning config 'sample-tuning' has been created on cluster 'cluster-example'
 $ I: To view all tuning configs, run 'rosa list tuning-configs -c cluster-example'
 ----
 
-.Validation
+.Verification
 
 * You can verify the existing tuning configurations that are applied by your account with the following command:
 +

--- a/modules/rosa-deleting-node-tuning.adoc
+++ b/modules/rosa-deleting-node-tuning.adoc
@@ -6,7 +6,8 @@
 [id="rosa-deleting-node-tuning_{context}"]
 = Deleting node tuning configurations
 
-You can delete tuning configurations by using the {product-title} (ROSA) CLI, `rosa`.
+[role="_abstract"]
+You can delete tuning configurations if you no longer need them by using the {product-title} (ROSA) CLI, `rosa`.
 
 [NOTE]
 ====

--- a/modules/rosa-modifying-node-tuning.adoc
+++ b/modules/rosa-modifying-node-tuning.adoc
@@ -6,7 +6,8 @@
 [id="rosa-modifying-node-tuning_{context}"]
 = Modifying your node tuning configurations
 
-You can view and update the node tuning configurations using the {product-title} (ROSA) CLI, `rosa`.
+[role="_abstract"]
+You can view and update the node tuning configurations by using the {product-title} (ROSA) CLI, `rosa`.
 
 .Prerequisites
 
@@ -20,16 +21,17 @@ You can view and update the node tuning configurations using the {product-title}
 +
 [source,terminal]
 ----
-$ rosa describe tuning-config -c <cluster_id> <1>
-       --name <name_of_tuning> <2>
-       [-o json] <3>
+$ rosa describe tuning-config -c <cluster_id> \
+       --name <name_of_tuning> \
+       [-o json]
 ----
+where:
 +
-The following items in this spec file are:
-+
-<1> Provide the cluster ID for the cluster that you own that you want to apply a node tuning configurations.
-<2> Provide the name of your tuning configuration.
-<3> Optionally, you can provide the output type. If you do not specify any outputs, you only see the ID and name of the tuning configuration.
+--
+`<cluster_id>`:: Specifies the cluster ID for the cluster that you own that you want to apply a node tuning configuration.
+`<name_of_tuning>`:: Specifies the name of your tuning configuration.
+`-o json`:: Specifies the output type. This parameter is optional. If you do not specify any outputs, you see only the ID and name of the tuning configuration.
+--
 +
 .Example output without specifying output type
 [source,terminal]

--- a/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
+++ b/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
@@ -2,10 +2,11 @@
 //
 // * nodes/nodes/nodes-sno-worker-nodes.adoc
 
-:_module-type: PROCEDURE
+:_mod-docs-content-type: PROCEDURE
 [id="sno-adding-worker-nodes-to-single-node-clusters-manually_{context}"]
 = Adding worker nodes to {sno} clusters manually
 
+[role="_abstract"]
 You can add a worker node to a {sno} cluster manually by booting the worker node from {op-system-first} ISO and by using the cluster `worker.ign` file to join the new worker node to the cluster.
 
 .Prerequisites
@@ -24,18 +25,19 @@ You can add a worker node to a {sno} cluster manually by booting the worker node
 +
 [source,terminal]
 ----
-$ OCP_VERSION=<ocp_version> <1>
+$ OCP_VERSION=<ocp_version>
 ----
 +
-<1> Replace `<ocp_version>` with the current version, for example, `latest-{product-version}`
+Replace `<ocp_version>` with the current version, for example, `latest-{product-version}`
 
 . Set the host architecture:
 +
 [source,terminal]
 ----
-$ ARCH=<architecture> <1>
+$ ARCH=<architecture>
 ----
-<1> Replace `<architecture>` with the target host architecture, for example, `aarch64` or `x86_64`.
++
+Replace `<architecture>` with the target host architecture, for example, `aarch64` or `x86_64`.
 
 . Get the `worker.ign` data from the running single-node cluster by running the following command:
 +
@@ -97,8 +99,8 @@ ipv4.addresses <static_ip> ipv4.gateway <network_gateway> ipv4.dns <dns_server> 
 where:
 +
 --
-<static_ip>:: Is the host static IP address and CIDR, for example, `10.1.101.50/24`
-<network_gateway>:: Is the network gateway, for example, `10.1.101.1`
+<static_ip>:: Specifies the host static IP address and CIDR, for example, `10.1.101.50/24`.
+<network_gateway>:: Specifies the network gateway, for example, `10.1.101.1`.
 --
 
 ... Activate the modified network interface:
@@ -118,7 +120,7 @@ $ nmcli con up <network_interface>
     "config":{
       "merge":[
         {
-          "source":"<hosted_worker_ign_file>" <1>
+          "source":"<hosted_worker_ign_file>"
         }
       ]
     }
@@ -128,7 +130,7 @@ $ nmcli con up <network_interface>
       {
         "path":"/etc/hostname",
         "contents":{
-          "source":"data:,<new_fqdn>" <2>
+          "source":"data:,<new_fqdn>"
         },
         "mode":420,
         "overwrite":true,
@@ -138,8 +140,10 @@ $ nmcli con up <network_interface>
   }
 }
 ----
-<1> `<hosted_worker_ign_file>` is the locally accessible URL for the original `worker.ign` file. For example, `http://webserver.example.com/worker.ign`
-<2> `<new_fqdn>` is the new FQDN that you set for the worker node. For example, `new-worker.example.com`.
+where:
++
+`<hosted_worker_ign_file>`:: Specifies the locally accessible URL for the original `worker.ign` file. For example, `http://webserver.example.com/worker.ign`.
+`<new_fqdn>`:: Specifies the new FQDN that you set for the worker node. For example, `new-worker.example.com`.
 
 ... Host the `new-worker.ign` file on a web server accessible from your network.
 
@@ -154,8 +158,8 @@ $ sudo coreos-installer install --copy-network /
 where:
 +
 --
-<new_worker_ign_file>:: is the locally accessible URL for the hosted `new-worker.ign` file, for example, `http://webserver.example.com/new-worker.ign`
-<hard_disk>:: Is the hard disk where you install {op-system}, for example, `/dev/sda`
+<new_worker_ign_file>:: Specifies the locally accessible URL for the hosted `new-worker.ign` file, for example, `http://webserver.example.com/new-worker.ign`.
+<hard_disk>:: Specifies the hard disk where you install {op-system}, for example, `/dev/sda`.
 --
 
 .. For networks that have DHCP enabled, you do not need to set a static IP. Run the following `coreos-installer` command from the target host console to install the system:
@@ -194,12 +198,12 @@ spec:
 +
 [IMPORTANT]
 ====
-The `NMStateConfig` CR is required for successful deployments of worker nodes with static IP addresses and for adding a worker node with a dynamic IP address if the {sno} was deployed with a static IP address. The cluster network DHCP does not automatically set these network settings for the new worker node.
+The `NMStateConfig` CR is required for successful deployment of worker nodes with static IP addresses and for adding a worker node with a dynamic IP address if the {sno} was deployed with a static IP address. The cluster network DHCP does not automatically set these network settings for the new worker node.
 ====
 
 . As the installation proceeds, the installation generates pending certificate signing requests (CSRs) for the worker node. When prompted, approve the pending CSRs to complete the installation.
 
-. When the install is complete, reboot the host. The host joins the cluster as a new worker node.
+. When the installation is complete, reboot the host. The host joins the cluster as a new worker node.
 
 .Verification
 

--- a/modules/sno-adding-worker-nodes-to-sno-clusters.adoc
+++ b/modules/sno-adding-worker-nodes-to-sno-clusters.adoc
@@ -6,7 +6,8 @@
 [id="sno-adding-worker-nodes-to-sno-clusters_{context}"]
 = Adding worker nodes using the Assisted Installer and {cluster-manager}
 
-You can add worker nodes to {sno} clusters that were created on link:https://console.redhat.com[{cluster-manager-first}] using the link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[Assisted Installer].
+[role="_abstract"]
+You can add worker nodes to {sno} clusters that were created on the {cluster-manager-url} by using the link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[Assisted Installer]. This method provides and alternative to using command-line commands.
 
 [IMPORTANT]
 ====
@@ -22,7 +23,7 @@ Adding worker nodes to {sno} clusters is only supported for clusters running {pr
 
 .Procedure
 
-. Log in to link:https://console.redhat.com/openshift[{cluster-manager}] and click the single-node cluster that you want to add a worker node to.
+. Log in to the {cluster-manager-url} and click the single-node cluster that you want to add a worker node to.
 
 . Click *Add hosts*, and download the discovery ISO for the new worker node, adding SSH public key and configuring cluster-wide proxy settings as required.
 
@@ -31,8 +32,8 @@ Adding worker nodes to {sno} clusters is only supported for clusters running {pr
 . As the installation proceeds, the installation generates pending certificate signing requests (CSRs) for the worker node. When prompted, approve the pending CSRs to complete the installation.
 +
 When the worker node is sucessfully installed, it is listed as a worker node in the cluster web console.
-
++
 [IMPORTANT]
 ====
-New worker nodes will be encrypted using the same method as the original cluster.
+New worker nodes are encrypted using the same method as the original cluster.
 ====

--- a/nodes/nodes/nodes-node-tuning-operator.adoc
+++ b/nodes/nodes/nodes-node-tuning-operator.adoc
@@ -6,13 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 ifndef::openshift-rosa-hcp[]
-Learn about the Node Tuning Operator and how you can use it to manage node-level
-tuning by orchestrating the tuned daemon.
+The Node Tuning Operator in {product-title} helps you manage node-level tuning by orchestrating the TuneD daemon. You can use this unified interface to apply custom tuning specifications and achieve low latency performance for high-performance applications.
 endif::openshift-rosa-hcp[]
 
 ifdef::openshift-rosa-hcp[]
-{product-title} supports the Node Tuning Operator to improve performance of your nodes on your clusters. Prior to creating a node tuning configuration, you must create a custom tuning specification.
+{product-title} supports the Node Tuning Operator to improve performance of your nodes on your clusters. The Node Tuning Operator in {product-title} helps you manage node-level tuning by orchestrating the TuneD daemon. You can use this unified interface to apply custom tuning specifications and achieve low latency performance for high-performance applications.
+
+Before creating a node tuning configuration, you must create a custom tuning specification.
 endif::openshift-rosa-hcp[]
 
 include::modules/node-tuning-operator.adoc[leveloffset=+1]

--- a/nodes/nodes/nodes-nodes-resources-cpus.adoc
+++ b/nodes/nodes/nodes-nodes-resources-cpus.adoc
@@ -7,7 +7,10 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-When using the xref:../../scalability_and_performance/using-cpu-manager.adoc[static CPU Manager policy], you can reserve specific CPUs for use by specific nodes in your cluster. For example, on a system with 24 CPUs, you could reserve CPUs numbered 0 - 3 for the control plane allowing the compute nodes to use CPUs 4 - 23.
+[role="_abstract"]
+When using the static CPU Manager policy, you can explicitly define a list of CPUs that are reserved for critical system processes on specific nodes. Reserving CPUs for critical system processes can help ensure cluster stability.
+
+For example, on a system with 24 CPUs, you could reserve CPUs numbered 0 - 3 for the control plane allowing the compute nodes to use CPUs 4 - 23.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
@@ -19,4 +22,5 @@ include::modules/nodes-nodes-resources-cpus-reserve.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For more information on the `systemReserved` parameter, see xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring[Allocating resources for nodes in an {product-title} cluster].
+* xref:../../scalability_and_performance/using-cpu-manager.adoc#setting_up_cpu_manager_using-cpu-manager-and-topology-manager[Setting up CPU Manager]
+* xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-about_nodes-nodes-resources-configuring[Allocating resources for nodes in an {product-title} cluster]

--- a/nodes/nodes/nodes-sno-worker-nodes.adoc
+++ b/nodes/nodes/nodes-sno-worker-nodes.adoc
@@ -6,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{sno-caps} clusters reduce the host prerequisites for deployment to a single host. This is useful for deployments in constrained environments or at the network edge. However, sometimes you need to add additional capacity to your cluster, for example, in telecommunications and network edge scenarios. In these scenarios, you can add worker nodes to the single-node cluster.
+[role="_abstract"]
+You can add worker nodes to {sno} clusters in case you need additional capacity in your cluster. 
+
+Single-node clusters reduce the host prerequisites for deployment to a single host. This is useful for deployments in constrained environments or at the network edge. However, sometimes you need to add additional capacity to your cluster, for example, in telecommunications and network edge scenarios. In these scenarios, you can add worker nodes to the single-node cluster.
 
 [NOTE]
 ====
@@ -27,14 +30,25 @@ To add worker nodes, you must have access to the {cluster-manager}. This method 
 
 include::modules/ai-sno-requirements-for-installing-worker-nodes.adoc[leveloffset=+1]
 
+include::modules/sno-adding-worker-nodes-to-sno-clusters.adoc[leveloffset=+1]
+
+include::modules/ai-adding-worker-nodes-using-the-assisted-installer-api.adoc[leveloffset=+1]
+
+include::modules/ai-authenticating-against-ai-rest-api.adoc[leveloffset=+2]
+
+include::modules/ai-adding-worker-nodes-to-cluster.adoc[leveloffset=+2]
+
+include::modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc[leveloffset=+1]
+
+include::modules/installation-approve-csrs.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
+[id="additional-resources_{context}"]
 .Additional resources
 
 * xref:../../installing/installing_bare_metal/upi/installing-restricted-networks-bare-metal.adoc#installation-minimum-resource-requirements_installing-restricted-networks-bare-metal[Minimum resource requirements for cluster installation]
 
 * xref:../../scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc#recommended-scale-practices_cluster-scaling[Recommended practices for scaling the cluster]
-
-* xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installation-dns-user-infra_installing-bare-metal-network-customizations[User-provisioned DNS requirements]
 
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#installing-with-usb-media_install-sno-installing-sno-with-the-assisted-installer[Creating a bootable ISO image on a USB drive]
 
@@ -42,37 +56,6 @@ include::modules/ai-sno-requirements-for-installing-worker-nodes.adoc[leveloffse
 
 * xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-deleting_nodes-nodes-working[Deleting nodes from a cluster]
 
-include::modules/sno-adding-worker-nodes-to-sno-clusters.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
 * xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installation-dns-user-infra_installing-bare-metal-network-customizations[User-provisioned DNS requirements]
 
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#installation-approve-csrs_add-workers[Approving the certificate signing requests for your machines]
-
-== Adding worker nodes using the Assisted Installer API
-
-You can add worker nodes to {sno} clusters using the Assisted Installer REST API. Before you add worker nodes, you must log in to link:https://console.redhat.com/openshift/token/show[{cluster-manager}] and authenticate against the API.
-
-include::modules/ai-authenticating-against-ai-rest-api.adoc[leveloffset=+2]
-
-include::modules/ai-adding-worker-nodes-to-cluster.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installation-dns-user-infra_installing-bare-metal-network-customizations[User-provisioned DNS requirements]
-
-* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#installation-approve-csrs_add-workers[Approving the certificate signing requests for your machines]
-
-include::modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../installing/installing_bare_metal/upi/installing-bare-metal-network-customizations.adoc#installation-dns-user-infra_installing-bare-metal-network-customizations[User-provisioned DNS requirements]
-
-* xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#installation-approve-csrs_add-workers[Approving the certificate signing requests for your machines]
-
-include::modules/installation-approve-csrs.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16931

[Using the Node Tuning Operator](https://106429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-node-tuning-operator.html)
[Allocating specific CPUs for nodes in a cluster](https://106429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-cpus.html)
[Adding worker nodes to Single-node OpenShift clusters](https://106429--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-sno-worker-nodes)
