### PR TITLE
OSDOCS-16945# CQA work Stor1-- non-graceful shutdown

### DIFF
--- a/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-overview.adoc
+++ b/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-overview.adoc
@@ -7,6 +7,7 @@
 [id="persistent-storage-csi-vol-detach-non-graceful-overview_{context}"]
 = Overview
 
-A graceful node shutdown occurs when the kubelet's node shutdown manager detects the upcoming node shutdown action. Non-graceful shutdowns occur when the kubelet does not detect a node shutdown action, which can occur because of system or hardware failures. Also, the kubelet may not detect a node shutdown action when the shutdown command does not trigger the Inhibitor Locks mechanism used by the kubelet on Linux, or because of a user error, for example, if the shutdownGracePeriod and shutdownGracePeriodCriticalPods details are not configured correctly for that node.
+[role="_abstract"] 
+Non-graceful node shutdowns from hardware failures or system crashes leave volumes attached to failed nodes, blocking pod rescheduling. Applying an out-of-service taint triggers automatic volume detachment from failed nodes, enabling workload recovery without manual volume management.
 
-With this feature, when a non-graceful node shutdown occurs, you can manually add an `out-of-service` taint on the node to allow volumes to automatically detach from the node.
+A graceful node shutdown occurs when the kubelet's node shutdown manager detects the upcoming node shutdown action. Non-graceful shutdowns occur when the kubelet does not detect a node shutdown action, which can occur because of system or hardware failures. Also, the kubelet might not detect a node shutdown action when the shutdown command does not trigger the Inhibitor Locks mechanism used by the kubelet on Linux, or because of a user error, for example, if the shutdownGracePeriod and shutdownGracePeriodCriticalPods details are not configured correctly for that node.

--- a/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
+++ b/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
@@ -7,13 +7,14 @@
 [id="persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure_{context}"]
 = Adding an out-of-service taint manually for automatic volume detachment
 
+[role="_abstract"] 
+After non-graceful shutdowns, to trigger automatic volume detachment and enable pod rescheduling, apply an out-of-service taint to the node. This recovers workloads faster than manually detaching volumes from failed nodes.
+
 .Prerequisites
 
 * Access to the cluster with cluster-admin privileges.
 
 .Procedure
-
-To allow volumes to detach automatically from a node after a non-graceful node shutdown:
 
 . After a node is detected as unhealthy, shut down the worker node.
 
@@ -21,9 +22,10 @@ To allow volumes to detach automatically from a node after a non-graceful node s
 +
 [source,terminal]
 ----
-$ oc get node <node_name> <1>
+$ oc get node <node_name>
 ----
-<1> <node_name> = name of the node that shut down non-gracefully
++
+* Use the `<node_name>` to specify the node that shut down non-gracefully.
 +
 [IMPORTANT]
 ====
@@ -34,22 +36,21 @@ If the node is not completely shut down, do not proceed with tainting the node. 
 +
 [IMPORTANT]
 ====
-Tainting a node this way deletes all pods on that node. This also causes any pods that are backed by 
-statefulsets to be evicted, and replacement pods to be created on a different node.
+Tainting a node this way deletes all pods on that node. This also causes any pods that are backed by statefulsets to be evicted, and replacement pods to be created on a different node.
 ====
 +
 [source,terminal]
 ----
-$ oc adm taint node <node_name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute <1>
+$ oc adm taint node <node_name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute
 ----
-<1> <node_name> = name of the node that shut down non-gracefully
++
+* Use the `<node_name>` to specify the node that shut down non-gracefully.
 +
 After the taint is applied, the volumes detach from the shutdown node allowing their disks to be attached to a different node.
 +
-.Example
+The resulting YAML file resembles the following example file:
 +
-The resulting YAML file resembles the following:
-+
+.Example node YAML file with out-of-service taint applied
 [source, yaml]
 ----
 spec:
@@ -65,6 +66,7 @@ spec:
 +
 [source, terminal]
 ----
-$ oc adm taint node <node_name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute- <1>
+$ oc adm taint node <node_name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute-
 ----
-<1> <node_name> = name of the node that shut down non-gracefully
++
+* Use the `<node_name>` to specify the node that shut down non-gracefully

--- a/storage/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc
+++ b/storage/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc
@@ -1,12 +1,16 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="ephemeral-storage-csi-vol-detach-non-graceful-shutdown"]
 = Detach volumes after non-graceful node shutdown
-include::_attributes/common-attributes.adoc[]
+:toc: 
+:toc-title:
 :context: ephemeral-storage-csi-vol-detach-non-graceful-shutdown
+include::_attributes/common-attributes.adoc[]
+
+[role="_abstract"] 
+Automatic volume detachment after non-graceful node shutdowns prevents volumes from remaining attached to failed nodes, enabling faster workload recovery by allowing pods to reschedule and reattach volumes on healthy nodes without manual intervention.
+
 
 toc::[]
-
-This feature allows drivers to automatically detach volumes when a node goes down non-gracefully.
 
 include::modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.20+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-16945
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://106592--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent-storage-csi-vol-detach-non-graceful-shutdown.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->