### PR TITLE
OSDOCS-16873-1: CQA 2.0 for SCALE-3 Low-Latency/CNF Provisioning and …

### DIFF
--- a/modules/cnf-configuring-high-priority-workload-pods.adoc
+++ b/modules/cnf-configuring-high-priority-workload-pods.adoc
@@ -6,9 +6,8 @@
 [id="cnf-configuring-high-priority-workload-pods_{context}"]
 = Disabling power saving mode for high priority pods
 
-You can configure pods to ensure that high priority workloads are unaffected when you configure power saving for the node that the workloads run on.
-
-When you configure a node with a power saving configuration, you must configure high priority workloads with performance configuration at the pod level, which means that the configuration applies to all the cores used by the pod.
+[role="_abstract"]
+To protect high priority workloads when using power saving configurations on a node, apply performance settings at the pod level. This ensures that the configuration applies to all cores used by the pod, maintaining performance stability.
 
 By disabling P-states and C-states at the pod level, you can configure high priority workloads for best performance and lowest latency.
 

--- a/modules/cnf-disabling-cpu-cfs-quota.adoc
+++ b/modules/cnf-disabling-cpu-cfs-quota.adoc
@@ -2,11 +2,17 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-provisioning-low-latency-workloads.adoc
 
+:_mod-docs-content-type: PROCEDURE
 [id="cnf-disabling-cpu-cfs-quota_{context}"]
 = Disabling CPU CFS quota
 
-To eliminate CPU throttling for pinned pods, create a pod with the `cpu-quota.crio.io: "disable"` annotation. This annotation disables the CPU completely fair scheduler (CFS) quota when the pod runs.
+[role="_abstract"]
+To prevent CPU throttling for latency-sensitive workloads, disable the CPU CFS quota. This configuration allows pods to use unallocated CPU resources on the node, ensuring consistent application performance.
 
+.Procedure
+
+* To eliminate CPU throttling for pinned pods, create a pod with the `cpu-quota.crio.io: "disable"` annotation. This annotation disables the CPU completely fair scheduler (CFS) quota when the pod runs.
++
 .Example pod specification with `cpu-quota.crio.io` disabled
 [source,yaml]
 ----
@@ -19,7 +25,7 @@ spec:
     runtimeClassName: performance-<profile_name>
 #...
 ----
-
++
 [NOTE]
 ====
 Only disable CPU CFS quota when the CPU manager static policy is enabled and for pods with guaranteed QoS that use whole CPUs. For example, pods that contain CPU-pinned containers. Otherwise, disabling CPU CFS quota can affect the performance of other containers in the cluster.

--- a/modules/cnf-disabling-interrupt-processing-for-individual-pods.adoc
+++ b/modules/cnf-disabling-interrupt-processing-for-individual-pods.adoc
@@ -6,6 +6,7 @@
 [id="cnf-disabling-interrupt-processing-for-individual-pods_{context}"]
 = Configuring interrupt processing for individual pods
 
+[role="_abstract"]
 To achieve low latency for workloads, some containers require that the CPUs they are pinned to do not process device interrupts. You can use the `irq-load-balancing.crio.io` pod annotation to control whether device interrupts are processed on CPUs where the pinned containers are running.
 
 The annotation supports the following values:
@@ -13,7 +14,7 @@ The annotation supports the following values:
 `disable`:: Disables IRQ load balancing for all CPUs allocated to the container. Use this value for latency-sensitive workloads when you want to exclude container CPUs from interrupt handling.
 
 `housekeeping`:: Preserves IRQ handling on the first CPU that is allocated to the container, including that CPU's thread siblings. The subsequent CPUs allocated to the container are excluded from interrupt processing. This configuration also injects the `OPENSHIFT_HOUSEKEEPING_CPUS` environment variable into the container. Use this variable to see which CPUs are designated for housekeeping tasks. 
-+
+
 You can use the `housekeeping` value to reduce the overall CPU footprint by allowing a small subset of container CPUs to handle both application housekeeping work and system interrupts.
 
 [NOTE]
@@ -53,8 +54,8 @@ spec:
         memory: "4Gi"
 ----
 +
