### PR TITLE
Fix typo in RHACS docs

### DIFF
--- a/modules/installing-rhacs-kubernetes-steps.adoc
+++ b/modules/installing-rhacs-kubernetes-steps.adoc
@@ -60,6 +60,7 @@ where:
 `<username>`:: Specifies the user name for your pull secret for Red{nbsp}Hat Container Registry authentication.
 `<password>`:: Specifies the password for your pull secret for Red{nbsp}Hat Container Registry authentication.
 --
+
 [id="installing-kube-roxctl-steps"]
 == Installing {product-title-short} on Kubernetes platforms by using the `roxctl` CLI
 


### PR DESCRIPTION
Version(s): 4.8+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: none
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://106483--ocpdocs-pr.netlify.app/openshift-acs/latest/installing/acs-high-level-overview.html#installing-kube-roxctl-steps
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: **N/A, typo fix**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
<img width="965" height="517" alt="Screenshot 2026-02-12 at 10 25 52 AM" src="https://github.com/user-attachments/assets/883854e0-67e5-4404-9df5-6a8c9e1886b3" />
