### PR TITLE
Updates MS backup and restore content

### DIFF
--- a/microshift_backup_and_restore/microshift-backup-and-restore.adoc
+++ b/microshift_backup_and_restore/microshift-backup-and-restore.adoc
@@ -1,7 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
+include::_attributes/attributes-microshift.adoc[]
 [id="microshift-backup-and-restore"]
 = Backing up and restoring {microshift-short} data
-include::_attributes/attributes-microshift.adoc[]
 :context: microshift-backup-and-restore
 
 toc::[]

--- a/modules/microshift-backing-up-manually.adoc
+++ b/modules/microshift-backing-up-manually.adoc
@@ -43,7 +43,9 @@ $ sudo microshift backup /var/lib/microshift-backups/_<manual_backup>_
 ----
 $ sudo microshift backup /mnt/_<other_backups_location>_/_<another_manual_backup>_
 ----
-Replace `_<other_backups_location>_` with the directory you want to use and `_<my_manual_backup>_` with the backup name you want to use.
++
+** For `_<other_backups_location>_`, specify the directory that you want to use.
+** For `_<another_manual_backup>_`, specify the backup name that you want to use.
 
 .Verification
 


### PR DESCRIPTION
The attribute isn't rendering live: https://docs.redhat.com/en/documentation/red_hat_build_of_microshift/4.21/html-single/backup_and_restore/index#microshift-backup-and-restore because the file is below the title. 

This PR just moves it and addresses one of thing kind of missed by the ADV tool.