### PR TITLE
OSDOCS-16881 fixes full dot notations for IR callouts

### DIFF
--- a/modules/images-image-pull-policy-overview.adoc
+++ b/modules/images-image-pull-policy-overview.adoc
@@ -48,6 +48,6 @@ spec:
 --
 where:
 
-`image`:: Specifies is the image to use. In this example, the image tag is explicitly set to `v1.2.3`.
-`imagePullPolicy`:: Specifies the policy to use. In this example, the policy is set to `IfNotPresent` because the image tag is not `latest`.
+`spec.template.spec.containers.image`:: Specifies is the image to use. In this example, the image tag is explicitly set to `v1.2.3`.
+`spec.template.spec.containers.imagePullPolicy`:: Specifies the policy to use. In this example, the policy is set to `IfNotPresent` because the image tag is not `latest`.
 --

--- a/modules/images-referencing-images-imagestreams.adoc
+++ b/modules/images-referencing-images-imagestreams.adoc
@@ -24,7 +24,7 @@ spec:
 --
 where:
 
-`image`:: Specifies the image to use from the image stream. For example, `ruby:2.0`.
+`spec.containers.image`:: Specifies the image to use from the image stream. For example, `ruby:2.0`.
 --
 
 * To reference a specific, immutable image ID, or digest, within an image stream, use the `<image_stream_name>@<image_id>` format in your build or deployment. For example:
@@ -41,7 +41,7 @@ spec:
 --
 where:
 
-`image`:: Specifies the image to use from the image stream. For example, `ruby@sha256:3a335d7d8a452970c5b4054ad7118ff134b3a6b50a2bb6d0c07c746e8986b28e`.
+`spec.containers.image`:: Specifies the image to use from the image stream. For example, `ruby@sha256:3a335d7d8a452970c5b4054ad7118ff134b3a6b50a2bb6d0c07c746e8986b28e`.
 --
 +
 [NOTE]
@@ -68,7 +68,7 @@ spec:
 --
 where:
 
-`image`:: Specifies the image to use from the external registry. For example, `registry.redhat.io/rhel7:latest`.
+`spec.strategy.dockerStrategy.from.name`:: Specifies the image to use from the external registry. For example, `registry.redhat.io/rhel7:latest`.
 --
 +
 [NOTE]

--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -70,7 +70,7 @@ endif::image-pull-secrets[]
 +
 [source,terminal]
 ----
-$ oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > <pull_secret_location> <1>
+$ oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > <pull_secret_location>
 ----
 +
 --

--- a/modules/nw-cfg-config-all-multi-cni.adoc
+++ b/modules/nw-cfg-config-all-multi-cni.adoc
@@ -39,14 +39,13 @@ where:
 +
 --
 
-`name`:: Specifies the name for the additional network attachment to create. The name must be unique within the specified namespace.
-`namespace`:: Specifies the namespace that the object is associated with.
-`cniVersion`:: Specifies the CNI specification version.
-`name`:: Specifies the name for the configuration. Match the configuration name to the name value of the network attachment definition.
-`main_CNI_plugin`:: Specifies the name of the main CNI plugin to configure.
-`tuning`:: Specifies the name of the CNI meta plugin.
-`allmulti`:: Specifies the all-multicast mode of interface. If enabled, all multicast packets on the network will be received by the interface.
-
+`<name>`:: Specifies the name for the additional network attachment to create. The name must be unique within the specified namespace.
+`default`:: Specifies the namespace that the object is associated with.
+`"0.4.0"`:: Specifies the CNI specification version.
+`"<name>"`:: Specifies the name for the configuration. Match the configuration name to the name value of the network attachment definition.
+`"<main_CNI_plugin>"`:: Specifies the name of the main CNI plugin to configure.
+`"tuning"`:: Specifies the name of the CNI meta plugin.
+`"true"`:: Specifies the all-multicast mode of interface. If enabled, all multicast packets on the network will be received by the interface.
 --
 +
 .Example network attachment definition
@@ -118,13 +117,13 @@ where:
 +
 --
 
