### PR TITLE
TELCODOCS-2717: fix(enabling-workload-partitioning): move assembly content into modul…

### DIFF
--- a/modules/create-perf-profile-workload-partitioning.adoc
+++ b/modules/create-perf-profile-workload-partitioning.adoc
@@ -11,6 +11,10 @@ To enable workload partitioning, apply a performance profile. This configuration
 
 An appropriately configured performance profile specifies the `isolated` and `reserved` CPUs. Create a performance profile by using the Performance Profile Creator (PPC) tool.
 
+.Sample performance profile configuration
+[source,yaml]
+----
+include::snippets/ztp_PerformanceProfile.yaml[]
+----
 
-
-
+include::snippets/performance-profile-workload-partitioning.adoc[]

--- a/scalability_and_performance/enabling-workload-partitioning.adoc
+++ b/scalability_and_performance/enabling-workload-partitioning.adoc
@@ -28,14 +28,6 @@ include::modules/enabling-workload-partitioning.adoc[leveloffset=+1]
 
 include::modules/create-perf-profile-workload-partitioning.adoc[leveloffset=+1]
 
-.Sample performance profile configuration
-[source,yaml]
-----
-include::snippets/ztp_PerformanceProfile.yaml[]
-----
-
-include::snippets/performance-profile-workload-partitioning.adoc[]
-
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][TELCODOCS-2717]: Fixing vale errors in enabling-workload-partitioning.adoc

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2717
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
https://106571--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/enabling-workload-partitioning.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
Move sample performance profile code block and snippet include from the assembly into create-perf-profile-workload-partitioning module to resolve AsciiDocDITA.AssemblyContents violation.


<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
