### PR TITLE
TELCODOCS-2759: Add short description attributes for DITA compatibility

### DIFF
--- a/modules/about-ztp.adoc
+++ b/modules/about-ztp.adoc
@@ -6,6 +6,7 @@
 [id="about-ztp_{context}"]
 = Using {ztp} to provision clusters at the network far edge
 
+[role="_abstract"]
 {rh-rhacm-first} manages clusters in a hub-and-spoke architecture, where a single hub cluster manages many spoke clusters. Hub clusters running {rh-rhacm} provision and deploy the managed clusters by using {ztp-first} and the assisted service that is deployed when you install {rh-rhacm}.
 
 The assisted service handles provisioning of {product-title} on single node clusters, three-node clusters, or standard clusters running on bare metal.

--- a/modules/ztp-challenges-of-far-edge-deployments.adoc
+++ b/modules/ztp-challenges-of-far-edge-deployments.adoc
@@ -6,6 +6,7 @@
 [id="ztp-challenges-of-far-edge-deployments_{context}"]
 = Overcoming the challenges of the network far edge
 
+[role="_abstract"]
 Today, service providers want to deploy their infrastructure at the edge of the network. This presents significant challenges:
 
 * How do you handle deployments of many edge sites in parallel?

--- a/modules/ztp-configuring-cluster-policies.adoc
+++ b/modules/ztp-configuring-cluster-policies.adoc
@@ -6,6 +6,7 @@
 [id="ztp-configuring-cluster-policies_{context}"]
 = Configuring managed clusters with policies and {policy-gen-cr} resources
 
+[role="_abstract"]
 {ztp-first} uses {rh-rhacm-first} to configure clusters by using a policy-based governance approach to applying the configuration.
 
 The policy generator is a plugin for the GitOps Operator that enables the creation of {rh-rhacm} policies from a concise template. The tool can combine multiple CRs into a single policy, and you can generate multiple policies that apply to various subsets of clusters in your fleet.

--- a/modules/ztp-creating-ztp-crs-for-multiple-managed-clusters.adoc
+++ b/modules/ztp-creating-ztp-crs-for-multiple-managed-clusters.adoc
@@ -6,6 +6,7 @@
 [id="ztp-creating-ztp-crs-for-multiple-managed-clusters_{context}"]
 = Installing managed clusters with ClusterInstance resources and {rh-rhacm}
 
+[role="_abstract"]
 {ztp-first} uses `ClusterInstance` custom resources (CRs) in a Git repository to manage the processes that install {product-title} clusters. The `ClusterInstance` CR contains cluster-specific parameters required for installation. It has options for applying select configuration CRs during installation including user defined extra manifests.
 
 The {ztp} plugin processes `ClusterInstance` CRs to generate a collection of CRs on the hub cluster. This triggers the assisted service in {rh-rhacm-first} to install {product-title} on the bare-metal host. You can find installation status and error messages in these CRs on the hub cluster.


### PR DESCRIPTION

Preview: https://106768--ocpdocs-pr.netlify.app/openshift-enterprise/latest/edge_computing/ztp-deploying-far-edge-clusters-at-scale.html
## Summary

- Added `[role="_abstract"]` to the first paragraph in 4 ZTP modules to support DITA `<shortdesc>` conversion
- Resolves all AsciiDocDITA.ShortDescription Vale warnings for the `ztp-deploying-far-edge-clusters-at-scale` assembly

## Files Modified

| File | Change |
|------|--------|
| `modules/about-ztp.adoc` | Added `[role="_abstract"]` |
| `modules/ztp-challenges-of-far-edge-deployments.adoc` | Added `[role="_abstract"]` |
| `modules/ztp-configuring-cluster-policies.adoc` | Added `[role="_abstract"]` |
| `modules/ztp-creating-ztp-crs-for-multiple-managed-clusters.adoc` | Added `[role="_abstract"]` |

## Test plan

- [x] Vale AsciiDocDITA validation passes with 0 errors, 0 warnings
- [ ] Verify AsciiDoc renders correctly
- [ ] Run DITA conversion on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)