### PR TITLE
TELCODOCS-2727: fix(node-tuning-operator): DITA compatibility fixes for assembly and modules

### DIFF
--- a/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
+++ b/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
@@ -8,6 +8,7 @@
 [id="accessing-an-example-node-tuning-operator-specification_{context}"]
 = Accessing an example Node Tuning Operator specification
 
+[role="_abstract"]
 Use this process to access an example Node Tuning Operator specification.
 
 .Procedure
@@ -18,9 +19,9 @@ Use this process to access an example Node Tuning Operator specification.
 ----
 oc get tuned.tuned.openshift.io/default -o yaml -n openshift-cluster-node-tuning-operator
 ----
-
++
 The default CR is meant for delivering standard node-level tuning for the {product-title} platform and it can only be modified to set the Operator Management state. Any other custom changes to the default CR will be overwritten by the Operator. For custom tuning, create your own Tuned CRs. Newly created CRs will be combined with the default CR and custom tuning applied to {product-title} nodes based on node or pod labels and profile priorities.
-
++
 [WARNING]
 ====
 While in certain situations the support for pod labels can be a convenient way of automatically delivering required tuning, this practice is discouraged and strongly advised against, especially in large-scale clusters. The default Tuned CR ships without pod label matching. If a custom profile is created with pod label matching, then the functionality will be enabled at that time. The pod label functionality will be deprecated in future versions of the Node Tuning Operator.

--- a/modules/advanced-node-tuning-hosted-cluster.adoc
+++ b/modules/advanced-node-tuning-hosted-cluster.adoc
@@ -7,6 +7,7 @@
 [id="advanced-node-tuning-hosted-cluster_{context}"]
 = Advanced node tuning for hosted clusters by setting kernel boot parameters
 
+[role="_abstract"]
 For more advanced tuning in {hcp}, which requires setting kernel boot parameters, you can also use the Node Tuning Operator. The following example shows how you can create a node pool with huge pages reserved.
 
 .Procedure
@@ -50,25 +51,31 @@ The `.spec.recommend.match` field is intentionally left blank. In this case, thi
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="<management_cluster_kubeconfig>" create -f tuned-hugepages.yaml <1>
+$ oc --kubeconfig="<management_cluster_kubeconfig>" create -f tuned-hugepages.yaml
 ----
-<1> Replace `<management_cluster_kubeconfig>` with the name of your management cluster `kubeconfig` file.
++
+Replace `<management_cluster_kubeconfig>` with the name of your management cluster `kubeconfig` file.
 
 . Create a `NodePool` manifest YAML file, customize the upgrade type of the `NodePool`, and reference the `ConfigMap` object that you created in the `spec.tuningConfig` section. Create the `NodePool` manifest and save it in a file named `hugepages-nodepool.yaml` by using the `hcp` CLI:
 +
 [source,terminal]
 ----
 $ hcp create nodepool aws \
-  --cluster-name <hosted_cluster_name> \// <1>
-  --name <nodepool_name> \// <2>
-  --node-count <nodepool_replicas> \// <3>
-  --instance-type <instance_type> \// <4>
+  --cluster-name <hosted_cluster_name> \
+  --name <nodepool_name> \
+  --node-count <nodepool_replicas> \
+  --instance-type <instance_type> \
   --render > hugepages-nodepool.yaml
 ----
-<1> Replace `<hosted_cluster_name>` with the name of your hosted cluster.
-<2> Replace `<nodepool_name>` with the name of your node pool.
-<3> Replace `<nodepool_replicas>` with the number of your node pool replicas, for example, `2`.
-<4> Replace `<instance_type>` with the instance type, for example, `m5.2xlarge`.
++
+where:
++
+--
+* `<hosted_cluster_name>`: The name of your hosted cluster.
+* `<nodepool_name>`: The name of your node pool.
+* `<nodepool_replicas>`: The number of your node pool replicas, for example, `2`.
+* `<instance_type>`: The instance type, for example, `m5.2xlarge`.
+--
 +
 [NOTE]
 ====