-`k8s.v1.cni.cncf.io/networks`:: Specifies the name of the configured `NetworkAttachmentDefinition`.
-`runAsUser`:: Specifies which user ID the container is run with.
-`runAsGroup`:: Specifies which primary group ID the containers is run with.
-`allowPrivilegeEscalation`:: Specifies if a pod can request to allow privilege escalation. If unspecified, it defaults to true. This boolean directly controls whether the `no_new_privs` flag gets set on the container process.
-`capabilities`:: Specifies privileged actions without giving full root access. This policy ensures all capabilities are dropped from the pod.
-`runAsNonRoot: true`:: Specifies that the container will run with a user with any UID other than 0.
-`seccompProfile`:: Specifies the default seccomp profile for a pod or container workload.
+`metadata.annotations.k8s.v1.cni.cncf.io/networks`:: Specifies the name of the configured `NetworkAttachmentDefinition`.
+`spec.containers.securityContext.runAsUser`:: Specifies which user ID the container is run with.
+`spec.containers.securityContext.runAsGroup`:: Specifies which primary group ID the containers is run with.
+`spec.containers.securityContext.allowPrivilegeEscalation`:: Specifies if a pod can request to allow privilege escalation. If unspecified, it defaults to true. This boolean directly controls whether the `no_new_privs` flag gets set on the container process.
+`spec.containers.securityContext.capabilities`:: Specifies privileged actions without giving full root access. This policy ensures all capabilities are dropped from the pod.
+`spec.containers.securityContext.runAsNonRoot: true`:: Specifies that the container will run with a user with any UID other than 0.
+`spec.containers.securityContext.seccompProfile`:: Specifies the default seccomp profile for a pod or container workload.
 
 --
 

--- a/modules/nw-cfg-tuning-interface-cni.adoc
+++ b/modules/nw-cfg-tuning-interface-cni.adoc
@@ -40,13 +40,12 @@ where:
 +
 --
 
-`name`:: Specifies the name for the additional network attachment to create. The name must be unique within the specified namespace.
-`namespace`:: Specifies the namespace that the object is associated with.
-`cniVersion`:: Specifies the CNI specification version.
-`name`:: Specifies the name for the configuration. It is recommended to match the configuration name to the name value of the network attachment definition.
-`main_CNI_plugin`:: Specifies the name of the main CNI plugin to configure.
-`tuning`:: Specifies the name of the CNI meta plugin.
-`sysctl`:: Specifies the sysctl to set. The interface name is represented by the `IFNAME` token and is replaced with the actual name of the interface at runtime.
+`metadata.name`:: Specifies the name for the additional network attachment to create. The name must be unique within the specified namespace.
+`metadata.namespace`:: Specifies the namespace that the object is associated with.
+`spec.config.cniVersion`:: Specifies the CNI specification version.
+`spec.config.name`:: Specifies the name for the configuration. It is recommended to match the configuration name to the name value of the network attachment definition.
+`spec.config.plugins.type`:: Specifies the name of the main CNI plugin to configure.
+`spec.config.plugins.tuning.sysctl`:: Specifies the sysctl to set. The interface name is represented by the `IFNAME` token and is replaced with the actual name of the interface at runtime.
 
 --
 +
@@ -120,13 +119,13 @@ where:
 +
 --
 
-`k8s.v1.cni.cncf.io/networks`:: Specifies the name of the configured `NetworkAttachmentDefinition`.
-`runAsUser`:: Specifies which user ID the container is run with.
-`runAsGroup`:: Specifies which primary group ID the containers is run with.
-`allowPrivilegeEscalation`:: Specifies if a pod can request to allow privilege escalation. If unspecified, it defaults to true. This boolean directly controls whether the `no_new_privs` flag gets set on the container process.
-`capabilities`:: Specifies privileged actions without giving full root access. This policy ensures all capabilities are dropped from the pod.
-`runAsNonRoot: true`:: Specifies that the container will run with a user with any UID other than 0.
-`seccompProfile`:: Specifies the default seccomp profile for a pod or container workload.
+`metadata.annotations.k8s.v1.cni.cncf.io/networks`:: Specifies the name of the configured `NetworkAttachmentDefinition`.
+`spec.containers.securityContext.runAsUser`:: Specifies which user ID the container is run with.
+`spec.containers.securityContext.runAsGroup`:: Specifies which primary group ID the containers is run with.
+`spec.containers.securityContext.allowPrivilegeEscalation`:: Specifies if a pod can request to allow privilege escalation. If unspecified, it defaults to true. This boolean directly controls whether the `no_new_privs` flag gets set on the container process.
+`spec.containers.securityContext.capabilities`:: Specifies privileged actions without giving full root access. This policy ensures all capabilities are dropped from the pod.
+`spec.securityContext.runAsNonRoot: true`:: Specifies that the container will run with a user with any UID other than 0.
+`spec.securityContext.seccompProfile`:: Specifies the default seccomp profile for a pod or container workload.
 
 --
 

