### PR TITLE
OCPBUGS-76940: updating MC snippet for chrony fix

### DIFF
--- a/snippets/ztp_99-sync-time-once-master.yaml
+++ b/snippets/ztp_99-sync-time-once-master.yaml
@@ -20,10 +20,10 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=300
-            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: sync-time-once.service
+          name: chrony-wait.service
+          

--- a/snippets/ztp_99-sync-time-once-worker.yaml
+++ b/snippets/ztp_99-sync-time-once-worker.yaml
@@ -20,10 +20,10 @@ spec:
             [Service]
             Type=oneshot
             TimeoutStartSec=300
-            ExecCondition=/bin/bash -c 'systemctl is-enabled chronyd.service --quiet && exit 1 || exit 0'
             ExecStart=/usr/sbin/chronyd -n -f /etc/chrony.conf -q
             RemainAfterExit=yes
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: sync-time-once.service
+          name: chrony-wait.service
+          


### PR DESCRIPTION
OCPBUGS-76940: updating MC snippet for chrony fix

Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/OCPBUGS-76940

Link to docs preview:
https://106605--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-reference-cluster-configuration-for-vdu#ztp-sno-du-configuring-time-sync_sno-configure-for-vdu

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
