### PR TITLE
CNV- 60613: File System Overhead description unclear

### DIFF
--- a/virt/storage/virt-reserving-pvc-space-fs-overhead.adoc
+++ b/virt/storage/virt-reserving-pvc-space-fs-overhead.adoc
@@ -6,10 +6,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-When you add a virtual machine disk to a persistent volume claim (PVC) that uses the `Filesystem` volume mode, you must ensure that there is enough space on the PVC for the VM disk and for file system overhead, such as metadata.
+When you create a `DataVolume` custom resource (CR) for a virtual machine (VM) by setting the `spec.storage.volumeMode`  attribute to `Filesystem`, {VirtProductName} automatically accounts for file system overhead.
 
-By default, {VirtProductName} reserves 5.5% of the PVC space for overhead, reducing the space available for virtual machine disks by that amount.
+If you specify the storage type by using the `spec.pvc` attribute in the `DataVolume` CR, {VirtProductName} does not add any file system overhead and the requested size is passed directly to Kubernetes.
 
-You can configure a different overhead value by editing the `HCO` object. You can change the value globally and you can specify values for specific storage classes.
+The default file system overhead value is 6%. For example, if you request a 10 GiB disk and the `spec.storage.volumeMode` attribute is set to `FileSystem`, Kubernetes provisions a PVC of approximately 10.6 GiB so that the VM has the full 10 GiB of space available.
+
+.Example file system overhead for data volumes
+[cols="1,1,1", options="header"]
+|===
+|Requested virtual disk size |Calculated overhead (6%) |Total PVC space provisioned
+|10 GiB |0.6 GiB|10.6 GiB  
+|100 GiB |6 GiB |106 GiB
+|===
+[NOTE]
+====
+You can change the default file system overhead value by editing the `HyperConverged` CR.
+====
 
 include::modules/virt-overriding-default-fs-overhead-value.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/CNV-60613

Link to docs preview:
https://106554--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-reserving-pvc-space-fs-overhead.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

