### PR TITLE
OCPBUGS 14928 Jobs documentation has no mention of ttlSecondsAfterFinished

### DIFF
--- a/modules/nodes-nodes-jobs-about.adoc
+++ b/modules/nodes-nodes-jobs-about.adoc
@@ -116,6 +116,17 @@ Doing this prevents them from generating unnecessary artifacts.
 ====
 endif::openshift-rosa,openshift-rosa-hcp,openshift-dedicated[]
 
+[id="jobs-ttl_{context}"]
+== Understanding how to automatically remove completed jobs
+
+You can specify that {product-title} should delete jobs when they are finished, either `Complete` or `Failed`, in order to limit the number of objects in your cluster.
+
+By default, for jobs that are not associated with a cron job or other controlling object, {product-title} does not delete the job or its related pods when the job is finished. If you keep these artifacts in your cluster, you can view the status of finished jobs or view job logs for errors, warnings, or other diagnostic output.
+
+However, having too many of these objects in the cluster can lead to etcd issues, latency issues, performance degradation, and other problems. 
+
+You can configure a time-to-live (TTL) duration for jobs without a controlling object by setting the `ttlSecondsAfterFinished` parameter in the job spec. When set, {product-title} deletes the jobs and any related pods immediately after the job is finished or after a specified period of time in seconds.
+
 [id="jobs-limits_{context}"]
 == Known limitations
 

--- a/modules/nodes-nodes-jobs-creating.adoc
+++ b/modules/nodes-nodes-jobs-creating.adoc
@@ -25,7 +25,8 @@ spec:
   completions: 1    <2>
   activeDeadlineSeconds: 1800 <3>
   backoffLimit: 6   <4>
-  template:         <5>
+  ttlSecondsAfterFinished: 100 <5>
+  template:         <6>
     metadata:
       name: pi
     spec:
@@ -33,7 +34,7 @@ spec:
       - name: pi
         image: perl
         command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
-      restartPolicy: OnFailure    <6>
+      restartPolicy: OnFailure    <7>
 #...
 ----
 <1> Optional: Specify how many pod replicas a job should run in parallel; defaults to `1`.
@@ -44,8 +45,9 @@ spec:
 * For parallel jobs with a work queue, leave unset. When unset defaults to the `parallelism` value.
 <3> Optional: Specify the maximum duration the job can run.
 <4> Optional: Specify the number of retries for a job. This field defaults to six.
-<5> Specify the template for the pod the controller creates.
-<6> Specify the restart policy of the pod:
+<5> Optional: Specify the period of time in seconds after which the job should be automatically deleted upon completion. If set to '0', the job is immediately deleted after completion. If this field is not included, the job is not automatically deleted.
+<6> Specify the template for the pod the controller creates.
+<7> Specify the restart policy of the pod:
 * `Never`. Do not restart the job.
 * `OnFailure`. Restart the job only if it fails.
 * `Always`. Always restart the job.

--- a/nodes/jobs/nodes-nodes-jobs.adoc
+++ b/nodes/jobs/nodes-nodes-jobs.adoc
@@ -27,7 +27,8 @@ spec:
   completions: 1    <2>
   activeDeadlineSeconds: 1800 <3>
   backoffLimit: 6   <4>
-  template:         <5>
+  ttlSecondsAfterFinished: 100 <5>
+  template:         <6>
     metadata:
       name: pi
     spec:
@@ -35,15 +36,16 @@ spec:
       - name: pi
         image: perl
         command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
-      restartPolicy: OnFailure    <6>
+      restartPolicy: OnFailure    <7>
 #...
 ----
 <1> The pod replicas a job should run in parallel.
 <2> Successful pod completions are needed to mark a job completed.
 <3> The maximum duration the job can run.
 <4> The number of retries for a job.
-<5> The template for the pod the controller creates.
-<6> The restart policy of the pod.
+<5> The period of time in seconds after which the job should be automatically deleted upon completion.
+<6> The template for the pod the controller creates.
+<7> The restart policy of the pod.
 
 .Additional resources
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-14928

Nodes -> Using jobs and daemon sets -> Running tasks in pods using jobs -- New section. This an several other section in this module should be on their own, or the module should be re-organized. This can be more appropriately cleaned up in a CQA or JTBD task. 