### PR TITLE
CNV-74970: fix callouts for DITA migration

### DIFF
--- a/modules/virt-attaching-vm-to-secondary-udn.adoc
+++ b/modules/virt-attaching-vm-to-secondary-udn.adoc
@@ -10,9 +10,11 @@
 You can connect a virtual machine (VM) to multiple secondary cluster-scoped user-defined networks (CUDNs) by configuring the interface binding.
 
 .Prerequisites
+
 * You have installed the {oc-first}.
 
 .Procedure
+
 . Edit the `VirtualMachine` manifest to add the CUDN interface details, as in the following example:
 +
 [source,yaml]
@@ -40,13 +42,10 @@ spec:
         multus:
           networkName: <localnet_cudn_name>
 ----
-+
-where:
-
-`metadata.namespace`:: Specifies the namespace in which the VM is located. This value must match a namespace that is associated with the secondary CUDN.
-`spec.template.spec.domain.devices.interfaces.name`:: Specifies the name of the secondary user-defined network interface.
-`spec.template.spec.networks.name`:: Specifies the name of the network. This value must match the value of the `spec.template.spec.domain.devices.interfaces.name` field.
-`spec.template.spec.networks.multus.networkName`:: Specifies the name of the localnet `ClusterUserDefinedNetwork` object that you previously created.
+** `metadata.namespace` specifies the namespace in which the VM is located. This value must match a namespace that is associated with the secondary CUDN.
+** `spec.template.spec.domain.devices.interfaces.name` specifies the name of the secondary user-defined network interface.
+** `spec.template.spec.networks.name` specifies the name of the network. This value must match the value of the `spec.template.spec.domain.devices.interfaces.name` field.
+** `spec.template.spec.networks.multus.networkName` specifies the name of the localnet `ClusterUserDefinedNetwork` object that you previously created.
 
 . Apply the `VirtualMachine` manifest by running the following command:
 +
@@ -56,8 +55,8 @@ $ oc apply -f <filename>.yaml
 ----
 +
 where:
-
-<filename>:: Specifies the name of your `VirtualMachine` manifest YAML file.
++
+`<filename>`:: Specifies the name of your `VirtualMachine` manifest YAML file.
 +
 [NOTE]
 ====

--- a/modules/virt-creating-rbac-cloning-dvs.adoc
+++ b/modules/virt-creating-rbac-cloning-dvs.adoc
@@ -12,7 +12,6 @@ You can create a new cluster role that enables permissions for all actions for t
 .Prerequisites
 
 * You have installed the {oc-first}.
-
 * You must have cluster admin privileges.
 
 [NOTE]
@@ -29,21 +28,28 @@ If you are a non-admin user that is an administrator for both the source and tar
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: <datavolume-cloner> <1>
+  name: <datavolume_cloner>
 rules:
 - apiGroups: ["cdi.kubevirt.io"]
   resources: ["datavolumes/source"]
   verbs: ["*"]
+# ...
 ----
-<1> Unique name for the cluster role.
++
+where:
++
+`<datavolume_cloner>`:: Specifies a unique name for the cluster role.
 
 . Create the cluster role in the cluster:
 +
 [source,terminal]
 ----
-$ oc create -f <datavolume-cloner.yaml> <1>
+$ oc create -f <datavolume_cloner.yaml>
 ----
-<1> The file name of the `ClusterRole` manifest created in the previous step.
++
+where:
++
+`<datavolume_cloner.yaml>`:: Specifies the file name of the `ClusterRole` manifest created in the previous step.
 
 . Create a `RoleBinding` manifest that applies to both the source and destination namespaces and references
 the cluster role created in the previous step.
@@ -53,26 +59,29 @@ the cluster role created in the previous step.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: <allow-clone-to-user> <1>
-  namespace: <Source namespace> <2>
+  name: <allow_clone_to_user>
+  namespace: <source_namespace>
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: <Destination namespace> <3>
+  namespace: <destination_namespace>
 roleRef:
   kind: ClusterRole
-  name: datavolume-cloner <4>
+  name: datavolume-cloner
   apiGroup: rbac.authorization.k8s.io
 ----
-<1> Unique name for the role binding.
-<2> The namespace for the source data volume.
-<3> The namespace to which the data volume is cloned.
-<4> The name of the cluster role created in the previous step.
+** `metadata.name` specifies a unique name for the role binding.
+** `metadata.namespace` specifies the namespace for the source data volume.
+** `subjects.namespace` specifies the namespace to which the data volume is cloned.
+** `roleRef.name` specifies the name of the cluster role created in the previous step.
 
 . Create the role binding in the cluster:
 +
 [source,terminal]
 ----
-$ oc create -f <datavolume-cloner.yaml> <1>
+$ oc create -f <datavolume_cloner.yaml>
 ----
