### PR TITLE
[OSDOCS-18247] Corrected Vale errors in Auth guide (OSD specific content)

### DIFF
--- a/authentication/osd-admin-roles.adoc
+++ b/authentication/osd-admin-roles.adoc
@@ -6,7 +6,8 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-// TODO: needs intro
+[role="_abstract"]
+Keep your {product-title} cluster secure and up-to-date by managing administration roles and users effectively.
 
 include::modules/understanding-admin-roles.adoc[leveloffset=+1]
 

--- a/modules/managing-dedicated-administrators.adoc
+++ b/modules/managing-dedicated-administrators.adoc
@@ -6,30 +6,19 @@
 [id="managing-dedicated-administrators_{context}"]
 =  Managing {product-title} administrators
 
+[role="_abstract"]
 Administrator roles are managed using a `cluster-admin` or `dedicated-admin` group on the cluster. Existing members of this group can edit membership through {cluster-manager-url}.
-
-// TODO: These two procedures should be separated and created as proper procedure modules.
-
-[id="dedicated-administrators-adding-user_{context}"]
-== Adding a user
 
 .Procedure
 
-. Navigate to the *Cluster Details* page and *Access Control* tab.
+. Navigate to the *Cluster Details* page and select the *Access Control* tab.
 . Select the *Cluster Roles and Access* tab and click *Add user*.
-. Enter the user name and select the group.
+. Enter the user name and select your group.
 . Click *Add user*.
-
-
++
 [NOTE]
 ====
 Adding a user to the `cluster-admin` group can take several minutes to complete.
 ====
-
-[id="dedicated-administrators-removing-user_{context}"]
-== Removing a user
-
-.Procedure
-
-. Navigate to the *Cluster Details* page and *Access Control* tab.
-. Click the Options menu {kebab} to the right of the user and group combination and click *Delete*.
++
+. Optional: To remove a {product-title} administrator, click the Options menu {kebab} to the right of the user and group combination and click *Delete*.

--- a/modules/security-context-constraints-command-reference.adoc
+++ b/modules/security-context-constraints-command-reference.adoc
@@ -6,6 +6,7 @@
 [id="security-context-constraints-command-reference_{context}"]
 = Reference of security context constraints commands
 
+[role="_abstract"]
 You can manage security context constraints (SCCs) in your instance as normal API objects by using the OpenShift CLI (`oc`).
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
@@ -61,8 +62,8 @@ $ oc describe scc restricted
 Name:                                  restricted
 Priority:                              <none>
 Access:
-  Users:                               <none> <1>
-  Groups:                              <none> <2>
+  Users:                               <none>
+  Groups:                              <none>
 Settings:
   Allow Privileged:                    false
   Allow Privilege Escalation:          true
@@ -93,8 +94,10 @@ Settings:
   Supplemental Groups Strategy: RunAsAny
     Ranges:                            <none>
 ----
-<1> Lists which users and service accounts the SCC is applied to.
-<2> Lists which groups the SCC is applied to.
+
+where::
+`Users`:: Lists which users and service accounts the SCC is applied to.
+`Groups`:: Lists which groups the SCC is applied to.
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [NOTE]

--- a/modules/security-context-constraints-creating.adoc
+++ b/modules/security-context-constraints-creating.adoc
@@ -9,21 +9,22 @@ ifndef::openshift-dedicated[]
 
 endif::[]
 ifdef::openshift-dedicated[]
-= Creating security context constraints for CCS clusters
+= Creating security context constraints for Customer Cloud Subscription clusters
 
-endif::[]
+endif::openshift-dedicated[]
 
+[role="_abstract"]
 If the default security context constraints (SCCs) do not satisfy your application workload requirements, you can create a custom SCC by using the OpenShift CLI (`oc`).
 
 [IMPORTANT]
 ====
-Creating and modifying your own SCCs are advanced operations that might cause instability to your cluster. If you have questions about using your own SCCs, contact Red Hat Support. For information about contacting Red Hat support, see _Getting support_.
+Creating and modifying your own SCCs are advanced operations that might cause instability to your cluster. If you have questions about using your own SCCs, contact Red{nbsp}Hat Support. For information about contacting Red{nbsp}Hat support, see _Getting support_.
 ====
 
 ifdef::openshift-dedicated[]
 [NOTE]
 ====
