### PR TITLE
PR for SRVLOGIC-815: Release notes, known issues and bug fixes for OSL 1.37.1

### DIFF
--- a/modules/serverless-rn-1-37-1.adoc
+++ b/modules/serverless-rn-1-37-1.adoc
@@ -7,7 +7,15 @@
 = Red{nbsp}Hat {ServerlessProductName} 1.37.1
 
 [role="_abstract"]
+
 {ServerlessProductName} 1.37.1 is now available. This release of {ServerlessProductName} addresses identified Common Vulnerabilities and Exposures (CVEs) to enhance security and reliability. Fixed issues and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes:
+
+[id="new-features-1-37-1_{context}"]
+== New features
+
+OpenTelemetry support for workflow observability in {ServerlessLogicProductName}::
+
+{ServerlessLogicProductName} now includes OpenTelemetry support to provide observability for workflow executions. This enhancement enables users to collect and export telemetry data for improved monitoring and tracing of workflows.
 
 [id="fixed-issues-1-37-1_{context}"]
 == Fixed issues
@@ -16,8 +24,26 @@
 
 Before this update, {ocp-product-title} 4.21 and later used a reduced default soft limit for the number of open files when running the `3scale Kourier gateway` with {ServerlessProductName} 1.37.0 and earlier. As a consequence, the `3scale Kourier gateway` could crash with the `socket(2) failed, got error: Too many open files` error. With this release, the `3scale Kourier gateway` deployment sets the soft limit for the maximum number of open files to the value of the hard limit.
 As a result, the `3scale Kourier gateway` no longer crashes due to file descriptor limits on {ocp-product-title} 4.21.
-
++
 link:https://issues.redhat.com/browse/SRVKS-1343[SRVKS-1343]
+
+Removal of unused webhook server initialization in {ServerlessLogicOperatorName}::
+
+Before this update, the {ServerlessLogicOperatorName} initialized webhook server code that the Operator did not use. As a consequence, the Operator included unnecessary initialization logic in its startup sequence. With this release, the {ServerlessLogicOperatorName} removes the unused webhook server initialization code. As a result, the Operator startup process no longer includes unused webhook server components.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-770[SRVLOGIC-770]
+
+Incorrect hibernate schema initialization option in Data Index PostgreSQL deployments::
+
+Before this update, the {ServerlessLogicOperatorName} configured Data Index PostgreSQL deployments with the `QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION=update` environment variable, resulting in an unintended database schema generation strategy. With this release, the Operator no longer sets this environment variable for Operator-managed Data Index deployments. As a result, Data Index now uses the correct schema initialization configuration.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-765[SRVLOGIC-765]
+
+Variables and metadata queries restored in {ServerlessLogicProductName} GraphQL::
+
+Before this update, {ServerlessLogicProductName} 1.37 did not support variables and metadata queries in GraphQL because JSON query capability was missing. As a consequence, GraphQL queries that relied on variables and metadata failed. With this release, {ServerlessLogicProductName} introduces JSON query capability for GraphQL. As a result, variables and metadata queries now function as expected.
++
+link:https://issues.redhat.com/browse/SRVLOGIC-763[SRVLOGIC-763]
 
 [id="known-issues-1-37-1_{context}"]
 == Known issues
@@ -25,5 +51,5 @@ link:https://issues.redhat.com/browse/SRVKS-1343[SRVKS-1343]
 Python runtime limited to 1024 open files on {ocp-product-title} 4.21::
 
 On {ocp-product-title} 4.21, the default `ulimit -n` soft limit for the number of open files is set to 1024, reduced from 1048576 in earlier {ocp-product-title} releases up to version 4.20. The hard limit remains 524288. As a result, Serverless functions that use the Python runtime cannot open more than 1024 file descriptors, such as open files or TCP sockets.
-
++
 link:https://issues.redhat.com/browse/SRVOCF-788[SRVOCF-788]


### PR DESCRIPTION
**Affected versions:** 

- `serverless-docs-1.37`
- `serverless-docs-1.38`

**Tracking JIRA:** https://issues.redhat.com/browse/SRVLOGIC-815

**Doc preview:**

- [1.37.1 Serverless release notes](https://106711--ocpdocs-pr.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-37-1_serverless-release-notes)

**Reviews:**
- [x] SME or QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

- [x] Peer has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->