### PR TITLE
OSDOCS CMA 2.18.1-2 release notes

### DIFF
--- a/modules/nodes-pods-autoscaling-custom-rn-2181-2.adoc
+++ b/modules/nodes-pods-autoscaling-custom-rn-2181-2.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-user-namespaces.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="nodes-pods-autoscaling-custom-rn-2181-2_{context}"]
+= Custom Metrics Autoscaler Operator 2.18.1-2 release notes
+
+Issued: 09 February 2026
+
+This release of the Custom Metrics Autoscaler Operator 2.18.1-2 addresses Common Vulnerabilities and Exposures (CVEs). The following advisory is available for the Custom Metrics Autoscaler Operator:
+
+* link:https://access.redhat.com/errata/RHSA-2026:2368[RHSA-2026:2368]
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of Kubernetes-based Event Driven Autoscaler (KEDA).
+====

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past.adoc
@@ -11,6 +11,8 @@ You can review the following release notes to learn about changes in previous ve
 
 For the current version, see xref:../../../nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc#nodes-cma-autoscaling-custom-rn[Custom Metrics Autoscaler Operator release notes].
 
+include::modules/nodes-pods-autoscaling-custom-rn-2181.adoc[leveloffset=+1]
+
 include::modules/nodes-pods-autoscaling-custom-rn-2172-2.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-autoscaling-custom-rn-2172.adoc[leveloffset=+1]

--- a/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 
 [role="_abstract"]
-You can review the following release notes to learn about changes in the Custom Metrics Autoscaler Operator version 2.18.1-1. The release notes for the Custom Metrics Autoscaler Operator for Red Hat OpenShift describe new features and enhancements, deprecated features, and known issues.
+You can review the following release notes to learn about changes in the Custom Metrics Autoscaler Operator version 2.18.1-2. The release notes for the Custom Metrics Autoscaler Operator for Red Hat OpenShift describe new features and enhancements, deprecated features, and known issues.
 
 The Custom Metrics Autoscaler Operator uses the Kubernetes-based Event Driven Autoscaler (KEDA) and is built on top of the {product-title} horizontal pod autoscaler (HPA).
 
@@ -28,46 +28,46 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |{product-title} version
 |General availability
 
-|2.18.1-1
-|4.20
-|General availability
-
-|2.18.1-1
+|2.18.1-2
 |4.21
 |General availability
 
-|2.18.1-1
+|2.18.1-2
+|4.20
+|General availability
+
+|2.18.1-2
 |4.19
 |General availability
 
-|2.18.1-1
+|2.18.1-2
 |4.18
 |General availability
 
 
-|2.18.1-1
+|2.18.1-2
 |4.17
 |General availability
 
-|2.18.1-1
+|2.18.1-2
 |4.16
 |General availability
 
-|2.18.1-1
+|2.18.1-2
 |4.15
 |General availability
 
-|2.18.1-1
+|2.18.1-2
 |4.14
 |General availability
 
-|2.18.1-1
+|2.18.1-2
 |4.13
 |General availability
 
-|2.18.1-1
+|2.18.1-2
 |4.12
 |General availability
 |===
 
-include::modules/nodes-pods-autoscaling-custom-rn-2181.adoc[leveloffset=+1]
+include::modules/nodes-pods-autoscaling-custom-rn-2181-2.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-18024

[Custom Metrics Autoscaler Operator release notes](https://106595--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn) -- Updated version number
Custom Metrics Autoscaler Operator release notes -> [Supported versions](https://106595--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn#nodes-pods-autoscaling-custom-rn-versions_nodes-cma-autoscaling-custom-rn) -- Updated version numbers
Custom Metrics Autoscaler Operator release notes -> [Custom Metrics Autoscaler Operator 2.18.1-2 release notes](https://106595--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn#nodes-pods-autoscaling-custom-rn-2181-2_nodes-cma-autoscaling-custom-rn) -- New module.
Release notes for past releases of the Custom Metrics Autoscaler Operator -> [Custom Metrics Autoscaler Operator 2.18.1-1 release notes](https://106595--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-rn/nodes-cma-autoscaling-custom-rn-past#nodes-pods-autoscaling-custom-rn-2181_nodes-cma-autoscaling-custom-rn-past) -- Moved 2.18.1 release notes to past releases with **NO CHANGE TO TEXT**. 

Will address CQA-level changes in a future PR.