-In {product-title} deployments, you can create your own SCCs only for clusters that use the Customer Cloud Subscription (CCS) model. You cannot create SCCs for {product-title} clusters that use a Red Hat cloud account, because SCC resource creation requires `cluster-admin` privileges.
+In {product-title} deployments, you can create your own SCCs only for clusters that use the Customer Cloud Subscription (CCS) model. You cannot create SCCs for {product-title} clusters that use a Red{nbsp}Hat cloud account, because SCC resource creation requires `cluster-admin` privileges.
 ====
 endif::openshift-dedicated[]
 

--- a/modules/security-context-constraints-example.adoc
+++ b/modules/security-context-constraints-example.adoc
@@ -2,11 +2,12 @@
 //
 // * authentication/managing-security-context-constraints.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="security-context-constraints-example_{context}"]
 = Example security context constraints
 
-The following examples show the security context constraints (SCC) format and
-annotations:
+[role="_abstract"]
+The following examples show how to define and use security context constraints (SCCs) in your cluster.
 
 .Annotated `privileged` SCC
 [source,yaml]
@@ -17,13 +18,13 @@ allowHostNetwork: true
 allowHostPID: true
 allowHostPorts: true
 allowPrivilegedContainer: true
-allowedCapabilities: <1>
+allowedCapabilities:
 - '*'
 apiVersion: security.openshift.io/v1
-defaultAddCapabilities: [] <2>
-fsGroup: <3>
+defaultAddCapabilities: []
+fsGroup:
   type: RunAsAny
-groups: <4>
+groups:
 - system:cluster-admins
 - system:nodes
 kind: SecurityContextConstraints
@@ -37,47 +38,41 @@ metadata:
   name: privileged
 priority: null
 readOnlyRootFilesystem: false
-requiredDropCapabilities: null <5>
-runAsUser: <6>
+requiredDropCapabilities: null
+runAsUser:
   type: RunAsAny
-seLinuxContext: <7>
+seLinuxContext:
   type: RunAsAny
 seccompProfiles:
 - '*'
-supplementalGroups: <8>
+supplementalGroups:
   type: RunAsAny
-users: <9>
+users:
 - system:serviceaccount:default:registry
 - system:serviceaccount:default:router
 - system:serviceaccount:openshift-infra:build-controller
-volumes: <10>
+volumes:
 - '*'
 ----
 
-<1> A list of capabilities that a pod can request. An empty list means
+where::
+
+`allowedCapabilities`:: A list of capabilities that a pod can request. An empty list means
 that none of capabilities can be requested while the special symbol `***`
 allows any capabilities.
-<2> A list of additional capabilities that are added to any pod.
-<3> The `FSGroup` strategy, which dictates the allowable values for the
-security context.
-<4> The groups that can access this SCC.
-<5> A list of capabilities to drop from a pod. Or, specify `ALL` to drop all
-capabilities.
-<6> The `runAsUser` strategy type, which dictates the allowable values for the
-security context.
+`defaultAddCapabilities`:: A list of additional capabilities that are added to any pod.
+`fsGroup`:: The `FSGroup` strategy, which dictates the allowable values for the security context.
+`groups`:: The groups that can access this SCC.
+`requiredDropCapabilities`:: A list of capabilities to drop from a pod. Or, specify `ALL` to drop all capabilities.
+`runAsUser`:: The `runAsUser` strategy type, which dictates the allowable values for the security context.
 //could use the available strategies
-<7> The `seLinuxContext` strategy type, which dictates the allowable values for
-the security context.
-<8> The `supplementalGroups` strategy, which dictates the allowable supplemental
-groups for the security context.
-<9> The users who can access this SCC.
-<10> The allowable volume types for the security context. In the example, `*` allows the use of all volume types.
+`seLinuxContext`:: The `seLinuxContext` strategy type, which dictates the allowable values for the security context.
+`supplementalGroups`:: The `supplementalGroups` strategy, which dictates the allowable supplemental groups for the security context.
+`users`:: The users who can access this SCC.
+`volumes`:: The allowable volume types for the security context. In the example, `*` allows the use of all volume types.
 
-The `users` and `groups` fields on the SCC control which users can access the
-SCC.
-By default, cluster administrators, nodes, and the build controller are granted
-access to the privileged SCC. All authenticated users are granted access to the
-`restricted-v2` SCC.
+The `users` and `groups` fields on the SCC control which users can access the SCC.
+By default, cluster administrators, nodes, and the build controller are granted access to the privileged SCC. All authenticated users are granted access to the `restricted-v2` SCC.
 
 .Without explicit `runAsUser` setting
 [source,yaml]
