### PR TITLE
TELCODOCS-2748: DITA compatibility fixes for MetalLB BGP peers docs

### DIFF
--- a/modules/nw-metallb-configure-vrf-bgppeer.adoc
+++ b/modules/nw-metallb-configure-vrf-bgppeer.adoc
@@ -185,7 +185,8 @@ $ oc apply -f deploy-service.yaml
 $ oc get -n metallb-system pods -l component=speaker
 ----
 +
-.Example output
+The following example output lists an available speaker pod:
++
 [source,terminal]
 ----
 NAME            READY   STATUS    RESTARTS   AGE
@@ -199,7 +200,8 @@ speaker-c6c5f   6/6     Running   0          69m
 $ oc exec -n metallb-system <speaker_pod> -c frr -- vtysh -c "show bgp vrf <vrf_name> neigh"
 ----
 +
-.Example output
+The following example output shows an established BGP session:
++
 [source,terminal]
 ----
 BGP neighbor is 192.168.30.1, remote AS 200, local AS 100, external link

--- a/networking/ingress_load_balancing/metallb/metallb-configure-bgp-peers.adoc
+++ b/networking/ingress_load_balancing/metallb/metallb-configure-bgp-peers.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="metallb-configure-bgp-peers"]
 = Configuring MetalLB BGP peers
+
 include::_attributes/common-attributes.adoc[]
 :context: configure-metallb-bgp-peers
 


### PR DESCRIPTION
Fix AuthorLine warning in assembly by adding blank line after title, and replace unsupported .Example output block titles with inline text in VRF BGP peer module.

[TELCODOCS-2748]: DITA compatibility fixes for MetalLB BGP peers docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
