### PR TITLE
[OBSDOCS-2822] Fix phrasing of Loki storage on AWS

### DIFF
--- a/modules/logging-loki-storage-aws.adoc
+++ b/modules/logging-loki-storage-aws.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="logging-loki-storage-aws_{context}"]
-= AWS storage
+= AWS object storage
 
-You can create an object storage in {aws-first} to store logs. 
+You can use {aws-first} object storage to store logs.
 
 .Prerequisites
 


### PR DESCRIPTION
Version(s):
- `standalone-logging-docs-6.0`
- `standalone-logging-docs-6.1`
- `standalone-logging-docs-6.2`
- `standalone-logging-docs-6.3`
- `standalone-logging-docs-6.4`
- `standalone-logging-docs-6.5`

Issue:
- https://issues.redhat.com/browse/OBSDOCS-2822

Link to docs preview:
- [AWS object storage](https://106469--ocpdocs-pr.netlify.app/openshift-logging/latest/configuring/configuring-the-log-store.html#logging-loki-storage-aws_configuring-the-log-store)

QE review:
- [x] QE approval not needed.
