### PR TITLE
OSDOCS 16932 CQA 2.0 of NODES-4: Container/Pod Runtime Configuration

### DIFF
--- a/modules/nodes-containers-copying-files-about.adoc
+++ b/modules/nodes-containers-copying-files-about.adoc
@@ -6,7 +6,8 @@
 [id="nodes-containers-copying-files-about_{context}"]
 = Understanding how to copy files
 
-The `oc rsync` command, or remote sync, is a useful tool for copying database archives to and from your pods for backup and restore purposes.
+[role="_abstract"]
+You can use the `oc rsync` command, or remote sync, for copying database archives to and from your pods for backup and restore purposes.
 You can also use `oc rsync` to copy source code changes into a running pod for development debugging, when the running pod supports hot reload of source files.
 
 [source,terminal]
@@ -14,13 +15,13 @@ You can also use `oc rsync` to copy source code changes into a running pod for d
 $ oc rsync <source> <destination> [-c <container>]
 ----
 
-== Requirements
+When using the `oc rysnc` command, note the following requirements. 
 
 Specifying the Copy Source::
 The source argument of the `oc rsync` command must point to either a local
 directory or a pod directory. Individual files are not supported.
 +
-When specifying a pod directory the directory name must be prefixed with the pod
+When specifying a pod directory, the directory name must be prefixed with the pod
 name:
 +
 [source,terminal]
@@ -37,13 +38,13 @@ the directory does not exist, but `rsync` is used for copy, the directory is
 created for you.
 
 Deleting Files at the Destination::
-The `--delete` flag may be used to delete any files in the remote directory that
+The `--delete` flag can be used to delete any files in the remote directory that
 are not in the local directory.
 
 Continuous Syncing on File Change::
 Using the `--watch` option causes the command to monitor the source path for any
 file system changes, and synchronizes changes when they occur. With this
-argument, the command runs forever.
+argument, the command runs continuously.
 +
 Synchronization occurs after short quiet periods to ensure a
 rapidly changing file system does not result in continuous synchronization

--- a/modules/nodes-containers-copying-files-procedure.adoc
+++ b/modules/nodes-containers-copying-files-procedure.adoc
@@ -6,11 +6,10 @@
 [id="nodes-containers-copying-files-procedure_{context}"]
 = Copying files to and from containers
 
-Support for copying local files to or from a container is built into the CLI.
+[role="_abstract"]
+You can use the `oc rsync` command for copying local files to or from a container.
 
 .Prerequisites
-
-When working with `oc rsync`, note the following:
 
 * rsync must be installed. The `oc rsync` command uses the local `rsync` tool, if present on the client
 machine and the remote container.

--- a/modules/nodes-containers-copying-files-rsync.adoc
+++ b/modules/nodes-containers-copying-files-rsync.adoc
@@ -6,11 +6,14 @@
 [id="nodes-containers-copying-files-rsync_{context}"]
 = Using advanced Rsync features
 
-The `oc rsync` command exposes fewer command-line options than standard `rsync`.
+[role="_abstract"]
+You can use the additional command-line options that are available with the standard `rsync` command if needed. 
+
+The `oc rsync` command exposes fewer command-line options than standard `rsync` command.
 In the case that you want to use a standard `rsync` command-line option that is
-not available in `oc rsync`, for example the `--exclude-from=FILE` option, it
-might be possible to use standard `rsync` 's `--rsh` (`-e`) option or `RSYNC_RSH`
-environment variable as a workaround, as follows:
+not available with the `oc rsync` command, for example the `--exclude-from=FILE` option, it
+might be possible to use standard `rsync` with the `--rsh` (`-e`) option or `RSYNC_RSH`
+environment variable as a workaround, as shown in the following examples:
 
 [source,terminal]
 ----
@@ -33,6 +36,6 @@ Then, run the rsync command:
 $ rsync --exclude-from=<file_name> <local-dir> <pod-name>:/<remote-dir>
 ----
 
