### PR TITLE
TELCODOCS-2675: Fixes for cnf-image-based-upgrade-generate-seed

### DIFF
--- a/modules/cnf-image-based-upgrade-generate-seed-image.adoc
+++ b/modules/cnf-image-based-upgrade-generate-seed-image.adoc
@@ -5,6 +5,7 @@
 [id="cnf-image-based-upgrade-generate-seed-image_{context}"]
 = Generating a seed image with the {lcao}
 
+[role="_abstract"]
 Use the {lcao} to generate a seed image from a managed cluster. The Operator checks for required system configurations, performs any necessary system cleanup before generating the seed image, and launches the image generation. The seed image generation includes the following tasks:
 
 * Stopping cluster Operators
@@ -102,10 +103,13 @@ metadata:
   namespace: openshift-lifecycle-agent
 type: Opaque
 data:
-  seedAuth: <encoded_AUTHFILE> <2>
+  seedAuth: <encoded_AUTHFILE>
 ----
-<1> The `Secret` resource must have the `name: seedgen` and `namespace: openshift-lifecycle-agent` fields.
-<2> Specifies a base64-encoded authfile for write-access to the registry for pushing the generated seed images.
++
+Where:
++
+* `name: seedgen` and `namespace: openshift-lifecycle-agent`: The `Secret` resource must have these fields.
+* `seedAuth`: Specifies a base64-encoded authfile for write-access to the registry for pushing the generated seed images.
 +
 .. Apply the `Secret` by running the following command:
 +
@@ -123,10 +127,13 @@ kind: SeedGenerator
 metadata:
   name: seedimage <1>
 spec:
-  seedImage: <seed_container_image> <2>
+  seedImage: <seed_container_image>
 ----
-<1> The `SeedGenerator` CR must be named `seedimage`.
-<2> Specify the container image URL, for example, `quay.io/example/seed-container-image:<tag>`. It is recommended to use the `<seed_cluster_name>:<ocp_version>` format.
++
+Where:
++
+* `name: seedimage`: The `SeedGenerator` CR must be named `seedimage`.
+* `seedImage`: Specify the container image URL, for example, `quay.io/example/seed-container-image:<tag>`. It is recommended to use the `<seed_cluster_name>:<ocp_version>` format.
 
 . Generate the seed image by running the following command:
 +
@@ -141,8 +148,6 @@ The cluster reboots and loses API capabilities while the {lcao} generates the se
 Applying the `SeedGenerator` CR stops the `kubelet` and the CRI-O operations, then it starts the image generation.
 ====
 
-If you want to generate more seed images, you must provision a new seed cluster with the version that you want to generate a seed image from.
-
 .Verification
 
 * After the cluster recovers and it is available, you can check the status of the `SeedGenerator` CR by running the following command:
@@ -151,8 +156,9 @@ If you want to generate more seed images, you must provision a new seed cluster 
 ----
 $ oc get seedgenerator -o yaml
 ----
-
-.Example output
++
+Example output:
++
 [source,yaml]
 ----
 status:
@@ -168,7 +174,10 @@ status:
     observedGeneration: 1
     reason: Completed
     status: "True"
-    type: SeedGenCompleted <1>
+    type: SeedGenCompleted
   observedGeneration: 1
 ----
-<1> The seed image generation is complete.
++
+The `SeedGenCompleted` type indicates that the seed image generation is complete.
++
+If you want to generate more seed images, you must provision a new seed cluster with the version that you want to generate a seed image from.

--- a/modules/cnf-image-based-upgrade-seed-image-config.adoc
+++ b/modules/cnf-image-based-upgrade-seed-image-config.adoc
@@ -9,17 +9,19 @@ ifeval::["{context}" == "generate-seed"]
 :ibu:
 endif::[]
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="cnf-image-based-upgrade-seed-image-config_{context}"]
 = Seed image configuration
 
 ifdef::ibu[]
+[role="_abstract"]
 The seed image targets a set of {sno} clusters with the same hardware and similar configuration.
 This means that the seed image must have all of the components and configuration that the seed cluster shares with the target clusters.
 Therefore, the seed image generated from the seed cluster cannot contain any cluster-specific configuration.
 endif::[]
 
 ifdef::ibi[]
+[role="_abstract"]
 You can create a seed image from a {sno} cluster with the same hardware as your bare-metal host, and with a similar target cluster configuration. However, the seed image generated from the seed cluster cannot contain any cluster-specific configuration.
 endif::[]
 


### PR DESCRIPTION
[TELCODOCS-2675](https://issues.redhat.com//browse/TELCODOCS-2675): Fixes for cnf-image-based-upgrade-generate-seed

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
