### PR TITLE
TELCODOCS-2716: Fix Vale warnings in compute-resource-quotas assembly and modules

### DIFF
--- a/modules/admin-quota-limits.adoc
+++ b/modules/admin-quota-limits.adoc
@@ -127,7 +127,7 @@ where:
 
 `type.max.ephemeral-storage`:: Specifies the maximum amount of ephemeral storage that a pod can request on a node across all containers.
 
-`min.cpu`:: Speciifes the minimum amount of CPU that a pod can request on a node across all containers. See the Supported Constraints table for important information.
+`min.cpu`:: Specifies the minimum amount of CPU that a pod can request on a node across all containers. See the Supported Constraints table for important information.
 
 `min.memory`:: Specifies the minimum amount of memory that a pod can request on a node across all containers. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` memory value.
 

--- a/modules/admin-quota-overview.adoc
+++ b/modules/admin-quota-overview.adoc
@@ -30,7 +30,7 @@ A pod is in a terminal state if `status.phase` is `Failed` or `Succeeded`.
 
 |`ephemeral-storage`
 |The sum of local ephemeral storage requests across all pods in a non-terminal state cannot exceed this value. `ephemeral-storage` and
-`requests.ephemeral-storage` are the same value and can be used interchangeably. This resource is available only if you enabled the ephemeral storage technology preview. This feature is disabled by default.
+`requests.ephemeral-storage` are the same value and can be used interchangeably. This resource is available only if you enabled the ephemeral storage Technology Preview. This feature is disabled by default.
 
 |`requests.cpu`
 |The sum of CPU requests across all pods in a non-terminal state cannot exceed this value. `cpu` and `requests.cpu` are the same value and can be used interchangeably.
@@ -40,7 +40,7 @@ A pod is in a terminal state if `status.phase` is `Failed` or `Succeeded`.
 
 |`requests.ephemeral-storage`
 |The sum of ephemeral storage requests across all pods in a non-terminal state cannot exceed this value. `ephemeral-storage` and
-`requests.ephemeral-storage` are the same value and can be used interchangeably. This resource is available only if you enabled the ephemeral storage technology preview. This feature is disabled by default.
+`requests.ephemeral-storage` are the same value and can be used interchangeably. This resource is available only if you enabled the ephemeral storage Technology Preview. This feature is disabled by default.
 
 |`limits.cpu`
 |The sum of CPU limits across all pods in a non-terminal state cannot exceed this value.
@@ -49,7 +49,7 @@ A pod is in a terminal state if `status.phase` is `Failed` or `Succeeded`.
 |The sum of memory limits across all pods in a non-terminal state cannot exceed this value.
 
 |`limits.ephemeral-storage`
-|The sum of ephemeral storage limits across all pods in a non-terminal state cannot exceed this value. This resource is available only if you enabled the ephemeral storage technology preview. This feature is disabled by default.
+|The sum of ephemeral storage limits across all pods in a non-terminal state cannot exceed this value. This resource is available only if you enabled the ephemeral storage Technology Preview. This feature is disabled by default.
 |===
 
 
@@ -105,7 +105,7 @@ A pod is in a terminal state if `status.phase` is `Failed` or `Succeeded`.
 
 |===
 
-You can configure an object count quota for these standard namespaced resource types using the `count/<resource>.<group>` syntax.
+You can configure an object count quota for these standard namespaced resource types by using the `count/<resource>.<group>` syntax.
 
 [source,terminal]
 ----

--- a/modules/quota-scopes.adoc
+++ b/modules/quota-scopes.adoc
@@ -46,5 +46,5 @@ A `Terminating`, `NotTerminating`, and `NotBestEffort` scope restricts a quota t
 
 [NOTE]
 ====
-Ephemeral storage requests and limits apply only if you enabled the ephemeral storage technology preview. This feature is disabled by default.
+Ephemeral storage requests and limits apply only if you enabled the ephemeral storage Technology Preview. This feature is disabled by default.
 ====

--- a/modules/setting-resource-quota-extended-resources.adoc
+++ b/modules/setting-resource-quota-extended-resources.adoc
@@ -163,4 +163,4 @@ $ oc create -f gpu-pod.yaml
 Error from server (Forbidden): error when creating "gpu-pod.yaml": pods "gpu-pod-f7z2w" is forbidden: exceeded quota: gpu-quota, requested: requests.nvidia.com/gpu=1, used: requests.nvidia.com/gpu=1, limited: requests.nvidia.com/gpu=1
 ----
 +
-You recieve this `Forbidden` error message because you have a quota of 1 GPU and the pod tried to allocate a second GPU, which exceeds the allowed quota.
+You receive this `Forbidden` error message because you have a quota of 1 GPU and the pod tried to allocate a second GPU, which exceeds the allowed quota.

--- a/modules/viewing-a-quota.adoc
+++ b/modules/viewing-a-quota.adoc
@@ -11,9 +11,9 @@ To monitor usage statistics against defined hard limits, navigate to the *Quota*
 
 .Procedure
 
-. Get the list of quotas defined in the project by entering the following commmand:
+. Get the list of quotas defined in the project by entering the following command:
 +
-.Example command with a project called demoproject
+.Example command with a project called `demoproject`
 [source,terminal]
 ----
 $ oc get quota -n demoproject

--- a/scalability_and_performance/compute-resource-quotas.adoc
+++ b/scalability_and_performance/compute-resource-quotas.adoc
@@ -9,9 +9,9 @@ toc::[]
 [role="_abstract"]
 As a cluster administrator, you can use quotas and limit ranges to set constraints. These constraints limit the number of objects or the amount of compute resources that are used in your project. 
 
-By using quotes and limits, you can better manage and allocate resoures across all projects. You can also ensure that no projects use more resources than is appropriate for the cluster size.
+By using quotas and limits, you can better manage and allocate resources across all projects. You can also ensure that no projects use more resources than is appropriate for the cluster size.
 
-A resource quota, defined by a `ResourceQuota` object, provides constraints that limit aggregate resource consumption per project. The quota can limit the quantity of objects that can be created in a project by type. Additinally, the quota can limit the total amount of compute resources and storage that might be consumed by resources in that project.
+A resource quota, defined by a `ResourceQuota` object, provides constraints that limit aggregate resource consumption per project. The quota can limit the quantity of objects that can be created in a project by type. Additionally, the quota can limit the total amount of compute resources and storage that might be consumed by resources in that project.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
[TELCODOCS-2716]: Fix vale errors in compute-resource-quotas.adoc

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2716
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://106570--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/compute-resource-quotas.html
 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:Fix spelling errors (resoures, Additinally, recieve, commmand, Speciifes), capitalize Technology Preview consistently, use 'by using' instead of 'using' after noun, and wrap example project name in backticks.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
