### PR TITLE
TELCODOCS-2696 DITA rewrite for security-host-sec.adoc

### DIFF
--- a/modules/security-command-line-host-access.adoc
+++ b/modules/security-command-line-host-access.adoc
@@ -6,6 +6,7 @@
 [id="security-command-line-host-access_{context}"]
 = Command-line host access
 
+[role="_abstract"]
 Direct access to a host must be restricted to avoid modifying the host or accessing pods that should not be accessed. For users who need direct access to a host, it is recommended to use an external authenticator, like SSSD with LDAP, to manage access. This helps maintain consistency across the cluster through the Machine Config Operator.
 
 [IMPORTANT]

--- a/modules/security-linux-capabilities-overview.adoc
+++ b/modules/security-linux-capabilities-overview.adoc
@@ -6,6 +6,7 @@
 [id="security-linux-capabilities-overview_{context}"]
 = Linux capabilities
 
+[role="_abstract"]
 Linux capabilities define the actions a process can perform on the host system. By default, pods are granted several capabilities unless security measures are applied. These default capabilities are as follows:
 
 * `CHOWN`

--- a/modules/security-rhcos-overview.adoc
+++ b/modules/security-rhcos-overview.adoc
@@ -6,6 +6,7 @@
 [id="security-rhcos-overview_{context}"]
 = {op-system-first}
 
+[role="_abstract"]
 {op-system-first} is different from {op-system-base-full} in key areas. For more information, see "About {op-system}".
 
 A major distinction is the control of `rpm-ostree`, which is updated through the Machine Config Operator. 


### PR DESCRIPTION
## Summary
- Fix Vale AsciiDocDITA rule violations in security-host-sec.adoc
- Automated DITA rewrite workflow

## JIRA
https://issues.redhat.com/browse/TELCODOCS-2696

## Test plan
- [ ] Verify Vale errors are resolved
- [ ] Review content changes for accuracy
- [ ] Build documentation locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)