-* `annotations.irq-load-balancing.crio.io` defines whether device interrupts are processed on the container CPUs. Set to `disable` to prevent all container CPUs from handling IRQs, or set to `housekeeping` to allow the first allocated CPU and its thread siblings to handle IRQs while excluding the remaining CPUs from IRQ handling.
-* `spec.runtimeClassName` sets the runtime class to the performance profile. Replace `<profile_name>` with the name of your performance profile.
+** `metadata.annotations.irq-load-balancing.crio.io`: Specifies if device interrupts are processed on the container CPUs. Set to `disable` to prevent all container CPUs from handling IRQs, or set to `housekeeping` to allow the first allocated CPU and its thread siblings to handle IRQs while excluding the remaining CPUs from IRQ handling.
+** `spec.runtimeClassName`: Specifies the runtime class for the performance profile. Replace `<profile_name>` with the name of your performance profile.
 
 . Apply the `Pod` resource by running the following command:
 +

--- a/modules/cnf-node-tuning-operator-creating-pod-with-guaranteed-qos-class.adoc
+++ b/modules/cnf-node-tuning-operator-creating-pod-with-guaranteed-qos-class.adoc
@@ -6,6 +6,7 @@
 [id="cnf-node-tuning-operator-creating-pod-with-guaranteed-qos-class_{context}"]
 = Creating a pod with a guaranteed QoS class
 
+[role="_abstract"]
 You can create a pod with a quality of service (QoS) class of `Guaranteed` for high-performance workloads. Configuring a pod with a QoS class of `Guaranteed` ensures that the pod has priority access to the specified CPU and memory resources. 
 
 To create a pod with a QoS class of `Guaranteed`, you must apply the following specifications:
@@ -17,9 +18,8 @@ In general, a pod with a QoS class of `Guaranteed` will not be evicted from a no
 
 .Prerequisites
 
-* Access to the cluster as a user with the `cluster-admin` role
-
-* The OpenShift CLI (`oc`)
+* Access to the cluster as a user with the `cluster-admin` role.
+* The {oc-first}.
 
 .Procedure
 
@@ -27,9 +27,9 @@ In general, a pod with a QoS class of `Guaranteed` will not be evicted from a no
 +
 [source,terminal]
 ----
-$ oc create namespace qos-example <1>
+$ oc create namespace qos-example
 ----
-<1> This example uses the `qos-example` namespace.
+** qos-example: Specifies a `qos-example` example namespace.
 +
 .Example output
 [source,terminal]
@@ -38,10 +38,9 @@ namespace/qos-example created
 ----
 
 . Create the `Pod` resource:
-
++
 .. Create a YAML file that defines the `Pod` resource:
 +
---
 .Example `qos-example.yaml` file
 [source,yaml]
 ----
@@ -57,31 +56,39 @@ spec:
       type: RuntimeDefault
   containers:
   - name: qos-demo-ctr
-    image: quay.io/openshifttest/hello-openshift:openshift <1>
+    image: quay.io/openshifttest/hello-openshift:openshift
     resources:
       limits:
-        memory: "200Mi" <2>
-        cpu: "1" <3>
+        memory: "200Mi"
+        cpu: "1"
       requests:
-        memory: "200Mi" <4>
-        cpu: "1" <5>
+        memory: "200Mi"
+        cpu: "1"
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop: [ALL]
 ----
-<1> This example uses a public `hello-openshift` image.
-<2> Sets the memory limit to 200 MB.
-<3> Sets the CPU limit to 1 CPU.
-<4> Sets the memory request to 200 MB.
-<5> Sets the CPU request to 1 CPU.
++
+--
+where:
+
+`spec.containers.image`:: Specifies public image, such as the `hello-openshift` image.
+
+`spec.containers.resources.limits.memory`:: Specifies a memory limit of 200 MB.
+
+`spec.containers.resources.limits.cpu`:: Specifies a CPU limit of 1 CPU.
+
+`spec.containers.resources.requests.memory`:: Specifies a memory request of 200 MB.
+
+`spec.containers.resources.requests.cpu`:: Specifies a CPU request of 1 CPU.
 +
 [NOTE]
 ====
 If you specify a memory limit for a container, but do not specify a memory request, {product-title} automatically assigns a memory request that matches the limit. Similarly, if you specify a CPU limit for a container, but do not specify a CPU request, {product-title} automatically assigns a CPU request that matches the limit.
 ====
 --
-
++
 .. Create the `Pod` resource by running the following command:
 +
 [source,terminal]

