### PR TITLE
Bad indentation in code snippet of Override individual TaskRun timeouts in a PipelineRun in OpenShift Pipelines v1.21 

### DIFF
--- a/modules/op-release-notes-1-21-0.adoc
+++ b/modules/op-release-notes-1-21-0.adoc
@@ -27,19 +27,19 @@ With this update, you can override the timeout for individual `TaksRun` objects 
 [source, yaml]
 ----
 apiVersion: tekton.dev/v1
-  kind: PipelineRun
-  metadata:
-    name: example-with-timeout-override
-  spec:
-    pipelineRef:
-      name: my-pipeline
-    timeouts:
-      pipeline: "2h"
-    taskRunSpecs:
-      - pipelineTaskName: build-task
-        timeout: "30m"
-      - pipelineTaskName: test-task
-        timeout: "1h"
+kind: PipelineRun
+metadata:
+  name: example-with-timeout-override
+spec:
+  pipelineRef:
+    name: my-pipeline
+  timeouts:
+    pipeline: "2h"
+  taskRunSpecs:
+    - pipelineTaskName: build-task
+      timeout: "30m"
+    - pipelineTaskName: test-task
+      timeout: "1h"
 ----
 +
 This allows finer-grained control over task execution duration without affecting the overall `PipelineRun` timeout.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
OpenShift Pipelines 1.21

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Bad indentation in code snippet of Override individual TaskRun timeouts in a PipelineRun
https://issues.redhat.com/browse/RHDEVDOCS-7256

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
