### PR TITLE
OSDOCS-17917: OVE ISO preconfig

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-ove.adoc
+++ b/installing/installing_with_agent_based_installer/installing-ove.adoc
@@ -36,7 +36,6 @@ include::modules/installing-ove-console-final.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-dns-none_preparing-to-install-with-agent-based-installer[Platform "none" DNS requirements]
-* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-load-balancing-none_preparing-to-install-with-agent-based-installer[Platform "none" Load balancing requirements]
 * xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#installing-virtctl_virt-using-the-cli-tools[Installing virtctl]
 * xref:../../virt/creating_vm/virt-creating-vms-from-instance-types.adoc#virt-creating-vms-from-instance-types[Creating virtual machines from instance types]
 * xref:../../virt/creating_vm/virt-creating-vms-from-templates.adoc#virt-creating-vms-from-templates[Creating virtual machines from templates]

--- a/installing/installing_with_agent_based_installer/installing-ove.adoc
+++ b/installing/installing_with_agent_based_installer/installing-ove.adoc
@@ -11,7 +11,7 @@ You can deploy an {product-title} cluster without the need for an external image
 
 Although the method supports general clusters, the downloaded media contains an Operator bundle that is curated specifically for {ove-first}, meaning additional Operators must be retrieved separately if required for other use cases.
 
-:FeatureName: Installing an {ove} cluster using this method
+:FeatureName: Installing a cluster without an external registry
 include::snippets/technology-preview.adoc[]
 
 include::modules/installing-ove-advantages.adoc[leveloffset=+1]
@@ -35,6 +35,8 @@ include::modules/installing-ove-console-final.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-dns-none_preparing-to-install-with-agent-based-installer[Platform "none" DNS requirements]
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-load-balancing-none_preparing-to-install-with-agent-based-installer[Platform "none" Load balancing requirements]
 * xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#installing-virtctl_virt-using-the-cli-tools[Installing virtctl]
 * xref:../../virt/creating_vm/virt-creating-vms-from-instance-types.adoc#virt-creating-vms-from-instance-types[Creating virtual machines from instance types]
 * xref:../../virt/creating_vm/virt-creating-vms-from-templates.adoc#virt-creating-vms-from-templates[Creating virtual machines from templates]

--- a/modules/installing-ove-console-final.adoc
+++ b/modules/installing-ove-console-final.adoc
@@ -19,6 +19,12 @@ You can add as many hosts as you want to your cluster.
 However, at this stage, you must at least have enough available hosts to match the value you specified in the *Number of control plane nodes* field of the installation console's *Cluster details* page.
 ====
 
+* You have created DNS records for the Kubernetes API (`api.<cluster_name>.<base_domain>` and `api-int.<cluster_name>.<base_domain>`).
+For more information, see "Platform "none" DNS requirements".
+
+* You have configured port 22623 to allow internal traffic between nodes.
+For more information, see "Platform "none" Load balancing requirements".
+
 .Procedure
 
 . On the installation console hosted by the rendezvous node, configure the hosts in the *Host discovery* page:

--- a/modules/installing-ove-console-final.adoc
+++ b/modules/installing-ove-console-final.adoc
@@ -22,8 +22,7 @@ However, at this stage, you must at least have enough available hosts to match t
 * You have created DNS records for the Kubernetes API (`api.<cluster_name>.<base_domain>` and `api-int.<cluster_name>.<base_domain>`).
 For more information, see "Platform "none" DNS requirements".
 
-* You have configured port 22623 to allow internal traffic between nodes.
-For more information, see "Platform "none" Load balancing requirements".
+* You have configured port 22625 to allow internal traffic between nodes.
 
 .Procedure
 

--- a/modules/installing-ove-iso.adoc
+++ b/modules/installing-ove-iso.adoc
@@ -39,8 +39,6 @@ The size of the ISO image can vary depending on the release you select.
 
 .. Upload a SSH public key in the *SSH public key* field.
 
-.. Select *Edit pull secret* and add a pull secret to the field that appears.
-
 .. Select *Configure proxy settings* and provide proxy details to the fields that appear.
 
 .. Select *Add your own NTP (Network Time Protocol) sources* and add NTP sources to the field that appears.

--- a/modules/installing-ove-iso.adoc
+++ b/modules/installing-ove-iso.adoc
@@ -45,6 +45,33 @@ The size of the ISO image can vary depending on the release you select.
 
 .. Select *Add your own NTP (Network Time Protocol) sources* and add NTP sources to the field that appears.
 
+.. Select a network configuration option in the *Hosts' network configuration* section.
+*DHCP only* is selected by default.
+
 . Click *Next*.
+
+. If you selected static networking, configure your network details in the *Static network configurations* page using one of the two views:
+
+** Configure details via the form view:
+
+... Select *Form view* and complete the fields in the *Network-wide configurations* section.
+
+... Click *Next*.
+
+... Complete the fields for *Host 1* in the *Host specific configurations* section.
+
+... For each additional host, click *Add another host configuration* and complete the fields for the host.
+
+... Click *Next*.
+
+** Configure details via the YAML view:
+
+... Select *YAML view*.
+
+... Upload a YAML file for *Host 1* and enter details in the *MAC to interface name mapping* section.
+
+... For each additional host, click *Add another host configuration* and repeat the configuration process for the host. You can select the *Copy the YAML content* checkbox to reuse the YAML file from the previous host.
+
+... Click *Next*.
 
 . Click *Download ISO*.

--- a/modules/installing-ove-iso.adoc
+++ b/modules/installing-ove-iso.adoc
@@ -29,6 +29,22 @@ The size of the ISO image can vary depending on the release you select.
 
 . In the *Cluster details* page, select the toggle for "I'm installing on a disconnected/air-gapped/secured environment".
 
+. Select an {product-title} version in the *OpenShift version* dropdown menu.
+
+. Click *Next*.
+
+. Optional: Preconfigure the ISO on the *Optional configurations* page:
+
+.. Enter the Rendezvous IP in the *Rendezvous IP* field.
+
+.. Upload a SSH public key in the *SSH public key* field.
+
+.. Select *Edit pull secret* and add a pull secret to the field that appears.
+
+.. Select *Configure proxy settings* and provide proxy details to the fields that appear.
+
+.. Select *Add your own NTP (Network Time Protocol) sources* and add NTP sources to the field that appears.
+
 . Click *Next*.
 
 . Click *Download ISO*.


### PR DESCRIPTION
[OSDOCS-17917](https://issues.redhat.com/browse/OSDOCS-17917)

Version: 4.21+

This PR adds additional changes to the OVE install UI that will be added for a 4.21.z version of the ISO.

QE review:
- [ ] QE has approved this change.

Previews:

- [Downloading the installation ISO](https://106670--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-ove.html#virt-installing-ove-iso_installing-ove)
- [Completing cluster configuration and initiating the installation](https://106670--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-ove.html#virt-installing-ove-console-final_installing-ove)