### PR TITLE
[OSDOCS#17986] Update ShiftStack docs for dual OCP on single IP6 OSP support

### DIFF
--- a/modules/install-osp-deploy-dualstack.adoc
+++ b/modules/install-osp-deploy-dualstack.adoc
@@ -5,13 +5,21 @@
 [id="install-osp-deploy-dualstack_{context}"]
 = Deploying the dual-stack cluster
 
+[role="_abstract"]
+Create dual-stack networks and VIPs, then edit the `install-config.yaml` file to deploy an cluster with both IPv4 and IPv6 addressing on {rh-openstack-first}.
+
 .Procedure
 
-. Create a network with IPv4 and IPv6 subnets. The available address modes for the `ipv6-ra-mode` and `ipv6-address-mode` fields are: `dhcpv6-stateful`, `dhcpv6-stateless`, and `slaac`.
+. Create a network with the required subnets:
++
+* For {rh-openstack} 17.1, you can create a network with an IPv6 subnet. The {product-title} cluster offers IPv4 connectivity internally. In the `install-config.yaml` file, you specify both IPv4 and IPv6 subnets in the `controlPlanePort.fixedIPs` section.
+* For earlier versions of {rh-openstack}, create a network with both IPv4 and IPv6 subnets.
++
+The available address modes for the `ipv6-ra-mode` and `ipv6-address-mode` fields are: `dhcpv6-stateful`, `dhcpv6-stateless`, and `slaac`.
 +
 [NOTE]
 ====
-The dualstack network MTU must accommodate both the minimum MTU for IPv6, which is 1280, and the OVN-Kubernetes encapsulation overhead, which is 100.
+The dual-stack network MTU must accommodate both the minimum MTU for IPv6, which is 1280, and the OVN-Kubernetes encapsulation requirement, which is 100 bytes.
 ====
 +
 [NOTE]
@@ -47,40 +55,45 @@ controlPlane:
 metadata:
   name: mycluster
 networking:
-  machineNetwork: <1>
+  machineNetwork:
   - cidr: "192.168.25.0/24"
   - cidr: "fd2e:6f44:5dd8:c956::/64"
-  clusterNetwork: <1>
+  clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   - cidr: fd01::/48
     hostPrefix: 64
-  serviceNetwork: <1>
+  serviceNetwork:
   - 172.30.0.0/16
   - fd02::/112
 platform:
   openstack:
-    ingressVIPs: ['192.168.25.79', 'fd2e:6f44:5dd8:c956:f816:3eff:fef1:1bad'] <2>
-    apiVIPs: ['192.168.25.199', 'fd2e:6f44:5dd8:c956:f816:3eff:fe78:cf36'] <3>
-    controlPlanePort: <4>
-      fixedIPs: <5>
-      - subnet: <6>
+    ingressVIPs: ['192.168.25.79', 'fd2e:6f44:5dd8:c956:f816:3eff:fef1:1bad']
+    apiVIPs: ['192.168.25.199', 'fd2e:6f44:5dd8:c956:f816:3eff:fe78:cf36']
+    controlPlanePort:
+      fixedIPs:
+      - subnet:
           name: subnet-v4
           id: subnet-v4-id
-      - subnet: <6>
+      - subnet:
           name: subnet-v6
           id: subnet-v6-id
-      network: <7>
+      network:
         name: dualstack
         id: network-id
 ----
-<1> You must specify an IP address range for both the IPv4 and IPv6 address families.
-<2> Specify the virtual IP (VIP) address endpoints for the Ingress VIP services to provide an interface to the cluster.
-<3> Specify the virtual IP (VIP) address endpoints for the API VIP services to provide an interface to the cluster.
-<4> Specify the dual-stack network details that are used by all of the nodes across the cluster.
-<5> The CIDR of any subnet specified in this field must match the CIDRs listed on `networks.machineNetwork`.
-<6> You can specify a value for either `name` or `id`, or both.
-<7> Specifying the `network` under the `ControlPlanePort` field is optional.
+* `networking.machineNetwork`, `networking.clusterNetwork`, and `networking.serviceNetwork` specify IP address ranges for both the IPv4 and IPv6 address families. For {rh-openstack} 17.1 deployments on single-stack IPv6 infrastructure, the {product-title} cluster offers IPv4 connectivity internally.
+* `platform.openstack.ingressVIPs` specifies the virtual IP (VIP) address endpoints for the Ingress VIP services to give an interface to the cluster.
+* `platform.openstack.apiVIPs` specifies the virtual IP (VIP) address endpoints for the API VIP services to give an interface to the cluster.
+* `platform.openstack.controlPlanePort` specifies the dual-stack network details that all the nodes across the cluster use.
+* `platform.openstack.controlPlanePort.fixedIPs` specifies the subnets for the control plane port. The CIDR of any subnet specified in this field must match the CIDRs listed on `networking.machineNetwork`.
+* `platform.openstack.controlPlanePort.fixedIPs[].subnet` specifies each subnet. You can specify a value for either `name` or `id`, or both.
+* `platform.openstack.controlPlanePort.network` specifies the network. Specifying the `network` under the `controlPlanePort` field is optional.
++
+[NOTE]
+====
+For {rh-openstack} 17.1 deployments on single-stack IPv6 infrastructure, you can deploy a dual-stack {product-title} cluster. In the `install-config.yaml` file, specify both IPv4 and IPv6 address ranges for the cluster and service networks. The {product-title} cluster offers IPv4 connectivity internally, even though the underlying {rh-openstack} network only has IPv6 subnets. In the `controlPlanePort.fixedIPs` section, specify both the IPv4 and IPv6 subnets.
+====
 +
 Alternatively, if you want an IPv6 primary dual-stack cluster, edit the `install-config.yaml` file following the example below:
 +
@@ -105,46 +118,46 @@ controlPlane:
 metadata:
   name: mycluster
 networking:
-  machineNetwork: <1>
+  machineNetwork:
   - cidr: "fd2e:6f44:5dd8:c956::/64"
   - cidr: "192.168.25.0/24"
-  clusterNetwork: <1>
+  clusterNetwork:
   - cidr: fd01::/48
     hostPrefix: 64
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  serviceNetwork: <1>
+  serviceNetwork:
   - fd02::/112
   - 172.30.0.0/16
 platform:
   openstack:
-    ingressVIPs: ['fd2e:6f44:5dd8:c956:f816:3eff:fef1:1bad', '192.168.25.79'] <2>
-    apiVIPs: ['fd2e:6f44:5dd8:c956:f816:3eff:fe78:cf36', '192.168.25.199'] <3>
-    controlPlanePort: <4>
-      fixedIPs: <5>
-      - subnet: <6>
+    ingressVIPs: ['fd2e:6f44:5dd8:c956:f816:3eff:fef1:1bad', '192.168.25.79']
+    apiVIPs: ['fd2e:6f44:5dd8:c956:f816:3eff:fe78:cf36', '192.168.25.199']
+    controlPlanePort:
+      fixedIPs:
+      - subnet:
           name: subnet-v6
           id: subnet-v6-id
-      - subnet: <6>
+      - subnet:
           name: subnet-v4
           id: subnet-v4-id
-      network: <7>
+      network:
         name: dualstack
         id: network-id
 ----
-<1> You must specify an IP address range for both the IPv4 and IPv6 address families.
-<2> Specify the virtual IP (VIP) address endpoints for the Ingress VIP services to provide an interface to the cluster.
-<3> Specify the virtual IP (VIP) address endpoints for the API VIP services to provide an interface to the cluster.
-<4> Specify the dual-stack network details that are used by all the nodes across the cluster.
-<5> The CIDR of any subnet specified in this field must match the CIDRs listed on `networks.machineNetwork`.
-<6> You can specify a value for either `name` or `id`, or both.
-<7> Specifying the `network` under the `ControlPlanePort` field is optional.
+* `networking.machineNetwork`, `networking.clusterNetwork`, and `networking.serviceNetwork` specify IP address ranges for both the IPv4 and IPv6 address families. For {rh-openstack} 17.1 deployments on single-stack IPv6 infrastructure, the {product-title} cluster offers IPv4 connectivity internally.
+* `platform.openstack.ingressVIPs` specifies the virtual IP (VIP) address endpoints for the Ingress VIP services to give an interface to the cluster.
+* `platform.openstack.apiVIPs` specifies the virtual IP (VIP) address endpoints for the API VIP services to give an interface to the cluster.
+* `platform.openstack.controlPlanePort` specifies the dual-stack network details that all the nodes across the cluster use.
+* `platform.openstack.controlPlanePort.fixedIPs` specifies the subnets for the control plane port. The CIDR of any subnet specified in this field must match the CIDRs listed on `networking.machineNetwork`.
+* `platform.openstack.controlPlanePort.fixedIPs[].subnet` specifies each subnet. You can specify a value for either `name` or `id`, or both.
+* `platform.openstack.controlPlanePort.network` specifies the network. Specifying the `network` under the `controlPlanePort` field is optional.
 
 [NOTE]
 ====
-When using an installation host in an isolated dual-stack network, the IPv6 address may not be reassigned correctly upon reboot. 
+When using an installation host in an isolated dual-stack network, the IPv6 address might not be reassigned correctly upon reboot. 
 
-To resolve this problem on {op-system-base-full} 8, create a file called `/etc/NetworkManager/system-connections/required-rhel8-ipv6.conf` that contains the following configuration:
+To resolve this problem on {op-system-base-full} 8, create a file called `/etc/NetworkManager/system-connections/required-rhel8-ipv6.conf` that has the following configuration:
 
 [source,text]
 ----
@@ -155,7 +168,7 @@ addr-gen-mode=eui64
 method=auto
 ----
 
-To resolve this problem on {op-system-base} 9, create a file called `/etc/NetworkManager/conf.d/required-rhel9-ipv6.conf` that contains the following configuration:
+To resolve this problem on {op-system-base} 9, create a file called `/etc/NetworkManager/conf.d/required-rhel9-ipv6.conf` that has the following configuration:
 
 [source,text]
 ----
@@ -168,6 +181,6 @@ After you create and edit the file, reboot the installation host.
 
 [NOTE]
 ====
-The `ip=dhcp,dhcp6` kernel argument, which is set on all of the nodes, results in a single Network Manager connection profile that is activated on multiple interfaces simultaneously.
-Because of this behavior, any additional network has the same connection enforced with an identical UUID. If you need an interface-specific configuration, create a new connection profile for that interface so that the default connection is no longer enforced on it.
+The `ip=dhcp,dhcp6` kernel argument, which is set on all of the nodes, results in a single Network Manager connection profile that activates on many interfaces simultaneously.
+Because of this behavior, any additional network has the same connection enforced with the same UUID. If you need an interface-specific configuration, create a new connection profile for that interface so that the default connection is no longer enforced on it.
 ====

--- a/modules/install-osp-dualstack.adoc
+++ b/modules/install-osp-dualstack.adoc
@@ -5,9 +5,16 @@
 [id="install-osp-dualstack_{context}"]
 = Configuring a cluster with dual-stack networking
 
+[role="_abstract"]
+Deploy a cluster with both IPv4 and IPv6 addressing on {rh-openstack-first}. From {rh-openstack} 17.1, you can use single-stack IPv6 infrastructure while the cluster provides internal IPv4 connectivity.
+
 :FeatureName: Dual-stack configuration for OpenStack
 
-You can create a dual-stack cluster on {rh-openstack}. However, the dual-stack configuration is enabled only if you are using an {rh-openstack} network with IPv4 and IPv6 subnets.
+You can create a dual-stack cluster on {rh-openstack}. 
+
+For {rh-openstack} 17.1, you can deploy a dual-stack {product-title} cluster on a single-stack IPv6 {rh-openstack} infrastructure. The {product-title} cluster offers IPv4 connectivity internally, even when the underlying {rh-openstack} network only has IPv6 subnets.
+
+For earlier versions of {rh-openstack}, you can enable the dual-stack configuration only if you are using an {rh-openstack} network with IPv4 and IPv6 subnets.
 
 [NOTE]
 ====

--- a/modules/installation-configuring-shiftstack-single-ipv6.adoc
+++ b/modules/installation-configuring-shiftstack-single-ipv6.adoc
@@ -6,7 +6,15 @@
 [id="installation-configuring-shiftstack-single-ipv6_{context}"]
 = Configuring a cluster with single-stack IPv6 networking
 
+[role="_abstract"]
+Create API and Ingress VIP ports and configure the `install-config.yaml` file to deploy a cluster with IPv6-only networking on {rh-openstack-first}.
+
 You can create a single-stack IPv6 cluster on {rh-openstack-first} after you configure your {rh-openstack} deployment.
+
+[NOTE]
+====
+For {rh-openstack} 17.1, you can also deploy a dual-stack {product-title} cluster on a single-stack IPv6 {rh-openstack} infrastructure. The {product-title} cluster offers IPv4 connectivity internally, even when the underlying {rh-openstack} network only has IPv6 subnets.
+====
 
 IMPORTANT: You cannot convert a dual-stack cluster into a single-stack IPv6 cluster.
 
@@ -60,7 +68,7 @@ metadata:
   name: mycluster
 networking:
   machineNetwork:
-  - cidr: "fd2e:6f44:5dd8:c956::/64" # <1>
+  - cidr: "fd2e:6f44:5dd8:c956::/64"
   clusterNetwork:
   - cidr: fd01::/48
     hostPrefix: 64
@@ -68,15 +76,15 @@ networking:
   - fd02::/112
 platform:
   openstack:
-    ingressVIPs: ['fd2e:6f44:5dd8:c956::383'] # <2>
-    apiVIPs: ['fd2e:6f44:5dd8:c956::9a'] # <2>
+    ingressVIPs: ['fd2e:6f44:5dd8:c956::383']
+    apiVIPs: ['fd2e:6f44:5dd8:c956::9a']
     controlPlanePort:
-      fixedIPs: # <3>
+      fixedIPs:
       - subnet:
           name: subnet-v6
-      network: # <3>
+      network:
         name: v6-network
-imageContentSources: #<4>
+imageContentSources:
 - mirrors:
   - <mirror>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
@@ -86,7 +94,7 @@ imageContentSources: #<4>
 additionalTrustBundle: |
 <certificate_of_the_mirror>
 ----
-<1> The CIDR of the subnet specified in this field must match the CIDR of the subnet that is specified in the `controlPlanePort` section.
-<2> Use the address from the ports you generated in the previous steps as the values for the parameters `platform.openstack.ingressVIPs` and `platform.openstack.apiVIPs`.
-<3> Items under the `platform.openstack.controlPlanePort.fixedIPs` and `platform.openstack.controlPlanePort.network` keys can contain an ID, a name, or both.
-<4> The `imageContentSources` section contains the mirror details. For more information on configuring a local image registry, see "Creating a mirror registry with mirror registry for Red Hat OpenShift". 
+* `networking.machineNetwork` specifies the CIDR of the subnet. The CIDR of the subnet specified in this field must match the CIDR of the subnet that is specified in the `controlPlanePort` section.
+* `platform.openstack.ingressVIPs` and `platform.openstack.apiVIPs` specify the virtual IP addresses. Use the address from the ports you generated in the earlier steps as the values for these parameters.
+* `platform.openstack.controlPlanePort.fixedIPs` and `platform.openstack.controlPlanePort.network` specify the control plane port configuration. Items under these keys can contain an ID, a name, or both.
+* `imageContentSources` specifies the mirror details. For more information on configuring a local image registry, see "Creating a mirror registry with mirror registry for Red Hat OpenShift". 


### PR DESCRIPTION
Add docs for GA of dual-stack networking clusters on IPv6 OpenStack for ShiftStack.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Do not create or rename a top-level directory (or any subdirectory in a directory that contains a hugebook.flag file) in the repository and topic map without checking with a docs program manager first.
If a book is being created or modified, there are changes on the Customer Portal that must also be made.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.21+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-17986](https://issues.redhat.com/browse/OSDOCS-17986), but also see [OSDOCS-17376](https://issues.redhat.com/browse/OSDOCS-17376) and [RHOSSTRAT-1130](https://issues.redhat.com/browse/RHOSSTRAT-1130). Tracking has been non-standard.
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: CM acks complete.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
