### PR TITLE
OLS-2628: Vale checks for modules in operation assembly

### DIFF
--- a/modules/ols-about-lightspeed-conversations.adoc
+++ b/modules/ols-about-lightspeed-conversations.adoc
@@ -1,10 +1,14 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="ols-about-lightspeed-conversations_{context}"]
 = About Lightspeed conversations
 
 [role="_abstract"]
-Get technical assistance for {ocp-short-name}, {k8s}, and specialized {ocp-short-name} components, such as {ocp-virt} and {ossm}, using {ols-long}.
 
-{ols-long} will not answer questions that are unrelated to the targeted topics. In some cases, you may need to rephrase an ambiguously worded question because {ols-long} could not correctly interpret what you asked. Conversation history helps provide context that {ols-long} references when generating answers. Using specific language helps increase the success of responses. For example, instead of asking "How do I start a virtual machine?" try asking "How do I start a virtual machine in {ocp-virt}?"
+Use {ols-long} to get help for {ocp-short-name}, {k8s}, and specialized {ocp-short-name} components such as {ocp-virt} and {ossm}
 
-Conversation history does not persist if you reload the console page. Reloading the console page performs the same action as clicking the *New Chat* button. Conversation history is also erased if {ols-long} is restarted.
+{ols-long} ignores questions unrelated to the target topics. If {ols-long} misinterprets your question, try rephrasing the question for better clarity. Conversation history provides context that {ols-long} references when generating answers. Using specific language helps increase the success of responses. For example, instead of asking "How do I start a virtual machine?" try asking "How do I start a virtual machine in {ocp-virt}?"
+
+Conversation history does not persist if you reload the console page. Reloading the console page performs the same action as clicking the *New Chat* button. Restarting {ols-long} erases conversation history.

--- a/modules/ols-asking-general-information.adoc
+++ b/modules/ols-asking-general-information.adoc
@@ -1,11 +1,12 @@
-// This module is used in the following assemblies:
-// ols-using-openshift-lightspeed.adoc
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-asking-general-information_{context}"]
 = Asking a general question
 
 [role="_abstract"]
+
 Ask general questions about {ocp-product-title} using {ols-long} to quickly find documentation, best practices, and product information.
 
 .Procedure
@@ -14,8 +15,8 @@ Ask general questions about {ocp-product-title} using {ols-long} to quickly find
 
 . Enter the following question into the *Send a message* field:
 +
-What is an OpenShift imagestream used for?
+What is an OpenShift image stream used for?
 
 . Click the *Submit* button.
 +
-{ols-long} returns information that provides an explanation of an imagestream and details about usage.
+{ols-long} returns information that provides an explanation of an image stream and details about usage.

--- a/modules/ols-asking-related-questions.adoc
+++ b/modules/ols-asking-related-questions.adoc
@@ -1,9 +1,13 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="ols-asking-related-questions_{context}"]
 = Asking related questions
 
 [role="_abstract"]
-Ask a series of follow-up questions in {ols-long} to refine your results. {ols-long} maintains conversation history to provide context-aware responses and more accurate information.
+
+Ask follow-up questions in {ols-long} to refine results and obtain specific examples based on prior conversation history.
 
 .Procedure
 
@@ -23,7 +27,7 @@ Can I control who can use a particular SCC?
 
 . Click the *Submit* button.
 +
-{ols-long} returns more highly refined information that contains additional details.
+{ols-long} returns refined information that has additional details.
 
 . Enter the following question into the *Send a message* field:
 +

--- a/modules/ols-attaching-a-resource-object-to-your-query.adoc
+++ b/modules/ols-attaching-a-resource-object-to-your-query.adoc
@@ -1,12 +1,13 @@
-// This module is used in the following assemblies:
-// ols-using-openshift-lightspeed.adoc
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-attaching-a-resource-object-to-your-query_{context}"]
 = Attaching a resource object to your question
 
 [role="_abstract"]
-Attach a cluster resource object to your {ols-long} query to provide specific context and receive more relevant, data-driven troubleshooting advice.
+
+Attach a cluster resource object to your {ols-long} query to give specific context and receive more relevant, data-driven troubleshooting advice.
 
 .Procedure
 

--- a/modules/ols-initiating-chat-using-chat-window.adoc
+++ b/modules/ols-initiating-chat-using-chat-window.adoc
@@ -1,12 +1,13 @@
-// This module is used in the following assemblies:
-// ols-using-openshift-lightspeed.adoc
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-initiating-chat-using-chat-window_{context}"]
 = Using the chat window to ask a question 
 
 [role="_abstract"]
-Ask questions using natural language by interacting with the {ols-official} icon to receive immediate support and information.
+
+Get immediate product information and support by asking questions through the {ols-official} icon.
 
 .Procedure
  

