### PR TITLE
TELCODOCS-2750: fix(metallb-configure-return-traffic): Add blank line after title for DITA compatibility

### DIFF
--- a/networking/ingress_load_balancing/metallb/metallb-configure-return-traffic.adoc
+++ b/networking/ingress_load_balancing/metallb/metallb-configure-return-traffic.adoc
@@ -1,6 +1,7 @@
 :_mod-docs-content-type: ASSEMBLY
 [id="metallb-configure-return-traffic"]
 = Managing symmetric routing with MetalLB
+
 include::_attributes/common-attributes.adoc[]
 :context: metallb-configure-return-traffic
 


### PR DESCRIPTION
[TELCODOCS-2750]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-2750

<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
Prevent include directive from being interpreted as an author line by adding a blank line between the document title and the attributes include.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
