### PR TITLE
OSDOCS-18286:Update the z-stream RNs for 4.16.57

### DIFF
--- a/modules/rn-async-errata.adoc
+++ b/modules/rn-async-errata.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ocp-release-asynchronous-errata-updates_{context}"]
+= Asynchronous errata updates
+
+Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
+
+Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified through email whenever new errata relevant to their registered systems are released.
+
+[NOTE]
+====
+Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
+====
+
+This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
+
+[IMPORTANT]
+====
+For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
+====

--- a/modules/zstream-4-16-57.adoc
+++ b/modules/zstream-4-16-57.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-16-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-16-57_{context}"]
+= RHSA-2026:2661 - {product-title} {product-version}.57 fixed issues and security updates
+
+[role="_abstract"]
+Issued: 18 February 2026
+
+{product-title} release {product-version}.57 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:2661[RHSA-2026:2661] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:2658[RHSA-2026:2658] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.16.57 --pullspecs
+----
+
+[id="zstream-4-16-57-fixed-issues_{context}"]
+== Fixed issues
+
+The following issues are fixed for this release:
+
+* Before this update, a bug in the `oc adm inspect --all-namespaces` command construction prevented the `must-gather` utility from correctly gathering information about leases, `csistoragecapacities` resources, and the `assisted-installer` namespace. With this release, the `must-gather` utility gathers the information correctly. (link:https://issues.redhat.com/browse/OCPBUGS-66106[OCPBUGS-66106])
+
+* Before this update, aggregated API servers on {product-title} used in-memory loopback certificates that were valid for only one year. With this release, these servers now use in-memory loopback certificates that are valid for three years. (link:https://issues.redhat.com/browse/OCPBUGS-74110[OCPBUGS-74110])
+
+* Before this update, when a hosted cluster was configured with a proxy URL such as `http://user:pass@host`, the authentication header was not getting forwarded by the Konnectivity proxy to the user proxy, which failed authentication. With this release, the proper authentication header is sent when a user and password are specified in the proxy URL. (link:https://issues.redhat.com/browse/OCPBUGS-74375[OCPBUGS-74375])
+
+[id="zstream-4-16-57-updating_{context}"]
+== Updating
+To update an {product-title} 4.16 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-16-release-notes.adoc
+++ b/release_notes/ocp-4-16-release-notes.adoc
@@ -3382,26 +3382,11 @@ Although the expected wake up latency is under 20μs, latencies exceeding this t
 Testing has shown that wake up latencies are under 20μs for over 99.99999% of the samples.
 (link:https://issues.redhat.com/browse/OCPBUGS-34022[OCPBUGS-34022])
 
-[id="ocp-4-16-asynchronous-errata-updates_{context}"]
+// 4.16.57 about async
+include::modules/rn-async-errata.adoc[leveloffset=+1]
 
-
-== Asynchronous errata updates
-
-Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red{nbsp}Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
-
-Red{nbsp}Hat Customer Portal users can enable errata notifications in the account settings for Red{nbsp}Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified through email whenever new errata relevant to their registered systems are released.
-
-[NOTE]
-====
-Red{nbsp}Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
-====
-
-This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
-
-[IMPORTANT]
-====
-For any {product-title} release, always review the instructions on xref:../updating/updating_a_cluster/updating-cluster-web-console.adoc#updating-cluster-web-console[updating your cluster] properly.
-====
+// 4.16.57 Rns and updating
+include::modules/zstream-4-16-57.adoc[leveloffset=+2]
 
 // About 4-16-56 release notes
 include::modules/zstream-4-16-56-about.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.16

Issue:
https://issues.redhat.com/browse/OSDOCS-18286

Link to docs preview:
https://106506--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-16-release-notes.html#zstream-4-16-57_release-notes

Additional information:
4.16.57 MR: https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/372
ART Dashboard: https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.16