--- a/modules/ols-providing-feedback-for-conversation.adoc
+++ b/modules/ols-providing-feedback-for-conversation.adoc
@@ -1,12 +1,13 @@
-// This module is used in the following assemblies:
-// configure/ols-using-openshift-lightspeed.adoc
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-providing-feedback-for-conversation_{context}"]
 = Providing feedback for a conversation 
 
 [role="_abstract"]
-Provide feedback to {red-hat} on specific {ols-long} interactions to improve the quality and accuracy of future responses.
+
+Send feedback to {red-hat} on specific {ols-long} interactions to improve the quality and accuracy of future responses.
 
 .Prerequisites
 
@@ -22,9 +23,9 @@ Provide feedback to {red-hat} on specific {ols-long} interactions to improve the
 +
 {ols-long} returns information.
 
-. To provide feedback on a particular question and response, click the thumbs up or thumbs down button.
+. To send feedback on a particular question and response, click the thumbs up or thumbs down button.
 + 
-This action presents a field that allows you to enter additional information.
+This action presents the field that you use to enter additional information.
 
 . Click the *Submit* button.
 +

--- a/modules/ols-sample-dialogs-overview.adoc
+++ b/modules/ols-sample-dialogs-overview.adoc
@@ -1,9 +1,12 @@
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="ols-sample-dialogs-overview_{context}"]
 = Sample conversation overview
 
 [role="_abstract"]
 
-Use these sample prompts and follow-up strategies to initiate effective conversations with {ols-long} and improve response accuracy. 
+Use these sample prompts and follow-up strategies to start effective conversations with {ols-long} and improve response accuracy. 
 
-Some of the examples suggest specific workflows to follow in the user interface. Be sure to ask the follow-up questions without starting a new dialog. {ols-long} uses the entire conversation as context, so follow-up questions should help refine answers. Rephrasing questions or asking a more precise follow-up question can help increase the success of the reply.
+Some examples show specific workflows to use in the interface. Ask your follow-up questions in the same chat to help create context. Because {ols-long} uses the whole chat, follow-up questions help refine the results. You can get better answers by rephrasing your question or asking for more detail.

--- a/modules/ols-starting-a-new-chat.adoc
+++ b/modules/ols-starting-a-new-chat.adoc
@@ -1,20 +1,21 @@
-// This module is used in the following assemblies:
-// ols-using-openshift-lightspeed.adoc
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-starting-a-new-chat_{context}"]
 = Starting a new chat conversation
 
 [role="_abstract"]
-Reset your {ols-long} session by clearing the chat history to start a new conversation without influence from previous context.
 
-When you ask follow-up questions, {ols-long} references the conversation history to provide additional context that influences the replies it generates. Whenever you initiate a new conversation with {ols-long} you should clear the chat history.
+Reset your {ols-long} session by clearing the chat history to start a new conversation without influence from the prior context.
+
+When you ask follow-up questions, {ols-long} references the conversation history for additional context that influences replies. Whenever you start a new conversation with {ols-long} you should clear the chat history.
 
 .Procedure
 
 . In the {ols-official} natural language interface, click *Clear chat*. 
 +
-This action clears the history of your previous conversation. 
+This action clears the history of prior conversations. 
 
 . Enter a question.
 

--- a/modules/ols-using-lightspeed-to-troubleshoot-alerts.adoc
+++ b/modules/ols-using-lightspeed-to-troubleshoot-alerts.adoc
@@ -1,11 +1,12 @@
-// This module is used in the following assemblies:
-// ols-using-openshift-lightspeed.adoc
+// Module included in the following assemblies:
+// lightspeed-docs-main/operate/ols-using-openshift-lightspeed.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="ols-using-lightspeed-to-troubleshoot-alerts_{context}"]
 = Using {ols-long} to troubleshoot alerts
 
 [role="_abstract"]
+
 Analyze and resolve cluster alerts by querying {ols-long} for root cause explanations, documentation links, and recommended remediation steps.
 
 .Procedure
@@ -26,4 +27,4 @@ What should I do about this alert?
 
 . Click the *Submit* button.
 +
-{ols-long} references the alert information to provide context when generating the information it returns.
+The alert provides {ols-long} with context when generating a response.

--- a/operate/ols-using-openshift-lightspeed.adoc
+++ b/operate/ols-using-openshift-lightspeed.adoc
@@ -7,6 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
+
 Submit questions to {ols-long}, manage resource attachments, and resolve system alerts to optimize your troubleshooting experience.
 
 include::modules/ols-initiating-chat-using-chat-window.adoc[leveloffset=+1]


### PR DESCRIPTION
Affects:
[lightspeed-main](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-main)
[lightspeed-docs-1.0](https://github.com/openshift/openshift-docs/tree/lightspeed-docs-1.0)

PR must be CP'd back to the lightspeed-docs-1.0 branch.

Issue:
https://issues.redhat.com/browse/OLS-2628

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
