### PR TITLE
OSDOCS-18282: Created networking IP families support table

### DIFF
--- a/modules/ipv4-ipv6-platform-support-table.adoc
+++ b/modules/ipv4-ipv6-platform-support-table.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * /networking/networking_overview/cidr-range-definitions.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="ipv4-ipv6-platform-support-table_{context}"]
+= Platform support for IP address families
+
+[role="_abstract"]
+To validate your networking architecture, review the platform support matrix for IPv4 single-stack, IPv6 single-stack, and dual-stack configurations. The overview identifies compatible combinations of platforms, installers, and connectivity states, that you can reference to ensure that your planned deployment is fully supported.
+
+// What about OpenShift Virtualization?
+
+.IP address family support per platform
+[cols="2,1,1,1,1", options="header"]
+|===
+| Platform | Installation method | Connectivity | IP families | Feature support
+
+| {aws-first} | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected | IPv4 single-stack, IPv6 single-stack, and dual-stack networking | GA
+| {azure-full} | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected | IPv4 single-stack, IPv6 single-stack, and dual-stack networking | GA
+| Bare metal | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected  | IPv4 single-stack, IPv6 single-stack, and dual-stack networking| GA
+| {gcp-short} | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected | IPv4 single-stack, IPv6 single-stack, and dual-stack networking  | GA
+| {ibm-power-title} | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected  | IPv4 single-stack, IPv6 single-stack, and dual-stack networking  | GA
+| {ibm-z-title} | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected | IPv4 single-stack, IPv6 single-stack, and dual-stack networking  | GA
+| Nutanix | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected | IPv4 single-stack  | GA
+| {rh-openstack-first} | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected | IPv4 single-stack, IPv6 single-stack, and dual-stack networking  | GA
+| {oci-first-no-rt} | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected  | IPv4 single-stack, IPv6 single-stack, and dual-stack networking  | GA
+| {vmw-first} | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected  | IPv4 single-stack, IPv6 single-stack, and dual-stack networking  | GA
+|===
+
+The Assisted Installer is primarly used in connected environments. 
+
+.IP address family support for the Assisted Installer 
+[cols="2,1,1,1", options="header"]
+|===
+| Platform | Installation method | IP families | Feature support
+
+| Bare metal | Installer-provisioned infrastructure and user-provisioned infrastructure | IPv4 single-stack, IPv6 single-stack, and dual-stack networking| GA
+
+| Nutanix | Installer-provisioned infrastructure and user-provisioned infrastructure | IPv4 single-stack and IPv6 single-stack | GA
+
+| {oci-first-no-rt} | Installer-provisioned infrastructure and user-provisioned infrastructure | IPv4 single-stack and IPv6 single-stack | GA
+
+| VMware vSphere | Installer-provisioned infrastructure and user-provisioned infrastructure | IPv4 single-stack and IPv6 single-stack | GA
+
+|===
+
+The Agent-based Installer is primarly used in disconnected environments. 
+
+// https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html-single/disconnected_environments/index
+
+.IP address family support for the Agent-based 
+[cols="2,1,1,1", options="header"]
+|===
+| Platform | Installation method | IP families | Feature support
+
+| Bare metal | Installer-provisioned infrastructure and user-provisioned infrastructure | IPv4 single-stack, IPv6 single-stack, and dual-stack networking| GA
+
+| Nutanix | Installer-provisioned infrastructure and user-provisioned infrastructure | IPv4 single-stack and IPv6 single-stack | GA
+
+| {oci-first-no-rt} | Installer-provisioned infrastructure and user-provisioned infrastructure | IPv4 single-stack and IPv6 single-stack | GA
+
+| {oci-first-no-rt} | Installer-provisioned infrastructure and user-provisioned infrastructure | Connected  | IPv4 single-stack, IPv6 single-stack, and dual-stack networking  | GA
+
+| VMware vSphere | Installer-provisioned infrastructure and user-provisioned infrastructure | IPv4 single-stack and IPv6 single-stack | GA
+
+|===
+
+

--- a/networking/networking_overview/cidr-range-definitions.adoc
+++ b/networking/networking_overview/cidr-range-definitions.adoc
@@ -60,6 +60,8 @@ ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 * xref:../../networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc#configure-ovn-kubernetes-subnets[Configuring OVN-Kubernetes internal IP address subnets]
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
+include::modules/ipv4-ipv6-platform-support-table.adoc[leveloffset=+1]
+
 include::modules/machine-cidr-description.adoc[leveloffset=+1]
 
 ifndef::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-18282](https://issues.redhat.com/browse/OSDOCS-18282)

Preview:
* [Platform support for IP address families](https://106467--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/networking_overview/cidr-range-definitions.html#ipv4-ipv6-platform-support-table_cidr-range-definitions)

Link to docs preview:

- [ ] SME has approved this change.
- [ ] QE has approved this change.

Reference: storage-persistent-storage-pv.adoc

Slack thread: [Slack](https://redhat-internal.slack.com/archives/CG6252WBY/p1770806858417849)