-Both of the above examples configure standard `rsync` to use `oc rsh` as its
+Both of the above examples configure the standard `rsync` command to use `oc rsh` as its
 remote shell program to enable it to connect to the remote pod, and are an
 alternative to running `oc rsync`.

--- a/modules/nodes-containers-dev-fuse-configuring.adoc
+++ b/modules/nodes-containers-dev-fuse-configuring.adoc
@@ -6,7 +6,10 @@
 [id="nodes-containers-dev-fuse-configuring_{context}"]
 = Configuring /dev/fuse for unprivileged builds in pods
 
-By exposing the `/dev/fuse` device to an unprivileged pod, you grant it the capability to perform Filesystem in Userspace (FUSE) mounts. This is achieved by adding the `io.kubernetes.cri-o.Devices: "/dev/fuse"` annotation to your pod definition. This setup allows an unprivileged user within the pod to use tools like `podman` with storage drivers such as `fuse-overlayfs` by mimicking privileged build capabilities in a secure and efficient manner without granting full privileged access to the pod.
+[role="_abstract"]
+You can grant an unprivileged pod the capability to perform Filesystem in Userspace (FUSE) mounts by exposing the `/dev/fuse` device. With this setup, an unprivileged user within the pod can use tools such as `podman` with storage drivers such as `fuse-overlayfs` by mimicking privileged build capabilities in a secure and efficient manner without granting full privileged access to the pod.
+
+You expose the `/dev/fuse` device by adding the `io.kubernetes.cri-o.Devices: "/dev/fuse"` annotation to your pod definition.
 
 .Procedure
 
@@ -34,10 +37,10 @@ spec:
 +
 where:
 +
-`io.kubernetes.cri-o.Devices`:: The `io.kubernetes.cri-o.Devices: "/dev/fuse"` annotation makes the FUSE device available.
-`image`:: This annotation specifies a container that uses an image that includes `podman` (for example, `quay.io/podman/stable`).
-`args`:: This command keeps the container running so you can `exec` into it.
-`securityContext`:: This annotation specifies a `securityContext` that runs the container as an unprivileged user (for example, `runAsUser: 1000`).
+`metadata.annotations`:: Specifies that the `io.kubernetes.cri-o.Devices: "/dev/fuse"` annotation makes the FUSE device available.
+`spec.containers.image`:: Specifies a container that uses an image that includes `podman` (for example, `quay.io/podman/stable`).
+`spec.containers.args`:: Specifies a command to keep the container running so you can `exec` into it.
+`spec.containers.securityContext`:: Specifies a `securityContext` that runs the container as an unprivileged user (for example, `runAsUser: 1000`).
 +
 [NOTE]
 ====
@@ -51,7 +54,7 @@ Depending on your cluster's Security Context Constraints (SCCs) or other policie
 $ oc apply -f fuse-builder-pod.yaml
 ----
 
-. Verify that the pod is running:
+. Verify that the pod is running by running the following command:
 +
 [source,terminal]
 ----
@@ -59,15 +62,17 @@ $ oc get pods fuse-builder-pod
 ----
 
 . Access the pod and prepare the build environment:
-+
-After the `fuse-builder-pod` pod is in the `Running` state, open a shell session into the `build-container` environment:
+
+.. After the `fuse-builder-pod` pod is in the `Running` state, open a shell session into the `build-container` environment by running the following command:
 +
 [source,terminal]
 ----
 $ oc exec -ti fuse-builder-pod -- /bin/bash
 ----
 +
-You are now inside the container. Because the default working directory might not be writable by the unprivileged user, change to a writable directory like `/tmp`:
+You are now inside the container. 
+
+.. Because the default working directory might not be writable by an unprivileged user, change to a writable directory such as `/tmp` by running the following commands:
 +
 [source,terminal]
 ----
@@ -84,7 +89,7 @@ $ pwd
 /tmp
 ----
 
