### PR TITLE
TELCODOCS-2746: fix(metallb-configure-address-pools): DITA compatibility fixes

### DIFF
--- a/modules/nw-metallb-configure-address-pool.adoc
+++ b/modules/nw-metallb-configure-address-pool.adoc
@@ -50,7 +50,6 @@ $ oc apply -f ipaddresspool.yaml
 $ oc describe -n metallb-system IPAddressPool doc-example
 ----
 +
-.Example output
 [source,terminal]
 ----
 Name:         doc-example

--- a/networking/ingress_load_balancing/metallb/metallb-configure-address-pools.adoc
+++ b/networking/ingress_load_balancing/metallb/metallb-configure-address-pools.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="metallb-configure-address-pools"]
 = Configuring MetalLB address pools
+
 include::_attributes/common-attributes.adoc[]
 :context: configure-metallb-address-pools
 


### PR DESCRIPTION
[TELCODOCS-2746]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://106706--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ingress_load_balancing/metallb/metallb-configure-address-pools.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Added blank line after document title to prevent author line interpretation
- Removed unsupported .Example output block title from source block
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
