### PR TITLE
DITA compatibility fixes for hosted CP low latency perf profile docs

### DIFF
--- a/modules/apply-performance-profile-hosted-cluster.adoc
+++ b/modules/apply-performance-profile-hosted-cluster.adoc
@@ -6,6 +6,7 @@
 [id="apply-performance-profile-hosted-cluster_{context}"]
 = Configuring low-latency tuning in a hosted cluster
 
+[role="_abstract"]
 To set low latency with the performance profile on the nodes in your hosted cluster, you can use the Node Tuning Operator. In {hcp}, you can configure low-latency tuning by creating config maps that contain `Tuned` objects and referencing those config maps in your node pools. The tuned object in this case is a `PerformanceProfile` object that defines the performance profile you want to apply to the nodes in a node pool.
 
 .Procedure

--- a/modules/cnf-gathering-data-about-hosted-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-hosted-cluster-using-must-gather.adoc
@@ -6,6 +6,7 @@
 [id="gathering-data-about-your-hosted-cluster-using-must-gather_{context}"]
 = Gathering data about your hosted control planes cluster for the PPC
 
+[role="_abstract"]
 The Performance Profile Creator (PPC) tool requires `must-gather` data. As a cluster administrator, run the `must-gather` command to capture information about your cluster.
 
 .Prerequisites

--- a/modules/cnf-running-the-performance-creator-profile-hosted.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-hosted.adoc
@@ -6,6 +6,7 @@
 [id="running-the-performance-profile-profile-hosted-cluster-using-podman_{context}"]
 = Running the Performance Profile Creator on a hosted cluster using Podman
 
+[role="_abstract"]
 As a cluster administrator, you can use Podman with the Performance Profile Creator (PPC) tool to create a performance profile.
 
 For more information about PPC arguments, see "Performance Profile Creator arguments".
@@ -49,28 +50,31 @@ Password: <password>
 [source,terminal,subs="attributes+"]
 ----
 $ podman run --entrypoint performance-profile-creator \
-    -v /path/to/must-gather:/must-gather:z \// <1>
+    -v /path/to/must-gather:/must-gather:z \
     registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator:v{product-version} \
     --must-gather-dir-path /must-gather \
-    --reserved-cpu-count=2 \// <2>
-    --rt-kernel=false \// <3>
-    --split-reserved-cpus-across-numa=false \ <4>
-    --topology-manager-policy=single-numa-node \// <5>
-    --node-pool-name=democluster-us-east-1a \ 
-    --power-consumption-mode=ultra-low-latency \// <6>
-    --offlined-cpu-count=1 \// <7>
+    --reserved-cpu-count=2 \
+    --rt-kernel=false \
+    --split-reserved-cpus-across-numa=false \
+    --topology-manager-policy=single-numa-node \
+    --node-pool-name=democluster-us-east-1a \
+    --power-consumption-mode=ultra-low-latency \
+    --offlined-cpu-count=1 \
     > my-hosted-cp-performance-profile.yaml
 ----
 +
-<1> Mounts the local directory where the output of an `oc adm must-gather` was created into the container. 
-<2> Specifies two reserved CPUs.
-<3> Disables the real-time kernel.
-<4> Disables reserved CPUs splitting across NUMA nodes.
-<5> Specifies the NUMA topology policy. If installing the NUMA Resources Operator, this must be set to `single-numa-node`.
-<6> Specifies minimal latency at the cost of increased power consumption.
-<7> Specifies one offlined CPU.
+where:
+
+`/path/to/must-gather`:: Mounts the local directory where the output of an `oc adm must-gather` was created into the container.
+`--reserved-cpu-count=2`:: Specifies two reserved CPUs.
+`--rt-kernel=false`:: Disables the real-time kernel.
+`--split-reserved-cpus-across-numa=false`:: Disables reserved CPUs splitting across NUMA nodes.
+`--topology-manager-policy=single-numa-node`:: Specifies the NUMA topology policy. If installing the NUMA Resources Operator, this must be set to `single-numa-node`.
+`--power-consumption-mode=ultra-low-latency`:: Specifies minimal latency at the cost of increased power consumption.
+`--offlined-cpu-count=1`:: Specifies one offlined CPU.
 +
-.Example output
+The output resembles the following example:
++
 [source,terminal]
 ----
 level=info msg="Nodes names targeted by democluster-us-east-1a pool are: ip-10-0-129-110.ec2.internal "
@@ -88,7 +92,8 @@ level=info msg="Additional Kernel Args based on configuration: []
 ----
 $ cat my-hosted-cp-performance-profile
 ----
-.Example output
++
+The output resembles the following example:
 +
 [source,yaml]
 ----

--- a/scalability_and_performance/cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile.adoc
+++ b/scalability_and_performance/cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile.adoc
@@ -30,9 +30,12 @@ include::modules/cnf-gathering-data-about-hosted-cluster-using-must-gather.adoc[
 
 * xref:../support/gathering-cluster-data.adoc#nodes-nodes-managing[Gathering data about your cluster] 
 
-* xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-must-gather-cli[Gathering data for a hosted cluster by using the CLI].
+* xref:../hosted_control_planes/hcp-troubleshooting.adoc#hcp-must-gather-cli[Gathering data for a hosted cluster by using the CLI]
 
 include::modules/cnf-running-the-performance-creator-profile-hosted.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
 
 * xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#performance-profile-creator-arguments_cnf-low-latency-perf-profile[Performance Profile Creator arguments]
 


### PR DESCRIPTION
[TELCODOCS-2744]: DITA compatibility fixes for hosted CP low latency perf profile docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://106503--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:Fix 7 AsciiDocDITA Vale issues across 3 modules and 1 assembly in the cnf-tuning-low-latency-hosted-cp-nodes-with-perf-profile assembly:

- Add [role="_abstract"] short descriptions to all modules
- Convert 7-item callout list to definition list in PPC module
- Convert unsupported block titles to inline text
- Remove trailing period from xref in Additional resources
- Wrap standalone xref in proper Additional resources section
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