@@ -87,20 +82,14 @@ kind: Pod
 metadata:
   name: security-context-demo
 spec:
-  securityContext: <1>
+  securityContext:
   containers:
   - name: sec-ctx-demo
     image: gcr.io/google-samples/node-hello:1.0
 ----
-<1> When a container or pod does not request a user ID under which it should be run,
-the effective UID depends on the SCC that emits this pod. Because the `restricted-v2` SCC
-is granted to all authenticated users by default, it will be available to all
-users and service accounts and used in most cases. The `restricted-v2` SCC uses
-`MustRunAsRange` strategy for constraining and defaulting the possible values of
-the `securityContext.runAsUser` field. The admission plugin will look for the
-`openshift.io/sa.scc.uid-range` annotation on the current project to populate
-range fields, as it does not provide this range. In the end, a container will
-have `runAsUser` equal to the first value of the range that is
+
+When a container or pod does not request a user ID under which it should be run,the effective UID depends on the SCC that emits this pod. Because the `restricted-v2` SCC is granted to all authenticated users by default, it will be available to all users and service accounts and used in most cases. The `restricted-v2` SCC uses `MustRunAsRange` strategy for constraining and defaulting the possible values of the `securityContext.runAsUser` field. The admission plugin will look for the `openshift.io/sa.scc.uid-range` annotation on the current project to populate
+range fields, as it does not provide this range. In the end, a container will have `runAsUser` equal to the first value of the range that is
 hard to predict because every project has different ranges.
 
 .With explicit `runAsUser` setting
@@ -112,14 +101,13 @@ metadata:
   name: security-context-demo
 spec:
   securityContext:
-    runAsUser: 1000 <1>
+    runAsUser: 1000
   containers:
     - name: sec-ctx-demo
       image: gcr.io/google-samples/node-hello:1.0
 ----
-<1> A container or pod that requests a specific user ID will be accepted by
-{product-title} only when a service account or a user is granted access to a SCC
-that allows such a user ID. The SCC can allow arbitrary IDs, an ID that falls
-into a range, or the exact user ID specific to the request.
+
+A container or pod that requests a specific user ID will be accepted by
+{product-title} only when a service account or a user is granted access to a SCC that allows such a user ID. The SCC can allow arbitrary IDs, an ID that falls into a range, or the exact user ID specific to the request.
 
 This configuration is valid for SELinux, fsGroup, and Supplemental Groups.

--- a/modules/security-context-constraints-rbac.adoc
+++ b/modules/security-context-constraints-rbac.adoc
@@ -2,9 +2,11 @@
 //
 // * authentication/managing-security-context-constraints.adoc
 
+:_mod-docs-content-type: CONCEPT
 [id="role-based-access-to-ssc_{context}"]
 = Role-based access to security context constraints
 
+[role="_abstract"]
 You can specify SCCs as resources that are handled by RBAC. This allows
 you to scope access to your SCCs to a certain project or to the entire
 cluster. Assigning users, groups, or service accounts directly to an
@@ -28,27 +30,29 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
 ...
-  name: role-name <1>
-  namespace: namespace <2>
+  name: role-name
+  namespace: namespace
 ...
 rules:
 - apiGroups:
-  - security.openshift.io <3>
+  - security.openshift.io
   resourceNames:
-  - scc-name <4>
+  - scc-name
   resources:
-  - securitycontextconstraints <5>
-  verbs: <6>
+  - securitycontextconstraints
+  verbs:
   - use
 ----
-<1> The role's name.
-<2> Namespace of the defined role. Defaults to `default` if not specified.
-<3> The API group that includes the `SecurityContextConstraints` resource.
+
+where::
+
+`name`:: The name of the role.
+`namespace`:: The namespace of the defined role. Defaults to `default` if not specified.
+`apiGroups`:: The API group that includes the `SecurityContextConstraints` resource.
 Automatically defined when `scc` is specified as a resource.
-<4> An example name for an SCC you want to have access.
-<5> Name of the resource group that allows users to specify SCC names in
-the `resourceNames` field.
-<6> A list of verbs to apply to the role.
+`resourceName`:: An example name for an SCC you want to have access.
+`resources`:: The name of the resource group that allows users to specify SCC names in the `resourceNames` field.
+`verbs`:: A list of verbs to apply to the role.
 
 A local or cluster role with such a rule allows the subjects that are
 bound to it with a role binding or a cluster role binding to use the