--- a/modules/cnf-node-tuning-operator-disabling-cpu-load-balancing-for-dpdk.adoc
+++ b/modules/cnf-node-tuning-operator-disabling-cpu-load-balancing-for-dpdk.adoc
@@ -2,9 +2,12 @@
 //
 // * scalability_and_performance/low_latency_tuning/cnf-provisioning-low-latency-workloads.adoc
 
-:_mod-docs-content-type: PROCEDURE
+:_mod-docs-content-type: REFERENCE
 [id="cnf-node-tuning-operator-disabling-cpu-load-balancing-for-dpdk_{context}"]
 = Disabling CPU load balancing in a Pod
+
+[role="_abstract"]
+To optimize performance, disable or enable CPU load balancing for your Pods. CRI-O implements this functionality and applies the configuration only when specific requirements are met.
 
 Functionality to disable or enable CPU load balancing is implemented on the CRI-O level. The code under the CRI-O disables or enables CPU load balancing only when the following requirements are met.
 

--- a/modules/cnf-scheduling-workload-onto-worker-with-real-time-capabilities.adoc
+++ b/modules/cnf-scheduling-workload-onto-worker-with-real-time-capabilities.adoc
@@ -4,23 +4,21 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cnf-scheduling-workload-onto-worker-with-real-time-capabilities_{context}"]
-= Scheduling a low latency workload onto a worker with real-time capabilities
+= Scheduling a low latency workload onto a compute node
 
-You can schedule low latency workloads onto a worker node where a performance profile that configures real-time capabilities is applied.
+[role="_abstract"]
+To run low latency workloads, schedule them onto a compute node associated with a performance profile that configures real-time capabilities. This ensures that the node is tuned to meet the specific timing and performance requirements of your application.
 
 [NOTE]
 ====
-To schedule the workload on specific nodes, use label selectors in the `Pod` custom resource (CR).
-The label selectors must match the nodes that are attached to the machine config pool that was configured for low latency by the Node Tuning Operator.
+To schedule a workload on specific nodes, use label selectors in the `Pod` custom resource (CR). The label selectors must match the nodes that are attached to the machine config pool that was configured for low latency by the Node Tuning Operator.
 ====
 
 .Prerequisites
 
-* You have installed the OpenShift CLI (`oc`).
-
+* You have installed the {oc-first}.
 * You have logged in as a user with `cluster-admin` privileges.
-
-* You have applied a performance profile in the cluster that tunes worker nodes for low latency workloads.
+* You have applied a performance profile in the cluster that tunes compute nodes for low latency workloads.
 
 .Procedure
 
@@ -34,9 +32,9 @@ kind: Pod
 metadata:
   name: dynamic-low-latency-pod
   annotations:
-    cpu-quota.crio.io: "disable" <1>
-    cpu-load-balancing.crio.io: "disable" <2>
-    irq-load-balancing.crio.io: "disable" <3>
+    cpu-quota.crio.io: "disable"
+    cpu-load-balancing.crio.io: "disable"
+    irq-load-balancing.crio.io: "disable"
 spec:
   securityContext:
     runAsNonRoot: true
@@ -58,20 +56,28 @@ spec:
       capabilities:
         drop: [ALL]
   nodeSelector:
-    node-role.kubernetes.io/worker-cnf: "" <4>
+    node-role.kubernetes.io/worker-cnf: ""
   runtimeClassName: performance-dynamic-low-latency-profile <5>
 # ...
 ----
-<1> Disables the CPU completely fair scheduler (CFS) quota at the pod run time.
-<2> Disables CPU load balancing.
-<3> Opts the pod out of interrupt handling on the node.
-<4> The `nodeSelector` label must match the label that you specify in the `Node` CR.
-<5> `runtimeClassName` must match the name of the performance profile configured in the cluster.
++
+--
+where
 
-. Enter the pod `runtimeClassName` in the form performance-<profile_name>, where <profile_name> is the `name` from the `PerformanceProfile` YAML.
-In the previous example, the `name` is `performance-dynamic-low-latency-profile`.
+`metadata.annotations.cpu-quota.crio.io`:: Disables the CPU completely fair scheduler (CFS) quota at the pod run time.
 
