### PR TITLE
OSSM-11573 [DOC] Document minimal disruption upgrade steps

### DIFF
--- a/modules/ossm-about-update-strategies-in-ambient-mode.adoc
+++ b/modules/ossm-about-update-strategies-in-ambient-mode.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+
+// update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-about-update-strategies-in-ambient-mode_{context}"]
+= About the update strategies in ambient mode
+
+[role="_abstract"]
+
+In ambient mode, components update directly through `InPlace` updates. Unlike sidecar mode, ambient mode allows you to move application pods to an upgraded ztunnel proxy without restarting or rescheduling the pods.
+
+Update sequence:: To update in ambient mode, use the following sequence:
+
+.. {istio} control plane: Update the patch version in the {istio} resource.
+
+.. {istio} CNI: Update to the same patch version as the control plane.
+
+.. ZTunnel: Update to the same patch version as the control plane.

--- a/modules/ossm-configuring-ztunnel-grace-period.adoc
+++ b/modules/ossm-configuring-ztunnel-grace-period.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+
+// update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-configuring-ztunnel-grace-period_{context}"]
+= Configuring the Ztunnel termination grace period
+
+[role="_abstract"]
+
+Configure a high termination grace period in the `ZTunnel` custom resource (CR) for the application pods to ensure that active connections close gracefully during a rolling update. 
+
+.Procedure
+
+* Update the `terminationGracePeriodSeconds` value in the `ZTunnel` CR to a higher value similar to the following example:
++
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: {istio-latest}
+  namespace: ztunnel
+  values:
+    ztunnel:
+      terminationGracePeriodSeconds: 300
+----
+

--- a/modules/ossm-updating-ztunnel-with-node-draining.adoc
+++ b/modules/ossm-updating-ztunnel-with-node-draining.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+
+// update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-updating-ztunnel-with-node-draining_{context}"]
+= Updating Ztunnel using node draining
+
+[role="_abstract"]
+
+Drain nodes to force long-lived TCP connections to reconnect through a new `Ztunnel` instance, without risking traffic loss because the node is empty during the proxy swap.
+
+.Procedure
+
+. Configure the `OnDelete` update strategy in the `ZTunnel` custom resource (CR) to need manual pod deletion before the update to the new version starts, similar to the following example:
++
+[source,yaml,subs="attributes,verbatim"]
+----
+apiVersion: sailoperator.io/v1
+kind: ZTunnel
+metadata:
+  name: default
+spec:
+  version: {istio-latest}
+  namespace: ztunnel
+  values:
+    ztunnel:
+      updateStrategy:
+        type: OnDelete
+----
+
+. Update the `version` field in the `ZTunnel` CR to the target version.
+
+. Drain a node to force all applications to move to other nodes, allowing their long-lived connections to close gracefully based on their `terminationGracePeriodSeconds`.
+
+. Delete the old `Ztunnel` pod on the empty node and wait for the new pod to start.
+
+. Mark the node as `schedulable`. Applications that return to the node will automatically use the new Ztunnel.
+
+. Repeat steps 3 through 5 for all remaining nodes in the cluster.

--- a/modules/ossm-ztunnel-update-lifecycle.adoc
+++ b/modules/ossm-ztunnel-update-lifecycle.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+
+// update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-ztunnel-update-lifecycle_{context}"]
+= About Ztunnel update lifecycle
+
+[role="_abstract"]
+
+Understand the Ztunnel rolling update process, and how the process affects connection persistence during a proxy restart.
+
+Ztunnel operates at Layer 4 (L4) of the Open Systems Interconnection (OSI) model and proxies TCP traffic. Ztunnel cannot transfer connection states to another process. Upgrading the Ztunnel DaemonSet affects all traffic on at least one node at a time.
+
+Ztunnel operates at Layer 4 (L4) of the Open Systems Interconnection (OSI) model and proxies TCP traffic. Ztunnel cannot transfer connection states to another process.  Upgrading the Ztunnel DaemonSet affects all traffic on at least one node at a time. By default, the Ztunnel DaemonSet uses a `RollingUpdate` strategy. During a restart, each node goes through the following phases:
+
+* Startup: A new `Ztunnel` pod starts on the node while the old pod continues running.
+
+* Readiness: The new `Ztunnel` establishes listeners in each pod on the node and marks itself as ready. For a brief period, both instances run simultaneously, and new connections may be handled by either one.
+
+* Draining: {k8s} sends a `SIGTERM` to the old `Ztunnel`, which begins the draining process. The old instance closes its listeners so that only the new `Ztunnel` accepts new connections. At all times, at least one `Ztunnel` remains available to handle incoming connections.
+
+* Connection processing: The old Ztunnel continues processing existing connections until the `terminationGracePeriodSeconds` expires.
+
+* Termination: Once the `terminationGracePeriodSeconds` expires, the old `Ztunnel` forcefully terminates any remaining connections.