--- a/modules/cluster-node-tuning-operator-default-profiles-set.adoc
+++ b/modules/cluster-node-tuning-operator-default-profiles-set.adoc
@@ -8,6 +8,7 @@
 [id="custom-tuning-default-profiles-set_{context}"]
 = Default profiles set on a cluster
 
+[role="_abstract"]
 The following are the default profiles set on a cluster.
 
 [source,yaml]

--- a/modules/cluster-node-tuning-operator-verify-profiles.adoc
+++ b/modules/cluster-node-tuning-operator-verify-profiles.adoc
@@ -6,13 +6,18 @@
 [id="verifying-tuned-profiles-are-applied_{context}"]
 =  Verifying that the TuneD profiles are applied
 
+[role="_abstract"]
 Verify the TuneD profiles that are applied to your cluster node.
 
+.Procedure
+
+. Run the following command to verify the TuneD profiles that are applied to your cluster node:
++
 [source,terminal]
 ----
 $ oc get profile.tuned.openshift.io -n openshift-cluster-node-tuning-operator
 ----
-
++
 .Example output
 [source,terminal]
 ----
@@ -23,27 +28,31 @@ master-2         openshift-control-plane   True      False      6h33m
 worker-a         openshift-node            True      False      6h28m
 worker-b         openshift-node            True      False      6h28m
 ----
-
++
+where:
++
+--
 * `NAME`: Name of the Profile object. There is one Profile object per node and their names match.
 * `TUNED`: Name of the desired TuneD profile to apply.
 * `APPLIED`: `True` if the TuneD daemon applied the desired profile. (`True/False/Unknown`).
 * `DEGRADED`: `True` if any errors were reported during application of the TuneD profile (`True/False/Unknown`).
 * `AGE`: Time elapsed since the creation of Profile object.
+--
 
-The `ClusterOperator/node-tuning` object also contains useful information about the Operator and its node agents' health. For example, Operator misconfiguration is reported by `ClusterOperator/node-tuning` status messages.
-
-To get status information about the `ClusterOperator/node-tuning` object, run the following command:
-
+. Run the following command to get status information about the `ClusterOperator/node-tuning` object:
++
 [source,terminal]
 ----
 $ oc get co/node-tuning -n openshift-cluster-node-tuning-operator
 ----
-
++
 .Example output
 [source,terminal,subs="attributes+"]
 ----
 NAME          VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
 node-tuning   {product-version}.1    True        False         True       60m     1/5 Profiles with bootcmdline conflict
 ----
-
++
+The `ClusterOperator/node-tuning` object also contains useful information about the Operator and its node agents' health. For example, Operator misconfiguration is reported by `ClusterOperator/node-tuning` status messages.
++
 If either the `ClusterOperator/node-tuning` or a profile object's status is `DEGRADED`, additional information is provided in the Operator or operand logs.

--- a/modules/custom-tuning-example.adoc
+++ b/modules/custom-tuning-example.adoc
@@ -6,6 +6,9 @@
 [id="custom-tuning-example_{context}"]
 = Custom tuning examples
 
+[role="_abstract"]
+The following examples demonstrate custom tuning configurations for {product-title} nodes using the Node Tuning Operator.
+
 *Using TuneD profiles from the default CR*
 
 The following CR applies custom node-level tuning for

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -12,6 +12,7 @@ endif::[]
 [id="custom-tuning-specification_{context}"]
 = Custom tuning specification
 
+[role="_abstract"]
 The custom resource (CR) for the Operator has two major sections. The first section, `profile:`, is a list of TuneD profiles and their names. The second, `recommend:`, defines the profile selection logic.
 
 Multiple custom tuning specifications can co-exist as multiple CRs in the Operator's namespace. The existence of new CRs or the deletion of old CRs is detected by the Operator. All existing custom tuning specifications are merged and appropriate objects for the containerized TuneD daemons are updated.
