### PR TITLE
Adds rootless podman configuration proc to OMR docs

### DIFF
--- a/disconnected/installing-mirroring-creating-registry.adoc
+++ b/disconnected/installing-mirroring-creating-registry.adoc
@@ -19,7 +19,7 @@ The _mirror registry for Red{nbsp}Hat OpenShift_ is not intended to be a substit
 == Prerequisites
 
 * An {product-title} subscription.
-* {op-system-base-full} 8 and 9 with Podman 3.4.2 or later and OpenSSL installed.
+* {op-system-base-full} 8 and 9 with Podman 3.4.2 or later and OpenSSL installed. If you are using Podman 5.7 or later, see "Configuring rootless Podman networking".
 * Fully qualified domain name for the Red{nbsp}Hat Quay service, which must resolve through a DNS server.
 * Key-based SSH connectivity on the target host. SSH keys are automatically generated for local installs. For remote hosts, you must generate your own SSH keys.
 * 2 or more vCPUs.
@@ -34,6 +34,8 @@ The _mirror registry for Red{nbsp}Hat OpenShift_ is not intended to be a substit
 ====
 
 include::modules/mirror-registry-introduction.adoc[leveloffset=+1]
+
+include::modules/configuring-rootless-podman-networking.adoc[leveloffset=+1]
 
 include::modules/mirror-registry-localhost.adoc[leveloffset=+1]
 

--- a/modules/configuring-rootless-podman-networking.adoc
+++ b/modules/configuring-rootless-podman-networking.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * installing/disconnected_install/installing-mirroring-installation-images.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="configuring-rootless-podman_{context}"]
+= Configuring rootless Podman networking
+
+[role="_abstract"]
+To restore rootless Podman networking when the default `pasta` stack fails on {product-title} mirror or install hosts, you can set the default rootless network back to `slirp4netns` in the `/etc/containers/containers.conf` file, or in the user's `~/.config/containers/container.conf` file. 
+
+You might need to configure rootless Podman networking after upgrading to {op-system-base} 9.5 or Podman 5.0. In these versions, the default networking stack changed from `slirp4netns` to `pasta`. As a result, systems that previously operated without a default route might no longer be able to establish network connectivity and could display the following error:
+
+[source,terminal]
+----
+Error: pasta failed with exit code 1:
+External interface not usable
+----
+
+.Prerequisites
+
+* You have updated to {op-system-base} 9.5 or Podman 5.0.
+
+.Procedure
+
+. Use your preferred IDE to modify the `/etc/containers/containers.conf` or `~/.config/containers/container.conf` file.
+
+.. To modify the `/etc/containers/containers.conf` file, enter the following command:
++
+[source,terminal]
+----
+$ nano /etc/containers/containers.conf
+----
+
+.. To modify the `~/.config/containers/container.conf` file, enter the following command:
++
+[source,terminal]
+----
+$ nano ~/.config/containers/container.conf
+----
+
+. Add, or update, the `[network]` section as in the following example:
++
+[source,text]
+----
+# ...
+[network]
+default_rootless_network_cmd = "slirp4netns"
+# ...
+----
+
+. Restart the Podman system as the rootless user by entering the following command. Note that all containers must be stopped and restarted for the change to take effect.
++
+[source,terminal]
+----
+$ podman system migrate
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-18274

Link to docs preview:
https://106593--ocpdocs-pr.netlify.app/openshift-enterprise/latest/disconnected/installing-mirroring-creating-registry.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