-. Ensure the pod is running correctly. Status should be `running`, and the correct cnf-worker node should be set:
+`metadata.annotations.cpu-load-balancing.crio.io`:: Disables CPU load balancing.
+
+`metadata.annotations.irq-load-balancing.crio.io`:: Opts the pod out of interrupt handling on the node.
+
+`spec.nodeSelector.node-role.kubernetes.io/worker-cnf`:: The `nodeSelector` label must match the label that you specify in the `Node` CR.
+
+`spec.runtimeClassName`:: `runtimeClassName` must match the name of the performance profile configured in the cluster.
+--
+
+. Enter the pod `runtimeClassName` in the form performance-<profile_name>, where <profile_name> is the `name` from the `PerformanceProfile` YAML. In the previous YAML example, the `name` is `performance-dynamic-low-latency-profile`.
+
+. Ensure the pod is running correctly. Status should be `running`, and the correct `cnf-worker` node should be set.
 +
 [source,terminal]
 ----
@@ -79,7 +85,6 @@ $ oc get pod -o wide
 ----
 +
 .Expected output
-+
 [source,terminal]
 ----
 NAME                     READY   STATUS    RESTARTS   AGE     IP           NODE
@@ -94,7 +99,6 @@ $ oc exec -it dynamic-low-latency-pod -- /bin/bash -c "grep Cpus_allowed_list /p
 ----
 +
 .Expected output
-+
 [source,terminal]
 ----
 Cpus_allowed_list:  2-3
@@ -119,7 +123,6 @@ sh-4.4# chroot /host
 ----
 +
 .Expected output
-+
 [source,terminal]
 ----
 sh-4.4#
@@ -133,7 +136,6 @@ sh-4.4# cat /proc/irq/default_smp_affinity
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 33
@@ -147,7 +149,6 @@ sh-4.4# find /proc/irq/ -name smp_affinity_list -exec sh -c 'i="$1"; mask=$(cat 
 ----
 +
 .Example output
-+
 [source,terminal]
 ----
 /proc/irq/0/smp_affinity_list: 0-5
@@ -174,7 +175,7 @@ sh-4.4# find /proc/irq/ -name smp_affinity_list -exec sh -c 'i="$1"; mask=$(cat 
 /proc/irq/29/smp_affinity_list: 0
 /proc/irq/30/smp_affinity_list: 0-5
 ----
-
++
 [WARNING]
 ====
 When you tune nodes for low latency, the usage of execution probes in conjunction with applications that require guaranteed CPUs can cause latency spikes. Use other probes, such as a properly configured set of network probes, as an alternative.

--- a/scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc
+++ b/scalability_and_performance/cnf-provisioning-low-latency-workloads.adoc
@@ -6,10 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Many organizations need high performance computing and low, predictable latency, especially in the financial and telecommunications industries.
+[role="_abstract"]
+To achieve low latency and consistent response times for {product-title} applications, use the Node Tuning Operator. This Operator implements automatic tuning to optimize your cluster for high-performance computing workloads.
 
-{product-title} provides the Node Tuning Operator to implement automatic tuning to achieve low latency performance and consistent response time for {product-title} applications.
 You use the performance profile configuration to make these changes.
+
 You can update the kernel to kernel-rt, reserve CPUs for cluster and operating system housekeeping duties, including pod infra containers, isolate CPUs for application containers to run the workloads, and disable unused CPUs to reduce power consumption.
 
 [NOTE]
@@ -40,7 +41,7 @@ include::modules/cnf-configuring-high-priority-workload-pods.adoc[leveloffset=+1
 [role="_additional-resources"]
 .Additional resources
 
-xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-configuring-power-saving-for-nodes_cnf-low-latency-perf-profile[Configuring power saving for nodes that run colocated high and low priority workloads]
+* xref:../scalability_and_performance/cnf-tuning-low-latency-nodes-with-perf-profile.adoc#cnf-configuring-power-saving-for-nodes_cnf-low-latency-perf-profile[Configuring power saving for nodes that run colocated high and low priority workloads]
 
 include::modules/cnf-disabling-cpu-cfs-quota.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.16+

Issue:
[OSDOCS-16873](https://issues.redhat.com/browse/OSDOCS-16873)

Link to docs preview:

* https://106850--ocpdocs-pr.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-provisioning-low-latency-workloads.html#cnf-scheduling-workload-onto-worker-with-real-time-capabilities_cnf-provisioning-low-latency

- [ ] SME has approved this change.
- [ ] QE has approved this change.