-<1> The file name of the `RoleBinding` manifest created in the previous step.
++
+where:
++
+`<datavolume_cloner.yaml>`:: Specifies the file name of the `RoleBinding` manifest created in the previous step.

--- a/modules/virt-creating-secondary-localnet-udn.adoc
+++ b/modules/virt-creating-secondary-localnet-udn.adoc
@@ -1,20 +1,22 @@
 // Module included in the following assemblies:
 //
-// * virt/vm_networking/virt-connecting-vm-to-secondary-udn.adoc        
+// * virt/vm_networking/virt-connecting-vm-to-secondary-udn.adoc
 
-:_mod-docs-content-type: PROCEDURE                                  
-[id="virt-creating-secondary-localnet-udn_{context}"]                                  
+:_mod-docs-content-type: PROCEDURE
+[id="virt-creating-secondary-localnet-udn_{context}"]
 = Creating a user-defined-network for localnet topology by using the CLI
 
 [role="_abstract"]
 You can create a secondary cluster-scoped user-defined-network (CUDN) for the localnet network topology by using the CLI.
 
 .Prerequisites
+
 * You are logged in to the cluster as a user with `cluster-admin` privileges.
 * You have installed the {oc-first}.
 * You installed the Kubernetes NMState Operator.
 
 .Procedure
+
 . Create a `NodeNetworkConfigurationPolicy` object to map the OVN-Kubernetes secondary network to an Open vSwitch (OVS) bridge.
 +
 Example `NodeNetworkConfigurationPolicy` manifest:
@@ -24,22 +26,22 @@ Example `NodeNetworkConfigurationPolicy` manifest:
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: mapping # <1>
+  name: mapping
 spec:
   nodeSelector:
-    node-role.kubernetes.io/worker: '' # <2>
+    node-role.kubernetes.io/worker: ''
   desiredState:
     ovn:
       bridge-mappings:
-      - localnet: localnet1 # <3>
-        bridge: br-ex # <4>
-        state: present # <5>
+      - localnet: localnet1
+        bridge: br-ex
+        state: present
 ----
-<1> The name of the configuration object.
-<2> Specifies the nodes to which the node network configuration policy is applied. The recommended node selector value is `node-role.kubernetes.io/worker: ''`.
-<3> The name of the additional network from which traffic is forwarded to the OVS bridge. This attribute must match the value of the `spec.network.localnet.physicalNetworkName` field of the `ClusterUserDefinedNetwork` object that defines the OVN-Kubernetes additional network. This example uses the name `localnet1`.
-<4> The name of the OVS bridge on the node. This value is required if the `state` attribute is `present` or not specified.
-<5> The state of the mapping. Must be either `present` to add the mapping or `absent` to remove the mapping. The default value is `present`.
+** `metadata.name` specifies the name of the configuration object.
+** `spec.nodeSelector` specifies the nodes to which the node network configuration policy is applied. The recommended node selector value is `node-role.kubernetes.io/worker: ''`.
+** `spec.desiredState.ovn.bridge-mappings.localnet` specifies the name of the additional network from which traffic is forwarded to the OVS bridge. This attribute must match the value of the `spec.network.localnet.physicalNetworkName` field of the `ClusterUserDefinedNetwork` object that defines the OVN-Kubernetes additional network. This example uses the name `localnet1`.
+** `spec.desiredState.ovn.bridge-mappings.bridge` specifies name of the OVS bridge on the node. This value is required if the `state` attribute is `present` or not specified.
+** `spec.desiredState.ovn.bridge-mappings.state` specifies the state of the mapping. Must be either `present` to add the mapping or `absent` to remove the mapping. The default value is `present`.
 +
 [IMPORTANT]
 ====
@@ -54,8 +56,8 @@ $ oc apply -f <filename>.yaml
 ----
 +
 where:
-
-<filename>:: Specifies the name of your `NodeNetworkConfigurationPolicy` manifest YAML file.
++
+`<filename>`:: Specifies the name of your `NodeNetworkConfigurationPolicy` manifest YAML file.
 
 . Create a `ClusterUserDefinedNetwork` object to create a localnet secondary network.
 +
@@ -66,30 +68,30 @@ Example `ClusterUserDefinedNetwork` manifest:
 apiVersion: k8s.ovn.org/v1
 kind: ClusterUserDefinedNetwork
 metadata:
-  name: cudn-localnet # <1>
+  name: cudn-localnet
 spec:
-  namespaceSelector: # <2>
-    matchExpressions: # <3>
+  namespaceSelector:
+    matchExpressions:
     - key: kubernetes.io/metadata.name
-      operator: In # <4>
+      operator: In
       values: ["red", "blue"]
   network:
-    topology: Localnet # <5>
+    topology: Localnet
     localnet:
-        role: Secondary # <6>
-        physicalNetworkName: localnet1 # <7>
+        role: Secondary
+        physicalNetworkName: localnet1
         ipam:
-          mode: Disabled # <8>
+          mode: Disabled
 # ...
 ----
