### PR TITLE
OCPBUGS-64566: Updated the prereqs in the UserDefinedNetwork CR docs

### DIFF
--- a/modules/nw-udn-cr-ui.adoc
+++ b/modules/nw-udn-cr-ui.adoc
@@ -16,8 +16,9 @@ Currently, creation of a `UserDefinedNetwork` CR with a `Layer3` topology or a `
 
 .Prerequisites
 
-* You have access to the {product-title} web console as a user with `cluster-admin` permissions.
-* You have created a namespace and applied the `k8s.ovn.org/primary-user-defined-network` label.
+* As a cluster administrator, you have created a namespace.
+** During namespace creation, ensure you also applied the `k8s.ovn.org/primary-user-defined-network` label to the namespace.
+** After you create the namespace, a user that has `view` and `edit` role-based access control (RBAC) permissions can create a `UserDefinedNetwork` CR in the namespace.
 
 .Procedure
 

--- a/modules/nw-udn-cr.adoc
+++ b/modules/nw-udn-cr.adoc
@@ -18,8 +18,9 @@ When deploying a `UserDefinedNetwork` custom resource (CR) on {ibm-power-name} V
 
 .Prerequisites
 
-* You have logged in with `cluster-admin` privileges, or you have `view` and `edit` role-based access control (RBAC).
-
+* As a cluster administrator, you have created a namespace.
+** During namespace creation, ensure you also applied the `k8s.ovn.org/primary-user-defined-network` label to the namespace.
+** After you create the namespace, a user that has `view` and `edit` role-based access control (RBAC) permissions can create a `UserDefinedNetwork` CR in the namespace.
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.17+

Issue:
[OCPBUGS-64566](https://issues.redhat.com/browse/OCPBUGS-64566)

Link to docs preview:

* [Creating a UserDefinedNetwork CR by using the CLI](https://106907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html#nw-udn-cr_user-defined-networks)
* [Creating a UserDefinedNetwork CR by using the web console](https://106907--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/primary_networks/about-user-defined-networks.html#nw-udn-cr-ui_user-defined-networks)

- [x] SME has approved this change (Or Mergi).
- [x] QE has approved this change (Yossi Segev and Anat Wax).
