### PR TITLE
[OSDOCS#17444]Fix acronyms for Prepare you environment

### DIFF
--- a/modules/rosa-sts-aws-requirements-account.adoc
+++ b/modules/rosa-sts-aws-requirements-account.adoc
@@ -9,6 +9,6 @@
 You must have an AWS account with the following considerations to deploy a {product-title} cluster.
 
 * Your AWS account must allow sufficient quota to deploy your cluster.
-* If your organization applies and enforces SCP policies, these policies must not be more restrictive than the roles and policies required by the cluster.
+* If your organization applies and enforces service control policies (SCPs), these policies must not be more restrictive than the roles and policies required by the cluster.
 * You can deploy native AWS services within the same AWS account.
 * Your account must have a service-linked role to allow the installation program to configure Elastic Load Balancing (ELB). See "Creating the Elastic Load Balancing (ELB) service-linked role" for more information.

--- a/modules/rosa-sts-policy-iam.adoc
+++ b/modules/rosa-sts-policy-iam.adoc
@@ -8,8 +8,8 @@
 
 [role="_abstract"]
 ifndef::openshift-rosa-hcp[]
-When you use STS as your cluster credential method,
+When you use Security Token Service (STS) as your cluster credential method,
 endif::openshift-rosa-hcp[]
-Red{nbsp}Hat is not responsible for creating and managing Amazon Web Services (AWS) IAM policies, IAM users, or IAM roles. For information on creating these roles and policies, see the following sections on IAM roles.
+Red{nbsp}Hat is not responsible for creating and managing Amazon Web Services (AWS) identity and access management (IAM) policies, IAM users, or IAM roles. For information on creating these roles and policies, see the following sections on IAM roles.
 
 * To use the `ocm` CLI, you must have an `ocm-role` and `user-role` resource.


### PR DESCRIPTION
Version(s):
4.20+

Issue:
https://issues.redhat.com/browse/OSDOCS-17444

Link to docs preview:
[ROSA HCP - Detailed requirements for deploying ROSA](https://106629--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/rosa_planning/rosa-sts-aws-prereqs.html#rosa-account_rosa-hcp-prereqs)
[ROSA Classic - Detailed requirements for deploying ROSA classic architecture](https://106629--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#rosa-account_rosa-sts-aws-prereqs)
[ROSA Classic - Ret Hat managed IAM references for AWS](https://106629--ocpdocs-pr.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#rosa-sts-policy-iam_rosa-sts-aws-prereqs)

Peer review:
- [x] Peer reviewer has approved this change.

QE review:
- QE approval not required for this PR.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