--- a/update/ossm-about-updating-openshift-service-mesh.adoc
+++ b/update/ossm-about-updating-openshift-service-mesh.adoc
@@ -24,6 +24,8 @@ include::modules/ossm-about-istio-update-process.adoc[leveloffset=+2]
 [id="additional-resources-ossm-about-updating-openshift-service-mesh_{context}"]
 == Additional resources
 
+* xref:../update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc#ossm-updating-openshift-service-mesh-in-ambient-mode[Updating OpenShift Service Mesh in ambient mode]
+
 * xref:../ossm-release-notes/ossm-release-notes-feature-support-tables.adoc#ossm-release-notes-feature-support-tables[{SMProductShortName} {SMProductVersion} feature support tables]
 
 * xref:../ossm-release-notes/ossm-release-notes-version-support-tables.adoc#ossm-release-notes-version-support-tables[Service Mesh version support tables]

--- a/update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
+++ b/update/ossm-updating-openshift-service-mesh-in-ambient-mode.adoc
@@ -10,6 +10,8 @@ toc::[]
 
 Update {SMProductName} in ambient mode by transitioning the control plane and waypoint proxies to new revisions while maintaining Layer 7 (L7) functionality and resource compatibility.
 
+include::modules/ossm-about-update-strategies-in-ambient-mode.adoc[leveloffset=+1]
+
 include::modules/ossm-updating-waypoint-proxies-with-inplace-strategy.adoc[leveloffset=+1]
 
 include::modules/ossm-updating-waypoint-proxies-with-revisionbased-strategy.adoc[leveloffset=+1]
@@ -19,6 +21,12 @@ include::modules/ossm-verifying-l7-features-with-traffic-routing.adoc[leveloffse
 include::modules/ossm-verifying-l7-features-with-authorization-policies.adoc[leveloffset=+1]
 
 include::modules/ossm-updating-cross-namespace-waypoint.adoc[leveloffset=+1]
+
+include::modules/ossm-ztunnel-update-lifecycle.adoc[leveloffset=+1]
+
+include::modules/ossm-configuring-ztunnel-grace-period.adoc[leveloffset=+2]
+
+include::modules/ossm-updating-ztunnel-with-node-draining.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 [id="additional-resources-ossm-updating-openshift-service-mesh-in-ambient-mode_{context}"]


### PR DESCRIPTION
Change type: Doc update; Document minimal disruption upgrade steps

Doc JIRA: https://issues.redhat.com/browse/OSSM-11573

Fix Version:

- [service-mesh-docs-main](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-main)
- [service-mesh-docs-3.3](https://github.com/openshift/openshift-docs/tree/service-mesh-docs-3.3)

Doc Preview:

- Update strategies: https://106600--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/update/ossm-updating-openshift-service-mesh-in-ambient-mode#ossm-about-update-strategies-in-ambient-mode_ossm-updating-openshift-service-mesh-in-ambient-mode
- Ztunnel-related changes: https://106600--ocpdocs-pr.netlify.app/openshift-service-mesh/latest/update/ossm-updating-openshift-service-mesh-in-ambient-mode#ossm-ztunnel-update-lifecycle_ossm-updating-openshift-service-mesh-in-ambient-mode

SME/QE review: @fjglira @sridhargaddam @FilipB 
Peer Review: @rh-tokeefe 