### PR TITLE
TELCODOCS#2570-420: kbase article URL updated for 4.20

### DIFF
--- a/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
+++ b/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
@@ -12,7 +12,7 @@ Specific limits, requirements and engineering considerations for individual comp
 
 [NOTE]
 ====
-For details of the telco RAN DU RDS KPI test results, see the link:https://access.redhat.com/articles/7107302[telco RAN DU {product-version} reference design specification KPI test results].
+For details of the telco RAN DU RDS KPI test results, see the link:https://access.redhat.com/articles/7137863[telco RAN DU {product-version} reference design specification KPI test results].
 This information is only available to customers and partners.
 ====
 
@@ -48,8 +48,8 @@ Supported cluster topologies for RAN DU::
 |Architecture
 |SNO
 |SNO+1
-|3-node 
-|Standard 
+|3-node
+|Standard
 |RWN
 
 |x86_64
@@ -70,7 +70,7 @@ Supported cluster topologies for RAN DU::
 |N/A
 |No
 |No
-|Yes 
+|Yes
 |No
 
 |===


### PR DESCRIPTION
[TELCODOCS#2570]: kbase article URL updated for 4.20

Version(s): 4.20

Issue: [TELCODOCS-2570](https://issues.redhat.com/browse/TELCODOCS-2570)

Link to docs preview: [Engineering considerations for the RAN DU use model](https://106603--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#telco-ran-engineering-considerations-for-the-ran-du-use-model_telco-ran-du)
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Small URL fix. NO QE approval needed.

