### PR TITLE
TELCODOCS#2570-419: kbase article URL updated for 4.19

### DIFF
--- a/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
+++ b/modules/telco-ran-engineering-considerations-for-the-ran-du-use-model.adoc
@@ -12,7 +12,7 @@ Specific limits, requirements and engineering considerations for individual comp
 
 [NOTE]
 ====
-For details of the telco RAN DU RDS KPI test results, see the link:https://access.redhat.com/articles/7107302[telco RAN DU {product-version} reference design specification KPI test results].
+For details of the telco RAN DU RDS KPI test results, see the link:https://access.redhat.com/articles/7137862[telco RAN DU {product-version} reference design specification KPI test results].
 This information is only available to customers and partners.
 ====
 


### PR DESCRIPTION
[TELCODOCS#2570]: kbase article URL updated for 4.19

Version(s): 4.19

Issue:  [TELCODOCS-2570](https://issues.redhat.com/browse/TELCODOCS-2570)

Link to docs preview: [Engineering considerations for the RAN DU use model](https://106604--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/telco-ran-du-rds.html#telco-ran-engineering-considerations-for-the-ran-du-use-model_telco-ran-du)

QE review:
- [ ] QE has approved this change.


Additional information: Small URL fix. NO QE approval needed.

