### PR TITLE
TELCODOCS-2722: fix: DITA compatibility for worker latency profile modules

### DIFF
--- a/modules/nodes-cluster-worker-latency-profiles-examining.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-examining.adoc
@@ -6,9 +6,10 @@
 [id="nodes-cluster-worker-latency-profiles-examining_{context}"]
 = Example steps for displaying resulting values of workerLatencyProfile
 
+[role="_abstract"]
 You can display the values in the `workerLatencyProfile` with the following commands.
 
-.Verification
+.Procedure
 
 . Check the `default-not-ready-toleration-seconds` and `default-unreachable-toleration-seconds` fields output by the Kube API Server:
 +
@@ -60,7 +61,7 @@ $ chroot /host
 .Example output
 [source,terminal]
 ----
-“nodeStatusUpdateFrequency”: “10s”
+"nodeStatusUpdateFrequency": "10s"
 ----
-
++
 These outputs validate the set of timing variables for the Worker Latency Profile.

--- a/modules/nodes-cluster-worker-latency-profiles-using-at-creation.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-using-at-creation.adoc
@@ -6,12 +6,17 @@
 [id="nodes-cluster-worker-latency-profiles-using-at-creation_{context}"]
 = Implementing worker latency profiles at cluster creation
 
+[role="_abstract"]
+You can implement a worker latency profile when you create a cluster by adding the `workerLatencyProfile` field to the installation manifest.
+
 [IMPORTANT]
 ====
 To edit the configuration of the installation program, first use the command `openshift-install create manifests` to create the default node manifest and other manifest YAML files. This file structure must exist before you can add `workerLatencyProfile`. The platform on which you are installing might have varying requirements. Refer to the Installing section of the documentation for your specific platform.
 ====
 
 The `workerLatencyProfile` must be added to the manifest in the following sequence:
+
+.Procedure
 
 . Create the manifest needed to build the cluster, using a folder name appropriate for your installation.
 . Create a YAML file to define `config.node`. The file must be in the `manifests` directory.


### PR DESCRIPTION
[TELCODOCS-2722]: Fixing vale errors in scaling-worker-latency-profiles.adoc
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2722
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://106576--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/scaling-worker-latency-profiles.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Add missing [role="_abstract"] paragraphs and .Procedure block titles to procedure modules, and fix standalone content outside procedure lists to resolve AsciiDocDITA validation issues.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