--- a/modules/nw-multus-add-pod.adoc
+++ b/modules/nw-multus-add-pod.adoc
@@ -91,9 +91,9 @@ metadata:
 +
 where:
 +
-`name`:: Specifies the name of the secondary network defined by a `NetworkAttachmentDefinition` object.
-`namespace`:: Specifies the namespace where the `NetworkAttachmentDefinition` object is defined.
-`default-route`:: Optional parameter. Specifies an override for the default route, such as `192.168.17.1`.
+`<network>`:: Specifies the name of the secondary network defined by a `NetworkAttachmentDefinition` object.
+`<namespace>`:: Specifies the namespace where the `NetworkAttachmentDefinition` object is defined.
+`<default-route>`:: Optional parameter. Specifies an override for the default route, such as `192.168.17.1`.
 
 . Create the pod by entering the following command.
 +

--- a/modules/nw-multus-advanced-annotations.adoc
+++ b/modules/nw-multus-advanced-annotations.adoc
@@ -72,9 +72,8 @@ spec:
 --
 where:
 
-`name`:: Specifies the name of the secondary network to associate
-with the pod.
-`default-route`:: Specifies a value of a gateway for traffic to be routed over if no other routing entry is present in the routing table. If more than one `default-route` key is specified, this will cause the pod to fail to become active.
+`net1`, `net2`:: Specifies the name of the `NetworkAttachmentDefinition` resource that defines the secondary network to associate with the pod.
+`192.0.2.1`:: Specifies a value of a gateway for traffic to be routed over if no other routing entry is present in the routing table. If more than one `default-route` key is specified, this will cause the pod to fail to become active.
 --
 +
 The default route will cause any traffic that is not specified in other routes to be routed to the gateway.
@@ -191,9 +190,9 @@ metadata:
 --
 where:
 
-`name`:: Specifies the name for the secondary network attachment to create. The name must be unique within the specified `namespace`. 
-`ips`:: Specifies an IP address including the subnet mask.
-`mac`:: Specifies the MAC address.
+`metadata.name`:: Specifies the name for the secondary network attachment to create. The name must be unique within the specified `namespace`. 
+`metadata.annotations.k8s.v1.cni.cncf.io/ips`:: Specifies an IP address including the subnet mask.
+`metadata.annotations.k8s.v1.cni.cncf.io/mac`:: Specifies the MAC address.
 --
 +
 [NOTE]

--- a/modules/nw-multus-delete-network.adoc
+++ b/modules/nw-multus-delete-network.adoc
@@ -40,7 +40,7 @@ spec:
 --
 where:
 
-`additionalNetworks`:: Specifies the secondary network attachment definition that you want to remove from the `additionalNetworks` collection. If you are removing the configuration mapping for the only secondary network attachment definition in the `additionalNetworks` collection, you must specify an empty collection.
+`spec.additionalNetworks`:: Specifies the secondary network attachment definition that you want to remove from the `additionalNetworks` collection. If you are removing the configuration mapping for the only secondary network attachment definition in the `additionalNetworks` collection, you must specify an empty collection.
 --
 
 . Remove the `NetworkAttachmentDefinition` CR from the network of your cluster by entering the following command:


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-docs/pull/105260 to fix callout notations.

Version(s):
4.16+

Issue:
https://issues.redhat.com/browse/OSDOCS-16861

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
