### PR TITLE
OLS-2627: Vale checks for modules in install assembly

### DIFF
--- a/install/ols-installing-openshift-lightspeed.adoc
+++ b/install/ols-installing-openshift-lightspeed.adoc
@@ -8,7 +8,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-To install {ols-official}, you must install the {ols-long} Operator and configure the service to interact with a large language model (LLM) provider.
+
+Enable {ols-long} in your cluster by installing the {ols-long} Operator and configuring the Service to interact with a large language model (LLM) provider.
 
 include::modules/ols-large-language-model-overview.adoc[leveloffset=+1]
 
@@ -16,13 +17,12 @@ include::modules/ols-about-subscription-requirements.adoc[leveloffset=+1]
 
 include::modules/ols-about-adding-operators-to-a-cluster.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
+include::modules/ols-installing-operator-from-operatorhub.adoc[leveloffset=+2]
+
+include::modules/ols-installing-operator-from-software-catalog.adoc[leveloffset=+2]
+
 .Additional resources
 
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/operators/administrator-tasks#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[About Operator installation with OperatorHub]
 
 * link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/administrator-tasks#olm-installing-operators-from-software-catalog_olm-adding-operators-to-a-cluster[About Operator installation with software catalog]
-
-include::modules/ols-installing-operator-from-operatorhub.adoc[leveloffset=+2]
-
-include::modules/ols-installing-operator-from-software-catalog.adoc[leveloffset=+2]

--- a/modules/ols-about-adding-operators-to-a-cluster.adoc
+++ b/modules/ols-about-adding-operators-to-a-cluster.adoc
@@ -7,4 +7,5 @@
 = About adding Operators to a cluster
 
 [role="_abstract"]
-Install Operators on your {ocp-product-title} cluster by using Operator Lifecycle Manager (OLM) through the OperatorHub or software catalog.
+
+Use the software catalog or OperatorHub to install Operators on your {ocp-product-title} cluster. These tools use the Operator Lifecycle Manager (OLM) to manage your software.

--- a/modules/ols-installing-operator-from-operatorhub.adoc
+++ b/modules/ols-installing-operator-from-operatorhub.adoc
@@ -3,16 +3,17 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-installing-operator-from-operatorhub_{context}"]
-= Installing the OpenShift Lightspeed Operator from the OperatorHub
+= Installing the {ols-long} Operator from the OperatorHub
 
 [role="_abstract"]
+
 Install the {ols-long} Operator so that you can configure the {ols-long} Service.
 
 .Prerequisites
 
 * You have deployed {ocp-product-title} 4.16 to 4.19.
 
-* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
+* You have logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
 
 * You have successfully configured your large language model (LLM) provider so that {ols-long} can communicate with it.
 
@@ -24,10 +25,10 @@ Install the {ols-long} Operator so that you can configure the {ols-long} Service
 
 . Locate the {ols-long} Operator, and click to select it.
 
-. When the prompt that discusses the community operator appears, click *Continue*.
+. When the prompt that discusses the community operator displays, click *Continue*.
 
 . Click *Install*.
 
 . Use the default installation settings presented, and click *Install* to continue.
 
-. Click *Operators* -> *Installed Operators* to verify that the {ols-long} Operator is installed. `Succeeded` should appear in the *Status* column.
+. Click *Operators* -> *Installed Operators* to verify the {ols-long} Operator installation. `Succeeded` displays in the *Status* column.

--- a/modules/ols-installing-operator-from-software-catalog.adoc
+++ b/modules/ols-installing-operator-from-software-catalog.adoc
@@ -1,15 +1,19 @@
-// This module is used in the following assemblies:
-// * install/ols-installing-openshift-lightspeed.adoc
+// Module included in the following assemblies:
+// * lightspeed-docs-main/install/ols-installing-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-installing-operator-from-software-catalog_{context}"]
-= Installing the OpenShift Lightspeed Operator from the software catalog
+= Installing the {ols-long} Operator from the software catalog
+
+[role="_abstract"]
+
+Install the {ols-long} Operator so that you can configure the {ols-long} Service.
 
 .Prerequisites
 
 * You have deployed {ocp-product-title} 4.20 or later.
 
-* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
+* You have logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role.
 
 * You have successfully configured your large language model (LLM) provider so that {ols-long} can communicate with it.
 
@@ -27,8 +31,8 @@
 
 . Locate the {ols-long} Operator, and click to select it.
 
-. When the prompt that discusses the {ols-long} Operator appears, click *Install*.
+. When the prompt that discusses the {ols-long} Operator displays, click *Install*.
 
 . Use the default installation settings presented, and click *Install* to continue.
 
-. Click *Ecosystem* -> *Installed Operators* to verify that the {ols-long} Operator was installed. `Succeeded` appears in the *Status* column.
+. Click *Ecosystem* -> *Installed Operators* to verify the {ols-long} Operator installation. `Succeeded` displays in the *Status* column.

--- a/modules/ols-large-language-model-overview.adoc
+++ b/modules/ols-large-language-model-overview.adoc
@@ -4,10 +4,11 @@
 :_mod-docs-content-type: CONCEPT
 [id="ols-large-language-model-overview_{context}"]
 
-= Large Language Model (LLM) overview
+= Large language model (LLM) overview
 
 [role="_abstract"]
-Learn how the {ols-long} Service uses large language models (LLMs) to provide intelligent, context-aware answers to your questions about {ocp-product-title}.
+
+Learn how the {ols-long} Service uses large language models (LLMs) to generate intelligent, context-aware answers to your questions about {ocp-product-title}.
 
 You can configure {rhelai} or {rhoai} as the LLM provider for the {ols-long} Service. Either LLM provider can use a server or inference service that processes inference queries. 
 
@@ -23,7 +24,7 @@ Installing the {ols-long} Operator does not install an LLM provider. You must ha
 
 You can use {rhelai} to host an LLM. 
 
-For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_ai/1.5/html/generating_a_custom_llm_using_rhel_ai/index[Generating a custom LLM using RHEL AI].
+For more information, see link:https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_ai/1.5/html/generating_a_custom_llm_using_rhel_ai/index[Generating a custom LLM by using RHEL AI].
 
 [id="rhoai-with-ols_{context}"]
 == {rhoai} with {ols-long}
@@ -35,7 +36,7 @@ For more information, see link:https://docs.redhat.com/en/documentation/red_hat_
 [id="watsnx-with-ols_{context}"]
 == {watsonx} with {ols-long}
 
-To configure {watsonx} as the LLM provider, you need an IBM Cloud project with access to {watsonx}. You also need your {watsonx} API key.
+To configure {watsonx} as the LLM provider, you need an {ibm-cloud-title} project with access to {watsonx}. You also need your {watsonx} API key.
 
 For more information, see the official {watsonx} link:https://dataplatform.cloud.ibm.com/docs/content/wsj/getting-started/welcome-main.html?context=wx&audience=wdp[product documentation].
 


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2627

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
