### PR TITLE
OSDOCS#18375: Update the MicroShift z-stream RNs for 4.17.49

### DIFF
--- a/microshift_release_notes/microshift-4-17-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-17-release-notes.adoc
@@ -52,3 +52,6 @@ include::modules/microshift-4-17-35-dp.adoc[leveloffset=+2]
 include::modules/microshift-4-17-37-dp.adoc[leveloffset=+2]
 
 include::modules/microshift-4-17-44-dp.adoc[leveloffset=+2]
+
+include::modules/microshift-4-17-49-dp.adoc[leveloffset=+2]
+

--- a/modules/microshift-4-17-49-dp.adoc
+++ b/modules/microshift-4-17-49-dp.adoc
@@ -1,0 +1,16 @@
+
+// Module included in the following assemblies:
+//
+//microshift_release_notes/microshift-4-17-release-notes.adoc
+
+:_mod-docs-content-type: REFERENCE
+[id="microshift-4-17-49-dp_{context}"]
+= RHSA-2026:2746 - {microshift-short} 4.17.49 bug fix and enhancement update
+
+[role="_abstract"]
+Issued: 18 February 2026
+
+{product-title} release 4.17.49 is now available, see the link:https://access.redhat.com/errata/RHSA-2026:2746[RHSA-2026:2746] advisory. Release notes for bug fixes and enhancements are provided in this documentation. The images that are included in the update are provided by the {OCP} link:https://access.redhat.com/errata/RHSA-2026:2672[RHSA-2026:2672] advisory.
+
+See the latest images included with {microshift-short} by xref:../microshift_updating/microshift-list-update-contents.adoc#microshift-get-rpm-release-info_microshift-list-update-contents[listing the contents of the {microshift-short} RPM release package].
+


### PR DESCRIPTION
Version(s):
4.17

Issue:
[OSDOCS-18375](https://issues.redhat.com/browse/OSDOCS-18375)

Link to docs preview:
[4.17.49](https://106810--ocpdocs-pr.netlify.app/microshift/latest/microshift_release_notes/microshift-4-17-release-notes.html#microshift-4-17-49-dp_release-notes)

QE review:
- [ ] QE has approved this change.
N/A for z-stream RNs.

Additional information:
Shipment [MR](https://gitlab.cee.redhat.com/hybrid-platforms/art/ocp-shipment-data/-/merge_requests/373)
ART [Dashboard](https://art-dash.engineering.redhat.com/dashboard/release/openshift-4.17)