--- a/modules/security-context-constraints-requiring.adoc
+++ b/modules/security-context-constraints-requiring.adoc
@@ -36,11 +36,10 @@ spec:
   template:
     metadata:
       annotations:
-        openshift.io/required-scc: "my-scc" <1>
+        openshift.io/required-scc: "my-scc"
 # ...
 ----
-<1> Specify the name of the SCC to require.
-
++
 . Create the resource by running the following command:
 +
 [source,terminal]
@@ -52,14 +51,13 @@ $ oc create -f deployment.yaml
 
 * Verify that the deployment used the specified SCC:
 
-.. View the value of the pod's `openshift.io/scc` annotation by running the following command:
+.. View the value of the pod's `openshift.io/scc` annotation by running the following command, replacing `<pod_name>` with the name of your deployment pod:
 +
 [source,terminal]
 ----
 $ oc get pod <pod_name> -o jsonpath='{.metadata.annotations.openshift\.io\/scc}{"\n"}' <1>
 ----
-<1> Replace `<pod_name>` with the name of your deployment pod.
-
++
 .. Examine the output and confirm that the displayed SCC matches the SCC that you defined in the deployment:
 +
 .Example output

--- a/modules/understanding-admin-roles.adoc
+++ b/modules/understanding-admin-roles.adoc
@@ -6,15 +6,17 @@
 [id="understanding-admin-roles_{context}"]
 = Understanding administration roles
 
+[role="_abstract"]
+As an administrator of an {product-title} cluster, you have access to the `cluster-admin` and `dedicated-admin` roles. These roles have different permissions and access levels that allow you to manage and configure your cluster effectively. Understanding the differences between these roles can help you assign the appropriate permissions to users and manage your cluster more efficiently.
+
 == The cluster-admin role
 As an administrator of an {product-title} cluster with Customer Cloud Subscriptions (CCS), you have access to the `cluster-admin` role. The user who created the cluster can add the `cluster-admin` user role to an account to have the maximum administrator privileges. These privileges are not automatically assigned to your user account when you create the cluster. While logged in to an account with the cluster-admin role, users have mostly unrestricted access to control and configure the cluster. There are some configurations that are blocked with webhooks to prevent destabilizing the cluster, or because they are managed in {cluster-manager-url} and any in-cluster changes would be overwritten. Usage of the cluster-admin role is subject to the restrictions listed in your Appendix 4 agreement with Red Hat. As a best practice, limit the number of `cluster-admin` users to as few as possible.
-
 
 == The dedicated-admin role
 As an administrator of an {product-title} cluster, your account has additional permissions and access to all user-created projects in your organization’s cluster. While logged in to an account with the `dedicated-admin` role, the developer CLI commands (under the `oc` command) allow you increased visibility and management capabilities over objects across projects, while the administrator CLI commands (under the `oc adm` command) allow you to complete additional operations.
 
 [NOTE]
 ====
-While your account does have these increased permissions, the actual cluster maintenance and host configuration is still performed by the OpenShift Operations Team.
+While your account does have these increased permissions, the actual cluster maintenance and host configuration is still performed by the Red{nbsp}Hat Site Reliability Engineering (SRE) team.
 ====
-// TODO: this is the only reference to the "OpenShift Operations Team". Should this be that SRE team?
+


### PR DESCRIPTION
Version(s):
4.21+

Issue:
[OSDOCS-18247](https://issues.redhat.com/browse/OSDOCS-18247)

Link to docs preview:

**OSD**
- [Managing security context constraints](https://106705--ocpdocs-pr.netlify.app/openshift-dedicated/latest/authentication/managing-security-context-constraints.html)
- [Managing administration roles and users](https://106705--ocpdocs-pr.netlify.app/openshift-dedicated/latest/authentication/osd-admin-roles.html)

**OCP**
[Managing security context constraints](https://106705--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html)

**ROSA**
[Managing security context constraints](https://106705--ocpdocs-pr.netlify.app/openshift-rosa-hcp/latest/authentication/managing-security-context-constraints.html)

**ROSA Classic**
[Managing security context constraints](https://106705--ocpdocs-pr.netlify.app/openshift-rosa/latest/authentication/managing-security-context-constraints.html)


Peer review:
- [ ] Peer reviewer has approved this change.

QE review:
- QE approval is not required for this PR.