@@ -102,26 +103,30 @@ The individual items of the list:
 ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
-- machineConfigLabels: <1>
-    <mcLabels> <2>
-  match: <3>
-    <match> <4>
-  priority: <priority> <5>
-  profile: <tuned_profile_name> <6>
-  operand: <7>
-    debug: <bool> <8>
+- machineConfigLabels:
+    <mcLabels>
+  match:
+    <match>
+  priority: <priority>
+  profile: <tuned_profile_name>
+  operand:
+    debug: <bool>
     tunedConfig:
-      reapply_sysctl: <bool> <9>
+      reapply_sysctl: <bool>
 ----
-<1> Optional.
-<2> A dictionary of key/value `MachineConfig` labels. The keys must be unique.
-<3> If omitted, profile match is assumed unless a profile with a higher priority matches first or `machineConfigLabels` is set.
-<4> An optional list.
-<5> Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
-<6> A TuneD profile to apply on a match. For example `tuned_profile_1`.
-<7> Optional operand configuration.
-<8> Turn debugging on or off for the TuneD daemon. Options are `true` for on or `false` for off. The default is `false`.
-<9> Turn `reapply_sysctl` functionality on or off for the TuneD daemon. Options are `true` for on and `false` for off.
+
+where:
+
+* `machineConfigLabels`: Optional.
+* `<mcLabels>`: A dictionary of key/value `MachineConfig` labels. The keys must be unique.
+* `match`: If omitted, profile match is assumed unless a profile with a higher priority matches first or `machineConfigLabels` is set.
+* `<match>`: An optional list.
+* `<priority>`: Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
+* `<tuned_profile_name>`: A TuneD profile to apply on a match. For example `tuned_profile_1`.
+* `operand`: Optional operand configuration.
+* `debug`: Turn debugging on or off for the TuneD daemon. Options are `true` for on or `false` for off. The default is `false`.
+* `reapply_sysctl`: Turn `reapply_sysctl` functionality on or off for the TuneD daemon. Options are `true` for on and `false` for off.
+
 endif::rosa-hcp-tuning[]
 ifdef::rosa-hcp-tuning[]
 [source,json]
