### PR TITLE
OLS-2615: Update OLS docs for Tools filtering based on query

### DIFF
--- a/configure/ols-configuring-openshift-lightspeed.adoc
+++ b/configure/ols-configuring-openshift-lightspeed.adoc
@@ -69,4 +69,6 @@ include::modules/ols-activating-token-quota-limits.adoc[leveloffset=+2]
 
 include::modules/ols-about-postgresql-persistence.adoc[leveloffset=+1]
 
-include::modules/ols-enabling-postgresql-persistence.adoc[leveloffset=+2]
+include::modules/ols-about-query-based-tool-filtering.adoc[leveloffset=+1]
+
+include::modules/ols-enabling-query-based-tool-filtering.adoc[leveloffset=+2]

--- a/modules/ols-about-query-based-tool-filtering.adoc
+++ b/modules/ols-about-query-based-tool-filtering.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ols-about-query-based-tools-filtering_{context}"]
+= About query-based tool filtering
+
+[role="_abstract"]
+
+Query-based filtering uses a hybrid retrieval-augmented generation (RAG) system to identify the most appropriate set of tool for a user request. 
+
+When a large language model (LLM) application has access to hundreds of tools, sending the full list in one prompt slows performance and raises costs. Query-based filtering finds and retrieves the most relevant set of tools for a request in milliseconds. This pre-processing step removes selection interference, and ensures that the LLM focuses its reasoning capabilities on a small, high-quality subset of functions.
+
+Restricting the set of tools available reduces token use, prevents model confusion, and maintains high execution accuracy. This approach transforms a massive tool library into a fast, lean interface.

--- a/modules/ols-enabling-query-based-tool-filtering.adoc
+++ b/modules/ols-enabling-query-based-tool-filtering.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+// * lightspeed-docs-main/configure/ols-configuring-openshift-lightspeed.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ols-enabling-query-based-tool-filtering_{context}"]
+= Enabling query-based tool filtering
+
+[role="_abstract"]
+
+Enable query-based tool filtering to automatically select the set of tools most relevant for your request.
+
+.Prerequisites
+
+* You are logged in to the {ocp-product-title} web console as a user with the `cluster-admin` role. Alternatively, you are logged in to a user account that has permission to create a cluster-scoped CR file.
+
+* You have an LLM provider available for use with the {ols-long} Service.
+
+* You have installed the {ols-long} Operator.
+
+.Procedure
+
+. In the {ocp-product-title} web console, click *Operators* -> *Installed Operators*. 
+
+. Select *All Projects* in the  *Project* dropdown at the top of the screen.
+
+. Click *{ols-long} Operator*.
+
+. Click *OLSConfig*, then click the `cluster` configuration instance in the list.
+
+. Click the *YAML* tab.
+
+. Modify the `ols.Config` custom resource (CR) file to define a feature gate and the tools filtering configuration. 
++
+[source,yaml]
+----
+apiVersion: ols.openshift.io/v1alpha1
+kind: OLSConfig
+metadata:
+  name: cluster
+spec:
+  featureGates:
+    - ToolFiltering
+  olsConfig:
+    toolFilteringConfig:
+      alpha: 0.8     
+      topK: 10        
+      threshold: 0.01 
+----
++
+* `spec.featureGates.ToolFilter` specifies the feature gate.
+
+* `spec.olsConfig.toolFilteringConfig.alpha` specifies the weight balance between semantic (RAG-based) and keyword matching. Increasing the value provides more weight to the semantic search. The valid range of values is `0` to `1`.
+
+* `spec.olsConfig.toolFilteringConfig.topk` specifies the maximum number of tools available for the LLM.
+
+* `spec.olsConfig.toolFilteringConfig.threshold` specifies the minimum score for the tool to be considered as a candidate. Tools with a value of the score lower then the threshold value are discarded. Increasing the value discards more tools. The valid range of values is `0.01` to `0.1`.
++
+[NOTE]
+====
+This example uses the default values for the `alpha`, `tpok` and `threshold` fields. If you use the default values in your configuration you do not have to specify them.
+====
+
+. Click *Save*.
+
+.Verification
+
+. Navigate to the {ocp-product-title} web console. 
+
+. Select *Workloads* -> *Pods* and then click the pod that contains {ols-long}.
+
+. Click *Logs* and confirm that the log displays RAG information.


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2615

Link to docs preview:
https://106597--ocpdocs-pr.netlify.app/openshift-lightspeed/latest/configure/ols-configuring-openshift-lightspeed.html#ols-about-tools-filtering_ols-configuring-openshift-lightspeed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