-. Create a dockerfile and build an image using Podman:
+. Create a dockerfile and build an image by using Podman:
 +
 Inside the pod's shell and within the `/tmp` directory, you can now create a `Dockerfile` and use `podman` to build a container image. If `fuse-overlayfs` is the default or configured storage driver, Podman is able to leverage `fuse-overlayfs` because of the available `/dev/fuse` device.
 +
@@ -102,7 +107,7 @@ CMD ["sh", "-c", "cat /app/build_info.txt && echo '--- Copied Dockerfile ---' &&
 EOF
 ----
 +
-.. Build the image using `podman`. The `-t` flag tags the image:
+.. Build the image by running the following command. The `-t` flag tags the image.
 +
 [source,terminal]
 ----
@@ -113,7 +118,7 @@ You should see Podman executing the build steps.
 
 . Optional: Test the built image:
 +
-Still inside the `fuse-builder-pod`, you can run a container from the image you just built to test it:
+Still inside the `fuse-builder-pod`, you can run a container from the image you just built to test it by running the following command:
 +
 [source,terminal]
 ----
@@ -124,21 +129,21 @@ This should output the content of the `/app/build_info.txt` file and the copied 
 
 . Exit the pod and clean up:
 +
-.. After you are done, exit the shell session in the pod:
+.. After you are done, exit the shell session in the pod by running the following command:
 +
 [source,terminal]
 ----
 $ exit
 ----
 +
-.. Delete the pod if it's no longer needed:
+.. Delete the pod if it is no longer needed by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete pod fuse-builder-pod
 ----
 +
-.. Remove the local YAML file:
+.. Remove the local YAML file by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-about.adoc
+++ b/modules/nodes-containers-downward-api-about.adoc
@@ -6,9 +6,9 @@
 [id="nodes-containers-projected-volumes-about_{context}"]
 = Expose pod information to Containers using the Downward API
 
-The Downward API contains such information as the pod's name, project, and resource values. Containers can consume
-information from the downward API using environment variables or a volume
-plugin.
+[role="_abstract"]
+You can review the following tables to learn what information the Downward API contains, including the pod's name, project, and resource values. Your containers can consume this
+information by using environment variables or a volume plugin.
 
 Fields within the pod are selected using the `FieldRef` API type. `FieldRef`
 has two fields:

--- a/modules/nodes-containers-downward-api-container-configmaps.adoc
+++ b/modules/nodes-containers-downward-api-container-configmaps.adoc
@@ -6,8 +6,9 @@
 [id="nodes-containers-downward-api-container-configmaps_{context}"]
 = Consuming configuration maps using the Downward API
 
+[role="_abstract"]
 When creating pods, you can use the Downward API to inject configuration map values
-so image and application authors can create an image for specific environments.
+so that image and application authors can create an image for specific environments.
 
 .Procedure
 
@@ -25,7 +26,7 @@ data:
   mykey: myvalue
 ----
 
-.. Create the config map from the `configmap.yaml` file:
+.. Create the config map from the `configmap.yaml` file by using the following command:
 +
 [source,terminal]
 ----
@@ -65,7 +66,7 @@ spec:
 # ...
 ----
 
-.. Create the pod from the `pod.yaml` file:
+.. Create the pod from the `pod.yaml` file by using the following command:
 +
 [source,terminal]
 ----
@@ -74,7 +75,7 @@ $ oc create -f pod.yaml
 
 .Verification
 
-* Check the container's logs for the `MY_CONFIGMAP_VALUE` value:
+* Check the container's logs for the `MY_CONFIGMAP_VALUE` value by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-envars.adoc
@@ -7,7 +7,7 @@
 = Referencing environment variables
 
 [role="_abstract"]
-When creating pods, you can reference the value of a previously defined environment variable by using the `$()` syntax. This allows you to reference variables that you define within a pod configuration elsewhere in that configuration.
+When creating pods, you can reference the value of a previously defined environment variable by using the `$()` syntax. By using this syntax, you can reference variables that you define within a pod configuration elsewhere in that configuration.
 
 If the environment variable
 reference cannot be resolved, the value will be left as the provided

--- a/modules/nodes-containers-downward-api-container-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-envars.adoc
@@ -6,9 +6,11 @@
 [id="nodes-containers-downward-api-container-envars_{context}"]
 = Referencing environment variables
 
-When creating pods, you can reference the value of a previously defined
-environment variable by using the `$()` syntax. If the environment variable
-reference can not be resolved, the value will be left as the provided
+[role="_abstract"]
+When creating pods, you can reference the value of a previously defined environment variable by using the `$()` syntax. This allows you to reference variables that you define within a pod configuration elsewhere in that configuration.
+
+If the environment variable
+reference cannot be resolved, the value will be left as the provided
 string.
 
 .Procedure
@@ -45,7 +47,7 @@ spec:
 # ...
 ----
 
-.. Create the pod from the `*_pod.yaml_*` file:
+.. Create the pod from the `*_pod.yaml_*` file by using the following command:
 +
 [source,terminal]
 ----
@@ -54,7 +56,7 @@ $ oc create -f pod.yaml
 
 .Verification
 
-* Check the container's logs for the `MY_ENV_VAR_REF_ENV` value:
+* Check the container's logs for the `MY_ENV_VAR_REF_ENV` value by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-escaping.adoc
+++ b/modules/nodes-containers-downward-api-container-escaping.adoc
@@ -6,6 +6,7 @@
 [id="nodes-containers-downward-api-container-escaping_{context}"]
 = Escaping environment variable references
 
+[role="_abstract"]
 When creating a pod, you can escape an environment variable reference by using
 a double dollar sign. The value will then be set to a single dollar sign version
 of the provided value.
@@ -42,7 +43,7 @@ spec:
 # ...
 ----
 
-.. Create the pod from the `*_pod.yaml_*` file:
+.. Create the pod from the `*_pod.yaml_*` file by using the following command:
 +
 [source,terminal]
 ----
@@ -51,7 +52,7 @@ $ oc create -f pod.yaml
 
 .Verification
 
-* Check the container's logs for the `MY_NEW_ENV` value:
+* Check the container's logs for the `MY_NEW_ENV` value by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-resources-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-resources-envars.adoc
@@ -6,8 +6,9 @@
 [id="nodes-containers-downward-api-container-resources-envars_{context}"]
 = Consuming container resources using environment variables
 
+[role="_abstract"]
 When creating pods, you can use the Downward API to inject information about
-computing resource requests and limits using environment variables.
+computing resource requests and limits by using environment variables.
 
 When creating the pod configuration, specify environment variables that
 correspond to the contents of the `resources` field in the `*spec.container*`
@@ -63,7 +64,7 @@ spec:
 # ...
 ----
 
-.. Create the pod from the `pod.yaml` file:
+.. Create the pod from the `pod.yaml` file by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-resources-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-resources-envars.adoc
@@ -8,9 +8,7 @@
 
 [role="_abstract"]
 When creating pods, you can use the Downward API to inject information about
-computing resource requests and limits by using environment variables.
-
-When creating the pod configuration, specify environment variables that
+computing resource requests and limits by using environment variables that
 correspond to the contents of the `resources` field in the `*spec.container*`
 field.
 

--- a/modules/nodes-containers-downward-api-container-resources-plugin.adoc
+++ b/modules/nodes-containers-downward-api-container-resources-plugin.adoc
@@ -6,6 +6,7 @@
 [id="nodes-containers-downward-api-container-resources-plugin_{context}"]
 = Consuming container resources using a volume plugin
 
+[role="_abstract"]
 When creating pods, you can use the Downward API to inject information about
 computing resource requests and limits using a volume plugin.
 
@@ -70,7 +71,7 @@ spec:
 # ...
 ----
 
-.. Create the pod from the `*_volume-pod.yaml_*` file:
+.. Create the pod from the `*_volume-pod.yaml_*` file by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-resources-plugin.adoc
+++ b/modules/nodes-containers-downward-api-container-resources-plugin.adoc
@@ -8,10 +8,7 @@
 
 [role="_abstract"]
 When creating pods, you can use the Downward API to inject information about
-computing resource requests and limits using a volume plugin.
-
-When creating the pod configuration, use the `spec.volumes.downwardAPI.items`
-field to describe the desired resources that correspond to the
+computing resource requests and limits by using a volume plugin to describe the desired resources that correspond to the
 `spec.resources` field.
 
 [NOTE]

--- a/modules/nodes-containers-downward-api-container-resources.adoc
+++ b/modules/nodes-containers-downward-api-container-resources.adoc
@@ -6,9 +6,9 @@
 [id="nodes-containers-downward-api-container-resources-api_{context}"]
 = Understanding how to consume container resources using the Downward API
 
+[role="_abstract"]
 When creating pods, you can use the Downward API to inject information about
 computing resource requests and limits so that image and application authors can
 correctly create an image for specific environments.
 
 You can do this using environment variable or a volume plugin.
-

--- a/modules/nodes-containers-downward-api-container-secrets.adoc
+++ b/modules/nodes-containers-downward-api-container-secrets.adoc
@@ -78,7 +78,7 @@ $ oc create -f pod.yaml
 
 .Verification
 
-* Check the container's logs for the `MY_SECRET_USERNAME` value by using the following command:
+* Check the container logs for the `MY_SECRET_USERNAME` value by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-secrets.adoc
+++ b/modules/nodes-containers-downward-api-container-secrets.adoc
@@ -6,6 +6,7 @@
 [id="nodes-containers-downward-api-container-secrets_{context}"]
 = Consuming secrets using the Downward API
 
+[role="_abstract"]
 When creating pods, you can use the downward API to inject secrets
 so image and application authors can create an image
 for specific environments.
@@ -28,7 +29,7 @@ data:
 type: kubernetes.io/basic-auth
 ----
 
-.. Create the secret object from the `secret.yaml` file:
+.. Create the secret object from the `secret.yaml` file by using the following command:
 +
 [source,terminal]
 ----
@@ -68,7 +69,7 @@ spec:
 # ...
 ----
 
-.. Create the pod from the `pod.yaml` file:
+.. Create the pod from the `pod.yaml` file by using the following command:
 +
 [source,terminal]
 ----
@@ -77,7 +78,7 @@ $ oc create -f pod.yaml
 
 .Verification
 
-* Check the container's logs for the `MY_SECRET_USERNAME` value:
+* Check the container's logs for the `MY_SECRET_USERNAME` value by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-values-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-values-envars.adoc
@@ -6,14 +6,13 @@
 [id="nodes-containers-downward-api-container-values-envars_{context}"]
 = Consuming container values using environment variables
 
-When using a container's environment variables, use the `EnvVar` type's `valueFrom` field (of type `EnvVarSource`)
-to specify that the variable's value should come from a `FieldRef`
-source instead of the literal value specified by the `value` field.
+[role="_abstract"]
+When using a container's environment variables, you can specify that the variable's value should come from a `FieldRef` source instead of the literal value specified.
 
-Only constant attributes of the pod can be consumed this way, as environment
-variables cannot be updated once a process is started in a way that allows the
-process to be notified that the value of a variable has changed. The fields
-supported using environment variables are:
+Only constant attributes of the pod can be consumed this way, because environment
+variables cannot be updated after a process is started in a way that allows the
+process to be notified that the value of a variable has changed. The following fields
+are supported for using with environment variables:
 
 - Pod name
 - Pod project/namespace
@@ -55,8 +54,11 @@ spec:
   restartPolicy: Never
 # ...
 ----
+where:
 
-.. Create the pod from the `pod.yaml` file:
+`spec.containers.env.valueFrom.fieldRef.fieldPath`:: Specifies that the environment variable gets its value from the specified pod value, either `metadata.name` for the pod name or `metadata.namespace` for the pod namespace, instead of a literal value specified by a `value` field.
+
+.. Create the pod from the `pod.yaml` file by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-values-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-values-envars.adoc
@@ -7,7 +7,7 @@
 = Consuming container values using environment variables
 
 [role="_abstract"]
-When using a container's environment variables, you can specify that the variable's value should come from a `FieldRef` source instead of the literal value specified.
+When using environment variables in a container, you can specify that the variable's value should come from a `FieldRef` source instead of the literal value specified.
 
 Only constant attributes of the pod can be consumed this way, because environment
 variables cannot be updated after a process is started in a way that allows the
@@ -67,7 +67,7 @@ $ oc create -f pod.yaml
 
 .Verification
 
-* Check the container's logs for the `MY_POD_NAME` and `MY_POD_NAMESPACE`
+* Check the container logs for the `MY_POD_NAME` and `MY_POD_NAMESPACE`
 values:
 +
 [source,terminal]

--- a/modules/nodes-containers-downward-api-container-values-plugin.adoc
+++ b/modules/nodes-containers-downward-api-container-values-plugin.adoc
@@ -6,9 +6,10 @@
 [id="nodes-containers-downward-api-container-values-plugin_{context}"]
 = Consuming container values using a volume plugin
 
-You containers can consume API values using a volume plugin.
+[role="_abstract"]
+Your containers can consume Downward API values by using a volume plugin.
 
-Containers can consume:
+Containers can consume the following values:
 
 * Pod name
 
@@ -18,9 +19,9 @@ Containers can consume:
 
 * Pod labels
 
-.Procedure
+The following procedure show how to use the volume plugin.
 
-To use the volume plugin:
+.Procedure
 
 . Create a new pod spec that contains the environment variables you want the container to consume:
 
@@ -77,7 +78,7 @@ spec:
 # ...
 ----
 
-.. Create the pod from the `volume-pod.yaml` file:
+.. Create the pod from the `volume-pod.yaml` file by using the following command:
 +
 [source,terminal]
 ----
@@ -86,7 +87,7 @@ $ oc create -f volume-pod.yaml
 
 .Verification
 
-* Check the container's logs and verify the presence of the configured fields:
+* Check the container's logs and verify the presence of the configured fields by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-values-plugin.adoc
+++ b/modules/nodes-containers-downward-api-container-values-plugin.adoc
@@ -87,7 +87,7 @@ $ oc create -f volume-pod.yaml
 
 .Verification
 
-* Check the container's logs and verify the presence of the configured fields by using the following command:
+* Check the container logs and verify the presence of the configured fields by using the following command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-values.adoc
+++ b/modules/nodes-containers-downward-api-container-values.adoc
@@ -6,7 +6,9 @@
 [id="nodes-containers-downward-api-container-values_{context}"]
 = Understanding how to consume container values using the downward API
 
-You containers can consume API values using environment variables or a volume plugin.
+[role="_abstract"]
+Your containers can consume API values by using environment variables or a volume plugin.
+
 Depending on the method you choose, containers can consume:
 
 * Pod name

--- a/modules/nodes-containers-init-about.adoc
+++ b/modules/nodes-containers-init-about.adoc
@@ -4,41 +4,39 @@
 
 :_mod-docs-content-type: CONCEPT
 [id="nodes-containers-init-about_{context}"]
-= Understanding Init Containers
+= Understanding init containers
 
-You can use an Init Container resource to perform tasks before the rest of a pod is deployed.
+[role="_abstract"]
+You can use an init container to perform tasks before the rest of a pod is deployed. You can use init containers to perform setup tasks that should be completed before the main application logic begins, such as environment preparation, dependency checks, or configuration generation. 
 
-A pod can have Init Containers in addition to application containers. Init
-containers allow you to reorganize setup scripts and binding code.
+A pod can have init containers in addition to application containers. Init containers allow you to reorganize setup scripts and binding code.
 
-An Init Container can:
+An init container can:
 
-* Contain and run utilities that are not desirable to include in the app Container image for security reasons.
+* Contain and run utilities that are not desirable to include in the app container image for security reasons.
 * Contain utilities or custom code for setup that is not present in an app image. For example, there is no requirement to make an image FROM another image just to use a tool like sed, awk, python, or dig during setup.
 * Use Linux namespaces so that they have different filesystem views from app containers, such as access to secrets that application containers are not able to access.
 
-Each Init Container must complete successfully before the next one is started. So, Init Containers provide an easy way to block or delay the startup of app containers until some set of preconditions are met.
+Because each init container must complete successfully before the next one is started, they provide an easy way to block or delay the startup of app containers until some set of preconditions are met.
 
-For example, the following are some ways you can use Init Containers:
+For example, the following are some ways you can use init containers:
 
-* Wait for a service to be created with a shell command like:
+* Wait for a service to be created by using a shell command similar to the following:
 +
 [source,terminal]
 ----
 for i in {1..100}; do sleep 1; if dig myservice; then exit 0; fi; done; exit 1
 ----
 
-* Register this pod with a remote server from the downward API with a command like:
+* Register this pod with a remote server from the Downward API by using a command similar to the following:
 +
 [source,terminal]
 ----
 $ curl -X POST http://$MANAGEMENT_SERVICE_HOST:$MANAGEMENT_SERVICE_PORT/register -d ‘instance=$()&ip=$()’
 ----
 
-* Wait for some time before starting the app Container with a command like `sleep 60`.
+* Delay starting the app container by using a command such as `sleep 60`.
 
 * Clone a git repository into a volume.
 
-* Place values into a configuration file and run a template tool to dynamically generate a configuration file for the main app Container. For example, place the POD_IP value in a configuration and generate the main app configuration file using Jinja.
-
-See the link:https://kubernetes.io/docs/concepts/workloads/pods/init-containers/[Kubernetes documentation] for more information.
+* Place values into a configuration file and run a template tool to dynamically generate a configuration file for the main app container. For example, place the `POD_IP` value in a configuration and generate the main app configuration file using Jinja.

--- a/modules/nodes-containers-init-creating.adoc
+++ b/modules/nodes-containers-init-creating.adoc
@@ -6,7 +6,10 @@
 [id="nodes-containers-init-creating_{context}"]
 = Creating Init Containers
 
-The following example outlines a simple pod which has two Init Containers. The first waits for `myservice` and the second waits for `mydb`. After both containers complete, the pod begins.
+[role="_abstract"]
+You create an init container by creating a pod spec that contains an `initContainers` configuration. 
+
+The following example outlines a simple pod which has two init containers. The first init continer waits for the `myservice` service to complete. After that, the second waits for `mydb` service to complete. After both init containers complete, the pod begins.
 
 .Procedure
 
@@ -52,14 +55,14 @@ spec:
         drop: [ALL]
 ----
 
-.. Create the pod:
+.. Create the pod by using the following command:
 +
 [source,terminal]
 ----
 $ oc create -f myapp.yaml
 ----
 
-.. View the status of the pod:
+.. View the status of the pod by using the following command:
 +
 [source,terminal]
 ----
@@ -92,14 +95,14 @@ spec:
     targetPort: 9376
 ----
 
-.. Create the pod:
+.. Create the pod by using the following command:
 +
 [source,terminal]
 ----
 $ oc create -f myservice.yaml
 ----
 
-.. View the status of the pod:
+.. View the status of the pod by using the following command:
 +
 [source,terminal]
 ----
@@ -132,14 +135,14 @@ spec:
     targetPort: 9377
 ----
 
-.. Create the pod:
+.. Create the pod by using the following command:
 +
 [source,terminal]
 ----
 $ oc create -f mydb.yaml
 ----
 
-.. View the status of the pod:
+.. View the status of the pod by using the following command:
 +
 [source,terminal]
 ----
@@ -153,4 +156,4 @@ NAME                          READY     STATUS              RESTARTS   AGE
 myapp-pod                     1/1       Running             0          2m
 ----
 +
-The pod status indicated that it is no longer waiting for the services and is running.
+The pod status, `Running`, indicates that it is no longer waiting for the services and is running.

--- a/nodes/containers/nodes-containers-copying-files.adoc
+++ b/nodes/containers/nodes-containers-copying-files.adoc
@@ -6,13 +6,21 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
+You can use the `oc rsync` command, or remote sync, to copy local files to or from a remote directory in a {product-title} container.
 
+//taken from nodes-containers-copying-files-about.adoc
+The `oc rsync` command leverages the local Rsync tool on the client machine and the remote container for tasks such as copying database archives to and from your pods for backup and restore purposes,
+or copying source code changes into a running pod for development debugging.
 
-
-
-
-You can use the CLI to copy local files to or from a remote directory in a container
-using the `rsync` command.
+//taken from nodes-containers-copying-files-procedure.adoc
+[NOTE]
+====
+If the Rsync tool is not found locally or in the remote container, a *tar* archive
+is created locally and sent to the container where the *tar* utility is used to
+extract the files. If *tar* is not available in the remote container, the
+copy fails.
+====
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference

--- a/nodes/containers/nodes-containers-dev-fuse.adoc
+++ b/nodes/containers/nodes-containers-dev-fuse.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can configure your pods with the `/dev/fuse` device to enable faster and more efficient container image builds, particularly for unprivileged users. This device allows unprivileged pods to mount overlay filesystems, which can be leveraged by tools like Podman.
+[role="_abstract"]
+You can configure your pods with the `/dev/fuse` device to enable faster and more efficient container image builds, particularly for unprivileged users. This device allows unprivileged pods to mount overlay filesystems, which can be leveraged by tools such as Podman.
 
 include::modules/nodes-containers-dev-fuse-configuring.adoc[leveloffset=+1]

--- a/nodes/containers/nodes-containers-downward-api.adoc
+++ b/nodes/containers/nodes-containers-downward-api.adoc
@@ -7,16 +7,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-
-
-
-The _Downward API_ is a mechanism that allows containers to consume information
-about API objects without coupling to {product-title}.
-Such information includes the pod's name, namespace, and resource values.
-Containers can consume information from the downward API using environment
-variables or a volume plugin.
-
-
+[role="_abstract"]
+You can use the _Downward API_ to allow containers to consume information about API objects, such as the pod's name, namespace, and resource values, without coupling to {product-title} by using environment variables or a volume plugin.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference

--- a/nodes/containers/nodes-containers-init.adoc
+++ b/nodes/containers/nodes-containers-init.adoc
@@ -7,9 +7,8 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 
-
-
-{product-title} provides _init containers_, which are specialized containers
+[role="_abstract"]
+You can use _init containers_, which are specialized containers
 that run before application containers and can contain utilities or setup scripts not present in an app image.
 
 // The following include statements pull in the module files that comprise
@@ -21,4 +20,8 @@ include::modules/nodes-containers-init-about.adoc[leveloffset=+1]
 
 include::modules/nodes-containers-init-creating.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
 
+* link:https://kubernetes.io/docs/concepts/workloads/pods/init-containers/[Init Containers (Kubernetes documentation)]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-16932

[Copying files to or from OpenShift Container Platform containers](https://106880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-copying-files)
[Accessing faster builds with /dev/fuse](https://106880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-dev-fuse)
[Allowing containers to consume API objects](https://106880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api)
[Using Init Containers to perform tasks before a pod is deployed](https://106880--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-init)

