### PR TITLE
OADP-7434: Add OADP 1.4.8 RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -46,9 +46,9 @@ endif::[]
 :oadp-first: OpenShift API for Data Protection (OADP)
 :oadp-full: OpenShift API for Data Protection
 :oadp-short: OADP
-:oadp-version: 1.4.7
+:oadp-version: 1.4.8
 :oadp-version-1-3: 1.3.8
-:oadp-version-1-4: 1.4.7
+:oadp-version-1-4: 1.4.8
 :oadp-bsl-api: backupstoragelocations.velero.io
 :velero-overview: link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]
 :velero-link: link:https://{velero-domain}/docs/v{velero-version}/[Velero {velero-version}]

--- a/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
@@ -15,6 +15,8 @@ The release notes for {oadp-first} describe new features and enhancements, depre
 For additional information about {oadp-short}, see link:https://access.redhat.com/articles/5456281[{oadp-first} FAQs]
 ====
 
+include::modules/oadp-1-4-8-release-notes.adoc[leveloffset=+1]
+
 include::modules/oadp-1-4-7-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-6-release-notes.adoc[leveloffset=+1]
 include::modules/oadp-1-4-5-release-notes.adoc[leveloffset=+1]

--- a/modules/oadp-1-4-8-release-notes.adoc
+++ b/modules/oadp-1-4-8-release-notes.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+
+[id="oadp-1-4-8-release-notes_{context}"]
+= {oadp-short} 1.4.8 release notes
+
+[role="_abstract"]
+{oadp-first} 1.4.8 is a Container Grade Only (CGO) release, which is released to refresh the health grades of the containers. No code was changed in the product itself compared to that of {oadp-short} 1.4.7. {oadp-short} 1.4.8 fixes several Common Vulnerabilities and Exposures (CVEs).
+
+
+[id="resolved-issues-1-4-8_{context}"]
+== Resolved issues
+
+{oadp-short} 1.4.8 fixes the following CVEs::
+
+* link:https://access.redhat.com/security/cve/cve-2025-47907[CVE-2025-47907]
+
+* link:https://access.redhat.com/security/cve/cve-2025-52881[CVE-2025-52881]
+
+* link:https://access.redhat.com/security/cve/cve-2025-61729[CVE-2025-61729]


### PR DESCRIPTION
Version(s):
OCP 4.14-4.18

Issue:
[OADP-7434](https://issues.redhat.com/browse/OADP-7434)

Link to docs preview:

- [OADP 1.4.8 release notes](https://106609--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/release-notes/oadp-1-4-release-notes.html#oadp-1-4-8-release-notes_oadp-1-4-release-notes)

QE review:
- [x] QE has approved this change.

Changes:

- Add OADP 1.4.8 Release Notes and change attributes.