-<1> The name of the `ClusterUserDefinedNetwork` custom resource.
-<2> The set of namespaces that the cluster UDN applies to. The namespace selector must not point to the following values: `default`; an `openshift-*` namespace; or any global namespaces that are defined by the Cluster Network Operator (CNO).
-<3> The type of selector. In this example, the `matchExpressions` selector selects objects that have the label `kubernetes.io/metadata.name` with the value `red` or `blue`.
-<4> The type of operator. Possible values are `In`, `NotIn`, and `Exists`.
-<5> The topological configuration of the network. A `Localnet` topology connects the logical network to the physical underlay.
-<6> Specifies whether the UDN is primary or secondary. The required value is `Secondary` for `topology: Localnet`.
-<7> The name of the OVN-Kubernetes bridge mapping that is configured on the node. This value must match the `spec.desiredState.ovn.bridge-mappings.localnet` field in the `NodeNetworkConfigurationPolicy` manifest that you previously created. This ensures that you are bridging to the intended segment of your physical network.
-<8> Specifies whether IP address management (IPAM) is enabled or disabled. The required value is `Disabled`. {VirtProductName} does not support configuring IPAM for virtual machines.
+** `metadata.name` specifies the name of the `ClusterUserDefinedNetwork` custom resource.
+** `spec.namespaceSelector` specifies a set of namespaces that the cluster UDN applies to. The namespace selector must not point to the following values: `default`; an `openshift-*` namespace; or any global namespaces that are defined by the Cluster Network Operator (CNO).
+** `spec.namespaceSelector.matchExpressions` specifies the type of selector. In this example, the `matchExpressions` selector selects objects that have the label `kubernetes.io/metadata.name` with the value `red` or `blue`.
+** `spec.namespaceSelector.matchExpressions.operator` specifies the type of operator. Possible values are `In`, `NotIn`, and `Exists`.
+** `spec.network.topology` specifies the topological configuration of the network. A `Localnet` topology connects the logical network to the physical underlay.
+** `spec.network.localnet.role` specifies whether the UDN is primary or secondary. The required value is `Secondary` for `topology: Localnet`.
+** `spec.network.localnet.physicalNetworkName` specifies the name of the OVN-Kubernetes bridge mapping that is configured on the node. This value must match the `spec.desiredState.ovn.bridge-mappings.localnet` field in the `NodeNetworkConfigurationPolicy` manifest that you previously created. This ensures that you are bridging to the intended segment of your physical network.
+** `spec.network.localnet.ipam.mode` specifies whether IP address management (IPAM) is enabled or disabled. The required value is `Disabled`. {VirtProductName} does not support configuring IPAM for virtual machines.
 
 . Apply the `ClusterUserDefinedNetwork` manifest by running the following command:
 +
@@ -99,7 +101,5 @@ $ oc apply -f <filename>.yaml
 ----
 +
 where:
-
-<filename>:: Specifies the name of your `ClusterUserDefinedNetwork` manifest YAML file.
-
-
++
+`<filename>`:: Specifies the name of your `ClusterUserDefinedNetwork` manifest YAML file.

--- a/modules/virt-creating-secondary-udn-namespace.adoc
+++ b/modules/virt-creating-secondary-udn-namespace.adoc
@@ -1,18 +1,18 @@
 // Module included in the following assemblies:
 //
-// * virt/vm_networking/virt-connecting-vm-to-secondary-udn.adoc              
+// * virt/vm_networking/virt-connecting-vm-to-secondary-udn.adoc
 
-:_mod-docs-content-type: PROCEDURE                                    
-[id="virt-creating-secondary-udn-namespace_{context}"]                                   
+:_mod-docs-content-type: PROCEDURE
+[id="virt-creating-secondary-udn-namespace_{context}"]
 = Creating a namespace for secondary user-defined networks by using the CLI
 
 [role="_abstract"]
 You can create a namespace to be used with an existing secondary cluster-scoped user-defined network (CUDN) by using the CLI.
 
 .Prerequisites
+
 * You are logged in to the cluster as a user with `cluster-admin` permissions.
 * You have installed the {oc-first}.
-
 
 .Procedure
 . Create a `Namespace` object similar to the following example:
@@ -34,5 +34,5 @@ oc apply -f <filename>.yaml
 ----
 +
 where:
-
-<filename>:: Specifies the name of your `Namespace` manifest YAML file.
++
+`<filename>`:: Specifies the name of your `Namespace` manifest YAML file.


### PR DESCRIPTION
Version(s):
4.18+

Issue:
https://issues.redhat.com/browse/CNV-74970

Link to docs preview:
- https://106645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/storage/virt-enabling-user-permissions-to-clone-datavolumes.html#virt-creating-rbac-cloning-dvs_virt-enabling-user-permissions-to-clone-datavolumes
- https://106645--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-secondary-udn.html

QE review:
N/A formatting update only

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
