### PR TITLE
Update usage for selinuxprofiles

### DIFF
--- a/modules/spo-applying-profiles.adoc
+++ b/modules/spo-applying-profiles.adoc
@@ -149,7 +149,7 @@ $ oc get selinuxprofile.security-profiles-operator.x-k8s.io/nginx-secure -ojsonp
 .Example output
 [source,terminal]
 ----
-nginx-secure_.process
+nginx-secure.process
 ----
 
 . Apply the output string in the workload manifest in the `.spec.containers[].securityContext.seLinuxOptions` attribute:
@@ -175,7 +175,7 @@ spec:
           drop: [ALL]
         seLinuxOptions:
           # NOTE: This uses an appropriate SELinux type
-          type: nginx-secure_.process
+          type: nginx-secure.process
 ----
 +
 [IMPORTANT]

--- a/modules/spo-binding-workloads.adoc
+++ b/modules/spo-binding-workloads.adoc
@@ -106,7 +106,7 @@ $ oc get pod test-pod -o jsonpath='{.spec.containers[*].securityContext.seLinuxO
 .Example output
 [source,terminal]
 ----
-profile_.process
+profile.process
 ----
 endif::[]
 

--- a/modules/spo-container-profile-instances.adoc
+++ b/modules/spo-container-profile-instances.adoc
@@ -104,8 +104,8 @@ ifdef::selinux[]
 .Example output for {object}
 [source,terminal]
 ----
-NAME                          USAGE                                  STATE
-test-recording-nginx-record   test-recording-nginx-record_.process   Installed
+NAME                          USAGE                            STATE
+test-recording-nginx-record   test-recording-nginx-record.process   Installed
 ----
 endif::[]
 ifdef::seccomp[]

--- a/modules/spo-creating-profiles.adoc
+++ b/modules/spo-creating-profiles.adoc
@@ -119,15 +119,15 @@ $ oc -n openshift-security-profiles rsh -c selinuxd ds/spod
 +
 [source,terminal]
 ----
-$ cat /etc/selinux.d/nginx-secure_.cil
+$ cat /etc/selinux.d/nginx-secure.cil
 ----
 +
 .Example output
 [source,terminal]
 ----
-(block nginx-secure_
+(block nginx-secure
 (blockinherit container)
-(allow process nginx-secure_.process ( tcp_socket ( listen )))
+(allow process nginx-secure.process ( tcp_socket ( listen )))
 (allow process http_cache_port_t ( tcp_socket ( name_bind )))
 (allow process node_t ( tcp_socket ( node_bind )))
 )
@@ -143,7 +143,7 @@ $ semodule -l | grep nginx-secure
 .Example output
 [source,terminal]
 ----
-nginx-secure_
+nginx-secure
 ----
 endif::[]
 

--- a/modules/spo-recording-profiles.adoc
+++ b/modules/spo-recording-profiles.adoc
@@ -173,9 +173,9 @@ $ oc get selinuxprofiles -lspo.x-k8s.io/recording-id=test-recording
 .Example output for selinuxprofile
 [source,terminal]
 ----
-NAME                   USAGE                                       STATE
-test-recording-nginx   test-recording-nginx_.process   Installed
-test-recording-redis   test-recording-redis_.process   Installed
+NAME                   USAGE                                 STATE
+test-recording-nginx   test-recording-nginx.process   Installed
+test-recording-redis   test-recording-redis.process   Installed
 ----
 endif::[]
 

--- a/modules/spo-replicating-controllers.adoc
+++ b/modules/spo-replicating-controllers.adoc
@@ -93,7 +93,7 @@ spec:
       serviceAccountName: spo-deploy-test
       securityContext:
         seLinuxOptions:
-          type: nginx-secure_.process <1>
+          type: nginx-secure.process <1>
       containers:
       - name: nginx-unpriv
         image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14-4.22

Issue:
This PR means to adapt the change upstream http://github.com/kubernetes-sigs/security-profiles-operator/pull/2746, which included in SPOv0.10.0.

Link to docs preview:
https://106598--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-seccomp.html
https://106598--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-selinux.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
