### PR TITLE
The current documentation describes restart behavior for the RerunOnF…

### DIFF
--- a/modules/virt-runstrategies-vms.adoc
+++ b/modules/virt-runstrategies-vms.adoc
@@ -16,7 +16,7 @@ The virtual machine instance (VMI) is always present when a virtual machine (VM)
 The VMI is re-created on another node if the previous instance fails. The instance is not re-created if the VM stops successfully, such as when it is shut down.
 [NOTE]
 ====
-Setting the RunStrategy to RerunOnFailure is an explicit command to start the virtual machine.
+Setting the RunStrategy to RerunOnFailure is an explicit command to start the non-running virtual machine.
 ====
 
 `Manual`::

--- a/modules/virt-runstrategies-vms.adoc
+++ b/modules/virt-runstrategies-vms.adoc
@@ -14,6 +14,10 @@ The virtual machine instance (VMI) is always present when a virtual machine (VM)
 
 `RerunOnFailure`::
 The VMI is re-created on another node if the previous instance fails. The instance is not re-created if the VM stops successfully, such as when it is shut down.
+[NOTE]
+====
+Setting the RunStrategy to RerunOnFailure is an explicit command to start the virtual machine.
+====
 
 `Manual`::
 You control the VMI state manually with the `start`, `stop`, and `restart` virtctl client commands. The VM is not automatically restarted.


### PR DESCRIPTION
The current documentation describes restart behavior for the **RerunOnFailure** RunStrategy but does not explicitly state that setting this **RunStrategy** starts a **non-running** VM.

This update clarifies that setting **RunStrategy=RerunOnFailure** is treated as an explicit request to run the non-running VM.

Related: [CNV-79383](https://issues.redhat.com/browse/CNV-79383)