### PR TITLE
OSDOCS#18369: Update the z-stream RNs for 4.21.2 

### DIFF
--- a/modules/zstream-4-21-1.adoc
+++ b/modules/zstream-4-21-1.adoc
@@ -9,7 +9,7 @@
 [role="_abstract"]
 Issued: 10 February 2026
 
-{product-title} release {product-version}.33 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:2129[RHSA-2026:2129] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:2082[RHSA-2026:2082] advisory.
+{product-title} release {product-version}.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2026:2129[RHSA-2026:2129] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2026:2082[RHSA-2026:2082] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory.
 
@@ -218,3 +218,8 @@ The following issues are fixed for this release:
 * Before this update, unexpected issues occurred during the initial provisioning of a `HostedCluster` resource. With this release, the system uses the `ControlPlaneComponent` resource to ensure that the `HostedCluster` resource is available only after all control plane components have been successfully rolled out. As a result, the rollout status of each control plane component is accurately tracked, which reduces the risk of unexpected issues. (link:https://issues.redhat.com/browse/OCPBUGS-74648[OCPBUGS-74648])
 
 * Before this update, {gcp-first} installations failed due to unspecified zones in the `us-south1` and `us-central1` regions, which caused installation issues. With this release, the GCP installer requires that you specify zones in `install-config` for regions with AI zones. As a result, {gcp-short} installations do not fail in these specified regions. (link:https://issues.redhat.com/browse/OCPBUGS-74672[OCPBUGS-74672])
+
+[id="zstream-4-21-1-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/modules/zstream-4-21-2.adoc
+++ b/modules/zstream-4-21-2.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * release_notes/ocp-4-21-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="zstream-4-21-2_{context}"]
+= RHBA-2026:2637 - {product-title} {product-version}.2 fixed issues
+
+[role="_abstract"]
+Issued: 17 February 2026
+
+{product-title} release {product-version}.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2026:2637[RHBA-2026:2637] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2026:2630[RHBA-2026:2630] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.21.2 --pullspecs
+----
+
+[id="zstream-4-21-2-enhancements_{context}"]
+== Enhancements
+
+This release contains the following enhancements:
+
+  * With this update, the application addresses a denial of service vulnerability in the Logrus library, specifically when handling large single-line payloads without newline characters. The new feature ensures that the Logrus library, when used in our application, does not fail to process large input data because of the `token too long` error. By implementing this fix, applications using Logrus do not experience unavailability due to this issue. This improvement is available in Logrus versions 1.8.3, 1.9.1, and 1.9.3 and later. (link:https://issues.redhat.com/browse/OCPBUGS-74282[OCPBUGS-74282])
+
+// [id="zstream-4-21-2-known-issues_{context}"]
+// == Known issues
+// 
+// This release contains the following known issues:
+
+[id="zstream-4-21-2-fixed-issues_{context}"]
+== Fixed issues
+
+The following issues are fixed for this release:
+
+* Before this update, the `cluster-node-tuning-operator` object used a hard-coded client certificate authority source that failed on HyperShift. As a consequence, the `cluster-node-tuning-operator` pod failed to listen on the 60000 port. With this release, the `cluster-node-tuning-operator` object listens on the 60000 port and the inactive target is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-55399[OCPBUGS-55399])
+
+* Before this update, `kubevirt` object virtual machine (VM) eviction strategy was not set to `external` during a node drain process. With this release, the eviction strategy for `kubevirt` VMs is customizable. As a result, `kubevirt` VMs in {hcp} correctly use the specified eviction strategy, ensuring smooth node draining during infrastructure cluster upgrades. (link:https://issues.redhat.com/browse/OCPBUGS-58397[OCPBUGS-58397])
+
+* Before this update, the agent did not compare the physical and usable RAM sizes correctly on certain virtual machines (VM), causing discrepancies. With this release, the incorrect RAM size calculation on certain VMs is fixed and uses a consistent method for all cases. As a result, the RAM calculation accuracy is improved, ensuring correct host memory reporting for users. (link:https://issues.redhat.com/browse/OCPBUGS-66374[OCPBUGS-66374])
+
+* Before this update, users attempted to access unauthorized API resources on vSphere clusters, and caused a `500` error when accessing metrics. With this release, the 8445 port issue on vSphere is fixed and returns a `401 forbidden` response, improving metrics access in vSphere environments. (link:https://issues.redhat.com/browse/OCPBUGS-74569[OCPBUGS-74569])
+
+* Before this update, autoscaling imbalance occurred because of ignored labels not added to worker nodes. As a consequence, nodes in 3 pools scaled unevenly, and caused workload imbalance. With this release, the autoscaler ignores certain labels for even distribution in node pools. As a result, nodes in 3 pools scale up more evenly, improving the distribution of the workload. (link:https://issues.redhat.com/browse/OCPBUGS-74893[OCPBUGS-74893])
+
+* Before this update, the *Subscription* details list page was empty because of a missing code fix in the release team build cycle. With this release, the *Subscription* details list page is populated, improving user navigation. (link:https://issues.redhat.com/browse/OCPBUGS-74998[OCPBUGS-74998])
+
+* Before this update, the `collect-profiles` job was affected by maintenance difficulties, causing confusion for customers and support engineers during troubleshooting. With this release, the `collect-profiles` job is removed, improving user experience and reducing maintenance effort. (link:https://issues.redhat.com/browse/OCPBUGS-76266[OCPBUGS-76266])
+
+* Before this update, the upgrade to {product-title} 4.21.0 enforced short name mode, and caused image pull failures with multiple sources. As a consequence, end users experienced image pull failure due to enforced short name mode. With this release, short name mode is disabled in {product-title} 4.21.0-0.nightly-2026-02-10-112229 and resolves the image pull failure issue. As a result, short name mode is disabled, preventing CRI-O failures when pulling images with an unqualified search. (link:https://issues.redhat.com/browse/OCPBUGS-76356[OCPBUGS-76356])
+
+[id="zstream-4-21-2-updating_{context}"]
+== Updating
+
+To update an {product-title} 4.21 cluster to this latest release, see xref:../updating/updating_a_cluster/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].

--- a/release_notes/ocp-4-21-release-notes.adoc
+++ b/release_notes/ocp-4-21-release-notes.adoc
@@ -44,5 +44,8 @@ include::modules/rn-ocp-release-notes-known-issues.adoc[leveloffset=+1]
 // Asynchronous errata updates 
 include::modules/rn-async-errata.adoc[leveloffset=+1]
 
+// 4.21.2 RNs
+include::modules/zstream-4-21-2.adoc[leveloffset=+2]
+
 // 4.21.1 Rns
 include::modules/zstream-4-21-1.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.21

Issue:
[OSDOCS-18369](https://issues.redhat.com/browse/OSDOCS-18369)

Link to docs preview:
[4.21.2](https://106696--ocpdocs-pr.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-21-release-notes.html#zstream-4-21-2_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/368#c47715a71ee09ba2393ef31301a74104c847f359)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.21)