@@ -134,22 +139,26 @@ ifdef::rosa-hcp-tuning[]
   ],
   "recommend": [
     {
-      "profile": <tuned_profile_name>, <1>
-      "priority":{ <priority>, <2>
+      "profile": <tuned_profile_name>,
+      "priority":{ <priority>,
       },
-      "match": [ <3>
+      "match": [
         {
-          "label": <label_information> <4>
+          "label": <label_information>
         },
       ]
     },
   ]
 }
 ----
-<1> A TuneD profile to apply on a match. For example `tuned_profile_1`.
-<2> Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
-<3> If omitted, profile match is assumed unless a profile with a higher priority matches first.
-<4> The label for the profile matched items.
+
+where:
+
+* `<tuned_profile_name>`: A TuneD profile to apply on a match. For example `tuned_profile_1`.
+* `<priority>`: Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
+* `match`: If omitted, profile match is assumed unless a profile with a higher priority matches first.
+* `<label_information>`: The label for the profile matched items.
+
 endif::[]
 
 `<match>` is an optional list recursively defined as follows:
@@ -157,26 +166,34 @@ endif::[]
 ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
-- label: <label_name> <1>
-  value: <label_value> <2>
-  type: <label_type> <3>
-    <match> <4>
+- label: <label_name>
+  value: <label_value>
+  type: <label_type>
+    <match>
 ----
-<1> Node or pod label name.
-<2> Optional node or pod label value. If omitted, the presence of `<label_name>` is enough to match.
-<3> Optional object type (`node` or `pod`). If omitted, `node` is assumed.
-<4> An optional `<match>` list.
+
+where:
+
+* `<label_name>`: Node or pod label name.
+* `<label_value>`: Optional node or pod label value. If omitted, the presence of `<label_name>` is enough to match.
+* `<label_type>`: Optional object type (`node` or `pod`). If omitted, `node` is assumed.
+* `<match>`: An optional `<match>` list.
+
 endif::rosa-hcp-tuning[]
 ifdef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 "match": [
         {
-          "label": <1>
+          "label": <label_name>
         },
 ]
 ----
-<1> Node or pod label name.
+
+where:
+
+* `<label_name>`: Node or pod label name.
+
 endif::[]
 
 If `<match>` is not omitted, all nested `<match>` sections must also evaluate to `true`. Otherwise, `false` is assumed and the profile with the respective `<match>` section will not be applied or recommended. Therefore, the nesting (child `<match>` sections) works as logical AND operator. Conversely, if any item of the `<match>` list matches, the entire `<match>` list evaluates to `true`. Therefore, the list acts as logical OR operator.

--- a/modules/defer-application-tuning-proc.adoc
+++ b/modules/defer-application-tuning-proc.adoc
@@ -6,6 +6,7 @@
 [id="defer-application-of-tuning-changes-example_{context}"]
 = Deferring application of tuning changes: An example
 
+[role="_abstract"]
 The following worked example describes how to defer the application of tuning changes by using the Node Tuning Operator.
 
 .Prerequisites
@@ -110,19 +111,23 @@ spec:
       data: |
         [main]
         summary=Configuration changes profile inherited from performance created tuned
-        include=openshift-node-performance-performance <1>
+        include=openshift-node-performance-performance
         [sysctl]
-        kernel.shmmni=8192 <2> 
+        kernel.shmmni=8192
   recommend:
     - machineConfigLabels:
-        machineconfiguration.openshift.io/role: worker-cnf <3>
+        machineconfiguration.openshift.io/role: worker-cnf
       priority: 19
       profile: performance-patch
 ----
 +
-<1> The `include` directive is used to inherit the `openshift-node-performance-performance` profile. This is a best practice to ensure that the profile is not missing any required settings.
-<2> The `kernel.shmmni` sysctl parameter is being changed to `8192`.
-<3> The `machineConfigLabels` field is used to target the `worker-cnf` role.
+where:
++
+--
+* The `include` directive is used to inherit the `openshift-node-performance-performance` profile. This is a best practice to ensure that the profile is not missing any required settings.
+* The `kernel.shmmni` sysctl parameter is being changed to `8192`.
+* The `machineConfigLabels` field is used to target the `worker-cnf` role.
+--
 
 . Apply the profile patch by running the following command:
 +
@@ -214,7 +219,7 @@ $ oc debug node/ip-10-0-32-74.ec2.internal  -q -- chroot host sysctl kernel.shmm
 ----
 kernel.shmmni = 8192
 ----
-
++
 [NOTE]
 ====
 An additional restart results in the restoration of the original value of the `kernel.shmmni` sysctl parameter.

--- a/modules/defer-applicaton-tuning-example.adoc
+++ b/modules/defer-applicaton-tuning-example.adoc
@@ -6,6 +6,7 @@
 [id="defer-application-of-tuning-changes_{context}"]
 = Deferring application of tuning changes
 
+[role="_abstract"]
 As an administrator, use the Node Tuning Operator (NTO) to update custom resources (CRs) on a running system and make tuning changes. For example, they can update or add a sysctl parameter to the [sysctl] section of the tuned object. When administrators apply a tuning change, the NTO prompts TuneD to reprocess all configurations, causing the tuned process to roll back all tuning and then reapply it.
 
 Latency-sensitive applications may not tolerate the removal and reapplication of the tuned profile, as it can briefly disrupt performance. This is particularly critical for configurations that partition CPUs and manage process or interrupt affinity using the performance profile. To avoid this issue, {product-title} introduced new methods for applying tuning changes. Before {product-title} 4.17, the only available method, immediate, applied changes instantly, often triggering a tuned restart.
@@ -43,19 +44,21 @@ spec:
       data: |
         [main]
         summary=Configuration changes profile inherited from performance created tuned
-        include=openshift-node-performance-performance <1>
+        include=openshift-node-performance-performance
         [sysctl]
-        kernel.shmmni=8192 <2>
+        kernel.shmmni=8192
   recommend:
     - machineConfigLabels:
-        machineconfiguration.openshift.io/role: worker-cnf <3>
+        machineconfiguration.openshift.io/role: worker-cnf
       priority: 19
       profile: performance-patch
 ----
 
-<1> The `include` directive is used to inherit the `openshift-node-performance-performance` profile. This is a best practice to ensure that the profile is not missing any required settings.
-<2> The `kernel.shmmni` sysctl parameter is being changed to `8192`.
-<3> The `machineConfigLabels` field is used to target the `worker-cnf` role. Configure a `MachineConfigPool` resource to ensure the profile is applied only to the correct nodes.
+where:
+
+* The `include` directive is used to inherit the `openshift-node-performance-performance` profile. This is a best practice to ensure that the profile is not missing any required settings.
+* The `kernel.shmmni` sysctl parameter is being changed to `8192`.
+* The `machineConfigLabels` field is used to target the `worker-cnf` role. Configure a `MachineConfigPool` resource to ensure the profile is applied only to the correct nodes.
 
 [NOTE]
 ====

--- a/modules/node-tuning-hosted-cluster.adoc
+++ b/modules/node-tuning-hosted-cluster.adoc
@@ -7,6 +7,7 @@
 [id="node-tuning-hosted-cluster_{context}"]
 = Configuring node tuning in a hosted cluster
 
+[role="_abstract"]
 To set node-level tuning on the nodes in your hosted cluster, you can use the Node Tuning Operator. In {hcp}, you can configure node tuning by creating config maps that contain `Tuned` objects and referencing those config maps in your node pools.
 
 .Procedure

--- a/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
+++ b/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
@@ -8,6 +8,7 @@
 [id="supported-tuned-daemon-plug-ins_{context}"]
 = Supported TuneD daemon plugins
 
+[role="_abstract"]
 Excluding the `[main]` section, the following TuneD plugins are supported when
 using custom profiles defined in the `profile:` section of the Tuned CR:
 

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -31,6 +31,7 @@ ifdef::cluster-caps[]
 The Node Tuning Operator provides features for the `NodeTuning` capability.
 endif::cluster-caps[]
 
+[role="_abstract"]
 The Node Tuning Operator helps you manage node-level tuning by orchestrating the TuneD daemon and achieves low latency performance by using the Performance Profile controller. The majority of high-performance applications require some level of kernel tuning. The Node Tuning Operator provides a unified management interface to users of node-level sysctls and more flexibility to add custom tuning specified by user needs.
 
 ifdef::cluster-caps[]


### PR DESCRIPTION
[TELCODOCS-2727]: Fix vale errors in using-node-tuning-operator.adoc

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-2727
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

- https://106586--ocpdocs-pr.netlify.app/openshift-dedicated/latest/nodes/nodes/nodes-node-tuning-operator.html
- https://106586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-machine-config.html
- https://106586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/overview/cluster-capabilities.html
- https://106586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-node-tuning-operator.html
- https://106586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/operators/operator-reference.html
- https://106586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html
- https://106586--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-node-tuning-operator.html
- https://106586--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/nodes/nodes/nodes-node-tuning-operator.html
- https://106586--ocpdocs-pr.netlify.app/openshift-rosa/latest/nodes/nodes/nodes-node-tuning-operator.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Resolve all 24 AsciiDocDITA Vale violations across 11 modules included in using-node-tuning-operator.adoc:

- ShortDescription: add [role="_abstract"] to 11 modules
- CalloutList: replace callout lists with bullet lists in 4 files
- TaskTitle: restructure procedure steps in verify-profiles module
- TaskContents: add missing .Procedure block title
- TaskStep: attach trailing content with list continuations in 2 files
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
