### PR TITLE
DITA compatibility fixes for ztp-sno-additional-worker-node assembly

### DIFF
--- a/edge_computing/ztp-sno-additional-worker-node.adoc
+++ b/edge_computing/ztp-sno-additional-worker-node.adoc
@@ -1,3 +1,4 @@
+:_mod-docs-content-type: ASSEMBLY
 [id="ztp-sno-additional-worker-node"]
 = Expanding single-node OpenShift clusters with GitOps ZTP
 include::_attributes/common-attributes.adoc[]
@@ -5,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 You can expand {sno} clusters with {ztp-first}. When you add a worker node to {sno} clusters, the original {sno} cluster retains the control plane node role. Adding a worker node does not require any downtime for the existing {sno} cluster.
 
 [NOTE]
@@ -19,15 +21,6 @@ If you create the workload partitioning manifests after installing the worker no
 
 :FeatureName: Adding a worker node to {sno} clusters with {ztp}
 include::snippets/technology-preview.adoc[]
-
-[role="_additional-resources"]
-.Additional resources
-
-* For more information about {sno} clusters tuned for vDU application deployments, see xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#sno-configure-for-vdu[Reference configuration for deploying vDUs on {sno}].
-
-* For more information about worker nodes, see xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters].
-
-* For information about removing a worker node from an expanded {sno} cluster, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#auto-remove-host-steps-cli[Removing managed cluster nodes by using the command line interface].
 
 include::modules/ztp-worker-node-applying-du-profile.adoc[leveloffset=+1]
 
@@ -44,3 +37,12 @@ include::modules/ztp-worker-node-preparing-policies.adoc[leveloffset=+1]
 include::modules/ztp-adding-worker-nodes.adoc[leveloffset=+1]
 
 :!policy-gen-cr:
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../edge_computing/ztp-reference-cluster-configuration-for-vdu.adoc#sno-configure-for-vdu[Reference configuration for deploying vDUs on {sno}]
+
+* xref:../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.10/html/clusters/cluster_mce_overview#auto-remove-host-steps-cli[Removing managed cluster nodes by using the command line interface]

--- a/modules/ztp-adding-worker-nodes.adoc
+++ b/modules/ztp-adding-worker-nodes.adoc
@@ -6,6 +6,7 @@
 [id="ztp-additional-worker-sno-proc_{context}"]
 = Adding an additional worker node {sno} clusters with {ztp}
 
+[role="_abstract"]
 You can add an additional worker node to existing {sno} clusters to increase available CPU resources in the cluster.
 
 .Prerequisites
@@ -131,9 +132,10 @@ $ oc get bmh -n example-sno
 ----
 NAME            STATE          CONSUMER   ONLINE   ERROR   AGE
 example-sno     provisioned               true             69m
-example-node2   provisioning              true             4m50s <1>
+example-node2   provisioning              true             4m50s
 ----
-<1> The `provisioning` state indicates that node booting from the installation media is in progress.
++
+The `provisioning` state indicates that node booting from the installation media is in progress.
 
 * Continuously monitor the installation process:
 

--- a/modules/ztp-worker-node-applying-du-profile.adoc
+++ b/modules/ztp-worker-node-applying-du-profile.adoc
@@ -6,6 +6,7 @@
 [id="ztp-additional-worker-apply-du-profile_{context}"]
 = Applying profiles to the worker node with PolicyGenerator or PolicyGenTemplate resources
 
+[role="_abstract"]
 You can configure the additional worker node with a DU profile.
 
 You can apply a RAN distributed unit (DU) profile to the worker node cluster using the {ztp-first} common, group, and site-specific `PolicyGenerator` or  `PolicyGenTemplate` resources. The {ztp} pipeline that is linked to the ArgoCD `policies` application includes the following CRs that you can find in the relevant `out/argocd/example` folder when you extract the `ztp-site-generate` container:

--- a/modules/ztp-worker-node-daemon-selector-compatibility.adoc
+++ b/modules/ztp-worker-node-daemon-selector-compatibility.adoc
@@ -6,6 +6,7 @@
 [id="ztp-additional-worker-daemon-selector-comp_{context}"]
 = Ensuring PTP and SR-IOV daemon selector compatibility
 
+[role="_abstract"]
 If the DU profile was deployed using the {ztp-first} plugin version 4.11 or earlier, the PTP and SR-IOV Operators might be configured to place the daemons only on nodes labeled as `master`. This configuration prevents the PTP and SR-IOV daemons from operating on the worker node. If the PTP and SR-IOV daemon node selectors are incorrectly configured on your system, you must change the daemons before proceeding with the worker DU profile configuration.
 
 .Procedure
@@ -17,13 +18,14 @@ If the DU profile was deployed using the {ztp-first} plugin version 4.11 or earl
 $ oc get ptpoperatorconfig/default -n openshift-ptp -ojsonpath='{.spec}' | jq
 ----
 +
-.Example output for PTP Operator
+The following example shows the output for the PTP Operator:
 +
 [source,json]
 ----
-{"daemonNodeSelector":{"node-role.kubernetes.io/master":""}} <1>
+{"daemonNodeSelector":{"node-role.kubernetes.io/master":""}}
 ----
-<1> If the node selector is set to `master`, the spoke was deployed with the version of the {ztp} plugin that requires changes.
++
+If the node selector is set to `master`, the spoke was deployed with the version of the {ztp} plugin that requires changes.
 
 . Check the daemon node selector settings of the SR-IOV Operator on one of the spoke clusters:
 +
@@ -33,13 +35,14 @@ $  oc get sriovoperatorconfig/default -n \
 openshift-sriov-network-operator -ojsonpath='{.spec}' | jq
 ----
 +
-.Example output for SR-IOV Operator
+The following example shows the output for the SR-IOV Operator:
 +
 [source,json]
 ----
-{"configDaemonNodeSelector":{"node-role.kubernetes.io/worker":""},"disableDrain":false,"enableInjector":true,"enableOperatorWebhook":true} <1>
+{"configDaemonNodeSelector":{"node-role.kubernetes.io/worker":""},"disableDrain":false,"enableInjector":true,"enableOperatorWebhook":true}
 ----
-<1> If the node selector is set to `master`, the spoke was deployed with the version of the {ztp} plugin that requires changes.
++
+If the node selector is set to `master`, the spoke was deployed with the version of the {ztp} plugin that requires changes.
 
 . In the group policy, add the following `complianceType` and `spec` entries:
 +

--- a/modules/ztp-worker-node-node-selector-compatibility.adoc
+++ b/modules/ztp-worker-node-node-selector-compatibility.adoc
@@ -6,4 +6,5 @@
 [id="ztp-additional-worker-node-selector-comp_{context}"]
 = PTP and SR-IOV node selector compatibility
 
+[role="_abstract"]
 The PTP configuration resources and SR-IOV network node policies use `node-role.kubernetes.io/master: ""` as the node selector. If the additional worker node has the same NIC configuration as the control plane node, the policies used to configure the control plane node can be reused for the worker node. However, the node selector must be changed to select both node types, for example with the `"node-role.kubernetes.io/worker"` label.

--- a/modules/ztp-worker-node-preparing-policies.adoc
+++ b/modules/ztp-worker-node-preparing-policies.adoc
@@ -6,6 +6,7 @@
 [id="ztp-additional-worker-policies-{policy-gen-cr}_{context}"]
 = Using {policy-gen-cr} CRs to apply worker node policies to the worker node
 
+[role="_abstract"]
 You can create policies for the additional worker node by using `{policy-gen-cr}` CRs.
 
 .Procedure

--- a/snippets/pg-ztp-worker-node-preparing-policies.adoc
+++ b/snippets/pg-ztp-worker-node-preparing-policies.adoc
@@ -15,7 +15,7 @@ policyDefaults:
                 - key: sites
                   operator: In
                   values:
-                    - example-sno <1>
+                    - example-sno # <1>
     remediationAction: inform
     severity: low
     namespaceSelector:
@@ -36,7 +36,7 @@ policies:
             - metadata:
                 name: openshift-worker-node-performance-profile
               spec:
-                cpu: <2>
+                cpu: # <2>
                     isolated: 4-47
                     reserved: 0-3
                 hugepages:
@@ -57,7 +57,7 @@ policies:
                       summary=Configuration changes profile inherited from performance created tuned
                       include=openshift-node-performance-openshift-worker-node-performance-profile
                       [bootloader]
-                      cmdline_crash=nohz_full=4-47 <3>
+                      cmdline_crash=nohz_full=4-47 # <3>
                       [sysctl]
                       kernel.timer_migration=1
                       [scheduler]
@@ -69,6 +69,9 @@ policies:
                 recommend:
                     - profile: performance-patch-worker
 ----
-<1> The policies are applied to all clusters with this label.
-<2> The `cpu.isolated` and `cpu.reserved` fields must be configured for each specific hardware platform.
-<3> The `cmdline_crash` CPU set must match the `cpu.isolated` set in the `PerformanceProfile` section.
++
+--
+. The policies are applied to all clusters with this label.
+. The `cpu.isolated` and `cpu.reserved` fields must be configured for each specific hardware platform.
+. The `cmdline_crash` CPU set must match the `cpu.isolated` set in the `PerformanceProfile` section.
+--

--- a/snippets/pgt-ztp-worker-node-preparing-policies.adoc
+++ b/snippets/pgt-ztp-worker-node-preparing-policies.adoc
@@ -8,10 +8,10 @@ metadata:
   namespace: "example-sno"
 spec:
   bindingRules:
-    sites: "example-sno" <1>
-  mcp: "worker" <2>
+    sites: "example-sno" # <1>
+  mcp: "worker" # <2>
   sourceFiles:
-    - fileName: MachineConfigGeneric.yaml <3>
+    - fileName: MachineConfigGeneric.yaml # <3>
       policyName: "config-policy"
       metadata:
         labels:
@@ -40,7 +40,7 @@ spec:
       metadata:
         name: openshift-worker-node-performance-profile
       spec:
-        cpu: <4>
+        cpu: # <4>
           isolated: "4-47"
           reserved: "0-3"
         hugepages:
@@ -62,7 +62,7 @@ spec:
               summary=Configuration changes profile inherited from performance created tuned
               include=openshift-node-performance-openshift-worker-node-performance-profile
               [bootloader]
-              cmdline_crash=nohz_full=4-47 <5>
+              cmdline_crash=nohz_full=4-47 # <5>
               [sysctl]
               kernel.timer_migration=1
               [scheduler]
@@ -73,8 +73,11 @@ spec:
         recommend:
         - profile: performance-patch-worker
 ----
-<1> The policies are applied to all clusters with this label.
-<2> The `MCP` field must be set to `worker`.
-<3> This generic `MachineConfig` CR is used to configure workload partitioning on the worker node.
-<4> The `cpu.isolated` and `cpu.reserved` fields must be configured for each particular hardware platform.
-<5> The `cmdline_crash` CPU set must match the `cpu.isolated` set in the `PerformanceProfile` section.
++
+--
+. The policies are applied to all clusters with this label.
+. The `MCP` field must be set to `worker`.
+. This generic `MachineConfig` CR is used to configure workload partitioning on the worker node.
+. The `cpu.isolated` and `cpu.reserved` fields must be configured for each particular hardware platform.
+. The `cmdline_crash` CPU set must match the `cpu.isolated` set in the `PerformanceProfile` section.
+--


### PR DESCRIPTION
Fix all 23 AsciiDocDITA Vale errors and warnings across the assembly and its included modules: add missing content type and short descriptions, convert callouts to comment-style markers with ordered lists, replace unsupported block titles with introductory text, and move additional resources to end of assembly with pure link-only bullets.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
